### PR TITLE
fix: title generation prompt leaking into chat (#172)

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -546,7 +546,11 @@ class ChatViewModel @Inject constructor(
         try {
             // generateOnce() reuses the existing conversation session (LiteRT only supports
             // one session at a time) and acquires generationMutex so it waits if engine is busy.
+            // After completion the title prompt + response sit in the KV cache. Mark
+            // needsHistoryReplay so the next sendMessage() resets the session and re-injects
+            // clean history, preventing the title instructions from leaking into the chat (#172).
             val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = null)
+            needsHistoryReplay = true
             Log.d("KernelAI", "Raw title output: \"$raw\"")
             val title = raw
                 .trim()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -543,14 +543,15 @@ class ChatViewModel @Inject constructor(
 
         Log.d("KernelAI", "Generating title for $id with prompt: ${titlePrompt.take(80)}...")
 
+        // Mark the KV cache dirty BEFORE sending the title prompt. generateOnce() writes the
+        // prompt + response into the live LiteRT session. Setting the flag early ensures any
+        // concurrent sendMessage() that slips past the isGenerating guard will still trigger
+        // a history replay and flush the title artefacts before the next generation (#172).
+        needsHistoryReplay = true
         try {
             // generateOnce() reuses the existing conversation session (LiteRT only supports
             // one session at a time) and acquires generationMutex so it waits if engine is busy.
-            // After completion the title prompt + response sit in the KV cache. Mark
-            // needsHistoryReplay so the next sendMessage() resets the session and re-injects
-            // clean history, preventing the title instructions from leaking into the chat (#172).
             val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = null)
-            needsHistoryReplay = true
             Log.d("KernelAI", "Raw title output: \"$raw\"")
             val title = raw
                 .trim()
@@ -581,6 +582,8 @@ class ChatViewModel @Inject constructor(
             }
         } catch (e: Exception) {
             Log.w("KernelAI", "Auto-title generation failed: ${e.message}", e)
+            // needsHistoryReplay is already true (set before the call) — KV cache may be
+            // partially dirty from the prompt write, so the flag correctly stays set.
             // Silent failure — title stays null, user can rename manually.
         }
     }


### PR DESCRIPTION
## Root cause

Closes #172

`generateOnce()` sends the title prompt as a real message into the live LiteRT conversation session, permanently writing both the prompt and its response into the KV cache. Without a subsequent session reset, the model retains the strict formatting instruction ("Reply with ONLY a short conversation title, 4-6 words...") and emits it verbatim when the user sends their next message.

## Fix

Set `needsHistoryReplay = true` immediately after `generateOnce()` returns. This causes the next `sendMessage()` call to trigger the existing history-replay path — `updateSystemPrompt()` resets the LiteRT session and re-injects clean conversation history — washing the title prompt/response out of the KV cache before the user's next message is processed.

**One-line change in `ChatViewModel.generateTitle()`.**

## Why this approach

- `resetConversation()` alone would lose conversation context (KV cache) with no way to restore it mid-conversation
- `needsHistoryReplay` is the existing mechanism for exactly this scenario — it reconstructs context safely from Room-persisted history via `buildSystemPrompt(historyTurns)`
- Zero risk to existing behaviour: if the user never sends another message, the flag is never acted on