### PR TITLE
feat(#61): full markdown renderer — tables, copy button, stream-safe, tag stripping

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -3,8 +3,6 @@ package com.kernel.ai.feature.chat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,9 +19,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -47,22 +43,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -229,10 +216,10 @@ private fun MessageBubble(message: ChatMessage) {
                     )
                 }
             } else {
-                // Assistant messages: render with clickable links and code block support.
+                // Assistant messages: render full Markdown with inline + block support.
                 Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
-                    AssistantMessageContent(
-                        text = message.content,
+                    MarkdownContent(
+                        text  = message.content,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                     if (message.isStreaming) {
@@ -247,147 +234,6 @@ private fun MessageBubble(message: ChatMessage) {
             }
         }
     }
-}
-
-// ── Rich assistant message rendering ─────────────────────────────────────────
-
-private val FENCED_CODE_BLOCK = Regex("```[\\w]*\\n([\\s\\S]*?)```", RegexOption.MULTILINE)
-private val INLINE_CODE = Regex("`([^`]+)`")
-
-private sealed class TextSegment {
-    data class Plain(val text: String) : TextSegment()
-    data class FencedCode(val code: String) : TextSegment()
-}
-
-private fun splitFencedCodeBlocks(text: String): List<TextSegment> {
-    val result = mutableListOf<TextSegment>()
-    var lastEnd = 0
-    for (match in FENCED_CODE_BLOCK.findAll(text)) {
-        if (match.range.first > lastEnd) {
-            result.add(TextSegment.Plain(text.substring(lastEnd, match.range.first)))
-        }
-        result.add(TextSegment.FencedCode(match.groupValues[1]))
-        lastEnd = match.range.last + 1
-    }
-    if (lastEnd < text.length) {
-        result.add(TextSegment.Plain(text.substring(lastEnd)))
-    }
-    if (result.isEmpty()) {
-        result.add(TextSegment.Plain(text))
-    }
-    return result
-}
-
-/**
- * Renders assistant message text with:
- * - Fenced code blocks in a monospace Surface with horizontal scroll (Fix #36)
- * - Inline code spans with monospace + surfaceVariant background (Fix #36)
- * - Tappable URLs via ClickableText (Fix #26)
- */
-@Composable
-private fun AssistantMessageContent(text: String, modifier: Modifier = Modifier, style: TextStyle) {
-    val segments = remember(text) { splitFencedCodeBlocks(text) }
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        segments.forEach { segment ->
-            when (segment) {
-                is TextSegment.Plain -> LinkedText(text = segment.text, style = style)
-                is TextSegment.FencedCode -> FencedCodeBlock(code = segment.code)
-            }
-        }
-    }
-}
-
-/**
- * Renders text with tappable URLs and inline-code spans styled in monospace.
- */
-@Suppress("DEPRECATION") // ClickableText deprecated in Compose 1.7 in favour of LinkAnnotation
-@Composable
-private fun LinkedText(text: String, modifier: Modifier = Modifier, style: TextStyle) {
-    val uriHandler = LocalUriHandler.current
-    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
-    val linkColor = MaterialTheme.colorScheme.primary
-
-    val annotated = remember(text, surfaceVariant, linkColor) {
-        buildLinkedAnnotatedString(text, surfaceVariant, linkColor)
-    }
-
-    ClickableText(
-        text = annotated,
-        style = style,
-        modifier = modifier,
-        onClick = { offset ->
-            annotated.getStringAnnotations("URL", offset, offset)
-                .firstOrNull()?.let { uriHandler.openUri(it.item) }
-        },
-    )
-}
-
-/**
- * Renders a fenced code block with monospace font, surfaceVariant background,
- * and horizontal scrolling for long lines.
- */
-@Composable
-private fun FencedCodeBlock(code: String, modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .horizontalScroll(rememberScrollState())
-            .padding(12.dp),
-    ) {
-        Text(
-            text = code.trimEnd('\n'),
-            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-            softWrap = false,
-        )
-    }
-}
-
-/** Builds an [AnnotatedString] with inline-code styling and URL click annotations. */
-private fun buildLinkedAnnotatedString(
-    text: String,
-    surfaceVariant: Color,
-    linkColor: Color,
-) = buildAnnotatedString {
-    data class Span(val start: Int, val end: Int, val type: String, val content: String)
-
-    val spans = mutableListOf<Span>()
-
-    // Collect inline code matches
-    INLINE_CODE.findAll(text).forEach { match ->
-        spans.add(Span(match.range.first, match.range.last + 1, "CODE", match.groupValues[1]))
-    }
-
-    // Collect URL matches (Java Pattern API)
-    val urlMatcher = android.util.Patterns.WEB_URL.matcher(text)
-    while (urlMatcher.find()) {
-        spans.add(Span(urlMatcher.start(), urlMatcher.end(), "URL", urlMatcher.group()))
-    }
-
-    spans.sortBy { it.start }
-
-    var cursor = 0
-    for (span in spans) {
-        if (span.start < cursor) continue // skip overlapping spans
-        append(text.substring(cursor, span.start))
-        when (span.type) {
-            "CODE" -> {
-                withStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = surfaceVariant)) {
-                    append(span.content)
-                }
-            }
-            "URL" -> {
-                pushStringAnnotation("URL", span.content)
-                withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
-                    append(span.content)
-                }
-                pop()
-            }
-        }
-        cursor = span.end
-    }
-    if (cursor < text.length) append(text.substring(cursor))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -1,0 +1,648 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import android.util.Patterns
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kernel.ai.core.ui.theme.KernelAITheme
+import kotlinx.coroutines.delay
+
+private const val TAG = "KernelAI"
+
+// ── Sealed block types ─────────────────────────────────────────────────────────
+
+private sealed class MarkdownBlock {
+    data class Paragraph(val text: String) : MarkdownBlock()
+    data class Header(val level: Int, val text: String) : MarkdownBlock()
+    data class Blockquote(val text: String) : MarkdownBlock()
+    data class BulletList(val items: List<String>) : MarkdownBlock()
+    data class OrderedList(val items: List<String>) : MarkdownBlock()
+    data class FencedCode(val language: String, val code: String) : MarkdownBlock()
+    data class Table(val headers: List<String>, val rows: List<List<String>>) : MarkdownBlock()
+}
+
+// ── System tag stripping ───────────────────────────────────────────────────────
+
+/**
+ * Strips model routing artefacts such as `<think>…</think>`, `<tool_call>…</tool_call>`,
+ * `<function_call>…</function_call>`, and any other `<snake_case_tag>…</snake_case_tag>` pair
+ * as well as self-closing variants like `<tag_name/>`.
+ */
+private val SYSTEM_TAG_PAIRED_REGEX = Regex(
+    "<[a-z][a-z_]*(?:\\s[^>]*)?>.*?</[a-z][a-z_]*>",
+    setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE),
+)
+
+private val SYSTEM_TAG_SELF_CLOSING_REGEX = Regex("<[a-z][a-z_]*/?>")
+
+private fun stripSystemTags(text: String): String =
+    text.replace(SYSTEM_TAG_PAIRED_REGEX, "")
+        .replace(SYSTEM_TAG_SELF_CLOSING_REGEX, "")
+        .trim()
+
+// ── Block-level regex patterns ─────────────────────────────────────────────────
+
+private val HEADER_REGEX       = Regex("^(#{1,6})\\s+(.*)")
+private val BULLET_REGEX       = Regex("^[-*+]\\s+(.*)")
+private val ORDERED_REGEX      = Regex("^\\d+\\.\\s+(.*)")
+private val TABLE_ROW_REGEX    = Regex("^\\|(.+)\\|\\s*\$")
+private val TABLE_SEP_REGEX    = Regex("^\\|[\\s|:-]+\\|\\s*\$")
+private val FENCED_START_REGEX = Regex("^```(\\w*)\\s*\$")
+private val FENCED_END_REGEX   = Regex("^```\\s*\$")
+
+// ── Block parser ───────────────────────────────────────────────────────────────
+
+/**
+ * Parses [text] into a list of [MarkdownBlock]s.
+ *
+ * Stream-safe: incomplete blocks (unclosed fenced code, partial table, unclosed inline span)
+ * are emitted as plain [MarkdownBlock.Paragraph] rather than crashing or silently dropping
+ * content. This allows safe calling on every streaming token.
+ */
+private fun parseBlocks(text: String): List<MarkdownBlock> {
+    val blocks = mutableListOf<MarkdownBlock>()
+    val lines  = text.lines()
+    var i      = 0
+
+    while (i < lines.size) {
+        val line = lines[i]
+
+        // ── Fenced code block ──────────────────────────────────────────────────
+        val fencedStart = FENCED_START_REGEX.matchEntire(line)
+        if (fencedStart != null) {
+            val language  = fencedStart.groupValues[1]
+            val codeLines = mutableListOf<String>()
+            var closed    = false
+            i++
+            while (i < lines.size) {
+                if (FENCED_END_REGEX.matches(lines[i])) {
+                    closed = true
+                    i++
+                    break
+                }
+                codeLines.add(lines[i])
+                i++
+            }
+            if (closed) {
+                blocks.add(MarkdownBlock.FencedCode(language, codeLines.joinToString("\n")))
+            } else {
+                // Stream-safe: unclosed block → plain text so rendering never breaks
+                val raw = buildString {
+                    append("```$language\n")
+                    append(codeLines.joinToString("\n"))
+                }
+                blocks.add(MarkdownBlock.Paragraph(raw))
+                Log.d(TAG, "MarkdownRenderer: unclosed fenced code block treated as plain text")
+            }
+            continue
+        }
+
+        // ── Heading ────────────────────────────────────────────────────────────
+        val headerMatch = HEADER_REGEX.matchEntire(line)
+        if (headerMatch != null) {
+            blocks.add(MarkdownBlock.Header(headerMatch.groupValues[1].length, headerMatch.groupValues[2]))
+            i++
+            continue
+        }
+
+        // ── Blockquote ─────────────────────────────────────────────────────────
+        if (line.startsWith("> ") || line == ">") {
+            val quoteLines = mutableListOf<String>()
+            while (i < lines.size && (lines[i].startsWith("> ") || lines[i] == ">")) {
+                quoteLines.add(lines[i].removePrefix("> ").removePrefix(">"))
+                i++
+            }
+            blocks.add(MarkdownBlock.Blockquote(quoteLines.joinToString("\n")))
+            continue
+        }
+
+        // ── Bullet list ────────────────────────────────────────────────────────
+        if (BULLET_REGEX.matches(line)) {
+            val items = mutableListOf<String>()
+            while (i < lines.size && BULLET_REGEX.matches(lines[i])) {
+                items.add(BULLET_REGEX.matchEntire(lines[i])!!.groupValues[1])
+                i++
+            }
+            blocks.add(MarkdownBlock.BulletList(items))
+            continue
+        }
+
+        // ── Ordered list ───────────────────────────────────────────────────────
+        if (ORDERED_REGEX.matches(line)) {
+            val items = mutableListOf<String>()
+            while (i < lines.size && ORDERED_REGEX.matches(lines[i])) {
+                items.add(ORDERED_REGEX.matchEntire(lines[i])!!.groupValues[1])
+                i++
+            }
+            blocks.add(MarkdownBlock.OrderedList(items))
+            continue
+        }
+
+        // ── Table (header row + separator on next line) ───────────────────────
+        if (TABLE_ROW_REGEX.matches(line) &&
+            i + 1 < lines.size &&
+            TABLE_SEP_REGEX.matches(lines[i + 1])
+        ) {
+            val headers = parseTableRow(line)
+            i += 2 // skip header row + separator row
+            val rows = mutableListOf<List<String>>()
+            while (i < lines.size && TABLE_ROW_REGEX.matches(lines[i])) {
+                rows.add(parseTableRow(lines[i]))
+                i++
+            }
+            blocks.add(MarkdownBlock.Table(headers, rows))
+            continue
+        }
+
+        // ── Blank line separator ───────────────────────────────────────────────
+        if (line.isBlank()) {
+            i++
+            continue
+        }
+
+        // ── Paragraph ─────────────────────────────────────────────────────────
+        // Accumulate consecutive non-special lines into one paragraph.
+        val paraLines = mutableListOf<String>()
+        while (i < lines.size) {
+            val pl = lines[i]
+            if (pl.isBlank()) break
+            if (HEADER_REGEX.matches(pl)) break
+            if (pl.startsWith("> ") || pl == ">") break
+            if (BULLET_REGEX.matches(pl)) break
+            if (ORDERED_REGEX.matches(pl)) break
+            if (FENCED_START_REGEX.matches(pl)) break
+            if (TABLE_ROW_REGEX.matches(pl) &&
+                i + 1 < lines.size &&
+                TABLE_SEP_REGEX.matches(lines[i + 1])
+            ) break
+            paraLines.add(pl)
+            i++
+        }
+        if (paraLines.isNotEmpty()) {
+            blocks.add(MarkdownBlock.Paragraph(paraLines.joinToString("\n")))
+        }
+    }
+
+    return blocks
+}
+
+private fun parseTableRow(line: String): List<String> =
+    line.trim().trimStart('|').trimEnd('|').split("|").map { it.trim() }
+
+// ── Inline span renderer ───────────────────────────────────────────────────────
+
+private data class InlineSpan(val start: Int, val end: Int, val type: String, val content: String)
+
+/**
+ * Converts [text] to an [AnnotatedString] with inline styling:
+ * bold, italic, strikethrough, inline code, and tappable URLs.
+ *
+ * Overlapping spans are resolved by earliest start (then longest span wins for ties).
+ * Unclosed spans are never applied — they silently fall back to plain text, keeping
+ * the renderer safe during streaming.
+ */
+private fun renderInlineSpans(
+    text: String,
+    surfaceVariant: androidx.compose.ui.graphics.Color,
+    linkColor: androidx.compose.ui.graphics.Color,
+): AnnotatedString {
+    val spans = mutableListOf<InlineSpan>()
+
+    // Bold: **text** or __text__
+    Regex("\\*\\*(.+?)\\*\\*|__(.+?)__").findAll(text).forEach { m ->
+        val content = m.groupValues[1].ifEmpty { m.groupValues[2] }
+        spans.add(InlineSpan(m.range.first, m.range.last + 1, "BOLD", content))
+    }
+
+    // Italic: *text* or _text_ — explicitly excludes ** and __ via lookahead/lookbehind
+    Regex("(?<!\\*)\\*(?!\\*)(.+?)(?<!\\*)\\*(?!\\*)|(?<!_)_(?!_)(.+?)(?<!_)_(?!_)")
+        .findAll(text)
+        .forEach { m ->
+            val content = m.groupValues[1].ifEmpty { m.groupValues[2] }
+            spans.add(InlineSpan(m.range.first, m.range.last + 1, "ITALIC", content))
+        }
+
+    // Strikethrough: ~~text~~
+    Regex("~~(.+?)~~").findAll(text).forEach { m ->
+        spans.add(InlineSpan(m.range.first, m.range.last + 1, "STRIKETHROUGH", m.groupValues[1]))
+    }
+
+    // Inline code: `code`
+    Regex("`([^`]+)`").findAll(text).forEach { m ->
+        spans.add(InlineSpan(m.range.first, m.range.last + 1, "CODE", m.groupValues[1]))
+    }
+
+    // URLs (Java Patterns — handles http/https/www links)
+    val urlMatcher = Patterns.WEB_URL.matcher(text)
+    while (urlMatcher.find()) {
+        spans.add(InlineSpan(urlMatcher.start(), urlMatcher.end(), "URL", urlMatcher.group()))
+    }
+
+    // Sort: earliest start first; for equal starts, prefer longer spans (negative length first)
+    spans.sortWith(compareBy({ it.start }, { it.start - it.end }))
+
+    return buildAnnotatedString {
+        var cursor = 0
+        for (span in spans) {
+            if (span.start < cursor) continue // skip overlapping spans
+            if (span.start > cursor) append(text.substring(cursor, span.start))
+            when (span.type) {
+                "BOLD"          -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(span.content) }
+                "ITALIC"        -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(span.content) }
+                "STRIKETHROUGH" -> withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) { append(span.content) }
+                "CODE"          -> withStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = surfaceVariant)) { append(span.content) }
+                "URL"           -> {
+                    pushStringAnnotation("URL", span.content)
+                    withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) { append(span.content) }
+                    pop()
+                }
+            }
+            cursor = span.end
+        }
+        if (cursor < text.length) append(text.substring(cursor))
+    }
+}
+
+// ── Block composables ──────────────────────────────────────────────────────────
+
+@Suppress("DEPRECATION") // ClickableText: will migrate to LinkAnnotation when API stabilises
+@Composable
+private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
+    val uriHandler      = LocalUriHandler.current
+    val surfaceVariant  = MaterialTheme.colorScheme.surfaceVariant
+    val linkColor       = MaterialTheme.colorScheme.primary
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+    val primaryColor    = MaterialTheme.colorScheme.primary
+
+    when (block) {
+        // ── Paragraph ──────────────────────────────────────────────────────────
+        is MarkdownBlock.Paragraph -> {
+            val annotated = remember(block.text, surfaceVariant, linkColor) {
+                renderInlineSpans(block.text, surfaceVariant, linkColor)
+            }
+            ClickableText(
+                text     = annotated,
+                style    = baseStyle,
+                onClick  = { offset ->
+                    annotated.getStringAnnotations("URL", offset, offset)
+                        .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                },
+            )
+        }
+
+        // ── Heading ────────────────────────────────────────────────────────────
+        is MarkdownBlock.Header -> {
+            val headingStyle = when (block.level) {
+                1    -> MaterialTheme.typography.headlineLarge
+                2    -> MaterialTheme.typography.headlineMedium
+                3    -> MaterialTheme.typography.headlineSmall
+                4    -> MaterialTheme.typography.titleLarge
+                5    -> MaterialTheme.typography.titleMedium
+                else -> MaterialTheme.typography.labelLarge
+            }
+            val annotated = remember(block.text, surfaceVariant, linkColor) {
+                renderInlineSpans(block.text, surfaceVariant, linkColor)
+            }
+            ClickableText(
+                text    = annotated,
+                style   = headingStyle,
+                onClick = { offset ->
+                    annotated.getStringAnnotations("URL", offset, offset)
+                        .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                },
+            )
+        }
+
+        // ── Blockquote ─────────────────────────────────────────────────────────
+        is MarkdownBlock.Blockquote -> {
+            val annotated = remember(block.text, surfaceVariant, linkColor) {
+                renderInlineSpans(block.text, surfaceVariant, linkColor)
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(surfaceVariant),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(4.dp)
+                        .fillMaxHeight()
+                        .background(primaryColor),
+                )
+                ClickableText(
+                    text     = annotated,
+                    style    = baseStyle.copy(fontStyle = FontStyle.Italic, color = onSurfaceVariant),
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                    onClick  = { offset ->
+                        annotated.getStringAnnotations("URL", offset, offset)
+                            .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                    },
+                )
+            }
+        }
+
+        // ── Bullet list ────────────────────────────────────────────────────────
+        is MarkdownBlock.BulletList -> {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                block.items.forEach { item ->
+                    val annotated = remember(item, surfaceVariant, linkColor) {
+                        renderInlineSpans("• $item", surfaceVariant, linkColor)
+                    }
+                    ClickableText(
+                        text    = annotated,
+                        style   = baseStyle,
+                        onClick = { offset ->
+                            annotated.getStringAnnotations("URL", offset, offset)
+                                .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                        },
+                    )
+                }
+            }
+        }
+
+        // ── Ordered list ───────────────────────────────────────────────────────
+        is MarkdownBlock.OrderedList -> {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                block.items.forEachIndexed { idx, item ->
+                    val annotated = remember(item, surfaceVariant, linkColor) {
+                        renderInlineSpans("${idx + 1}. $item", surfaceVariant, linkColor)
+                    }
+                    ClickableText(
+                        text    = annotated,
+                        style   = baseStyle,
+                        onClick = { offset ->
+                            annotated.getStringAnnotations("URL", offset, offset)
+                                .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                        },
+                    )
+                }
+            }
+        }
+
+        // ── Fenced code block ──────────────────────────────────────────────────
+        is MarkdownBlock.FencedCode -> {
+            FencedCodeBlock(code = block.code)
+        }
+
+        // ── Table ──────────────────────────────────────────────────────────────
+        is MarkdownBlock.Table -> {
+            MarkdownTable(headers = block.headers, rows = block.rows, baseStyle = baseStyle)
+        }
+    }
+}
+
+/**
+ * Renders a fenced code block with:
+ *  - `surfaceVariant` background and `RoundedCornerShape(8.dp)`
+ *  - `FontFamily.Monospace`, `softWrap = false`, horizontal scroll
+ *  - A copy-to-clipboard button anchored top-right; icon changes to ✓ for 2 seconds after copy
+ */
+@Composable
+private fun FencedCodeBlock(code: String, modifier: Modifier = Modifier) {
+    val clipboardManager = LocalClipboardManager.current
+    var copied by remember { mutableStateOf(false) }
+
+    LaunchedEffect(copied) {
+        if (copied) {
+            delay(2_000)
+            copied = false
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                // Right padding leaves room so long lines don't slide under the copy button
+                .padding(start = 12.dp, end = 48.dp, top = 12.dp, bottom = 12.dp),
+        ) {
+            Text(
+                text     = code.trimEnd('\n'),
+                style    = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                softWrap = false,
+            )
+        }
+
+        IconButton(
+            onClick = {
+                clipboardManager.setText(AnnotatedString(code))
+                copied = true
+                Log.d(TAG, "MarkdownRenderer: code block copied to clipboard")
+            },
+            modifier = Modifier.align(Alignment.TopEnd),
+        ) {
+            Icon(
+                imageVector     = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                contentDescription = if (copied) "Copied" else "Copy code",
+                modifier        = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Renders a Markdown table as a scrollable grid with per-cell borders.
+ * The header row is displayed on a `surfaceVariant` background with bold text.
+ * If a data row has fewer columns than the header, missing cells are rendered as empty.
+ */
+@Composable
+private fun MarkdownTable(
+    headers: List<String>,
+    rows: List<List<String>>,
+    baseStyle: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    val outlineColor   = MaterialTheme.colorScheme.outline
+    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+    ) {
+        Column(
+            modifier = Modifier
+                .border(1.dp, outlineColor, RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(8.dp)),
+        ) {
+            // Header row
+            Row(modifier = Modifier.background(surfaceVariant)) {
+                headers.forEach { header ->
+                    Text(
+                        text     = header,
+                        style    = baseStyle.copy(fontWeight = FontWeight.Bold),
+                        modifier = Modifier
+                            .border(0.5.dp, outlineColor)
+                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                    )
+                }
+            }
+            // Data rows
+            rows.forEach { row ->
+                Row {
+                    headers.indices.forEach { idx ->
+                        Text(
+                            text     = row.getOrElse(idx) { "" },
+                            style    = baseStyle,
+                            modifier = Modifier
+                                .border(0.5.dp, outlineColor)
+                                .padding(horizontal = 10.dp, vertical = 6.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Renders [text] as full Markdown inside a [Column].
+ *
+ * Supports:
+ *  - **Bold**, *italic*, ~~strikethrough~~, `inline code`, tappable URLs (inline)
+ *  - H1–H6 headings, blockquotes, bullet lists, ordered lists (block)
+ *  - Fenced code blocks with copy button and horizontal scroll (block)
+ *  - Tables with scrollable header + data rows (block)
+ *
+ * Model routing artefacts (`<think>`, `<tool_call>`, etc.) are stripped before parsing.
+ * The renderer is stream-safe: incomplete syntax gracefully falls back to plain text.
+ *
+ * @param text     Raw Markdown text (may include model artefact tags).
+ * @param modifier [Modifier] applied to the outer [Column].
+ * @param style    Base [TextStyle] for body text; headings override this with Material 3 type scale.
+ */
+@Composable
+fun MarkdownContent(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+) {
+    val cleaned = remember(text) { stripSystemTags(text) }
+    val blocks  = remember(cleaned) { parseBlocks(cleaned) }
+
+    Column(
+        modifier           = modifier,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        blocks.forEach { block ->
+            BlockContent(block = block, baseStyle = style)
+        }
+    }
+}
+
+// ── Previews ───────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Markdown — full sample")
+@Composable
+private fun MarkdownContentPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """
+                # Heading 1
+                ## Heading 2
+                ### Heading 3
+
+                This is a **bold** and *italic* paragraph with a `code span` and ~~strikethrough~~.
+                Visit https://example.com for more.
+
+                > This is a blockquote with *italic* text and a [link](https://example.com).
+
+                - Item one
+                - Item **two**
+                - Item three
+
+                1. First item
+                2. Second item
+                3. Third item
+
+                ```kotlin
+                fun greet(name: String) {
+                    println("Hello, ${'$'}name!")
+                }
+                ```
+
+                | Name  | Age | City    |
+                |-------|-----|---------|
+                | Alice | 30  | London  |
+                | Bob   | 25  | Berlin  |
+            """.trimIndent(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Markdown — stream-safe incomplete block")
+@Composable
+private fun MarkdownStreamSafePreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            // Unclosed fenced block — must render as plain text, not crash
+            text = "Here is some text\n```kotlin\nfun incomplete() {",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Markdown — tag stripping")
+@Composable
+private fun MarkdownTagStrippingPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = "<think>internal reasoning</think>The visible answer is **here**.",
+        )
+    }
+}


### PR DESCRIPTION
Implements full Markdown rendering for assistant messages per #61.

## What's new

| Feature | Detail |
|---|---|
| Bold, italic, strikethrough | `**bold**`, `*italic*`, `~~strike~~` via AnnotatedString spans |
| Headers H1–H6 | Mapped to Material 3 typography scale |
| Blockquotes | 4dp `primary` left border + `surfaceVariant` background |
| Bullet + ordered lists | `- / * / +` and `1.` items |
| Fenced code blocks | `surfaceVariant` bg, monospace, horizontal scroll |
| **Copy button** | `ContentCopy` icon top-right; switches to `Check` for 2s on tap |
| **Tables** | `\| col \|` syntax → scrollable grid with borders |
| **Stream-safe** | Unclosed spans / partial blocks fall back to plain text — no crashes mid-stream |
| **Tag stripping** | Strips `<think>`, `<tool_call>`, `<function_call>`, any `<snake_case_tag>` before parsing |

## Architecture
All rendering extracted into new `MarkdownRenderer.kt`. `ChatScreen.kt` calls `MarkdownContent(text, style)` — 157 lines removed from chat screen.

## Build
`assembleDebug` ✅ — no new dependencies.

Closes #61