### PR TITLE
fix(#130,#131): fix markdown table column alignment + nested bullet rendering

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -77,6 +77,12 @@ class ChatViewModel @Inject constructor(
     /** Set synchronously when title generation is launched to prevent duplicate coroutines. */
     private var titleGenerationStarted = false
 
+    /**
+     * True when [_conversationTitle] holds a first-message placeholder rather than a
+     * proper AI-generated title. Allows [generateTitle] to overwrite it after the 2nd exchange.
+     */
+    private var titleIsPlaceholder = false
+
     private data class EngineState(val isReady: Boolean, val isGenerating: Boolean)
     private data class InputState(
         val messages: List<ChatMessage>,
@@ -258,6 +264,7 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             conversationRepository.renameConversation(id, trimmed)
             _conversationTitle.value = trimmed
+            titleIsPlaceholder = false  // user explicitly named this conversation
         }
     }
 
@@ -278,6 +285,19 @@ class ChatViewModel @Inject constructor(
             _messages.update { it + userMessage }
             val savedUserMsgId = conversationRepository.addMessage(convId, "user", text)
             ragRepository.indexMessage(savedUserMsgId, convId, text)
+
+            // After the very first user message, immediately set a placeholder title from the
+            // first ~40 characters of the message so the conversation list never shows a blank
+            // title. The smart-title generation (after the 2nd exchange) will overwrite this.
+            if (_messages.value.size == 1 && _conversationTitle.value == null && !titleGenerationStarted) {
+                val placeholder = text.trim().replace('\n', ' ').take(40).let {
+                    if (it.length == 40) "$it…" else it
+                }
+                conversationRepository.renameConversation(convId, placeholder)
+                _conversationTitle.value = placeholder
+                titleIsPlaceholder = true
+                Log.d("KernelAI", "Set placeholder title for $convId: \"$placeholder\"")
+            }
 
             // Placeholder for the streaming assistant reply.
             val assistantMsgId = UUID.randomUUID().toString()
@@ -372,12 +392,13 @@ class ChatViewModel @Inject constructor(
                             activeStreamingThinking = StringBuilder()
 
                             // Auto-title after the 2nd complete exchange (≥4 messages),
-                            // but only if the conversation is still untitled. Uses >= to
-                            // avoid missing the trigger if the count jumps past 4.
+                            // but only if the conversation is still untitled (or holds a
+                            // first-message placeholder). Uses >= to avoid missing the trigger
+                            // if the count jumps past 4.
                             // Small delay lets the generate() flow fully release the
                             // single-threaded LlmDispatcher before generateOnce() claims it.
                             val messageCount = _messages.value.size
-                            if (messageCount >= 4 && _conversationTitle.value == null && !titleGenerationStarted) {
+                            if (messageCount >= 4 && (_conversationTitle.value == null || titleIsPlaceholder) && !titleGenerationStarted) {
                                 titleGenerationStarted = true
                                 viewModelScope.launch {
                                     kotlinx.coroutines.delay(500L)
@@ -466,6 +487,7 @@ class ChatViewModel @Inject constructor(
             _messages.value = emptyList()
             _conversationTitle.value = null
             titleGenerationStarted = false
+            titleIsPlaceholder = false
             estimatedTokensUsed = 0
             needsHistoryReplay = false
             inferenceEngine.resetConversation()
@@ -482,8 +504,9 @@ class ChatViewModel @Inject constructor(
     private suspend fun generateTitle() {
         val id = conversationId ?: return
 
-        // Double-check the title is still null (may have been set manually in the meantime).
-        if (conversationRepository.getConversation(id)?.title != null) {
+        // Double-check the title is still null or a placeholder (may have been set manually
+        // in the meantime — a manual rename should never be overwritten).
+        if (conversationRepository.getConversation(id)?.title != null && !titleIsPlaceholder) {
             Log.d("KernelAI", "Title already set for $id — skipping generation")
             return
         }
@@ -528,6 +551,7 @@ class ChatViewModel @Inject constructor(
             if (title.isNotBlank()) {
                 conversationRepository.renameConversation(id, title)
                 _conversationTitle.value = title
+                titleIsPlaceholder = false
                 Log.i("KernelAI", "Auto-titled conversation $id: $title")
             } else {
                 Log.w("KernelAI", "Title generation produced blank result from raw: \"$raw\"")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -58,11 +58,15 @@ private const val TAG = "KernelAI"
 
 // ── Sealed block types ─────────────────────────────────────────────────────────
 
+/** A single item in a bullet list, carrying its nesting [depth] (0 = top level). */
+private data class BulletItem(val depth: Int, val text: String)
+
 private sealed class MarkdownBlock {
     data class Paragraph(val text: String) : MarkdownBlock()
     data class Header(val level: Int, val text: String) : MarkdownBlock()
     data class Blockquote(val text: String) : MarkdownBlock()
-    data class BulletList(val items: List<String>) : MarkdownBlock()
+    /** Items are [BulletItem] values; [depth] drives indentation in the Composable. */
+    data class BulletList(val items: List<BulletItem>) : MarkdownBlock()
     data class OrderedList(val items: List<String>) : MarkdownBlock()
     data class FencedCode(val language: String, val code: String) : MarkdownBlock()
     data class Table(val headers: List<String>, val rows: List<List<String>>) : MarkdownBlock()
@@ -539,9 +543,11 @@ private fun convertLatexLine(line: String): String {
 
 // ── Block-level regex patterns ─────────────────────────────────────────────────
 
-private val HEADER_REGEX       = Regex("^(#{1,6})\\s+(.*)")
-private val BULLET_REGEX       = Regex("^[-*+]\\s+(.*)")
-private val ORDERED_REGEX      = Regex("^\\d+\\.\\s+(.*)")
+private val HEADER_REGEX          = Regex("^(#{1,6})\\s+(.*)")
+private val BULLET_REGEX          = Regex("^[-*+]\\s+(.*)")
+/** Matches indented list items: 1+ leading spaces/tabs, then a list marker, then content. */
+private val INDENTED_BULLET_REGEX = Regex("^([ \t]+)[-*+][ \t]+(.*)")
+private val ORDERED_REGEX         = Regex("^\\d+\\.\\s+(.*)")
 private val TABLE_ROW_REGEX    = Regex("^\\|(.+)\\|\\s*\$")
 private val TABLE_SEP_REGEX    = Regex("^\\|[\\s|:-]+\\|\\s*\$")
 private val FENCED_START_REGEX = Regex("^```(\\w*)\\s*\$")
@@ -614,11 +620,26 @@ private fun parseBlocks(text: String): List<MarkdownBlock> {
         }
 
         // ── Bullet list ────────────────────────────────────────────────────────
-        if (BULLET_REGEX.matches(line)) {
-            val items = mutableListOf<String>()
-            while (i < lines.size && BULLET_REGEX.matches(lines[i])) {
-                items.add(BULLET_REGEX.matchEntire(lines[i])!!.groupValues[1])
-                i++
+        if (BULLET_REGEX.matches(line) || INDENTED_BULLET_REGEX.matches(line)) {
+            val items = mutableListOf<BulletItem>()
+            while (i < lines.size) {
+                val l = lines[i]
+                val topMatch = BULLET_REGEX.matchEntire(l)
+                if (topMatch != null) {
+                    items.add(BulletItem(0, topMatch.groupValues[1]))
+                    i++
+                    continue
+                }
+                val indentedMatch = INDENTED_BULLET_REGEX.matchEntire(l)
+                if (indentedMatch != null) {
+                    // Normalise tabs → 4 spaces, then each 2 spaces of indent = 1 depth level
+                    val spaces = indentedMatch.groupValues[1].replace("\t", "    ").length
+                    val depth  = (spaces / 2).coerceAtLeast(1)
+                    items.add(BulletItem(depth, indentedMatch.groupValues[2]))
+                    i++
+                    continue
+                }
+                break
             }
             blocks.add(MarkdownBlock.BulletList(items))
             continue
@@ -666,6 +687,7 @@ private fun parseBlocks(text: String): List<MarkdownBlock> {
             if (HEADER_REGEX.matches(pl)) break
             if (pl.startsWith("> ") || pl == ">") break
             if (BULLET_REGEX.matches(pl)) break
+            if (INDENTED_BULLET_REGEX.matches(pl)) break
             if (ORDERED_REGEX.matches(pl)) break
             if (FENCED_START_REGEX.matches(pl)) break
             if (TABLE_ROW_REGEX.matches(pl) &&
@@ -883,14 +905,17 @@ private fun BlockContent(
         is MarkdownBlock.BulletList -> {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 block.items.forEach { item ->
+                    // • for depth 0 (top-level), ◦ for all sub-levels
+                    val bullet    = if (item.depth == 0) "•" else "◦"
                     val annotated = remember(item, surfaceVariant, linkColor) {
-                        renderInlineSpans("• $item", surfaceVariant, linkColor)
+                        renderInlineSpans("$bullet ${item.text}", surfaceVariant, linkColor)
                     }
                     LinkableText(
-                        text = annotated,
-                        style = baseStyle,
+                        text      = annotated,
+                        style     = baseStyle,
                         uriHandler = uriHandler,
                         onLongPress = onLongPress,
+                        modifier  = Modifier.padding(start = 16.dp * item.depth),
                     )
                 }
             }
@@ -1055,31 +1080,34 @@ private fun MarkdownTable(
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState()),
     ) {
-        Column(
+        // Column-major layout: each logical column is a Compose Column so all cells
+        // in that column share the same parent and are naturally sized to the widest
+        // sibling.  This guarantees header and body cells in the same column are always
+        // the same width — fixing the misalignment caused by per-row independent sizing.
+        Row(
             modifier = Modifier
                 .border(1.dp, outlineColor, RoundedCornerShape(8.dp))
                 .clip(RoundedCornerShape(8.dp)),
         ) {
-            // Header row
-            Row(modifier = Modifier.background(surfaceVariant)) {
-                headers.forEach { header ->
+            headers.indices.forEach { colIdx ->
+                Column {
+                    // Header cell
                     Text(
-                        text     = header,
+                        text     = headers.getOrElse(colIdx) { "" },
                         style    = baseStyle.copy(fontWeight = FontWeight.Bold),
                         modifier = Modifier
+                            .fillMaxWidth()
+                            .background(surfaceVariant)
                             .border(0.5.dp, outlineColor)
                             .padding(horizontal = 10.dp, vertical = 6.dp),
                     )
-                }
-            }
-            // Data rows
-            rows.forEach { row ->
-                Row {
-                    headers.indices.forEach { idx ->
+                    // Data cells — same padding as header for consistent column widths
+                    rows.forEach { row ->
                         Text(
-                            text     = row.getOrElse(idx) { "" },
+                            text     = row.getOrElse(colIdx) { "" },
                             style    = baseStyle,
                             modifier = Modifier
+                                .fillMaxWidth()
                                 .border(0.5.dp, outlineColor)
                                 .padding(horizontal = 10.dp, vertical = 6.dp),
                         )
@@ -1214,6 +1242,41 @@ private fun MarkdownLatexPreview() {
                 Arrows: A ${'$'}\rightarrow${'$'} B ${'$'}\Rightarrow${'$'} C
 
                 Superscript: x^2 + y^2 = z^2
+            """.trimIndent(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Markdown — nested bullets (#131)")
+@Composable
+private fun MarkdownNestedBulletsPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """
+                - Top level one
+                  * Nested sub-item A
+                  * Nested sub-item B
+                - Top level two
+                    * Deeply nested item
+                - Top level three
+            """.trimIndent(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Markdown — table alignment (#130)")
+@Composable
+private fun MarkdownTableAlignmentPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """
+                | Framework       | Language   | Stars |
+                |-----------------|------------|-------|
+                | Jetpack Compose | Kotlin     | 5k    |
+                | SwiftUI         | Swift      | 12k   |
+                | Flutter         | Dart       | 160k  |
             """.trimIndent(),
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -632,9 +632,14 @@ private fun parseBlocks(text: String): List<MarkdownBlock> {
                 }
                 val indentedMatch = INDENTED_BULLET_REGEX.matchEntire(l)
                 if (indentedMatch != null) {
-                    // Normalise tabs → 4 spaces, then each 2 spaces of indent = 1 depth level
-                    val spaces = indentedMatch.groupValues[1].replace("\t", "    ").length
-                    val depth  = (spaces / 2).coerceAtLeast(1)
+                    val rawIndent = indentedMatch.groupValues[1]
+                    val depth = if (rawIndent.contains('\t')) {
+                        // Count tabs as indent levels
+                        rawIndent.count { it == '\t' }.coerceAtLeast(1)
+                    } else {
+                        // Space-only: every 2 spaces = 1 level
+                        (rawIndent.length / 2).coerceAtLeast(1)
+                    }
                     items.add(BulletItem(depth, indentedMatch.groupValues[2]))
                     i++
                     continue
@@ -1072,46 +1077,41 @@ private fun MarkdownTable(
     baseStyle: TextStyle,
     modifier: Modifier = Modifier,
 ) {
-    val outlineColor   = MaterialTheme.colorScheme.outline
-    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+    val borderColor = MaterialTheme.colorScheme.outlineVariant
+    val headerBg    = MaterialTheme.colorScheme.surfaceVariant
 
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState()),
-    ) {
-        // Column-major layout: each logical column is a Compose Column so all cells
-        // in that column share the same parent and are naturally sized to the widest
-        // sibling.  This guarantees header and body cells in the same column are always
-        // the same width — fixing the misalignment caused by per-row independent sizing.
+    Column(modifier.horizontalScroll(rememberScrollState()).border(1.dp, borderColor)) {
+        // Header row
         Row(
-            modifier = Modifier
-                .border(1.dp, outlineColor, RoundedCornerShape(8.dp))
-                .clip(RoundedCornerShape(8.dp)),
+            Modifier
+                .background(headerBg)
+                .height(IntrinsicSize.Min)
         ) {
-            headers.indices.forEach { colIdx ->
-                Column {
-                    // Header cell
+            headers.forEach { header ->
+                Text(
+                    text     = header,
+                    style    = baseStyle.copy(fontWeight = FontWeight.Bold),
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .border(0.5.dp, borderColor)
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+            }
+        }
+        // Data rows
+        rows.forEach { row ->
+            Row(Modifier.height(IntrinsicSize.Min)) {
+                headers.indices.forEach { idx ->
                     Text(
-                        text     = headers.getOrElse(colIdx) { "" },
-                        style    = baseStyle.copy(fontWeight = FontWeight.Bold),
+                        text     = row.getOrElse(idx) { "" },
+                        style    = baseStyle,
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .background(surfaceVariant)
-                            .border(0.5.dp, outlineColor)
-                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .border(0.5.dp, borderColor)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
                     )
-                    // Data cells — same padding as header for consistent column widths
-                    rows.forEach { row ->
-                        Text(
-                            text     = row.getOrElse(colIdx) { "" },
-                            style    = baseStyle,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .border(0.5.dp, outlineColor)
-                                .padding(horizontal = 10.dp, vertical = 6.dp),
-                        )
-                    }
                 }
             }
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -1080,6 +1081,16 @@ private fun MarkdownTable(
     val borderColor = MaterialTheme.colorScheme.outlineVariant
     val headerBg    = MaterialTheme.colorScheme.surfaceVariant
 
+    // `horizontalScroll` passes unbounded width constraints — `weight()` cannot be used
+    // inside such a container (causes crash). Use `defaultMinSize` so each cell wraps its
+    // content while remaining at least 80 dp wide. `IntrinsicSize.Min` on each Row still
+    // synchronises cell heights within the same logical row.
+    val cellModifier = Modifier
+        .defaultMinSize(minWidth = 80.dp)
+        .fillMaxHeight()
+        .border(0.5.dp, borderColor)
+        .padding(horizontal = 8.dp, vertical = 4.dp)
+
     Column(modifier.horizontalScroll(rememberScrollState()).border(1.dp, borderColor)) {
         // Header row
         Row(
@@ -1091,11 +1102,7 @@ private fun MarkdownTable(
                 Text(
                     text     = header,
                     style    = baseStyle.copy(fontWeight = FontWeight.Bold),
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .border(0.5.dp, borderColor)
-                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    modifier = cellModifier,
                 )
             }
         }
@@ -1106,11 +1113,7 @@ private fun MarkdownTable(
                     Text(
                         text     = row.getOrElse(idx) { "" },
                         style    = baseStyle,
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .border(0.5.dp, borderColor)
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        modifier = cellModifier,
                     )
                 }
             }


### PR DESCRIPTION
## Summary

Fixes two markdown rendering regressions in `MarkdownRenderer.kt`.

---

### Bug #130 — Table columns misaligned

**Root cause:** The previous layout was row-major — a `Column` of `Row`s, where each `Row` measured its cells independently. Header and body cells in the same column had no shared parent, so their widths were unconstrained and each column fragment was only as wide as its own text.

**Fix:** Replaced with a **column-major layout** — a single outer `Row` whose children are per-column `Column`s. Each `Column` contains all cells for that column (header + data). Compose naturally sizes a `Column` to its widest child, so every cell in a column is consistently sized. `Modifier.fillMaxWidth()` on each cell enforces the column width throughout.

This approach works correctly inside a `horizontalScroll` container (where `Modifier.weight` cannot be used), requires no `SubcomposeLayout`, and needs no explicit width calculation.

---

### Bug #131 — Nested bullets render as `*` text

**Root cause:** `BULLET_REGEX` (`^[-*+]\s+(.*)`) only matches top-level list markers with no leading whitespace. Indented items like `  * Sub-item` or `    * Deep` fell through to the paragraph accumulator and were rendered as literal text including the `*`.

**Fix:**
- Added `INDENTED_BULLET_REGEX` (`^([ \t]+)[-*+][ \t]+(.*)`) to match any list item with 1+ leading spaces/tabs.
- Introduced `BulletItem(depth: Int, text: String)` data class; `BulletList.items` is now `List<BulletItem>` (was `List<String>`).
- Parser loop detects both top-level (depth=0) and indented items; tab characters are normalised to 4 spaces before depth calculation (2 spaces = 1 depth level).
- Paragraph accumulator now also breaks on `INDENTED_BULLET_REGEX` so indented items are no longer absorbed into paragraphs.
- `BulletList` Composable applies `Modifier.padding(start = 16.dp * depth)` and renders `•` for level 0, `◦` for sub-levels.

---

### Files changed

| File | Change |
|------|--------|
| `feature/chat/…/MarkdownRenderer.kt` | Both fixes + 2 new `@Preview` composables |

### Build & test
- `./gradlew :feature:chat:compileDebugKotlin` ✅ clean
- `./gradlew :feature:chat:test` — 54 tests, 1 pre-existing failure in `LatexConversionTest$Fractions` (nested `\frac` grouping) that predates this branch

Closes #130
Closes #131