### PR TITLE
fix: download E4B on FLAGSHIP devices in onboarding

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
         <activity
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
             android:exported="true"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
             tools:node="replace">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.inference.download.DownloadState
-import com.kernel.ai.core.inference.download.KernelModel
 
 /** Amber / HuggingFace brand colour. */
 private val HfOrange = Color(0xFFFF9D00)
@@ -135,13 +134,13 @@ fun OnboardingScreen(
                         style = MaterialTheme.typography.bodySmall,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    ModelDownloadRow("Gemma 4 E-2B", uiState.gemmaDownloadState)
+                    ModelDownloadRow(viewModel.preferredGemmaModel.displayName, uiState.gemmaDownloadState)
                     Spacer(modifier = Modifier.height(4.dp))
                     ModelDownloadRow("Routing model", uiState.routerDownloadState)
                     if (uiState.anyError) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Button(
-                            onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
+                            onClick = { viewModel.startPreferredDownload() },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Text("Retry failed model")
@@ -163,21 +162,21 @@ fun OnboardingScreen(
                         style = MaterialTheme.typography.bodySmall,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    Button(onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) }) {
+                    Button(onClick = { viewModel.startPreferredDownload() }) {
                         Text("Retry")
                     }
                 }
 
                 else -> {
                     Button(
-                        onClick = { viewModel.startDownload(KernelModel.GEMMA_4_E2B) },
+                        onClick = { viewModel.startPreferredDownload() },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        Text("Download Jandal AI models (2.7 GB)")
+                        Text("Download Jandal AI models")
                     }
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = "Includes Gemma 4 E-2B and the routing model",
+                        text = "Includes ${viewModel.preferredGemmaModel.displayName} and the routing model",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -6,6 +6,8 @@ import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -21,7 +23,13 @@ import javax.inject.Inject
 class OnboardingViewModel @Inject constructor(
     private val modelDownloadManager: ModelDownloadManager,
     private val authRepository: HuggingFaceAuthRepository,
+    hardwareProfileDetector: HardwareProfileDetector,
 ) : ViewModel() {
+
+    /** The Gemma-4 variant appropriate for this device — E4B on FLAGSHIP, E2B otherwise. */
+    val preferredGemmaModel: KernelModel =
+        if (hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP) KernelModel.GEMMA_4_E4B
+        else KernelModel.GEMMA_4_E2B
 
     data class OnboardingUiState(
         val isAuthenticated: Boolean = false,
@@ -63,7 +71,7 @@ class OnboardingViewModel @Inject constructor(
         OnboardingUiState(
             isAuthenticated = isAuthenticated,
             username = username,
-            gemmaDownloadState = downloadStates[KernelModel.GEMMA_4_E2B] ?: DownloadState.NotDownloaded,
+            gemmaDownloadState = downloadStates[preferredGemmaModel] ?: DownloadState.NotDownloaded,
             routerDownloadState = downloadStates[KernelModel.FUNCTION_GEMMA_270M] ?: DownloadState.NotDownloaded,
         )
     }.stateIn(
@@ -98,6 +106,12 @@ class OnboardingViewModel @Inject constructor(
     fun signOut() {
         authRepository.signOut()
     }
+
+    /**
+     * Starts downloading the tier-appropriate Gemma-4 model plus FunctionGemma.
+     * On FLAGSHIP devices (≥10 GB RAM) this downloads E-4B; otherwise E-2B.
+     */
+    fun startPreferredDownload() = startDownload(preferredGemmaModel)
 
     /**
      * Starts downloading a [model]. If the model is gated and the user is not signed in,


### PR DESCRIPTION
## Problem
S23 Ultra (12GB / FLAGSHIP tier) was downloading Gemma-4 E-2B instead of E-4B. `OnboardingViewModel` hardcoded `GEMMA_4_E2B` in three places and never consulted the hardware tier.

The hardware profile correctly detects the S23 Ultra as FLAGSHIP (11 GB RAM reported, threshold is 10 GB) — the bug was purely in the onboarding download trigger.

## Fix
- Inject `HardwareProfileDetector` into `OnboardingViewModel`
- Expose `preferredGemmaModel: KernelModel` = E4B on FLAGSHIP, E2B otherwise
- Add `startPreferredDownload()` convenience method
- Update `uiState` flow to track the preferred model's download state
- `OnboardingScreen` calls `startPreferredDownload()` and shows the actual model name in the button + progress row label