### PR TITLE
fix: show actual preference in Settings model info row

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -77,8 +77,9 @@ fun SettingsScreen(
                 ListItem(
                     headlineContent = { Text("Preferred model") },
                     supportingContent = {
+                        val label = uiState.preferredModel?.displayName ?: "Auto"
                         Text(
-                            text = "${uiState.activeModelLabel} · ${uiState.activeBackend} · ${uiState.activeTier} (takes effect on next launch)",
+                            text = "$label · ${uiState.activeBackend} · ${uiState.activeTier} (takes effect on next launch)",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )


### PR DESCRIPTION
Follow-up to #72. The 'Preferred model' info row was showing the computed fallback model rather than the user's actual stored preference.

**Before:** When E4B is preferred but not downloaded, shows `Gemma 4 E-2B` (the fallback)
**After:** Shows `Gemma 4 E-4B` (the actual preference), or `Auto` if none set

Found by the code re-review pass.