### PR TITLE
fix(#144): instant scroll + near-bottom guard (snap regression fix)

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -172,10 +172,16 @@ private fun ChatContent(
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
 
-    // Scroll to bottom when a new message is appended.
+    // Auto-scroll when a new message is appended, but only if the user is already
+    // near the bottom (within 2 items). If they've scrolled up to read history,
+    // the scroll-to-bottom button handles getting back. Uses instant scrollToItem
+    // (not animated) so it never holds the scroll mutex long enough to fight gestures.
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(state.messages.lastIndex)
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            if (lastVisible >= state.messages.size - 2) {
+                listState.scrollToItem(state.messages.lastIndex)
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

After PR #143, scrolling snaps back to the original position during streaming and on static lists.

Two root causes:
1. `animateScrollToItem` holds the scroll mutex for ~300ms during animation. On long lists this creates a window where the running animation conflicts with user gesture cancellation, causing perceived snap-back.
2. No near-bottom guard — `LaunchedEffect(messages.size)` always scrolled to the bottom even when the user had scrolled up to read history (also means TC5 would fail).

## Fix

- Replace `animateScrollToItem` with instant `scrollToItem` — completes in one frame, can't fight gestures
- Add near-bottom guard: `lastVisible >= messages.size - 2` — only auto-scroll if already near bottom; if scrolled up, the scroll-to-bottom button handles it

## Test coverage

- TC4: New message while at bottom → auto-scrolls ✅
- TC5: New message while scrolled up → does NOT auto-scroll ✅ (was broken)
- Snap-back during streaming: eliminated by instant scroll

Closes #144