### PR TITLE
fix(#178): conversation bulk delete — wire Select into context menu

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -240,6 +240,13 @@ fun ConversationListScreen(
                                     onDismissRequest = { contextMenuTarget = null },
                                 ) {
                                     DropdownMenuItem(
+                                        text = { Text("Select") },
+                                        onClick = {
+                                            contextMenuTarget = null
+                                            viewModel.enterSelectionMode(conversation.id)
+                                        },
+                                    )
+                                    DropdownMenuItem(
                                         text = { Text("Rename") },
                                         onClick = {
                                             pendingRenameId = conversation.id


### PR DESCRIPTION
## Summary

Fixes the conversation bulk delete feature from #178 which was silently broken.

### Root cause
`enterSelectionMode()` existed in `ConversationListViewModel` but was never called from any UI path. Long-press on a conversation opened a context menu with **Rename** and **Delete** (single), but no way to enter multi-select mode. The bulk delete toolbar, Select All, and Delete (N) buttons were implemented correctly but completely unreachable.

### Fix
Added **Select** as the first item in the long-press context menu. Tapping it calls `viewModel.enterSelectionMode(conversation.id)`, entering selection mode with that conversation pre-selected. From there the existing Select All + Delete (N) toolbar works as intended.