### PR TITLE
feat(#8): Chat UI — Room persistence, streaming chat, conversation list

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -1,10 +1,17 @@
 package com.kernel.ai.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.kernel.ai.feature.chat.ChatScreen
+import com.kernel.ai.feature.chat.ConversationListScreen
+
+private const val ROUTE_LIST = "conversation_list"
+private const val ROUTE_CHAT = "chat"
+private const val ARG_CONVERSATION_ID = "conversationId"
 
 @Composable
 fun KernelNavHost() {
@@ -12,16 +19,51 @@ fun KernelNavHost() {
 
     NavHost(
         navController = navController,
-        startDestination = "chat"
+        startDestination = ROUTE_LIST,
     ) {
-        composable("chat") {
-            ChatScreen()
+        composable(ROUTE_LIST) {
+            ConversationListScreen(
+                onOpenConversation = { id ->
+                    navController.navigate("$ROUTE_CHAT/$id")
+                },
+                onNewConversation = {
+                    navController.navigate(ROUTE_CHAT)
+                },
+            )
         }
-        composable("settings") {
-            // SettingsScreen — implemented in Phase 2+
+
+        // New conversation (no conversationId arg)
+        composable(ROUTE_CHAT) {
+            ChatScreen(
+                conversationId = null,
+                onNewConversation = {
+                    navController.navigate(ROUTE_CHAT) {
+                        popUpTo(ROUTE_CHAT) { inclusive = true }
+                    }
+                },
+                onNavigateToList = {
+                    navController.navigate(ROUTE_LIST) {
+                        popUpTo(ROUTE_LIST) { inclusive = true }
+                    }
+                },
+            )
         }
-        composable("onboarding") {
-            // OnboardingScreen — implemented in Phase 1.3
+
+        // Existing conversation
+        composable(
+            route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
+            arguments = listOf(navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType }),
+        ) { backStackEntry ->
+            val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
+            ChatScreen(
+                conversationId = conversationId,
+                onNewConversation = {
+                    navController.navigate(ROUTE_CHAT)
+                },
+                onNavigateToList = {
+                    navController.popBackStack()
+                },
+            )
         }
     }
 }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/1.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/1.json
@@ -1,0 +1,119 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "71cb95062e97b477192b94cdef8ea094",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '71cb95062e97b477192b94cdef8ea094')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -1,0 +1,18 @@
+package com.kernel.ai.core.memory
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.kernel.ai.core.memory.dao.ConversationDao
+import com.kernel.ai.core.memory.dao.MessageDao
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.entity.MessageEntity
+
+@Database(
+    entities = [ConversationEntity::class, MessageEntity::class],
+    version = 1,
+    exportSchema = true,
+)
+abstract class KernelDatabase : RoomDatabase() {
+    abstract fun conversationDao(): ConversationDao
+    abstract fun messageDao(): MessageDao
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -1,6 +1,30 @@
 package com.kernel.ai.core.memory
 
-/**
- * Placeholder — Room database and RAG pipeline implemented in Phase 2.
- */
-object MemoryModule
+import android.content.Context
+import androidx.room.Room
+import com.kernel.ai.core.memory.dao.ConversationDao
+import com.kernel.ai.core.memory.dao.MessageDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MemoryModule {
+
+    @Provides
+    @Singleton
+    fun provideKernelDatabase(@ApplicationContext context: Context): KernelDatabase =
+        Room.databaseBuilder(context, KernelDatabase::class.java, "kernel_db")
+            .fallbackToDestructiveMigration(dropAllTables = false)
+            .build()
+
+    @Provides
+    fun provideConversationDao(db: KernelDatabase): ConversationDao = db.conversationDao()
+
+    @Provides
+    fun provideMessageDao(db: KernelDatabase): MessageDao = db.messageDao()
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -1,0 +1,35 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ConversationDao {
+
+    @Query("SELECT * FROM conversations ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<ConversationEntity>>
+
+    @Query("SELECT * FROM conversations WHERE id = :id")
+    suspend fun getById(id: String): ConversationEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(conversation: ConversationEntity)
+
+    @Update
+    suspend fun update(conversation: ConversationEntity)
+
+    @Delete
+    suspend fun delete(conversation: ConversationEntity)
+
+    @Query("UPDATE conversations SET title = :title, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateTitle(id: String, title: String, updatedAt: Long)
+
+    @Query("UPDATE conversations SET updatedAt = :updatedAt WHERE id = :id")
+    suspend fun touchUpdatedAt(id: String, updatedAt: Long)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
@@ -1,0 +1,27 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.MessageEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MessageDao {
+
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp ASC")
+    fun observeByConversation(conversationId: String): Flow<List<MessageEntity>>
+
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp ASC")
+    suspend fun getByConversation(conversationId: String): List<MessageEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(message: MessageEntity)
+
+    @Query("UPDATE messages SET content = :content WHERE id = :id")
+    suspend fun updateContent(id: String, content: String)
+
+    @Query("UPDATE messages SET content = :content, thinkingText = :thinkingText WHERE id = :id")
+    suspend fun updateContentAndThinking(id: String, content: String, thinkingText: String?)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
@@ -1,0 +1,12 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "conversations")
+data class ConversationEntity(
+    @PrimaryKey val id: String,
+    val title: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MessageEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MessageEntity.kt
@@ -1,0 +1,28 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "messages",
+    foreignKeys = [
+        ForeignKey(
+            entity = ConversationEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["conversationId"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("conversationId")],
+)
+data class MessageEntity(
+    @PrimaryKey val id: String,
+    val conversationId: String,
+    /** "user" or "assistant" */
+    val role: String,
+    val content: String,
+    val thinkingText: String?,
+    val timestamp: Long,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -1,0 +1,69 @@
+package com.kernel.ai.core.memory.repository
+
+import com.kernel.ai.core.memory.dao.ConversationDao
+import com.kernel.ai.core.memory.dao.MessageDao
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.entity.MessageEntity
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConversationRepository @Inject constructor(
+    private val conversationDao: ConversationDao,
+    private val messageDao: MessageDao,
+) {
+
+    fun observeConversations(): Flow<List<ConversationEntity>> =
+        conversationDao.observeAll()
+
+    fun observeMessages(conversationId: String): Flow<List<MessageEntity>> =
+        messageDao.observeByConversation(conversationId)
+
+    suspend fun createConversation(): String {
+        val id = UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        conversationDao.insert(
+            ConversationEntity(id = id, title = null, createdAt = now, updatedAt = now)
+        )
+        return id
+    }
+
+    suspend fun addMessage(
+        conversationId: String,
+        role: String,
+        content: String,
+        thinkingText: String? = null,
+    ): String {
+        val id = UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        messageDao.insert(
+            MessageEntity(
+                id = id,
+                conversationId = conversationId,
+                role = role,
+                content = content,
+                thinkingText = thinkingText,
+                timestamp = now,
+            )
+        )
+        conversationDao.touchUpdatedAt(conversationId, now)
+        return id
+    }
+
+    suspend fun updateMessage(id: String, content: String, thinkingText: String? = null) {
+        messageDao.updateContentAndThinking(id, content, thinkingText)
+    }
+
+    suspend fun renameConversation(id: String, title: String) {
+        conversationDao.updateTitle(id, title, System.currentTimeMillis())
+    }
+
+    suspend fun deleteConversation(conversation: ConversationEntity) {
+        conversationDao.delete(conversation)
+    }
+
+    suspend fun getMessagesOnce(conversationId: String): List<MessageEntity> =
+        messageDao.getByConversation(conversationId)
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -1,24 +1,323 @@
 package com.kernel.ai.feature.chat
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.feature.chat.model.ChatMessage
+import com.kernel.ai.feature.chat.model.ChatUiState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChatScreen() {
-    Scaffold { innerPadding ->
-        Box(
+fun ChatScreen(
+    conversationId: String? = null,
+    onNewConversation: () -> Unit = {},
+    onNavigateToList: () -> Unit = {},
+    viewModel: ChatViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is ChatUiState.Loading -> LoadingContent()
+        is ChatUiState.ModelsNotReady -> OnboardingContent(
+            isDownloading = state.isDownloading,
+        )
+        is ChatUiState.Ready -> ChatContent(
+            state = state,
+            onInputChanged = viewModel::onInputChanged,
+            onSend = viewModel::sendMessage,
+            onCancel = viewModel::cancelGeneration,
+            onNewConversation = {
+                viewModel.startNewConversation()
+                onNewConversation()
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChatContent(
+    state: ChatUiState.Ready,
+    onInputChanged: (String) -> Unit,
+    onSend: () -> Unit,
+    onCancel: () -> Unit,
+    onNewConversation: () -> Unit,
+) {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(state.messages.size) {
+        if (state.messages.isNotEmpty()) {
+            listState.animateScrollToItem(state.messages.lastIndex)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Kernel", style = MaterialTheme.typography.titleMedium) },
+                actions = {
+                    IconButton(onClick = onNewConversation) {
+                        Icon(Icons.Default.Add, contentDescription = "New conversation")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
+                .padding(innerPadding)
+                .imePadding(),
         ) {
-            Text("Kernel AI — Chat coming soon")
+            if (state.messages.isEmpty()) {
+                EmptyConversationHint(modifier = Modifier.weight(1f))
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.messages, key = { it.id }) { message ->
+                        MessageBubble(message = message)
+                    }
+                }
+            }
+
+            AnimatedVisibility(visible = state.error != null) {
+                state.error?.let { err ->
+                    Text(
+                        text = err,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
+                }
+            }
+
+            InputBar(
+                text = state.inputText,
+                isGenerating = state.isGenerating,
+                onTextChanged = onInputChanged,
+                onSend = onSend,
+                onCancel = onCancel,
+                modifier = Modifier.navigationBarsPadding(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MessageBubble(message: ChatMessage) {
+    val isUser = message.role == ChatMessage.Role.USER
+    val bubbleColor = if (isUser) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
+    ) {
+        // Thinking text (collapsed, italics)
+        if (!message.thinkingText.isNullOrBlank()) {
+            Text(
+                text = "Thinking…",
+                style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
+                color = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.padding(bottom = 2.dp),
+            )
+        }
+
+        Surface(
+            color = bubbleColor,
+            shape = RoundedCornerShape(
+                topStart = if (isUser) 18.dp else 4.dp,
+                topEnd = if (isUser) 4.dp else 18.dp,
+                bottomStart = 18.dp,
+                bottomEnd = 18.dp,
+            ),
+            modifier = Modifier.widthIn(max = 300.dp),
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = message.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (message.isStreaming) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InputBar(
+    text: String,
+    isGenerating: Boolean,
+    onTextChanged: (String) -> Unit,
+    onSend: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        tonalElevation = 4.dp,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextField(
+                value = text,
+                onValueChange = onTextChanged,
+                placeholder = { Text("Message Kernel…") },
+                modifier = Modifier.weight(1f),
+                maxLines = 5,
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                ),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                    imeAction = ImeAction.Send,
+                ),
+                keyboardActions = KeyboardActions(onSend = { if (!isGenerating) onSend() }),
+            )
+
+            AnimatedVisibility(visible = isGenerating, enter = fadeIn(), exit = fadeOut()) {
+                IconButton(onClick = onCancel) {
+                    Icon(Icons.Default.Close, contentDescription = "Stop generation")
+                }
+            }
+
+            AnimatedVisibility(visible = !isGenerating && text.isNotBlank(), enter = fadeIn(), exit = fadeOut()) {
+                IconButton(onClick = onSend) {
+                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyConversationHint(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "👋",
+                style = MaterialTheme.typography.displayMedium,
+            )
+            Text(
+                text = "Hi, I'm Kernel. How can I help?",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Text(
+                text = "Loading model…",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnboardingContent(isDownloading: Boolean) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp),
+        ) {
+            Text(text = "🧠", style = MaterialTheme.typography.displayLarge)
+            Text(
+                text = "Welcome to Kernel",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            Text(
+                text = if (isDownloading) {
+                    "Downloading AI models… this may take a few minutes on Wi-Fi."
+                } else {
+                    "On-device AI models are required. They will be downloaded automatically."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 12.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (isDownloading) {
+                CircularProgressIndicator(modifier = Modifier.padding(top = 24.dp))
+            }
         }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1,0 +1,243 @@
+package com.kernel.ai.feature.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.GenerationResult
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.ModelConfig
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.feature.chat.model.ChatMessage
+import com.kernel.ai.feature.chat.model.ChatUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val inferenceEngine: InferenceEngine,
+    private val downloadManager: ModelDownloadManager,
+    private val conversationRepository: ConversationRepository,
+) : ViewModel() {
+
+    /** Passed via nav arg; null means "start a new conversation". */
+    private val navConversationId: String? = savedStateHandle["conversationId"]
+
+    private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
+    private val _inputText = MutableStateFlow("")
+    private val _error = MutableStateFlow<String?>(null)
+    private var conversationId: String? = null
+
+    private data class EngineState(val isReady: Boolean, val isGenerating: Boolean)
+    private data class InputState(
+        val messages: List<ChatMessage>,
+        val inputText: String,
+        val error: String?,
+    )
+
+    private val engineState = combine(
+        inferenceEngine.isReady,
+        inferenceEngine.isGenerating,
+    ) { isReady, isGenerating -> EngineState(isReady, isGenerating) }
+
+    private val inputState = combine(
+        _messages,
+        _inputText,
+        _error,
+    ) { messages, inputText, error -> InputState(messages, inputText, error) }
+
+    val uiState: StateFlow<ChatUiState> = combine(
+        engineState,
+        downloadManager.downloadStates,
+        inputState,
+    ) { engine, downloadStates, input ->
+        val allRequired = KernelModel.entries.filter { it.isRequired }
+        val allDownloaded = allRequired.all { downloadStates[it] is DownloadState.Downloaded }
+
+        when {
+            !allDownloaded -> {
+                val anyDownloading = allRequired.any { downloadStates[it] is DownloadState.Downloading }
+                ChatUiState.ModelsNotReady(isDownloading = anyDownloading)
+            }
+            !engine.isReady -> ChatUiState.Loading
+            else -> ChatUiState.Ready(
+                conversationId = conversationId ?: "",
+                messages = input.messages,
+                isGenerating = engine.isGenerating,
+                inputText = input.inputText,
+                error = input.error,
+            )
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ChatUiState.Loading,
+    )
+
+    init {
+        viewModelScope.launch {
+            initializeConversation()
+        }
+    }
+
+    private suspend fun initializeConversation() {
+        val id = navConversationId ?: conversationRepository.createConversation()
+        conversationId = id
+
+        val persisted = conversationRepository.getMessagesOnce(id)
+        if (persisted.isNotEmpty()) {
+            _messages.value = persisted.map { entity ->
+                ChatMessage(
+                    id = entity.id,
+                    role = if (entity.role == "user") ChatMessage.Role.USER else ChatMessage.Role.ASSISTANT,
+                    content = entity.content,
+                    thinkingText = entity.thinkingText,
+                )
+            }
+        }
+
+        // Initialize the inference engine if not already ready.
+        val states = downloadManager.downloadStates.value
+        val mainModel = states[KernelModel.GEMMA_4_E2B]
+        if (mainModel is DownloadState.Downloaded && !inferenceEngine.isReady.value) {
+            try {
+                inferenceEngine.initialize(ModelConfig(modelPath = mainModel.localPath))
+            } catch (e: Exception) {
+                _error.value = "Failed to load model: ${e.message}"
+            }
+        }
+    }
+
+    fun onInputChanged(text: String) {
+        _inputText.value = text
+        if (_error.value != null) _error.value = null
+    }
+
+    fun sendMessage() {
+        val text = _inputText.value.trim()
+        if (text.isBlank() || inferenceEngine.isGenerating.value) return
+
+        _inputText.value = ""
+        val convId = conversationId ?: return
+
+        viewModelScope.launch {
+            val userMsgId = UUID.randomUUID().toString()
+            val userMessage = ChatMessage(
+                id = userMsgId,
+                role = ChatMessage.Role.USER,
+                content = text,
+            )
+            _messages.update { it + userMessage }
+            conversationRepository.addMessage(convId, "user", text)
+
+            // Placeholder for the streaming assistant reply.
+            val assistantMsgId = UUID.randomUUID().toString()
+            val streamingPlaceholder = ChatMessage(
+                id = assistantMsgId,
+                role = ChatMessage.Role.ASSISTANT,
+                content = "",
+                isStreaming = true,
+            )
+            _messages.update { it + streamingPlaceholder }
+
+            var accumulatedContent = StringBuilder()
+            var accumulatedThinking = StringBuilder()
+
+            try {
+                inferenceEngine.generate(text).collect { result ->
+                    when (result) {
+                        is GenerationResult.Token -> {
+                            accumulatedContent.append(result.text)
+                            _messages.update { msgs ->
+                                msgs.map { msg ->
+                                    if (msg.id == assistantMsgId) {
+                                        msg.copy(content = accumulatedContent.toString())
+                                    } else msg
+                                }
+                            }
+                        }
+
+                        is GenerationResult.Thinking -> {
+                            accumulatedThinking.append(result.text)
+                            _messages.update { msgs ->
+                                msgs.map { msg ->
+                                    if (msg.id == assistantMsgId) {
+                                        msg.copy(thinkingText = accumulatedThinking.toString())
+                                    } else msg
+                                }
+                            }
+                        }
+
+                        is GenerationResult.Complete -> {
+                            _messages.update { msgs ->
+                                msgs.map { msg ->
+                                    if (msg.id == assistantMsgId) msg.copy(isStreaming = false) else msg
+                                }
+                            }
+                            val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
+                            conversationRepository.addMessage(convId, "assistant", accumulatedContent.toString(), thinking)
+                            autoTitleConversation(convId, text)
+                        }
+
+                        is GenerationResult.Error -> {
+                            _messages.update { msgs ->
+                                msgs.map { msg ->
+                                    if (msg.id == assistantMsgId) {
+                                        msg.copy(content = "Sorry, I ran into an error.", isStreaming = false)
+                                    } else msg
+                                }
+                            }
+                            _error.value = result.message
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                _messages.update { msgs ->
+                    msgs.map { msg ->
+                        if (msg.id == assistantMsgId) {
+                            msg.copy(content = "Sorry, generation was cancelled.", isStreaming = false)
+                        } else msg
+                    }
+                }
+            }
+        }
+    }
+
+    fun cancelGeneration() {
+        inferenceEngine.cancelGeneration()
+    }
+
+    fun startNewConversation() {
+        viewModelScope.launch {
+            val id = conversationRepository.createConversation()
+            conversationId = id
+            _messages.value = emptyList()
+            inferenceEngine.resetConversation()
+        }
+    }
+
+    /** Auto-generate a short title from the user's first message. */
+    private suspend fun autoTitleConversation(convId: String, firstUserMessage: String) {
+        val maxLen = 40
+        val title = firstUserMessage.trim().take(maxLen).let { t ->
+            if (firstUserMessage.length > maxLen) "$t…" else t
+        }
+        conversationRepository.renameConversation(convId, title)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelScope.launch { inferenceEngine.shutdown() }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -1,0 +1,149 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun ConversationListScreen(
+    onOpenConversation: (String) -> Unit,
+    onNewConversation: () -> Unit,
+    viewModel: ConversationListViewModel = hiltViewModel(),
+) {
+    val conversations by viewModel.conversations.collectAsStateWithLifecycle()
+    var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Kernel") })
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onNewConversation) {
+                Icon(Icons.Default.Add, contentDescription = "New conversation")
+            }
+        },
+    ) { innerPadding ->
+        if (conversations.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("🧵", style = MaterialTheme.typography.displayMedium)
+                    Text(
+                        text = "No conversations yet",
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                    Text(
+                        text = "Tap + to start chatting",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                items(conversations, key = { it.id }) { conversation ->
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = conversation.title ?: "New conversation",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                text = formatTimestamp(conversation.updatedAt),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                        },
+                        trailingContent = {
+                            IconButton(onClick = { pendingDelete = conversation }) {
+                                Icon(Icons.Default.Delete, contentDescription = "Delete")
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .combinedClickable(
+                                onClick = { onOpenConversation(conversation.id) },
+                            ),
+                    )
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    pendingDelete?.let { conversation ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete conversation?") },
+            text = {
+                Text("\"${conversation.title ?: "New conversation"}\" will be permanently deleted.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteConversation(conversation)
+                        pendingDelete = null
+                    }
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+private fun formatTimestamp(millis: Long): String {
+    val sdf = SimpleDateFormat("MMM d, h:mm a", Locale.getDefault())
+    return sdf.format(Date(millis))
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -1,0 +1,38 @@
+package com.kernel.ai.feature.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ConversationListViewModel @Inject constructor(
+    private val repository: ConversationRepository,
+) : ViewModel() {
+
+    val conversations: StateFlow<List<ConversationEntity>> = repository
+        .observeConversations()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList(),
+        )
+
+    fun deleteConversation(conversation: ConversationEntity) {
+        viewModelScope.launch {
+            repository.deleteConversation(conversation)
+        }
+    }
+
+    fun renameConversation(id: String, title: String) {
+        viewModelScope.launch {
+            repository.renameConversation(id, title)
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatMessage.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatMessage.kt
@@ -1,0 +1,11 @@
+package com.kernel.ai.feature.chat.model
+
+data class ChatMessage(
+    val id: String,
+    val role: Role,
+    val content: String,
+    val thinkingText: String? = null,
+    val isStreaming: Boolean = false,
+) {
+    enum class Role { USER, ASSISTANT }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -1,0 +1,16 @@
+package com.kernel.ai.feature.chat.model
+
+sealed interface ChatUiState {
+    data object Loading : ChatUiState
+
+    data class Ready(
+        val conversationId: String,
+        val messages: List<ChatMessage>,
+        val isGenerating: Boolean,
+        val inputText: String,
+        val error: String?,
+    ) : ChatUiState
+
+    /** Models need to be downloaded before chatting. */
+    data class ModelsNotReady(val isDownloading: Boolean) : ChatUiState
+}


### PR DESCRIPTION
## Summary

Implements `p1-chat-ui` — the full chat experience for Phase 1.

### core:memory
- `KernelDatabase` (Room v1): `conversations` + `messages` tables with FK cascade
- `ConversationDao` / `MessageDao` — Flow-based queries + suspend mutations
- `ConversationRepository` — singleton repo for all conversation CRUD
- `MemoryModule` — Hilt providers for database and DAOs (replaces placeholder)
- Room schema exported to `core/memory/schemas/`

### feature:chat
- `ChatMessage` data class with streaming + thinking state
- `ChatUiState` sealed interface: `Loading | Ready | ModelsNotReady`
- `ChatViewModel`: typed nested `combine` (avoids vararg casts), inference streaming, auto-titling
- `ChatScreen`: Material 3 message bubbles, animated send/cancel, thinking indicator, onboarding gate
- `ConversationListScreen` + `ConversationListViewModel`: list + delete dialog
- Onboarding shown inline when models not yet downloaded

### app:navigation
- `KernelNavHost` wired: `conversation_list → chat → chat/{conversationId}`

## Verified
- `assembleDebug` ✅ BUILD SUCCESSFUL
- Room schema generated and exported