### PR TITLE
fix(#15): directive system prompt for title generation so output is terse

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
@@ -49,9 +49,13 @@ interface InferenceEngine {
      * not share KV cache state with the active chat. Safe to call for side tasks such
      * as title generation — the chat context is not affected.
      *
+     * @param systemPrompt Optional system prompt for the isolated conversation. Pass a
+     *   directive prompt (e.g. "Reply with only a title, no explanation") to constrain
+     *   the model's output format. Defaults to null (no system instruction).
+     *
      * Blocks until generation completes. Returns an empty string on error.
      */
-    suspend fun generateOnce(prompt: String): String
+    suspend fun generateOnce(prompt: String, systemPrompt: String? = null): String
 
     /**
      * Clear the conversation context window and start fresh.

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -227,12 +227,12 @@ class LiteRtInferenceEngine @Inject constructor(
      * cache state with the active chat. Acquires [generationMutex] — if the engine
      * is currently generating, this suspends until the active generation completes.
      */
-    override suspend fun generateOnce(prompt: String): String = withContext(LlmDispatcher) {
+    override suspend fun generateOnce(prompt: String, systemPrompt: String?): String = withContext(LlmDispatcher) {
         generationMutex.withLock {
             val eng = engine ?: return@withLock ""
             if (currentConfig == null) return@withLock ""
             val backend = _activeBackend.value ?: BackendType.CPU
-            val isolatedConv = eng.createConversation(buildConversationConfig(backend, null))
+            val isolatedConv = eng.createConversation(buildConversationConfig(backend, systemPrompt))
             val sb = StringBuilder()
             val latch = CompletableDeferred<Unit>()
             try {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -180,12 +182,20 @@ private fun ChatContent(
 
             AnimatedVisibility(visible = state.error != null) {
                 state.error?.let { err ->
-                    Text(
-                        text = err,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                    )
+                    val errorQuip = remember(err) { LoadingMessages.randomError() }
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+                        Text(
+                            text = err,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        Text(
+                            text = errorQuip,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
+                            modifier = Modifier.padding(top = 2.dp),
+                        )
+                    }
                 }
             }
 
@@ -296,7 +306,9 @@ private fun MessageBubble(message: ChatMessage) {
                             )
                             Text(
                                 text = generatingMessage,
-                                style = MaterialTheme.typography.labelSmall,
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontStyle = FontStyle.Italic,
+                                ),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
@@ -380,32 +392,46 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
 
 @Composable
 private fun LoadingContent() {
-    var messageIndex by remember { mutableIntStateOf(0) }
+    val theme = remember { LoadingMessages.randomTheme() }
+    val steps = listOf(theme.first, theme.second, theme.third)
+    var step by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(Unit) {
-        while (true) {
-            delay(3_000L)
-            messageIndex = (messageIndex + 1) % LoadingMessages.modelLoading.size
+        repeat(steps.size - 1) { i ->
+            delay(2_500L)
+            step = i + 1
         }
     }
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 32.dp),
+        ) {
             CircularProgressIndicator()
             AnimatedContent(
-                targetState = messageIndex,
+                targetState = step,
                 transitionSpec = {
-                    fadeIn(animationSpec = tween(400)) togetherWith fadeOut(animationSpec = tween(400))
+                    (fadeIn(animationSpec = tween(400)) +
+                        slideInVertically(animationSpec = tween(400)) { it / 2 }) togetherWith
+                        (fadeOut(animationSpec = tween(200)) +
+                            slideOutVertically(animationSpec = tween(200)) { -it / 2 })
                 },
                 modifier = Modifier.padding(top = 12.dp),
-                label = "loadingMessage",
-            ) { index ->
+                label = "loadingStep",
+            ) { currentStep ->
                 Text(
-                    text = LoadingMessages.modelLoading[index],
+                    text = steps[currentStep],
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
             }
+            Text(
+                text = "${step + 1} / ${steps.size}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp),
+            )
         }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -1,8 +1,11 @@
 package com.kernel.ai.feature.chat
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -54,9 +57,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -279,12 +284,22 @@ private fun MessageBubble(message: ChatMessage) {
                         style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
                     )
                     if (message.isStreaming) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .padding(top = 6.dp)
-                                .size(12.dp),
-                            strokeWidth = 2.dp,
-                        )
+                        val generatingMessage = remember { LoadingMessages.randomGenerating() }
+                        Row(
+                            modifier = Modifier.padding(top = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(12.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Text(
+                                text = generatingMessage,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
             }
@@ -365,14 +380,32 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
 
 @Composable
 private fun LoadingContent() {
+    var messageIndex by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(3_000L)
+            messageIndex = (messageIndex + 1) % LoadingMessages.modelLoading.size
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             CircularProgressIndicator()
-            Text(
-                text = "Loading model…",
-                style = MaterialTheme.typography.bodyMedium,
+            AnimatedContent(
+                targetState = messageIndex,
+                transitionSpec = {
+                    fadeIn(animationSpec = tween(400)) togetherWith fadeOut(animationSpec = tween(400))
+                },
                 modifier = Modifier.padding(top = 12.dp),
-            )
+                label = "loadingMessage",
+            ) { index ->
+                Text(
+                    text = LoadingMessages.modelLoading[index],
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -454,16 +454,22 @@ class ChatViewModel @Inject constructor(
             .take(2)
             .joinToString(" / ") { it.content.take(100) }
 
-        val titlePrompt = "Generate a short, descriptive title (4-6 words max, no quotes) for a conversation that starts with: $userMessages"
+        // Directive system prompt constrains Gemma to output only the title — no preamble,
+        // no "Here's a title:", no explanation. Without this, the model responds conversationally.
+        val titleSystemPrompt = "You are a title generator. Output ONLY a short title of 4-6 words. " +
+            "No explanation, no preamble, no quotes, no punctuation at the end. Just the title itself."
+        val titlePrompt = "Title for a conversation that starts with: $userMessages"
 
         try {
             // generateOnce() uses an isolated conversation — the chat KV cache is untouched.
             // It also acquires generationMutex, so it waits politely if the engine is busy.
-            val raw = inferenceEngine.generateOnce(titlePrompt)
+            val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = titleSystemPrompt)
             val title = raw
                 .trim()
                 .trimStart('"', '\'')
                 .trimEnd('"', '\'', '.')
+                .lines().first() // take only first line in case model adds extras
+                .trim()
                 .take(60)
             if (title.isNotBlank()) {
                 conversationRepository.renameConversation(id, title)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -466,10 +466,10 @@ class ChatViewModel @Inject constructor(
             val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = titleSystemPrompt)
             val title = raw
                 .trim()
+                .lines().first()          // extract first line before stripping quotes
+                .trim()
                 .trimStart('"', '\'')
                 .trimEnd('"', '\'', '.')
-                .lines().first() // take only first line in case model adds extras
-                .trim()
                 .take(60)
             if (title.isNotBlank()) {
                 conversationRepository.renameConversation(id, title)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
@@ -1,0 +1,34 @@
+package com.kernel.ai.feature.chat
+
+internal object LoadingMessages {
+    // Shown while the model is initialising (ChatUiState.Loading screen)
+    val modelLoading: List<String> = listOf(
+        "Lacing up the jandals…",
+        "Waking up the neurons, sweet as…",
+        "Chucking the model on the barbie…",
+        "She'll be right, loading up…",
+        "Giving the AI a good tiki tour…",
+        "Cranking up the inference engine…",
+        "Sweet as bro, nearly there…",
+        "Warming up the GPU, not even a drama…",
+        "Loading weights, choice as…",
+        "Just need a tick…",
+    )
+
+    // Shown in the typing indicator bubble while the model is generating
+    val generating: List<String> = listOf(
+        "Thinking…",
+        "On it…",
+        "Mull it over…",
+        "Sweet as, gimme a sec…",
+        "She's processing…",
+        "Churning through it…",
+        "Getting there…",
+        "Noodling on that…",
+        "Chewing the fat…",
+        "Brain going brrr…",
+    )
+
+    fun randomModelLoading(): String = modelLoading.random()
+    fun randomGenerating(): String = generating.random()
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
@@ -1,34 +1,119 @@
 package com.kernel.ai.feature.chat
 
+/**
+ * Fun themed loading messages for Kernel AI.
+ *
+ * Model loading uses 3-step narrative sequences. Call [randomTheme] on each init to pick a theme,
+ * then display step 1, 2, 3 sequentially as the engine warms up.
+ *
+ * Tone: casual, playful, slightly Kiwi (New Zealand).
+ */
 internal object LoadingMessages {
-    // Shown while the model is initialising (ChatUiState.Loading screen)
-    val modelLoading: List<String> = listOf(
-        "Lacing up the jandals…",
-        "Waking up the neurons, sweet as…",
-        "Chucking the model on the barbie…",
-        "She'll be right, loading up…",
-        "Giving the AI a good tiki tour…",
-        "Cranking up the inference engine…",
-        "Sweet as bro, nearly there…",
-        "Warming up the GPU, not even a drama…",
-        "Loading weights, choice as…",
-        "Just need a tick…",
+
+    /** Each theme is a Triple of (step1, step2, step3) strings. */
+    val themes: List<Triple<String, String, String>> = listOf(
+        // 🏗️ Digital Construction
+        Triple(
+            "Gathering the stray pixels…",
+            "Building the logic bridge…",
+            "Painting the interface gold.",
+        ),
+        // 💎 Gemologist (Gemma Theme)
+        Triple(
+            "Mining the raw weights…",
+            "Faceting the neural network…",
+            "Setting the gems in the crown.",
+        ),
+        // 🍳 Kernel Kitchen
+        Triple(
+            "Preheating the GPU…",
+            "Seasoning the data points…",
+            "Letting the tokens simmer.",
+        ),
+        // 💾 Retro Hardware
+        Triple(
+            "Adjusting the rabbit ear antennas…",
+            "Inserting Disc 2 of 4…",
+            "Tapping the side of the monitor.",
+        ),
+        // 🧙 Techno-Wizard
+        Triple(
+            "Casting the initialization spell…",
+            "Summoning the hidden layers…",
+            "Binding the spirit to the silicon.",
+        ),
+        // 🦆 Duck Pond
+        Triple(
+            "Rounding up the ducks…",
+            "Convincing them to stand in a row…",
+            "Giving them tiny little hats.",
+        ),
+        // 🛸 Sci-Fi Reboot
+        Triple(
+            "Recalibrating the flux capacitors…",
+            "Diverting power from life support to logic…",
+            "Engaging the hyper-drive.",
+        ),
+        // 🖖 Chief Engineer (Star Trek)
+        Triple(
+            "Re-aligning the dilithium crystals…",
+            "Venting drive plasma from the nacelles…",
+            "Overclocking the warp core (Don't tell the Captain).",
+        ),
+        // 🚀 Transporter Room
+        Triple(
+            "Energizing the pattern buffers…",
+            "Compensating for annular confinement beam drift…",
+            "Materializing the neural network.",
+        ),
+        // 📡 Sensor Sweep
+        Triple(
+            "Adjusting the lateral sensor array…",
+            "Filtering out subspace interference…",
+            "Locking onto the Gemma signal.",
+        ),
+        // ⚕️ Sickbay
+        Triple(
+            "Please state the nature of the medical emergency…",
+            "Calibrating the cortical monitors…",
+            "Stimulating the synaptic pathways.",
+        ),
+        // 🧊 Borg Collective
+        Triple(
+            "Assimilating local datasets…",
+            "Harmonizing the hive mind…",
+            "Resistance is futile (but loading is mandatory).",
+        ),
+        // 🪐 Technobabble Special
+        Triple(
+            "Modulating the phase variance…",
+            "Reversing the polarity of the neutron flow…",
+            "Rerouting auxiliary power to the logic sub-routines.",
+        ),
     )
 
-    // Shown in the typing indicator bubble while the model is generating
+    /** Shown when something goes sideways — Scotty/McCoy energy. */
+    val errorMessages: List<String> = listOf(
+        "Dammit Jim, I'm an AI, not a miracle worker!",
+        "I'm givin' her all she's got, Captain!",
+    )
+
+    /** Short messages shown in the typing indicator while the model is streaming a response. */
     val generating: List<String> = listOf(
-        "Thinking…",
         "On it…",
         "Mull it over…",
-        "Sweet as, gimme a sec…",
         "She's processing…",
         "Churning through it…",
-        "Getting there…",
         "Noodling on that…",
-        "Chewing the fat…",
         "Brain going brrr…",
     )
 
-    fun randomModelLoading(): String = modelLoading.random()
+    /** Picks a random 3-step theme for this loading session. */
+    fun randomTheme(): Triple<String, String, String> = themes.random()
+
+    /** Picks a random generating message for the typing indicator. */
     fun randomGenerating(): String = generating.random()
+
+    /** Picks a random error fallback quip. */
+    fun randomError(): String = errorMessages.random()
 }


### PR DESCRIPTION
## Bug
Auto-titles weren't generating properly. Root cause: `generateOnce()` created an isolated conversation with `systemPrompt = null`, so Gemma 4 responded conversationally — e.g. *"Sure! Here's a title: Chat About Android"* — which then got `take(60)`'d into junk.

## Fix
- Added optional `systemPrompt` parameter to `generateOnce()` in both `InferenceEngine` interface and `LiteRtInferenceEngine`
- `generateTitle()` passes a directive system prompt: *"Output ONLY a short title of 4-6 words. No explanation, no preamble, no quotes."*
- Simplified user-facing prompt: *"Title for a conversation that starts with: ..."*
- Added `.lines().first()` as a safety net in case the model still adds a trailing line

## Test
Send 2 exchanges in a new conversation → title should auto-appear in conversation list within a few seconds.