### PR TITLE
feat(#151): conversation search by title

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -33,6 +33,6 @@ interface ConversationDao {
     @Query("UPDATE conversations SET updatedAt = :updatedAt WHERE id = :id")
     suspend fun touchUpdatedAt(id: String, updatedAt: Long)
 
-    @Query("SELECT * FROM conversations WHERE title LIKE '%' || :query || '%' ORDER BY updatedAt DESC")
+    @Query("SELECT * FROM conversations WHERE title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\' ORDER BY updatedAt DESC")
     fun searchByTitle(query: String): Flow<List<ConversationEntity>>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -32,4 +32,7 @@ interface ConversationDao {
 
     @Query("UPDATE conversations SET updatedAt = :updatedAt WHERE id = :id")
     suspend fun touchUpdatedAt(id: String, updatedAt: Long)
+
+    @Query("SELECT * FROM conversations WHERE title LIKE '%' || :query || '%' ORDER BY updatedAt DESC")
+    fun searchByTitle(query: String): Flow<List<ConversationEntity>>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -69,4 +69,7 @@ class ConversationRepository @Inject constructor(
 
     suspend fun getMessagesOnce(conversationId: String): List<MessageEntity> =
         messageDao.getByConversation(conversationId)
+
+    fun searchByTitle(query: String): Flow<List<ConversationEntity>> =
+        conversationDao.searchByTitle(query)
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -54,6 +56,7 @@ fun ConversationListScreen(
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
     // Store ID only (String is Parcelable-safe) to survive configuration changes.
     var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -77,33 +80,65 @@ fun ConversationListScreen(
             }
         },
     ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Search bar
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { viewModel.onSearchQueryChanged(it) },
+                placeholder = { Text("Search conversations") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (searchQuery.isNotBlank()) {
+                        IconButton(onClick = { viewModel.clearSearch() }) {
+                            Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                        }
+                    }
+                },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
         if (conversations.isEmpty()) {
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                    .fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("🧵", style = MaterialTheme.typography.displayMedium)
-                    Text(
-                        text = "No conversations yet",
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                    Text(
-                        text = "Tap + to start chatting",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline,
-                        modifier = Modifier.padding(top = 4.dp),
-                    )
+                if (searchQuery.isNotBlank()) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("🔍", style = MaterialTheme.typography.displayMedium)
+                        Text(
+                            text = "No conversations match \"$searchQuery\"",
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                    }
+                } else {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("🧵", style = MaterialTheme.typography.displayMedium)
+                        Text(
+                            text = "No conversations yet",
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                        Text(
+                            text = "Tap + to start chatting",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
                 }
             }
         } else {
             LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                modifier = Modifier.fillMaxSize(),
             ) {
                 items(conversations, key = { it.id }) { conversation ->
                     Box {
@@ -159,6 +194,7 @@ fun ConversationListScreen(
                 }
             }
         }
+        } // end Column
     }
 
     // Delete confirmation dialog

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -16,13 +19,19 @@ class ConversationListViewModel @Inject constructor(
     private val repository: ConversationRepository,
 ) : ViewModel() {
 
-    val conversations: StateFlow<List<ConversationEntity>> = repository
-        .observeConversations()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = emptyList(),
-        )
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    val conversations: StateFlow<List<ConversationEntity>> = _searchQuery
+        .flatMapLatest { query ->
+            if (query.isBlank()) repository.observeConversations()
+            else repository.searchByTitle(query)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun onSearchQueryChanged(query: String) { _searchQuery.value = query }
+
+    fun clearSearch() { _searchQuery.value = "" }
 
     fun deleteConversation(conversation: ConversationEntity) {
         viewModelScope.launch {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -25,13 +25,16 @@ class ConversationListViewModel @Inject constructor(
     val conversations: StateFlow<List<ConversationEntity>> = _searchQuery
         .flatMapLatest { query ->
             if (query.isBlank()) repository.observeConversations()
-            else repository.searchByTitle(query)
+            else repository.searchByTitle(query.escapeLikeWildcards())
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun onSearchQueryChanged(query: String) { _searchQuery.value = query }
 
     fun clearSearch() { _searchQuery.value = "" }
+
+    private fun String.escapeLikeWildcards(): String =
+        replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     fun deleteConversation(conversation: ConversationEntity) {
         viewModelScope.launch {


### PR DESCRIPTION
Adds a real-time search bar to the conversation list screen that filters by title as the user types.

## Changes
- `ConversationDao`: new `searchByTitle()` Flow query with `IS NULL` guard (untitled convos always match) and `ESCAPE '\\'` for wildcard safety
- `ConversationRepository`: delegates `searchByTitle()` to DAO
- `ConversationListViewModel`: `flatMapLatest` switches between `observeConversations()` (blank) and `searchByTitle()` (active); wildcards escaped before query reaches DAO
- `ConversationListScreen`: `OutlinedTextField` search bar with Search/Clear icons; two distinct empty states (no convos vs no match)

## Testing
- `:core:memory:test` ✅
- `assembleDebug` ✅
- `:feature:chat:test` has 1 pre-existing failure (`LatexConversionTest` nested fractions) unrelated to this PR — confirmed failing on `main` before changes

Closes #151