### PR TITLE
fix: 'takes effect on next launch' only shown when preference changes

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -54,6 +54,12 @@ fun SettingsScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.saveSuccess.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -79,7 +85,7 @@ fun SettingsScreen(
                     supportingContent = {
                         val label = uiState.preferredModel?.displayName ?: "Auto"
                         Text(
-                            text = "$label · ${uiState.activeBackend} · ${uiState.activeTier} (takes effect on next launch)",
+                            text = "$label · ${uiState.activeBackend} · ${uiState.activeTier}",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -214,7 +220,7 @@ private fun SettingsScreenPreview() {
             ) {
                 ListItem(
                     headlineContent = { Text("Preferred model") },
-                    supportingContent = { Text("Gemma 4 E-4B · GPU · FLAGSHIP (takes effect on next launch)") },
+                    supportingContent = { Text("Gemma 4 E-4B · GPU · FLAGSHIP") },
                     leadingContent = { Icon(Icons.Default.SmartToy, contentDescription = null) },
                 )
                 HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -69,10 +69,17 @@ class SettingsViewModel @Inject constructor(
     private val _saveError = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val saveError: SharedFlow<String> = _saveError.asSharedFlow()
 
+    private val _saveSuccess = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val saveSuccess: SharedFlow<String> = _saveSuccess.asSharedFlow()
+
     fun setPreferredModel(model: KernelModel?) {
         viewModelScope.launch {
+            val current = uiState.value.preferredModel
+            if (model == current) return@launch  // no change — don't show toast
             try {
                 modelPreferences.setPreferredModel(model)
+                val label = model?.displayName ?: "Auto"
+                _saveSuccess.tryEmit("Preference set to $label — takes effect on next launch")
             } catch (e: IOException) {
                 Log.e("KernelAI", "SettingsViewModel: failed to save model preference", e)
                 _saveError.tryEmit("Couldn't save preference — please try again")


### PR DESCRIPTION
Removes the static '(takes effect on next launch)' text that was always visible on the Settings info row regardless of whether anything had changed.

Now shows a Snackbar confirmation only when the user actually selects a different option. Tapping the already-selected option is a no-op (no toast).

No new issues — small UX polish to the Settings screen introduced in #72/#74.