### PR TITLE
docs: add #59, #60, #64, #65 to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The app operates on a **Brain–Memory–Action** triad:
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| 1 | Core LiteRT-LM integration + GPU/NPU acceleration + Chat UI | 🚧 |
+| 1 | Core LiteRT-LM integration + GPU/NPU acceleration + Chat UI (+ #59 active model display, #60 model selection) | 🚧 |
 | 2 | sqlite-vec + EmbeddingGemma for local RAG | ⬜ |
-| 3 | FunctionGemma intent router + Native Skills + Voice I/O | ⬜ |
+| 3 | FunctionGemma intent router + Native Skills + Voice I/O (Live Mode #64, "Hey Jandal" wake word #65) | ⬜ |
 | 4 | Chicory Wasm runtime + GitHub Skill Store | ⬜ |
 | 5 | 8GB device optimization (dynamic weight loading) | ⬜ |
 

--- a/specification.md
+++ b/specification.md
@@ -86,8 +86,8 @@ For community-driven and logic-heavy extensions, the system supports a **Wasm (W
 ---
 
 ## 8. Implementation Roadmap
-1.  **Phase 1:** Core LiteRT-LM integration with GPU acceleration for Gemma-4.
-2.  **Phase 2:** Deployment of SQLite-VSS and Gecko for local semantic search.
-3.  **Phase 3:** Implementation of the FunctionGemma "Intent Router" and initial Native Skills.
-4.  **Phase 4:** Integration of the Wasm Runtime and the GitHub-based Skill Store.
+1.  **Phase 1:** Core LiteRT-LM integration with GPU/NPU acceleration for Gemma-4. Backlog polish: active model/backend/tier display in Settings (#59); user-controlled E2B/E4B model selection persisted via DataStore (#60).
+2.  **Phase 2:** Deployment of sqlite-vec and EmbeddingGemma-300M for local semantic search and RAG.
+3.  **Phase 3:** FunctionGemma intent router + Native Skills + full Voice I/O. Includes **Live Mode** (#64) — real-time offline voice conversation via Silero VAD endpointing → Gemma-4 audio tensor input → Sherpa-ONNX/Piper TTS → barge-in, 28s rolling buffer, <1.5s time-to-first-audio. Includes **"Hey Jandal" wake word** (#65) — always-on local detection via openWakeWord (ONNX Runtime) + VoiceInteractionService with 3s ring buffer handoff to Live Mode pipeline.
+4.  **Phase 4:** Integration of the Chicory Wasm Runtime and the GitHub-based Skill Store.
 5.  **Phase 5:** Optimization for 8GB devices (dynamic loading/unloading of weights).


### PR DESCRIPTION
Updates the roadmap in both `README.md` and `specification.md`.

### README.md
- Phase 1: adds parenthetical references for #59 (active model display in Settings) and #60 (user model selection)
- Phase 3: expands Voice I/O description to explicitly mention Live Mode (#64) and "Hey Jandal" wake word (#65)

### specification.md
- Phase 1: adds #59 and #60 to the description
- Phase 2: corrects outdated tech references (SQLite-VSS → sqlite-vec, Gecko → EmbeddingGemma-300M)
- Phase 3: expands with Live Mode architecture details (Silero VAD, Gemma-4 audio encoder, Sherpa-ONNX/Piper TTS, barge-in, 28s buffer, <1.5s TTFA) and wake word details (openWakeWord, ONNX Runtime, VoiceInteractionService, 3s ring buffer)
- Phase 4: corrects "Wasm Runtime" → "Chicory Wasm Runtime"

Closes #59, #60, #64, #65

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>