### PR TITLE
feat(#197): Gemma-4 native tool calling + tool call UI chip

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/7.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/7.json
@@ -1,0 +1,394 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "22ba0855b37449a4579ed5e0b28359c2",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '22ba0855b37449a4579ed5e0b28359c2')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -30,7 +30,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         CoreMemoryEntity::class,
         ModelSettingsEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -69,6 +69,13 @@ abstract class KernelDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Adds toolCallJson column to messages for Gemma-4 native tool calling (#197). */
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE messages ADD COLUMN toolCallJson TEXT DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -45,7 +45,7 @@ abstract class MemoryModule {
         @Singleton
         fun provideKernelDatabase(@ApplicationContext context: Context): KernelDatabase =
             Room.databaseBuilder(context, KernelDatabase::class.java, "kernel_db")
-                .addMigrations(KernelDatabase.MIGRATION_4_5, KernelDatabase.MIGRATION_5_6)
+                .addMigrations(KernelDatabase.MIGRATION_4_5, KernelDatabase.MIGRATION_5_6, KernelDatabase.MIGRATION_6_7)
                 .build()
 
         @Provides

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
@@ -27,4 +27,7 @@ interface MessageDao {
 
     @Query("UPDATE messages SET content = :content, thinkingText = :thinkingText WHERE id = :id")
     suspend fun updateContentAndThinking(id: String, content: String, thinkingText: String?)
+
+    @Query("UPDATE messages SET toolCallJson = :toolCallJson WHERE id = :id")
+    suspend fun updateToolCallJson(id: String, toolCallJson: String?)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MessageEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MessageEntity.kt
@@ -25,4 +25,5 @@ data class MessageEntity(
     val content: String,
     val thinkingText: String?,
     val timestamp: Long,
+    val toolCallJson: String? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -47,6 +47,7 @@ class ConversationRepository @Inject constructor(
         role: String,
         content: String,
         thinkingText: String? = null,
+        toolCallJson: String? = null,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -58,6 +59,7 @@ class ConversationRepository @Inject constructor(
                 content = content,
                 thinkingText = thinkingText,
                 timestamp = now,
+                toolCallJson = toolCallJson,
             )
         )
         conversationDao.touchUpdatedAt(conversationId, now)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -43,6 +44,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
@@ -108,6 +111,7 @@ import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
+import com.kernel.ai.feature.chat.model.ToolCallInfo
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -374,6 +378,14 @@ private fun MessageBubble(
                 style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
                 color = MaterialTheme.colorScheme.outline,
                 modifier = Modifier.padding(bottom = 2.dp),
+            )
+        }
+
+        // Tool call chip (shown above message bubble for assistant messages)
+        if (!isUser && message.toolCall != null) {
+            ToolCallChip(
+                toolCall = message.toolCall,
+                modifier = Modifier.padding(bottom = 4.dp),
             )
         }
 
@@ -737,5 +749,52 @@ private fun formatEta(remainingMs: Long): String {
         totalSecs < 60 -> "~${totalSecs}s remaining"
         totalSecs < 3600 -> "~${totalSecs / 60}m ${totalSecs % 60}s remaining"
         else -> "~${totalSecs / 3600}h ${(totalSecs % 3600) / 60}m remaining"
+    }
+}
+
+@Composable
+private fun ToolCallChip(toolCall: ToolCallInfo, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 1.dp,
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("🔧", style = MaterialTheme.typography.bodySmall)
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = if (toolCall.isSuccess) toolCall.skillName else "⚠ ${toolCall.skillName}",
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = if (expanded) "Collapse" else "Expand",
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+            if (expanded) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Request: ${toolCall.requestJson}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Result: ${toolCall.resultText}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -385,7 +385,9 @@ private fun MessageBubble(
         if (!isUser && message.toolCall != null) {
             ToolCallChip(
                 toolCall = message.toolCall,
-                modifier = Modifier.padding(bottom = 4.dp),
+                modifier = Modifier
+                    .padding(bottom = 4.dp)
+                    .widthIn(max = 300.dp),
             )
         }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -26,6 +26,7 @@ import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
+import com.kernel.ai.feature.chat.model.ToolCallInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -186,6 +187,10 @@ class ChatViewModel @Inject constructor(
                 }
                 append("[End of previous conversation context]")
             }
+            val skillDeclarations = skillRegistry.buildFunctionDeclarationsJson()
+            if (skillDeclarations != "[]") {
+                append("\n\n[Tool Use]\nYou have access to tools. When a user asks for something a tool can help with, output ONLY the following JSON — no explanation, no extra text:\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n\nAvailable tools:\n$skillDeclarations")
+            }
         }
     }
 
@@ -215,6 +220,20 @@ class ChatViewModel @Inject constructor(
                     role = if (entity.role == "user") ChatMessage.Role.USER else ChatMessage.Role.ASSISTANT,
                     content = entity.content,
                     thinkingText = entity.thinkingText,
+                    toolCall = entity.toolCallJson?.let { json ->
+                        try {
+                            val obj = org.json.JSONObject(json)
+                            ToolCallInfo(
+                                skillName = obj.getString("skillName"),
+                                requestJson = obj.getString("requestJson"),
+                                resultText = obj.getString("resultText"),
+                                isSuccess = obj.getBoolean("isSuccess"),
+                            )
+                        } catch (e: Exception) {
+                            Log.w("KernelAI", "Failed to deserialize toolCallJson: ${e.message}")
+                            null
+                        }
+                    },
                 )
             }
             // History is in Room but not in LiteRT's KV cache — replay on next send.
