### PR TITLE
feat(#38): HuggingFace OAuth PKCE — gated model downloads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,9 @@ android {
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "HF_CLIENT_ID", "\"2607cec6-3d70-4df0-ba39-eb9cef1ba8c8\"")
+        buildConfigField("String", "HF_REDIRECT_URI", "\"com.kernel.ai://oauth/callback\"")
     }
 
     signingConfigs {
@@ -42,6 +45,7 @@ android {
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
             signingConfig = signingConfigs.getByName("debugSigning")
+            buildConfigField("String", "HF_REDIRECT_URI", "\"com.kernel.ai.debug://oauth/callback\"")
         }
     }
 
@@ -98,6 +102,10 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
     debugImplementation(libs.leakcanary)
+
+    // Auth — AppAuth + EncryptedSharedPreferences
+    implementation(libs.appauth)
+    implementation(libs.security.crypto)
 
     // Testing
     testImplementation(libs.junit.jupiter)

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Debug-variant manifest overlay.
+    Adds the com.kernel.ai.debug URI scheme to AppAuth's RedirectUriReceiverActivity so that
+    debug builds (applicationId = com.kernel.ai.debug) receive the OAuth callback correctly.
+    This entry is merged on top of the main AndroidManifest.xml by the manifest merger.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="com.kernel.ai.debug"
+                    android:host="oauth"
+                    android:pathPrefix="/callback" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,26 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+
+        <!--
+            AppAuth redirect receiver — handles com.kernel.ai://oauth/callback (release).
+            The debug scheme (com.kernel.ai.debug://...) is added via app/src/debug/AndroidManifest.xml
+            so it does not pollute the release manifest.
+        -->
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            tools:node="replace">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="com.kernel.ai"
+                    android:host="oauth"
+                    android:pathPrefix="/callback" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kernel/ai/auth/AuthModule.kt
+++ b/app/src/main/java/com/kernel/ai/auth/AuthModule.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.auth
+
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Hilt module that binds [HuggingFaceAuthManager] (app-module implementation) to the
+ * [HuggingFaceAuthRepository] interface defined in :core:inference.
+ *
+ * Because [HuggingFaceAuthManager] is annotated with `@Singleton @Inject constructor`,
+ * Hilt can construct it automatically — this module only needs to declare the binding.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AuthModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindHuggingFaceAuthRepository(
+        impl: HuggingFaceAuthManager,
+    ): HuggingFaceAuthRepository
+}

--- a/app/src/main/java/com/kernel/ai/auth/HuggingFaceAuthManager.kt
+++ b/app/src/main/java/com/kernel/ai/auth/HuggingFaceAuthManager.kt
@@ -11,9 +11,13 @@ import androidx.security.crypto.MasterKey
 import com.kernel.ai.BuildConfig
 import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
