### PR TITLE
fix(#137,#138): auto-scroll during streaming + placeholder title ellipsis fix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,6 +92,8 @@ tri-tiered memory architecture inspired by the
 | Fun loading screens ([#13](https://github.com/NickMonrad/kernel-ai-assistant/issues/13)) | ✅ Done | #85 | 13 themed 3-step narratives (Kernel Kitchen, Techno-Wizard, Star Trek, etc.), animated transitions. |
 | Episodic + Core memory tiers | ⬜ Next | — | Split flat index into episodic (volatile) + core (permanent). Separate vec0 tables. |
 | Memory management UI | ⬜ Pending | — | Profile editor, core memories CRUD, episodic browser, stats |
+| Bulk delete core memories ([#110](https://github.com/NickMonrad/kernel-ai-assistant/issues/110)) | ⬜ Pending | — | Multi-select + delete in the core memories list in Memory UI |
+| Fun loading screens v2 ([#96](https://github.com/NickMonrad/kernel-ai-assistant/issues/96)) | ⬜ Pending | — | Additional themed narratives and animation improvements beyond the initial 13 |
 | Dreaming Engine | ⬜ Pending | — | WorkManager: Light Sleep → REM Sleep → Deep Sleep consolidation |
 | Self-Healing Identity System ([#47](https://github.com/NickMonrad/kernel-ai-assistant/issues/47)) | ⬜ Pending | — | Replace free-text profile with structured YAML identity (name, role, env, rules, sandbox). Dreaming Engine promotes sandbox → Core Identity or Core Memories overnight. |
 | SM8550 Qualcomm AI Engine delegate ([#44](https://github.com/NickMonrad/kernel-ai-assistant/issues/44)) | ⬜ Pending | — | Bundle QNN TFLite delegate so SM8550-optimised EmbeddingGemma model uses Hexagon NPU |
@@ -130,6 +132,7 @@ FunctionGemma routes user intents to native Android actions without loading the 
 | Gemma 4 native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ⬜ Pending | Leverage Gemma 4's built-in function calling instead of separate FunctionGemma |
 | Semantic Caching ([#49](https://github.com/NickMonrad/kernel-ai-assistant/issues/49)) | ⬜ Pending | sqlite-vec `semantic_cache` table; bypass Gemma-4 for repeated knowledge queries (0.95 cosine threshold); parallel FunctionGemma intent check + cache lookup; 7-day LRU pruning in Dreaming Light Sleep |
 | GetSystemInfo native skill ([#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86)) | ⬜ Pending | Runtime device/model/backend info via callable skill, replaces static `[Runtime]` block |
+| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⬜ Pending | Agent-initiated `addEpisodicMemory()` / `addCoreMemory()` — model decides what to remember |
 | Skill registry + JSON schema generation | ⬜ Pending | Uses LiteRT-LM's `@Tool`/`@ToolParam` annotations |
 | Native skills (8+ Kotlin skills) | ⬜ Pending | Flashlight, DND, Bluetooth, Alarms, SMS, Notes, Media |
 | Model cascade orchestrator | ⬜ Pending | FunctionGemma → skill exec OR escalate to Gemma-4 |
@@ -239,6 +242,9 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#78](https://github.com/NickMonrad/kernel-ai-assistant/issues/78) | Copy chat content | Phase 3 | ⬜ Pending |
 | [#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84) | Gemma 4 native tool calling | Phase 3 | ⬜ Pending |
 | [#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86) | GetSystemInfo native skill | Phase 3 | ⬜ Pending |
+| [#96](https://github.com/NickMonrad/kernel-ai-assistant/issues/96) | Fun loading screens v2 | Phase 2 | ⬜ Pending |
+| [#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103) | SaveMemory native skill | Phase 3 | ⬜ Pending |
+| [#110](https://github.com/NickMonrad/kernel-ai-assistant/issues/110) | Bulk delete core memories | Phase 2 | ⬜ Pending |
 
 ---
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.Dispatchers
@@ -168,6 +169,22 @@ private fun ChatContent(
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
             listState.animateScrollToItem(state.messages.lastIndex)
+        }
+    }
+
+    // During streaming, keep scrolling to the bottom as content grows — but only if the
+    // user hasn't manually scrolled up (i.e. the last item is still visible or close to it).
+    LaunchedEffect(state.isGenerating) {
+        if (state.isGenerating) {
+            snapshotFlow { state.messages.lastOrNull()?.content?.length ?: 0 }
+                .collect {
+                    if (state.messages.isNotEmpty()) {
+                        val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+                        if (state.messages.lastIndex - lastVisible <= 2) {
+                            listState.scrollToItem(state.messages.lastIndex)
+                        }
+                    }
+                }
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -166,6 +167,10 @@ private fun ChatContent(
     val listState = rememberLazyListState()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
 
+    // rememberUpdatedState wraps `state` in a MutableState so snapshotFlow can track
+    // content changes across recompositions without restarting the LaunchedEffect.
+    val currentState by rememberUpdatedState(state)
+
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
             listState.animateScrollToItem(state.messages.lastIndex)
@@ -173,15 +178,16 @@ private fun ChatContent(
     }
 
     // During streaming, keep scrolling to the bottom as content grows — but only if the
-    // user hasn't manually scrolled up (i.e. the last item is still visible or close to it).
+    // user hasn't manually scrolled up (last visible item within 2 of end) and no scroll
+    // animation is already in progress (avoid cancelling the animated scroll on new messages).
     LaunchedEffect(state.isGenerating) {
-        if (state.isGenerating) {
-            snapshotFlow { state.messages.lastOrNull()?.content?.length ?: 0 }
+        if (currentState.isGenerating) {
+            snapshotFlow { currentState.messages.lastOrNull()?.content?.length ?: 0 }
                 .collect {
-                    if (state.messages.isNotEmpty()) {
+                    if (currentState.messages.isNotEmpty()) {
                         val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
-                        if (state.messages.lastIndex - lastVisible <= 2) {
-                            listState.scrollToItem(state.messages.lastIndex)
+                        if (currentState.messages.lastIndex - lastVisible <= 2 && !listState.isScrollInProgress) {
+                            listState.scrollToItem(currentState.messages.lastIndex)
                         }
                     }
                 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -309,9 +309,7 @@ class ChatViewModel @Inject constructor(
             // first ~40 characters of the message so the conversation list never shows a blank
             // title. The smart-title generation (after the 2nd exchange) will overwrite this.
             if (_messages.value.size == 1 && _conversationTitle.value == null && !titleGenerationStarted) {
-                val placeholder = text.trim().replace('\n', ' ').take(40).let {
-                    if (it.length == 40) "$it…" else it
-                }
+                val placeholder = text.trim().replace('\n', ' ').take(40) + "…"
                 conversationRepository.renameConversation(convId, placeholder)
                 _conversationTitle.value = placeholder
                 titleIsPlaceholder = true

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -764,9 +764,13 @@ private fun renderInlineSpans(
         spans.add(InlineSpan(m.range.first, m.range.last + 1, "STRIKETHROUGH", m.groupValues[1]))
     }
 
-    // Inline code: `code`
+    // Inline code: `code` — but if the entire content is a URL, treat as a clickable link.
+    // The model often wraps bare URLs in backticks, which would otherwise render as monospace
+    // code spans rather than tappable links.
     Regex("`([^`]+)`").findAll(text).forEach { m ->
-        spans.add(InlineSpan(m.range.first, m.range.last + 1, "CODE", m.groupValues[1]))
+        val content = m.groupValues[1].trim()
+        val isUrl = content.startsWith("http://") || content.startsWith("https://") || content.startsWith("www.")
+        spans.add(InlineSpan(m.range.first, m.range.last + 1, if (isUrl) "URL" else "CODE", content))
     }
 
     // Markdown links: [text](url) — parsed before raw URL detection so the full

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -769,7 +769,8 @@ private fun renderInlineSpans(
     // code spans rather than tappable links.
     Regex("`([^`]+)`").findAll(text).forEach { m ->
         val content = m.groupValues[1].trim()
-        val isUrl = content.startsWith("http://") || content.startsWith("https://") || content.startsWith("www.")
+        val isUrl = (content.startsWith("http://") || content.startsWith("https://") || content.startsWith("www."))
+                && !content.contains(' ')
         spans.add(InlineSpan(m.range.first, m.range.last + 1, if (isUrl) "URL" else "CODE", content))
     }
 


### PR DESCRIPTION
Fixes two bugs found in device testing round 4 (issue #135).

## Changes

### Auto-scroll during streaming (Closes #137)
`LaunchedEffect(state.messages.size)` only fires on new messages, not while content grows.
Added `LaunchedEffect(state.isGenerating)` with `snapshotFlow` to track content-length changes
and scroll to the last item during generation — but only if the user is already near the bottom,
so manual scroll-up is respected.

### Placeholder title ellipsis (Closes #138)
For short first messages (<40 chars), the placeholder title was set without a trailing `…`,
so the session-restore heuristic (`endsWith("…")`) never matched and smart titles were
permanently suppressed after a session exit. Fix: always append `…`.