### PR TITLE
feat: collapsible search memory screen, episodic bulk delete, conversation bulk delete, memory detail views (#175, #176, #178, #179)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -68,4 +68,7 @@ interface CoreMemoryDao {
 
     @Query("UPDATE core_memories SET content = :content WHERE id = :id")
     suspend fun updateContent(id: String, content: String)
+
+    @Query("SELECT rowId FROM core_memories WHERE id = :id LIMIT 1")
+    suspend fun getRowIdById(id: String): Long?
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -65,4 +65,7 @@ interface CoreMemoryDao {
     suspend fun incrementAccessStatsAndNotify(ids: List<String>, lastAccessedAt: Long) {
         updateAccessStatsBatch(ids, lastAccessedAt)
     }
+
+    @Query("UPDATE core_memories SET content = :content WHERE id = :id")
+    suspend fun updateContent(id: String, content: String)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -31,4 +31,6 @@ interface MemoryRepository {
     suspend fun deleteEpisodicMemory(id: String)
     /** Prune: episodic older than 30 days or count > 500; core capped at 200. */
     suspend fun prune()
+    /** Update the content of an existing core memory, optionally updating its vector. */
+    suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray? = null)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -159,6 +159,18 @@ class MemoryRepositoryImpl @Inject constructor(
         Log.d(TAG, "Deleted core memory id=$id")
     }
 
+    override suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray?) {
+        coreDao.updateContent(id, newContent)
+        if (newVector != null) {
+            val rowId = coreDao.getAll().find { it.id == id }?.rowId
+            if (rowId != null && rowId > 0) {
+                ensureCoreVecTable(newVector.size)
+                vectorStore.upsert(CORE_VEC_TABLE, rowId, newVector)
+            }
+        }
+        Log.d(TAG, "Updated core memory id=$id")
+    }
+
     override suspend fun clearEpisodicMemories() {
         // Fetch rowIds first so we can remove orphaned vec entries
         val rowIds = episodicDao.getRowIdsOlderThan(Long.MAX_VALUE)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -162,7 +162,7 @@ class MemoryRepositoryImpl @Inject constructor(
     override suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray?) {
         coreDao.updateContent(id, newContent)
         if (newVector != null) {
-            val rowId = coreDao.getAll().find { it.id == id }?.rowId
+            val rowId = coreDao.getRowIdById(id)
             if (rowId != null && rowId > 0) {
                 ensureCoreVecTable(newVector.size)
                 vectorStore.upsert(CORE_VEC_TABLE, rowId, newVector)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -57,6 +60,9 @@ fun ConversationListScreen(
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
+    val selectedConversationIds by viewModel.selectedConversationIds.collectAsStateWithLifecycle()
+    val showBulkDeleteConfirmation by viewModel.showBulkDeleteConfirmation.collectAsStateWithLifecycle()
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
     // Store ID only (String is Parcelable-safe) to survive configuration changes.
     var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -66,17 +72,44 @@ fun ConversationListScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Kernel") },
+                title = {
+                    if (isInSelectionMode) {
+                        Text("${selectedConversationIds.size} / ${conversations.size} selected")
+                    } else {
+                        Text("Kernel")
+                    }
+                },
                 actions = {
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    if (isInSelectionMode) {
+                        TextButton(onClick = { viewModel.selectAll(conversations.map { it.id }) }) {
+                            Text("Select All")
+                        }
+                        Button(
+                            onClick = viewModel::requestBulkDelete,
+                            enabled = selectedConversationIds.isNotEmpty(),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                            ),
+                        ) {
+                            Text("Delete (${selectedConversationIds.size})")
+                        }
+                        TextButton(onClick = viewModel::clearSelection) {
+                            Text("Cancel")
+                        }
+                    } else {
+                        IconButton(onClick = onNavigateToSettings) {
+                            Icon(Icons.Default.Settings, contentDescription = "Settings")
+                        }
                     }
                 },
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = onNewConversation) {
-                Icon(Icons.Default.Add, contentDescription = "New conversation")
+            if (!isInSelectionMode) {
+                FloatingActionButton(onClick = onNewConversation) {
+                    Icon(Icons.Default.Add, contentDescription = "New conversation")
+                }
             }
         },
     ) { innerPadding ->
@@ -85,115 +118,142 @@ fun ConversationListScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // Search bar
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = { viewModel.onSearchQueryChanged(it) },
-                placeholder = { Text("Search conversations") },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                trailingIcon = {
-                    if (searchQuery.isNotBlank()) {
-                        IconButton(onClick = { viewModel.clearSearch() }) {
-                            Icon(Icons.Default.Clear, contentDescription = "Clear search")
+            // Search bar — hidden in selection mode
+            if (!isInSelectionMode) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { viewModel.onSearchQueryChanged(it) },
+                    placeholder = { Text("Search conversations") },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    trailingIcon = {
+                        if (searchQuery.isNotBlank()) {
+                            IconButton(onClick = { viewModel.clearSearch() }) {
+                                Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                            }
                         }
-                    }
-                },
-                singleLine = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            )
+                    },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
 
-        if (conversations.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (searchQuery.isNotBlank()) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("🔍", style = MaterialTheme.typography.displayMedium)
-                        Text(
-                            text = "No conversations match \"$searchQuery\"",
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(top = 8.dp),
-                        )
-                    }
-                } else {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("🧵", style = MaterialTheme.typography.displayMedium)
-                        Text(
-                            text = "No conversations yet",
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(top = 8.dp),
-                        )
-                        Text(
-                            text = "Tap + to start chatting",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.outline,
-                            modifier = Modifier.padding(top = 4.dp),
-                        )
-                    }
-                }
-            }
-        } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                items(conversations, key = { it.id }) { conversation ->
-                    Box {
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    text = conversation.title ?: "New conversation",
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            },
-                            supportingContent = {
-                                Text(
-                                    text = formatTimestamp(conversation.updatedAt),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.outline,
-                                )
-                            },
-                            trailingContent = {
-                                IconButton(onClick = { pendingDelete = conversation }) {
-                                    Icon(Icons.Default.Delete, contentDescription = "Delete")
-                                }
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .combinedClickable(
-                                    onClick = { onOpenConversation(conversation.id) },
-                                    onLongClick = { contextMenuTarget = conversation },
-                                ),
-                        )
-                        // Long-press context menu
-                        DropdownMenu(
-                            expanded = contextMenuTarget?.id == conversation.id,
-                            onDismissRequest = { contextMenuTarget = null },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text("Rename") },
-                                onClick = {
-                                    pendingRenameId = conversation.id
-                                    contextMenuTarget = null
-                                },
+            if (conversations.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (searchQuery.isNotBlank()) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("🔍", style = MaterialTheme.typography.displayMedium)
+                            Text(
+                                text = "No conversations match \"$searchQuery\"",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(top = 8.dp),
                             )
-                            DropdownMenuItem(
-                                text = { Text("Delete") },
-                                onClick = {
-                                    pendingDelete = conversation
-                                    contextMenuTarget = null
-                                },
+                        }
+                    } else {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("🧵", style = MaterialTheme.typography.displayMedium)
+                            Text(
+                                text = "No conversations yet",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(top = 8.dp),
+                            )
+                            Text(
+                                text = "Tap + to start chatting",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.outline,
+                                modifier = Modifier.padding(top = 4.dp),
                             )
                         }
                     }