@@ -91,12 +95,15 @@ class HuggingFaceAuthManager @Inject constructor(
     override val username: StateFlow<String?> = _username.asStateFlow()
 
     init {
-        // Restore persisted state on startup (lazy prefs not triggered until first access,
-        // so wrap in a safe-call block to avoid ANR from Keystore on main thread)
-        val storedToken = runCatching { prefs.getString(KEY_ACCESS_TOKEN, null) }.getOrNull()
-        _isAuthenticated.value = storedToken != null
-        _username.value = runCatching { prefs.getString(KEY_USERNAME, null) }.getOrNull()
-        Log.d(TAG, "HuggingFaceAuthManager: restored auth=${_isAuthenticated.value}, user=${_username.value}")
+        // Restore persisted state off the main thread — EncryptedSharedPreferences initialises
+        // MasterKey and the Keystore, which can block 100–500 ms on first use.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            val storedToken = runCatching { prefs.getString(KEY_ACCESS_TOKEN, null) }.getOrNull()
+            val storedUser  = runCatching { prefs.getString(KEY_USERNAME, null) }.getOrNull()
+            _isAuthenticated.value = !storedToken.isNullOrBlank()
+            _username.value = storedUser
+            Log.d(TAG, "HuggingFaceAuthManager: restored auth=${_isAuthenticated.value}, user=${_username.value}")
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -159,7 +166,13 @@ class HuggingFaceAuthManager @Inject constructor(
                     return@performTokenRequest
                 }
 
-                val accessToken = tokenResponse.accessToken.orEmpty()
+                val accessToken = tokenResponse.accessToken
+                if (accessToken.isNullOrBlank()) {
+                    val err = IllegalStateException("HF token response contained no access token")
+                    Log.e(TAG, err.message!!)
+                    continuation.resume(Result.failure(err))
+                    return@performTokenRequest
+                }
                 val username = extractUsername(tokenResponse.idToken)
 
                 runCatching {
@@ -173,7 +186,7 @@ class HuggingFaceAuthManager @Inject constructor(
                     return@performTokenRequest
                 }
 
-                _isAuthenticated.value = accessToken.isNotBlank()
+                _isAuthenticated.value = true
                 _username.value = username
                 Log.i(TAG, "HF auth success — user: $username")
                 continuation.resume(Result.success(Unit))

--- a/app/src/main/java/com/kernel/ai/auth/HuggingFaceAuthManager.kt
+++ b/app/src/main/java/com/kernel/ai/auth/HuggingFaceAuthManager.kt
@@ -1,0 +1,219 @@
+package com.kernel.ai.auth
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.net.Uri
+import android.util.Base64
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.kernel.ai.BuildConfig
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.ResponseTypeValues
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+private const val TAG = "KernelAI"
+private const val PREFS_FILE_NAME = "hf_auth_prefs"
+private const val KEY_ACCESS_TOKEN = "hf_access_token"
+private const val KEY_USERNAME = "hf_username"
+
+/**
+ * Singleton that manages HuggingFace OAuth 2.0 PKCE authentication.
+ *
+ * - Tokens are stored in [EncryptedSharedPreferences] (AES-256-GCM key in Android Keystore).
+ * - Uses AppAuth-Android for the Chrome Custom Tab PKCE flow — no WebView.
+ * - Implements [HuggingFaceAuthRepository] so that feature modules and [ModelDownloadManager]
+ *   interact with the interface only; AppAuth types are fully encapsulated here.
+ *
+ * HuggingFace OAuth app details:
+ *   clientId   = [BuildConfig.HF_CLIENT_ID]  (public, no client secret)
+ *   redirectUri = [BuildConfig.HF_REDIRECT_URI] (release: com.kernel.ai://oauth/callback,
+ *                                                 debug:   com.kernel.ai.debug://oauth/callback)
+ *   scopes     = openid profile gated-repos
+ */
+@Singleton
+class HuggingFaceAuthManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : HuggingFaceAuthRepository {
+
+    // -------------------------------------------------------------------------
+    // Encrypted preferences
+    // -------------------------------------------------------------------------
+
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // AppAuth service + configuration
+    // -------------------------------------------------------------------------
+
+    private val authService: AuthorizationService by lazy {
+        AuthorizationService(context)
+    }
+
+    private val serviceConfig = AuthorizationServiceConfiguration(
+        Uri.parse("https://huggingface.co/oauth/authorize"),
+        Uri.parse("https://huggingface.co/oauth/token"),
+    )
+
+    // -------------------------------------------------------------------------
+    // Observable state
+    // -------------------------------------------------------------------------
+
+    private val _isAuthenticated = MutableStateFlow(false)
+    override val isAuthenticated: StateFlow<Boolean> = _isAuthenticated.asStateFlow()
+
+    private val _username = MutableStateFlow<String?>(null)
+    override val username: StateFlow<String?> = _username.asStateFlow()
+
+    init {
+        // Restore persisted state on startup (lazy prefs not triggered until first access,
+        // so wrap in a safe-call block to avoid ANR from Keystore on main thread)
+        val storedToken = runCatching { prefs.getString(KEY_ACCESS_TOKEN, null) }.getOrNull()
+        _isAuthenticated.value = storedToken != null
+        _username.value = runCatching { prefs.getString(KEY_USERNAME, null) }.getOrNull()
+        Log.d(TAG, "HuggingFaceAuthManager: restored auth=${_isAuthenticated.value}, user=${_username.value}")
+    }
+
+    // -------------------------------------------------------------------------
+    // HuggingFaceAuthRepository implementation
+    // -------------------------------------------------------------------------
+
+    override fun getAccessToken(): String? =
+        runCatching { prefs.getString(KEY_ACCESS_TOKEN, null) }.getOrNull()
+
+    /**
+     * Builds an intent that launches the Authorization Code + PKCE flow.
+     * PKCE (S256) is automatically applied by AppAuth when using [ResponseTypeValues.CODE].
+     *
+     * Must be called on the main thread (AppAuth requirement for Chrome Custom Tab setup).
+     */
+    override fun buildAuthIntent(): Intent {
+        val request = AuthorizationRequest.Builder(
+            serviceConfig,
+            BuildConfig.HF_CLIENT_ID,
+            ResponseTypeValues.CODE,
+            Uri.parse(BuildConfig.HF_REDIRECT_URI),
+        )
+            .setScopes("openid", "profile", "gated-repos")
+            .build()
+
+        return authService.getAuthorizationRequestIntent(request)
+    }
+
+    /**
+     * Exchanges the authorization code for an access token and persists the result.
+     *
+     * Called with the [Intent] delivered by AppAuth's [RedirectUriReceiverActivity] after
+     * the user completes the browser flow.
+     */
+    override suspend fun handleAuthResponse(intent: Intent): Result<Unit> {
+        val authResponse = AuthorizationResponse.fromIntent(intent)
+        val authException = AuthorizationException.fromIntent(intent)
+
+        if (authException != null) {
+            Log.e(TAG, "HF OAuth error: ${authException.message}", authException)
+            return Result.failure(authException)
+        }
+        if (authResponse == null) {
+            val err = IllegalStateException("HF OAuth: no authorization response in intent")
+            Log.e(TAG, err.message!!)
+            return Result.failure(err)
+        }
+
+        return suspendCancellableCoroutine { continuation ->
+            authService.performTokenRequest(authResponse.createTokenExchangeRequest()) { tokenResponse, tokenException ->
+                if (tokenException != null) {
+                    Log.e(TAG, "HF token exchange failed: ${tokenException.message}", tokenException)
+                    continuation.resume(Result.failure(tokenException))
+                    return@performTokenRequest
+                }
+                if (tokenResponse == null) {
+                    val err = IllegalStateException("HF OAuth: null token response")
+                    Log.e(TAG, err.message!!)
+                    continuation.resume(Result.failure(err))
+                    return@performTokenRequest
+                }
+
+                val accessToken = tokenResponse.accessToken.orEmpty()
+                val username = extractUsername(tokenResponse.idToken)
+
+                runCatching {
+                    prefs.edit()
+                        .putString(KEY_ACCESS_TOKEN, accessToken)
+                        .apply { if (username != null) putString(KEY_USERNAME, username) }
+                        .apply()
+                }.onFailure { e ->
+                    Log.e(TAG, "HF auth: failed to persist token", e)
+                    continuation.resume(Result.failure(e))
+                    return@performTokenRequest
+                }
+
+                _isAuthenticated.value = accessToken.isNotBlank()
+                _username.value = username
+                Log.i(TAG, "HF auth success — user: $username")
+                continuation.resume(Result.success(Unit))
+            }
+        }
+    }
+
+    override fun signOut() {
+        runCatching {
+            prefs.edit()
+                .remove(KEY_ACCESS_TOKEN)
+                .remove(KEY_USERNAME)
+                .apply()
+        }.onFailure { e -> Log.e(TAG, "HF sign-out: failed to clear prefs", e) }
+
+        _isAuthenticated.value = false
+        _username.value = null
+        Log.i(TAG, "HF auth: signed out")
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Attempts to extract `preferred_username` (or `name`) from the OIDC id_token JWT payload.
+     * Returns `null` if the token is absent or the claim is missing.
+     */
+    private fun extractUsername(idToken: String?): String? {
+        if (idToken.isNullOrBlank()) return null
+        return runCatching {
+            val parts = idToken.split(".")
+            if (parts.size < 2) return null
+            val payloadJson = String(
+                Base64.decode(parts[1], Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP),
+                Charsets.UTF_8,
+            )
+            val json = JSONObject(payloadJson)
+            json.optString("preferred_username").takeIf { it.isNotBlank() }
+                ?: json.optString("name").takeIf { it.isNotBlank() }
+        }.getOrNull()
+    }
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/auth/HuggingFaceAuthRepository.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/auth/HuggingFaceAuthRepository.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.core.inference.auth
+
+import android.content.Intent
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Contract for HuggingFace OAuth 2.0 PKCE authentication.
+ *
+ * The interface lives in :core:inference so that [ModelDownloadManager] and the feature
+ * modules (onboarding, settings) can all depend on it without touching the AppAuth
+ * implementation, which is confined to :app.
+ *
+ * Flow:
+ * 1. Call [buildAuthIntent] to obtain an [Intent] that launches a Chrome Custom Tab for login.
+ * 2. Launch the intent via [android.app.Activity.startActivityForResult] /
+ *    [androidx.activity.result.ActivityResultLauncher].
+ * 3. When the OAuth redirect returns (AppAuth's RedirectUriReceiverActivity delivers the
+ *    result), pass the [Intent] to [handleAuthResponse] to exchange the code for a token.
+ * 4. [isAuthenticated] and [username] update automatically.
+ */
+interface HuggingFaceAuthRepository {
+
+    /** Emits `true` when a valid access token is stored locally. */
+    val isAuthenticated: StateFlow<Boolean>
+
+    /** HuggingFace username extracted from the OIDC id_token, or `null` if not signed in. */
+    val username: StateFlow<String?>
+
+    /**
+     * Returns the stored HF access token, or `null` if the user is not signed in.
+     * Must be called off the main thread when used in network code.
+     */
+    fun getAccessToken(): String?
+
+    /**
+     * Builds an [Intent] that starts the Authorization Code + PKCE flow via a Chrome Custom
+     * Tab. The intent should be launched with [android.app.Activity.startActivityForResult] or
+     * [androidx.activity.result.ActivityResultLauncher] with
+     * [androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult].
+     */
+    fun buildAuthIntent(): Intent
+
+    /**
+     * Handles the redirect [Intent] returned by AppAuth's RedirectUriReceiverActivity.
+     * Performs the token exchange (authorization code → access token) on the caller's
+     * coroutine context and stores the result in EncryptedSharedPreferences.
+     *
+     * @return [Result.success] on success, [Result.failure] with the underlying exception otherwise.
+     */
+    suspend fun handleAuthResponse(intent: Intent): Result<Unit>
+
+    /**
+     * Clears the stored token and username, effectively signing the user out.
+     * [isAuthenticated] transitions to `false` immediately.
+     */
+    fun signOut()
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -23,6 +23,12 @@ enum class KernelModel(
      * Null means the model is suitable for any tier (or is not a conversation model).
      */
     val preferredForTier: HardwareTier?,
+    /**
+     * If `true`, this model is gated on HuggingFace and requires an authenticated
+     * access token to download. The [ModelDownloadManager] will attach a Bearer token
+     * to the download request when this is `true`.
+     */
+    val isGated: Boolean = false,
 ) {
     GEMMA_4_E2B(
         displayName = "Gemma 4 E-2B",
@@ -32,6 +38,7 @@ enum class KernelModel(
         isRequired = true,
         /** Suitable for all hardware tiers. */
         preferredForTier = null,
+        isGated = true,
     ),
 
     /**
@@ -45,6 +52,7 @@ enum class KernelModel(
         approxSizeBytes = 3_654_467_584L, // 3.4 GB
         isRequired = false,
         preferredForTier = HardwareTier.FLAGSHIP,
+        isGated = true,
     ),
 
     FUNCTION_GEMMA_270M(
@@ -56,6 +64,7 @@ enum class KernelModel(
         // Note: this HuggingFace repo is currently gated — public URL needed before enabling.
         isRequired = false,
         preferredForTier = null,
+        isGated = false,
     ),
 
     /**
@@ -70,6 +79,7 @@ enum class KernelModel(
         approxSizeBytes = 6_120_274L,
         isRequired = false,
         preferredForTier = null,
+        isGated = false,
     ),
 
     /**
@@ -84,6 +94,7 @@ enum class KernelModel(
         approxSizeBytes = 350_000_000L,
         isRequired = false,
         preferredForTier = null,
+        isGated = true,
     ),
 
     /**
@@ -97,6 +108,7 @@ enum class KernelModel(
         approxSizeBytes = 350_000_000L,
         isRequired = false,
         preferredForTier = null,
+        isGated = true,
     ),
 
     /**
@@ -110,6 +122,7 @@ enum class KernelModel(
         approxSizeBytes = 4_500_000L,
         isRequired = false,
         preferredForTier = null,
+        isGated = true,
     );
 
     /**

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -10,6 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,6 +45,7 @@ class ModelDownloadManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val hardwareProfileDetector: com.kernel.ai.core.inference.hardware.HardwareProfileDetector,
     private val modelPreferences: com.kernel.ai.core.inference.prefs.ModelPreferences,
+    private val authRepository: HuggingFaceAuthRepository,
 ) {
     private val workManager = WorkManager.getInstance(context)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -102,12 +104,23 @@ class ModelDownloadManager @Inject constructor(
         Log.i(TAG, "Enqueuing download for ${model.displayName}")
         updateState(model, DownloadState.Downloading())
 
-        val inputData = Data.Builder()
+        val dataBuilder = Data.Builder()
             .putString(KEY_DOWNLOAD_URL, model.downloadUrl)
             .putString(KEY_FILE_NAME, model.fileName)
             .putString(KEY_MODEL_DISPLAY_NAME, model.displayName)
             .putLong(KEY_TOTAL_BYTES, model.approxSizeBytes)
-            .build()
+
+        // Attach HF access token for gated models so the worker can authenticate
+        if (model.isGated) {
+            val token = authRepository.getAccessToken()
+            if (token != null) {
+                dataBuilder.putString(KEY_HF_ACCESS_TOKEN, token)
+            } else {
+                Log.w(TAG, "Model ${model.displayName} is gated but no HF token available")
+            }
+        }
+
+        val inputData = dataBuilder.build()
 
         val request = OneTimeWorkRequestBuilder<ModelDownloadWorker>()
             .setInputData(inputData)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadWorker.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadWorker.kt
@@ -33,6 +33,8 @@ const val KEY_PROGRESS_BYTES = "progress_bytes"
 const val KEY_DOWNLOAD_RATE = "download_rate_bps"
 const val KEY_REMAINING_MS = "remaining_ms"
 const val KEY_ERROR_MESSAGE = "error_message"
+/** Optional HuggingFace Bearer token — present when downloading a gated model. */
+const val KEY_HF_ACCESS_TOKEN = "hf_access_token"
 
 /**
  * WorkManager [CoroutineWorker] that downloads a single `.litertlm` model file.
@@ -66,6 +68,7 @@ class ModelDownloadWorker(
             ?: return@withContext Result.failure(errorData("Missing file name"))
         val displayName = inputData.getString(KEY_MODEL_DISPLAY_NAME) ?: fileName
         val totalBytes = inputData.getLong(KEY_TOTAL_BYTES, 0L)
+        val hfAccessToken = inputData.getString(KEY_HF_ACCESS_TOKEN)
 
         val modelsDir = (applicationContext.getExternalFilesDir("models")
             ?: File(applicationContext.filesDir, "models")).also { it.mkdirs() }
@@ -83,6 +86,7 @@ class ModelDownloadWorker(
                 outputFile = outputFile,
                 totalBytes = totalBytes,
                 displayName = displayName,
+                hfAccessToken = hfAccessToken,
             )
             Log.i(TAG, "Download complete: ${outputFile.absolutePath}")
             Result.success()
@@ -98,8 +102,14 @@ class ModelDownloadWorker(
         outputFile: File,
         totalBytes: Long,
         displayName: String,
+        hfAccessToken: String? = null,
     ) {
         val connection = URL(url).openConnection() as HttpURLConnection
+
+        // Attach Bearer token for gated HuggingFace models
+        if (!hfAccessToken.isNullOrBlank()) {
+            connection.setRequestProperty("Authorization", "Bearer $hfAccessToken")
+        }
 
         // Resume from partial download if tmp file exists
         val resumeFrom = tmpFile.length()

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -56,8 +56,12 @@ fun OnboardingScreen(
     val authLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            result.data?.let { viewModel.handleAuthResponse(it) }
+        when {
+            result.resultCode == Activity.RESULT_OK && result.data != null ->
+                viewModel.handleAuthResponse(result.data!!)
+            result.resultCode == Activity.RESULT_OK ->
+                viewModel.emitAuthError("Sign-in failed: no response from HuggingFace")
+            // RESULT_CANCELED: user closed the tab — no feedback needed
         }
     }
 

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -1,24 +1,274 @@
 package com.kernel.ai.feature.onboarding
 
-import androidx.compose.foundation.layout.Box
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+
+/** Amber / HuggingFace brand colour. */
+private val HfOrange = Color(0xFFFF9D00)
 
 @Composable
-fun OnboardingScreen() {
-    Scaffold { innerPadding ->
-        Box(
+fun OnboardingScreen(
+    viewModel: OnboardingViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Launcher for the AppAuth Chrome Custom Tab OAuth flow
+    val authLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.let { viewModel.handleAuthResponse(it) }
+        }
+    }
+
+    // Consume one-shot events
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is OnboardingViewModel.OnboardingEvent.AuthError ->
+                    snackbarHostState.showSnackbar(event.message)
+
+                is OnboardingViewModel.OnboardingEvent.AuthSuccess ->
+                    snackbarHostState.showSnackbar("Signed in to HuggingFace ✓")
+
+                is OnboardingViewModel.OnboardingEvent.GatedModelRequiresAuth ->
+                    snackbarHostState.showSnackbar(
+                        "\"${event.model.displayName}\" requires a HuggingFace account. Sign in to continue."
+                    )
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
+                .padding(innerPadding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text("Welcome to Kernel AI — Model download will appear here")
+            Text(
+                text = "Welcome to Kernel AI",
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "On-device AI — private by design.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // ── HuggingFace sign-in card ──────────────────────────────────
+            HuggingFaceAuthCard(
+                isAuthenticated = uiState.isAuthenticated,
+                username = uiState.username,
+                onSignIn = { authLauncher.launch(viewModel.buildAuthIntent()) },
+                onSignOut = { viewModel.signOut() },
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Download progress ─────────────────────────────────────────
+            val downloadState = uiState.downloadState
+            when (downloadState) {
+                is DownloadState.NotDownloaded -> {
+                    Button(
+                        onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Download Gemma 4 E-2B (2.4 GB)")
+                    }
+                }
+
+                is DownloadState.Downloading -> {
+                    Text(
+                        text = "Downloading model…",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    CircularProgressIndicator(
+                        progress = { downloadState.progress },
+                        modifier = Modifier.size(48.dp),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "${(downloadState.progress * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+
+                is DownloadState.Downloaded -> {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.CheckCircle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Model ready",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+
+                is DownloadState.Error -> {
+                    Text(
+                        text = "Download error: ${downloadState.message}",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) }) {
+                        Text("Retry")
+                    }
+                }
+            }
         }
     }
 }
+
+@Composable
+private fun HuggingFaceAuthCard(
+    isAuthenticated: Boolean,
+    username: String?,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "HuggingFace Account",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (isAuthenticated) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.AccountCircle,
+                        contentDescription = null,
+                        tint = HfOrange,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = if (username != null) "Signed in as @$username ✓"
+                               else "Signed in ✓",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    TextButton(onClick = onSignOut) {
+                        Text("Sign out", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Gated models (Gemma 4, EmbeddingGemma) are unlocked.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Text(
+                    text = "Sign in to download gated models (Gemma 4, EmbeddingGemma).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onSignIn,
+                    colors = ButtonDefaults.buttonColors(containerColor = HfOrange),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AccountCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Sign in with HuggingFace", color = Color.Black)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OnboardingScreenNotSignedInPreview() {
+    MaterialTheme {
+        HuggingFaceAuthCard(
+            isAuthenticated = false,
+            username = null,
+            onSignIn = {},
+            onSignOut = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OnboardingScreenSignedInPreview() {
+    MaterialTheme {
+        HuggingFaceAuthCard(
+            isAuthenticated = true,
+            username = "kerneluser",
+            onSignIn = {},
+            onSignOut = {},
+        )
+    }
+}
+

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -79,6 +79,12 @@ class OnboardingViewModel @Inject constructor(
         }
     }
 
+    /** Emits an [OnboardingEvent.AuthError] directly — used when the screen detects a
+     *  RESULT_OK callback that carries no data intent. */
+    fun emitAuthError(message: String) {
+        _events.tryEmit(OnboardingEvent.AuthError(message))
+    }
+
     fun signOut() {
         authRepository.signOut()
     }

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,104 @@
+package com.kernel.ai.feature.onboarding
+
+import android.content.Intent
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val modelDownloadManager: ModelDownloadManager,
+    private val authRepository: HuggingFaceAuthRepository,
+) : ViewModel() {
+
+    data class OnboardingUiState(
+        val isAuthenticated: Boolean = false,
+        val username: String? = null,
+        /** Download progress 0..1 for the required E2B model. */
+        val downloadProgress: Float = 0f,
+        val downloadState: DownloadState = DownloadState.NotDownloaded,
+    )
+
+    val uiState: StateFlow<OnboardingUiState> = combine(
+        authRepository.isAuthenticated,
+        authRepository.username,
+        modelDownloadManager.downloadStates,
+    ) { isAuthenticated, username, downloadStates ->
+        val e2bState = downloadStates[KernelModel.GEMMA_4_E2B] ?: DownloadState.NotDownloaded
+        val progress = when (e2bState) {
+            is DownloadState.Downloading -> e2bState.progress
+            is DownloadState.Downloaded -> 1f
+            else -> 0f
+        }
+        OnboardingUiState(
+            isAuthenticated = isAuthenticated,
+            username = username,
+            downloadProgress = progress,
+            downloadState = e2bState,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = OnboardingUiState(),
+    )
+
+    private val _events = MutableSharedFlow<OnboardingEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<OnboardingEvent> = _events.asSharedFlow()
+
+    /** Returns an [Intent] for the HuggingFace OAuth Chrome Custom Tab flow. */
+    fun buildAuthIntent(): Intent = authRepository.buildAuthIntent()
+
+    /**
+     * Called with the result [Intent] from [android.app.Activity.RESULT_OK] after AppAuth
+     * redirects back to the app. Performs the token exchange and updates auth state.
+     */
+    fun handleAuthResponse(intent: Intent) {
+        viewModelScope.launch {
+            authRepository.handleAuthResponse(intent)
+                .onFailure { e ->
+                    Log.e("KernelAI", "OnboardingViewModel: HF auth failed", e)
+                    _events.tryEmit(OnboardingEvent.AuthError("Sign-in failed: ${e.message}"))
+                }
+                .onSuccess {
+                    _events.tryEmit(OnboardingEvent.AuthSuccess)
+                }
+        }
+    }
+
+    fun signOut() {
+        authRepository.signOut()
+    }
+
+    /**
+     * Starts downloading a [model]. If the model is gated and the user is not signed in,
+     * emits [OnboardingEvent.GatedModelRequiresAuth] instead.
+     */
+    fun startDownload(model: KernelModel) {
+        if (model.isGated && !uiState.value.isAuthenticated) {
+            _events.tryEmit(OnboardingEvent.GatedModelRequiresAuth(model))
+            return
+        }
+        modelDownloadManager.startDownload(model)
+    }
+
+    sealed interface OnboardingEvent {
+        data object AuthSuccess : OnboardingEvent
+        data class AuthError(val message: String) : OnboardingEvent
+        /** Fired when the user tries to download a gated model without signing in. */
+        data class GatedModelRequiresAuth(val model: KernelModel) : OnboardingEvent
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package com.kernel.ai.feature.settings
 
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +21,8 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -61,6 +66,19 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+
+    // Launcher for the AppAuth Chrome Custom Tab OAuth re-authentication flow
+    val authLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        when {
+            result.resultCode == Activity.RESULT_OK && result.data != null ->
+                viewModel.handleAuthResponse(result.data!!)
+            result.resultCode == Activity.RESULT_OK ->
+                scope.launch { snackbarHostState.showSnackbar("Sign-in failed: no response from HuggingFace") }
+            // RESULT_CANCELED: user dismissed — no feedback needed
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.saveError.collect { message ->
@@ -250,6 +268,7 @@ fun SettingsScreen(
             HuggingFaceAccountRow(
                 isAuthenticated = uiState.hfAuthenticated,
                 username = uiState.hfUsername,
+                onSignIn = { authLauncher.launch(viewModel.buildAuthIntent()) },
                 onSignOut = { viewModel.signOutHuggingFace() },
             )
             HorizontalDivider()
@@ -286,13 +305,14 @@ private fun SettingsScreenPreview() {
 /**
  * Inline row shown in the Settings screen for the HuggingFace account section.
  *
- * - Not signed in: shows an info label (sign-in happens via OnboardingScreen or deep link).
+ * - Not signed in: shows an info label + "Sign in" button to launch the OAuth flow.
  * - Signed in: shows username + Sign Out button.
  */
 @Composable
 private fun HuggingFaceAccountRow(
     isAuthenticated: Boolean,
     username: String?,
+    onSignIn: () -> Unit,
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -323,13 +343,21 @@ private fun HuggingFaceAccountRow(
         ListItem(
             modifier = modifier.fillMaxWidth(),
             headlineContent = { Text("Not signed in") },
-            supportingContent = { Text("Sign in via onboarding to download gated models") },
+            supportingContent = { Text("Sign in to download gated models (Gemma 4, EmbeddingGemma)") },
             leadingContent = {
                 Icon(
                     imageVector = Icons.Default.AccountCircle,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+            },
+            trailingContent = {
+                Button(
+                    onClick = onSignIn,
+                    colors = ButtonDefaults.buttonColors(containerColor = HfOrange),
+                ) {
+                    Text("Sign in", color = Color.Black)
+                }
             },
         )
     }
@@ -342,6 +370,7 @@ private fun HuggingFaceAccountRowSignedInPreview() {
         HuggingFaceAccountRow(
             isAuthenticated = true,
             username = "kerneluser",
+            onSignIn = {},
             onSignOut = {},
         )
     }
@@ -354,6 +383,7 @@ private fun HuggingFaceAccountRowNotSignedInPreview() {
         HuggingFaceAccountRow(
             isAuthenticated = false,
             username = null,
+            onSignIn = {},
             onSignOut = {},
         )
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -2,13 +2,17 @@ package com.kernel.ai.feature.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Person
@@ -25,19 +29,25 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.inference.download.KernelModel
 import kotlinx.coroutines.launch
+
+/** Amber / HuggingFace brand colour — same as in OnboardingScreen. */
+private val HfOrange = Color(0xFFFF9D00)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -227,6 +237,22 @@ fun SettingsScreen(
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // ── HuggingFace Account ───────────────────────────────────────────────
+            Text(
+                text = "HuggingFace Account",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            HuggingFaceAccountRow(
+                isAuthenticated = uiState.hfAuthenticated,
+                username = uiState.hfUsername,
+                onSignOut = { viewModel.signOutHuggingFace() },
+            )
+            HorizontalDivider()
         }
     }
 }
@@ -254,6 +280,82 @@ private fun SettingsScreenPreview() {
                 HorizontalDivider()
             }
         }
+    }
+}
+
+/**
+ * Inline row shown in the Settings screen for the HuggingFace account section.
+ *
+ * - Not signed in: shows an info label (sign-in happens via OnboardingScreen or deep link).
+ * - Signed in: shows username + Sign Out button.
+ */
+@Composable
+private fun HuggingFaceAccountRow(
+    isAuthenticated: Boolean,
+    username: String?,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isAuthenticated) {
+        ListItem(
+            modifier = modifier.fillMaxWidth(),
+            headlineContent = {
+                Text(
+                    text = if (username != null) "@$username" else "Signed in",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            supportingContent = { Text("Gated models unlocked") },
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = null,
+                    tint = HfOrange,
+                )
+            },
+            trailingContent = {
+                TextButton(onClick = onSignOut) {
+                    Text("Sign out", color = MaterialTheme.colorScheme.error)
+                }
+            },
+        )
+    } else {
+        ListItem(
+            modifier = modifier.fillMaxWidth(),
+            headlineContent = { Text("Not signed in") },
+            supportingContent = { Text("Sign in via onboarding to download gated models") },
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HuggingFaceAccountRowSignedInPreview() {
+    MaterialTheme {
+        HuggingFaceAccountRow(
+            isAuthenticated = true,
+            username = "kerneluser",
+            onSignOut = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HuggingFaceAccountRowNotSignedInPreview() {
+    MaterialTheme {
+        HuggingFaceAccountRow(
+            isAuthenticated = false,
+            username = null,
+            onSignOut = {},
+        )
     }
 }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.settings
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.ModelDownloadManager
@@ -25,6 +26,7 @@ class SettingsViewModel @Inject constructor(
     private val hardwareProfileDetector: HardwareProfileDetector,
     private val modelDownloadManager: ModelDownloadManager,
     private val modelPreferences: ModelPreferences,
+    private val authRepository: HuggingFaceAuthRepository,
 ) : ViewModel() {
 
     data class SettingsUiState(
@@ -33,12 +35,18 @@ class SettingsViewModel @Inject constructor(
         val activeTier: String = "",
         val preferredModel: KernelModel? = null,   // null = auto
         val e4bDownloaded: Boolean = false,
+        /** True when a valid HF token is stored. */
+        val hfAuthenticated: Boolean = false,
+        /** HuggingFace username from OIDC id_token, or null. */
+        val hfUsername: String? = null,
     )
 
     val uiState: StateFlow<SettingsUiState> = combine(
         modelPreferences.preferredConversationModel,
         modelDownloadManager.downloadStates,
-    ) { preferredModel, downloadStates ->
+        authRepository.isAuthenticated,
+        authRepository.username,
+    ) { preferredModel, downloadStates, hfAuthenticated, hfUsername ->
         val profile = hardwareProfileDetector.profile
         val e4bDownloaded = downloadStates[KernelModel.GEMMA_4_E4B] is DownloadState.Downloaded
 
@@ -59,6 +67,8 @@ class SettingsViewModel @Inject constructor(
             activeTier = profile.tier.name,
             preferredModel = preferredModel,
             e4bDownloaded = e4bDownloaded,
+            hfAuthenticated = hfAuthenticated,
+            hfUsername = hfUsername,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -85,5 +95,11 @@ class SettingsViewModel @Inject constructor(
                 _saveError.tryEmit("Couldn't save preference — please try again")
             }
         }
+    }
+
+    /** Signs the user out of HuggingFace and clears the stored token. */
+    fun signOutHuggingFace() {
+        authRepository.signOut()
+        _saveSuccess.tryEmit("Signed out of HuggingFace")
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -101,5 +102,25 @@ class SettingsViewModel @Inject constructor(
     fun signOutHuggingFace() {
         authRepository.signOut()
         _saveSuccess.tryEmit("Signed out of HuggingFace")
+    }
+
+    /** Returns an [Intent] for the HuggingFace OAuth Chrome Custom Tab flow. */
+    fun buildAuthIntent(): Intent = authRepository.buildAuthIntent()
+
+    /**
+     * Called with the result [Intent] from [android.app.Activity.RESULT_OK] after AppAuth
+     * redirects back to the app. Performs the token exchange and updates auth state.
+     */
+    fun handleAuthResponse(intent: Intent) {
+        viewModelScope.launch {
+            authRepository.handleAuthResponse(intent)
+                .onFailure { e ->
+                    Log.e("KernelAI", "SettingsViewModel: HF auth failed", e)
+                    _saveError.tryEmit("Sign-in failed: ${e.message}")
+                }
+                .onSuccess {
+                    _saveSuccess.tryEmit("Signed in to HuggingFace ✓")
+                }
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,10 @@ hiltWork = "1.3.0"
 # Debug
 leakcanary = "2.14"
 
+# Auth
+appauth = "0.11.1"
+securityCrypto = "1.1.0-alpha06"
+
 [libraries]
 # Compose BOM
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
@@ -97,6 +101,10 @@ coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 
 # Debug
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
+
+# Auth
+appauth = { group = "net.openid", name = "appauth", version.ref = "appauth" }
+security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Closes #38

Implements Sign in with Hugging Face using OAuth 2.0 Authorization Code + PKCE (S256). Allows users to authenticate and download gated models (Gemma-4, EmbeddingGemma).

### Flow
1. User taps **Sign in with Hugging Face** in onboarding or settings
2. Chrome Custom Tab opens `huggingface.co/oauth/authorize` with PKCE challenge
3. User authenticates on HuggingFace; redirected back to `com.kernel.ai://oauth/callback`
4. AppAuth `RedirectUriReceiverActivity` intercepts, code exchanged for token
5. Token stored in `EncryptedSharedPreferences`; attached as `Authorization: Bearer` on all gated model downloads

### Architecture
- `HuggingFaceAuthRepository` interface in `:core:inference` (no AppAuth types leak to feature modules)
- `HuggingFaceAuthManager` in `:app` — AppAuth + EncryptedSharedPreferences implementation
- Hilt `@Binds` in `AuthModule` (SingletonComponent)
- `KernelModel.isGated` marks Gemma-4 E2B/E4B + EmbeddingGemma variants; token attached in `ModelDownloadManager` only for gated models
- Debug manifest overlay adds `com.kernel.ai.debug://oauth/callback` scheme

### Config
- clientId: `2607cec6-3d70-4df0-ba39-eb9cef1ba8c8` (public app — no secret, in BuildConfig)
- Scopes: `openid profile gated-repos`
- Required: both redirect URIs registered in HuggingFace OAuth app settings