### PR TITLE
feat(#13): fun themed 3-step loading narratives

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
@@ -380,12 +382,14 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
 
 @Composable
 private fun LoadingContent() {
-    var messageIndex by remember { mutableIntStateOf(0) }
+    val theme = remember { LoadingMessages.randomTheme() }
+    val steps = remember(theme) { listOf(theme.first, theme.second, theme.third) }
+    var step by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(Unit) {
-        while (true) {
-            delay(3_000L)
-            messageIndex = (messageIndex + 1) % LoadingMessages.modelLoading.size
+        repeat(2) {
+            delay(2_500L)
+            step++
         }
     }
 
@@ -393,19 +397,26 @@ private fun LoadingContent() {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             CircularProgressIndicator()
             AnimatedContent(
-                targetState = messageIndex,
+                targetState = step,
                 transitionSpec = {
-                    fadeIn(animationSpec = tween(400)) togetherWith fadeOut(animationSpec = tween(400))
+                    (fadeIn(animationSpec = tween(400)) + slideInVertically { it / 2 }) togetherWith
+                        (fadeOut(animationSpec = tween(400)) + slideOutVertically { -it / 2 })
                 },
-                modifier = Modifier.padding(top = 12.dp),
-                label = "loadingMessage",
-            ) { index ->
+                modifier = Modifier.padding(top = 12.dp).widthIn(max = 280.dp),
+                label = "loadingStep",
+            ) { s ->
                 Text(
-                    text = LoadingMessages.modelLoading[index],
+                    text = steps[s],
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
             }
+            Text(
+                text = "${step + 1} / 3",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 6.dp),
+            )
         }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
@@ -1,34 +1,43 @@
 package com.kernel.ai.feature.chat
 
 internal object LoadingMessages {
-    // Shown while the model is initialising (ChatUiState.Loading screen)
-    val modelLoading: List<String> = listOf(
-        "Lacing up the jandals…",
-        "Waking up the neurons, sweet as…",
-        "Chucking the model on the barbie…",
-        "She'll be right, loading up…",
-        "Giving the AI a good tiki tour…",
-        "Cranking up the inference engine…",
-        "Sweet as bro, nearly there…",
-        "Warming up the GPU, not even a drama…",
-        "Loading weights, choice as…",
-        "Just need a tick…",
+
+    /** 13 themed 3-step narrative sequences. One is picked randomly per loading session. */
+    val themes: List<Triple<String, String, String>> = listOf(
+        Triple("Gathering the stray pixels…", "Building the logic bridge…", "Painting the interface gold."),
+        Triple("Mining the raw weights…", "Faceting the neural network…", "Setting the gems in the crown."),
+        Triple("Preheating the GPU…", "Seasoning the data points…", "Letting the tokens simmer."),
+        Triple("Adjusting the rabbit ear antennas…", "Inserting Disc 2 of 4…", "Tapping the side of the monitor."),
+        Triple("Casting the initialization spell…", "Summoning the hidden layers…", "Binding the spirit to the silicon."),
+        Triple("Rounding up the ducks…", "Convincing them to stand in a row…", "Giving them tiny little hats."),
+        Triple("Recalibrating the flux capacitors…", "Diverting power from life support to logic…", "Engaging the hyper-drive."),
+        Triple("Re-aligning the dilithium crystals…", "Venting drive plasma from the nacelles…", "Overclocking the warp core (Don't tell the Captain)."),
+        Triple("Energizing the pattern buffers…", "Compensating for annular confinement beam drift…", "Materializing the neural network."),
+        Triple("Adjusting the lateral sensor array…", "Filtering out subspace interference…", "Locking onto the Gemma signal."),
+        Triple("Please state the nature of the medical emergency…", "Calibrating the cortical monitors…", "Stimulating the synaptic pathways."),
+        Triple("Assimilating local datasets…", "Harmonizing the hive mind…", "Resistance is futile (but loading is mandatory)."),
+        Triple("Modulating the phase variance…", "Reversing the polarity of the neutron flow…", "Rerouting auxiliary power to the logic sub-routines."),
     )
 
-    // Shown in the typing indicator bubble while the model is generating
+    /** Shown in the typing indicator while the model is streaming a response. */
     val generating: List<String> = listOf(
-        "Thinking…",
         "On it…",
         "Mull it over…",
         "Sweet as, gimme a sec…",
         "She's processing…",
         "Churning through it…",
-        "Getting there…",
         "Noodling on that…",
         "Chewing the fat…",
         "Brain going brrr…",
     )
 
-    fun randomModelLoading(): String = modelLoading.random()
+    /** Shown as secondary text when the engine fails to load. */
+    val errorMessages: List<String> = listOf(
+        "Dammit Jim, I'm an AI, not a miracle worker!",
+        "I'm givin' her all she's got, Captain!",
+    )
+
+    fun randomTheme(): Triple<String, String, String> = themes.random()
     fun randomGenerating(): String = generating.random()
+    fun randomError(): String = errorMessages.random()
 }


### PR DESCRIPTION
Closes #13

## What's new

### LoadingMessages.kt
13 themed 3-step narrative sequences from the issue spec:
- Digital Construction, Gemologist, Kernel Kitchen, Retro Hardware
- Techno-Wizard, Duck Pond, Sci-Fi Reboot
- Chief Engineer, Transporter Room, Sensor Sweep, Sickbay
- Borg Collective, Technobabble Special
- Error fallbacks: "Dammit Jim, I'm an AI, not a miracle worker!" / "I'm givin' her all she's got, Captain!"
- Generating indicator messages (casual/Kiwi-toned)

### LoadingContent()
- Random theme picked once per loading session
- Steps advance every 2.5s via LaunchedEffect
- AnimatedContent with fade + slide-up transition
- Step counter "1 / 3" in secondary style

### Typing indicator
- Casual generating message shown while streaming, stable per composable instance

### Error state
- Scotty/McCoy quip as secondary text below engine errors

## Test
Force-close and relaunch the app — each launch should pick a different theme and step through all 3 stages.