### PR TITLE
feat(#92): memory management screen in Settings

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
+import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
 
@@ -15,6 +16,7 @@ private const val ROUTE_LIST = "conversation_list"
 private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
+private const val ROUTE_MEMORY = "settings/memory"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
 @Composable
@@ -81,11 +83,20 @@ fun KernelNavHost() {
                 onNavigateToUserProfile = {
                     navController.navigate(ROUTE_USER_PROFILE)
                 },
+                onNavigateToMemory = {
+                    navController.navigate(ROUTE_MEMORY)
+                },
             )
         }
 
         composable(ROUTE_USER_PROFILE) {
             UserProfileScreen(
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(ROUTE_MEMORY) {
+            MemoryScreen(
                 onBack = { navController.popBackStack() },
             )
         }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -57,7 +57,9 @@ fun MemoryScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = viewModel::openAddDialog) {
+            FloatingActionButton(
+                onClick = { if (!uiState.isSubmitting) viewModel.openAddDialog() },
+            ) {
                 Icon(Icons.Default.Add, contentDescription = "Add core memory")
             }
         },
@@ -164,7 +166,7 @@ fun MemoryScreen(
             confirmButton = {
                 TextButton(
                     onClick = viewModel::addCoreMemory,
-                    enabled = uiState.addDialogText.isNotBlank(),
+                    enabled = uiState.addDialogText.isNotBlank() && !uiState.isSubmitting,
                 ) {
                     Text("Add")
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -1,0 +1,202 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MemoryScreen(
+    onBack: () -> Unit,
+    viewModel: MemoryViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Memory") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = viewModel::openAddDialog) {
+                Icon(Icons.Default.Add, contentDescription = "Add core memory")
+            }
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(bottom = 88.dp), // avoid FAB overlap
+        ) {
+            // ── Stats ──────────────────────────────────────────────────────
+            item {
+                SectionHeader("Stats")
+            }
+            item {
+                val total = uiState.coreMemories.size + uiState.episodicCount
+                ListItem(
+                    headlineContent = {
+                        Text("Total: $total (Core: ${uiState.coreMemories.size}, Episodic: ${uiState.episodicCount})")
+                    },
+                )
+                HorizontalDivider()
+            }
+
+            // ── Core Memories ──────────────────────────────────────────────
+            item {
+                SectionHeader("Core Memories")
+            }
+
+            if (uiState.coreMemories.isEmpty()) {
+                item {
+                    Text(
+                        text = "No core memories yet. Tap + to add one.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+            } else {
+                items(uiState.coreMemories, key = { it.id }) { memory ->
+                    ListItem(
+                        headlineContent = { Text(memory.content) },
+                        supportingContent = {
+                            Text(
+                                text = "Source: ${memory.source} · Accessed ${memory.accessCount}×",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        trailingContent = {
+                            IconButton(onClick = { viewModel.deleteCoreMemory(memory.id) }) {
+                                Icon(Icons.Default.Delete, contentDescription = "Delete memory")
+                            }
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            // ── Episodic Memories ──────────────────────────────────────────
+            item {
+                Spacer(Modifier.height(8.dp))
+                SectionHeader("Episodic Memories")
+            }
+            item {
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    Text(
+                        text = "${uiState.episodicCount} stored memories",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        OutlinedButton(
+                            onClick = viewModel::showClearEpisodicConfirmation,
+                            enabled = uiState.episodicCount > 0,
+                        ) {
+                            Text("Clear all episodic")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Add Core Memory Dialog ─────────────────────────────────────────────
+    if (uiState.isAddDialogOpen) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissAddDialog,
+            title = { Text("Add core memory") },
+            text = {
+                OutlinedTextField(
+                    value = uiState.addDialogText,
+                    onValueChange = viewModel::onAddDialogTextChange,
+                    label = { Text("Memory") },
+                    placeholder = { Text("e.g. I prefer short answers") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = false,
+                    minLines = 2,
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = viewModel::addCoreMemory,
+                    enabled = uiState.addDialogText.isNotBlank(),
+                ) {
+                    Text("Add")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissAddDialog) { Text("Cancel") }
+            },
+        )
+    }
+
+    // ── Clear Episodic Confirmation Dialog ─────────────────────────────────
+    if (uiState.showClearConfirmation) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissClearConfirmation,
+            title = { Text("Clear episodic memories?") },
+            text = { Text("This will delete all episodic memories. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = viewModel::clearEpisodicMemories) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissClearConfirmation) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -25,23 +25,27 @@ class MemoryViewModel @Inject constructor(
         val isAddDialogOpen: Boolean = false,
         val addDialogText: String = "",
         val showClearConfirmation: Boolean = false,
+        val isSubmitting: Boolean = false,
     )
 
     private val _dialogState = MutableStateFlow(
         Triple(/* isAddDialogOpen */ false, /* addDialogText */ "", /* showClearConfirmation */ false)
     )
+    private val _isSubmitting = MutableStateFlow(false)
 
     val uiState: StateFlow<MemoryUiState> = combine(
         memoryRepository.observeCoreMemories(),
         memoryRepository.observeEpisodicCount(),
         _dialogState,
-    ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation) ->
+        _isSubmitting,
+    ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
         MemoryUiState(
             coreMemories = coreMemories,
             episodicCount = episodicCount,
             isAddDialogOpen = isAddDialogOpen,
             addDialogText = addDialogText,
             showClearConfirmation = showClearConfirmation,
+            isSubmitting = isSubmitting,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -62,11 +66,19 @@ class MemoryViewModel @Inject constructor(
     }
 
     fun addCoreMemory() {
+        if (!_isSubmitting.compareAndSet(expect = false, update = true)) return
         val text = _dialogState.value.second.trim()
-        if (text.isBlank()) return
+        if (text.isBlank()) {
+            _isSubmitting.value = false
+            return
+        }
         viewModelScope.launch {
-            memoryRepository.addCoreMemory(content = text, source = "user")
-            dismissAddDialog()
+            try {
+                memoryRepository.addCoreMemory(content = text, source = "user")
+                dismissAddDialog()
+            } finally {
+                _isSubmitting.value = false
+            }
         }
     }
 
@@ -84,8 +96,11 @@ class MemoryViewModel @Inject constructor(
 
     fun clearEpisodicMemories() {
         viewModelScope.launch {
-            memoryRepository.clearEpisodicMemories()
-            _dialogState.update { it.copy(third = false) }
+            try {
+                memoryRepository.clearEpisodicMemories()
+            } finally {
+                _dialogState.update { it.copy(third = false) }
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -1,0 +1,91 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.entity.CoreMemoryEntity
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MemoryViewModel @Inject constructor(
+    private val memoryRepository: MemoryRepository,
+) : ViewModel() {
+
+    data class MemoryUiState(
+        val coreMemories: List<CoreMemoryEntity> = emptyList(),
+        val episodicCount: Int = 0,
+        val isAddDialogOpen: Boolean = false,
+        val addDialogText: String = "",
+        val showClearConfirmation: Boolean = false,
+    )
+
+    private val _dialogState = MutableStateFlow(
+        Triple(/* isAddDialogOpen */ false, /* addDialogText */ "", /* showClearConfirmation */ false)
+    )
+
+    val uiState: StateFlow<MemoryUiState> = combine(
+        memoryRepository.observeCoreMemories(),
+        memoryRepository.observeEpisodicCount(),
+        _dialogState,
+    ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation) ->
+        MemoryUiState(
+            coreMemories = coreMemories,
+            episodicCount = episodicCount,
+            isAddDialogOpen = isAddDialogOpen,
+            addDialogText = addDialogText,
+            showClearConfirmation = showClearConfirmation,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = MemoryUiState(),
+    )
+
+    fun openAddDialog() {
+        _dialogState.update { it.copy(first = true) }
+    }
+
+    fun dismissAddDialog() {
+        _dialogState.update { it.copy(first = false, second = "") }
+    }
+
+    fun onAddDialogTextChange(text: String) {
+        _dialogState.update { it.copy(second = text) }
+    }
+
+    fun addCoreMemory() {
+        val text = _dialogState.value.second.trim()
+        if (text.isBlank()) return
+        viewModelScope.launch {
+            memoryRepository.addCoreMemory(content = text, source = "user")
+            dismissAddDialog()
+        }
+    }
+
+    fun deleteCoreMemory(id: String) {
+        viewModelScope.launch { memoryRepository.deleteCoreMemory(id) }
+    }
+
+    fun showClearEpisodicConfirmation() {
+        _dialogState.update { it.copy(third = true) }
+    }
+
+    fun dismissClearConfirmation() {
+        _dialogState.update { it.copy(third = false) }
+    }
+
+    fun clearEpisodicMemories() {
+        viewModelScope.launch {
+            memoryRepository.clearEpisodicMemories()
+            _dialogState.update { it.copy(third = false) }
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
@@ -42,6 +43,7 @@ import kotlinx.coroutines.launch
 fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
+    onNavigateToMemory: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -196,6 +198,18 @@ fun SettingsScreen(
                 headlineContent = { Text("User Profile") },
                 supportingContent = { Text("Tell Kernel about yourself") },
                 leadingContent = { Icon(Icons.Default.Person, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            // ── Memory ────────────────────────────────────────────────────
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToMemory() },
+                headlineContent = { Text("Memory") },
+                supportingContent = { Text("Manage stored memories") },
+                leadingContent = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -50,6 +51,7 @@ class MemoryViewModelTest {
         Dispatchers.resetMain()
     }
 
+    @Suppress("unused")
     private fun coreMemory(id: String, content: String) = CoreMemoryEntity(
         id = id,
         content = content,
@@ -96,19 +98,31 @@ class MemoryViewModelTest {
     fun `clearEpisodicMemories calls repository and dismisses confirmation`() = runTest {
         coEvery { memoryRepository.clearEpisodicMemories() } just Runs
 
+        // Subscribe to uiState so WhileSubscribed upstream starts emitting
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
         viewModel.showClearEpisodicConfirmation()
         testDispatcher.scheduler.advanceUntilIdle()
-        assertTrue(viewModel.uiState.value.showClearConfirmation)
+        assertTrue(states.last().showClearConfirmation)
 
         viewModel.clearEpisodicMemories()
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify(exactly = 1) { memoryRepository.clearEpisodicMemories() }
-        assertFalse(viewModel.uiState.value.showClearConfirmation)
+        assertFalse(states.last().showClearConfirmation)
+
+        collectJob.cancel()
     }
 
     @Test
     fun `dismissAddDialog clears dialog text`() = runTest {
+        // Subscribe to uiState so WhileSubscribed upstream starts emitting
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
         viewModel.openAddDialog()
         viewModel.onAddDialogTextChange("some text")
         testDispatcher.scheduler.advanceUntilIdle()
@@ -116,8 +130,10 @@ class MemoryViewModelTest {
         viewModel.dismissAddDialog()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val state = viewModel.uiState.value
+        val state = states.last()
         assertFalse(state.isAddDialogOpen)
         assertEquals("", state.addDialogText)
+
+        collectJob.cancel()
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.kernel.ai.feature.settings
+
+import com.kernel.ai.core.memory.entity.CoreMemoryEntity
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockKExtension::class)
+class MemoryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val memoryRepository: MemoryRepository = mockk()
+
+    private val coreMemoriesFlow = MutableStateFlow<List<CoreMemoryEntity>>(emptyList())
+    private val episodicCountFlow = MutableStateFlow(0)
+
+    private lateinit var viewModel: MemoryViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { memoryRepository.observeCoreMemories() } returns coreMemoriesFlow
+        every { memoryRepository.observeEpisodicCount() } returns episodicCountFlow
+        viewModel = MemoryViewModel(memoryRepository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun coreMemory(id: String, content: String) = CoreMemoryEntity(
+        id = id,
+        content = content,
+        createdAt = 0L,
+        lastAccessedAt = 0L,
+        source = "user",
+    )
+
+    @Test
+    fun `addCoreMemory calls repository with trimmed text`() = runTest {
+        coEvery { memoryRepository.addCoreMemory(any(), any(), any()) } returns "id-1"
+
+        viewModel.openAddDialog()
+        viewModel.onAddDialogTextChange("  remember this  ")
+        viewModel.addCoreMemory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            memoryRepository.addCoreMemory(content = "remember this", source = "user")
+        }
+    }
+
+    @Test
+    fun `addCoreMemory does not call repository when text is blank`() = runTest {
+        viewModel.openAddDialog()
+        viewModel.onAddDialogTextChange("   ")
+        viewModel.addCoreMemory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { memoryRepository.addCoreMemory(any(), any(), any()) }
+    }
+
+    @Test
+    fun `deleteCoreMemory delegates to repository`() = runTest {
+        coEvery { memoryRepository.deleteCoreMemory(any()) } just Runs
+
+        viewModel.deleteCoreMemory("test-id")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { memoryRepository.deleteCoreMemory("test-id") }
+    }
+
+    @Test
+    fun `clearEpisodicMemories calls repository and dismisses confirmation`() = runTest {
+        coEvery { memoryRepository.clearEpisodicMemories() } just Runs
+
+        viewModel.showClearEpisodicConfirmation()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.showClearConfirmation)
+
+        viewModel.clearEpisodicMemories()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { memoryRepository.clearEpisodicMemories() }
+        assertFalse(viewModel.uiState.value.showClearConfirmation)
+    }
+
+    @Test
+    fun `dismissAddDialog clears dialog text`() = runTest {
+        viewModel.openAddDialog()
+        viewModel.onAddDialogTextChange("some text")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.dismissAddDialog()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isAddDialogOpen)
+        assertEquals("", state.addDialogText)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Memory screen under Settings to inspect and manage stored memories.

### Sections
- **Stats**: total memory count (core + episodic)
- **Core Memories**: scrollable list with per-item delete, + Add FAB opens dialog
- **Episodic Memories**: count + Clear all button with confirmation dialog

### Navigation
Settings screen gains a 'Memory' row → navigates to new MemoryScreen

### Changes
- New `MemoryViewModel` backed by `MemoryRepository` (Flow-based)  
- New `MemoryScreen` composable (Material 3, Compose)
- `SettingsScreen` updated with Memory navigation row
- `KernelNavHost` updated with `settings/memory` route
- Unit tests for MemoryViewModel actions

Closes #92

> **Note**: Depends on #101 (feature/memory-tiers). This PR targets main and will apply cleanly once that branch is merged.