### PR TITLE
fix(#20): don't let stale WorkManager FAILED state override Downloaded

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -194,6 +195,15 @@ class ModelDownloadManager @Inject constructor(
 
                 val newState: DownloadState = when (info.state) {
                     WorkInfo.State.RUNNING, WorkInfo.State.ENQUEUED -> {
+                        // Guard: a stale ENQUEUED job from a previous session must not
+                        // overwrite a file that is already present on disk.
+                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
+                        val alreadyPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
+                        if (alreadyPresent) {
+                            Log.i(TAG, "Stale enqueued/running worker but file present — cancelling: ${model.displayName}")
+                            workManager.cancelUniqueWork(model.workerTag)
+                            return@collect
+                        }
                         val progress = info.progress
                         val totalBytes = model.approxSizeBytes
                         val downloadedBytes = progress.getLong(KEY_PROGRESS_BYTES, 0L)
@@ -209,7 +219,7 @@ class ModelDownloadManager @Inject constructor(
                     }
 
                     WorkInfo.State.SUCCEEDED -> {
-                        val path = model.localFile(context).absolutePath
+                        val path = withContext(Dispatchers.IO) { model.localFile(context).absolutePath }
                         Log.i(TAG, "Download succeeded: $path")
                         DownloadState.Downloaded(localPath = path)
                     }
@@ -217,10 +227,13 @@ class ModelDownloadManager @Inject constructor(
                     WorkInfo.State.FAILED -> {
                         // Stale WorkManager jobs from a previous session can fire FAILED
                         // after the file was already pushed manually (e.g. via ADB). Trust
-                        // the file system over the worker state.
-                        if (model.isDownloaded(context)) {
+                        // the file system over the worker state. Materialise the File once
+                        // to avoid a TOCTOU race between the existence check and path use.
+                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
+                        val isPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
+                        if (isPresent) {
                             Log.i(TAG, "Worker failed but file present — treating as Downloaded: ${model.displayName}")
-                            DownloadState.Downloaded(localPath = model.localFile(context).absolutePath)
+                            DownloadState.Downloaded(localPath = localFile.absolutePath)
                         } else {
                             val errorMsg = info.outputData.getString(KEY_ERROR_MESSAGE)
                                 ?: "Download failed"
@@ -230,9 +243,11 @@ class ModelDownloadManager @Inject constructor(
                     }
 
                     WorkInfo.State.CANCELLED -> {
-                        if (model.isDownloaded(context)) {
+                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
+                        val isPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
+                        if (isPresent) {
                             Log.i(TAG, "Worker cancelled but file present — treating as Downloaded: ${model.displayName}")
-                            DownloadState.Downloaded(localPath = model.localFile(context).absolutePath)
+                            DownloadState.Downloaded(localPath = localFile.absolutePath)
                         } else {
                             Log.i(TAG, "Download cancelled for ${model.displayName}")
                             DownloadState.NotDownloaded

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -215,15 +215,28 @@ class ModelDownloadManager @Inject constructor(
                     }
 
                     WorkInfo.State.FAILED -> {
-                        val errorMsg = info.outputData.getString(KEY_ERROR_MESSAGE)
-                            ?: "Download failed"
-                        Log.w(TAG, "Download failed for ${model.displayName}: $errorMsg")
-                        DownloadState.Error(message = errorMsg)
+                        // Stale WorkManager jobs from a previous session can fire FAILED
+                        // after the file was already pushed manually (e.g. via ADB). Trust
+                        // the file system over the worker state.
+                        if (model.isDownloaded(context)) {
+                            Log.i(TAG, "Worker failed but file present — treating as Downloaded: ${model.displayName}")
+                            DownloadState.Downloaded(localPath = model.localFile(context).absolutePath)
+                        } else {
+                            val errorMsg = info.outputData.getString(KEY_ERROR_MESSAGE)
+                                ?: "Download failed"
+                            Log.w(TAG, "Download failed for ${model.displayName}: $errorMsg")
+                            DownloadState.Error(message = errorMsg)
+                        }
                     }
 
                     WorkInfo.State.CANCELLED -> {
-                        Log.i(TAG, "Download cancelled for ${model.displayName}")
-                        DownloadState.NotDownloaded
+                        if (model.isDownloaded(context)) {
+                            Log.i(TAG, "Worker cancelled but file present — treating as Downloaded: ${model.displayName}")
+                            DownloadState.Downloaded(localPath = model.localFile(context).absolutePath)
+                        } else {
+                            Log.i(TAG, "Download cancelled for ${model.displayName}")
+                            DownloadState.NotDownloaded
+                        }
                     }
 
                     else -> return@collect

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -188,6 +188,10 @@ class ModelDownloadManager @Inject constructor(
      * Uses LiveData → coroutine bridge (WorkManager 2.8+ API).
      */
     private suspend fun observeWorkInfo(model: KernelModel) {
+        // One-shot flag: the stale-worker guard only needs to run once per observation
+        // session (the first ENQUEUED/RUNNING emission). Subsequent progress ticks skip
+        // the filesystem check entirely, avoiding redundant mkdirs() syscalls.
+        var filesystemChecked = false
         workManager
             .getWorkInfosByTagFlow(model.workerTag)
             .collect { infoList ->
@@ -196,13 +200,19 @@ class ModelDownloadManager @Inject constructor(
                 val newState: DownloadState = when (info.state) {
                     WorkInfo.State.RUNNING, WorkInfo.State.ENQUEUED -> {
                         // Guard: a stale ENQUEUED job from a previous session must not
-                        // overwrite a file that is already present on disk.
-                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
-                        val alreadyPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
-                        if (alreadyPresent) {
-                            Log.i(TAG, "Stale enqueued/running worker but file present — cancelling: ${model.displayName}")
-                            workManager.cancelUniqueWork(model.workerTag)
-                            return@collect
+                        // overwrite a file that is already present on disk. Only check
+                        // once per observation session to avoid per-tick filesystem I/O.
+                        if (!filesystemChecked) {
+                            filesystemChecked = true
+                            val (localFile, alreadyPresent) = withContext(Dispatchers.IO) {
+                                val f = model.localFile(context)
+                                f to (f.exists() && f.length() > 0)
+                            }
+                            if (alreadyPresent) {
+                                Log.i(TAG, "Stale enqueued/running worker but file present — cancelling: ${model.displayName}")
+                                workManager.cancelUniqueWork(model.workerTag)
+                                return@collect
+                            }
                         }
                         val progress = info.progress
                         val totalBytes = model.approxSizeBytes
@@ -227,10 +237,12 @@ class ModelDownloadManager @Inject constructor(
                     WorkInfo.State.FAILED -> {
                         // Stale WorkManager jobs from a previous session can fire FAILED
                         // after the file was already pushed manually (e.g. via ADB). Trust
-                        // the file system over the worker state. Materialise the File once
-                        // to avoid a TOCTOU race between the existence check and path use.
-                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
-                        val isPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
+                        // the file system over the worker state. Single withContext block
+                        // materialises the File and checks it atomically (no TOCTOU window).
+                        val (localFile, isPresent) = withContext(Dispatchers.IO) {
+                            val f = model.localFile(context)
+                            f to (f.exists() && f.length() > 0)
+                        }
                         if (isPresent) {
                             Log.i(TAG, "Worker failed but file present — treating as Downloaded: ${model.displayName}")
                             DownloadState.Downloaded(localPath = localFile.absolutePath)
@@ -243,8 +255,10 @@ class ModelDownloadManager @Inject constructor(
                     }
 
                     WorkInfo.State.CANCELLED -> {
-                        val localFile = withContext(Dispatchers.IO) { model.localFile(context) }
-                        val isPresent = withContext(Dispatchers.IO) { localFile.exists() && localFile.length() > 0 }
+                        val (localFile, isPresent) = withContext(Dispatchers.IO) {
+                            val f = model.localFile(context)
+                            f to (f.exists() && f.length() > 0)
+                        }
                         if (isPresent) {
                             Log.i(TAG, "Worker cancelled but file present — treating as Downloaded: ${model.displayName}")
                             DownloadState.Downloaded(localPath = localFile.absolutePath)


### PR DESCRIPTION
## Problem

Settings showed E4B as "not downloaded" despite the 3.4 GB file being present on device.

**Root cause:** `ModelDownloadManager.observeWorkInfo()` resumes watching all persisted WorkManager jobs on every app start, including stale ones from previous sessions. If a prior E4B download attempt failed (network error, connection abort, etc.) and the WorkInfo was never pruned, the `FAILED` state fires on next launch and overwrites the correctly-initialised `Downloaded` state.

## Fix

In `observeWorkInfo()`, before transitioning to `DownloadState.Error` or `DownloadState.NotDownloaded`, call `model.isDownloaded(context)`. If the file is present on disk, keep `DownloadState.Downloaded` — the file-system check is authoritative over the stale worker state.

Applies to both `FAILED` and `CANCELLED` worker states.

## Testing

- Build and install on S23 Ultra  
- Open Settings → Model  
- E4B should show as Downloaded (not "Not downloaded" / "Error")  
- Settings should show the correct preferred model  

Closes #20