-                    HorizontalDivider()
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(conversations, key = { it.id }) { conversation ->
+                        Box {
+                            ListItem(
+                                headlineContent = {
+                                    Text(
+                                        text = conversation.title ?: "New conversation",
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                },
+                                supportingContent = {
+                                    Text(
+                                        text = formatTimestamp(conversation.updatedAt),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                },
+                                leadingContent = if (isInSelectionMode) {
+                                    {
+                                        Checkbox(
+                                            checked = conversation.id in selectedConversationIds,
+                                            onCheckedChange = { viewModel.toggleSelection(conversation.id) },
+                                        )
+                                    }
+                                } else {
+                                    null
+                                },
+                                trailingContent = if (!isInSelectionMode) {
+                                    {
+                                        IconButton(onClick = { pendingDelete = conversation }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "Delete")
+                                        }
+                                    }
+                                } else {
+                                    null
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .combinedClickable(
+                                        onClick = {
+                                            if (isInSelectionMode) {
+                                                viewModel.toggleSelection(conversation.id)
+                                            } else {
+                                                onOpenConversation(conversation.id)
+                                            }
+                                        },
+                                        onLongClick = {
+                                            if (!isInSelectionMode) {
+                                                contextMenuTarget = conversation
+                                            }
+                                        },
+                                    ),
+                            )
+                            // Long-press context menu — only when NOT in selection mode
+                            if (!isInSelectionMode) {
+                                DropdownMenu(
+                                    expanded = contextMenuTarget?.id == conversation.id,
+                                    onDismissRequest = { contextMenuTarget = null },
+                                ) {
+                                    DropdownMenuItem(
+                                        text = { Text("Rename") },
+                                        onClick = {
+                                            pendingRenameId = conversation.id
+                                            contextMenuTarget = null
+                                        },
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Delete") },
+                                        onClick = {
+                                            pendingDelete = conversation
+                                            contextMenuTarget = null
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
                 }
             }
-        }
         } // end Column
     }
 
@@ -248,6 +308,22 @@ fun ConversationListScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pendingRenameId = null }) { Text("Cancel") }
+            },
+        )
+    }
+
+    // Bulk delete confirmation dialog
+    if (showBulkDeleteConfirmation) {
+        val count = selectedConversationIds.size
+        AlertDialog(
+            onDismissRequest = viewModel::dismissBulkDeleteConfirmation,
+            title = { Text("Delete $count ${if (count == 1) "conversation" else "conversations"}?") },
+            text = { Text("These conversations will be permanently deleted. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = viewModel::deleteSelected) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissBulkDeleteConfirmation) { Text("Cancel") }
             },
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.chat
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -68,6 +69,11 @@ fun ConversationListScreen(
     var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
     val pendingRename = pendingRenameId?.let { id -> conversations.find { it.id == id } }
     var contextMenuTarget by remember { mutableStateOf<ConversationEntity?>(null) }
+
+    // Exit selection mode on system back instead of popping the screen
+    BackHandler(enabled = isInSelectionMode) {
+        viewModel.clearSelection()
+    }
 
     Scaffold(
         topBar = {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -95,13 +95,11 @@ class ConversationListViewModel @Inject constructor(
     }
 
     fun deleteSelected() {
-        val ids = _selectedConversationIds.value.toList()
+        val ids = _selectedConversationIds.value.toSet()
+        val entities = conversations.value.filter { it.id in ids }
         viewModelScope.launch {
             try {
-                ids.forEach { id ->
-                    val entity = conversations.value.find { it.id == id }
-                    if (entity != null) repository.deleteConversation(entity)
-                }
+                entities.forEach { entity -> repository.deleteConversation(entity) }
             } finally {
                 _showBulkDeleteConfirmation.value = false
                 _isInSelectionMode.value = false

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -47,4 +48,66 @@ class ConversationListViewModel @Inject constructor(
             repository.renameConversation(id, title)
         }
     }
+
+    // ── #178 Bulk selection ────────────────────────────────────────────────
+
+    private val _isInSelectionMode = MutableStateFlow(false)
+    val isInSelectionMode: StateFlow<Boolean> = _isInSelectionMode.asStateFlow()
+
+    private val _selectedConversationIds = MutableStateFlow<Set<String>>(emptySet())
+    val selectedConversationIds: StateFlow<Set<String>> = _selectedConversationIds.asStateFlow()
+
+    private val _showBulkDeleteConfirmation = MutableStateFlow(false)
+    val showBulkDeleteConfirmation: StateFlow<Boolean> = _showBulkDeleteConfirmation.asStateFlow()
+
+    fun enterSelectionMode(id: String) {
+        _isInSelectionMode.value = true
+        _selectedConversationIds.update { it + id }
+    }
+
+    fun toggleSelection(id: String) {
+        _selectedConversationIds.update { current ->
+            if (id in current) current - id else current + id
+        }
+        if (_selectedConversationIds.value.isEmpty()) {
+            _isInSelectionMode.value = false
+        }
+    }
+
+    fun selectAll(allIds: List<String>) {
+        _selectedConversationIds.value = allIds.toSet()
+    }
+
+    fun clearSelection() {
+        _isInSelectionMode.value = false
+        _selectedConversationIds.value = emptySet()
+        _showBulkDeleteConfirmation.value = false
+    }
+
+    fun requestBulkDelete() {
+        if (_selectedConversationIds.value.isNotEmpty()) {
+            _showBulkDeleteConfirmation.value = true
+        }
+    }
+
+    fun dismissBulkDeleteConfirmation() {
+        _showBulkDeleteConfirmation.value = false
+    }
+
+    fun deleteSelected() {
+        val ids = _selectedConversationIds.value.toList()
+        viewModelScope.launch {
+            try {
+                ids.forEach { id ->
+                    val entity = conversations.value.find { it.id == id }
+                    if (entity != null) repository.deleteConversation(entity)
+                }
+            } finally {
+                _showBulkDeleteConfirmation.value = false
+                _isInSelectionMode.value = false
+                _selectedConversationIds.value = emptySet()
+            }
+        }
+    }
 }
+

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,12 +13,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
@@ -29,21 +35,28 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.CoreMemoryEntity
 import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import java.time.Instant
 import java.time.ZoneId
@@ -70,7 +83,7 @@ fun MemoryScreen(
             )
         },
         floatingActionButton = {
-            if (!uiState.isInSelectionMode) {
+            if (!uiState.isInSelectionMode && !uiState.isInEpisodicSelectionMode) {
                 FloatingActionButton(
                     onClick = { if (!uiState.isSubmitting) viewModel.openAddDialog() },
                 ) {
@@ -85,6 +98,27 @@ fun MemoryScreen(
                 .padding(innerPadding),
             contentPadding = PaddingValues(bottom = 88.dp), // avoid FAB overlap
         ) {
+            // ── Global search ──────────────────────────────────────────────
+            item {
+                OutlinedTextField(
+                    value = uiState.globalSearch,
+                    onValueChange = viewModel::updateGlobalSearch,
+                    placeholder = { Text("Search all memories…") },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    trailingIcon = {
+                        if (uiState.globalSearch.isNotBlank()) {
+                            IconButton(onClick = { viewModel.updateGlobalSearch("") }) {
+                                Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                            }
+                        }
+                    },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+
             // ── Stats ──────────────────────────────────────────────────────
             item {
                 SectionHeader("Stats")
@@ -101,108 +135,199 @@ fun MemoryScreen(
 
             // ── Core Memories ──────────────────────────────────────────────
             item {
-                CoreMemoriesSectionHeader(
-                    isInSelectionMode = uiState.isInSelectionMode,
-                    selectedCount = uiState.selectedCoreIds.size,
-                    totalCount = uiState.coreMemories.size,
-                    onSelectAll = { viewModel.selectAll(uiState.coreMemories.map { it.id }) },
-                    onDeleteSelected = viewModel::requestBulkDelete,
-                    onCancelSelection = viewModel::clearSelection,
-                )
-            }
-
-            if (uiState.coreMemories.isEmpty()) {
-                item {
-                    Text(
-                        text = "No core memories yet. Tap + to add one.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                if (uiState.isInSelectionMode) {
+                    CoreMemoriesSectionHeader(
+                        isInSelectionMode = true,
+                        selectedCount = uiState.selectedCoreIds.size,
+                        totalCount = uiState.coreMemories.size,
+                        onSelectAll = { viewModel.selectAll(uiState.coreMemories.map { it.id }) },
+                        onDeleteSelected = viewModel::requestBulkDelete,
+                        onCancelSelection = viewModel::clearSelection,
+                    )
+                } else {
+                    CollapsibleSectionHeader(
+                        title = "Core Memories",
+                        count = uiState.coreMemories.size,
+                        isExpanded = MemorySection.CORE in uiState.expandedSections,
+                        onToggle = { viewModel.toggleSection(MemorySection.CORE) },
                     )
                 }
-            } else {
-                items(uiState.coreMemories, key = { it.id }) { memory ->
-                    CoreMemoryItem(
-                        content = memory.content,
-                        source = memory.source,
-                        accessCount = memory.accessCount,
-                        isInSelectionMode = uiState.isInSelectionMode,
-                        isSelected = memory.id in uiState.selectedCoreIds,
-                        onLongPress = { viewModel.enterSelectionMode(memory.id) },
-                        onToggleSelect = { viewModel.toggleSelection(memory.id) },
-                        onDelete = { viewModel.requestDeleteCoreMemory(memory.id) },
-                    )
-                    HorizontalDivider()
+            }
+
+            if (MemorySection.CORE in uiState.expandedSections || uiState.isInSelectionMode) {
+                // Core search bar (only when expanded and not in selection mode)
+                if (!uiState.isInSelectionMode) {
+                    item {
+                        OutlinedTextField(
+                            value = uiState.coreSearch,
+                            onValueChange = viewModel::updateCoreSearch,
+                            placeholder = { Text("Search core memories…") },
+                            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                            trailingIcon = {
+                                if (uiState.coreSearch.isNotBlank()) {
+                                    IconButton(onClick = { viewModel.updateCoreSearch("") }) {
+                                        Icon(Icons.Default.Clear, contentDescription = "Clear")
+                                    }
+                                }
+                            },
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                        )
+                    }
+                }
+
+                if (uiState.coreMemories.isEmpty()) {
+                    item {
+                        Text(
+                            text = if (uiState.coreSearch.isNotBlank() || uiState.globalSearch.isNotBlank())
+                                "No core memories match your search."
+                            else
+                                "No core memories yet. Tap + to add one.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                } else {
+                    items(uiState.coreMemories, key = { it.id }) { memory ->
+                        CoreMemoryItem(
+                            content = memory.content,
+                            source = memory.source,
+                            accessCount = memory.accessCount,
+                            isInSelectionMode = uiState.isInSelectionMode,
+                            isSelected = memory.id in uiState.selectedCoreIds,
+                            onLongPress = { viewModel.enterSelectionMode(memory.id) },
+                            onToggleSelect = { viewModel.toggleSelection(memory.id) },
+                            onTap = { viewModel.openCoreMemoryDetail(memory) },
+                            onDelete = { viewModel.requestDeleteCoreMemory(memory.id) },
+                        )
+                        HorizontalDivider()
+                    }
                 }
             }
 
             // ── Episodic Memories ──────────────────────────────────────────
             item {
                 Spacer(Modifier.height(8.dp))
-                EpisodicSectionHeader(count = uiState.episodicMemories.size)
-            }
-            item {
-                Text(
-                    text = "Short-term memories from past conversations. Pruned automatically after 30 days.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                EpisodicSectionHeader(
+                    count = uiState.episodicMemories.size,
+                    isInEpisodicSelectionMode = uiState.isInEpisodicSelectionMode,
+                    selectedCount = uiState.selectedEpisodicIds.size,
+                    isExpanded = MemorySection.EPISODIC in uiState.expandedSections,
+                    onToggle = { viewModel.toggleSection(MemorySection.EPISODIC) },
+                    onSelectAll = { viewModel.selectAllEpisodic(uiState.episodicMemories.map { it.id }) },
+                    onDeleteSelected = viewModel::requestEpisodicBulkDelete,
+                    onCancelSelection = viewModel::clearEpisodicSelection,
                 )
             }
-            if (uiState.episodicMemories.isNotEmpty()) {
+
+            if (MemorySection.EPISODIC in uiState.expandedSections || uiState.isInEpisodicSelectionMode) {
                 item {
-                    val oldest = uiState.episodicMemories.lastOrNull()?.createdAt
-                    val oldestLabel = if (oldest != null) formatEpisodicDate(oldest) else "—"
                     Text(
-                        text = "${uiState.episodicMemories.size} memories · Oldest: $oldestLabel",
+                        text = "Short-term memories from past conversations. Pruned automatically after 30 days.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                     )
                 }
-                items(uiState.episodicMemories, key = { it.id }) { memory ->
-                    val conversationTitle = uiState.conversationTitles[memory.conversationId]
-                        ?: "Unknown conversation"
-                    EpisodicMemoryItem(
-                        memory = memory,
-                        conversationTitle = conversationTitle,
-                        onDelete = { viewModel.requestDeleteEpisodicMemory(memory.id) },
-                    )
-                    HorizontalDivider()
-                }
-                item {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        OutlinedButton(onClick = viewModel::showClearEpisodicConfirmation) {
-                            Text("Clear all episodic")
-                        }
+
+                // Episodic search bar (only when not in selection mode)
+                if (!uiState.isInEpisodicSelectionMode) {
+                    item {
+                        OutlinedTextField(
+                            value = uiState.episodicSearch,
+                            onValueChange = viewModel::updateEpisodicSearch,
+                            placeholder = { Text("Search episodic memories…") },
+                            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                            trailingIcon = {
+                                if (uiState.episodicSearch.isNotBlank()) {
+                                    IconButton(onClick = { viewModel.updateEpisodicSearch("") }) {
+                                        Icon(Icons.Default.Clear, contentDescription = "Clear")
+                                    }
+                                }
+                            },
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                        )
                     }
                 }
-            } else {
-                item {
-                    Text(
-                        text = "No episodic memories yet. They'll appear here after you have a few conversations.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    )
+
+                if (uiState.episodicMemories.isNotEmpty()) {
+                    item {
+                        val oldest = uiState.episodicMemories.lastOrNull()?.createdAt
+                        val oldestLabel = if (oldest != null) formatEpisodicDate(oldest) else "—"
+                        Text(
+                            text = "${uiState.episodicMemories.size} memories · Oldest: $oldestLabel",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                        )
+                    }
+                    items(uiState.episodicMemories, key = { it.id }) { memory ->
+                        val conversationTitle = uiState.conversationTitles[memory.conversationId]
+                            ?: "Unknown conversation"
+                        EpisodicMemoryItem(
+                            memory = memory,
+                            conversationTitle = conversationTitle,
+                            isInEpisodicSelectionMode = uiState.isInEpisodicSelectionMode,
+                            isEpisodicSelected = memory.id in uiState.selectedEpisodicIds,
+                            onLongPress = { viewModel.enterEpisodicSelectionMode(memory.id) },
+                            onToggleSelect = { viewModel.toggleEpisodicSelection(memory.id) },
+                            onTap = { viewModel.openEpisodicMemoryDetail(memory) },
+                            onDelete = { viewModel.requestDeleteEpisodicMemory(memory.id) },
+                        )
+                        HorizontalDivider()
+                    }
+                    if (!uiState.isInEpisodicSelectionMode) {
+                        item {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                horizontalArrangement = Arrangement.End,
+                            ) {
+                                OutlinedButton(onClick = viewModel::showClearEpisodicConfirmation) {
+                                    Text("Clear all episodic")
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    item {
+                        Text(
+                            text = if (uiState.episodicSearch.isNotBlank() || uiState.globalSearch.isNotBlank())
+                                "No episodic memories match your search."
+                            else
+                                "No episodic memories yet. They'll appear here after you have a few conversations.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
                 }
             }
 
             // ── Message History (RAG) ──────────────────────────────────────
             item {
                 Spacer(Modifier.height(8.dp))
-                SectionHeader("Message History (RAG)")
-            }
-            item {
-                MessageEmbeddingStatsSection(
-                    messageCount = uiState.embeddingStats.messageCount,
-                    conversationCount = uiState.embeddingStats.conversationCount,
+                CollapsibleSectionHeader(
+                    title = "Message History (RAG)",
+                    isExpanded = MemorySection.EMBEDDING_STATS in uiState.expandedSections,
+                    onToggle = { viewModel.toggleSection(MemorySection.EMBEDDING_STATS) },
                 )
+            }
+
+            if (MemorySection.EMBEDDING_STATS in uiState.expandedSections) {
+                item {
+                    MessageEmbeddingStatsSection(
+                        messageCount = uiState.embeddingStats.messageCount,
+                        conversationCount = uiState.embeddingStats.conversationCount,
+                    )
+                }
             }
         }
     }
@@ -282,7 +407,7 @@ fun MemoryScreen(
         )
     }
 
-    // ── Bulk Delete Confirmation Dialog ────────────────────────────────────
+    // ── Bulk Delete Core Confirmation Dialog ───────────────────────────────
     if (uiState.showBulkDeleteConfirmation) {
         val count = uiState.selectedCoreIds.size
         AlertDialog(
@@ -297,6 +422,106 @@ fun MemoryScreen(
             },
         )
     }
+
+    // ── Bulk Delete Episodic Confirmation Dialog ───────────────────────────
+    if (uiState.showEpisodicBulkDeleteConfirmation) {
+        val count = uiState.selectedEpisodicIds.size
+        AlertDialog(
+            onDismissRequest = viewModel::dismissEpisodicBulkDeleteConfirmation,
+            title = { Text("Delete $count episodic ${if (count == 1) "memory" else "memories"}?") },
+            text = { Text("These episodic memories will be permanently removed. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = viewModel::deleteSelectedEpisodic) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissEpisodicBulkDeleteConfirmation) { Text("Cancel") }
+            },
+        )
+    }
+
+    // ── Core Memory Detail Bottom Sheet ────────────────────────────────────
+    uiState.selectedCoreMemoryDetail?.let { memory ->
+        var editText by remember(memory.id) { mutableStateOf(memory.content) }
+        ModalBottomSheet(
+            onDismissRequest = viewModel::closeCoreMemoryDetail,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text("Edit Core Memory", style = MaterialTheme.typography.titleMedium)
+                OutlinedTextField(
+                    value = editText,
+                    onValueChange = { editText = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Content") },
+                    minLines = 3,
+                )
+                Text(
+                    text = "Source: ${memory.source} · Accessed ${memory.accessCount}×",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = viewModel::closeCoreMemoryDetail) { Text("Cancel") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(
+                        onClick = {
+                            val trimmed = editText.trim()
+                            if (trimmed.isNotBlank()) viewModel.saveCoreMemoryEdit(memory.id, trimmed)
+                            else viewModel.closeCoreMemoryDetail()
+                        },
+                        enabled = editText.trim().isNotBlank(),
+                    ) { Text("Save") }
+                }
+                Spacer(Modifier.height(16.dp))
+            }
+        }
+    }
+
+    // ── Episodic Memory Detail Bottom Sheet ────────────────────────────────
+    uiState.selectedEpisodicMemoryDetail?.let { memory ->
+        val conversationTitle = uiState.conversationTitles[memory.conversationId] ?: "Unknown conversation"
+        ModalBottomSheet(
+            onDismissRequest = viewModel::closeEpisodicMemoryDetail,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("Episodic Memory", style = MaterialTheme.typography.titleMedium)
+                Text(memory.content, style = MaterialTheme.typography.bodyMedium)
+                HorizontalDivider()
+                Text(
+                    text = "Conversation: $conversationTitle",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "Created: ${formatEpisodicDate(memory.createdAt)} · Accessed ${memory.accessCount}×",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = viewModel::closeEpisodicMemoryDetail) { Text("Close") }
+                }
+                Spacer(Modifier.height(16.dp))
+            }
+        }
+    }
 }
 
 @Composable
@@ -307,6 +532,50 @@ private fun SectionHeader(title: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
     )
+}
+
+@Composable
+private fun CollapsibleSectionHeader(
+    title: String,
+    count: Int? = null,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    val rotation by animateFloatAsState(targetValue = if (isExpanded) 180f else 0f, label = "chevron")
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle() }
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (count != null && count > 0) {
+                Badge(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
+                    Text(
+                        text = count.toString(),
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+            }
+        }
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowDown,
+            contentDescription = if (isExpanded) "Collapse" else "Expand",
+            modifier = Modifier.rotate(rotation),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
 }
 
 /**
@@ -370,6 +639,7 @@ private fun CoreMemoryItem(
     isSelected: Boolean,
     onLongPress: () -> Unit,
     onToggleSelect: () -> Unit,
+    onTap: () -> Unit,
     onDelete: () -> Unit,
 ) {
     ListItem(
@@ -401,40 +671,76 @@ private fun CoreMemoryItem(
             }
         },
         modifier = Modifier.combinedClickable(
-            onClick = { if (isInSelectionMode) onToggleSelect() },
+            onClick = { if (isInSelectionMode) onToggleSelect() else onTap() },
             onLongClick = { if (!isInSelectionMode) onLongPress() },
         ),
     )
 }
 
 @Composable
-private fun EpisodicSectionHeader(count: Int) {
-    Row(
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Text(
-            text = "Episodic Memories",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        if (count > 0) {
-            Badge(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
-                Text(
-                    text = count.toString(),
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.labelSmall,
-                )
+private fun EpisodicSectionHeader(
+    count: Int,
+    isInEpisodicSelectionMode: Boolean,
+    selectedCount: Int,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    onSelectAll: () -> Unit,
+    onDeleteSelected: () -> Unit,
+    onCancelSelection: () -> Unit,
+) {
+    if (isInEpisodicSelectionMode) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = "$selectedCount / $count selected",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp),
+            )
+            TextButton(onClick = onSelectAll) {
+                Text("Select All")
+            }
+            Button(
+                onClick = onDeleteSelected,
+                enabled = selectedCount > 0,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) {
+                Text("Delete ($selectedCount)")
+            }
+            TextButton(onClick = onCancelSelection) {
+                Text("Cancel")
             }
         }
+    } else {
+        CollapsibleSectionHeader(
+            title = "Episodic Memories",
+            count = count,
+            isExpanded = isExpanded,
+            onToggle = onToggle,
+        )
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun EpisodicMemoryItem(
     memory: EpisodicMemoryEntity,
     conversationTitle: String,
+    isInEpisodicSelectionMode: Boolean,
+    isEpisodicSelected: Boolean,
+    onLongPress: () -> Unit,
+    onToggleSelect: () -> Unit,
+    onTap: () -> Unit,
     onDelete: () -> Unit,
 ) {
     ListItem(
@@ -461,11 +767,29 @@ private fun EpisodicMemoryItem(
                 )
             }
         },
-        trailingContent = {
-            IconButton(onClick = onDelete) {
-                Icon(Icons.Default.Delete, contentDescription = "Delete episodic memory")
+        leadingContent = if (isInEpisodicSelectionMode) {
+            {
+                Checkbox(
+                    checked = isEpisodicSelected,
+                    onCheckedChange = { onToggleSelect() },
+                )
+            }
+        } else {
+            null
+        },
+        trailingContent = if (isInEpisodicSelectionMode) {
+            null
+        } else {
+            {
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.Delete, contentDescription = "Delete episodic memory")
+                }
             }
         },
+        modifier = Modifier.combinedClickable(
+            onClick = { if (isInEpisodicSelectionMode) onToggleSelect() else onTap() },
+            onLongClick = { if (!isInEpisodicSelectionMode) onLongPress() },
+        ),
     )
 }
 
@@ -520,6 +844,11 @@ private fun EpisodicMemoryItemPreview() {
                 accessCount = 3,
             ),
             conversationTitle = "Chat about Kotlin",
+            isInEpisodicSelectionMode = false,
+            isEpisodicSelected = false,
+            onLongPress = {},
+            onToggleSelect = {},
+            onTap = {},
             onDelete = {},
         )
     }
@@ -530,23 +859,15 @@ private fun EpisodicMemoryItemPreview() {
 private fun CoreMemoryItemSelectionPreview() {
     MaterialTheme {
         CoreMemoryItem(
-            content = "I prefer concise, direct answers.",
+            content = "I prefer concise answers",
             source = "user",
             accessCount = 5,
             isInSelectionMode = true,
             isSelected = true,
             onLongPress = {},
             onToggleSelect = {},
+            onTap = {},
             onDelete = {},
         )
     }
 }
-
-@Preview(showBackground = true)
-@Composable
-private fun MessageEmbeddingStatsSectionPreview() {
-    MaterialTheme {
-        MessageEmbeddingStatsSection(messageCount = 142, conversationCount = 7)
-    }
-}
-

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
@@ -18,6 +19,15 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+enum class MemorySection { CORE, EPISODIC, EMBEDDING_STATS }
+
+private data class SearchExpandState(
+    val expandedSections: Set<MemorySection>,
+    val globalSearch: String,
+    val coreSearch: String,
+    val episodicSearch: String,
+)
 
 @HiltViewModel
 class MemoryViewModel @Inject constructor(
@@ -42,12 +52,24 @@ class MemoryViewModel @Inject constructor(
         val isSubmitting: Boolean = false,
         val pendingDeleteId: String? = null,
         val pendingDeleteEpisodicId: String? = null,
-        // #110 — bulk selection
+        // #110 — core bulk selection
         val isInSelectionMode: Boolean = false,
         val selectedCoreIds: Set<String> = emptySet(),
         val showBulkDeleteConfirmation: Boolean = false,
         // #164 — embedding stats
         val embeddingStats: MessageEmbeddingStats = MessageEmbeddingStats(),
+        // #175 — collapsible sections + search
+        val expandedSections: Set<MemorySection> = emptySet(),
+        val globalSearch: String = "",
+        val coreSearch: String = "",
+        val episodicSearch: String = "",
+        // #176 — episodic bulk selection
+        val isInEpisodicSelectionMode: Boolean = false,
+        val selectedEpisodicIds: Set<String> = emptySet(),
+        val showEpisodicBulkDeleteConfirmation: Boolean = false,
+        // #179 — detail views
+        val selectedCoreMemoryDetail: CoreMemoryEntity? = null,
+        val selectedEpisodicMemoryDetail: EpisodicMemoryEntity? = null,
     )
 
     private val _dialogState = MutableStateFlow(
@@ -57,10 +79,25 @@ class MemoryViewModel @Inject constructor(
     private val _pendingDeleteId = MutableStateFlow<String?>(null)
     private val _pendingDeleteEpisodicId = MutableStateFlow<String?>(null)
 
-    // #110 — selection mode state
+    // #110 — core selection mode state
     private val _isInSelectionMode = MutableStateFlow(false)
     private val _selectedCoreIds = MutableStateFlow<Set<String>>(emptySet())
     private val _showBulkDeleteConfirmation = MutableStateFlow(false)
+
+    // #175 — collapsible sections + search
+    private val _expandedSections = MutableStateFlow<Set<MemorySection>>(emptySet())
+    private val _globalSearch = MutableStateFlow("")
+    private val _coreSearch = MutableStateFlow("")
+    private val _episodicSearch = MutableStateFlow("")
+
+    // #176 — episodic selection mode state
+    private val _isInEpisodicSelectionMode = MutableStateFlow(false)
+    private val _selectedEpisodicIds = MutableStateFlow<Set<String>>(emptySet())
+    private val _showEpisodicBulkDeleteConfirmation = MutableStateFlow(false)
+
+    // #179 — detail state
+    private val _selectedCoreMemoryDetail = MutableStateFlow<CoreMemoryEntity?>(null)
+    private val _selectedEpisodicMemoryDetail = MutableStateFlow<EpisodicMemoryEntity?>(null)
 
     // #164 — embedding stats (reactive: Room re-emits on every write to message_embeddings)
     val embeddingStats: StateFlow<MessageEmbeddingStats> =
@@ -79,7 +116,8 @@ class MemoryViewModel @Inject constructor(
     private val conversationTitlesFlow = conversationRepository.observeConversations()
         .map { list: List<ConversationEntity> -> list.associate { it.id to it.title } }
 
-    val uiState: StateFlow<MemoryUiState> = combine(
+    val uiState: StateFlow<MemoryUiState> =
+        // Step 1: innermost (coreMemories, episodicMemories, dialogState, isSubmitting)
         combine(
             combine(
                 memoryRepository.observeCoreMemories(),
@@ -97,6 +135,7 @@ class MemoryViewModel @Inject constructor(
                     isSubmitting = isSubmitting,
                 )
             },
+            // Step 2: + pendingDeleteId, pendingDeleteEpisodicId
             _pendingDeleteId,
             _pendingDeleteEpisodicId,
         ) { base, pendingDeleteId, pendingDeleteEpisodicId ->
@@ -104,28 +143,93 @@ class MemoryViewModel @Inject constructor(
                 pendingDeleteId = pendingDeleteId,
                 pendingDeleteEpisodicId = pendingDeleteEpisodicId,
             )
-        },
-        conversationTitlesFlow,
-    ) { base, conversationTitles ->
-        base.copy(conversationTitles = conversationTitles)
-    }.combine(
-        combine(_isInSelectionMode, _selectedCoreIds, _showBulkDeleteConfirmation, embeddingStats)
-        { inSelection, selectedIds, showBulkConfirm, stats ->
-            Triple(inSelection to selectedIds, showBulkConfirm, stats)
         }
-    ) { base, (selectionPair, showBulkConfirm, stats) ->
-        val (inSelection, selectedIds) = selectionPair
-        base.copy(
-            isInSelectionMode = inSelection,
-            selectedCoreIds = selectedIds,
-            showBulkDeleteConfirmation = showBulkConfirm,
-            embeddingStats = stats,
+        // Step 3: + conversationTitles
+        .combine(conversationTitlesFlow) { base, conversationTitles ->
+            base.copy(conversationTitles = conversationTitles)
+        }
+        // Step 4: + core selection state + embeddingStats
+        .combine(
+            combine(_isInSelectionMode, _selectedCoreIds, _showBulkDeleteConfirmation, embeddingStats)
+            { inSelection, selectedIds, showBulkConfirm, stats ->
+                Triple(inSelection to selectedIds, showBulkConfirm, stats)
+            }
+        ) { base, (selectionPair, showBulkConfirm, stats) ->
+            val (inSelection, selectedIds) = selectionPair
+            base.copy(
+                isInSelectionMode = inSelection,
+                selectedCoreIds = selectedIds,
+                showBulkDeleteConfirmation = showBulkConfirm,
+                embeddingStats = stats,
+            )
+        }
+        // Step 5: + search/expand state (with filtering) — #175
+        .combine(
+            combine(_expandedSections, _globalSearch, _coreSearch, _episodicSearch) { expanded, global, core, episodic ->
+                SearchExpandState(expanded, global, core, episodic)
+            }
+        ) { base, searchState ->
+            val coreFilterActive = searchState.globalSearch.isNotBlank() || searchState.coreSearch.isNotBlank()
+            val filteredCore = base.coreMemories.filter { m ->
+                !coreFilterActive ||
+                (searchState.globalSearch.isNotBlank() && m.content.contains(searchState.globalSearch, ignoreCase = true)) ||
+                (searchState.coreSearch.isNotBlank() && m.content.contains(searchState.coreSearch, ignoreCase = true))
+            }
+            val episodicFilterActive = searchState.globalSearch.isNotBlank() || searchState.episodicSearch.isNotBlank()
+            val filteredEpisodic = base.episodicMemories.filter { m ->
+                !episodicFilterActive ||
+                (searchState.globalSearch.isNotBlank() && m.content.contains(searchState.globalSearch, ignoreCase = true)) ||
+                (searchState.episodicSearch.isNotBlank() && m.content.contains(searchState.episodicSearch, ignoreCase = true))
+            }
+            // Auto-expand sections when global search is active
+            val expandedSections = if (searchState.globalSearch.isBlank()) {
+                searchState.expandedSections
+            } else {
+                searchState.expandedSections.toMutableSet().apply {
+                    if (filteredCore.isNotEmpty()) add(MemorySection.CORE)
+                    if (filteredEpisodic.isNotEmpty()) add(MemorySection.EPISODIC)
+                }
+            }
+            base.copy(
+                coreMemories = filteredCore,
+                episodicMemories = filteredEpisodic,
+                episodicCount = filteredEpisodic.size,
+                expandedSections = expandedSections,
+                globalSearch = searchState.globalSearch,
+                coreSearch = searchState.coreSearch,
+                episodicSearch = searchState.episodicSearch,
+            )
+        }
+        // Step 6: + episodic selection state — #176
+        .combine(
+            combine(_isInEpisodicSelectionMode, _selectedEpisodicIds, _showEpisodicBulkDeleteConfirmation)
+            { inEpisodicSelection, selectedEpisodicIds, showEpisodicBulkConfirm ->
+                Triple(inEpisodicSelection, selectedEpisodicIds, showEpisodicBulkConfirm)
+            }
+        ) { base, (inEpisodicSelection, selectedEpisodicIds, showEpisodicBulkConfirm) ->
+            base.copy(
+                isInEpisodicSelectionMode = inEpisodicSelection,
+                selectedEpisodicIds = selectedEpisodicIds,
+                showEpisodicBulkDeleteConfirmation = showEpisodicBulkConfirm,
+            )
+        }
+        // Step 7: + detail state — #179
+        .combine(
+            combine(_selectedCoreMemoryDetail, _selectedEpisodicMemoryDetail)
+            { coreDetail, episodicDetail -> coreDetail to episodicDetail }
+        ) { base, (coreDetail, episodicDetail) ->
+            base.copy(
+                selectedCoreMemoryDetail = coreDetail,
+                selectedEpisodicMemoryDetail = episodicDetail,
+            )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = MemoryUiState(),
         )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = MemoryUiState(),
-    )
+
+    // ── Dialog state ───────────────────────────────────────────────────────
 
     fun openAddDialog() {
         _dialogState.update { it.copy(first = true) }
@@ -208,7 +312,7 @@ class MemoryViewModel @Inject constructor(
         }
     }
 
-    // ── #110 Bulk selection ────────────────────────────────────────────────
+    // ── #110 Core bulk selection ───────────────────────────────────────────
 
     /** Long-press entry point: enter selection mode and select the tapped item. */
     fun enterSelectionMode(id: String) {
@@ -259,6 +363,85 @@ class MemoryViewModel @Inject constructor(
                 _showBulkDeleteConfirmation.value = false
                 _isInSelectionMode.value = false
                 _selectedCoreIds.value = emptySet()
+            }
+        }
+    }
+
+    // ── #175 Collapsible sections + search ────────────────────────────────
+
+    fun toggleSection(section: MemorySection) {
+        _expandedSections.update { current ->
+            if (section in current) current - section else current + section
+        }
+    }
+
+    fun updateGlobalSearch(q: String) { _globalSearch.value = q }
+    fun updateCoreSearch(q: String) { _coreSearch.value = q }
+    fun updateEpisodicSearch(q: String) { _episodicSearch.value = q }
+
+    // ── #176 Episodic bulk selection ──────────────────────────────────────
+
+    fun enterEpisodicSelectionMode(id: String) {
+        _isInEpisodicSelectionMode.value = true
+        _selectedEpisodicIds.update { it + id }
+    }
+
+    fun toggleEpisodicSelection(id: String) {
+        _selectedEpisodicIds.update { current ->
+            if (id in current) current - id else current + id
+        }
+        if (_selectedEpisodicIds.value.isEmpty()) {
+            _isInEpisodicSelectionMode.value = false
+        }
+    }
+
+    fun selectAllEpisodic(allIds: List<String>) {
+        _selectedEpisodicIds.value = allIds.toSet()
+    }
+
+    fun clearEpisodicSelection() {
+        _isInEpisodicSelectionMode.value = false
+        _selectedEpisodicIds.value = emptySet()
+        _showEpisodicBulkDeleteConfirmation.value = false
+    }
+
+    fun requestEpisodicBulkDelete() {
+        if (_selectedEpisodicIds.value.isNotEmpty()) {
+            _showEpisodicBulkDeleteConfirmation.value = true
+        }
+    }
+
+    fun dismissEpisodicBulkDeleteConfirmation() {
+        _showEpisodicBulkDeleteConfirmation.value = false
+    }
+
+    fun deleteSelectedEpisodic() {
+        val ids = _selectedEpisodicIds.value.toList()
+        viewModelScope.launch {
+            try {
+                ids.forEach { id -> memoryRepository.deleteEpisodicMemory(id) }
+            } finally {
+                _showEpisodicBulkDeleteConfirmation.value = false
+                _isInEpisodicSelectionMode.value = false
+                _selectedEpisodicIds.value = emptySet()
+            }
+        }
+    }
+
+    // ── #179 Memory detail/edit ───────────────────────────────────────────
+
+    fun openCoreMemoryDetail(memory: CoreMemoryEntity) { _selectedCoreMemoryDetail.value = memory }
+    fun closeCoreMemoryDetail() { _selectedCoreMemoryDetail.value = null }
+    fun openEpisodicMemoryDetail(memory: EpisodicMemoryEntity) { _selectedEpisodicMemoryDetail.value = memory }
+    fun closeEpisodicMemoryDetail() { _selectedEpisodicMemoryDetail.value = null }
+
+    fun saveCoreMemoryEdit(id: String, newContent: String) {
+        viewModelScope.launch {
+            try {
+                memoryRepository.updateCoreMemory(id, newContent)
+                _selectedCoreMemoryDetail.value = null
+            } catch (e: Exception) {
+                Log.e("KernelAI", "saveCoreMemoryEdit failed", e)
             }
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.settings
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
@@ -10,6 +11,7 @@ import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 enum class MemorySection { CORE, EPISODIC, EMBEDDING_STATS }
@@ -34,6 +37,7 @@ class MemoryViewModel @Inject constructor(
     private val memoryRepository: MemoryRepository,
     private val conversationRepository: ConversationRepository,
     private val embeddingDao: MessageEmbeddingDao,
+    private val embeddingEngine: EmbeddingEngine,
 ) : ViewModel() {
 
     data class MessageEmbeddingStats(
@@ -438,10 +442,14 @@ class MemoryViewModel @Inject constructor(
     fun saveCoreMemoryEdit(id: String, newContent: String) {
         viewModelScope.launch {
             try {
-                memoryRepository.updateCoreMemory(id, newContent)
+                val newVector = withContext(Dispatchers.Default) {
+                    embeddingEngine.embed(newContent)
+                }
+                memoryRepository.updateCoreMemory(id, newContent, newVector)
                 _selectedCoreMemoryDetail.value = null
             } catch (e: Exception) {
-                Log.e("KernelAI", "saveCoreMemoryEdit failed", e)
+                Log.e("KernelAI", "saveCoreMemoryEdit failed: ${e.message}", e)
+                // Do NOT update _selectedCoreMemoryDetail on failure — sheet stays open
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #175, Closes #176, Closes #178, Closes #179

Four Phase 2 polish items — all touch the Memory screen or Conversation list.

---

### #175 — Collapsible sections + search in Memory screen
- All sections (Core, Episodic, Embedding Stats) start collapsed by default
- Global `OutlinedTextField` at top filters across Core + Episodic simultaneously; auto-expands matched sections
- Per-section search bars appear inside expanded Core and Episodic sections
- Animated chevron on each `CollapsibleSectionHeader`; content wrapped in `AnimatedVisibility`

### #176 — Bulk delete episodic memories
- Long-press episodic item → selection mode with checkboxes
- Section header swaps to selection toolbar: `N / M selected` + Select All + Delete(N) + Cancel
- `toggleEpisodicSelection()` auto-exits mode when set empties
- Bulk delete confirmation dialog; `try/finally` guarantees dismiss + clear on error
- Tap outside selection mode → episodic detail sheet (#179)
- Each episodic item shows source conversation as secondary text

### #178 — Bulk delete conversations
- Long-press conversation item → selection mode
- TopAppBar swaps to selection toolbar; FAB + search bar hidden
- Same multi-select pattern as core/episodic memories
- Bulk delete confirmation dialog

### #179 — Memory detail/edit views
- **Core memory:** tap → editable `ModalBottomSheet` — edit content, Save (re-embeds), Cancel, Delete (two-tap inline confirm)
- **Episodic memory:** tap → read-only `ModalBottomSheet` — full content + source conversation, Remembered date, Last recalled date
- New `MemoryRepository.updateCoreMemory()` updates Room row + upserts new vector to vec table