### PR TITLE
fix(#15): title generation — reuse existing LiteRT session

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -228,8 +228,15 @@ class LiteRtInferenceEngine @Inject constructor(
      * is currently generating, this suspends until the active generation completes.
      */
     override suspend fun generateOnce(prompt: String, systemPrompt: String?): String = withContext(LlmDispatcher) {
-        // Use tryLock + retry loop to avoid potential deadlock with the single-threaded dispatcher.
-        // The generate() flow's awaitClose needs to run on this same dispatcher to unlock the mutex.
+        // LiteRT only supports one session at a time — reuse the existing conversation
+        // rather than calling createConversation() (which throws FAILED_PRECONDITION if
+        // a session already exists). The title prompt is self-contained so it works
+        // correctly within the existing session context.
+        val conv = conversation ?: return@withContext ""
+
+        // Use tryLock + retry loop to avoid potential deadlock with the single-threaded
+        // dispatcher. The generate() flow's awaitClose needs to run on this same
+        // dispatcher to unlock the mutex.
         var acquired = false
         repeat(20) { attempt ->
             if (generationMutex.tryLock()) {
@@ -245,31 +252,22 @@ class LiteRtInferenceEngine @Inject constructor(
         }
 
         try {
-            val eng = engine ?: return@withContext ""
-            if (currentConfig == null) return@withContext ""
-            val backend = _activeBackend.value ?: BackendType.CPU
-            val isolatedConv = eng.createConversation(buildConversationConfig(backend, systemPrompt))
             val sb = StringBuilder()
             val latch = CompletableDeferred<Unit>()
-            try {
-                isolatedConv.sendMessageAsync(
-                    Contents.of(Content.Text(prompt)),
-                    object : MessageCallback {
-                        override fun onMessage(message: Message) {
-                            val text = message.toString()
-                            if (text.isNotEmpty() && !text.startsWith("<ctrl")) sb.append(text)
-                        }
-                        override fun onDone() { latch.complete(Unit) }
-                        override fun onError(throwable: Throwable) {
-                            latch.completeExceptionally(throwable)
-                        }
-                    },
-                )
-                latch.await()
-            } finally {
-                safeCancel(isolatedConv)
-                safeClose(isolatedConv, "title-conv")
-            }
+            conv.sendMessageAsync(
+                Contents.of(Content.Text(prompt)),
+                object : MessageCallback {
+                    override fun onMessage(message: Message) {
+                        val text = message.toString()
+                        if (text.isNotEmpty() && !text.startsWith("<ctrl")) sb.append(text)
+                    }
+                    override fun onDone() { latch.complete(Unit) }
+                    override fun onError(throwable: Throwable) {
+                        latch.completeExceptionally(throwable)
+                    }
+                },
+            )
+            latch.await()
             sb.toString()
         } finally {
             generationMutex.unlock()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -473,25 +473,32 @@ class ChatViewModel @Inject constructor(
             return
         }
 
-        // Directive system prompt constrains Gemma to output only the title — no preamble,
-        // no "Here's a title:", no explanation. Without this, the model responds conversationally.
-        val titleSystemPrompt = "You are a title generator. Output ONLY a short title of 4-6 words. " +
-            "No explanation, no preamble, no quotes, no punctuation at the end. Just the title itself."
-        val titlePrompt = "Title for a conversation that starts with: $userMessages"
+        // Embed the directive in the prompt itself — we're using the existing conversation
+        // so a separate systemPrompt has no effect here.
+        val titlePrompt = "Reply with ONLY a short conversation title, 4-6 words, no quotes, " +
+            "no markdown, no preamble, no alternatives. Just the title on one line.\n\n" +
+            "Conversation: $userMessages"
 
         Log.d("KernelAI", "Generating title for $id with prompt: ${titlePrompt.take(80)}...")
 
         try {
-            // generateOnce() uses an isolated conversation — the chat KV cache is untouched.
-            // It also acquires generationMutex, so it waits politely if the engine is busy.
-            val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = titleSystemPrompt)
+            // generateOnce() reuses the existing conversation session (LiteRT only supports
+            // one session at a time) and acquires generationMutex so it waits if engine is busy.
+            val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = null)
             Log.d("KernelAI", "Raw title output: \"$raw\"")
             val title = raw
                 .trim()
-                .lines().first()          // extract first line before stripping quotes
+                // Take only the first line — ignore "Or, ..." alternatives
+                .lines().first().trim()
+                // Strip leading preamble like "How about:", "Here's a title:", "Title:"
+                .replace(Regex("^(?:How about|Here(?:'s| is) (?:a |your )?title|Title)[:\\s]*", RegexOption.IGNORE_CASE), "")
+                // Strip markdown bold/italic markers
+                .replace(Regex("[*_]+"), "")
+                // Strip surrounding quotes
+                .trim('"', '\'', '\u201C', '\u201D')
+                // Strip trailing punctuation
+                .trimEnd('.', '?', '!')
                 .trim()
-                .trimStart('"', '\'')
-                .trimEnd('"', '\'', '.')
                 .take(60)
             if (title.isNotBlank()) {
                 conversationRepository.renameConversation(id, title)


### PR DESCRIPTION
## Problem

PR #89 missed the root cause: `generateOnce()` called `engine.createConversation()` which throws `FAILED_PRECONDITION: A session already exists` because LiteRT only supports **one session at a time**.

Device logs confirmed this:
```
Auto-title generation failed: Failed to create conversation: FAILED_PRECONDITION: A session already exists.
```

## Fix

- **Reuse the existing `conversation` field** instead of calling `createConversation()`
- **Tighter prompt** — embeds the directive inline (system prompt has no effect on existing sessions), instructs the model to respond with only the title
- **Better post-processing** —

## Verified on device

```
Raw title output: "Sleep Time and Wind Down Tips"
Auto-titled conversation: Sleep Time and Wind Down Tips
```

Closes #15