### PR TITLE
fix(p2): address code review findings on context management

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -5,6 +5,7 @@ import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
+import com.kernel.ai.core.inference.ContextWindowManager
 import com.kernel.ai.core.memory.vector.VectorStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -82,7 +83,7 @@ class RagRepository @Inject constructor(
         query: String,
         topK: Int = DEFAULT_TOP_K,
         excludeMessageIds: Set<String> = emptySet(),
-        maxTokens: Int = Int.MAX_VALUE,
+        maxTokens: Int = ContextWindowManager.EPISODIC_BUDGET,
     ): String = withContext(Dispatchers.IO) {
         if (!tableCreated) return@withContext ""
 
@@ -120,7 +121,7 @@ class RagRepository @Inject constructor(
             var tokenBudgetRemaining = maxTokens
             val header = "[Episodic Memories]\n"
             val footer = "[End of episodic memories]"
-            tokenBudgetRemaining -= (header.length + footer.length) / charsPerToken
+            tokenBudgetRemaining -= (header.length + footer.length + charsPerToken - 1) / charsPerToken
 
             val lines = mutableListOf<String>()
             for (msg in messages) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -251,7 +251,7 @@ class ChatViewModel @Inject constructor(
                 query = text,
                 maxTokens = ContextWindowManager.EPISODIC_BUDGET,
             )
-            estimatedTokensUsed += contextWindowManager.estimateTokens(ragContext)
+            val ragTokenCost = contextWindowManager.estimateTokens(ragContext)
 
             // Proactive context reset: if we're at ~75% of the token budget, reset
             // the conversation and replay history to avoid LiteRT locking up.
@@ -268,9 +268,12 @@ class ChatViewModel @Inject constructor(
                 // Inject history into the system prompt so Gemma treats it as background context.
                 val systemPromptWithHistory = buildSystemPrompt(selected)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)
+                // Re-baseline from selected history, then add the RAG cost for this turn.
                 estimatedTokensUsed = selected.sumOf {
                     contextWindowManager.estimateTokens(it.first) + contextWindowManager.estimateTokens(it.second)
-                }
+                } + ragTokenCost
+            } else {
+                estimatedTokensUsed += ragTokenCost
             }
 
             val prompt = if (ragContext.isNotBlank()) "$ragContext\n\n$text" else text


### PR DESCRIPTION
Follow-up fixes to PR #77 based on code review:

- **RAG token cost preserved after reset** — was being overwritten by `estimatedTokensUsed = selected.sumOf {...}`, silently losing 400 tokens from the running total on every reset cycle. Now included in the post-reset baseline.
- **Safe default for `maxTokens`** — changed from `Int.MAX_VALUE` to `ContextWindowManager.EPISODIC_BUDGET` so future call sites can't silently bypass the budget by omitting the parameter.
- **Ceiling division for header/footer overhead** — avoids 1-token over-budget edge case at the boundary.