### PR TITLE
chore: auto-increment versionCode from CI run number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build (debug)
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug -PversionCode=${{ github.run_number }}
 
       # - name: Lint
       #   run: ./gradlew lint

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         applicationId = "com.kernel.ai"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 1
+        versionCode = (project.findProperty("versionCode") as String?)?.toInt() ?: 1
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/docs/testing/PR-51-ui-polish.md
+++ b/docs/testing/PR-51-ui-polish.md
@@ -1,0 +1,123 @@
+# PR #51 — UI Polish Batch Manual Test Plan
+
+**Issues:** #22 (back button), #25 (partial message persistence), #26 (clickable links), #27 (keyboard gap), #36 (code blocks)
+**Branch:** `feature/ui-polish`
+**Device:** Samsung Galaxy S23 Ultra (SM-S918B, SD 8 Gen 2, 12GB RAM, Android 16 / One UI 8.0)
+
+---
+
+## Setup
+
+```bash
+adb -s 192.168.31.54:5555 install -r app-debug.apk
+adb -s 192.168.31.54:5555 shell am start -n com.kernel.ai.debug/.MainActivity
+```
+
+Logcat to watch for errors:
+```bash
+adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 192.168.31.54:5555 shell pidof com.kernel.ai.debug)
+```
+
+---
+
+## Test Cases
+
+### TC-1 — #27: Keyboard gap
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Open any conversation | — |
+| 2 | Tap the text input field | Keyboard opens |
+| 3 | Observe gap between keyboard and input bar | **No gap — input sits flush against keyboard** |
+| 4 | Dismiss keyboard | — |
+| 5 | Observe bottom of screen | **No excess space at the bottom** |
+
+**Result:** ⏳
+
+---
+
+### TC-2 — #22: Back navigation
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | From conversation list, open a conversation | — |
+| 2 | Observe TopAppBar | **← arrow visible top-left** |
+| 3 | Tap ← | **Returns to conversation list** |
+| 4 | From list, tap Settings | — |
+| 5 | Observe Settings TopAppBar | **← arrow visible** |
+| 6 | Tap ← | **Returns to conversation list** |
+| 7 | Settings → User Profile | — |
+| 8 | Observe User Profile TopAppBar | **← arrow visible** |
+| 9 | Tap ← | **Returns to Settings** |
+
+**Result:** ⏳
+
+---
+
+### TC-3 — #25: Partial message persisted on nav away
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Send: *"Write me a 500 word essay on penguins"* | Streaming starts |
+| 2 | After ~2s of streaming, press system **back button** | Returns to list |
+| 3 | Re-open that conversation | **Partial assistant response is visible** |
+| 4 | Send another long message, tap **✕ stop button** mid-stream | — |
+| 5 | Observe the assistant bubble | **Partial response shown (not "Generation cancelled.")** |
+
+**Result:** ⏳
+
+---
+
+### TC-4 — #26: Clickable links
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Send: *"What is the URL for the Android developer documentation?"* | — |
+| 2 | Observe response | **URL renders as a tappable hyperlink (underlined/coloured)** |
+| 3 | Tap the link | **Opens in system browser** |
+
+**Result:** ⏳
+
+---
+
+### TC-5 — #36: Code block rendering
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Send: *"Show me a simple docker-compose.yml for nginx"* | — |
+| 2 | Observe response | **Code block renders with monospace font and distinct background** |
+| 3 | Send: *"Give me a one-liner bash command to list all running processes"* | — |
+| 4 | Observe inline code | **Inline code styled distinctly — no raw backticks** |
+
+**Result:** ⏳
+
+---
+
+### TC-6 — Regression
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Send a normal conversational message | **Streaming works, no crash** |
+| 2 | Tap + to create a new conversation | **Works** |
+| 3 | Navigate: List → Chat → Back → Settings → Back | **No stack weirdness** |
+
+**Result:** ⏳
+
+---
+
+## Results Summary
+
+**Build:** ⏳ TBD
+**Tested by:** NickMonrad
+**Test date:** ⏳ TBD
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC-1 Keyboard gap | ⏳ | |
+| TC-2 Back navigation | ⏳ | |
+| TC-3 Partial message persistence | ⏳ | |
+| TC-4 Clickable links | ⏳ | |
+| TC-5 Code block rendering | ⏳ | |
+| TC-6 Regression | ⏳ | |
+
+**Overall:** ⏳ Pending

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,19 @@
+# Manual Test Logs
+
+Each PR with user-facing changes gets a test plan filed here before deployment.
+Results are recorded after manual testing on the S23 Ultra.
+
+## Format
+
+Files are named `PR-{number}-{short-description}.md`.
+
+Each file contains:
+- **Test plan** — steps written before deployment
+- **Results** — pass/fail recorded after manual testing on device
+- **Device** — build + device info for the test run
+
+## Log
+
+| PR | Description | Status |
+|----|-------------|--------|
+| [PR-51](PR-51-ui-polish.md) | UI polish batch (#22, #25, #26, #27, #36) | ⏳ Pending |


### PR DESCRIPTION
Sets `versionCode = github.run_number` on CI builds so each merge to main produces a unique APK version code.

**Why:** `adb install -r` treats same versionCode as a same-version install. With versionCode always = 1, reinstalling wouldn't reliably upgrade. This also means uninstall (which wipes the vector DB) is no longer needed for testing.

Local builds fall back to `versionCode = 1` unchanged.