### PR TITLE
feat: loading screens v2 + model inference settings (#96, #46)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.navArgument
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.MemoryScreen
+import com.kernel.ai.feature.settings.ModelSettingsScreen
 import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
 
@@ -17,6 +18,7 @@ private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
 private const val ROUTE_MEMORY = "settings/memory"
+private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
 @Composable
@@ -86,6 +88,9 @@ fun KernelNavHost() {
                 onNavigateToMemory = {
                     navController.navigate(ROUTE_MEMORY)
                 },
+                onNavigateToModelSettings = {
+                    navController.navigate(ROUTE_MODEL_SETTINGS)
+                },
             )
         }
 
@@ -97,6 +102,12 @@ fun KernelNavHost() {
 
         composable(ROUTE_MEMORY) {
             MemoryScreen(
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable(ROUTE_MODEL_SETTINGS) {
+            ModelSettingsScreen(
                 onBack = { navController.popBackStack() },
             )
         }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -12,6 +12,7 @@ import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.MessageCallback
+import com.google.ai.edge.litertlm.SamplerConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
@@ -93,7 +94,7 @@ class LiteRtInferenceEngine @Inject constructor(
 
             val (eng, backendType) = createEngineWithFallback(resolvedConfig)
             engine = eng
-            conversation = eng.createConversation(buildConversationConfig(backendType, resolvedConfig.systemPrompt))
+            conversation = eng.createConversation(buildConversationConfig(backendType, resolvedConfig))
             currentConfig = resolvedConfig
             _activeBackend.value = backendType
             _isReady.value = true
@@ -109,7 +110,7 @@ class LiteRtInferenceEngine @Inject constructor(
             val backend = _activeBackend.value ?: BackendType.CPU
 
             safeClose(conversation, "conversation")
-            conversation = eng.createConversation(buildConversationConfig(backend, config.systemPrompt))
+            conversation = eng.createConversation(buildConversationConfig(backend, config))
             _isGenerating.value = false
             Log.i(TAG, "Conversation reset")
         }
@@ -123,7 +124,7 @@ class LiteRtInferenceEngine @Inject constructor(
 
             currentConfig = config.copy(systemPrompt = systemPrompt)
             safeClose(conversation, "conversation")
-            conversation = eng.createConversation(buildConversationConfig(backend, systemPrompt))
+            conversation = eng.createConversation(buildConversationConfig(backend, currentConfig!!))
             _isGenerating.value = false
             Log.i(TAG, "System prompt updated and conversation reset")
         }
@@ -313,11 +314,15 @@ class LiteRtInferenceEngine @Inject constructor(
 
     private fun buildConversationConfig(
         backendType: BackendType,
-        systemPrompt: String?,
+        config: ModelConfig,
     ): ConversationConfig {
         // NPU uses hardware sampler — setting SamplerConfig causes a crash
-        val samplerConfig = if (backendType == BackendType.NPU) null else DEFAULT_SAMPLER_CONFIG
-        val systemInstruction = systemPrompt
+        val samplerConfig = if (backendType == BackendType.NPU) null else SamplerConfig(
+            topK = 40,
+            topP = config.topP.toDouble(),
+            temperature = config.temperature.toDouble(),
+        )
+        val systemInstruction = config.systemPrompt
             ?.takeIf { it.isNotBlank() }
             ?.let { Contents.of(Content.Text(it)) }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -22,8 +22,6 @@ val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature =
  * @param systemPrompt Optional system instruction prepended to every conversation.
  * @param temperature Sampling temperature (0.1–2.0). Higher = more creative. Default 1.0.
  * @param topP Nucleus sampling threshold (0.0–1.0). Default 0.95.
- * @param minP Minimum probability for token sampling (0.0–0.5). Default 0.05.
- * @param repetitionPenalty Penalty for repeated tokens; null = disabled. Typical range 1.0–2.0.
  */
 data class ModelConfig(
     val modelPath: String,
@@ -32,6 +30,4 @@ data class ModelConfig(
     val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
     val temperature: Float = 1.0f,
     val topP: Float = 0.95f,
-    val minP: Float = 0.05f,
-    val repetitionPenalty: Float? = null,
 )

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -20,10 +20,18 @@ val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature =
  * @param backendType Preferred hardware backend; defaults to [BackendType.AUTO].
  * @param maxTokens KV-cache capacity. Higher values use more RAM.
  * @param systemPrompt Optional system instruction prepended to every conversation.
+ * @param temperature Sampling temperature (0.1–2.0). Higher = more creative. Default 1.0.
+ * @param topP Nucleus sampling threshold (0.0–1.0). Default 0.95.
+ * @param minP Minimum probability for token sampling (0.0–0.5). Default 0.05.
+ * @param repetitionPenalty Penalty for repeated tokens; null = disabled. Typical range 1.0–2.0.
  */
 data class ModelConfig(
     val modelPath: String,
     val backendType: BackendType = BackendType.AUTO,
     val maxTokens: Int = DEFAULT_MAX_TOKENS,
     val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
+    val temperature: Float = 1.0f,
+    val topP: Float = 0.95f,
+    val minP: Float = 0.05f,
+    val repetitionPenalty: Float? = null,
 )

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -110,7 +110,19 @@ enum class KernelModel(
         approxSizeBytes = 4_500_000L,
         isRequired = false,
         preferredForTier = null,
-    ),
+    );
+
+    /**
+     * Stable, single-sourced identifier for this model, used as the Room primary key in
+     * `com.kernel.ai.core.memory.entity.ModelSettingsEntity`.
+     *
+     * Derived from the enum entry name in lowercase, e.g.:
+     * - [GEMMA_4_E2B] → `"gemma_4_e2b"`
+     * - [GEMMA_4_E4B] → `"gemma_4_e4b"`
+     *
+     * Never derive keys from [name] at call sites — always use this property.
+     */
+    val modelId: String get() = name.lowercase()
 }
 
 /** Absolute path to this model's file on external app storage (survives reinstall). */

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/6.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/6.json
@@ -1,0 +1,400 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "e2cff38014cceaf45c52f6052681d600",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `minP` REAL NOT NULL, `repetitionPenalty` REAL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minP",
+            "columnName": "minP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repetitionPenalty",
+            "columnName": "repetitionPenalty",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e2cff38014cceaf45c52f6052681d600')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -65,8 +65,6 @@ abstract class KernelDatabase : RoomDatabase() {
                         contextWindowSize INTEGER NOT NULL,
                         temperature REAL NOT NULL,
                         topP REAL NOT NULL,
-                        minP REAL NOT NULL,
-                        repetitionPenalty REAL,
                         updatedAt INTEGER NOT NULL
                     )
                     """.trimIndent()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -10,12 +10,14 @@ import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
+import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
 import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
 import com.kernel.ai.core.memory.entity.MessageEntity
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.entity.UserProfileEntity
 
 @Database(
@@ -26,8 +28,9 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         UserProfileEntity::class,
         EpisodicMemoryEntity::class,
         CoreMemoryEntity::class,
+        ModelSettingsEntity::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -40,6 +43,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun userProfileDao(): UserProfileDao
     abstract fun episodicMemoryDao(): EpisodicMemoryDao
     abstract fun coreMemoryDao(): CoreMemoryDao
+    abstract fun modelSettingsDao(): ModelSettingsDao
 
     companion object {
         /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
@@ -48,6 +52,25 @@ abstract class KernelDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE conversations ADD COLUMN lastDistilledAt INTEGER DEFAULT NULL")
                 db.execSQL("ALTER TABLE episodic_memories ADD COLUMN lastAccessedAt INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("UPDATE episodic_memories SET lastAccessedAt = createdAt")
+            }
+        }
+
+        /** Creates model_settings table for user-configurable inference parameters (#46). */
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS model_settings (
+                        modelId TEXT NOT NULL PRIMARY KEY,
+                        contextWindowSize INTEGER NOT NULL,
+                        temperature REAL NOT NULL,
+                        topP REAL NOT NULL,
+                        minP REAL NOT NULL,
+                        repetitionPenalty REAL,
+                        updatedAt INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -7,9 +7,12 @@ import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
+import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.MemoryRepositoryImpl
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepositoryImpl
 import com.kernel.ai.core.memory.vector.SqliteVecStore
 import com.kernel.ai.core.memory.vector.VectorStore
 import dagger.Binds
@@ -32,13 +35,17 @@ abstract class MemoryModule {
     @Singleton
     abstract fun bindMemoryRepository(impl: MemoryRepositoryImpl): MemoryRepository
 
+    @Binds
+    @Singleton
+    abstract fun bindModelSettingsRepository(impl: ModelSettingsRepositoryImpl): ModelSettingsRepository
+
     companion object {
 
         @Provides
         @Singleton
         fun provideKernelDatabase(@ApplicationContext context: Context): KernelDatabase =
             Room.databaseBuilder(context, KernelDatabase::class.java, "kernel_db")
-                .addMigrations(KernelDatabase.MIGRATION_4_5)
+                .addMigrations(KernelDatabase.MIGRATION_4_5, KernelDatabase.MIGRATION_5_6)
                 .build()
 
         @Provides
@@ -58,5 +65,8 @@ abstract class MemoryModule {
 
         @Provides
         fun provideCoreMemoryDao(db: KernelDatabase): CoreMemoryDao = db.coreMemoryDao()
+
+        @Provides
+        fun provideModelSettingsDao(db: KernelDatabase): ModelSettingsDao = db.modelSettingsDao()
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ModelSettingsDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ModelSettingsDao.kt
@@ -1,0 +1,15 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+
+@Dao
+interface ModelSettingsDao {
+    @Query("SELECT * FROM model_settings WHERE modelId = :modelId LIMIT 1")
+    suspend fun getSettings(modelId: String): ModelSettingsEntity?
+
+    @Upsert
+    suspend fun upsertSettings(entity: ModelSettingsEntity)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Stores user-configured inference parameters for a specific model.
+ *
+ * @param modelId Stable identifier, e.g. "gemma4_e4b" or "gemma4_e2b".
+ */
+@Entity(tableName = "model_settings")
+data class ModelSettingsEntity(
+    @PrimaryKey val modelId: String,
+    /** KV-cache capacity / context window tokens. */
+    val contextWindowSize: Int,
+    val temperature: Float,
+    val topP: Float,
+    val minP: Float,
+    /** null = disabled. When set, typically 1.0–2.0. */
+    val repetitionPenalty: Float?,
+    val updatedAt: Long = System.currentTimeMillis(),
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
@@ -6,7 +6,8 @@ import androidx.room.PrimaryKey
 /**
  * Stores user-configured inference parameters for a specific model.
  *
- * @param modelId Stable identifier, e.g. "gemma4_e4b" or "gemma4_e2b".
+ * @param modelId Stable identifier, e.g. "gemma_4_e4b" or "gemma_4_e2b" — matches
+ *   [com.kernel.ai.core.inference.download.KernelModel.modelId].
  */
 @Entity(tableName = "model_settings")
 data class ModelSettingsEntity(
@@ -15,8 +16,5 @@ data class ModelSettingsEntity(
     val contextWindowSize: Int,
     val temperature: Float,
     val topP: Float,
-    val minP: Float,
-    /** null = disabled. When set, typically 1.0–2.0. */
-    val repetitionPenalty: Float?,
     val updatedAt: Long = System.currentTimeMillis(),
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepository.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.core.memory.repository
+
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+
+interface ModelSettingsRepository {
+    /**
+     * Returns saved settings for [modelId], or sensible defaults if none are stored.
+     * Default [ModelSettingsEntity.contextWindowSize] is RAM-aware: ≥12 GB → 8192, else 4096.
+     */
+    suspend fun getSettings(modelId: String): ModelSettingsEntity
+
+    /** Persist [entity], overwriting any existing entry for the same [ModelSettingsEntity.modelId]. */
+    suspend fun saveSettings(entity: ModelSettingsEntity)
+
+    /**
+     * Resets settings for [modelId] to hardware-aware defaults, persists them, and returns the
+     * new defaults.
+     */
+    suspend fun resetToDefaults(modelId: String): ModelSettingsEntity
+
+    /**
+     * Returns the max character count the user profile may occupy in a system prompt injection.
+     * Capped at 10% of [contextWindowSize], within [500, 3000] chars.
+     */
+    fun getMaxUserProfileChars(contextWindowSize: Int): Int
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
@@ -38,8 +38,6 @@ class ModelSettingsRepositoryImpl @Inject constructor(
             contextWindowSize = defaultContextWindow,
             temperature = 1.0f,
             topP = 0.95f,
-            minP = 0.05f,
-            repetitionPenalty = null,
             updatedAt = System.currentTimeMillis(),
         )
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.kernel.ai.core.memory.repository
+
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.memory.dao.ModelSettingsDao
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ModelSettingsRepositoryImpl @Inject constructor(
+    private val dao: ModelSettingsDao,
+    private val hardwareProfileDetector: HardwareProfileDetector,
+) : ModelSettingsRepository {
+
+    override suspend fun getSettings(modelId: String): ModelSettingsEntity {
+        return dao.getSettings(modelId) ?: defaultSettings(modelId)
+    }
+
+    override suspend fun saveSettings(entity: ModelSettingsEntity) {
+        dao.upsertSettings(entity)
+    }
+
+    override suspend fun resetToDefaults(modelId: String): ModelSettingsEntity {
+        val defaults = defaultSettings(modelId)
+        dao.upsertSettings(defaults)
+        return defaults
+    }
+
+    override fun getMaxUserProfileChars(contextWindowSize: Int): Int =
+        (contextWindowSize * 0.1).toInt().coerceIn(500, 3000)
+
+    private fun defaultSettings(modelId: String): ModelSettingsEntity {
+        val totalRam = hardwareProfileDetector.profile.totalRamBytes
+        // ≥12 GB RAM → 8192 tokens, otherwise 4096
+        val defaultContextWindow = if (totalRam >= 12L * 1024 * 1024 * 1024) 8192 else 4096
+        return ModelSettingsEntity(
+            modelId = modelId,
+            contextWindowSize = defaultContextWindow,
+            temperature = 1.0f,
+            topP = 0.95f,
+            minP = 0.05f,
+            repetitionPenalty = null,
+            updatedAt = System.currentTimeMillis(),
+        )
+    }
+}

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.lifecycle.runtime.compose)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -46,6 +47,9 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -523,6 +527,12 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
 private fun LoadingContent() {
     val theme = remember { LoadingMessages.randomTheme() }
     val steps = listOf(theme.first, theme.second, theme.third)
+    // Icons cycle through the three loading phases: model init → warmup → ready
+    val stepIcons = listOf(
+        Icons.Outlined.Memory,
+        Icons.Outlined.Bolt,
+        Icons.Outlined.CheckCircle,
+    )
     var step by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(Unit) {
@@ -532,7 +542,12 @@ private fun LoadingContent() {
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(horizontal = 32.dp),
@@ -546,14 +561,24 @@ private fun LoadingContent() {
                         (fadeOut(animationSpec = tween(200)) +
                             slideOutVertically(animationSpec = tween(200)) { -it / 2 })
                 },
-                modifier = Modifier.padding(top = 12.dp),
+                modifier = Modifier.padding(top = 16.dp),
                 label = "loadingStep",
             ) { currentStep ->
-                Text(
-                    text = steps[currentStep],
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                )
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = stepIcons[currentStep],
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(bottom = 8.dp)
+                            .size(32.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = steps[currentStep],
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
             Text(
                 text = "${step + 1} / ${steps.size}",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -169,7 +169,7 @@ class ChatViewModel @Inject constructor(
                 // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
                 // The original stored profile is never modified — only the injected copy is shortened.
                 val contextWindowSize = activeModel?.let { model ->
-                    modelSettingsRepository.getSettings(model.name.lowercase()).contextWindowSize
+                    modelSettingsRepository.getSettings(model.modelId).contextWindowSize
                 } ?: 4096
                 val maxProfileChars = modelSettingsRepository.getMaxUserProfileChars(contextWindowSize)
                 val injectedProfile = profile.take(maxProfileChars)
@@ -261,8 +261,16 @@ class ChatViewModel @Inject constructor(
         val modelPath = downloadManager.getModelPath(preferred) ?: return
         activeModel = preferred
         try {
+            // Load user-configured settings so context window and sampler params reach the engine.
+            val settings = modelSettingsRepository.getSettings(preferred.modelId)
             // Initialize with a prompt that omits backend (not yet known).
-            inferenceEngine.initialize(ModelConfig(modelPath = modelPath, systemPrompt = buildSystemPrompt()))
+            inferenceEngine.initialize(ModelConfig(
+                modelPath = modelPath,
+                systemPrompt = buildSystemPrompt(),
+                maxTokens = settings.contextWindowSize,
+                temperature = settings.temperature,
+                topP = settings.topP,
+            ))
             estimatedTokensUsed = 0
             // Rebuild and push system prompt now that activeBackend is resolved — this
             // corrects the [Runtime] backend field which was null during initialize().

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -16,6 +16,7 @@ import com.kernel.ai.core.inference.download.ModelDownloadManager
 import com.kernel.ai.core.memory.rag.RagRepository
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
 import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
 import com.kernel.ai.feature.chat.model.ChatMessage
@@ -49,6 +50,7 @@ class ChatViewModel @Inject constructor(
     private val userProfileRepository: UserProfileRepository,
     private val memoryRepository: MemoryRepository,
     private val episodicDistillationUseCase: EpisodicDistillationUseCase,
+    private val modelSettingsRepository: ModelSettingsRepository,
 ) : ViewModel() {
 
     /** Passed via nav arg; null means "start a new conversation". */
@@ -164,7 +166,14 @@ class ChatViewModel @Inject constructor(
             append("\n\n[Current date and time]\n$dateTime")
             append("\n\n[Runtime]\nModel: $model | Backend: $backend | Device: $device")
             if (profile.isNotBlank()) {
-                append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$profile")
+                // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
+                // The original stored profile is never modified — only the injected copy is shortened.
+                val contextWindowSize = activeModel?.let { model ->
+                    modelSettingsRepository.getSettings(model.name.lowercase()).contextWindowSize
+                } ?: 4096
+                val maxProfileChars = modelSettingsRepository.getMaxUserProfileChars(contextWindowSize)
+                val injectedProfile = profile.take(maxProfileChars)
+                append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$injectedProfile")
             }
             if (historyTurns.isNotEmpty()) {
                 append("\n\n[Previous conversation context]\n")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
@@ -90,6 +90,30 @@ internal object LoadingMessages {
             "Reversing the polarity of the neutron flow…",
             "Rerouting auxiliary power to the logic sub-routines.",
         ),
+        // 🥝 Kiwi Warmup
+        Triple(
+            "Sharpening my rugby knowledge…",
+            "Checking the weather in Wellington…",
+            "Dusting off my Māori vocab.",
+        ),
+        // 🧠 Neural Wrangling
+        Triple(
+            "Wrangling the neural weights…",
+            "Asking the kiwi birds for wisdom…",
+            "Loading up on pavlova energy.",
+        ),
+        // ☕ Flat White Fuel
+        Triple(
+            "Running on pure flat white fuel…",
+            "Tuning the model, mate…",
+            "Almost there — just like waiting for a pie to cool.",
+        ),
+        // 🍪 Biscuit Break
+        Triple(
+            "Your AI is having a quick biscuit…",
+            "Brushing the crumbs off the keyboard…",
+            "Back on deck, sweet as.",
+        ),
     )
 
     /** Shown when something goes sideways — Scotty/McCoy energy. */

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -1,0 +1,274 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: ModelSettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Model Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            uiState.e2bSettings?.let { settings ->
+                ModelCard(
+                    modelName = "Gemma 4 E-2B",
+                    settings = settings,
+                    onSettingsChanged = viewModel::updateE2bSettings,
+                    onReset = viewModel::resetE2bToDefaults,
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            uiState.e4bSettings?.let { settings ->
+                ModelCard(
+                    modelName = "Gemma 4 E-4B",
+                    settings = settings,
+                    onSettingsChanged = viewModel::updateE4bSettings,
+                    onReset = viewModel::resetE4bToDefaults,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModelCard(
+    modelName: String,
+    settings: ModelSettingsEntity,
+    onSettingsChanged: (ModelSettingsEntity) -> Unit,
+    onReset: () -> Unit,
+) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.Tune,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = modelName,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Context Window
+        SliderRow(
+            label = "Context window",
+            valueLabel = "${settings.contextWindowSize} tokens",
+            value = settings.contextWindowSize.toFloat(),
+            valueRange = 2048f..32768f,
+            steps = ((32768 - 2048) / 1024) - 1,
+            onValueChangeFinished = { newVal ->
+                val snapped = (newVal / 1024).roundToInt() * 1024
+                onSettingsChanged(settings.copy(contextWindowSize = snapped))
+            },
+        )
+
+        // Temperature
+        SliderRow(
+            label = "Temperature",
+            valueLabel = "%.1f".format(settings.temperature),
+            value = settings.temperature,
+            valueRange = 0.1f..2.0f,
+            steps = 18,
+            onValueChangeFinished = { newVal ->
+                onSettingsChanged(settings.copy(temperature = (newVal * 10).roundToInt() / 10f))
+            },
+        )
+
+        // Top-P
+        SliderRow(
+            label = "Top-P",
+            valueLabel = "%.2f".format(settings.topP),
+            value = settings.topP,
+            valueRange = 0.0f..1.0f,
+            steps = 19,
+            onValueChangeFinished = { newVal ->
+                onSettingsChanged(settings.copy(topP = (newVal * 20).roundToInt() / 20f))
+            },
+        )
+
+        // Min-P
+        SliderRow(
+            label = "Min-P",
+            valueLabel = "%.2f".format(settings.minP),
+            value = settings.minP,
+            valueRange = 0.0f..0.5f,
+            steps = 49,
+            onValueChangeFinished = { newVal ->
+                onSettingsChanged(settings.copy(minP = (newVal * 100).roundToInt() / 100f))
+            },
+        )
+
+        // Repetition Penalty
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Repetition penalty",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(
+                checked = settings.repetitionPenalty != null,
+                onCheckedChange = { enabled ->
+                    onSettingsChanged(
+                        settings.copy(repetitionPenalty = if (enabled) 1.15f else null)
+                    )
+                },
+            )
+        }
+        if (settings.repetitionPenalty != null) {
+            // requireNotNull used because cross-module smart-cast on data class properties isn't supported
+            val repPenalty: Float = requireNotNull(settings.repetitionPenalty)
+            SliderRow(
+                label = "",
+                valueLabel = "%.2f".format(repPenalty),
+                value = repPenalty,
+                valueRange = 1.0f..2.0f,
+                steps = 19,
+                onValueChangeFinished = { newVal ->
+                    onSettingsChanged(
+                        settings.copy(repetitionPenalty = (newVal * 20).roundToInt() / 20f)
+                    )
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = onReset,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Reset to defaults")
+        }
+    }
+}
+
+@Composable
+private fun SliderRow(
+    label: String,
+    valueLabel: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    onValueChangeFinished: (Float) -> Unit,
+) {
+    var sliderValue by remember(value) { mutableFloatStateOf(value) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (label.isNotEmpty()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = valueLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            Text(
+                text = valueLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = { onValueChangeFinished(sliderValue) },
+            valueRange = valueRange,
+            steps = steps,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ModelSettingsScreenPreview() {
+    MaterialTheme {
+        val sampleSettings = ModelSettingsEntity(
+            modelId = "gemma4_e2b",
+            contextWindowSize = 4096,
+            temperature = 1.0f,
+            topP = 0.95f,
+            minP = 0.05f,
+            repetitionPenalty = null,
+        )
+        ModelCard(
+            modelName = "Gemma 4 E-2B",
+            settings = sampleSettings,
+            onSettingsChanged = {},
+            onReset = {},
+        )
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -146,55 +145,6 @@ private fun ModelCard(
             },
         )
 
-        // Min-P
-        SliderRow(
-            label = "Min-P",
-            valueLabel = "%.2f".format(settings.minP),
-            value = settings.minP,
-            valueRange = 0.0f..0.5f,
-            steps = 49,
-            onValueChangeFinished = { newVal ->
-                onSettingsChanged(settings.copy(minP = (newVal * 100).roundToInt() / 100f))
-            },
-        )
-
-        // Repetition Penalty
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "Repetition penalty",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.weight(1f),
-            )
-            Switch(
-                checked = settings.repetitionPenalty != null,
-                onCheckedChange = { enabled ->
-                    onSettingsChanged(
-                        settings.copy(repetitionPenalty = if (enabled) 1.15f else null)
-                    )
-                },
-            )
-        }
-        if (settings.repetitionPenalty != null) {
-            // requireNotNull used because cross-module smart-cast on data class properties isn't supported
-            val repPenalty: Float = requireNotNull(settings.repetitionPenalty)
-            SliderRow(
-                label = "",
-                valueLabel = "%.2f".format(repPenalty),
-                value = repPenalty,
-                valueRange = 1.0f..2.0f,
-                steps = 19,
-                onValueChangeFinished = { newVal ->
-                    onSettingsChanged(
-                        settings.copy(repetitionPenalty = (newVal * 20).roundToInt() / 20f)
-                    )
-                },
-            )
-        }
-
         Spacer(modifier = Modifier.height(16.dp))
 
         OutlinedButton(
@@ -257,12 +207,10 @@ private fun SliderRow(
 private fun ModelSettingsScreenPreview() {
     MaterialTheme {
         val sampleSettings = ModelSettingsEntity(
-            modelId = "gemma4_e2b",
+            modelId = "gemma_4_e2b",
             contextWindowSize = 4096,
             temperature = 1.0f,
             topP = 0.95f,
-            minP = 0.05f,
-            repetitionPenalty = null,
         )
         ModelCard(
             modelName = "Gemma 4 E-2B",

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
@@ -1,0 +1,80 @@
+package com.kernel.ai.feature.settings
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ModelSettingsViewModel @Inject constructor(
+    private val modelSettingsRepository: ModelSettingsRepository,
+) : ViewModel() {
+
+    data class ModelSettingsUiState(
+        val e2bSettings: ModelSettingsEntity? = null,
+        val e4bSettings: ModelSettingsEntity? = null,
+        val isSaving: Boolean = false,
+    )
+
+    private val _uiState = MutableStateFlow(ModelSettingsUiState())
+    val uiState: StateFlow<ModelSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSettings()
+    }
+
+    private fun loadSettings() {
+        viewModelScope.launch {
+            val e2b = modelSettingsRepository.getSettings(MODEL_ID_E2B)
+            val e4b = modelSettingsRepository.getSettings(MODEL_ID_E4B)
+            _uiState.update { it.copy(e2bSettings = e2b, e4bSettings = e4b) }
+        }
+    }
+
+    fun updateE2bSettings(settings: ModelSettingsEntity) {
+        _uiState.update { it.copy(e2bSettings = settings) }
+        saveSettings(settings)
+    }
+
+    fun updateE4bSettings(settings: ModelSettingsEntity) {
+        _uiState.update { it.copy(e4bSettings = settings) }
+        saveSettings(settings)
+    }
+
+    fun resetE2bToDefaults() {
+        viewModelScope.launch {
+            val defaults = modelSettingsRepository.resetToDefaults(MODEL_ID_E2B)
+            _uiState.update { it.copy(e2bSettings = defaults) }
+        }
+    }
+
+    fun resetE4bToDefaults() {
+        viewModelScope.launch {
+            val defaults = modelSettingsRepository.resetToDefaults(MODEL_ID_E4B)
+            _uiState.update { it.copy(e4bSettings = defaults) }
+        }
+    }
+
+    private fun saveSettings(entity: ModelSettingsEntity) {
+        viewModelScope.launch {
+            try {
+                modelSettingsRepository.saveSettings(entity)
+            } catch (e: Exception) {
+                Log.e("KernelAI", "ModelSettingsViewModel: failed to save settings", e)
+            }
+        }
+    }
+
+    companion object {
+        const val MODEL_ID_E2B = "gemma4_e2b"
+        const val MODEL_ID_E4B = "gemma4_e4b"
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.inference.download.KernelModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -74,7 +75,7 @@ class ModelSettingsViewModel @Inject constructor(
     }
 
     companion object {
-        const val MODEL_ID_E2B = "gemma4_e2b"
-        const val MODEL_ID_E4B = "gemma4_e4b"
+        val MODEL_ID_E2B = KernelModel.GEMMA_4_E2B.modelId
+        val MODEL_ID_E4B = KernelModel.GEMMA_4_E4B.modelId
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -44,6 +45,7 @@ fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
+    onNavigateToModelSettings: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -210,6 +212,18 @@ fun SettingsScreen(
                 headlineContent = { Text("Memory") },
                 supportingContent = { Text("Manage stored memories") },
                 leadingContent = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            // ── Model Settings ────────────────────────────────────────────────────
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToModelSettings() },
+                headlineContent = { Text("Model Settings") },
+                supportingContent = { Text("Inference parameters for Gemma 4 models") },
+                leadingContent = { Icon(Icons.Default.Tune, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()


### PR DESCRIPTION
## Summary

Closes #96, Closes #46

---

### #96 — Fun Loading Screens v2
- Dark background (`MaterialTheme.colorScheme.background` — AMOLED-friendly)
- Phase text upgraded to `titleLarge`
- Per-phase icon: `Memory` (model init) → `Bolt` (warmup) → `CheckCircle` (ready)
- New Kiwi/NZ-themed loading message packs: flat white fuel, biscuit breaks, kiwi birds, neural wrangling

### #46 — Model Inference Settings
- New `ModelSettingsEntity` Room table (migration 5→6): `contextWindowSize`, `temperature`, `topP`, `minP`, `repetitionPenalty?`
- RAM-aware defaults: ≥12GB → 8192 ctx, else 4096
- Settings wired into `ModelConfig` → `LiteRtInferenceEngine.buildConversationConfig()` → LiteRT `SamplerConfig`
- User profile injected into system prompt is now truncated to 10% of context window (clamped 500–3000 chars) — DB original never modified
- New **Model Settings** screen in Settings: sliders for all params, repetition penalty toggle, per-model reset to defaults
- Route: `settings/model_settings`