### PR TITLE
feat(#21): Jandal AI brand and persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kernel AI Assistant
+# Jandal AI
 
 A high-performance, **local-first** intelligent agent for Android. All inference runs entirely on-device — no cloud APIs, no telemetry, no data leakage. Built on Google's **Gemma-4** model family via **LiteRT**.
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Kernel AI</string>
+    <string name="app_name">Jandal AI</string>
 </resources>

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -2,10 +2,11 @@ package com.kernel.ai.core.inference
 
 import com.google.ai.edge.litertlm.SamplerConfig
 
-/** Kernel's default system prompt. Injected into every new conversation. */
+/** Jandal's default system prompt. Injected into every new conversation. */
 const val DEFAULT_SYSTEM_PROMPT =
-    "You are Kernel, a helpful and concise AI assistant running entirely on-device. " +
-        "Be friendly, direct, and slightly playful. Keep responses short unless asked for detail."
+    "You are Jandal, a friendly and capable AI assistant. You're concise, helpful, and have a " +
+        "slightly playful NZ character — like a smart mate who happens to know a lot. You run " +
+        "entirely on-device, so the user's data never leaves their phone."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8192

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -6,7 +6,8 @@ import com.google.ai.edge.litertlm.SamplerConfig
 const val DEFAULT_SYSTEM_PROMPT =
     "You are Jandal, a friendly and capable AI assistant. You're concise, helpful, and have a " +
         "slightly playful NZ character — like a smart mate who happens to know a lot. You run " +
-        "entirely on-device, so the user's data never leaves their phone."
+        "entirely on-device, so the user's data never leaves their phone. " +
+        "Keep responses short unless asked for detail."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8192

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -200,7 +200,7 @@ private fun ChatContent(
             TopAppBar(
                 title = {
                     Text(
-                        text = state.conversationTitle ?: "Kernel",
+                        text = state.conversationTitle ?: "Jandal",
                         style = MaterialTheme.typography.titleMedium,
                         maxLines = 1,
                         overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
@@ -476,7 +476,7 @@ private fun InputBar(
             TextField(
                 value = text,
                 onValueChange = onTextChanged,
-                placeholder = { Text("Message Kernel…") },
+                placeholder = { Text("Message Jandal…") },
                 modifier = Modifier.weight(1f),
                 maxLines = 5,
                 colors = TextFieldDefaults.colors(
@@ -516,7 +516,7 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.displayMedium,
             )
             Text(
-                text = "Hi, I'm Kernel. How can I help?",
+                text = "Hi, I'm Jandal. How can I help?",
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.padding(top = 8.dp),
             )
@@ -607,7 +607,7 @@ private fun OnboardingContent(
         ) {
             Text(text = "🧠", style = MaterialTheme.typography.displayLarge)
             Text(
-                text = "Welcome to Kernel",
+                text = "Welcome to Jandal",
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.padding(top = 16.dp),
             )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -82,7 +82,7 @@ fun ConversationListScreen(
                     if (isInSelectionMode) {
                         Text("${selectedConversationIds.size} / ${conversations.size} selected")
                     } else {
-                        Text("Kernel")
+                        Text("Jandal")
                     }
                 },
                 actions = {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoadingMessages.kt
@@ -1,7 +1,7 @@
 package com.kernel.ai.feature.chat
 
 /**
- * Fun themed loading messages for Kernel AI.
+ * Fun themed loading messages for Jandal AI.
  *
  * Model loading uses 3-step narrative sequences. Call [randomTheme] on each init to pick a theme,
  * then display step 1, 2, 3 sequentially as the engine warms up.

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -95,12 +95,12 @@ fun OnboardingScreen(
             verticalArrangement = Arrangement.Center,
         ) {
             Text(
-                text = "Welcome to Kernel AI",
+                text = "Welcome to Jandal AI",
                 style = MaterialTheme.typography.headlineMedium,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "On-device AI — private by design.",
+                text = "Your private AI mate — all on-device.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -226,7 +226,7 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .clickable { onNavigateToUserProfile() },
                 headlineContent = { Text("User Profile") },
-                supportingContent = { Text("Tell Kernel about yourself") },
+                supportingContent = { Text("Tell Jandal about yourself") },
                 leadingContent = { Icon(Icons.Default.Person, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileScreen.kt
@@ -70,7 +70,7 @@ fun UserProfileScreen(
             Spacer(Modifier.height(4.dp))
 
             Text(
-                text = "Tell Kernel about yourself. This is injected into every conversation so the assistant always has context about you.",
+                text = "Tell Jandal about yourself. This is injected into every conversation so Jandal always has context about you.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,6 @@
 ***
 
-# Technical Specification: Local-First Android AI Assistant ("Project Gemma-Mobile")
+# Technical Specification: Jandal AI — Local-First Android AI Assistant ("Project Gemma-Mobile")
 
 ## 1. Executive Summary
 This document outlines the architecture for a privacy-centric, on-device mobile assistant. By leveraging the Google AI Edge (LiteRT) ecosystem and the Gemma-4 family of models, the assistant provides reasoning, memory retrieval, and device actions without relying on cloud APIs. The system uses a tiered hardware approach to ensure performance across a wide range of Android devices while maintaining a modular "Skill" framework for extensibility.


### PR DESCRIPTION
## Summary

Implements the Jandal AI brand and persona across the entire app, resolving issue #21.

**What is Jandal?** "Jandal" is the New Zealand slang word for flip-flop (the footwear). The brand is friendly, concise, slightly irreverent, and very NZ in character.

## Changes

All changes are **UI strings and copy only** — no class names, package names, or log tags were modified.

| File | Change |
|------|--------|
| `app/src/main/res/values/strings.xml` | `app_name` → `"Jandal AI"` |
| `core/inference/.../ModelConfig.kt` | `DEFAULT_SYSTEM_PROMPT` updated to Jandal persona |
| `feature/onboarding/.../OnboardingScreen.kt` | Welcome headline/subtitle → Jandal AI |
| `feature/chat/.../ChatScreen.kt` | Input placeholder, empty state, welcome text → Jandal |
| `feature/chat/.../LoadingMessages.kt` | File doc comment → Jandal AI |
| `feature/settings/.../SettingsScreen.kt` | User Profile list item subtitle → Jandal |
| `feature/settings/.../UserProfileScreen.kt` | Profile description body text → Jandal |
| `README.md` | Project title → Jandal AI |
| `specification.md` | Spec heading → Jandal AI |

## Validation

- ✅ `./gradlew assembleDebug` — BUILD SUCCESSFUL (41s)
- ⚠️ `./gradlew lint` — pre-existing failure on `main`: `SpecifyForegroundServiceType` in `ModelDownloadWorker.kt` (not introduced by this branch)
- ⚠️ `./gradlew test` — pre-existing failure on `main`: `LatexConversionTest` nested fractions (not introduced by this branch)

Closes #21