### PR TITLE
feat(#155): episodic memory browser in Memory screen

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -43,4 +43,13 @@ interface EpisodicMemoryDao {
         )
     """)
     suspend fun deleteOldestBeyondLimit(count: Int)
+
+    @Query("SELECT * FROM episodic_memories ORDER BY createdAt DESC")
+    fun observeAll(): Flow<List<EpisodicMemoryEntity>>
+
+    @Query("DELETE FROM episodic_memories WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("SELECT rowId FROM episodic_memories WHERE id = :id LIMIT 1")
+    suspend fun getRowIdById(id: String): Long?
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -52,4 +53,11 @@ interface EpisodicMemoryDao {
 
     @Query("SELECT rowId FROM episodic_memories WHERE id = :id LIMIT 1")
     suspend fun getRowIdById(id: String): Long?
+
+    @Transaction
+    suspend fun getRowIdAndDelete(id: String): Long? {
+        val rowId = getRowIdById(id)
+        if (rowId != null) deleteById(id)
+        return rowId
+    }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.memory.repository
 
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
+import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import kotlinx.coroutines.flow.Flow
 
 interface MemoryRepository {
@@ -20,6 +21,10 @@ interface MemoryRepository {
     fun observeEpisodicCount(): Flow<Int>
     /** Record that core memories with the given [ids] were accessed (increments accessCount). */
     suspend fun recordCoreMemoryAccess(ids: List<String>)
+    /** Observe all episodic memories ordered by most recent first (for UI). */
+    fun observeEpisodicMemories(): Flow<List<EpisodicMemoryEntity>>
+    /** Delete a single episodic memory and its vector entry. */
+    suspend fun deleteEpisodicMemory(id: String)
     /** Prune: episodic older than 30 days or count > 500; core capped at 200. */
     suspend fun prune()
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -159,6 +159,17 @@ class MemoryRepositoryImpl @Inject constructor(
 
     override fun observeEpisodicCount(): Flow<Int> = episodicDao.observeCount()
 
+    override fun observeEpisodicMemories(): Flow<List<EpisodicMemoryEntity>> = episodicDao.observeAll()
+
+    override suspend fun deleteEpisodicMemory(id: String) {
+        val rowId = episodicDao.getRowIdById(id)
+        if (rowId != null) {
+            vectorStore.delete(EPISODIC_VEC_TABLE, rowId)
+        }
+        episodicDao.deleteById(id)
+        Log.d(TAG, "Deleted episodic memory id=$id rowId=$rowId")
+    }
+
     override suspend fun recordCoreMemoryAccess(ids: List<String>) {
         if (ids.isEmpty()) return
         runCatching {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -162,11 +162,10 @@ class MemoryRepositoryImpl @Inject constructor(
     override fun observeEpisodicMemories(): Flow<List<EpisodicMemoryEntity>> = episodicDao.observeAll()
 
     override suspend fun deleteEpisodicMemory(id: String) {
-        val rowId = episodicDao.getRowIdById(id)
+        val rowId = episodicDao.getRowIdAndDelete(id)
         if (rowId != null) {
-            vectorStore.delete(EPISODIC_VEC_TABLE, rowId)
+            runCatching { vectorStore.delete(EPISODIC_VEC_TABLE, rowId) }
         }
-        episodicDao.deleteById(id)
         Log.d(TAG, "Deleted episodic memory id=$id rowId=$rowId")
     }
 

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
@@ -294,24 +294,20 @@ class MemoryRepositoryImplTest {
 
     @Test
     fun `deleteEpisodicMemory — deletes vec entry and Room entity`() = runTest {
-        coEvery { episodicDao.getRowIdById("ep-id-1") } returns 77L
+        coEvery { episodicDao.getRowIdAndDelete("ep-id-1") } returns 77L
         every { vectorStore.delete(any(), any()) } just Runs
-        coEvery { episodicDao.deleteById("ep-id-1") } just Runs
 
         repository.deleteEpisodicMemory("ep-id-1")
 
         verify(exactly = 1) { vectorStore.delete(any(), 77L) }
-        coVerify(exactly = 1) { episodicDao.deleteById("ep-id-1") }
     }
 
     @Test
-    fun `deleteEpisodicMemory — still deletes Room entity even when rowId is null`() = runTest {
-        coEvery { episodicDao.getRowIdById("ep-orphan") } returns null
-        coEvery { episodicDao.deleteById("ep-orphan") } just Runs
+    fun `deleteEpisodicMemory — still deletes vec-cleanup even when rowId is null`() = runTest {
+        coEvery { episodicDao.getRowIdAndDelete("ep-orphan") } returns null
 
         repository.deleteEpisodicMemory("ep-orphan")
 
         verify(exactly = 0) { vectorStore.delete(any(), any()) }
-        coVerify(exactly = 1) { episodicDao.deleteById("ep-orphan") }
     }
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
@@ -273,4 +273,45 @@ class MemoryRepositoryImplTest {
         // Should not throw — errors are logged and swallowed
         repository.recordCoreMemoryAccess(listOf("id-1"))
     }
+
+    // ─────────────────────────────── observeEpisodicMemories ─────────────────────────
+
+    @Test
+    fun `observeEpisodicMemories — delegates to episodicDao observeAll`() = runTest {
+        val flow = kotlinx.coroutines.flow.flowOf(emptyList<com.kernel.ai.core.memory.entity.EpisodicMemoryEntity>())
+        every { episodicDao.observeAll() } returns flow
+
+        val result = repository.observeEpisodicMemories()
+
+        // Verify the call went through — collect one emission
+        var collected = false
+        result.collect { collected = true }
+        assertTrue(collected, "observeEpisodicMemories should emit at least one value")
+        verify(exactly = 1) { episodicDao.observeAll() }
+    }
+
+    // ─────────────────────────────── deleteEpisodicMemory ────────────────────────────
+
+    @Test
+    fun `deleteEpisodicMemory — deletes vec entry and Room entity`() = runTest {
+        coEvery { episodicDao.getRowIdById("ep-id-1") } returns 77L
+        every { vectorStore.delete(any(), any()) } just Runs
+        coEvery { episodicDao.deleteById("ep-id-1") } just Runs
+
+        repository.deleteEpisodicMemory("ep-id-1")
+
+        verify(exactly = 1) { vectorStore.delete(any(), 77L) }
+        coVerify(exactly = 1) { episodicDao.deleteById("ep-id-1") }
+    }
+
+    @Test
+    fun `deleteEpisodicMemory — still deletes Room entity even when rowId is null`() = runTest {
+        coEvery { episodicDao.getRowIdById("ep-orphan") } returns null
+        coEvery { episodicDao.deleteById("ep-orphan") } just Runs
+
+        repository.deleteEpisodicMemory("ep-orphan")
+
+        verify(exactly = 0) { vectorStore.delete(any(), any()) }
+        coVerify(exactly = 1) { episodicDao.deleteById("ep-orphan") }
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -335,12 +335,12 @@ private fun EpisodicMemoryItem(
     )
 }
 
-private fun formatEpisodicDate(epochMs: Long): String {
-    val formatter = DateTimeFormatter
-        .ofPattern("MMM d, yyyy", Locale.getDefault())
-        .withZone(ZoneId.systemDefault())
-    return formatter.format(Instant.ofEpochMilli(epochMs))
-}
+private val EPISODIC_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("MMM d, yyyy", Locale.getDefault())
+    .withZone(ZoneId.systemDefault())
+
+private fun formatEpisodicDate(epochMs: Long): String =
+    EPISODIC_DATE_FORMATTER.format(Instant.ofEpochMilli(epochMs))
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Badge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -31,11 +32,19 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -122,26 +131,57 @@ fun MemoryScreen(
             // ── Episodic Memories ──────────────────────────────────────────
             item {
                 Spacer(Modifier.height(8.dp))
-                SectionHeader("Episodic Memories")
+                EpisodicSectionHeader(count = uiState.episodicMemories.size)
             }
             item {
-                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                Text(
+                    text = "Short-term memories from past conversations. Pruned automatically after 30 days.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+            if (uiState.episodicMemories.isNotEmpty()) {
+                item {
+                    val oldest = uiState.episodicMemories.lastOrNull()?.createdAt
+                    val oldestLabel = if (oldest != null) formatEpisodicDate(oldest) else "—"
                     Text(
-                        text = "${uiState.episodicCount} stored memories",
-                        style = MaterialTheme.typography.bodyMedium,
+                        text = "${uiState.episodicMemories.size} memories · Oldest: $oldestLabel",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                     )
-                    Spacer(Modifier.height(8.dp))
+                }
+                items(uiState.episodicMemories, key = { it.id }) { memory ->
+                    val conversationTitle = uiState.conversationTitles[memory.conversationId]
+                        ?: "Unknown conversation"
+                    EpisodicMemoryItem(
+                        memory = memory,
+                        conversationTitle = conversationTitle,
+                        onDelete = { viewModel.requestDeleteEpisodicMemory(memory.id) },
+                    )
+                    HorizontalDivider()
+                }
+                item {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                         horizontalArrangement = Arrangement.End,
                     ) {
-                        OutlinedButton(
-                            onClick = viewModel::showClearEpisodicConfirmation,
-                            enabled = uiState.episodicCount > 0,
-                        ) {
+                        OutlinedButton(onClick = viewModel::showClearEpisodicConfirmation) {
                             Text("Clear all episodic")
                         }
                     }
+                }
+            } else {
+                item {
+                    Text(
+                        text = "No episodic memories yet. They'll appear here after you have a few conversations.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
                 }
             }
         }
@@ -158,6 +198,21 @@ fun MemoryScreen(
             },
             dismissButton = {
                 TextButton(onClick = viewModel::dismissDeleteConfirmation) { Text("Cancel") }
+            },
+        )
+    }
+
+    // ── Delete Episodic Memory Confirmation Dialog ─────────────────────────
+    uiState.pendingDeleteEpisodicId?.let { pendingId ->
+        AlertDialog(
+            onDismissRequest = viewModel::dismissDeleteEpisodicConfirmation,
+            title = { Text("Delete memory?") },
+            text = { Text("This episodic memory will be permanently removed. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteEpisodicMemory(pendingId) }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissDeleteEpisodicConfirmation) { Text("Cancel") }
             },
         )
     }
@@ -216,4 +271,92 @@ private fun SectionHeader(title: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
     )
+}
+
+@Composable
+private fun EpisodicSectionHeader(count: Int) {
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "Episodic Memories",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        if (count > 0) {
+            Badge(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
+                Text(
+                    text = count.toString(),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodicMemoryItem(
+    memory: EpisodicMemoryEntity,
+    conversationTitle: String,
+    onDelete: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = memory.content,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        supportingContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = conversationTitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${formatEpisodicDate(memory.createdAt)} · accessed ${memory.accessCount}×",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        trailingContent = {
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = "Delete episodic memory")
+            }
+        },
+    )
+}
+
+private fun formatEpisodicDate(epochMs: Long): String {
+    val formatter = DateTimeFormatter
+        .ofPattern("MMM d, yyyy", Locale.getDefault())
+        .withZone(ZoneId.systemDefault())
+    return formatter.format(Instant.ofEpochMilli(epochMs))
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EpisodicMemoryItemPreview() {
+    MaterialTheme {
+        EpisodicMemoryItem(
+            memory = EpisodicMemoryEntity(
+                rowId = 1L,
+                id = "preview-id",
+                conversationId = "conv-1",
+                content = "The user prefers concise answers and dislikes long explanations.",
+                createdAt = System.currentTimeMillis(),
+                accessCount = 3,
+            ),
+            conversationTitle = "Chat about Kotlin",
+            onDelete = {},
+        )
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -51,14 +51,13 @@ class MemoryViewModel @Inject constructor(
         combine(
             combine(
                 memoryRepository.observeCoreMemories(),
-                memoryRepository.observeEpisodicCount(),
                 memoryRepository.observeEpisodicMemories(),
                 _dialogState,
                 _isSubmitting,
-            ) { coreMemories, episodicCount, episodicMemories, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
+            ) { coreMemories, episodicMemories, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
                 MemoryUiState(
                     coreMemories = coreMemories,
-                    episodicCount = episodicCount,
+                    episodicCount = episodicMemories.size,
                     episodicMemories = episodicMemories,
                     isAddDialogOpen = isAddDialogOpen,
                     addDialogText = addDialogText,
@@ -134,8 +133,13 @@ class MemoryViewModel @Inject constructor(
     }
 
     fun deleteEpisodicMemory(id: String) {
-        _pendingDeleteEpisodicId.value = null
-        viewModelScope.launch { memoryRepository.deleteEpisodicMemory(id) }
+        viewModelScope.launch {
+            try {
+                memoryRepository.deleteEpisodicMemory(id)
+            } finally {
+                _pendingDeleteEpisodicId.value = null
+            }
+        }
     }
 
     suspend fun getConversationTitle(conversationId: String): String? =

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -2,13 +2,17 @@ package com.kernel.ai.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
+import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
+import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -17,16 +21,20 @@ import javax.inject.Inject
 @HiltViewModel
 class MemoryViewModel @Inject constructor(
     private val memoryRepository: MemoryRepository,
+    private val conversationRepository: ConversationRepository,
 ) : ViewModel() {
 
     data class MemoryUiState(
         val coreMemories: List<CoreMemoryEntity> = emptyList(),
         val episodicCount: Int = 0,
+        val episodicMemories: List<EpisodicMemoryEntity> = emptyList(),
+        val conversationTitles: Map<String, String?> = emptyMap(),
         val isAddDialogOpen: Boolean = false,
         val addDialogText: String = "",
         val showClearConfirmation: Boolean = false,
         val isSubmitting: Boolean = false,
         val pendingDeleteId: String? = null,
+        val pendingDeleteEpisodicId: String? = null,
     )
 
     private val _dialogState = MutableStateFlow(
@@ -34,26 +42,41 @@ class MemoryViewModel @Inject constructor(
     )
     private val _isSubmitting = MutableStateFlow(false)
     private val _pendingDeleteId = MutableStateFlow<String?>(null)
+    private val _pendingDeleteEpisodicId = MutableStateFlow<String?>(null)
+
+    private val conversationTitlesFlow = conversationRepository.observeConversations()
+        .map { list: List<ConversationEntity> -> list.associate { it.id to it.title } }
 
     val uiState: StateFlow<MemoryUiState> = combine(
         combine(
-            memoryRepository.observeCoreMemories(),
-            memoryRepository.observeEpisodicCount(),
-            _dialogState,
-            _isSubmitting,
-        ) { coreMemories, episodicCount, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
-            MemoryUiState(
-                coreMemories = coreMemories,
-                episodicCount = episodicCount,
-                isAddDialogOpen = isAddDialogOpen,
-                addDialogText = addDialogText,
-                showClearConfirmation = showClearConfirmation,
-                isSubmitting = isSubmitting,
+            combine(
+                memoryRepository.observeCoreMemories(),
+                memoryRepository.observeEpisodicCount(),
+                memoryRepository.observeEpisodicMemories(),
+                _dialogState,
+                _isSubmitting,
+            ) { coreMemories, episodicCount, episodicMemories, (isAddDialogOpen, addDialogText, showClearConfirmation), isSubmitting ->
+                MemoryUiState(
+                    coreMemories = coreMemories,
+                    episodicCount = episodicCount,
+                    episodicMemories = episodicMemories,
+                    isAddDialogOpen = isAddDialogOpen,
+                    addDialogText = addDialogText,
+                    showClearConfirmation = showClearConfirmation,
+                    isSubmitting = isSubmitting,
+                )
+            },
+            _pendingDeleteId,
+            _pendingDeleteEpisodicId,
+        ) { base, pendingDeleteId, pendingDeleteEpisodicId ->
+            base.copy(
+                pendingDeleteId = pendingDeleteId,
+                pendingDeleteEpisodicId = pendingDeleteEpisodicId,
             )
         },
-        _pendingDeleteId,
-    ) { base, pendingDeleteId ->
-        base.copy(pendingDeleteId = pendingDeleteId)
+        conversationTitlesFlow,
+    ) { base, conversationTitles ->
+        base.copy(conversationTitles = conversationTitles)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -101,6 +124,22 @@ class MemoryViewModel @Inject constructor(
         _pendingDeleteId.value = null
         viewModelScope.launch { memoryRepository.deleteCoreMemory(id) }
     }
+
+    fun requestDeleteEpisodicMemory(id: String) {
+        _pendingDeleteEpisodicId.value = id
+    }
+
+    fun dismissDeleteEpisodicConfirmation() {
+        _pendingDeleteEpisodicId.value = null
+    }
+
+    fun deleteEpisodicMemory(id: String) {
+        _pendingDeleteEpisodicId.value = null
+        viewModelScope.launch { memoryRepository.deleteEpisodicMemory(id) }
+    }
+
+    suspend fun getConversationTitle(conversationId: String): String? =
+        conversationRepository.getConversation(conversationId)?.title
 
     fun showClearEpisodicConfirmation() {
         _dialogState.update { it.copy(third = true) }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.kernel.ai.feature.settings
 
+import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
+import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
+import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -20,6 +23,8 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -32,9 +37,12 @@ class MemoryViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private val memoryRepository: MemoryRepository = mockk()
+    private val conversationRepository: ConversationRepository = mockk()
 
     private val coreMemoriesFlow = MutableStateFlow<List<CoreMemoryEntity>>(emptyList())
     private val episodicCountFlow = MutableStateFlow(0)
+    private val episodicMemoriesFlow = MutableStateFlow<List<EpisodicMemoryEntity>>(emptyList())
+    private val conversationsFlow = MutableStateFlow<List<ConversationEntity>>(emptyList())
 
     private lateinit var viewModel: MemoryViewModel
 
@@ -43,7 +51,9 @@ class MemoryViewModelTest {
         Dispatchers.setMain(testDispatcher)
         every { memoryRepository.observeCoreMemories() } returns coreMemoriesFlow
         every { memoryRepository.observeEpisodicCount() } returns episodicCountFlow
-        viewModel = MemoryViewModel(memoryRepository)
+        every { memoryRepository.observeEpisodicMemories() } returns episodicMemoriesFlow
+        every { conversationRepository.observeConversations() } returns conversationsFlow
+        viewModel = MemoryViewModel(memoryRepository, conversationRepository)
     }
 
     @AfterEach
@@ -59,6 +69,15 @@ class MemoryViewModelTest {
         lastAccessedAt = 0L,
         source = "user",
     )
+
+    private fun episodicMemory(id: String, content: String, conversationId: String = "conv-1") =
+        EpisodicMemoryEntity(
+            rowId = 0L,
+            id = id,
+            conversationId = conversationId,
+            content = content,
+            createdAt = System.currentTimeMillis(),
+        )
 
     @Test
     fun `addCoreMemory calls repository with trimmed text`() = runTest {
@@ -133,6 +152,89 @@ class MemoryViewModelTest {
         val state = states.last()
         assertFalse(state.isAddDialogOpen)
         assertEquals("", state.addDialogText)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `episodicMemories state reflects repository flow`() = runTest {
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val memories = listOf(episodicMemory("ep-1", "content one"))
+        episodicMemoriesFlow.value = memories
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, states.last().episodicMemories.size)
+        assertEquals("ep-1", states.last().episodicMemories.first().id)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `requestDeleteEpisodicMemory sets pendingDeleteEpisodicId`() = runTest {
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.requestDeleteEpisodicMemory("ep-42")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("ep-42", states.last().pendingDeleteEpisodicId)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `dismissDeleteEpisodicConfirmation clears pendingDeleteEpisodicId`() = runTest {
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.requestDeleteEpisodicMemory("ep-42")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNotNull(states.last().pendingDeleteEpisodicId)
+
+        viewModel.dismissDeleteEpisodicConfirmation()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(states.last().pendingDeleteEpisodicId)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `deleteEpisodicMemory delegates to repository and clears pending id`() = runTest {
+        coEvery { memoryRepository.deleteEpisodicMemory(any()) } just Runs
+
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.requestDeleteEpisodicMemory("ep-99")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.deleteEpisodicMemory("ep-99")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { memoryRepository.deleteEpisodicMemory("ep-99") }
+        assertNull(states.last().pendingDeleteEpisodicId)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `conversationTitles map reflects conversations flow`() = runTest {
+        val states = mutableListOf<MemoryViewModel.MemoryUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states.add(it) } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        conversationsFlow.value = listOf(
+            ConversationEntity(id = "conv-1", title = "My Chat", createdAt = 0L, updatedAt = 0L),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("My Chat", states.last().conversationTitles["conv-1"])
 
         collectJob.cancel()
     }


### PR DESCRIPTION
Adds an episodic memory browser section to the existing Memory screen in Settings.

## Changes
- `EpisodicMemoryDao`: added `observeAll()`, `deleteById()`, `getRowIdById()`, and `@Transaction getRowIdAndDelete()` (atomic fetch+delete to prevent race with `prune()`)
- `MemoryRepository` interface + `MemoryRepositoryImpl`: `observeEpisodicMemories()` and `deleteEpisodicMemory()` — uses `getRowIdAndDelete()` + `runCatching` on vec delete to handle missing-key gracefully
- `MemoryViewModel`: episodic memories StateFlow, conversation title lookup, delete with `finally` block (dialog stays open on failure); removed redundant `observeEpisodicCount()` flow — derived from `episodicMemories.size` to eliminate transient count/list mismatch
- `MemoryScreen`: full episodic browser section — section header with count badge, stats row, lazy list of memory items (content, conversation title, date, access count, delete), confirmation dialog, empty state, clear-all button; `DateTimeFormatter` hoisted to file-level val
- Tests: 9 new tests across `MemoryRepositoryImplTest` and `MemoryViewModelTest`

## Testing
- `:core:memory:test` ✅
- `:feature:settings:test` ✅
- `assembleDebug` ✅

Closes #155