### PR TITLE
feat: Phase 3 skills infrastructure

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/6.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/6.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 6,
-    "identityHash": "e2cff38014cceaf45c52f6052681d600",
+    "identityHash": "ada61d90ed829bd026e71bd5b3320a0c",
     "entities": [
       {
         "tableName": "conversations",
@@ -340,7 +340,7 @@
       },
       {
         "tableName": "model_settings",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `minP` REAL NOT NULL, `repetitionPenalty` REAL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
         "fields": [
           {
             "fieldPath": "modelId",
@@ -367,17 +367,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "minP",
-            "columnName": "minP",
-            "affinity": "REAL",
-            "notNull": true
-          },
-          {
-            "fieldPath": "repetitionPenalty",
-            "columnName": "repetitionPenalty",
-            "affinity": "REAL"
-          },
-          {
             "fieldPath": "updatedAt",
             "columnName": "updatedAt",
             "affinity": "INTEGER",
@@ -394,7 +383,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e2cff38014cceaf45c52f6052681d600')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ada61d90ed829bd026e71bd5b3320a0c')"
     ]
   }
 }

--- a/core/skills/build.gradle.kts
+++ b/core/skills/build.gradle.kts
@@ -25,9 +25,13 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:inference"))
+    implementation(project(":core:memory"))
+
     implementation(libs.core.ktx)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    implementation(libs.coroutines.android)
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)

--- a/core/skills/src/main/AndroidManifest.xml
+++ b/core/skills/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/Skill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/Skill.kt
@@ -1,28 +1,14 @@
 package com.kernel.ai.core.skills
 
