### PR TITLE
fix: TC-1 through TC-5 polish bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.KernelAI">
+            android:theme="@style/Theme.KernelAI"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -77,6 +77,7 @@ fun KernelNavHost() {
 
         composable(ROUTE_SETTINGS) {
             SettingsScreen(
+                onBack = { navController.popBackStack() },
                 onNavigateToUserProfile = {
                     navController.navigate(ROUTE_USER_PROFILE)
                 },

--- a/docs/testing/PR-51-ui-polish.md
+++ b/docs/testing/PR-51-ui-polish.md
@@ -59,7 +59,7 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 4 | Dismiss keyboard | — |
 | 5 | Observe bottom of screen | **No excess space at the bottom** |
 
-**Result:** ⏳
+**Result:** ❌ Gap still present. Root cause: `windowSoftInputMode` not set in manifest — `imePadding()` unreliable on Samsung One UI without `adjustResize`. Fixed in PR #67.
 
 ---
 
@@ -77,7 +77,7 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 8 | Observe User Profile TopAppBar | **← arrow visible** |
 | 9 | Tap ← | **Returns to Settings** |
 
-**Result:** ⏳
+**Result:** ⚠️ Back arrow visible in conversations ✅ and User Profile ✅. Missing in Settings screen ❌. Fixed in PR #67.
 
 ---
 
@@ -91,7 +91,7 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 4 | Send another long message, tap **✕ stop button** mid-stream | — |
 | 5 | Observe the assistant bubble | **Partial response shown (not "Generation cancelled.")** |
 
-**Result:** ⏳
+**Result:** ❌ Partial response disappeared on nav away and stop. Root cause: `viewModelScope` already cancelled when `onCleared()` runs — `withContext(NonCancellable)` inside dead scope never executed. Fixed with `runBlocking` in PR #67.
 
 ---
 
@@ -103,7 +103,7 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 2 | Observe response | **URL renders as a tappable hyperlink (underlined/coloured)** |
 | 3 | Tap the link | **Opens in system browser** |
 
-**Result:** ⏳
+**Result:** ❌ Links appeared during streaming then reverted. All chat text rendered black (dark theme regression). Root cause: `ClickableText` doesn't inherit `LocalContentColor` — `Color.Unspecified` renders black. Fixed by passing `LocalContentColor.current` explicitly in PR #67.
 
 ---
 
@@ -116,7 +116,7 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 3 | Send: *"Give me a one-liner bash command to list all running processes"* | — |
 | 4 | Observe inline code | **Inline code styled distinctly — no raw backticks** |
 
-**Result:** ⏳
+**Result:** ⚠️ Code block rendered with copy button ✅. No visual separation between code block and surrounding commentary ❌. Fixed in PR #67 — added vertical padding and language label above block.
 
 ---
 
@@ -128,23 +128,23 @@ adb -s 192.168.31.54:5555 logcat -s KernelAI:D AndroidRuntime:E --pid=$(adb -s 1
 | 2 | Tap + to create a new conversation | **Works** |
 | 3 | Navigate: List → Chat → Back → Settings → Back | **No stack weirdness** |
 
-**Result:** ⏳
+**Result:** ✅ No regressions. Streaming, new conversations, and navigation all stable.
 
 ---
 
 ## Results Summary
 
-**Build:** ⏳ TBD
+**Build:** PR #62 + PR #63 (CI runs #82, #84)
 **Tested by:** NickMonrad
-**Test date:** ⏳ TBD
+**Test date:** 2026-04-10
 
 | Test | Result | Notes |
 |------|--------|-------|
-| TC-1 Keyboard gap | ⏳ | |
-| TC-2 Back navigation | ⏳ | |
-| TC-3 Partial message persistence | ⏳ | |
-| TC-4 Clickable links | ⏳ | |
-| TC-5 Code block rendering | ⏳ | |
-| TC-6 Regression | ⏳ | |
+| TC-1 Keyboard gap | ❌ | `adjustResize` missing in manifest — fixed PR #67 |
+| TC-2 Back navigation | ⚠️ | Chat ✅ UserProfile ✅ Settings ❌ — fixed PR #67 |
+| TC-3 Partial message persistence | ❌ | `onCleared()` flush never ran — fixed PR #67 |
+| TC-4 Clickable links | ❌ | Black text regression + links reverting — fixed PR #67 |
+| TC-5 Code block rendering | ⚠️ | Copy works, no visual separator — fixed PR #67 |
+| TC-6 Regression | ✅ | No regressions found |
 
-**Overall:** ⏳ Pending
+**Overall:** ❌ Fixes pending in PR #67 — re-test required after merge.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -218,9 +219,10 @@ private fun MessageBubble(message: ChatMessage) {
             } else {
                 // Assistant messages: render full Markdown with inline + block support.
                 Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                    val contentColor = LocalContentColor.current
                     MarkdownContent(
                         text  = message.content,
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
                     )
                     if (message.isStreaming) {
                         CircularProgressIndicator(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -18,8 +18,7 @@ import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -403,15 +402,16 @@ class ChatViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         // Flush any in-progress streamed content to Room before the ViewModel is destroyed.
-        // Uses NonCancellable so the save completes even though viewModelScope is about to cancel.
-        val partialContent = activeStreamingContent.toString()
-        val partialThinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
+        // runBlocking is acceptable here — called once on ViewModel teardown,
+        // Room insert is fast (<10ms), main thread briefly blocked on nav back.
+        // viewModelScope is already cancelled at this point so withContext(NonCancellable)
+        // inside a viewModelScope.launch does not work reliably.
+        val content = activeStreamingContent.toString()
+        val thinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
         val convId = conversationId
-        if (partialContent.isNotBlank() && convId != null) {
-            viewModelScope.launch {
-                withContext(NonCancellable) {
-                    conversationRepository.addMessage(convId, "assistant", partialContent, partialThinking)
-                }
+        if (content.isNotBlank() && convId != null) {
+            runBlocking {
+                conversationRepository.addMessage(convId, "assistant", content, thinking)
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -309,7 +309,7 @@ private fun renderInlineSpans(
 
 // ── Block composables ──────────────────────────────────────────────────────────
 
-@Suppress("DEPRECATION") // ClickableText: will migrate to LinkAnnotation when API stabilises
+@Suppress("DEPRECATION") // ClickableText: BasicText.onClick not available in this Compose version
 @Composable
 private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
     val uriHandler      = LocalUriHandler.current
@@ -427,7 +427,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
 
         // ── Fenced code block ──────────────────────────────────────────────────
         is MarkdownBlock.FencedCode -> {
-            FencedCodeBlock(code = block.code)
+            FencedCodeBlock(language = block.language, code = block.code)
         }
 
         // ── Table ──────────────────────────────────────────────────────────────
@@ -442,9 +442,11 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
  *  - `surfaceVariant` background and `RoundedCornerShape(8.dp)`
  *  - `FontFamily.Monospace`, `softWrap = false`, horizontal scroll
  *  - A copy-to-clipboard button anchored top-right; icon changes to ✓ for 2 seconds after copy
+ *  - An optional language label above the block (e.g. "yaml", "bash") when present
+ *  - Vertical padding (8.dp) to visually separate the block from surrounding text
  */
 @Composable
-private fun FencedCodeBlock(code: String, modifier: Modifier = Modifier) {
+private fun FencedCodeBlock(language: String = "", code: String, modifier: Modifier = Modifier) {
     val clipboardManager = LocalClipboardManager.current
     var copied by remember { mutableStateOf(false) }
 
@@ -455,38 +457,48 @@ private fun FencedCodeBlock(code: String, modifier: Modifier = Modifier) {
         }
     }
 
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant),
-    ) {
-        Row(
-            modifier = Modifier
-                .horizontalScroll(rememberScrollState())
-                // Right padding leaves room so long lines don't slide under the copy button
-                .padding(start = 12.dp, end = 48.dp, top = 12.dp, bottom = 12.dp),
-        ) {
+    Column(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        if (language.isNotBlank()) {
             Text(
-                text     = code.trimEnd('\n'),
-                style    = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                softWrap = false,
+                text = language,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 2.dp),
             )
         }
-
-        IconButton(
-            onClick = {
-                clipboardManager.setText(AnnotatedString(code))
-                copied = true
-                Log.d(TAG, "MarkdownRenderer: code block copied to clipboard")
-            },
-            modifier = Modifier.align(Alignment.TopEnd),
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
-            Icon(
-                imageVector     = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
-                contentDescription = if (copied) "Copied" else "Copy code",
-                modifier        = Modifier.size(16.dp),
-            )
+            Row(
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    // Right padding leaves room so long lines don't slide under the copy button
+                    .padding(start = 12.dp, end = 48.dp, top = 12.dp, bottom = 12.dp),
+            ) {
+                Text(
+                    text     = code.trimEnd('\n'),
+                    style    = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    softWrap = false,
+                )
+            }
+
+            IconButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(code))
+                    copied = true
+                    Log.d(TAG, "MarkdownRenderer: code block copied to clipboard")
+                },
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                Icon(
+                    imageVector     = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                    contentDescription = if (copied) "Copied" else "Copy code",
+                    modifier        = Modifier.size(16.dp),
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -21,11 +23,19 @@ import androidx.compose.ui.Modifier
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
+    onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Settings") })
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
         }
     ) { innerPadding ->
         Column(


### PR DESCRIPTION
Fixes 5 issues found during manual device testing on S23 Ultra.

### Fix 1 — TC-1 · #27: Keyboard gap
`windowSoftInputMode="adjustResize"` added to `MainActivity` in manifest. Without this, `imePadding()` doesn't work reliably on Samsung One UI — keyboard was overlaying content instead of pushing it up.

### Fix 2 — TC-2 · #22: Settings missing back button
Added `onBack` parameter + `AutoMirrored.Filled.ArrowBack` `navigationIcon` to `SettingsScreen`. Wired in `KernelNavHost`.

### Fix 3 — TC-3 · #25: Partial message not persisted
Replaced `viewModelScope.launch { withContext(NonCancellable) }` in `onCleared()` with `runBlocking`. `viewModelScope` is already cancelled when `onCleared()` runs so NonCancellable inside a dead scope never executed. `runBlocking` is safe here — single Room insert, <10ms.

### Fix 4 — TC-4 · #26: Black text + links reverting
Captured `LocalContentColor.current` in `MessageBubble` and passed it explicitly to `MarkdownContent` via `.copy(color = contentColor)`. `ClickableText` doesn't inherit `LocalContentColor` like `Text` does — base text was rendering black, making link spans invisible against dark backgrounds.

### Fix 5 — TC-5 · #36: Code block visual separation
- Added `Modifier.padding(vertical = 8.dp)` around code block container
- Added language label (`typography.labelSmall`, `onSurfaceVariant`) above block when language tag is present (e.g. `yaml`, `bash`)
- Makes it visually clear where the code block starts and ends