### PR TITLE
fix: UX fixes batch — memory editing, model settings precision, loading screen (#183, #184)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -70,6 +70,9 @@ interface EpisodicMemoryDao {
     @Query("SELECT rowId FROM episodic_memories WHERE id = :id LIMIT 1")
     suspend fun getRowIdById(id: String): Long?
 
+    @Query("UPDATE episodic_memories SET content = :content WHERE id = :id")
+    suspend fun updateContent(id: String, content: String)
+
     @Transaction
     suspend fun getRowIdAndDelete(id: String): Long? {
         val rowId = getRowIdById(id)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -33,4 +33,6 @@ interface MemoryRepository {
     suspend fun prune()
     /** Update the content of an existing core memory, optionally updating its vector. */
     suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray? = null)
+    /** Update the content of an existing episodic memory and re-embed it. */
+    suspend fun updateEpisodicMemory(id: String, newContent: String, newVector: FloatArray)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -171,6 +171,17 @@ class MemoryRepositoryImpl @Inject constructor(
         Log.d(TAG, "Updated core memory id=$id")
     }
 
+    override suspend fun updateEpisodicMemory(id: String, newContent: String, newVector: FloatArray) {
+        // Atomicity: update vec first; only write content if vec succeeds.
+        val rowId = episodicDao.getRowIdById(id)
+        if (rowId != null && rowId > 0) {
+            ensureEpisodicVecTable(newVector.size)
+            vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, newVector)
+        }
+        episodicDao.updateContent(id, newContent)
+        Log.d(TAG, "Updated episodic memory id=$id")
+    }
+
     override suspend fun clearEpisodicMemories() {
         // Fetch rowIds first so we can remove orphaned vec entries
         val rowIds = episodicDao.getRowIdsOlderThan(Long.MAX_VALUE)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
@@ -30,9 +30,7 @@ class ModelSettingsRepositoryImpl @Inject constructor(
         (contextWindowSize * 0.1).toInt().coerceIn(500, 3000)
 
     private fun defaultSettings(modelId: String): ModelSettingsEntity {
-        val totalRam = hardwareProfileDetector.profile.totalRamBytes
-        // ≥12 GB RAM → 8192 tokens, otherwise 4096
-        val defaultContextWindow = if (totalRam >= 12L * 1024 * 1024 * 1024) 8192 else 4096
+        val defaultContextWindow = hardwareProfileDetector.profile.recommendedMaxTokens
         return ModelSettingsEntity(
             modelId = modelId,
             contextWindowSize = defaultContextWindow,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -548,11 +549,12 @@ private fun LoadingContent() {
             .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center,
     ) {
+        CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(horizontal = 32.dp),
         ) {
-            CircularProgressIndicator()
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             AnimatedContent(
                 targetState = step,
                 transitionSpec = {
@@ -577,6 +579,7 @@ private fun LoadingContent() {
                         text = steps[currentStep],
                         style = MaterialTheme.typography.titleLarge,
                         textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                 }
             }
@@ -586,6 +589,7 @@ private fun LoadingContent() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 8.dp),
             )
+        }
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -470,6 +470,15 @@ fun MemoryScreen(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    // Destructive delete on the left
+                    var showDeleteConfirm by remember { mutableStateOf(false) }
+                    TextButton(
+                        onClick = { showDeleteConfirm = true },
+                        colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) { Text("Delete") }
+                    Spacer(Modifier.weight(1f))
                     TextButton(onClick = viewModel::closeCoreMemoryDetail) { Text("Cancel") }
                     Spacer(Modifier.width(8.dp))
                     Button(
@@ -480,6 +489,29 @@ fun MemoryScreen(
                         },
                         enabled = editText.trim().isNotBlank(),
                     ) { Text("Save") }
+
+                    if (showDeleteConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showDeleteConfirm = false },
+                            title = { Text("Delete memory?") },
+                            text = { Text("This core memory will be permanently removed. This cannot be undone.") },
+                            confirmButton = {
+                                TextButton(
+                                    onClick = {
+                                        showDeleteConfirm = false
+                                        viewModel.requestDeleteCoreMemory(memory.id)
+                                        viewModel.closeCoreMemoryDetail()
+                                    },
+                                    colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.error,
+                                    ),
+                                ) { Text("Delete") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+                            },
+                        )
+                    }
                 }
                 Spacer(Modifier.height(16.dp))
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryScreen.kt
@@ -521,6 +521,7 @@ fun MemoryScreen(
     // ── Episodic Memory Detail Bottom Sheet ────────────────────────────────
     uiState.selectedEpisodicMemoryDetail?.let { memory ->
         val conversationTitle = uiState.conversationTitles[memory.conversationId] ?: "Unknown conversation"
+        var editText by remember(memory.id) { mutableStateOf(memory.content) }
         ModalBottomSheet(
             onDismissRequest = viewModel::closeEpisodicMemoryDetail,
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -531,8 +532,14 @@ fun MemoryScreen(
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Text("Episodic Memory", style = MaterialTheme.typography.titleMedium)
-                Text(memory.content, style = MaterialTheme.typography.bodyMedium)
+                Text("Edit Episodic Memory", style = MaterialTheme.typography.titleMedium)
+                OutlinedTextField(
+                    value = editText,
+                    onValueChange = { editText = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Content") },
+                    minLines = 3,
+                )
                 HorizontalDivider()
                 Text(
                     text = "Conversation: $conversationTitle",
@@ -547,8 +554,50 @@ fun MemoryScreen(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(onClick = viewModel::closeEpisodicMemoryDetail) { Text("Close") }
+                    // Destructive delete on the left
+                    var showDeleteConfirm by remember { mutableStateOf(false) }
+                    TextButton(
+                        onClick = { showDeleteConfirm = true },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) { Text("Delete") }
+                    Spacer(Modifier.weight(1f))
+                    TextButton(onClick = viewModel::closeEpisodicMemoryDetail) { Text("Cancel") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(
+                        onClick = {
+                            val trimmed = editText.trim()
+                            if (trimmed.isNotBlank()) viewModel.saveEpisodicMemoryEdit(memory.id, trimmed)
+                            else viewModel.closeEpisodicMemoryDetail()
+                        },
+                        enabled = editText.trim().isNotBlank() && !uiState.isSubmitting,
+                    ) { Text("Save") }
+
+                    if (showDeleteConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showDeleteConfirm = false },
+                            title = { Text("Delete memory?") },
+                            text = { Text("This episodic memory will be permanently removed. This cannot be undone.") },
+                            confirmButton = {
+                                TextButton(
+                                    onClick = {
+                                        showDeleteConfirm = false
+                                        viewModel.requestDeleteEpisodicMemory(memory.id)
+                                        viewModel.closeEpisodicMemoryDetail()
+                                    },
+                                    colors = ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.error,
+                                    ),
+                                ) { Text("Delete") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+                            },
+                        )
+                    }
                 }
                 Spacer(Modifier.height(16.dp))
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -453,4 +453,21 @@ class MemoryViewModel @Inject constructor(
             }
         }
     }
+
+    fun saveEpisodicMemoryEdit(id: String, newContent: String) {
+        viewModelScope.launch {
+            _isSubmitting.value = true
+            try {
+                val embedding = withContext(Dispatchers.Default) {
+                    embeddingEngine.embed(newContent)
+                }
+                memoryRepository.updateEpisodicMemory(id, newContent, embedding)
+                closeEpisodicMemoryDetail()
+            } catch (e: Exception) {
+                Log.e("KernelAI", "saveEpisodicMemoryEdit failed: ${e.message}", e)
+            } finally {
+                _isSubmitting.value = false
+            }
+        }
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -241,7 +242,11 @@ private fun SliderRow(
             OutlinedTextField(
                 value = textValue,
                 onValueChange = { textValue = it },
-                modifier = Modifier.width(76.dp),
+                modifier = Modifier
+                    .width(76.dp)
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) commitText(textValue)
+                    },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.bodySmall,
                 keyboardOptions = KeyboardOptions(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -18,6 +21,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -25,10 +29,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -115,6 +123,7 @@ private fun ModelCard(
             value = settings.contextWindowSize.toFloat(),
             valueRange = 2048f..32768f,
             steps = ((32768 - 2048) / 1024) - 1,
+            isInteger = true,
             onValueChangeFinished = { newVal ->
                 val snapped = (newVal / 1024).roundToInt() * 1024
                 onSettingsChanged(settings.copy(contextWindowSize = snapped))
@@ -128,6 +137,7 @@ private fun ModelCard(
             value = settings.temperature,
             valueRange = 0.1f..2.0f,
             steps = 18,
+            isInteger = false,
             onValueChangeFinished = { newVal ->
                 onSettingsChanged(settings.copy(temperature = (newVal * 10).roundToInt() / 10f))
             },
@@ -140,6 +150,7 @@ private fun ModelCard(
             value = settings.topP,
             valueRange = 0.0f..1.0f,
             steps = 19,
+            isInteger = false,
             onValueChangeFinished = { newVal ->
                 onSettingsChanged(settings.copy(topP = (newVal * 20).roundToInt() / 20f))
             },
@@ -163,9 +174,29 @@ private fun SliderRow(
     value: Float,
     valueRange: ClosedFloatingPointRange<Float>,
     steps: Int,
+    isInteger: Boolean = false,
     onValueChangeFinished: (Float) -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
     var sliderValue by remember(value) { mutableFloatStateOf(value) }
+    // Text field tracks what the user types; synced when slider moves or on commit
+    var textValue by remember(value) {
+        mutableStateOf(if (isInteger) value.roundToInt().toString() else "%.2f".format(value))
+    }
+
+    fun commitText(raw: String) {
+        val parsed = if (isInteger) raw.trim().toIntOrNull()?.toFloat() else raw.trim().toFloatOrNull()
+        if (parsed != null) {
+            val clamped = parsed.coerceIn(valueRange.start, valueRange.endInclusive)
+            sliderValue = clamped
+            textValue = if (isInteger) clamped.roundToInt().toString() else "%.2f".format(clamped)
+            onValueChangeFinished(clamped)
+        } else {
+            // Revert to current slider value on invalid input
+            textValue = if (isInteger) sliderValue.roundToInt().toString() else "%.2f".format(sliderValue)
+        }
+    }
+
     Column(modifier = Modifier.fillMaxWidth()) {
         if (label.isNotEmpty()) {
             Row(
@@ -191,14 +222,40 @@ private fun SliderRow(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
-        Slider(
-            value = sliderValue,
-            onValueChange = { sliderValue = it },
-            onValueChangeFinished = { onValueChangeFinished(sliderValue) },
-            valueRange = valueRange,
-            steps = steps,
+        Row(
             modifier = Modifier.fillMaxWidth(),
-        )
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Slider(
+                value = sliderValue,
+                onValueChange = { newVal ->
+                    sliderValue = newVal
+                    textValue = if (isInteger) newVal.roundToInt().toString() else "%.2f".format(newVal)
+                },
+                onValueChangeFinished = { onValueChangeFinished(sliderValue) },
+                valueRange = valueRange,
+                steps = steps,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            OutlinedTextField(
+                value = textValue,
+                onValueChange = { textValue = it },
+                modifier = Modifier.width(76.dp),
+                singleLine = true,
+                textStyle = MaterialTheme.typography.bodySmall,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = if (isInteger) KeyboardType.Number else KeyboardType.Decimal,
+                    imeAction = ImeAction.Done,
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        commitText(textValue)
+                        focusManager.clearFocus()
+                    },
+                ),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes bugs reported in #183 (testing) and #184 (bugs).

Closes #184

---

### Fix 1 — Correct default context window on flagship devices (#183)
- `ModelSettingsRepositoryImpl.defaultSettings()` was using its own `totalRam >= 12 GiB` check. `ActivityManager.MemoryInfo.totalMem` reports ~11.8 GiB on the S23 Ultra (kernel-reserved memory excluded), so it always returned 4096. Fixed to use `hardwareProfileDetector.profile.recommendedMaxTokens` which already uses the correct 10 GB FLAGSHIP threshold → 8192 on S23 Ultra.

### Fix 2 — Loading screen text visible on dark background (#183)
- Added `CompositionLocalProvider(LocalContentColor provides colorScheme.onBackground)` around the column, explicit `onBackground` colour on the step text, explicit `primary` on the progress indicator.

### Fix 3 — Model settings sliders with editable number fields (#183)
- `SliderRow` now has a 76dp `OutlinedTextField` to the right of each slider. Synced bidirectionally: dragging updates the field, typing a valid value moves the slider and saves on Done/focus-lost. Invalid/out-of-range input reverts to current value.

### Fix 4 — Delete button in core memory edit sheet (#184)
- Added destructive Delete button (left side) with `AlertDialog` confirmation to the core memory detail bottom sheet.

### Fix 5 — Episodic memories are now editable (#184)
- Episodic detail sheet is now fully editable with re-embed-on-save (same atomic pattern as core memories). Delete button added to episodic sheet too.