### PR TITLE
feat(#84): FunctionGemma intent routing — skill dispatch with Gemma-4 fallback

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -1,0 +1,205 @@
+package com.kernel.ai.core.inference
+
+import android.content.Context
+import android.util.Log
+import com.google.ai.edge.litertlm.Content
+import com.google.ai.edge.litertlm.Contents
+import com.google.ai.edge.litertlm.ConversationConfig
+import com.google.ai.edge.litertlm.Engine
+import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.Message
+import com.google.ai.edge.litertlm.MessageCallback
+import com.google.ai.edge.litertlm.SamplerConfig
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Routes user messages to either a skill or plain conversation using FunctionGemma-270M.
+ *
+ * FunctionGemma runs on CPU (XNNPACK, 4 threads) and is always-hot — loaded at app start.
+ * It never shares its session with the main conversation (isolated Engine + Conversation).
+ *
+ * Output contract:
+ * - Valid JSON object with "name" field → [RouteDecision.SkillCall]
+ * - Anything else (including "CONVERSATION") → [RouteDecision.PlainConversation]
+ * - Engine not yet initialised → [RouteDecision.RouterNotReady]
+ */
+@Singleton
+class FunctionGemmaRouter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @Suppress("UnusedPrivateMember")
+    private val hardwareProfileDetector: HardwareProfileDetector,
+) {
+    sealed class RouteDecision {
+        data class SkillCall(val rawJson: String) : RouteDecision()
+        object PlainConversation : RouteDecision()
+        object RouterNotReady : RouteDecision()
+    }
+
+    private var engine: Engine? = null
+    private var conversation: com.google.ai.edge.litertlm.Conversation? = null
+
+    private val _isReady = MutableStateFlow(false)
+    val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    /**
+     * Initialises FunctionGemma on [LlmDispatcher].
+     *
+     * Always forces CPU/XNNPACK backend — FunctionGemma-270M is the always-hot router and
+     * must not compete with the main model on GPU/NPU resources.
+     *
+     * @param functionGemmaPath Absolute path to the `.litertlm` model file on disk.
+     * @param functionDeclarationsJson JSON array of available skill declarations injected
+     *        into the system prompt so the model knows which functions it may call.
+     */
+    suspend fun initialize(functionGemmaPath: String, functionDeclarationsJson: String) {
+        withContext(LlmDispatcher) {
+            _isReady.value = false
+            try {
+                Log.i(TAG, "FunctionGemmaRouter: initialising from $functionGemmaPath")
+
+                val engineConfig = EngineConfig(
+                    modelPath = functionGemmaPath,
+                    backend = BackendType.CPU.toBackend(context),
+                    maxNumTokens = MAX_TOKENS,
+                )
+                val eng = Engine(engineConfig)
+                eng.initialize()
+
+                val systemInstruction = buildSystemPrompt(functionDeclarationsJson)
+                val samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.0)
+                val convConfig = ConversationConfig(
+                    samplerConfig = samplerConfig,
+                    systemInstruction = Contents.of(Content.Text(systemInstruction)),
+                )
+                val conv = eng.createConversation(convConfig)
+
+                engine = eng
+                conversation = conv
+                _isReady.value = true
+                Log.i(TAG, "FunctionGemmaRouter: ready (CPU/XNNPACK, maxTokens=$MAX_TOKENS)")
+            } catch (e: Exception) {
+                Log.e(TAG, "FunctionGemmaRouter: initialisation failed — ${e.message}", e)
+                _isReady.value = false
+            }
+        }
+    }
+
+    /**
+     * Routes [userMessage] to a skill call or plain conversation.
+     *
+     * Must only be called after [initialize] completes successfully (i.e., [isReady] is true).
+     * If the router is not ready, returns [RouteDecision.RouterNotReady] so the caller can
+     * fall through to Gemma-4.
+     *
+     * Runs on [LlmDispatcher] — safe to call from any coroutine context.
+     */
+    suspend fun route(userMessage: String): RouteDecision = withContext(LlmDispatcher) {
+        val conv = conversation
+        if (conv == null) {
+            Log.w(TAG, "FunctionGemmaRouter: route() called before initialisation — falling back")
+            return@withContext RouteDecision.RouterNotReady
+        }
+
+        try {
+            val sb = StringBuilder()
+            val latch = CompletableDeferred<Unit>()
+
+            conv.sendMessageAsync(
+                Contents.of(Content.Text(userMessage)),
+                object : MessageCallback {
+                    override fun onMessage(message: Message) {
+                        val text = message.toString()
+                        if (text.isNotEmpty() && !text.startsWith("<ctrl")) sb.append(text)
+                    }
+
+                    override fun onDone() {
+                        latch.complete(Unit)
+                    }
+
+                    override fun onError(throwable: Throwable) {
+                        latch.completeExceptionally(throwable)
+                    }
+                },
+            )
+            latch.await()
+
+            val raw = sb.toString().trim()
+            Log.d(TAG, "FunctionGemmaRouter: raw output=\"$raw\"")
+            parseRouteDecision(raw)
+        } catch (e: Exception) {
+            Log.e(TAG, "FunctionGemmaRouter: inference failed — ${e.message}", e)
+            RouteDecision.RouterNotReady
+        }
+    }
+
+    /** Releases native resources. Call from [androidx.lifecycle.ViewModel.onCleared]. */
+    fun release() {
+        try { conversation?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close conversation: ${e.message}") }
+        try { engine?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close engine: ${e.message}") }
+        conversation = null
+        engine = null
+        _isReady.value = false
+        Log.i(TAG, "FunctionGemmaRouter: released")
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parses the raw model output and returns the appropriate [RouteDecision].
+     *
+     * Strips code fences (same pattern as `SkillExecutor.parseSkillCall`) then tries to
+     * deserialise as a JSON object with a non-blank "name" field.
+     */
+    private fun parseRouteDecision(raw: String): RouteDecision {
+        return try {
+            val cleaned = raw.trim()
+                .removePrefix("```json").removePrefix("```")
+                .removeSuffix("```")
+                .trim()
+            val json = org.json.JSONObject(cleaned)
+            val name = json.optString("name").takeIf { it.isNotBlank() }
+            if (name != null) {
+                Log.d(TAG, "FunctionGemmaRouter: skill call detected — name=$name")
+                RouteDecision.SkillCall(cleaned)
+            } else {
+                Log.d(TAG, "FunctionGemmaRouter: JSON has no 'name' field — plain conversation")
+                RouteDecision.PlainConversation
+            }
+        } catch (e: Exception) {
+            // Not valid JSON — treat as plain conversation (includes "CONVERSATION" literal)
+            Log.d(TAG, "FunctionGemmaRouter: non-JSON output — plain conversation")
+            RouteDecision.PlainConversation
+        }
+    }
+
+    private fun buildSystemPrompt(functionDeclarationsJson: String): String = """
+You are a function router. Given a user message, decide if it requires a function call or a normal conversation response.
+
+Available functions:
+$functionDeclarationsJson
+
+If the user message requires a function call, respond with ONLY a JSON object:
+{"name": "function_name", "arguments": {"param": "value"}}
+
+If the user message is a normal conversation, respond with ONLY the word: CONVERSATION
+
+Do not add any explanation or extra text.
+    """.trimIndent()
+
+    private companion object {
+        /** Token budget for the router — 256 is sufficient for a compact JSON function call. */
+        private const val MAX_TOKENS = 256
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.FunctionGemmaRouter
 import com.kernel.ai.core.inference.GenerationResult
 import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.LlmDispatcher
 import com.kernel.ai.core.inference.ModelConfig
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
@@ -375,6 +376,7 @@ class ChatViewModel @Inject constructor(
                     when (result) {
                         is SkillResult.Success -> {
                             appendAssistantMessage(convId, result.content)
+                            needsHistoryReplay = true
                             return@launch
                         }
                         is SkillResult.ParseError, is SkillResult.UnknownSkill -> {
@@ -386,6 +388,7 @@ class ChatViewModel @Inject constructor(
                                 convId,
                                 "I tried to do that but something went wrong: ${(result as SkillResult.Failure).error}",
                             )
+                            needsHistoryReplay = true
                             return@launch
                         }
                     }
@@ -696,7 +699,9 @@ class ChatViewModel @Inject constructor(
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }
-        functionGemmaRouter.release()
+        CoroutineScope(LlmDispatcher).launch {
+            functionGemmaRouter.release()
+        }
     }
 }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.inference.ContextWindowManager
 import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
+import com.kernel.ai.core.inference.FunctionGemmaRouter
 import com.kernel.ai.core.inference.GenerationResult
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.inference.ModelConfig
@@ -20,6 +21,7 @@ import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
 import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
@@ -53,8 +55,8 @@ class ChatViewModel @Inject constructor(
     private val episodicDistillationUseCase: EpisodicDistillationUseCase,
     private val modelSettingsRepository: ModelSettingsRepository,
     private val skillRegistry: SkillRegistry,
-    @Suppress("UnusedPrivateMember") // wired in next PR: FunctionGemma routing (#84)
     private val skillExecutor: SkillExecutor,
+    private val functionGemmaRouter: FunctionGemmaRouter,
 ) : ViewModel() {
 
     /** Passed via nav arg; null means "start a new conversation". */
@@ -285,6 +287,34 @@ class ChatViewModel @Inject constructor(
         } catch (e: Exception) {
             _error.value = "Failed to load model: ${e.message}"
         }
+
+        // Initialise FunctionGemmaRouter in parallel — non-fatal if model is absent.
+        val routerPath = downloadManager.getModelPath(KernelModel.FUNCTION_GEMMA_270M)
+        if (routerPath != null) {
+            try {
+                functionGemmaRouter.initialize(routerPath, buildSkillContext())
+            } catch (e: Exception) {
+                Log.w("KernelAI", "FunctionGemmaRouter: init failed (non-fatal): ${e.message}", e)
+            }
+        } else {
+            Log.i("KernelAI", "FunctionGemmaRouter: model not downloaded — intent routing disabled")
+        }
+    }
+
+    /**
+     * Immediately appends a completed assistant message to the UI and persists it to Room.
+     * Used by the FunctionGemma skill-dispatch path where there is no streaming.
+     */
+    private suspend fun appendAssistantMessage(convId: String, content: String) {
+        val msgId = UUID.randomUUID().toString()
+        val msg = ChatMessage(
+            id = msgId,
+            role = ChatMessage.Role.ASSISTANT,
+            content = content,
+        )
+        _messages.update { it + msg }
+        val savedId = conversationRepository.addMessage(convId, "assistant", content)
+        ragRepository.indexMessage(savedId, convId, content)
     }
 
     fun retryDownload(model: KernelModel) {
@@ -337,7 +367,36 @@ class ChatViewModel @Inject constructor(
                 Log.d("KernelAI", "Set placeholder title for $convId: \"$placeholder\"")
             }
 
-            // Placeholder for the streaming assistant reply.
+            // 1. Route via FunctionGemma — fast CPU classifier decides skill vs. conversation.
+            val routeDecision = functionGemmaRouter.route(text)
+            when (routeDecision) {
+                is FunctionGemmaRouter.RouteDecision.SkillCall -> {
+                    val result = skillExecutor.execute(routeDecision.rawJson)
+                    when (result) {
+                        is SkillResult.Success -> {
+                            appendAssistantMessage(convId, result.content)
+                            return@launch
+                        }
+                        is SkillResult.ParseError, is SkillResult.UnknownSkill -> {
+                            Log.w("KernelAI", "Skill routing failed: $result — falling back to Gemma-4")
+                            // fall through to Gemma-4
+                        }
+                        is SkillResult.Failure -> {
+                            appendAssistantMessage(
+                                convId,
+                                "I tried to do that but something went wrong: ${(result as SkillResult.Failure).error}",
+                            )
+                            return@launch
+                        }
+                    }
+                }
+                is FunctionGemmaRouter.RouteDecision.PlainConversation,
+                is FunctionGemmaRouter.RouteDecision.RouterNotReady -> {
+                    // fall through to Gemma-4
+                }
+            }
+
+            // 2. Gemma-4 streaming inference path.
             val assistantMsgId = UUID.randomUUID().toString()
             val streamingPlaceholder = ChatMessage(
                 id = assistantMsgId,
@@ -637,6 +696,7 @@ class ChatViewModel @Inject constructor(
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }
+        functionGemmaRouter.release()
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #84

Adds FunctionGemma-270M as the always-hot CPU intent router. Every user message is now classified before Gemma-4 fires — skills execute directly, plain conversation falls through to Gemma-4 unchanged.

### FunctionGemmaRouter (`core/inference`)
- CPU-only (XNNPACK, 4 threads) — isolated session, never shares with Gemma-4
- `maxTokens = 256`, greedy decoding (`temperature = 0.0, topK = 1`) — deterministic, low-latency
- System prompt embeds `functionDeclarationsJson` at init so FunctionGemma knows all registered skills
- Output classification: valid JSON with `name` → `SkillCall`; anything else → `PlainConversation`
- `RouterNotReady` (model not downloaded) silently falls back to Gemma-4 — no regression on clean install

### ChatViewModel routing flow
```
User message
  → FunctionGemmaRouter.route()
    ├── SkillCall → SkillExecutor.execute()
    │     ├── Success    → appendAssistantMessage(), return (Gemma-4 never fires)
    │     ├── Failure    → error message shown, return
    │     └── ParseError/UnknownSkill → fall through to Gemma-4
    ├── PlainConversation → Gemma-4 (unchanged path)
    └── RouterNotReady   → Gemma-4 (unchanged path)
```

### Skill results
- `appendAssistantMessage()`: Room persist + RAG index + UI state update — same pipeline as Gemma-4 responses
- `@Suppress` removed from `skillExecutor` (now actively used)
- `onCleared()` releases the FunctionGemma session