### PR TITLE
feat(#15): auto-generate conversation titles after 2nd exchange

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
@@ -45,6 +45,15 @@ interface InferenceEngine {
     fun cancelGeneration()
 
     /**
+     * Generate a response for [prompt] using an **isolated conversation** that does
+     * not share KV cache state with the active chat. Safe to call for side tasks such
+     * as title generation — the chat context is not affected.
+     *
+     * Blocks until generation completes. Returns an empty string on error.
+     */
+    suspend fun generateOnce(prompt: String): String
+
+    /**
      * Clear the conversation context window and start fresh.
      * The engine stays warm — no model reload required.
      */

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -161,9 +161,10 @@ class LiteRtInferenceEngine @Inject constructor(
         val start = System.currentTimeMillis()
         var firstTokenMs: Long = -1
 
-        conv.sendMessageAsync(
-            Contents.of(Content.Text(userMessage)),
-            object : MessageCallback {
+        try {
+            conv.sendMessageAsync(
+                Contents.of(Content.Text(userMessage)),
+                object : MessageCallback {
                 override fun onMessage(message: Message) {
                     // Route thinking tokens separately (Gemma thinking mode)
                     val thinkingText = message.channels["thought"]
@@ -201,6 +202,12 @@ class LiteRtInferenceEngine @Inject constructor(
                 }
             },
         )
+        } catch (e: Exception) {
+            _isGenerating.value = false
+            generationMutex.unlock()
+            close(InferenceException("sendMessageAsync failed: ${e.message}", e))
+            return@callbackFlow
+        }
 
         // When the Flow collector cancels (e.g. user navigates away), stop inference.
         awaitClose {
@@ -223,7 +230,7 @@ class LiteRtInferenceEngine @Inject constructor(
     override suspend fun generateOnce(prompt: String): String = withContext(LlmDispatcher) {
         generationMutex.withLock {
             val eng = engine ?: return@withLock ""
-            val config = currentConfig ?: return@withLock ""
+            if (currentConfig == null) return@withLock ""
             val backend = _activeBackend.value ?: BackendType.CPU
             val isolatedConv = eng.createConversation(buildConversationConfig(backend, null))
             val sb = StringBuilder()

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -19,8 +19,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -58,6 +61,9 @@ class LiteRtInferenceEngine @Inject constructor(
     private var engine: Engine? = null
     private var conversation: com.google.ai.edge.litertlm.Conversation? = null
     private var currentConfig: ModelConfig? = null
+
+    /** Ensures only one generation (chat or isolated) runs at a time. */
+    private val generationMutex = Mutex()
 
     // -------------------------------------------------------------------------
     // Lifecycle
@@ -143,8 +149,10 @@ class LiteRtInferenceEngine @Inject constructor(
     // -------------------------------------------------------------------------
 
     override fun generate(userMessage: String): Flow<GenerationResult> = callbackFlow {
+        generationMutex.lock()
         val conv = conversation
         if (conv == null) {
+            generationMutex.unlock()
             close(InferenceException("Engine not initialized — call initialize() first"))
             return@callbackFlow
         }
@@ -198,12 +206,48 @@ class LiteRtInferenceEngine @Inject constructor(
         awaitClose {
             _isGenerating.value = false
             conv.cancelProcess()
+            generationMutex.unlock()
         }
     }.flowOn(LlmDispatcher)
 
     override fun cancelGeneration() {
         conversation?.cancelProcess()
         _isGenerating.value = false
+    }
+
+    /**
+     * Generate a response using an **isolated conversation** that does not share KV
+     * cache state with the active chat. Acquires [generationMutex] — if the engine
+     * is currently generating, this suspends until the active generation completes.
+     */
+    override suspend fun generateOnce(prompt: String): String = withContext(LlmDispatcher) {
+        generationMutex.withLock {
+            val eng = engine ?: return@withLock ""
+            val config = currentConfig ?: return@withLock ""
+            val backend = _activeBackend.value ?: BackendType.CPU
+            val isolatedConv = eng.createConversation(buildConversationConfig(backend, null))
+            val sb = StringBuilder()
+            val latch = CompletableDeferred<Unit>()
+            try {
+                isolatedConv.sendMessageAsync(
+                    Contents.of(Content.Text(prompt)),
+                    object : MessageCallback {
+                        override fun onMessage(message: Message) {
+                            val text = message.toString()
+                            if (text.isNotEmpty() && !text.startsWith("<ctrl")) sb.append(text)
+                        }
+                        override fun onDone() { latch.complete(Unit) }
+                        override fun onError(throwable: Throwable) {
+                            latch.completeExceptionally(throwable)
+                        }
+                    },
+                )
+                latch.await()
+            } finally {
+                safeClose(isolatedConv, "title-conv")
+            }
+            sb.toString()
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -64,6 +64,9 @@ class ConversationRepository @Inject constructor(
         conversationDao.delete(conversation)
     }
 
+    suspend fun getConversation(id: String): ConversationEntity? =
+        conversationDao.getById(id)
+
     suspend fun getMessagesOnce(conversationId: String): List<MessageEntity> =
         messageDao.getByConversation(conversationId)
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -117,7 +118,7 @@ private fun ChatContent(
     onRenameConversation: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
-    var showRenameDialog by remember { mutableStateOf(false) }
+    var showRenameDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
@@ -196,7 +197,7 @@ private fun ChatContent(
 
     // Rename dialog triggered by tapping the title in the top bar.
     if (showRenameDialog) {
-        var renameText by remember { mutableStateOf(state.conversationTitle ?: "") }
+        var renameText by rememberSaveable(state.conversationTitle) { mutableStateOf(state.conversationTitle ?: "") }
         AlertDialog(
             onDismissRequest = { showRenameDialog = false },
             title = { Text("Rename conversation") },

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.chat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,15 +42,20 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -93,6 +100,7 @@ fun ChatScreen(
                 viewModel.startNewConversation()
                 onNewConversation()
             },
+            onRenameConversation = viewModel::renameConversation,
         )
     }
 }
@@ -106,8 +114,10 @@ private fun ChatContent(
     onCancel: () -> Unit,
     onBack: () -> Unit,
     onNewConversation: () -> Unit,
+    onRenameConversation: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
+    var showRenameDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
@@ -119,7 +129,15 @@ private fun ChatContent(
         contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
-                title = { Text("Kernel", style = MaterialTheme.typography.titleMedium) },
+                title = {
+                    Text(
+                        text = state.conversationTitle ?: "Kernel",
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier.clickable { showRenameDialog = true },
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -174,6 +192,35 @@ private fun ChatContent(
             modifier = Modifier.navigationBarsPadding(),
             )
         }
+    }
+
+    // Rename dialog triggered by tapping the title in the top bar.
+    if (showRenameDialog) {
+        var renameText by remember { mutableStateOf(state.conversationTitle ?: "") }
+        AlertDialog(
+            onDismissRequest = { showRenameDialog = false },
+            title = { Text("Rename conversation") },
+            text = {
+                OutlinedTextField(
+                    value = renameText,
+                    onValueChange = { renameText = it },
+                    singleLine = true,
+                    placeholder = { Text("Enter a title…") },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val trimmed = renameText.trim()
+                        if (trimmed.isNotBlank()) onRenameConversation(trimmed)
+                        showRenameDialog = false
+                    }
+                ) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRenameDialog = false }) { Text("Cancel") }
+            },
+        )
     }
 }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.chat
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -49,6 +50,7 @@ class ChatViewModel @Inject constructor(
     private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
     private val _inputText = MutableStateFlow("")
     private val _error = MutableStateFlow<String?>(null)
+    private val _conversationTitle = MutableStateFlow<String?>(null)
     private var conversationId: String? = null
     private val contextWindowManager = ContextWindowManager()
 
@@ -71,6 +73,7 @@ class ChatViewModel @Inject constructor(
         val messages: List<ChatMessage>,
         val inputText: String,
         val error: String?,
+        val conversationTitle: String?,
     )
 
     private val engineState = combine(
@@ -82,7 +85,8 @@ class ChatViewModel @Inject constructor(
         _messages,
         _inputText,
         _error,
-    ) { messages, inputText, error -> InputState(messages, inputText, error) }
+        _conversationTitle,
+    ) { messages, inputText, error, title -> InputState(messages, inputText, error, title) }
 
     val uiState: StateFlow<ChatUiState> = combine(
         engineState,
@@ -108,6 +112,7 @@ class ChatViewModel @Inject constructor(
             !engine.isReady -> ChatUiState.Loading
             else -> ChatUiState.Ready(
                 conversationId = conversationId ?: "",
+                conversationTitle = input.conversationTitle,
                 messages = input.messages,
                 isGenerating = engine.isGenerating,
                 inputText = input.inputText,
@@ -147,6 +152,9 @@ class ChatViewModel @Inject constructor(
     private suspend fun initializeConversation() {
         val id = navConversationId ?: conversationRepository.createConversation()
         conversationId = id
+
+        // Load persisted title immediately so UI shows it on back-navigation.
+        _conversationTitle.value = conversationRepository.getConversation(id)?.title
 
         val persisted = conversationRepository.getMessagesOnce(id)
         if (persisted.isNotEmpty()) {
@@ -211,6 +219,16 @@ class ChatViewModel @Inject constructor(
         if (_error.value != null) _error.value = null
     }
 
+    fun renameConversation(newTitle: String) {
+        val id = conversationId ?: return
+        val trimmed = newTitle.trim()
+        if (trimmed.isBlank()) return
+        viewModelScope.launch {
+            conversationRepository.renameConversation(id, trimmed)
+            _conversationTitle.value = trimmed
+        }
+    }
+
     fun sendMessage() {
         val text = _inputText.value.trim()
         if (text.isBlank() || inferenceEngine.isGenerating.value) return
@@ -251,7 +269,7 @@ class ChatViewModel @Inject constructor(
                 query = text,
                 maxTokens = ContextWindowManager.EPISODIC_BUDGET,
             )
-            estimatedTokensUsed += contextWindowManager.estimateTokens(ragContext)
+            val ragTokenCost = contextWindowManager.estimateTokens(ragContext)
 
             // Proactive context reset: if we're at ~75% of the token budget, reset
             // the conversation and replay history to avoid LiteRT locking up.
@@ -268,9 +286,12 @@ class ChatViewModel @Inject constructor(
                 // Inject history into the system prompt so Gemma treats it as background context.
                 val systemPromptWithHistory = buildSystemPrompt(selected)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)
+                // Re-baseline from selected history, then add the RAG cost for this turn.
                 estimatedTokensUsed = selected.sumOf {
                     contextWindowManager.estimateTokens(it.first) + contextWindowManager.estimateTokens(it.second)
-                }
+                } + ragTokenCost
+            } else {
+                estimatedTokensUsed += ragTokenCost
             }
 
             val prompt = if (ragContext.isNotBlank()) "$ragContext\n\n$text" else text
@@ -316,7 +337,14 @@ class ChatViewModel @Inject constructor(
                             activeStreamingMsgId = null
                             activeStreamingContent = StringBuilder()
                             activeStreamingThinking = StringBuilder()
-                            autoTitleConversation(convId, text)
+
+                            // Auto-title after the 2nd complete exchange (4 messages: 2 user + 2 assistant),
+                            // but only if the conversation is still untitled. Launched in a separate
+                            // coroutine so it never blocks or delays the chat UI.
+                            val messageCount = _messages.value.size
+                            if (messageCount == 4 && _conversationTitle.value == null) {
+                                viewModelScope.launch { generateTitle() }
+                            }
                         }
 
                         is GenerationResult.Error -> {
@@ -389,19 +417,62 @@ class ChatViewModel @Inject constructor(
             val id = conversationRepository.createConversation()
             conversationId = id
             _messages.value = emptyList()
+            _conversationTitle.value = null
             estimatedTokensUsed = 0
             needsHistoryReplay = false
             inferenceEngine.resetConversation()
         }
     }
 
-    /** Auto-generate a short title from the user's first message. */
-    private suspend fun autoTitleConversation(convId: String, firstUserMessage: String) {
-        val maxLen = 40
-        val title = firstUserMessage.trim().take(maxLen).let { t ->
-            if (firstUserMessage.length > maxLen) "$t…" else t
+    /**
+     * Generates a short AI title for the current conversation using the first two user messages
+     * as context. Only called after the 2nd complete exchange when the conversation is untitled.
+     *
+     * Runs in its own coroutine — never blocks the chat UI. Silent failure: if generation
+     * fails or the engine is busy, the title stays null and the user can rename manually.
+     */
+    private suspend fun generateTitle() {
+        val id = conversationId ?: return
+
+        // Skip if the engine is still busy (e.g. called right at the edge of a generation).
+        if (inferenceEngine.isGenerating.value) {
+            Log.w("KernelAI", "Auto-title skipped: engine is still generating")
+            return
         }
-        conversationRepository.renameConversation(convId, title)
+
+        // Double-check the title is still null (may have been set manually in the meantime).
+        if (conversationRepository.getConversation(id)?.title != null) return
+
+        val userMessages = _messages.value
+            .filter { it.role == ChatMessage.Role.USER }
+            .take(2)
+            .joinToString(" / ") { it.content.take(100) }
+
+        val titlePrompt = "Generate a short, descriptive title (4-6 words max, no quotes) for a conversation that starts with: $userMessages"
+
+        val sb = StringBuilder()
+        try {
+            inferenceEngine.generate(titlePrompt).collect { result ->
+                when (result) {
+                    is GenerationResult.Token -> sb.append(result.text)
+                    is GenerationResult.Complete -> return@collect
+                    else -> {}
+                }
+            }
+            val title = sb.toString()
+                .trim()
+                .trimStart('"', '\'')
+                .trimEnd('"', '\'', '.')
+                .take(60)
+            if (title.isNotBlank()) {
+                conversationRepository.renameConversation(id, title)
+                _conversationTitle.value = title
+                Log.i("KernelAI", "Auto-titled conversation $id: $title")
+            }
+        } catch (e: Exception) {
+            Log.w("KernelAI", "Auto-title generation failed: ${e.message}")
+            // Silent failure — title stays null, user can rename manually.
+        }
     }
 
     override fun onCleared() {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -434,12 +434,6 @@ class ChatViewModel @Inject constructor(
     private suspend fun generateTitle() {
         val id = conversationId ?: return
 
-        // Skip if the engine is still busy (e.g. called right at the edge of a generation).
-        if (inferenceEngine.isGenerating.value) {
-            Log.w("KernelAI", "Auto-title skipped: engine is still generating")
-            return
-        }
-
         // Double-check the title is still null (may have been set manually in the meantime).
         if (conversationRepository.getConversation(id)?.title != null) return
 
@@ -450,16 +444,11 @@ class ChatViewModel @Inject constructor(
 
         val titlePrompt = "Generate a short, descriptive title (4-6 words max, no quotes) for a conversation that starts with: $userMessages"
 
-        val sb = StringBuilder()
         try {
-            inferenceEngine.generate(titlePrompt).collect { result ->
-                when (result) {
-                    is GenerationResult.Token -> sb.append(result.text)
-                    is GenerationResult.Complete -> return@collect
-                    else -> {}
-                }
-            }
-            val title = sb.toString()
+            // generateOnce() uses an isolated conversation — the chat KV cache is untouched.
+            // It also acquires generationMutex, so it waits politely if the engine is busy.
+            val raw = inferenceEngine.generateOnce(titlePrompt)
+            val title = raw
                 .trim()
                 .trimStart('"', '\'')
                 .trimEnd('"', '\'', '.')

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -21,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -51,6 +54,8 @@ fun ConversationListScreen(
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
+    var pendingRename by remember { mutableStateOf<ConversationEntity?>(null) }
+    var contextMenuTarget by remember { mutableStateOf<ConversationEntity?>(null) }
 
     Scaffold(
         topBar = {
@@ -98,38 +103,62 @@ fun ConversationListScreen(
                     .padding(innerPadding),
             ) {
                 items(conversations, key = { it.id }) { conversation ->
-                    ListItem(
-                        headlineContent = {
-                            Text(
-                                text = conversation.title ?: "New conversation",
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
+                    Box {
+                        ListItem(
+                            headlineContent = {
+                                Text(
+                                    text = conversation.title ?: "New conversation",
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                            supportingContent = {
+                                Text(
+                                    text = formatTimestamp(conversation.updatedAt),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.outline,
+                                )
+                            },
+                            trailingContent = {
+                                IconButton(onClick = { pendingDelete = conversation }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "Delete")
+                                }
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .combinedClickable(
+                                    onClick = { onOpenConversation(conversation.id) },
+                                    onLongClick = { contextMenuTarget = conversation },
+                                ),
+                        )
+                        // Long-press context menu
+                        DropdownMenu(
+                            expanded = contextMenuTarget?.id == conversation.id,
+                            onDismissRequest = { contextMenuTarget = null },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Rename") },
+                                onClick = {
+                                    pendingRename = conversation
+                                    contextMenuTarget = null
+                                },
                             )
-                        },
-                        supportingContent = {
-                            Text(
-                                text = formatTimestamp(conversation.updatedAt),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.outline,
+                            DropdownMenuItem(
+                                text = { Text("Delete") },
+                                onClick = {
+                                    pendingDelete = conversation
+                                    contextMenuTarget = null
+                                },
                             )
-                        },
-                        trailingContent = {
-                            IconButton(onClick = { pendingDelete = conversation }) {
-                                Icon(Icons.Default.Delete, contentDescription = "Delete")
-                            }
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .combinedClickable(
-                                onClick = { onOpenConversation(conversation.id) },
-                            ),
-                    )
+                        }
+                    }
                     HorizontalDivider()
                 }
             }
         }
     }
 
+    // Delete confirmation dialog
     pendingDelete?.let { conversation ->
         AlertDialog(
             onDismissRequest = { pendingDelete = null },
@@ -147,6 +176,39 @@ fun ConversationListScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+            },
+        )
+    }
+
+    // Rename dialog
+    pendingRename?.let { conversation ->
+        var renameText by remember(conversation.id) {
+            mutableStateOf(conversation.title ?: "")
+        }
+        AlertDialog(
+            onDismissRequest = { pendingRename = null },
+            title = { Text("Rename conversation") },
+            text = {
+                OutlinedTextField(
+                    value = renameText,
+                    onValueChange = { renameText = it },
+                    singleLine = true,
+                    placeholder = { Text("Enter a title…") },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val trimmed = renameText.trim()
+                        if (trimmed.isNotBlank()) {
+                            viewModel.renameConversation(conversation.id, trimmed)
+                        }
+                        pendingRename = null
+                    }
+                ) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRename = null }) { Text("Cancel") }
             },
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -54,7 +55,9 @@ fun ConversationListScreen(
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
-    var pendingRename by remember { mutableStateOf<ConversationEntity?>(null) }
+    // Store ID only (String is Parcelable-safe) to survive configuration changes.
+    var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
+    val pendingRename = pendingRenameId?.let { id -> conversations.find { it.id == id } }
     var contextMenuTarget by remember { mutableStateOf<ConversationEntity?>(null) }
 
     Scaffold(
@@ -139,7 +142,7 @@ fun ConversationListScreen(
                             DropdownMenuItem(
                                 text = { Text("Rename") },
                                 onClick = {
-                                    pendingRename = conversation
+                                    pendingRenameId = conversation.id
                                     contextMenuTarget = null
                                 },
                             )
@@ -186,7 +189,7 @@ fun ConversationListScreen(
             mutableStateOf(conversation.title ?: "")
         }
         AlertDialog(
-            onDismissRequest = { pendingRename = null },
+            onDismissRequest = { pendingRenameId = null },
             title = { Text("Rename conversation") },
             text = {
                 OutlinedTextField(
@@ -203,12 +206,12 @@ fun ConversationListScreen(
                         if (trimmed.isNotBlank()) {
                             viewModel.renameConversation(conversation.id, trimmed)
                         }
-                        pendingRename = null
+                        pendingRenameId = null
                     }
                 ) { Text("Save") }
             },
             dismissButton = {
-                TextButton(onClick = { pendingRename = null }) { Text("Cancel") }
+                TextButton(onClick = { pendingRenameId = null }) { Text("Cancel") }
             },
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -185,7 +185,7 @@ fun ConversationListScreen(
 
     // Rename dialog
     pendingRename?.let { conversation ->
-        var renameText by remember(conversation.id) {
+        var renameText by rememberSaveable(conversation.id) {
             mutableStateOf(conversation.title ?: "")
         }
         AlertDialog(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -8,6 +8,7 @@ sealed interface ChatUiState {
 
     data class Ready(
         val conversationId: String,
+        val conversationTitle: String?,
         val messages: List<ChatMessage>,
         val isGenerating: Boolean,
         val inputText: String,


### PR DESCRIPTION
## Summary

Implements smart conversation titles with manual override.

## Auto-titling
- Triggers after the **2nd complete exchange** (4 messages) when the conversation has no title yet
- Fire-and-forget: launched after streaming completes, never blocks the chat
- Guards on `isGenerating` — silently skips if engine is busy
- Prompt: first 2 user messages → 4-6 word title, quotes stripped, capped at 60 chars
- Silent failure — title stays null if generation fails

## Manual rename
- **Chat screen**: tap the title in the TopAppBar → AlertDialog with pre-filled TextField
- **Conversation list**: long-press any row → DropdownMenu with Rename / Delete options

## Files changed
- `ConversationRepository` — added `getConversation(id)` for nil-title guard
- `ChatUiState` — added `conversationTitle` field
- `ChatViewModel` — `generateTitle()`, `renameConversation()`, title state
- `ChatScreen` — tappable TopAppBar title with rename dialog
- `ConversationListScreen` — long-press context menu with rename + delete

Closes #15