### PR TITLE
fix(#108): confirmation dialog before deleting a core memory

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -148,8 +148,7 @@ fun MemoryScreen(
     }
 
     // ── Delete Core Memory Confirmation Dialog ─────────────────────────────
-    val pendingDeleteId by viewModel.pendingDeleteId.collectAsStateWithLifecycle()
-    pendingDeleteId?.let { pendingId ->
+    uiState.pendingDeleteId?.let { pendingId ->
         AlertDialog(
             onDismissRequest = viewModel::dismissDeleteConfirmation,
             title = { Text("Delete memory?") },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -110,7 +110,7 @@ fun MemoryScreen(
                             )
                         },
                         trailingContent = {
-                            IconButton(onClick = { viewModel.deleteCoreMemory(memory.id) }) {
+                            IconButton(onClick = { viewModel.requestDeleteCoreMemory(memory.id) }) {
                                 Icon(Icons.Default.Delete, contentDescription = "Delete memory")
                             }
                         },
@@ -145,6 +145,22 @@ fun MemoryScreen(
                 }
             }
         }
+    }
+
+    // ── Delete Core Memory Confirmation Dialog ─────────────────────────────
+    val pendingDeleteId by viewModel.pendingDeleteId.collectAsStateWithLifecycle()
+    pendingDeleteId?.let { pendingId ->
+        AlertDialog(
+            onDismissRequest = viewModel::dismissDeleteConfirmation,
+            title = { Text("Delete memory?") },
+            text = { Text("This memory will be permanently removed. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteCoreMemory(pendingId) }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissDeleteConfirmation) { Text("Cancel") }
+            },
+        )
     }
 
     // ── Add Core Memory Dialog ─────────────────────────────────────────────

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -33,6 +33,9 @@ class MemoryViewModel @Inject constructor(
     )
     private val _isSubmitting = MutableStateFlow(false)
 
+    /** ID of the core memory awaiting delete confirmation; null when no dialog is shown. */
+    val pendingDeleteId = MutableStateFlow<String?>(null)
+
     val uiState: StateFlow<MemoryUiState> = combine(
         memoryRepository.observeCoreMemories(),
         memoryRepository.observeEpisodicCount(),
@@ -82,7 +85,16 @@ class MemoryViewModel @Inject constructor(
         }
     }
 
+    fun requestDeleteCoreMemory(id: String) {
+        pendingDeleteId.value = id
+    }
+
+    fun dismissDeleteConfirmation() {
+        pendingDeleteId.value = null
+    }
+
     fun deleteCoreMemory(id: String) {
+        pendingDeleteId.value = null
         viewModelScope.launch { memoryRepository.deleteCoreMemory(id) }
     }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -26,30 +26,34 @@ class MemoryViewModel @Inject constructor(
         val addDialogText: String = "",
         val showClearConfirmation: Boolean = false,
         val isSubmitting: Boolean = false,
+        val pendingDeleteId: String? = null,
     )
 
     private val _dialogState = MutableStateFlow(
         Triple(/* isAddDialogOpen */ false, /* addDialogText */ "", /* showClearConfirmation */ false)
     )
     private val _isSubmitting = MutableStateFlow(false)
-
-    /** ID of the core memory awaiting delete confirmation; null when no dialog is shown. */
-    val pendingDeleteId = MutableStateFlow<String?>(null)
+    private val _pendingDeleteId = MutableStateFlow<String?>(null)
 
     val uiState: StateFlow<MemoryUiState> = combine(
-        memoryRepository.observeCoreMemories(),
-        memoryRepository.observeEpisodicCount(),
-        _dialogState,
-        _isSubmitting,
-    ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
-        MemoryUiState(
-            coreMemories = coreMemories,
-            episodicCount = episodicCount,
-            isAddDialogOpen = isAddDialogOpen,
-            addDialogText = addDialogText,
-            showClearConfirmation = showClearConfirmation,
-            isSubmitting = isSubmitting,
-        )
+        combine(
+            memoryRepository.observeCoreMemories(),
+            memoryRepository.observeEpisodicCount(),
+            _dialogState,
+            _isSubmitting,
+        ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
+            MemoryUiState(
+                coreMemories = coreMemories,
+                episodicCount = episodicCount,
+                isAddDialogOpen = isAddDialogOpen,
+                addDialogText = addDialogText,
+                showClearConfirmation = showClearConfirmation,
+                isSubmitting = isSubmitting,
+            )
+        },
+        _pendingDeleteId,
+    ) { base, pendingDeleteId ->
+        base.copy(pendingDeleteId = pendingDeleteId)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -86,15 +90,15 @@ class MemoryViewModel @Inject constructor(
     }
 
     fun requestDeleteCoreMemory(id: String) {
-        pendingDeleteId.value = id
+        _pendingDeleteId.value = id
     }
 
     fun dismissDeleteConfirmation() {
-        pendingDeleteId.value = null
+        _pendingDeleteId.value = null
     }
 
     fun deleteCoreMemory(id: String) {
-        pendingDeleteId.value = null
+        _pendingDeleteId.value = null
         viewModelScope.launch { memoryRepository.deleteCoreMemory(id) }
     }
 


### PR DESCRIPTION
## Problem

Tapping the delete icon on a core memory immediately deleted it with no confirmation — destructive and irreversible.

## Fix

Added `pendingDeleteId: MutableStateFlow<String?>` to `MemoryViewModel`. Tapping the delete icon calls `requestDeleteCoreMemory(id)`, which shows an `AlertDialog` ("Delete memory? This cannot be undone."). Confirming calls `deleteCoreMemory()`; Cancel calls `dismissDeleteConfirmation()`.

Consistent with how Clear Episodic already works.

Closes #108