### PR TITLE
fix: rebuild system prompt post-initialize so [Runtime] backend is correct

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -210,10 +210,13 @@ class ChatViewModel @Inject constructor(
         // e.g. a worker is RUNNING for a model that was already pushed via ADB.
         val modelPath = downloadManager.getModelPath(preferred) ?: return
         activeModel = preferred
-        val systemPrompt = buildSystemPrompt()
         try {
-            inferenceEngine.initialize(ModelConfig(modelPath = modelPath, systemPrompt = systemPrompt))
+            // Initialize with a prompt that omits backend (not yet known).
+            inferenceEngine.initialize(ModelConfig(modelPath = modelPath, systemPrompt = buildSystemPrompt()))
             estimatedTokensUsed = 0
+            // Rebuild and push system prompt now that activeBackend is resolved — this
+            // corrects the [Runtime] backend field which was null during initialize().
+            inferenceEngine.updateSystemPrompt(buildSystemPrompt())
         } catch (e: Exception) {
             _error.value = "Failed to load model: ${e.message}"
         }


### PR DESCRIPTION
## Bug
The `[Runtime]` block always showed `Backend: CPU` because `buildSystemPrompt()` was called *before* `initialize()`. At that point `activeBackend` is `null`, which fell back to `"CPU"`.

## Fix
Call `updateSystemPrompt(buildSystemPrompt())` immediately after `initialize()` returns. By then `activeBackend` is correctly resolved (GPU/NPU/CPU). The conversation has no KV cache yet so the reset in `updateSystemPrompt()` is harmless.