### PR TITLE
feat: LiteRT-LM inference engine integration

### DIFF
--- a/core/inference/build.gradle.kts
+++ b/core/inference/build.gradle.kts
@@ -21,6 +21,9 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
+        // LiteRT-LM is compiled with an internal Kotlin build (metadata 2.3.0).
+        // Skip the strict metadata version check to allow compilation.
+        freeCompilerArgs += "-Xskip-metadata-version-check"
     }
 }
 
@@ -29,9 +32,10 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.datastore.preferences)
+    implementation(libs.coroutines.android)
 
-    // LiteRT-LM — uncomment when dependency is available
-    // implementation("com.google.ai.edge.litertlm:litertlm-android:+")
+    // LiteRT-LM on-device inference
+    implementation(libs.litertlm.android)
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/BackendType.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/BackendType.kt
@@ -1,0 +1,25 @@
+package com.kernel.ai.core.inference
+
+import android.content.Context
+import com.google.ai.edge.litertlm.Backend
+
+enum class BackendType {
+    /** Force CPU execution with XNNPACK delegate. */
+    CPU,
+
+    /** GPU via OpenCL delegate. Requires libOpenCL.so on the device. */
+    GPU,
+
+    /** Qualcomm Hexagon NPU via QNN delegate. Requires nativeLibraryDir. */
+    NPU,
+
+    /** Try NPU → GPU → CPU in order. */
+    AUTO;
+}
+
+fun BackendType.toBackend(context: Context): Backend = when (this) {
+    BackendType.CPU -> Backend.CPU(numOfThreads = 4)
+    BackendType.GPU -> Backend.GPU()
+    BackendType.NPU -> Backend.NPU(nativeLibraryDir = context.applicationInfo.nativeLibraryDir)
+    BackendType.AUTO -> Backend.GPU() // AUTO is resolved before calling toBackend
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/GenerationResult.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/GenerationResult.kt
@@ -1,0 +1,17 @@
+package com.kernel.ai.core.inference
+
+/** Represents a single unit of output from the LLM streaming pipeline. */
+sealed class GenerationResult {
+
+    /** A partial text token from the model. */
+    data class Token(val text: String) : GenerationResult()
+
+    /** Internal reasoning token (from Gemma thinking mode). */
+    data class Thinking(val text: String) : GenerationResult()
+
+    /** Generation finished successfully. */
+    data class Complete(val durationMs: Long) : GenerationResult()
+
+    /** Generation failed with an error. */
+    data class Error(val message: String, val cause: Throwable? = null) : GenerationResult()
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
@@ -1,22 +1,55 @@
 package com.kernel.ai.core.inference
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Core interface for on-device LLM inference.
- * Implementations wrap LiteRT-LM for different model types.
+ * Core interface for on-device LLM inference backed by LiteRT-LM.
+ *
+ * Lifecycle:
+ * 1. [initialize] — loads model weights onto the chosen hardware backend (10–30 s).
+ * 2. [generate] — streams [GenerationResult] tokens for one or more turns.
+ * 3. [resetConversation] — clears context window while keeping the engine warm.
+ * 4. [shutdown] — releases all native resources.
+ *
+ * Thread-safety: implementations pin all work to [LlmDispatcher].
  */
 interface InferenceEngine {
 
-    /** Whether the engine has a model loaded and ready for inference. */
-    val isReady: Boolean
+    /** True once the engine has initialized and is ready to generate. */
+    val isReady: StateFlow<Boolean>
 
-    /** Load model weights from the given file path. */
-    suspend fun loadModel(modelPath: String)
+    /** True while a [generate] call is in flight. */
+    val isGenerating: StateFlow<Boolean>
 
-    /** Generate a streaming response for the given prompt. */
-    fun generate(prompt: String): Flow<String>
+    /** The hardware backend currently in use, or null before initialization. */
+    val activeBackend: StateFlow<BackendType?>
 
-    /** Release model weights and free memory. */
-    suspend fun unload()
+    /**
+     * Load model weights and initialize the LiteRT-LM engine.
+     * Blocks the [LlmDispatcher] thread; observe [isReady] for completion.
+     *
+     * @throws [InferenceException] if all backends fail.
+     */
+    suspend fun initialize(config: ModelConfig)
+
+    /**
+     * Send [userMessage] to the model and stream back [GenerationResult] events.
+     * The conversation history is preserved across calls until [resetConversation].
+     *
+     * Cancel the returned [Flow] to abort generation mid-stream.
+     */
+    fun generate(userMessage: String): Flow<GenerationResult>
+
+    /** Cancel any in-flight generation immediately. */
+    fun cancelGeneration()
+
+    /**
+     * Clear the conversation context window and start fresh.
+     * The engine stays warm — no model reload required.
+     */
+    suspend fun resetConversation()
+
+    /** Release the engine and all native resources. Safe to call multiple times. */
+    suspend fun shutdown()
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceException.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceException.kt
@@ -1,0 +1,3 @@
+package com.kernel.ai.core.inference
+
+class InferenceException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -1,0 +1,229 @@
+package com.kernel.ai.core.inference
+
+import android.content.Context
+import android.util.Log
+import com.google.ai.edge.litertlm.Content
+import com.google.ai.edge.litertlm.Contents
+import com.google.ai.edge.litertlm.ConversationConfig
+import com.google.ai.edge.litertlm.Engine
+import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.Message
+import com.google.ai.edge.litertlm.MessageCallback
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "LiteRtInferenceEngine"
+
+/**
+ * LiteRT-LM implementation of [InferenceEngine].
+ *
+ * Engine is a thread-safe singleton; Conversation is NOT thread-safe.
+ * All operations are dispatched to [LlmDispatcher] (single named thread)
+ * to guarantee safety and keep the "llm-inference" thread visible in profiling.
+ *
+ * Backend selection: AUTO tries NPU → GPU → CPU. The first backend that
+ * initialises successfully is used for the lifetime of the engine.
+ *
+ * NPU note: SamplerConfig must be null when using Backend.NPU (hardware
+ * sampler is used instead). This matches Gallery reference behaviour.
+ */
+@Singleton
+class LiteRtInferenceEngine @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : InferenceEngine {
+
+    private val _isReady = MutableStateFlow(false)
+    override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    private val _isGenerating = MutableStateFlow(false)
+    override val isGenerating: StateFlow<Boolean> = _isGenerating.asStateFlow()
+
+    private val _activeBackend = MutableStateFlow<BackendType?>(null)
+    override val activeBackend: StateFlow<BackendType?> = _activeBackend.asStateFlow()
+
+    private var engine: Engine? = null
+    private var conversation: com.google.ai.edge.litertlm.Conversation? = null
+    private var currentConfig: ModelConfig? = null
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    override suspend fun initialize(config: ModelConfig) {
+        withContext(LlmDispatcher) {
+            _isReady.value = false
+            Log.i(TAG, "Initializing engine for model: ${config.modelPath}")
+
+            val (eng, backendType) = createEngineWithFallback(config)
+            engine = eng
+            conversation = eng.createConversation(buildConversationConfig(backendType, config.systemPrompt))
+            currentConfig = config
+            _activeBackend.value = backendType
+            _isReady.value = true
+
+            Log.i(TAG, "Engine ready — backend: $backendType, maxTokens: ${config.maxTokens}")
+        }
+    }
+
+    override suspend fun resetConversation() {
+        withContext(LlmDispatcher) {
+            val eng = engine ?: return@withContext
+            val config = currentConfig ?: return@withContext
+            val backend = _activeBackend.value ?: BackendType.CPU
+
+            safeClose(conversation, "conversation")
+            conversation = eng.createConversation(buildConversationConfig(backend, config.systemPrompt))
+            _isGenerating.value = false
+            Log.i(TAG, "Conversation reset")
+        }
+    }
+
+    override suspend fun shutdown() {
+        withContext(LlmDispatcher) {
+            _isReady.value = false
+            _isGenerating.value = false
+            safeCancel(conversation)
+            safeClose(conversation, "conversation")
+            safeClose(engine, "engine")
+            conversation = null
+            engine = null
+            _activeBackend.value = null
+            currentConfig = null
+            Log.i(TAG, "Engine shut down")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Generation
+    // -------------------------------------------------------------------------
+
+    override fun generate(userMessage: String): Flow<GenerationResult> = callbackFlow {
+        val conv = conversation
+        if (conv == null) {
+            close(InferenceException("Engine not initialized — call initialize() first"))
+            return@callbackFlow
+        }
+
+        _isGenerating.value = true
+        val start = System.currentTimeMillis()
+
+        conv.sendMessageAsync(
+            Contents.of(Content.Text(userMessage)),
+            object : MessageCallback {
+                override fun onMessage(message: Message) {
+                    // Route thinking tokens separately (Gemma thinking mode)
+                    val thinkingText = message.channels["thought"]
+                    if (!thinkingText.isNullOrEmpty()) {
+                        trySend(GenerationResult.Thinking(thinkingText))
+                    }
+
+                    val text = message.toString()
+                    if (text.isNotEmpty() && !text.startsWith("<ctrl")) {
+                        trySend(GenerationResult.Token(text))
+                    }
+                }
+
+                override fun onDone() {
+                    val durationMs = System.currentTimeMillis() - start
+                    Log.d(TAG, "Generation complete in ${durationMs}ms")
+                    _isGenerating.value = false
+                    trySend(GenerationResult.Complete(durationMs = durationMs))
+                    close()
+                }
+
+                override fun onError(throwable: Throwable) {
+                    _isGenerating.value = false
+                    if (throwable is CancellationException) {
+                        Log.i(TAG, "Generation cancelled by user")
+                        close()
+                    } else {
+                        Log.e(TAG, "Generation error", throwable)
+                        close(InferenceException("Generation failed: ${throwable.message}", throwable))
+                    }
+                }
+            },
+        )
+
+        // When the Flow collector cancels (e.g. user navigates away), stop inference.
+        awaitClose {
+            _isGenerating.value = false
+            conv.cancelProcess()
+        }
+    }.flowOn(LlmDispatcher)
+
+    override fun cancelGeneration() {
+        conversation?.cancelProcess()
+        _isGenerating.value = false
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private fun createEngineWithFallback(config: ModelConfig): Pair<Engine, BackendType> {
+        val orderedBackends: List<BackendType> = when (config.backendType) {
+            BackendType.CPU -> listOf(BackendType.CPU)
+            BackendType.GPU -> listOf(BackendType.GPU, BackendType.CPU)
+            BackendType.NPU -> listOf(BackendType.NPU, BackendType.GPU, BackendType.CPU)
+            BackendType.AUTO -> listOf(BackendType.NPU, BackendType.GPU, BackendType.CPU)
+        }
+
+        var lastException: Exception? = null
+        for (backendType in orderedBackends) {
+            try {
+                Log.d(TAG, "Trying backend: $backendType")
+                val engineConfig = EngineConfig(
+                    modelPath = config.modelPath,
+                    backend = backendType.toBackend(context),
+                    maxNumTokens = config.maxTokens,
+                )
+                val eng = Engine(engineConfig)
+                eng.initialize()
+                Log.i(TAG, "Backend $backendType initialized successfully")
+                return Pair(eng, backendType)
+            } catch (e: Exception) {
+                Log.w(TAG, "Backend $backendType failed: ${e.message}")
+                lastException = e
+            }
+        }
+
+        throw InferenceException(
+            "All backends failed for ${config.modelPath}. Last error: ${lastException?.message}",
+            lastException,
+        )
+    }
+
+    private fun buildConversationConfig(
+        backendType: BackendType,
+        systemPrompt: String?,
+    ): ConversationConfig {
+        // NPU uses hardware sampler — setting SamplerConfig causes a crash
+        val samplerConfig = if (backendType == BackendType.NPU) null else DEFAULT_SAMPLER_CONFIG
+        val systemInstruction = systemPrompt
+            ?.takeIf { it.isNotBlank() }
+            ?.let { Contents.of(Content.Text(it)) }
+
+        return ConversationConfig(
+            samplerConfig = samplerConfig,
+            systemInstruction = systemInstruction,
+        )
+    }
+
+    private fun safeCancel(conv: com.google.ai.edge.litertlm.Conversation?) {
+        try { conv?.cancelProcess() } catch (e: Exception) { Log.w(TAG, "cancelProcess: ${e.message}") }
+    }
+
+    private fun safeClose(closeable: AutoCloseable?, label: String) {
+        try { closeable?.close() } catch (e: Exception) { Log.w(TAG, "close $label: ${e.message}") }
+    }
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LlmDispatcher.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LlmDispatcher.kt
@@ -1,0 +1,15 @@
+package com.kernel.ai.core.inference
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+/**
+ * Dedicated single-threaded dispatcher for all LiteRT-LM operations.
+ *
+ * LiteRT-LM's [com.google.ai.edge.litertlm.Conversation] is NOT thread-safe.
+ * Pinning all inference work to a single named thread ensures safety and makes
+ * profiling/debugging straightforward (look for "llm-inference" in traces).
+ */
+val LlmDispatcher = Executors.newSingleThreadExecutor { runnable ->
+    Thread(runnable, "llm-inference").apply { isDaemon = true }
+}.asCoroutineDispatcher()

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -1,0 +1,29 @@
+package com.kernel.ai.core.inference
+
+import com.google.ai.edge.litertlm.SamplerConfig
+
+/** Kernel's default system prompt. Injected into every new conversation. */
+const val DEFAULT_SYSTEM_PROMPT =
+    "You are Kernel, a helpful and concise AI assistant running entirely on-device. " +
+        "Be friendly, direct, and slightly playful. Keep responses short unless asked for detail."
+
+/** Maximum context window tokens (KV-cache size). */
+const val DEFAULT_MAX_TOKENS = 2048
+
+/** Sampler defaults for CPU/GPU backends. NPU requires null samplerConfig. */
+val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature = 0.7)
+
+/**
+ * Configuration used when loading a model into [InferenceEngine].
+ *
+ * @param modelPath Absolute path to the `.litertlm` model file on-device storage.
+ * @param backendType Preferred hardware backend; defaults to [BackendType.AUTO].
+ * @param maxTokens KV-cache capacity. Higher values use more RAM.
+ * @param systemPrompt Optional system instruction prepended to every conversation.
+ */
+data class ModelConfig(
+    val modelPath: String,
+    val backendType: BackendType = BackendType.AUTO,
+    val maxTokens: Int = DEFAULT_MAX_TOKENS,
+    val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
+)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/di/InferenceModule.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/di/InferenceModule.kt
@@ -1,0 +1,18 @@
+package com.kernel.ai.core.inference.di
+
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.LiteRtInferenceEngine
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class InferenceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindInferenceEngine(impl: LiteRtInferenceEngine): InferenceEngine
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+# AGP 8.7.x was tested up to compileSdk 35; suppress the warning for 36
+android.suppressUnsupportedCompileSdk=36

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,9 @@ junit = "5.11.4"
 mockk = "1.13.16"
 coroutinesTest = "1.10.1"
 
+# LiteRT
+litertlm = "0.10.0"
+
 # Debug
 leakcanary = "2.14"
 
@@ -63,6 +66,12 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+# LiteRT-LM
+litertlm-android = { group = "com.google.ai.edge.litertlm", name = "litertlm-android", version.ref = "litertlm" }
+
+# Coroutines
+coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutinesTest" }
 
 # Testing
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }


### PR DESCRIPTION
## Summary
Implements the `core:inference` module with full LiteRT-LM integration.

## Changes
- **LiteRT-LM 0.10.0** added as dependency (`core:inference`)
- **`LiteRtInferenceEngine`** — Hilt singleton implementing `InferenceEngine`:
  - Backend fallback chain: NPU → GPU → CPU (AUTO mode)
  - Dedicated `LlmDispatcher` single-threaded executor for thread-safe `Conversation` access
  - Streaming via `callbackFlow` → `Flow<GenerationResult>`
  - Thinking-mode token routing (`message.channels["thought"]`)
  - Conversation `cancelProcess()` wired to Flow cancellation
- **`InferenceEngine`** interface updated: `StateFlow<Boolean>` for ready/generating state, multi-turn `resetConversation()`, `cancelGeneration()`
- **Supporting types**: `BackendType`, `ModelConfig`, `GenerationResult` (sealed), `InferenceException`, `LlmDispatcher`
- **`InferenceModule`** Hilt binding in `SingletonComponent`

## Build notes
- Added `-Xskip-metadata-version-check` to `core:inference` — LiteRT-LM 0.10.0 uses an internal Google Kotlin 2.3.x build (metadata 2.3.0) while the project targets stable Kotlin 2.1.0
- Added `android.suppressUnsupportedCompileSdk=36` to gradle.properties
- Full `assembleDebug` verified ✅ — `liblitertlm_jni.so` bundled in APK

## Testing
Inference can only be integration-tested on a physical device with a downloaded model. Unit test stubs will be added in the test-writer pass.