### PR TITLE
fix(#196): download FunctionGemma alongside Gemma-4 in onboarding

### DIFF
--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -20,8 +20,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -118,36 +118,8 @@ fun OnboardingScreen(
             Spacer(modifier = Modifier.height(24.dp))
 
             // ── Download progress ─────────────────────────────────────────
-            val downloadState = uiState.downloadState
-            when (downloadState) {
-                is DownloadState.NotDownloaded -> {
-                    Button(
-                        onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text("Download Gemma 4 E-2B (2.4 GB)")
-                    }
-                }
-
-                is DownloadState.Downloading -> {
-                    Text(
-                        text = "Downloading model…",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    CircularProgressIndicator(
-                        progress = { downloadState.progress },
-                        modifier = Modifier.size(48.dp),
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = "${(downloadState.progress * 100).toInt()}%",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-
-                is DownloadState.Downloaded -> {
+            when {
+                uiState.allDownloaded -> {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
@@ -156,15 +128,44 @@ fun OnboardingScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = "Model ready",
+                            text = "All models ready",
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }
                 }
 
-                is DownloadState.Error -> {
+                uiState.isDownloading -> {
                     Text(
-                        text = "Download error: ${downloadState.message}",
+                        text = "Downloading models…",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        progress = { uiState.overallProgress },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "${(uiState.overallProgress * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    ModelDownloadRow("Gemma 4 E-2B", uiState.gemmaDownloadState)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    ModelDownloadRow("Routing model", uiState.routerDownloadState)
+                }
+
+                uiState.anyError -> {
+                    val errorMsg = when {
+                        uiState.gemmaDownloadState is DownloadState.Error ->
+                            (uiState.gemmaDownloadState as DownloadState.Error).message
+                        uiState.routerDownloadState is DownloadState.Error ->
+                            (uiState.routerDownloadState as DownloadState.Error).message
+                        else -> "Download failed"
+                    }
+                    Text(
+                        text = "Download error: $errorMsg",
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -173,7 +174,58 @@ fun OnboardingScreen(
                         Text("Retry")
                     }
                 }
+
+                else -> {
+                    Button(
+                        onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Download Jandal AI models (2.7 GB)")
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Includes Gemma 4 E-2B and the routing model",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun ModelDownloadRow(label: String, state: DownloadState) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(1f),
+        )
+        when (state) {
+            is DownloadState.Downloaded -> Icon(
+                imageVector = Icons.Default.CheckCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(16.dp),
+            )
+            is DownloadState.Downloading -> Text(
+                text = "${(state.progress * 100).toInt()}%",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            is DownloadState.Error -> Text(
+                text = "Error",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+            else -> Text(
+                text = "Waiting…",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -275,4 +327,3 @@ private fun OnboardingScreenSignedInPreview() {
         )
     }
 }
-

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -154,6 +154,15 @@ fun OnboardingScreen(
                     ModelDownloadRow("Gemma 4 E-2B", uiState.gemmaDownloadState)
                     Spacer(modifier = Modifier.height(4.dp))
                     ModelDownloadRow("Routing model", uiState.routerDownloadState)
+                    if (uiState.anyError) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(
+                            onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text("Retry failed model")
+                        }
+                    }
                 }
 
                 uiState.anyError -> {

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -28,27 +28,45 @@ class OnboardingViewModel @Inject constructor(
     data class OnboardingUiState(
         val isAuthenticated: Boolean = false,
         val username: String? = null,
-        /** Download progress 0..1 for the required E2B model. */
-        val downloadProgress: Float = 0f,
-        val downloadState: DownloadState = DownloadState.NotDownloaded,
-    )
+        val gemmaDownloadState: DownloadState = DownloadState.NotDownloaded,
+        val routerDownloadState: DownloadState = DownloadState.NotDownloaded,
+    ) {
+        val overallProgress: Float
+            get() {
+                val gemmaP = when (gemmaDownloadState) {
+                    is DownloadState.Downloading -> gemmaDownloadState.progress
+                    is DownloadState.Downloaded -> 1f
+                    else -> 0f
+                }
+                val routerP = when (routerDownloadState) {
+                    is DownloadState.Downloading -> routerDownloadState.progress
+                    is DownloadState.Downloaded -> 1f
+                    else -> 0f
+                }
+                // FunctionGemma is ~289MB, Gemma-4 E2B is ~2.4GB — weight accordingly
+                return (gemmaP * 0.89f) + (routerP * 0.11f)
+            }
+        val allDownloaded: Boolean
+            get() = gemmaDownloadState is DownloadState.Downloaded &&
+                    routerDownloadState is DownloadState.Downloaded
+        val anyError: Boolean
+            get() = gemmaDownloadState is DownloadState.Error ||
+                    routerDownloadState is DownloadState.Error
+        val isDownloading: Boolean
+            get() = gemmaDownloadState is DownloadState.Downloading ||
+                    routerDownloadState is DownloadState.Downloading
+    }
 
     val uiState: StateFlow<OnboardingUiState> = combine(
         authRepository.isAuthenticated,
         authRepository.username,
         modelDownloadManager.downloadStates,
     ) { isAuthenticated, username, downloadStates ->
-        val e2bState = downloadStates[KernelModel.GEMMA_4_E2B] ?: DownloadState.NotDownloaded
-        val progress = when (e2bState) {
-            is DownloadState.Downloading -> e2bState.progress
-            is DownloadState.Downloaded -> 1f
-            else -> 0f
-        }
         OnboardingUiState(
             isAuthenticated = isAuthenticated,
             username = username,
-            downloadProgress = progress,
-            downloadState = e2bState,
+            gemmaDownloadState = downloadStates[KernelModel.GEMMA_4_E2B] ?: DownloadState.NotDownloaded,
+            routerDownloadState = downloadStates[KernelModel.FUNCTION_GEMMA_270M] ?: DownloadState.NotDownloaded,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -92,6 +110,9 @@ class OnboardingViewModel @Inject constructor(
     /**
      * Starts downloading a [model]. If the model is gated and the user is not signed in,
      * emits [OnboardingEvent.GatedModelRequiresAuth] instead.
+     *
+     * Always queues [KernelModel.FUNCTION_GEMMA_270M] alongside the primary model so that
+     * [com.kernel.ai.core.inference.FunctionGemmaRouter] can initialise correctly and skills fire.
      */
     fun startDownload(model: KernelModel) {
         if (model.isGated && !uiState.value.isAuthenticated) {
@@ -99,6 +120,10 @@ class OnboardingViewModel @Inject constructor(
             return
         }
         modelDownloadManager.startDownload(model)
+        // FunctionGemma is always required and never gated — queue alongside any Gemma-4 download
+        if (model != KernelModel.FUNCTION_GEMMA_270M) {
+            modelDownloadManager.startDownload(KernelModel.FUNCTION_GEMMA_270M)
+        }
     }
 
     sealed interface OnboardingEvent {


### PR DESCRIPTION
Closes #196

## Summary
FunctionGemma_270M was never queued during onboarding, causing FunctionGemmaRouter to silently fail and leaving all skills permanently broken.

## Changes
- `OnboardingUiState`: replaced single `downloadState` with `gemmaDownloadState` + `routerDownloadState`; added computed properties `overallProgress`, `allDownloaded`, `anyError`, `isDownloading`
- `OnboardingViewModel.startDownload()`: always queues `FUNCTION_GEMMA_270M` alongside the primary model (skips if already targeting FunctionGemma itself)
- `OnboardingScreen`: replaced single-model `when (downloadState)` with priority-ordered `when { uiState.allDownloaded / isDownloading / anyError / else }`; added `LinearProgressIndicator` showing combined weighted progress (89% Gemma-4 / 11% FunctionGemma); added `ModelDownloadRow` composable showing per-model status

## Testing
`./gradlew assembleDebug` ✓  `./gradlew :feature:onboarding:lintDebug` ✓

Note: `./gradlew lint` fails on a pre-existing `SpecifyForegroundServiceType` error in `:core:inference` (ModelDownloadWorker.kt:224) unrelated to this change.