### PR TITLE
fix(#144): scroll to true bottom with scrollOffset=Int.MAX_VALUE

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -180,7 +180,7 @@ private fun ChatContent(
         if (state.messages.isNotEmpty()) {
             val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
             if (lastVisible >= state.messages.size - 2) {
-                listState.scrollToItem(state.messages.lastIndex)
+                listState.scrollToItem(state.messages.lastIndex, scrollOffset = Int.MAX_VALUE)
             }
         }
     }
@@ -250,7 +250,7 @@ private fun ChatContent(
                         Surface(
                             onClick = {
                                 scope.launch {
-                                    listState.animateScrollToItem(state.messages.lastIndex)
+                                    listState.animateScrollToItem(state.messages.lastIndex, scrollOffset = Int.MAX_VALUE)
                                 }
                             },
                             shape = androidx.compose.foundation.shape.CircleShape,


### PR DESCRIPTION
## Root cause

`scrollToItem(lastIndex)` and `animateScrollToItem(lastIndex)` position the **top** of the target item at the top of the viewport. For messages taller than the screen, this lands mid-message rather than at the actual bottom of the list — causing the "stuck at a point" scroll behaviour reported in round 6 testing.

## Fix

Pass `scrollOffset = Int.MAX_VALUE` to both calls. LazyColumn's layout engine clamps this to the maximum valid scroll offset, which is the true end of the list. No overflow risk — the clamping happens during the layout pass.

Closes #144