### PR TITLE
fix(#27/#36): keyboard gap root cause + code block border

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -13,6 +13,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -111,6 +116,7 @@ private fun ChatContent(
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
                 title = { Text("Kernel", style = MaterialTheme.typography.titleMedium) },
@@ -165,7 +171,7 @@ private fun ChatContent(
                 onTextChanged = onInputChanged,
                 onSend = onSend,
                 onCancel = onCancel,
-                modifier = Modifier,
+            modifier = Modifier.navigationBarsPadding(),
             )
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -469,6 +469,7 @@ private fun FencedCodeBlock(language: String = "", code: String, modifier: Modif
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
                 .clip(RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {


### PR DESCRIPTION
Two remaining issues from TC-1 and TC-5 re-test.

### TC-1 — Keyboard gap (root cause fix)
`adjustResize` in manifest is silently ignored on API 30+ with `enableEdgeToEdge()`. The real cause: Material3 `Scaffold` defaults to consuming bottom window insets via `contentWindowInsets`, so by the time `imePadding()` runs on the Column the IME inset is already gone.

Fix: `contentWindowInsets = WindowInsets(0)` on Scaffold — it no longer consumes any insets. `imePadding()` on the Column now receives the full IME inset and lifts the content correctly. `navigationBarsPadding()` restored on InputBar for nav gesture bar.

### TC-5 — Code block border
Added `border(1.dp, outlineVariant, RoundedCornerShape(8.dp))` to the fenced code block `Box` so the boundary is visually clear against both light and dark backgrounds.