### PR TITLE
fix: crash on download screen — UnknownFormatConversionException

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -367,7 +367,7 @@ private fun ModelProgressRow(item: ModelDownloadProgress, onRetry: (KernelModel)
                         val pct = (state.progress * 100).toInt()
                         if (state.bytesPerSecond > 0) {
                             val mbps = state.bytesPerSecond / 1_048_576.0
-                            "$pct% · %.1f MB/s".format(mbps)
+                            "$pct% · ${"%.1f".format(mbps)} MB/s"
                         } else "$pct%"
                     }
                     is DownloadState.Error -> "Error"


### PR DESCRIPTION
Fixes a FATAL crash on the model download screen when download speed > 0.

**Root cause:** `"$pct% · %.1f MB/s".format(mbps)` — Java's `String.format()` sees the literal `%` after `$pct` as the start of a format specifier, then treats `·` as the conversion character → `UnknownFormatConversionException`.

**Fix:** Use string interpolation for the `pct` portion: `"$pct% · ${%.1f.format(mbps)} MB/s"`

This is a pre-existing bug in the original code that only surfaces on a fresh install (download screen shown).