### PR TITLE
fix(#118,#119): URL crash on schemeless links + copy regression from #116

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -14,9 +14,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.indication
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -77,7 +74,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.material3.ripple
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
@@ -304,7 +300,6 @@ private fun MessageBubble(
         MaterialTheme.colorScheme.surfaceVariant
     }
     var showMenu by remember { mutableStateOf(false) }
-    val interactionSource = remember { MutableInteractionSource() }
 
     // Assistant messages: use pointerInput with requireUnconsumed=false so long-press fires
     // even when inner ClickableText nodes (URL handlers in MarkdownContent) have consumed
@@ -312,18 +307,8 @@ private fun MessageBubble(
     val bubbleModifier = if (!isUser) {
         Modifier
             .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = { offset ->
-                        val press = PressInteraction.Press(offset)
-                        interactionSource.emit(press)
-                        val released = tryAwaitRelease()
-                        if (released) interactionSource.emit(PressInteraction.Release(press))
-                        else interactionSource.emit(PressInteraction.Cancel(press))
-                    },
-                    onLongPress = { showMenu = true },
-                )
+                detectTapGestures(onLongPress = { showMenu = true })
             }
-            .indication(interactionSource, ripple())
             .semantics {
                 customActions = listOf(
                     CustomAccessibilityAction(label = "Copy message") { showMenu = true; true }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -732,6 +732,16 @@ private fun renderInlineSpans(
 
 // ── Block composables ──────────────────────────────────────────────────────────
 
+/** Opens [url] safely — prepends https:// if no scheme present, swallows unresolvable URIs. */
+private fun openUrlSafely(uriHandler: androidx.compose.ui.platform.UriHandler, url: String) {
+    val safeUrl = if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+    try {
+        uriHandler.openUri(safeUrl)
+    } catch (e: Exception) {
+        android.util.Log.w("MarkdownRenderer", "Could not open URL: $safeUrl — ${e.message}")
+    }
+}
+
 @Suppress("DEPRECATION") // ClickableText: BasicText.onClick not available in this Compose version
 @Composable
 private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
@@ -752,7 +762,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
                 style    = baseStyle,
                 onClick  = { offset ->
                     annotated.getStringAnnotations("URL", offset, offset)
-                        .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                        .firstOrNull()?.let { openUrlSafely(uriHandler, it.item) }
                 },
             )
         }
@@ -775,7 +785,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
                 style   = headingStyle,
                 onClick = { offset ->
                     annotated.getStringAnnotations("URL", offset, offset)
-                        .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                        .firstOrNull()?.let { openUrlSafely(uriHandler, it.item) }
                 },
             )
         }
@@ -804,7 +814,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
                     onClick  = { offset ->
                         annotated.getStringAnnotations("URL", offset, offset)
-                            .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                            .firstOrNull()?.let { openUrlSafely(uriHandler, it.item) }
                     },
                 )
             }
@@ -822,7 +832,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
                         style   = baseStyle,
                         onClick = { offset ->
                             annotated.getStringAnnotations("URL", offset, offset)
-                                .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                                .firstOrNull()?.let { openUrlSafely(uriHandler, it.item) }
                         },
                     )
                 }
@@ -841,7 +851,7 @@ private fun BlockContent(block: MarkdownBlock, baseStyle: TextStyle) {
                         style   = baseStyle,
                         onClick = { offset ->
                             annotated.getStringAnnotations("URL", offset, offset)
-                                .firstOrNull()?.let { uriHandler.openUri(it.item) }
+                                .firstOrNull()?.let { openUrlSafely(uriHandler, it.item) }
                         },
                     )
                 }


### PR DESCRIPTION
## Fixes two critical regressions from device testing

### fix(#119): copy assistant message regression
The `onPress` handler added for ripple feedback in PR #116's review fixes was interfering with `onLongPress` detection in `detectTapGestures`, making long-press copy completely non-functional on assistant messages.

**Fix:** Removed `onPress` (and ripple). `detectTapGestures(onLongPress = ...)` alone is reliable. Accessibility `semantics { customActions }` retained.

### fix(#118): app crash on URL without scheme
`uriHandler.openUri()` crashes when the model generates a URL without a scheme (e.g. `recipeinteats.com.au`). Android requires a valid URI scheme.

**Fix:** Extracted `openUrlSafely()` helper that prepends `https://` if no scheme is present and wraps in try/catch. All 5 `ClickableText` URL call sites in `MarkdownRenderer.kt` updated.

Closes #118
Closes #119