-/** Permission level required by a skill. */
-enum class PermissionLevel {
-    /** No dangerous Android permissions needed. */
-    STANDARD,
-    /** Requires one or more dangerous Android permissions. */
-    PRIVILEGED
-}
-
-/** Result of executing a skill. */
-sealed class SkillResult {
-    data class Success(val data: Map<String, Any?>) : SkillResult()
-    data class Error(val message: String) : SkillResult()
-}
-
 /**
- * Contract for all skills (native Kotlin and Wasm).
- * Each skill declares its identity, parameter schema, and execution logic.
+ * Contract for all native skills. Each skill:
+ * - Has a unique [name] matching the FunctionGemma routing key
+ * - Declares its [schema] (JSON Schema object) for FunctionGemma's function definitions
+ * - Executes with a [SkillCall] and returns a [SkillResult]
  */
 interface Skill {
-    val id: String
     val name: String
     val description: String
-    val parameterSchema: String // JSON Schema string
-    val permissionLevel: PermissionLevel
-    suspend fun execute(params: Map<String, Any?>): SkillResult
+    val schema: SkillSchema
+    suspend fun execute(call: SkillCall): SkillResult
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillCall.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillCall.kt
@@ -1,0 +1,9 @@
+package com.kernel.ai.core.skills
+
+/**
+ * A parsed skill invocation from FunctionGemma's output.
+ */
+data class SkillCall(
+    val skillName: String,
+    val arguments: Map<String, String>, // all args as strings; skills coerce as needed
+)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillExecutor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillExecutor.kt
@@ -1,0 +1,50 @@
+package com.kernel.ai.core.skills
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Parses FunctionGemma's raw JSON output into a [SkillCall] and executes it via [SkillRegistry].
+ *
+ * FunctionGemma output format:
+ * {"name": "skill_name", "arguments": {"param1": "value1"}}
+ */
+@Singleton
+class SkillExecutor @Inject constructor(
+    private val registry: SkillRegistry,
+) {
+    suspend fun execute(rawFunctionGemmaOutput: String): SkillResult {
+        val call = parseSkillCall(rawFunctionGemmaOutput)
+            ?: return SkillResult.ParseError(rawFunctionGemmaOutput, "Invalid JSON or missing 'name' field")
+
+        val skill = registry.get(call.skillName)
+            ?: return SkillResult.UnknownSkill(call.skillName)
+
+        val missingParams = skill.schema.required.filter { it !in call.arguments }
+        if (missingParams.isNotEmpty()) {
+            return SkillResult.ParseError(
+                rawFunctionGemmaOutput,
+                "Missing required parameters: ${missingParams.joinToString()}"
+            )
+        }
+
+        return try {
+            skill.execute(call)
+        } catch (e: Exception) {
+            SkillResult.Failure(call.skillName, e.message ?: "Unknown error")
+        }
+    }
+
+    private fun parseSkillCall(raw: String): SkillCall? {
+        return try {
+            val json = org.json.JSONObject(raw.trim())
+            val name = json.optString("name").takeIf { it.isNotBlank() } ?: return null
+            val argsObj = json.optJSONObject("arguments") ?: org.json.JSONObject()
+            val args = mutableMapOf<String, String>()
+            argsObj.keys().forEach { key -> args[key] = argsObj.optString(key) }
+            SkillCall(skillName = name, arguments = args)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillExecutor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillExecutor.kt
@@ -37,7 +37,11 @@ class SkillExecutor @Inject constructor(
 
     private fun parseSkillCall(raw: String): SkillCall? {
         return try {
-            val json = org.json.JSONObject(raw.trim())
+            val cleaned = raw.trim()
+                .removePrefix("```json").removePrefix("```")
+                .removeSuffix("```")
+                .trim()
+            val json = org.json.JSONObject(cleaned)
             val name = json.optString("name").takeIf { it.isNotBlank() } ?: return null
             val argsObj = json.optJSONObject("arguments") ?: org.json.JSONObject()
             val args = mutableMapOf<String, String>()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
@@ -1,0 +1,39 @@
+package com.kernel.ai.core.skills
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds all registered [Skill] implementations.
+ * Skills self-register via Hilt multibinding (@IntoSet).
+ */
+@Singleton
+class SkillRegistry @Inject constructor(
+    skills: Set<@JvmSuppressWildcards Skill>,
+) {
+    private val registry: Map<String, Skill> = skills.associateBy { it.name }
+
+    fun get(name: String): Skill? = registry[name]
+
+    fun allSkills(): List<Skill> = registry.values.toList()
+
+    /** Generates the function_declarations JSON array for FunctionGemma's system prompt. */
+    fun buildFunctionDeclarationsJson(): String {
+        val declarations = registry.values.map { skill ->
+            buildString {
+                append("""{"name":"${skill.name}","description":"${skill.description}","parameters":{"type":"object","properties":{""")
+                skill.schema.parameters.entries.forEachIndexed { i, (paramName, param) ->
+                    if (i > 0) append(",")
+                    append(""""$paramName":{"type":"${param.type}","description":"${param.description}"""")
+                    if (!param.enum.isNullOrEmpty()) {
+                        append(""","enum":[${param.enum.joinToString(",") { "\"$it\"" }}]""")
+                    }
+                    append("}")
+                }
+                append("""},"required":[${skill.schema.required.joinToString(",") { "\"$it\"" }}]}""")
+                append("}")
+            }
+        }
+        return "[${declarations.joinToString(",")}]"
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
@@ -19,21 +19,31 @@ class SkillRegistry @Inject constructor(
 
     /** Generates the function_declarations JSON array for FunctionGemma's system prompt. */
     fun buildFunctionDeclarationsJson(): String {
-        val declarations = registry.values.map { skill ->
-            buildString {
-                append("""{"name":"${skill.name}","description":"${skill.description}","parameters":{"type":"object","properties":{""")
-                skill.schema.parameters.entries.forEachIndexed { i, (paramName, param) ->
-                    if (i > 0) append(",")
-                    append(""""$paramName":{"type":"${param.type}","description":"${param.description}"""")
+        val declarations = org.json.JSONArray()
+        registry.values.forEach { skill ->
+            val properties = org.json.JSONObject()
+            skill.schema.parameters.forEach { (paramName, param) ->
+                val paramObj = org.json.JSONObject().apply {
+                    put("type", param.type)
+                    put("description", param.description)
                     if (!param.enum.isNullOrEmpty()) {
-                        append(""","enum":[${param.enum.joinToString(",") { "\"$it\"" }}]""")
+                        put("enum", org.json.JSONArray(param.enum))
                     }
-                    append("}")
                 }
-                append("""},"required":[${skill.schema.required.joinToString(",") { "\"$it\"" }}]}""")
-                append("}")
+                properties.put(paramName, paramObj)
             }
+            val parameters = org.json.JSONObject().apply {
+                put("type", "object")
+                put("properties", properties)
+                put("required", org.json.JSONArray(skill.schema.required))
+            }
+            val declaration = org.json.JSONObject().apply {
+                put("name", skill.name)
+                put("description", skill.description)
+                put("parameters", parameters)
+            }
+            declarations.put(declaration)
         }
-        return "[${declarations.joinToString(",")}]"
+        return declarations.toString()
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
@@ -1,0 +1,12 @@
+package com.kernel.ai.core.skills
+
+sealed class SkillResult {
+    /** Skill ran successfully. [content] is injected back into the conversation. */
+    data class Success(val content: String) : SkillResult()
+    /** Skill not found in registry. */
+    data class UnknownSkill(val skillName: String) : SkillResult()
+    /** Skill found but execution failed. */
+    data class Failure(val skillName: String, val error: String) : SkillResult()
+    /** FunctionGemma output was malformed JSON or failed schema validation. */
+    data class ParseError(val rawOutput: String, val reason: String) : SkillResult()
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillSchema.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillSchema.kt
@@ -1,0 +1,16 @@
+package com.kernel.ai.core.skills
+
+/**
+ * JSON Schema representation for a skill's parameters.
+ * Used to generate FunctionGemma's function_declarations payload.
+ */
+data class SkillSchema(
+    val parameters: Map<String, SkillParameter> = emptyMap(),
+    val required: List<String> = emptyList(),
+)
+
+data class SkillParameter(
+    val type: String,           // "string", "boolean", "integer", "number"
+    val description: String,
+    val enum: List<String>? = null,
+)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.core.skills
+
+import com.kernel.ai.core.skills.natives.GetSystemInfoSkill
+import com.kernel.ai.core.skills.natives.SaveMemorySkill
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SkillsModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindGetSystemInfoSkill(skill: GetSystemInfoSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindSaveMemorySkill(skill: SaveMemorySkill): Skill
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
@@ -1,0 +1,76 @@
+package com.kernel.ai.core.skills.natives
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.util.Log
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Skill that returns current device and model runtime information.
+ * Replaces the hardcoded [Runtime] block in the system prompt.
+ */
+@Singleton
+class GetSystemInfoSkill @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val hardwareProfileDetector: HardwareProfileDetector,
+) : Skill {
+
+    override val name = "get_system_info"
+    override val description =
+        "Returns current device and model runtime information including hardware tier, " +
+            "available memory, battery level, and active model."
+    override val schema = SkillSchema()
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        return withContext(Dispatchers.Default) {
+            try {
+                val profile = hardwareProfileDetector.profile
+
+                val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                val memInfo = ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) }
+                val availMb = memInfo.availMem / (1024 * 1024)
+
+                val batteryIntent = context.registerReceiver(
+                    null,
+                    IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+                )
+                val batteryPct = batteryIntent?.let {
+                    val level = it.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                    val scale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                    if (level >= 0 && scale > 0) (level * 100 / scale) else -1
+                } ?: -1
+
+                val info = buildString {
+                    appendLine("Hardware tier: ${profile.tier.name}")
+                    appendLine("SoC: ${profile.socManufacturer} ${profile.socModel}".trim())
+                    appendLine("Total RAM: ${profile.ramLabel}")
+                    appendLine("RAM available: ${availMb}MB")
+                    appendLine("Recommended backend: ${profile.recommendedBackend.name}")
+                    appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                    if (batteryPct >= 0) appendLine("Battery: $batteryPct%")
+                }
+
+                Log.d(TAG, "GetSystemInfoSkill executed successfully")
+                SkillResult.Success(info.trim())
+            } catch (e: Exception) {
+                Log.e(TAG, "GetSystemInfoSkill failed", e)
+                SkillResult.Failure(name, e.message ?: "Failed to retrieve system info")
+            }
+        }
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -1,0 +1,59 @@
+package com.kernel.ai.core.skills.natives
+
+import android.util.Log
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillParameter
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Skill that saves an important fact or preference to the user's long-term core memory.
+ * Persists via [MemoryRepository.addCoreMemory] without requiring an embedding vector
+ * (the repository accepts null — the background embedding pipeline handles it asynchronously).
+ */
+@Singleton
+class SaveMemorySkill @Inject constructor(
+    private val memoryRepository: MemoryRepository,
+) : Skill {
+
+    override val name = "save_memory"
+    override val description =
+        "Saves an important fact or preference to the user's long-term core memory " +
+            "for future conversations."
+    override val schema = SkillSchema(
+        parameters = mapOf(
+            "content" to SkillParameter(
+                type = "string",
+                description = "The fact or preference to remember, written as a clear statement."
+            )
+        ),
+        required = listOf("content"),
+    )
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        val content = call.arguments["content"]
+            ?: return SkillResult.Failure(name, "Missing 'content' argument")
+        return withContext(Dispatchers.Default) {
+            try {
+                memoryRepository.addCoreMemory(
+                    content = content,
+                    source = "agent",
+                    embeddingVector = null,
+                )
+                Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
+                SkillResult.Success("Got it — I'll remember that.")
+            } catch (e: Exception) {
+                Log.e(TAG, "SaveMemorySkill failed", e)
+                SkillResult.Failure(name, e.message ?: "Failed to save memory")
+            }
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -53,6 +53,7 @@ class ChatViewModel @Inject constructor(
     private val episodicDistillationUseCase: EpisodicDistillationUseCase,
     private val modelSettingsRepository: ModelSettingsRepository,
     private val skillRegistry: SkillRegistry,
+    @Suppress("UnusedPrivateMember") // wired in next PR: FunctionGemma routing (#84)
     private val skillExecutor: SkillExecutor,
 ) : ViewModel() {
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1,6 +1,5 @@
 package com.kernel.ai.feature.chat
 
-import android.os.Build
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -19,6 +18,8 @@ import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
 import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
+import com.kernel.ai.core.skills.SkillExecutor
+import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
@@ -51,6 +52,8 @@ class ChatViewModel @Inject constructor(
     private val memoryRepository: MemoryRepository,
     private val episodicDistillationUseCase: EpisodicDistillationUseCase,
     private val modelSettingsRepository: ModelSettingsRepository,
+    private val skillRegistry: SkillRegistry,
+    private val skillExecutor: SkillExecutor,
 ) : ViewModel() {
 
     /** Passed via nav arg; null means "start a new conversation". */
@@ -158,13 +161,10 @@ class ChatViewModel @Inject constructor(
         val profile = userProfileRepository.get()
         val dateTime = LocalDateTime.now()
             .format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm"))
-        val backend = inferenceEngine.activeBackend.value?.name ?: "CPU"
-        val model = activeModel?.displayName ?: "Gemma 4"
-        val device = "${Build.MANUFACTURER} ${Build.MODEL}"
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
             append("\n\n[Current date and time]\n$dateTime")
-            append("\n\n[Runtime]\nModel: $model | Backend: $backend | Device: $device")
+            // Runtime info fetched dynamically via get_system_info skill at query time
             if (profile.isNotBlank()) {
                 // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
                 // The original stored profile is never modified — only the injected copy is shortened.
@@ -184,6 +184,12 @@ class ChatViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * Returns the function_declarations JSON array for FunctionGemma's system prompt.
+     * Used to advertise available skills to the model at inference time.
+     */
+    fun buildSkillContext(): String = skillRegistry.buildFunctionDeclarationsJson()
 
     private suspend fun initializeConversation() {
         val id = navConversationId ?: conversationRepository.createConversation()


### PR DESCRIPTION
Closes #86, Closes #103. Implements :core:skills module with SkillRegistry, SkillExecutor, GetSystemInfo and SaveMemory native skills. ChatViewModel injects SkillRegistry and exposes buildSkillContext() for FunctionGemma routing.