### PR TITLE
fix(#158): add instructional framing to RAG context block

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -98,7 +98,11 @@ class RagRepository @Inject constructor(
         if (queryVector.isEmpty()) return@withContext ""
 
         val charsPerToken = 3
-        var tokenBudgetRemaining = maxTokens
+        // Reserve tokens for the framing header that wraps the entire RAG block.
+        val framingHeader = "The following context has been retrieved from memory. " +
+            "Use it to inform your response where relevant — do not repeat it verbatim.\n\n"
+        val framingTokenCost = (framingHeader.length + charsPerToken - 1) / charsPerToken
+        var tokenBudgetRemaining = maxTokens - framingTokenCost
 
         // --- Core Memories ---
         val coreMemoryLines = mutableListOf<String>()
@@ -140,7 +144,7 @@ class RagRepository @Inject constructor(
                             .firstOrNull { it.id == entity.messageId }
                     }
 
-                    val episodicHeader = "[Episodic Memories]\n"
+                    val episodicHeader = "[Episodic Memories — recalled from a past conversation]\n"
                     val episodicFooter = "[End of episodic memories]"
                     val episodicOverhead = (episodicHeader.length + episodicFooter.length + charsPerToken - 1) / charsPerToken
                     var episodicBudget = tokenBudgetRemaining - episodicOverhead
@@ -160,14 +164,15 @@ class RagRepository @Inject constructor(
         if (coreMemoryLines.isEmpty() && episodicLines.isEmpty()) return@withContext ""
 
         buildString {
+            append(framingHeader)
             if (coreMemoryLines.isNotEmpty()) {
-                append("[Core Memories]\n")
+                append("[Core Memories — permanent facts about the user]\n")
                 coreMemoryLines.forEach { appendLine(it) }
                 append("[End of core memories]")
             }
             if (episodicLines.isNotEmpty()) {
                 if (coreMemoryLines.isNotEmpty()) append("\n\n")
-                append("[Episodic Memories]\n")
+                append("[Episodic Memories — recalled from a past conversation]\n")
                 episodicLines.forEach { appendLine(it) }
                 append("[End of episodic memories]")
             }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -82,9 +82,10 @@ class RagRepositoryTest {
 
         val result = ragRepository.getRelevantContext("user preferences", conversationId = "test-conv")
 
-        assertTrue(result.contains("[Core Memories]"), "Output must contain [Core Memories] section")
+        assertTrue(result.contains("[Core Memories"), "Output must contain [Core Memories] section")
         assertTrue(result.contains("User prefers dark mode"), "Output must include the core memory content")
-        assertTrue(!result.contains("[Episodic Memories]"), "Output must NOT contain [Episodic Memories] when table not initialised")
+        assertTrue(!result.contains("[Episodic Memories"), "Output must NOT contain [Episodic Memories] when table not initialised")
+        assertTrue(result.startsWith("The following context has been retrieved from memory."), "Output must start with framing instruction")
     }
 
     @Test
@@ -118,11 +119,15 @@ class RagRepositoryTest {
 
         val result = ragRepository.getRelevantContext("tell me about preferences", conversationId = "conv-1")
 
-        assertTrue(result.contains("[Core Memories]"), "Output must contain [Core Memories]")
-        assertTrue(result.contains("[Episodic Memories]"), "Output must contain [Episodic Memories]")
+        assertTrue(result.startsWith("The following context has been retrieved from memory."), "Output must start with framing instruction")
+        assertTrue(result.contains("[Core Memories"), "Output must contain [Core Memories]")
+        assertTrue(result.contains("[Episodic Memories"), "Output must contain [Episodic Memories]")
+        assertTrue(result.contains("past conversation"), "Episodic header must clarify source as past conversation")
 
-        val coreIndex = result.indexOf("[Core Memories]")
-        val episodicIndex = result.indexOf("[Episodic Memories]")
+        val framingIndex = result.indexOf("The following context")
+        val coreIndex = result.indexOf("[Core Memories")
+        val episodicIndex = result.indexOf("[Episodic Memories")
+        assertTrue(framingIndex < coreIndex, "Framing must appear before [Core Memories]")
         assertTrue(coreIndex < episodicIndex, "[Core Memories] must appear before [Episodic Memories]")
     }
 
@@ -207,7 +212,7 @@ class RagRepositoryTest {
         // Must not throw
         val result = ragRepository.getRelevantContext("what did the user say earlier", conversationId = "conv-2")
 
-        assertTrue(!result.contains("[Core Memories]"), "Failed core search must not produce a [Core Memories] section")
-        assertTrue(result.contains("[Episodic Memories]"), "Episodic content must still appear despite core failure")
+        assertTrue(!result.contains("[Core Memories"), "Failed core search must not produce a [Core Memories] section")
+        assertTrue(result.contains("[Episodic Memories"), "Episodic content must still appear despite core failure")
     }
 }


### PR DESCRIPTION
Gemma-4 was receiving the memory context block with no instruction about what it is or how to use it.

## Problem
The RAG block was prepended raw — no framing, no intent. Gemma-4 could ignore it, repeat it verbatim, or confuse episodic messages with the current conversation (same `User:`/`Assistant:` format).

## Fix
- Framing instruction prepended: *"The following context has been retrieved from memory. Use it to inform your response where relevant — do not repeat it verbatim."*
- Core memory label updated: `[Core Memories — permanent facts about the user]`
- Episodic memory label updated: `[Episodic Memories — recalled from a past conversation]`
- Framing token cost (~10 tokens) deducted from the RAG budget upfront

## Testing
- `:core:memory:test` ✅ (RagRepositoryTest updated + new framing assertions)
- `assembleDebug` ✅

Closes #158