### PR TITLE
feat: UI polish batch (#22, #25, #26, #27, #36)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -43,6 +43,7 @@ fun KernelNavHost() {
         composable(ROUTE_CHAT) {
             ChatScreen(
                 conversationId = null,
+                onBack = { navController.popBackStack() },
                 onNewConversation = {
                     navController.navigate(ROUTE_CHAT) {
                         popUpTo(ROUTE_CHAT) { inclusive = true }
@@ -64,6 +65,7 @@ fun KernelNavHost() {
             val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
             ChatScreen(
                 conversationId = conversationId,
+                onBack = { navController.popBackStack() },
                 onNewConversation = {
                     navController.navigate(ROUTE_CHAT)
                 },

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
@@ -63,6 +64,7 @@ import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 @Composable
 fun ChatScreen(
     conversationId: String? = null,
+    onBack: () -> Unit = {},
     onNewConversation: () -> Unit = {},
     onNavigateToList: () -> Unit = {},
     viewModel: ChatViewModel = hiltViewModel(),
@@ -81,6 +83,7 @@ fun ChatScreen(
             onInputChanged = viewModel::onInputChanged,
             onSend = viewModel::sendMessage,
             onCancel = viewModel::cancelGeneration,
+            onBack = onBack,
             onNewConversation = {
                 viewModel.startNewConversation()
                 onNewConversation()
@@ -96,6 +99,7 @@ private fun ChatContent(
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
+    onBack: () -> Unit,
     onNewConversation: () -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -110,6 +114,11 @@ private fun ChatContent(
         topBar = {
             TopAppBar(
                 title = { Text("Kernel", style = MaterialTheme.typography.titleMedium) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
                 actions = {
                     IconButton(onClick = onNewConversation) {
                         Icon(Icons.Default.Add, contentDescription = "New conversation")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -157,7 +156,7 @@ private fun ChatContent(
                 onTextChanged = onInputChanged,
                 onSend = onSend,
                 onCancel = onCancel,
-                modifier = Modifier.navigationBarsPadding(),
+                modifier = Modifier,
             )
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.feature.chat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,12 +17,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -44,13 +47,22 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -204,26 +216,181 @@ private fun MessageBubble(message: ChatMessage) {
             ),
             modifier = Modifier.widthIn(max = 300.dp),
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = message.content,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-                if (message.isStreaming) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        strokeWidth = 2.dp,
+            if (isUser) {
+                // User messages: plain text, no link/code parsing needed.
+                Row(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = message.content,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
+                }
+            } else {
+                // Assistant messages: render with clickable links and code block support.
+                Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                    AssistantMessageContent(
+                        text = message.content,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    if (message.isStreaming) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .padding(top = 6.dp)
+                                .size(12.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    }
                 }
             }
         }
     }
 }
+
+// ── Rich assistant message rendering ─────────────────────────────────────────
+
+private val FENCED_CODE_BLOCK = Regex("```[\\w]*\\n([\\s\\S]*?)```", RegexOption.MULTILINE)
+private val INLINE_CODE = Regex("`([^`]+)`")
+
+private sealed class TextSegment {
+    data class Plain(val text: String) : TextSegment()
+    data class FencedCode(val code: String) : TextSegment()
+}
+
+private fun splitFencedCodeBlocks(text: String): List<TextSegment> {
+    val result = mutableListOf<TextSegment>()
+    var lastEnd = 0
+    for (match in FENCED_CODE_BLOCK.findAll(text)) {
+        if (match.range.first > lastEnd) {
+            result.add(TextSegment.Plain(text.substring(lastEnd, match.range.first)))
+        }
+        result.add(TextSegment.FencedCode(match.groupValues[1]))
+        lastEnd = match.range.last + 1
+    }
+    if (lastEnd < text.length) {
+        result.add(TextSegment.Plain(text.substring(lastEnd)))
+    }
+    if (result.isEmpty()) {
+        result.add(TextSegment.Plain(text))
+    }
+    return result
+}
+
+/**
+ * Renders assistant message text with:
+ * - Fenced code blocks in a monospace Surface with horizontal scroll (Fix #36)
+ * - Inline code spans with monospace + surfaceVariant background (Fix #36)
+ * - Tappable URLs via ClickableText (Fix #26)
+ */
+@Composable
+private fun AssistantMessageContent(text: String, modifier: Modifier = Modifier, style: TextStyle) {
+    val segments = remember(text) { splitFencedCodeBlocks(text) }
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        segments.forEach { segment ->
+            when (segment) {
+                is TextSegment.Plain -> LinkedText(text = segment.text, style = style)
+                is TextSegment.FencedCode -> FencedCodeBlock(code = segment.code)
+            }
+        }
+    }
+}
+
+/**
+ * Renders text with tappable URLs and inline-code spans styled in monospace.
+ */
+@Suppress("DEPRECATION") // ClickableText deprecated in Compose 1.7 in favour of LinkAnnotation
+@Composable
+private fun LinkedText(text: String, modifier: Modifier = Modifier, style: TextStyle) {
+    val uriHandler = LocalUriHandler.current
+    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+    val linkColor = MaterialTheme.colorScheme.primary
+
+    val annotated = remember(text, surfaceVariant, linkColor) {
+        buildLinkedAnnotatedString(text, surfaceVariant, linkColor)
+    }
+
+    ClickableText(
+        text = annotated,
+        style = style,
+        modifier = modifier,
+        onClick = { offset ->
+            annotated.getStringAnnotations("URL", offset, offset)
+                .firstOrNull()?.let { uriHandler.openUri(it.item) }
+        },
+    )
+}
+
+/**
+ * Renders a fenced code block with monospace font, surfaceVariant background,
+ * and horizontal scrolling for long lines.
+ */
+@Composable
+private fun FencedCodeBlock(code: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .horizontalScroll(rememberScrollState())
+            .padding(12.dp),
+    ) {
+        Text(
+            text = code.trimEnd('\n'),
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            softWrap = false,
+        )
+    }
+}
+
+/** Builds an [AnnotatedString] with inline-code styling and URL click annotations. */
+private fun buildLinkedAnnotatedString(
+    text: String,
+    surfaceVariant: Color,
+    linkColor: Color,
+) = buildAnnotatedString {
+    data class Span(val start: Int, val end: Int, val type: String, val content: String)
+
+    val spans = mutableListOf<Span>()
+
+    // Collect inline code matches
+    INLINE_CODE.findAll(text).forEach { match ->
+        spans.add(Span(match.range.first, match.range.last + 1, "CODE", match.groupValues[1]))
+    }
+
+    // Collect URL matches (Java Pattern API)
+    val urlMatcher = android.util.Patterns.WEB_URL.matcher(text)
+    while (urlMatcher.find()) {
+        spans.add(Span(urlMatcher.start(), urlMatcher.end(), "URL", urlMatcher.group()))
+    }
+
+    spans.sortBy { it.start }
+
+    var cursor = 0
+    for (span in spans) {
+        if (span.start < cursor) continue // skip overlapping spans
+        append(text.substring(cursor, span.start))
+        when (span.type) {
+            "CODE" -> {
+                withStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = surfaceVariant)) {
+                    append(span.content)
+                }
+            }
+            "URL" -> {
+                pushStringAnnotation("URL", span.content)
+                withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+                    append(span.content)
+                }
+                pop()
+            }
+        }
+        cursor = span.end
+    }
+    if (cursor < text.length) append(text.substring(cursor))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun InputBar(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -18,7 +18,8 @@ import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -50,6 +51,11 @@ class ChatViewModel @Inject constructor(
     private val _error = MutableStateFlow<String?>(null)
     private var conversationId: String? = null
     private val contextWindowManager = ContextWindowManager()
+
+    // Tracks the in-progress streaming response so it can be flushed to Room on cancel/clear.
+    private var activeStreamingMsgId: String? = null
+    private var activeStreamingContent = StringBuilder()
+    private var activeStreamingThinking = StringBuilder()
 
     /**
      * When true, the next [sendMessage] will re-inject conversation history into the
@@ -235,6 +241,11 @@ class ChatViewModel @Inject constructor(
             var accumulatedContent = StringBuilder()
             var accumulatedThinking = StringBuilder()
 
+            // Register active streaming state so cancel/onCleared can flush to Room.
+            activeStreamingMsgId = assistantMsgId
+            activeStreamingContent = accumulatedContent
+            activeStreamingThinking = accumulatedThinking
+
             val ragContext = ragRepository.getRelevantContext(text)
 
             // Proactive context reset: if we're at ~75% of the token budget, reset
@@ -296,6 +307,10 @@ class ChatViewModel @Inject constructor(
                             // Track cumulative token usage for proactive context window management.
                             estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
                                 contextWindowManager.estimateTokens(accumulatedContent.toString())
+                            // Clear streaming tracking now that the message is fully persisted.
+                            activeStreamingMsgId = null
+                            activeStreamingContent = StringBuilder()
+                            activeStreamingThinking = StringBuilder()
                             autoTitleConversation(convId, text)
                         }
 
@@ -308,6 +323,9 @@ class ChatViewModel @Inject constructor(
                                 }
                             }
                             _error.value = result.message
+                            activeStreamingMsgId = null
+                            activeStreamingContent = StringBuilder()
+                            activeStreamingThinking = StringBuilder()
                         }
                     }
                 }
@@ -319,21 +337,39 @@ class ChatViewModel @Inject constructor(
                         } else msg
                     }
                 }
+                activeStreamingMsgId = null
+                activeStreamingContent = StringBuilder()
+                activeStreamingThinking = StringBuilder()
             }
         }
     }
 
     fun cancelGeneration() {
         inferenceEngine.cancelGeneration()
-        // Clear any message stuck in streaming state
+        val partialContent = activeStreamingContent.toString()
+        val partialThinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
+        val convId = conversationId
+
+        // Update UI: mark streaming message as complete with whatever was streamed.
         _messages.update { msgs ->
             msgs.map { msg ->
-                if (msg.isStreaming) msg.copy(
-                    isStreaming = false,
-                    content = msg.content.ifBlank { "Generation cancelled." },
-                ) else msg
+                if (msg.isStreaming) msg.copy(isStreaming = false) else msg
             }
         }
+
+        // Persist partial content to Room if we have anything streamed.
+        if (partialContent.isNotBlank() && convId != null) {
+            viewModelScope.launch {
+                val savedId = conversationRepository.addMessage(convId, "assistant", partialContent, partialThinking)
+                ragRepository.indexMessage(savedId, convId, partialContent)
+            }
+        }
+
+        // Clear streaming tracking.
+        activeStreamingMsgId = null
+        activeStreamingContent = StringBuilder()
+        activeStreamingThinking = StringBuilder()
+
         // Reset LiteRT conversation — cancelProcess() leaves it in a partial state.
         // Mark needsHistoryReplay so the next message re-injects prior context.
         needsHistoryReplay = true
@@ -365,6 +401,18 @@ class ChatViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        // Flush any in-progress streamed content to Room before the ViewModel is destroyed.
+        // Uses NonCancellable so the save completes even though viewModelScope is about to cancel.
+        val partialContent = activeStreamingContent.toString()
+        val partialThinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
+        val convId = conversationId
+        if (partialContent.isNotBlank() && convId != null) {
+            viewModelScope.launch {
+                withContext(NonCancellable) {
+                    conversationRepository.addMessage(convId, "assistant", partialContent, partialThinking)
+                }
+            }
+        }
         viewModelScope.launch { inferenceEngine.shutdown() }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -20,6 +20,7 @@ import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine


### PR DESCRIPTION
## Changes

Implements all 5 UI polish issues. Verified non-empty (248 lines changed across 3 files).

### TC-1 — #27: Keyboard gap
Removed duplicate `.navigationBarsPadding()` from `InputBar` modifier. `Scaffold` `innerPadding` + `.imePadding()` on the `Column` is the correct pattern with `enableEdgeToEdge()`.

### TC-2 — #22: Back navigation
Added `onBack: () -> Unit` to `ChatScreen` / `ChatContent`. `AutoMirrored.Filled.ArrowBack` button in `TopAppBar` `navigationIcon`. Wired `navController.popBackStack()` in `KernelNavHost` for both chat routes.

### TC-3 — #25: Partial message persistence
Added `activeStreamingMsgId/Content` tracking in `ChatViewModel`. `cancelGeneration()` saves non-empty partial content to Room. `onCleared()` flushes via `withContext(NonCancellable)` so the insert survives ViewModel teardown.

### TC-4 — #26: Clickable links
`LinkedText` composable with `ClickableText` + `AnnotatedString`. URLs detected via `Patterns.WEB_URL`, styled `primary + Underline`, opened via `LocalUriHandler`.

### TC-5 — #36: Code blocks
`AssistantMessageContent` parses text into segments via fenced/inline code regexes. Fenced blocks render in a `Box` with `surfaceVariant` background, `RoundedCornerShape(8.dp)`, `FontFamily.Monospace`, horizontal scroll. Inline code uses `SpanStyle` in `LinkedText`.

## Notes
- Full rich text (tables, copy button, stream-safe rendering, system tag stripping) tracked in #61
- User messages stay as plain `Text()`

Closes #22
Closes #25
Closes #26
Closes #27
Closes #36