### PR TITLE
fix(#36): use outline token for visible code block border in dark theme

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -469,8 +469,8 @@ private fun FencedCodeBlock(language: String = "", code: String, modifier: Modif
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
                 .clip(RoundedCornerShape(8.dp))
+                .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             Row(


### PR DESCRIPTION
## Summary
Fixes TC-5: the code block border was invisible in dark mode because `outlineVariant` on `surfaceVariant` has near-zero contrast in Material 3 dark theme.

## Changes
- `MarkdownRenderer.kt`: swap `outlineVariant` → `outline` for the fenced code block border (outline is the M3 token for visible/interactive borders)
- Fix modifier order: `clip` before `border` so the border renders fully within the rounded shape

## Testing
- TC-5 ✅: code block border visible in dark theme
- No other UI changes