### PR TITLE
feat(#59/#60): show active model info and manual model selection in Settings

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,6 +42,7 @@ private const val TAG = "ModelDownloadManager"
 class ModelDownloadManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val hardwareProfileDetector: com.kernel.ai.core.inference.hardware.HardwareProfileDetector,
+    private val modelPreferences: com.kernel.ai.core.inference.prefs.ModelPreferences,
 ) {
     private val workManager = WorkManager.getInstance(context)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -147,12 +149,25 @@ class ModelDownloadManager @Inject constructor(
             .all { it.isDownloaded(context) }
 
     /**
-     * Returns the best available conversation model for the current hardware tier.
+     * Returns the best available conversation model.
      *
-     * Prefers a tier-specific model (e.g. E-4B on FLAGSHIP) if it is already downloaded.
-     * Falls back to [KernelModel.GEMMA_4_E2B] which is always the baseline.
+     * Priority:
+     * 1. User-set preference (DataStore) — if the model is downloaded.
+     * 2. Tier-based auto-select (e.g. E-4B on FLAGSHIP) — if downloaded.
+     * 3. E-2B fallback (always available as required model).
+     *
+     * If the user-preferred model is not downloaded, falls back to tier/auto logic
+     * and logs a warning.
      */
-    fun preferredConversationModel(): KernelModel {
+    suspend fun preferredConversationModel(): KernelModel {
+        val userPref = modelPreferences.preferredConversationModel.first()
+        if (userPref != null) {
+            if (userPref.isDownloaded(context)) {
+                return userPref
+            } else {
+                Log.w(TAG, "User-preferred model ${userPref.displayName} not downloaded — falling back to auto")
+            }
+        }
         val tier = hardwareProfileDetector.profile.tier
         val tierModel = KernelModel.entries
             .firstOrNull { it.preferredForTier == tier && it.isDownloaded(context) }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/prefs/ModelPreferences.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/prefs/ModelPreferences.kt
@@ -10,7 +10,9 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.kernel.ai.core.inference.download.KernelModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,6 +27,12 @@ class ModelPreferences @Inject constructor(
 
     /** Null means "auto" — let tier-based logic decide. */
     val preferredConversationModel: Flow<KernelModel?> = context.modelPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "ModelPreferences: DataStore read error, falling back to auto", e)
+                emit(androidx.datastore.preferences.core.emptyPreferences())
+            } else throw e
+        }
         .map { prefs ->
             prefs[preferredModelKey]?.let { name ->
                 KernelModel.entries.find { it.name == name }
@@ -33,14 +41,19 @@ class ModelPreferences @Inject constructor(
         }
 
     suspend fun setPreferredModel(model: KernelModel?) {
-        context.modelPrefsDataStore.edit { prefs ->
-            if (model == null) {
-                prefs.remove(preferredModelKey)
-                Log.i(TAG, "ModelPreferences: cleared preferred model (auto mode)")
-            } else {
-                prefs[preferredModelKey] = model.name
-                Log.i(TAG, "ModelPreferences: set preferred model to ${model.displayName}")
+        try {
+            context.modelPrefsDataStore.edit { prefs ->
+                if (model == null) {
+                    prefs.remove(preferredModelKey)
+                    Log.i(TAG, "ModelPreferences: cleared preferred model (auto mode)")
+                } else {
+                    prefs[preferredModelKey] = model.name
+                    Log.i(TAG, "ModelPreferences: set preferred model to ${model.displayName}")
+                }
             }
+        } catch (e: IOException) {
+            Log.e(TAG, "ModelPreferences: failed to save preference", e)
+            throw e  // re-throw so caller can surface feedback to the user
         }
     }
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/prefs/ModelPreferences.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/prefs/ModelPreferences.kt
@@ -1,0 +1,46 @@
+package com.kernel.ai.core.inference.prefs
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.kernel.ai.core.inference.download.KernelModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+private val Context.modelPrefsDataStore: DataStore<Preferences> by preferencesDataStore(name = "model_preferences")
+
+@Singleton
+class ModelPreferences @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val preferredModelKey = stringPreferencesKey("preferred_conversation_model")
+
+    /** Null means "auto" — let tier-based logic decide. */
+    val preferredConversationModel: Flow<KernelModel?> = context.modelPrefsDataStore.data
+        .map { prefs ->
+            prefs[preferredModelKey]?.let { name ->
+                KernelModel.entries.find { it.name == name }
+                    .also { if (it == null) Log.w(TAG, "ModelPreferences: unknown model key '$name', ignoring") }
+            }
+        }
+
+    suspend fun setPreferredModel(model: KernelModel?) {
+        context.modelPrefsDataStore.edit { prefs ->
+            if (model == null) {
+                prefs.remove(preferredModelKey)
+                Log.i(TAG, "ModelPreferences: cleared preferred model (auto mode)")
+            } else {
+                prefs[preferredModelKey] = model.name
+                Log.i(TAG, "ModelPreferences: set preferred model to ${model.displayName}")
+            }
+        }
+    }
+}

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.lifecycle.runtime.compose)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -2,30 +2,51 @@ package com.kernel.ai.feature.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.inference.download.KernelModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
+    viewModel: SettingsViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -36,13 +57,124 @@ fun SettingsScreen(
                     }
                 },
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
+            // ── Active Model Info ─────────────────────────────────────────────
+            if (uiState.activeModelLabel.isNotEmpty()) {
+                ListItem(
+                    headlineContent = { Text("Active model") },
+                    supportingContent = {
+                        Text(
+                            text = "${uiState.activeModelLabel} · ${uiState.activeBackend} · ${uiState.activeTier}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    leadingContent = {
+                        Icon(Icons.Default.SmartToy, contentDescription = null)
+                    },
+                )
+                HorizontalDivider()
+            }
+
+            // ── Conversation Model Selection ──────────────────────────────────
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Conversation model",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            // Auto option
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { viewModel.setPreferredModel(null) },
+                headlineContent = { Text("Auto") },
+                supportingContent = { Text("Select best model for your hardware") },
+                leadingContent = {
+                    RadioButton(
+                        selected = uiState.preferredModel == null,
+                        onClick = { viewModel.setPreferredModel(null) },
+                    )
+                },
+            )
+
+            // E2B option
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B) },
+                headlineContent = { Text("E2B — Gemma 4 E-2B") },
+                supportingContent = { Text("2.4 GB · Efficient, runs on all devices") },
+                leadingContent = {
+                    RadioButton(
+                        selected = uiState.preferredModel == KernelModel.GEMMA_4_E2B,
+                        onClick = { viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B) },
+                    )
+                },
+            )
+
+            // E4B option
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        if (uiState.e4bDownloaded) {
+                            viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
+                        } else {
+                            scope.launch {
+                                snackbarHostState.showSnackbar("E4B not downloaded — using E2B")
+                            }
+                        }
+                    },
+                headlineContent = {
+                    Text(
+                        text = "E4B — Gemma 4 E-4B",
+                        color = if (uiState.e4bDownloaded)
+                            MaterialTheme.colorScheme.onSurface
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                supportingContent = {
+                    Text(
+                        text = if (uiState.e4bDownloaded) "3.4 GB · Higher quality, flagship devices"
+                               else "Not downloaded",
+                        color = if (uiState.e4bDownloaded)
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        else
+                            MaterialTheme.colorScheme.error,
+                    )
+                },
+                leadingContent = {
+                    RadioButton(
+                        selected = uiState.preferredModel == KernelModel.GEMMA_4_E4B,
+                        onClick = {
+                            if (uiState.e4bDownloaded) {
+                                viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
+                            } else {
+                                scope.launch {
+                                    snackbarHostState.showSnackbar("E4B not downloaded — using E2B")
+                                }
+                            }
+                        },
+                        enabled = uiState.e4bDownloaded,
+                    )
+                },
+            )
+
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // ── User Profile ──────────────────────────────────────────────────
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -56,3 +188,30 @@ fun SettingsScreen(
         }
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenPreview() {
+    MaterialTheme {
+        Scaffold(
+            topBar = {
+                @OptIn(ExperimentalMaterial3Api::class)
+                TopAppBar(title = { Text("Settings") })
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+            ) {
+                ListItem(
+                    headlineContent = { Text("Active model") },
+                    supportingContent = { Text("Gemma 4 E-4B · GPU · FLAGSHIP") },
+                    leadingContent = { Icon(Icons.Default.SmartToy, contentDescription = null) },
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -47,6 +47,12 @@ fun SettingsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        viewModel.saveError.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -65,13 +71,13 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // ── Active Model Info ─────────────────────────────────────────────
+            // ── Preferred Model Info ──────────────────────────────────────────
             if (uiState.activeModelLabel.isNotEmpty()) {
                 ListItem(
-                    headlineContent = { Text("Active model") },
+                    headlineContent = { Text("Preferred model") },
                     supportingContent = {
                         Text(
-                            text = "${uiState.activeModelLabel} · ${uiState.activeBackend} · ${uiState.activeTier}",
+                            text = "${uiState.activeModelLabel} · ${uiState.activeBackend} · ${uiState.activeTier} (takes effect on next launch)",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -205,8 +211,8 @@ private fun SettingsScreenPreview() {
                     .padding(padding),
             ) {
                 ListItem(
-                    headlineContent = { Text("Active model") },
-                    supportingContent = { Text("Gemma 4 E-4B · GPU · FLAGSHIP") },
+                    headlineContent = { Text("Preferred model") },
+                    supportingContent = { Text("Gemma 4 E-4B · GPU · FLAGSHIP (takes effect on next launch)") },
                     leadingContent = { Icon(Icons.Default.SmartToy, contentDescription = null) },
                 )
                 HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.inference.download.DownloadState
@@ -8,11 +9,15 @@ import com.kernel.ai.core.inference.download.ModelDownloadManager
 import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
 import com.kernel.ai.core.inference.prefs.ModelPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -61,7 +66,17 @@ class SettingsViewModel @Inject constructor(
         initialValue = SettingsUiState(),
     )
 
+    private val _saveError = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val saveError: SharedFlow<String> = _saveError.asSharedFlow()
+
     fun setPreferredModel(model: KernelModel?) {
-        viewModelScope.launch { modelPreferences.setPreferredModel(model) }
+        viewModelScope.launch {
+            try {
+                modelPreferences.setPreferredModel(model)
+            } catch (e: IOException) {
+                Log.e("KernelAI", "SettingsViewModel: failed to save model preference", e)
+                _saveError.tryEmit("Couldn't save preference — please try again")
+            }
+        }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -1,0 +1,67 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.inference.prefs.ModelPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val hardwareProfileDetector: HardwareProfileDetector,
+    private val modelDownloadManager: ModelDownloadManager,
+    private val modelPreferences: ModelPreferences,
+) : ViewModel() {
+
+    data class SettingsUiState(
+        val activeModelLabel: String = "",
+        val activeBackend: String = "",
+        val activeTier: String = "",
+        val preferredModel: KernelModel? = null,   // null = auto
+        val e4bDownloaded: Boolean = false,
+    )
+
+    val uiState: StateFlow<SettingsUiState> = combine(
+        modelPreferences.preferredConversationModel,
+        modelDownloadManager.downloadStates,
+    ) { preferredModel, downloadStates ->
+        val profile = hardwareProfileDetector.profile
+        val e4bDownloaded = downloadStates[KernelModel.GEMMA_4_E4B] is DownloadState.Downloaded
+
+        fun isDownloadedInStates(model: KernelModel) = downloadStates[model] is DownloadState.Downloaded
+
+        val activeModel: KernelModel = when {
+            preferredModel != null && isDownloadedInStates(preferredModel) -> preferredModel
+            else -> {
+                val tierModel = KernelModel.entries
+                    .firstOrNull { it.preferredForTier == profile.tier && isDownloadedInStates(it) }
+                tierModel ?: KernelModel.GEMMA_4_E2B
+            }
+        }
+
+        SettingsUiState(
+            activeModelLabel = activeModel.displayName,
+            activeBackend = profile.recommendedBackend.name,
+            activeTier = profile.tier.name,
+            preferredModel = preferredModel,
+            e4bDownloaded = e4bDownloaded,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = SettingsUiState(),
+    )
+
+    fun setPreferredModel(model: KernelModel?) {
+        viewModelScope.launch { modelPreferences.setPreferredModel(model) }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #59 and #60.

### Issue #59 — Active model info in Settings
Adds a read-only info row at the top of SettingsScreen showing the currently active conversation model, backend type, and hardware tier:
```
Active model    Gemma 4 E-4B · GPU · FLAGSHIP
```

### Issue #60 — Manual E2B/E4B model selection
Adds a `ModelPreferences` DataStore in `:core:inference` and a radio group in Settings to let the user pick:
- **Auto** — tier-based selection (existing behavior, default)
- **E2B — Gemma 4 E-2B** — always available
- **E4B — Gemma 4 E-4B** — greyed out with "Not downloaded" if absent; shows Snackbar if user taps

The user preference is persisted across app restarts. `ModelDownloadManager.preferredConversationModel()` now respects it, falling back gracefully if the selected model is not on disk.

## Files changed
- `core/inference/.../prefs/ModelPreferences.kt` — new
- `core/inference/.../download/ModelDownloadManager.kt` — preferredConversationModel() now suspend + DataStore-aware
- `feature/settings/.../SettingsViewModel.kt` — new
- `feature/settings/.../SettingsScreen.kt` — updated

Closes #59
Closes #60