### PR TITLE
fix(#107): convert LaTeX to Unicode before clipboard copy

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -127,11 +127,11 @@ fun ChatScreen(
             onRenameConversation = viewModel::renameConversation,
             snackbarHostState = snackbarHostState,
             onCopyMessage = { content ->
-                clipboardManager.setText(AnnotatedString(stripMarkdown(content)))
+                clipboardManager.setText(AnnotatedString(stripMarkdownForClipboard(content)))
                 scope.launch { snackbarHostState.showSnackbar("Message copied") }
             },
             onCopyAll = {
-                val text = stripMarkdown(viewModel.getConversationAsText())
+                val text = stripMarkdownForClipboard(viewModel.getConversationAsText())
                 clipboardManager.setText(AnnotatedString(text))
                 scope.launch { snackbarHostState.showSnackbar("Conversation copied") }
             },

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -1,6 +1,13 @@
 package com.kernel.ai.feature.chat
 
 /**
+ * Converts LaTeX expressions to Unicode and strips Markdown syntax,
+ * producing clean plain text suitable for clipboard output.
+ */
+internal fun stripMarkdownForClipboard(text: String): String =
+    stripMarkdown(convertLatexToUnicode(text))
+
+/**
  * Strips common Markdown syntax from text for plain-text clipboard output.
  */
 internal fun stripMarkdown(text: String): String {


### PR DESCRIPTION
## Summary

Fixes the clipboard copy feature (introduced in PR #100) where raw LaTeX expressions such as `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` were pasted verbatim instead of being converted to readable Unicode.

## Changes

### `ChatTextUtils.kt`
Added `stripMarkdownForClipboard()` — a thin wrapper that pipelines text through `convertLatexToUnicode()` (already in `MarkdownRenderer.kt`, same module) before `stripMarkdown()`:

```kotlin
internal fun stripMarkdownForClipboard(text: String): String =
    stripMarkdown(convertLatexToUnicode(text))
```

`stripMarkdown()` is left unchanged (used in tests).

### `ChatScreen.kt`
Updated both clipboard call sites to use the new function:
- `onCopyMessage` (line 130)
- `onCopyAll` (line 134)

## Testing
- `./gradlew :feature:chat:compileDebugKotlin` ✅

Closes #107