### PR TITLE
feat(p2): structured episodic context + token budget accounting

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
@@ -23,6 +23,13 @@ class ContextWindowManager {
         /** Reserved for system prompt + datetime + user profile + RAG context. */
         const val SYSTEM_OVERHEAD = 2048
 
+        /**
+         * Token budget allocated for episodic RAG context within [SYSTEM_OVERHEAD].
+         * Passed to [com.kernel.ai.core.memory.rag.RagRepository.getRelevantContext] as
+         * `maxTokens` to keep retrieved memories within a predictable slice of the budget.
+         */
+        const val EPISODIC_BUDGET = 400
+
         /** Tokens available for conversation history replay. */
         const val HISTORY_BUDGET = MAX_CONTEXT_TOKENS - RESPONSE_RESERVE - SYSTEM_OVERHEAD // 5120
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -75,11 +75,14 @@ class RagRepository @Inject constructor(
      * empty string when no relevant context is available.
      *
      * @param excludeMessageIds Message IDs to exclude (e.g. the current turn's user message).
+     * @param maxTokens Maximum token budget for the returned context block (estimated at chars/3).
+     *   Results are truncated to fit within the budget. Defaults to [Int.MAX_VALUE] (no limit).
      */
     suspend fun getRelevantContext(
         query: String,
         topK: Int = DEFAULT_TOP_K,
         excludeMessageIds: Set<String> = emptySet(),
+        maxTokens: Int = Int.MAX_VALUE,
     ): String = withContext(Dispatchers.IO) {
         if (!tableCreated) return@withContext ""
 
@@ -112,12 +115,28 @@ class RagRepository @Inject constructor(
         if (messages.isEmpty()) return@withContext ""
 
         buildString {
-            appendLine("[Relevant context from memory:]")
-            messages.forEach { msg ->
+            // Estimate token cost of all lines before committing to include them.
+            val charsPerToken = 3
+            var tokenBudgetRemaining = maxTokens
+            val header = "[Episodic Memories]\n"
+            val footer = "[End of episodic memories]"
+            tokenBudgetRemaining -= (header.length + footer.length) / charsPerToken
+
+            val lines = mutableListOf<String>()
+            for (msg in messages) {
                 val role = if (msg.role == "user") "User" else "Assistant"
-                appendLine("$role: ${msg.content.take(300)}")
+                val line = "$role: ${msg.content.take(300)}"
+                val lineCost = (line.length + 1) / charsPerToken // +1 for newline
+                if (tokenBudgetRemaining - lineCost < 0) break
+                lines.add(line)
+                tokenBudgetRemaining -= lineCost
             }
-            append("---")
+
+            if (lines.isEmpty()) return@withContext ""
+
+            append(header)
+            lines.forEach { appendLine(it) }
+            append(footer)
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -133,6 +133,7 @@ class ChatViewModel @Inject constructor(
             append(DEFAULT_SYSTEM_PROMPT)
             append("\n\n[Current date and time]\n$dateTime")
             if (profile.isNotBlank()) append("\n\n[User Profile]\n$profile")
+            // TODO p2-memory-tiers: add [Core Memories] section here
             if (historyTurns.isNotEmpty()) {
                 append("\n\n[Previous conversation context]\n")
                 for ((user, assistant) in historyTurns) {
@@ -246,7 +247,11 @@ class ChatViewModel @Inject constructor(
             activeStreamingContent = accumulatedContent
             activeStreamingThinking = accumulatedThinking
 
-            val ragContext = ragRepository.getRelevantContext(text)
+            val ragContext = ragRepository.getRelevantContext(
+                query = text,
+                maxTokens = ContextWindowManager.EPISODIC_BUDGET,
+            )
+            estimatedTokensUsed += contextWindowManager.estimateTokens(ragContext)
 
             // Proactive context reset: if we're at ~75% of the token budget, reset
             // the conversation and replay history to avoid LiteRT locking up.


### PR DESCRIPTION
## Summary

Completes `p2-context-management`.

### Changes

**`RagRepository`**
- Section label: `[Relevant context from memory:]` → `[Episodic Memories]`
- Footer: `---` → `[End of episodic memories]`
- New `maxTokens` parameter — budget-aware truncation using the same `chars/3` heuristic as `ContextWindowManager`; returns empty string if nothing fits

**`ContextWindowManager`**
- Added `EPISODIC_BUDGET = 400` constant — makes the RAG token allocation within `SYSTEM_OVERHEAD` explicit

**`ChatViewModel`**
- Passes `maxTokens = ContextWindowManager.EPISODIC_BUDGET` to `getRelevantContext()`
- Adds RAG token cost to `estimatedTokensUsed` so the 75% proactive-reset threshold correctly accounts for episodic context
- Adds `TODO p2-memory-tiers` placeholder in `buildSystemPrompt()` for the future `[Core Memories]` section

### Why RAG stays in the user turn (not system prompt)
`updateSystemPrompt()` recreates the LiteRT-LM conversation object, resetting the KV cache. Calling it on every message send would evict all accumulated context. Per-turn RAG injection is the correct approach for LiteRT-LM.