### PR TITLE
feat: episodic distillation on conversation close + LRU episodic pruning (#165, #167)

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/5.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/5.json
@@ -1,0 +1,347 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "0f83964a9c0e0c63c0ca7e022e7af0c4",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0f83964a9c0e0c63c0ca7e022e7af0c4')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -47,6 +47,7 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE conversations ADD COLUMN lastDistilledAt INTEGER DEFAULT NULL")
                 db.execSQL("ALTER TABLE episodic_memories ADD COLUMN lastAccessedAt INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("UPDATE episodic_memories SET lastAccessedAt = createdAt")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.core.memory
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.kernel.ai.core.memory.dao.ConversationDao
 import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
@@ -25,7 +27,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         EpisodicMemoryEntity::class,
         CoreMemoryEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -38,4 +40,14 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun userProfileDao(): UserProfileDao
     abstract fun episodicMemoryDao(): EpisodicMemoryDao
     abstract fun coreMemoryDao(): CoreMemoryDao
+
+    companion object {
+        /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
+        val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE conversations ADD COLUMN lastDistilledAt INTEGER DEFAULT NULL")
+                db.execSQL("ALTER TABLE episodic_memories ADD COLUMN lastAccessedAt INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+    }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -38,6 +38,7 @@ abstract class MemoryModule {
         @Singleton
         fun provideKernelDatabase(@ApplicationContext context: Context): KernelDatabase =
             Room.databaseBuilder(context, KernelDatabase::class.java, "kernel_db")
+                .addMigrations(KernelDatabase.MIGRATION_4_5)
                 .build()
 
         @Provides

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -33,6 +33,9 @@ interface ConversationDao {
     @Query("UPDATE conversations SET updatedAt = :updatedAt WHERE id = :id")
     suspend fun touchUpdatedAt(id: String, updatedAt: Long)
 
+    @Query("UPDATE conversations SET lastDistilledAt = :timestamp WHERE id = :id")
+    suspend fun updateLastDistilledAt(id: String, timestamp: Long)
+
     @Query("SELECT * FROM conversations WHERE title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\' ORDER BY updatedAt DESC")
     fun searchByTitle(query: String): Flow<List<ConversationEntity>>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -35,9 +35,6 @@ interface EpisodicMemoryDao {
     @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoffMs")
     suspend fun deleteOlderThan(cutoffMs: Long)
 
-    @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoff")
-    suspend fun deleteBefore(cutoff: Long)
-
     @Query("SELECT rowId FROM episodic_memories ORDER BY createdAt ASC LIMIT :count")
     suspend fun getOldestRowIds(count: Int): List<Long>
 
@@ -51,8 +48,15 @@ interface EpisodicMemoryDao {
     @Query("SELECT rowId FROM episodic_memories ORDER BY lastAccessedAt ASC LIMIT :count")
     suspend fun getOldestRowIdsByLRU(count: Int): List<Long>
 
-    @Query("DELETE FROM episodic_memories WHERE id IN (SELECT id FROM episodic_memories ORDER BY lastAccessedAt ASC LIMIT :count)")
-    suspend fun deleteOldest(count: Int)
+    @Query("DELETE FROM episodic_memories WHERE rowId IN (:rowIds)")
+    suspend fun deleteByRowIds(rowIds: List<Long>)
+
+    @Transaction
+    suspend fun getRowIdsAndDeleteByLRU(count: Int): List<Long> {
+        val rowIds = getOldestRowIdsByLRU(count)
+        if (rowIds.isNotEmpty()) deleteByRowIds(rowIds)
+        return rowIds
+    }
 
     @Query("UPDATE episodic_memories SET lastAccessedAt = :timestamp WHERE id = :id")
     suspend fun updateLastAccessedAt(id: String, timestamp: Long)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -35,6 +35,9 @@ interface EpisodicMemoryDao {
     @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoffMs")
     suspend fun deleteOlderThan(cutoffMs: Long)
 
+    @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoff")
+    suspend fun deleteBefore(cutoff: Long)
+
     @Query("SELECT rowId FROM episodic_memories ORDER BY createdAt ASC LIMIT :count")
     suspend fun getOldestRowIds(count: Int): List<Long>
 
@@ -44,6 +47,15 @@ interface EpisodicMemoryDao {
         )
     """)
     suspend fun deleteOldestBeyondLimit(count: Int)
+
+    @Query("SELECT rowId FROM episodic_memories ORDER BY lastAccessedAt ASC LIMIT :count")
+    suspend fun getOldestRowIdsByLRU(count: Int): List<Long>
+
+    @Query("DELETE FROM episodic_memories WHERE id IN (SELECT id FROM episodic_memories ORDER BY lastAccessedAt ASC LIMIT :count)")
+    suspend fun deleteOldest(count: Int)
+
+    @Query("UPDATE episodic_memories SET lastAccessedAt = :timestamp WHERE id = :id")
+    suspend fun updateLastAccessedAt(id: String, timestamp: Long)
 
     @Query("SELECT * FROM episodic_memories ORDER BY createdAt DESC")
     fun observeAll(): Flow<List<EpisodicMemoryEntity>>

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
@@ -16,6 +16,9 @@ interface MessageDao {
     @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp ASC")
     suspend fun getByConversation(conversationId: String): List<MessageEntity>
 
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId AND timestamp > :since ORDER BY timestamp ASC")
+    suspend fun getByConversationSince(conversationId: String, since: Long): List<MessageEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(message: MessageEntity)
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
@@ -9,4 +9,5 @@ data class ConversationEntity(
     val title: String?,
     val createdAt: Long,
     val updatedAt: Long,
+    val lastDistilledAt: Long? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
@@ -12,4 +12,6 @@ data class EpisodicMemoryEntity(
     val content: String,
     val createdAt: Long,
     val accessCount: Int = 0,
+    // NOTE: defaults to 0 (not createdAt) due to SQLite migration constraint
+    val lastAccessedAt: Long = 0,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -141,6 +141,13 @@ class MemoryRepositoryImpl @Inject constructor(
                         )
                     )
                 }
+                // Update last accessed timestamp for LRU pruning (#167)
+                val now = System.currentTimeMillis()
+                entities.forEach { entity ->
+                    runCatching {
+                        episodicDao.updateLastAccessedAt(entity.id, now)
+                    }.onFailure { Log.w(TAG, "updateLastAccessedAt failed for ${entity.id}: ${it.message}") }
+                }
             }
         }.onFailure { Log.w(TAG, "Episodic memory search failed: ${it.message}") }
 
@@ -195,8 +202,8 @@ class MemoryRepositoryImpl @Inject constructor(
         val episodicCount = episodicDao.count()
         if (episodicCount > EPISODIC_MAX) {
             val overflow = episodicCount - EPISODIC_MAX
-            val overflowRowIds = episodicDao.getOldestRowIds(overflow)
-            episodicDao.deleteOldestBeyondLimit(overflow)
+            val overflowRowIds = episodicDao.getOldestRowIdsByLRU(overflow)
+            episodicDao.deleteOldest(overflow)
             overflowRowIds.forEach { vectorStore.delete(EPISODIC_VEC_TABLE, it) }
         }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -202,8 +202,7 @@ class MemoryRepositoryImpl @Inject constructor(
         val episodicCount = episodicDao.count()
         if (episodicCount > EPISODIC_MAX) {
             val overflow = episodicCount - EPISODIC_MAX
-            val overflowRowIds = episodicDao.getOldestRowIdsByLRU(overflow)
-            episodicDao.deleteOldest(overflow)
+            val overflowRowIds = episodicDao.getRowIdsAndDeleteByLRU(overflow)
             overflowRowIds.forEach { vectorStore.delete(EPISODIC_VEC_TABLE, it) }
         }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -28,6 +28,7 @@ class EpisodicDistillationUseCase @Inject constructor(
     companion object {
         private const val TAG = "KernelAI"
         private const val MIN_TURNS = 4
+        private val LEADING_JUNK = Regex("""^[\s\d]+[.)]\s*|^[-•*]\s*""")
     }
 
     /**
@@ -68,7 +69,9 @@ $transcript
                 return
             }
 
-            val sentences = response.lines().map { it.trim() }.filter { it.isNotBlank() }
+            val sentences = response.lines()
+                .map { LEADING_JUNK.replace(it.trim(), "") }
+                .filter { it.isNotBlank() }
             if (sentences.isEmpty()) {
                 Log.w(TAG, "Episodic distillation: no sentences parsed for $conversationId")
                 return

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -1,0 +1,88 @@
+package com.kernel.ai.core.memory.usecase
+
+import android.util.Log
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.memory.dao.ConversationDao
+import com.kernel.ai.core.memory.dao.MessageDao
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Distils a conversation into standalone episodic memory sentences on conversation close.
+ *
+ * Fetches messages since [lastDistilledAt] (or all messages if null), formats them as a
+ * transcript, calls the inference engine for a summary, embeds each sentence and stores
+ * them as episodic memories. Updates [ConversationDao.updateLastDistilledAt] on success.
+ */
+@Singleton
+class EpisodicDistillationUseCase @Inject constructor(
+    private val messageDao: MessageDao,
+    private val conversationDao: ConversationDao,
+    private val memoryRepository: MemoryRepository,
+    private val inferenceEngine: InferenceEngine,
+    private val embeddingEngine: EmbeddingEngine,
+) {
+
+    companion object {
+        private const val TAG = "KernelAI"
+        private const val MIN_TURNS = 4
+    }
+
+    /**
+     * Distil the conversation identified by [conversationId].
+     *
+     * @param conversationId The conversation to distil.
+     * @param lastDistilledAt Timestamp of the last distillation run, or null to distil everything.
+     */
+    suspend fun distil(conversationId: String, lastDistilledAt: Long?) {
+        try {
+            val messages = if (lastDistilledAt != null) {
+                messageDao.getByConversationSince(conversationId, lastDistilledAt)
+            } else {
+                messageDao.getByConversation(conversationId)
+            }
+
+            if (messages.size < MIN_TURNS) {
+                Log.d(TAG, "Episodic distillation skipped for $conversationId: only ${messages.size} messages (min $MIN_TURNS)")
+                return
+            }
+
+            val transcript = messages.joinToString("\n") { msg ->
+                val label = if (msg.role == "user") "User" else "Assistant"
+                "$label: ${msg.content}"
+            }
+
+            val prompt = """
+Summarise the key facts, preferences, and events from this conversation in 3–5 short sentences. Each sentence should be a standalone fact. Output only the sentences, one per line, with no numbering or bullet points.
+
+[CONVERSATION]
+$transcript
+[END CONVERSATION]
+            """.trimIndent()
+
+            val response = inferenceEngine.generateOnce(prompt)
+            if (response.isBlank()) {
+                Log.w(TAG, "Episodic distillation returned blank response for $conversationId")
+                return
+            }
+
+            val sentences = response.lines().map { it.trim() }.filter { it.isNotBlank() }
+            if (sentences.isEmpty()) {
+                Log.w(TAG, "Episodic distillation: no sentences parsed for $conversationId")
+                return
+            }
+
+            sentences.forEach { sentence ->
+                val vector = embeddingEngine.embed(sentence)
+                memoryRepository.addEpisodicMemory(conversationId, sentence, vector)
+            }
+
+            conversationDao.updateLastDistilledAt(conversationId, System.currentTimeMillis())
+            Log.i(TAG, "Episodic distillation complete for $conversationId: ${sentences.size} memories stored")
+        } catch (e: Exception) {
+            Log.w(TAG, "Episodic distillation failed for $conversationId: ${e.message}")
+        }
+    }
+}

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
@@ -208,14 +208,14 @@ class MemoryRepositoryImplTest {
         coEvery { episodicDao.getRowIdsOlderThan(any()) } returns emptyList()
         coEvery { episodicDao.deleteOlderThan(any()) } just Runs
         coEvery { episodicDao.count() } returns 600   // 100 over the 500 limit
-        coEvery { episodicDao.getOldestRowIds(100) } returns listOf(1L, 2L)
-        coEvery { episodicDao.deleteOldestBeyondLimit(100) } just Runs
+        coEvery { episodicDao.getRowIdsAndDeleteByLRU(100) } returns listOf(1L, 2L)
         every { vectorStore.delete(any(), any()) } just Runs
         coEvery { coreDao.count() } returns 10
 
         repository.prune()
 
-        coVerify(exactly = 1) { episodicDao.deleteOldestBeyondLimit(100) }
+        coVerify(exactly = 1) { episodicDao.getRowIdsAndDeleteByLRU(100) }
+        verify(exactly = 2) { vectorStore.delete(any(), any()) }
     }
 
     @Test
@@ -243,7 +243,7 @@ class MemoryRepositoryImplTest {
 
         repository.prune()
 
-        coVerify(exactly = 0) { episodicDao.deleteOldestBeyondLimit(any()) }
+        coVerify(exactly = 0) { episodicDao.getOldestRowIdsByLRU(any()) }
         coVerify(exactly = 0) { coreDao.deleteOldestBeyondLimit(any()) }
         verify(exactly = 0) { vectorStore.delete(any(), any()) }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -17,10 +17,13 @@ import com.kernel.ai.core.memory.rag.RagRepository
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -45,6 +48,7 @@ class ChatViewModel @Inject constructor(
     private val ragRepository: RagRepository,
     private val userProfileRepository: UserProfileRepository,
     private val memoryRepository: MemoryRepository,
+    private val episodicDistillationUseCase: EpisodicDistillationUseCase,
 ) : ViewModel() {
 
     /** Passed via nav arg; null means "start a new conversation". */
@@ -56,6 +60,9 @@ class ChatViewModel @Inject constructor(
     private val _conversationTitle = MutableStateFlow<String?>(null)
     private var conversationId: String? = null
     private val contextWindowManager = ContextWindowManager()
+
+    /** Tracks the timestamp of the last episodic distillation for the current conversation. */
+    private var lastDistilledAt: Long? = null
 
     // Tracks the in-progress streaming response so it can be flushed to Room on cancel/clear.
     private var activeStreamingMsgId: String? = null
@@ -177,6 +184,9 @@ class ChatViewModel @Inject constructor(
         val conversation = conversationRepository.getConversation(id)
         val existingTitle = conversation?.title
         _conversationTitle.value = existingTitle
+
+        // Track lastDistilledAt for episodic distillation on close.
+        lastDistilledAt = conversation?.lastDistilledAt
 
         val persisted = conversationRepository.getMessagesOnce(id)
         if (persisted.isNotEmpty()) {
@@ -584,6 +594,15 @@ class ChatViewModel @Inject constructor(
         if (content.isNotBlank() && convId != null) {
             runBlocking {
                 conversationRepository.addMessage(convId, "assistant", content, thinking)
+            }
+        }
+        // Fire-and-forget episodic distillation on conversation close.
+        if (convId != null) {
+            val lastDistilled = lastDistilledAt
+            CoroutineScope(Dispatchers.IO).launch {
+                runCatching {
+                    episodicDistillationUseCase.distil(convId, lastDistilled)
+                }.onFailure { Log.w("KernelAI", "Episodic distillation failed: ${it.message}") }
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }


### PR DESCRIPTION
## Summary

Closes #165, Closes #167

Two Phase 3 memory features in one PR — they share a single Room migration (version 4→5).

---

### #165 — Episodic distillation on conversation close

When `ChatViewModel.onCleared()` fires, a fire-and-forget coroutine checks if there are ≥ 4 new message turns since `lastDistilledAt`. If so, it calls `EpisodicDistillationUseCase.distil()` which:

1. Fetches messages since last distillation (or all messages if never distilled)
2. Formats them as a conversation transcript
3. Calls Gemma-4 with a distillation prompt asking for 3–5 standalone fact sentences
4. Splits the response line-by-line
5. Embeds each sentence via EmbeddingGemma
6. Stores each as an episodic memory via `addEpisodicMemory()`
7. Updates `lastDistilledAt` on the conversation

If Gemma-4 is busy or throws, the error is caught and logged — Phase 4 WorkManager will retry.

**New field:** `ConversationEntity.lastDistilledAt: Long? = null`  
**New class:** `EpisodicDistillationUseCase`  
**New DAO query:** `ConversationDao.updateLastDistilledAt()`, `MessageDao.getByConversationSince()`

---

### #167 — LRU pruning for episodic memories

Episodic memories are now pruned by last-accessed time rather than creation time, so rarely-retrieved memories age out while actively-recalled ones are retained.

- `lastAccessedAt` updated on every RAG hit in `searchMemories()`
- Cap overflow pruning now uses `ORDER BY lastAccessedAt ASC` (least recently accessed first)
- TTL pruning still checks `createdAt` (memories that were never recalled expire first)

**New field:** `EpisodicMemoryEntity.lastAccessedAt: Long = 0`  
**Updated:** `MemoryRepositoryImpl.prune()`, `searchMemories()`

---

### Room migration

Single migration 4→5:
```sql
ALTER TABLE conversations ADD COLUMN lastDistilledAt INTEGER DEFAULT NULL
ALTER TABLE episodic_memories ADD COLUMN lastAccessedAt INTEGER NOT NULL DEFAULT 0
```