### PR TITLE
docs: device testing checklist for PRs #95, #100, #101, #102

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ models/
 !keystore/debug.keystore
 google-services.json
 .kotlin/
-docs/testing/
+# docs/testing/ intentionally excluded — local test notes only
+# docs/testing/
 local.properties

--- a/docs/testing/PR-95-100-101-102-testing.md
+++ b/docs/testing/PR-95-100-101-102-testing.md
@@ -1,0 +1,100 @@
+# Device Testing — PRs #95, #100, #101, #102
+
+Install the latest build and run through the test cases below.
+
+```bash
+JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew installDebug
+```
+
+Or download the APK from the latest CI run on `main`.
+
+---
+
+## PR #95 — Complex LaTeX rendering
+
+**What changed:** Extended the LaTeX-to-Unicode pipeline to handle structural math expressions: fractions, square roots, subscripts, superscripts, math functions (`\sin`, `\lim`, etc.), `\left`/`\right` delimiters, and `$...$` / `$$...$$` wrappers.
+
+### Test cases
+
+| # | Steps | Expected |
+|---|-------|----------|
+| 1 | Ask: *"show me the quadratic formula in LaTeX"* | Renders as `x = (-b ± √(b² - 4ac))/2a` — no raw `\frac`, `\sqrt`, `\pm` |
+| 2 | Ask: *"what is the limit of sin(x)/x as x approaches 0?"* | Renders as `lim_(x → 0) sin(x)/x = 1` — no raw `\lim`, `\frac`, `\to` |
+| 3 | Ask: *"write Euler's identity using LaTeX"* | `e^(iπ) + 1 = 0` — no raw `\pi` or `^` with brace |
+| 4 | Ask: *"show a sum formula using sigma notation"* | `∑` symbol appears, subscript/superscript rendered (e.g. `∑ᵢ₌₁ⁿ`) |
+| 5 | Ask: *"what does alpha + beta equal in LaTeX?"* | `α + β` — Greek letters correct |
+| 6 | Ask a question with code in the response (e.g. *"show me a Python function"*) | Code block content unchanged — no LaTeX corruption inside ` ``` ` blocks |
+| 7 | Trigger a response with `\to` in prose AND `\top` in math | Arrow `→` appears, `\top` is NOT corrupted to `→p` |
+
+---
+
+## PR #100 — Copy chat content
+
+**What changed:** Long-press any message bubble to copy it. Tap the copy icon in the top bar to copy the full conversation. Both strip markdown before copying.
+
+### Test cases
+
+| # | Steps | Expected |
+|---|-------|----------|
+| 1 | Long-press a user message bubble | Context menu appears with "Copy message" option |
+| 2 | Tap "Copy message", paste into Notes | Plain text — no `**`, `*`, `#`, backticks, `[link](url)` |
+| 3 | Long-press an assistant message with **bold** and `code` | Same — stripped to plain text on paste |
+| 4 | Long-press triggers a brief snackbar | "Message copied" snackbar appears at bottom |
+| 5 | Tap the copy icon in the chat top bar | Snackbar: "Conversation copied" |
+| 6 | Paste full conversation into Notes | Format: `You: <message>` / `Jandal: <response>` alternating, markdown stripped |
+| 7 | Long-press a message while AI is generating | Should not crash; context menu may be suppressed or work normally |
+
+---
+
+## PR #101 — Episodic + Core memory tiers
+
+**What changed:** Memory split into two Room tables — `episodic_memories` (volatile, 30d TTL, 500 max) and `core_memories` (permanent, 200 max). RAG retrieves from both. Core memories injected into system prompt.
+
+### Test cases
+
+| # | Steps | Expected |
+|---|-------|----------|
+| 1 | Open the app after installing | No crash on DB migration (v3 → v4) |
+| 2 | Start a new chat, send a few messages | App functions normally — no regression in chat |
+| 3 | Enable logcat: `adb logcat -s KernelAI \| grep -i "memory\|rag"` | See `[Core Memories]` and `[Episodic Memories]` sections in context log lines |
+| 4 | Go to Settings → Memory → add a core memory: *"I am vegetarian"* | Memory appears in Core Memories list |
+| 5 | Start a new conversation, ask *"what should I eat for dinner?"* | Response takes vegetarian preference into account (core memory injected into prompt) |
+| 6 | Check logcat for RAG context | Core memory *"I am vegetarian"* appears in context block |
+| 7 | Return to Settings → Memory, delete the core memory | It disappears from the list immediately |
+| 8 | Start a new conversation, ask the same dinner question | No vegetarian preference (memory was deleted) |
+
+---
+
+## PR #102 — Memory management UI
+
+**What changed:** New "Memory" screen in Settings — Core Memories CRUD, Episodic memory browser and clear, stats.
+
+### Test cases
+
+| # | Steps | Expected |
+|---|-------|----------|
+| 1 | Open Settings | "Memory" row visible with Bookmarks icon |
+| 2 | Tap "Memory" | Memory screen opens with three sections: Core Memories, Episodic Memories, Stats |
+| 3 | Stats section | Shows total count, core count, episodic count (all 0 on fresh install) |
+| 4 | Tap "+" FAB | Dialog appears with text input and Add/Cancel buttons |
+| 5 | Type a memory and tap Add | Memory appears in Core Memories list; Stats count increments |
+| 6 | Add 3 core memories | All 3 visible in the list |
+| 7 | Tap the delete icon on one memory | Confirmation not needed — memory removed, count decrements |
+| 8 | Chat for a while (send 5+ messages) | Episodic count in Stats increments |
+| 9 | Tap "Clear all episodic" | Confirmation dialog appears |
+| 10 | Confirm clear | Episodic count resets to 0 |
+| 11 | Tap "Clear all episodic" then Cancel | Nothing deleted, count unchanged |
+| 12 | Tap Add, leave text blank, tap Add | Button disabled or no memory added (blank input rejected) |
+| 13 | Rapidly double-tap Add button | Only one memory added (double-tap guard works) |
+
+---
+
+## Regression — General smoke test
+
+| # | Steps | Expected |
+|---|-------|----------|
+| 1 | Start a new conversation, send 2 exchanges | Title auto-generates correctly (no "How about:" prefix) |
+| 2 | Backend shown in settings/system prompt | "GPU" or "CPU" — not blank |
+| 3 | Loading screen on cold start | Animated 3-step narrative plays; dark background |
+| 4 | Model selection in Settings | Can switch between E-2B and E-4B |
+| 5 | Rename a conversation | Title updates in list and header |


### PR DESCRIPTION
Adds `docs/testing/PR-95-100-101-102-testing.md` with device test cases covering:

- **PR #95** — Complex LaTeX rendering (fractions, limits, subscripts, superscripts)
- **PR #100** — Copy chat content (long-press message, copy all conversation)
- **PR #101** — Episodic + core memory tiers (DB migration, RAG context, logcat validation)
- **PR #102** — Memory management UI (CRUD, stats, clear episodic)
- **Regression** — General smoke test

Also unignores `docs/testing/` in `.gitignore` so checklists are tracked.