### PR TITLE
fix(#160): move core memories from system prompt to RAG-only retrieval

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -7,6 +7,7 @@ import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.MemorySearchResult
 import com.kernel.ai.core.memory.vector.VectorStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -107,12 +108,15 @@ class RagRepository @Inject constructor(
         // --- Core Memories ---
         val coreMemoryLines = mutableListOf<String>()
         runCatching {
-            val coreResults = memoryRepository.searchMemories(queryVector, topK = 5)
-            val coreHeader = "[Core Memories]\n"
+            val coreResults = memoryRepository.searchMemories(queryVector, coreTopK = 10, episodicTopK = 0)
+                .filter { it.source == "core" }
+                // Primary: semantic relevance. Secondary: recency (recently-accessed facts win ties).
+                .sortedWith(compareByDescending<MemorySearchResult> { it.score }.thenByDescending { it.lastAccessedAt })
+            val coreHeader = "[Core Memories — permanent facts about the user]\n"
             val coreFooter = "[End of core memories]"
             val coreOverhead = (coreHeader.length + coreFooter.length + charsPerToken - 1) / charsPerToken
             var coreBudget = tokenBudgetRemaining - coreOverhead
-            for (result in coreResults.filter { it.source == "core" }) {
+            for (result in coreResults) {
                 val line = result.content.take(300)
                 val cost = (line.length + 1 + charsPerToken - 1) / charsPerToken
                 if (coreBudget - cost < 0) break

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -10,7 +10,11 @@ interface MemoryRepository {
     /** Store a permanent cross-conversation memory. */
     suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray? = null): String
     /** Search BOTH tiers; core ranked above episodic. */
-    suspend fun searchMemories(queryVector: FloatArray, topK: Int = 5): List<MemorySearchResult>
+    suspend fun searchMemories(
+        queryVector: FloatArray,
+        coreTopK: Int = 10,
+        episodicTopK: Int = 5,
+    ): List<MemorySearchResult>
     /** Delete a specific core memory. */
     suspend fun deleteCoreMemory(id: String)
     /** Delete all episodic memories. */

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -28,8 +28,10 @@ class MemoryRepositoryImpl @Inject constructor(
         private const val EPISODIC_MAX = 500
         private const val CORE_MAX = 200
         private const val EPISODIC_TTL_MS = 30L * 24 * 60 * 60 * 1000  // 30 days
-        /** Mirror of RagRepository.MAX_DISTANCE — filter out low-relevance results. */
-        private const val MAX_SEARCH_DISTANCE = 0.4f
+        /** Looser threshold for core memories — user deliberately added these, cast a wide net. */
+        private const val CORE_MAX_DISTANCE = 0.55f
+        /** Stricter threshold for episodic memories — only surface clearly relevant past exchanges. */
+        private const val EPISODIC_MAX_DISTANCE = 0.40f
     }
 
     // AtomicBoolean + Mutex for thread-safe lazy table creation
@@ -87,12 +89,16 @@ class MemoryRepositoryImpl @Inject constructor(
 
     // Remove flag-guards: persisted vec tables must be searched after app restart.
     // runCatching already swallows "no such table" when no embeddings have been stored.
-    override suspend fun searchMemories(queryVector: FloatArray, topK: Int): List<MemorySearchResult> {
+    override suspend fun searchMemories(
+        queryVector: FloatArray,
+        coreTopK: Int,
+        episodicTopK: Int,
+    ): List<MemorySearchResult> {
         val results = mutableListOf<MemorySearchResult>()
 
         runCatching {
-            val coreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, topK)
-                .filter { it.distance <= MAX_SEARCH_DISTANCE }
+            val coreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, coreTopK)
+                .filter { it.distance <= CORE_MAX_DISTANCE }
             val rowIds = coreResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
                 val entities = coreDao.getAll().filter { it.rowId in rowIds }
@@ -104,6 +110,7 @@ class MemoryRepositoryImpl @Inject constructor(
                             content = entity.content,
                             source = "core",
                             score = 1f - (distanceMap[entity.rowId] ?: 1f),
+                            lastAccessedAt = entity.lastAccessedAt,
                         )
                     )
                 }
@@ -117,8 +124,8 @@ class MemoryRepositoryImpl @Inject constructor(
         }.onFailure { Log.w(TAG, "Core memory search failed: ${it.message}") }
 
         runCatching {
-            val episodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, topK)
-                .filter { it.distance <= MAX_SEARCH_DISTANCE }
+            val episodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, episodicTopK)
+                .filter { it.distance <= EPISODIC_MAX_DISTANCE }
             val rowIds = episodicResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
                 val entities = episodicDao.getAll().filter { it.rowId in rowIds }
@@ -136,10 +143,7 @@ class MemoryRepositoryImpl @Inject constructor(
             }
         }.onFailure { Log.w(TAG, "Episodic memory search failed: ${it.message}") }
 
-        // Core ranked above episodic, then by score descending
         return results
-            .sortedWith(compareBy<MemorySearchResult> { if (it.source == "core") 0 else 1 }.thenByDescending { it.score })
-            .take(topK)
     }
 
     override suspend fun deleteCoreMemory(id: String) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -124,6 +124,7 @@ class MemoryRepositoryImpl @Inject constructor(
         }.onFailure { Log.w(TAG, "Core memory search failed: ${it.message}") }
 
         runCatching {
+            if (episodicTopK <= 0) return@runCatching  // skip until Dreaming Engine populates the table
             val episodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, episodicTopK)
                 .filter { it.distance <= EPISODIC_MAX_DISTANCE }
             val rowIds = episodicResults.map { it.rowId }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.memory.repository
 data class MemorySearchResult(
     val id: String,
     val content: String,
-    val source: String,  // "episodic" or "core"
+    val source: String,       // "episodic" or "core"
     val score: Float,
+    val lastAccessedAt: Long = 0L, // populated for core memories; used as tiebreaker when truncating
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -235,7 +235,7 @@ class RagRepositoryTest {
             MemorySearchResult(id = "recent", content = "Recent fact", source = "core", score = 0.9f, lastAccessedAt = 9_000L),
         )
 
-        val result = ragRepository.getRelevantContext("query", conversationId = "c", maxTokens = 30)
+        val result = ragRepository.getRelevantContext("query", conversationId = "c", maxTokens = 75)
 
         assertTrue(result.contains("Recent fact"), "Higher lastAccessedAt must win the tiebreak and appear in output")
         assertFalse(result.contains("Stale fact"), "Lower lastAccessedAt must be truncated when budget is tight")

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -71,7 +71,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns queryVector
 
         // Memory tier: one core result — episodic table NOT created so no [Episodic Memories]
-        coEvery { memoryRepository.searchMemories(any(), any()) } returns listOf(
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
             MemorySearchResult(
                 id = "core-1",
                 content = "User prefers dark mode",
@@ -99,7 +99,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
 
         // Memory tier: core only (episodic from searchMemories is NOT rendered)
-        coEvery { memoryRepository.searchMemories(any(), any()) } returns listOf(
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
             MemorySearchResult(id = "core-1", content = "Core preference fact", source = "core", score = 0.9f),
         )
 
@@ -137,7 +137,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns queryVector
 
         // No memory results from either tier
-        coEvery { memoryRepository.searchMemories(any(), any()) } returns emptyList()
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns emptyList()
 
         // Note: tableCreated is false so vectorStore.search is NOT called;
         // both sections are empty → result is ""
@@ -155,7 +155,7 @@ class RagRepositoryTest {
         primeEpisodicTable(sharedVector)
 
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
-        coEvery { memoryRepository.searchMemories(any(), any()) } returns emptyList()
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns emptyList()
 
         // Vector search returns two candidates — one from each conversation
         every { vectorStore.search(any(), any(), any()) } returns listOf(
@@ -193,7 +193,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
 
         // Memory tier throws — should be caught, not propagated
-        coEvery { memoryRepository.searchMemories(any(), any()) } throws RuntimeException("Memory DB failure")
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } throws RuntimeException("Memory DB failure")
 
         // Message history is still available
         val embeddingEntity = MessageEmbeddingEntity(rowId = 2L, messageId = "msg-2", conversationId = "conv-2")

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -12,11 +12,13 @@ import com.kernel.ai.core.memory.vector.VectorSearchResult
 import com.kernel.ai.core.memory.vector.VectorStore
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -86,6 +88,11 @@ class RagRepositoryTest {
         assertTrue(result.contains("User prefers dark mode"), "Output must include the core memory content")
         assertTrue(!result.contains("[Episodic Memories"), "Output must NOT contain [Episodic Memories] when table not initialised")
         assertTrue(result.startsWith("The following context has been retrieved from memory."), "Output must start with framing instruction")
+
+        // Verify the correct topK contract — core gets 10 slots, episodic is suppressed (0)
+        coVerify(exactly = 1) {
+            memoryRepository.searchMemories(any(), coreTopK = 10, episodicTopK = 0)
+        }
     }
 
     @Test
@@ -214,5 +221,23 @@ class RagRepositoryTest {
 
         assertTrue(!result.contains("[Core Memories"), "Failed core search must not produce a [Core Memories] section")
         assertTrue(result.contains("[Episodic Memories"), "Episodic content must still appear despite core failure")
+    }
+
+    @Test
+    fun `getRelevantContext — lastAccessedAt tiebreaker orders memories with equal score by recency`() = runTest {
+        val queryVector = floatArrayOf(1.0f, 0.0f, 0.0f)
+        coEvery { embeddingEngine.embed(any()) } returns queryVector
+
+        // Two memories with identical score — stale predates recent by access time.
+        // Budget is deliberately tight (≈30 tokens) so only one fits.
+        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
+            MemorySearchResult(id = "stale",  content = "Stale fact",  source = "core", score = 0.9f, lastAccessedAt = 1_000L),
+            MemorySearchResult(id = "recent", content = "Recent fact", source = "core", score = 0.9f, lastAccessedAt = 9_000L),
+        )
+
+        val result = ragRepository.getRelevantContext("query", conversationId = "c", maxTokens = 30)
+
+        assertTrue(result.contains("Recent fact"), "Higher lastAccessedAt must win the tiebreak and appear in output")
+        assertFalse(result.contains("Stale fact"), "Lower lastAccessedAt must be truncated when budget is tight")
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -145,32 +145,19 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch { initEngineWhenReady() }
     }
 
-    private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList(), recordAccess: Boolean = false): String {
+    private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
         val profile = userProfileRepository.get()
         val dateTime = LocalDateTime.now()
             .format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm"))
         val backend = inferenceEngine.activeBackend.value?.name ?: "CPU"
         val model = activeModel?.displayName ?: "Gemma 4"
         val device = "${Build.MANUFACTURER} ${Build.MODEL}"
-        // Fetch core memories before buildString so we can update access stats (suspend call).
-        val coreMemories = runCatching {
-            memoryRepository.observeCoreMemories().first().take(10)
-        }.getOrDefault(emptyList())
-        // Record access so the Memory screen reflects real usage counts.
-        // Errors are silently swallowed — the repository impl already logs failures,
-        // and access-stat updates must never block prompt construction.
-        if (recordAccess && coreMemories.isNotEmpty()) {
-            runCatching { memoryRepository.recordCoreMemoryAccess(coreMemories.map { it.id }) }
-        }
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
             append("\n\n[Current date and time]\n$dateTime")
             append("\n\n[Runtime]\nModel: $model | Backend: $backend | Device: $device")
-            if (profile.isNotBlank()) append("\n\n[User Profile]\n$profile")
-            if (coreMemories.isNotEmpty()) {
-                append("\n\n[Core Memories]\n")
-                coreMemories.forEach { append("- ${it.content}\n") }
-                append("[End of core memories]")
+            if (profile.isNotBlank()) {
+                append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$profile")
             }
             if (historyTurns.isNotEmpty()) {
                 append("\n\n[Previous conversation context]\n")
@@ -354,7 +341,7 @@ class ChatViewModel @Inject constructor(
                 )
                 val selected = contextWindowManager.selectHistory(turns)
                 // Inject history into the system prompt so Gemma treats it as background context.
-                val systemPromptWithHistory = buildSystemPrompt(selected, recordAccess = true)
+                val systemPromptWithHistory = buildSystemPrompt(selected)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)
                 // Re-baseline from selected history, then add the RAG cost for this turn.
                 estimatedTokensUsed = selected.sumOf {


### PR DESCRIPTION
## Summary

Closes #160

Core memories were previously injected in two places:
1. **System prompt** — top 10 by recency (not relevance)
2. **RAG block** — top 5 by semantic similarity

This caused duplication and used the wrong selection criterion in the system prompt. This PR removes the system prompt injection entirely and gives RAG full ownership of core memory retrieval.

## Changes

### `MemorySearchResult`
- Added `lastAccessedAt: Long = 0` field — populated for core memories, used as sort tiebreaker

### `MemoryRepository` interface + `MemoryRepositoryImpl`
- Split `MAX_SEARCH_DISTANCE = 0.4f` into two constants:
  - `CORE_MAX_DISTANCE = 0.55f` — looser threshold (cosine similarity ≥ 0.45), core memories deliberately added deserve wider recall
  - `EPISODIC_MAX_DISTANCE = 0.40f` — stricter threshold (cosine similarity ≥ 0.60)
- `searchMemories()` signature changed: `coreTopK = 10, episodicTopK = 5` (separate budgets per tier)
- Core `MemorySearchResult` now carries `lastAccessedAt` from the entity

### `RagRepository`
- Calls `searchMemories(coreTopK = 10, episodicTopK = 0)` (episodic_memories_vec not yet populated — handled separately when Dreaming Engine lands)
- Sorts core results: **similarity DESC, lastAccessedAt DESC** — most relevant first; recently-accessed wins ties when truncating to token budget
- Added `MemorySearchResult` import

### `ChatViewModel.buildSystemPrompt()`
- Removed `[Core Memories]` block and `observeCoreMemories()` / `recordCoreMemoryAccess()` calls
- Removed `recordAccess` parameter (access stats are now updated by RAG search via `incrementAccessStatsAndNotify`)
- Added framing instruction before `[User Profile]`: *"The following is background context about the user — use it to personalise responses"*

### `RagRepositoryTest`
- Updated `searchMemories` mock calls from 2-arg to 3-arg to match new interface

## Behaviour after this change

| Scenario | Before | After |
|----------|--------|-------|
| Core memories with no relevant query | Injected in every system prompt (top 10 by recency) | Not injected — only appear when semantically relevant |
| Core memories with matching query | Injected twice (system prompt + RAG) | Injected once via RAG block with framing header |
| Token budget for core memories | Fixed ~400 tokens, recency-ordered | Up to 10 results, similarity-ordered, truncated by token budget with lastAccessedAt tiebreaker |
| User profile framing | No instruction — Gemma-4 could ignore it | Explicit framing instruction added |
