### PR TITLE
fix(#150): inline markdown in table cells (bold, URLs, italic, code)

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -1114,9 +1114,11 @@ private fun MarkdownTable(
     // three measurement passes without duplicating the layout code.
     // Inline spans (bold, italic, URLs, code) are rendered so table cells support full markdown.
     fun cellContent(text: String, isHeader: Boolean): @Composable () -> Unit = {
-        val bgMod = if (isHeader) Modifier.background(headerBg) else Modifier
+        val bgMod     = if (isHeader) Modifier.background(headerBg) else Modifier
         val cellStyle = if (isHeader) baseStyle.copy(fontWeight = FontWeight.Bold) else baseStyle
-        val annotated = renderInlineSpans(text, surfaceVariant, linkColor)
+        val annotated = remember(text, surfaceVariant, linkColor) {
+            renderInlineSpans(text, surfaceVariant, linkColor)
+        }
         Box(
             modifier = bgMod
                 .fillMaxHeight()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -1096,9 +1096,12 @@ private fun MarkdownTable(
     baseStyle: TextStyle,
     modifier: Modifier = Modifier,
 ) {
-    val borderColor = MaterialTheme.colorScheme.outlineVariant
-    val headerBg    = MaterialTheme.colorScheme.surfaceVariant
-    val colCount    = headers.size
+    val borderColor  = MaterialTheme.colorScheme.outlineVariant
+    val headerBg     = MaterialTheme.colorScheme.surfaceVariant
+    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+    val linkColor    = MaterialTheme.colorScheme.primary
+    val uriHandler   = LocalUriHandler.current
+    val colCount     = headers.size
 
     // Normalise all rows to colCount cells up-front (headers + data).
     val allRows: List<List<String>> = remember(headers, rows) {
@@ -1109,17 +1112,21 @@ private fun MarkdownTable(
 
     // Returns the composable content lambda for a single cell so it can be reused across the
     // three measurement passes without duplicating the layout code.
+    // Inline spans (bold, italic, URLs, code) are rendered so table cells support full markdown.
     fun cellContent(text: String, isHeader: Boolean): @Composable () -> Unit = {
         val bgMod = if (isHeader) Modifier.background(headerBg) else Modifier
+        val cellStyle = if (isHeader) baseStyle.copy(fontWeight = FontWeight.Bold) else baseStyle
+        val annotated = renderInlineSpans(text, surfaceVariant, linkColor)
         Box(
             modifier = bgMod
                 .fillMaxHeight()
                 .border(0.5.dp, borderColor)
                 .padding(horizontal = 8.dp, vertical = 4.dp),
         ) {
-            Text(
-                text  = text,
-                style = if (isHeader) baseStyle.copy(fontWeight = FontWeight.Bold) else baseStyle,
+            LinkableText(
+                text       = annotated,
+                style      = cellStyle,
+                uriHandler = uriHandler,
             )
         }
     }


### PR DESCRIPTION
## Problem

Table cells used plain `Text` — no inline markdown parsing. This caused:
- `**bold**` to render literally as `**bold**`
- URLs to appear as plain unclickable text
- `*italic*`, ``code``, `[label](url)` all ignored

## Fix

Replace `Text` with `LinkableText(renderInlineSpans(...))` in `cellContent` inside `MarkdownTable`. Same inline rendering pipeline used by all other block types (paragraphs, bullets, headings).

Added `uriHandler`, `surfaceVariant`, and `linkColor` from `MaterialTheme`/`LocalUriHandler` — all already imported in the file.

Closes #150