@@ -475,17 +494,52 @@ class ChatViewModel @Inject constructor(
                         }
 
                         is GenerationResult.Complete -> {
-                            _messages.update { msgs ->
-                                msgs.map { msg ->
-                                    if (msg.id == assistantMsgId) msg.copy(isStreaming = false) else msg
-                                }
-                            }
+                            val fullContent = accumulatedContent.toString()
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
-                            val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", accumulatedContent.toString(), thinking)
-                            ragRepository.indexMessage(savedAssistantMsgId, convId, accumulatedContent.toString())
-                            // Track cumulative token usage for proactive context window management.
-                            estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
-                                contextWindowManager.estimateTokens(accumulatedContent.toString())
+
+                            // Detect if Gemma-4 output is a function call JSON
+                            val toolCallResult = tryExecuteToolCall(fullContent)
+                            if (toolCallResult != null) {
+                                val (toolCall, resultContent) = toolCallResult
+
+                                // Update streaming message with result text (not raw JSON)
+                                _messages.update { msgs ->
+                                    msgs.map { msg ->
+                                        if (msg.id == assistantMsgId) msg.copy(
+                                            content = resultContent,
+                                            isStreaming = false,
+                                            toolCall = toolCall,
+                                        ) else msg
+                                    }
+                                }
+
+                                // Persist with toolCallJson
+                                val toolCallJsonStr = org.json.JSONObject().apply {
+                                    put("skillName", toolCall.skillName)
+                                    put("requestJson", toolCall.requestJson)
+                                    put("resultText", toolCall.resultText)
+                                    put("isSuccess", toolCall.isSuccess)
+                                }.toString()
+                                val savedId = conversationRepository.addMessage(
+                                    convId, "assistant", resultContent,
+                                    thinkingText = thinking,
+                                    toolCallJson = toolCallJsonStr,
+                                )
+                                ragRepository.indexMessage(savedId, convId, resultContent)
+                                estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
+                                    contextWindowManager.estimateTokens(resultContent)
+                                needsHistoryReplay = true
+                            } else {
+                                // Normal text response
+                                _messages.update { msgs ->
+                                    msgs.map { if (it.id == assistantMsgId) it.copy(isStreaming = false) else it }
+                                }
+                                val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", fullContent, thinking)
+                                ragRepository.indexMessage(savedAssistantMsgId, convId, fullContent)
+                                estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
+                                    contextWindowManager.estimateTokens(fullContent)
+                            }
+
                             // Clear streaming tracking now that the message is fully persisted.
                             activeStreamingMsgId = null
                             activeStreamingContent = StringBuilder()
@@ -671,6 +725,46 @@ class ChatViewModel @Inject constructor(
             // needsHistoryReplay is already true (set before the call) — KV cache may be
             // partially dirty from the prompt write, so the flag correctly stays set.
             // Silent failure — title stays null, user can rename manually.
+        }
+    }
+
+    /**
+     * Attempts to parse [raw] as a skill function call JSON and execute it.
+     * Returns a pair of (ToolCallInfo, humanReadableResult) if successful, null otherwise.
+     * Returns null for ParseError/UnknownSkill so Gemma-4 output is treated as plain text.
+     * Limits to 1 tool call per Gemma-4 response to prevent loops.
+     */
+    private suspend fun tryExecuteToolCall(raw: String): Pair<ToolCallInfo, String>? {
+        val trimmed = raw.trim()
+        // Quick check: must look like a JSON object
+        if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null
+        // Must contain "name" key (function call format)
+        if (!trimmed.contains("\"name\"")) return null
+
+        val result = skillExecutor.execute(trimmed)
+        return when (result) {
+            is SkillResult.Success -> {
+                val skillName = try {
+                    org.json.JSONObject(trimmed).optString("name", "unknown")
+                } catch (e: Exception) { "unknown" }
+                val toolCall = ToolCallInfo(
+                    skillName = skillName,
+                    requestJson = trimmed,
+                    resultText = result.content,
+                    isSuccess = true,
+                )
+                Pair(toolCall, result.content)
+            }
+            is SkillResult.Failure -> {
+                val toolCall = ToolCallInfo(
+                    skillName = result.skillName,
+                    requestJson = trimmed,
+                    resultText = result.error,
+                    isSuccess = false,
+                )
+                Pair(toolCall, "I tried to do that but something went wrong: ${result.error}")
+            }
+            is SkillResult.ParseError, is SkillResult.UnknownSkill -> null
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatMessage.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatMessage.kt
@@ -6,6 +6,7 @@ data class ChatMessage(
     val content: String,
     val thinkingText: String? = null,
     val isStreaming: Boolean = false,
+    val toolCall: ToolCallInfo? = null,
 ) {
     enum class Role { USER, ASSISTANT }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfo.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfo.kt
@@ -1,0 +1,8 @@
+package com.kernel.ai.feature.chat.model
+
+data class ToolCallInfo(
+    val skillName: String,
+    val requestJson: String,   // the raw JSON Gemma-4 output
+    val resultText: String,    // the skill result (success message or error)
+    val isSuccess: Boolean,
+)


### PR DESCRIPTION
## Summary

Implements native tool calling for Gemma-4 as a fallback when FunctionGemma is not ready or routes to plain conversation.

## Changes

- **`ToolCallInfo`** — new data class (skillName, requestJson, resultText, isSuccess)
- **`ChatMessage`** — extended with `toolCall: ToolCallInfo?`
- **DB v6→7 migration** — adds `toolCallJson TEXT` column to messages table
- **`tryExecuteToolCall()`** — post-stream JSON detection in ChatViewModel; executes via SkillExecutor (max 1 call/turn, no loops)
- **Tool-calling instructions** injected into Gemma-4 system prompt when skills are registered
- **`ToolCallChip` UI** — collapsible 🔧 chip above assistant bubble showing skill name, request JSON, and result
- **Conversation restore** — deserializes `toolCallJson` back to `ToolCallInfo` on session load

## Behaviour guarantees

- `SkillResult.ParseError` / `UnknownSkill` → falls through to plain text (no breakage)
- `needsHistoryReplay = true` after tool execution so Gemma-4 sees the result next turn
- FunctionGemma routing path is completely unchanged

Closes #197