### PR TITLE
feat: lazy-load Gemma-4, eager FunctionGemma, auto-download all required models

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -60,9 +60,9 @@ enum class KernelModel(
         fileName = "mobile_actions_q8_ekv1024.litertlm",
         downloadUrl = "https://huggingface.co/litert-community/functiongemma-270m-ft-mobile-actions/resolve/main/mobile_actions_q8_ekv1024.litertlm",
         approxSizeBytes = 303_000_000L, // ~289 MB
-        // Not required for Phase 1 (basic chat). Needed for Phase 2 intent routing.
-        // Note: this HuggingFace repo is currently gated — public URL needed before enabling.
-        isRequired = false,
+        // Required — powers the intent router (FunctionGemmaRouter) so skills fire on every device.
+        // Public HuggingFace repo — no auth token needed.
+        isRequired = true,
         preferredForTier = null,
         isGated = false,
     ),
@@ -84,7 +84,8 @@ enum class KernelModel(
 
     /**
      * EmbeddingGemma-300M — high-quality 1024-dim embeddings for RAG memory.
-     * Generic build (CPU/GPU, all devices). Gated on HuggingFace — push manually via ADB.
+     * Generic build (CPU/GPU, all devices). Gated on HuggingFace — downloaded automatically
+     * during onboarding once the user has authenticated.
      * seq512 variant: balanced context window vs. inference speed.
      */
     EMBEDDING_GEMMA_300M(
@@ -92,35 +93,39 @@ enum class KernelModel(
         fileName = "embeddinggemma-300M_seq512_mixed-precision.tflite",
         downloadUrl = "https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq512_mixed-precision.tflite",
         approxSizeBytes = 350_000_000L,
-        isRequired = false,
+        // Required — powers the RAG memory pipeline on all non-flagship devices.
+        isRequired = true,
         preferredForTier = null,
         isGated = true,
     ),
 
     /**
      * EmbeddingGemma-300M — Qualcomm SM8550 (Snapdragon 8 Gen 2 / S23 Ultra) optimised build.
-     * Uses Hexagon NPU for faster embedding inference. Push manually via ADB.
+     * Uses Hexagon NPU for faster embedding inference. Auto-queued on FLAGSHIP devices.
      */
     EMBEDDING_GEMMA_300M_SM8550(
         displayName = "EmbeddingGemma 300M (SM8550)",
         fileName = "embeddinggemma-300M_seq512_mixed-precision.qualcomm.sm8550.tflite",
         downloadUrl = "https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq512_mixed-precision.qualcomm.sm8550.tflite",
         approxSizeBytes = 350_000_000L,
+        // Not globally required — falls back to EMBEDDING_GEMMA_300M on non-flagship devices.
+        // preferredForTier = FLAGSHIP causes ModelDownloadManager to auto-queue it on S23 Ultra etc.
         isRequired = false,
-        preferredForTier = null,
+        preferredForTier = HardwareTier.FLAGSHIP,
         isGated = true,
     ),
 
     /**
      * SentencePiece tokeniser vocabulary required by all EmbeddingGemma variants.
-     * Push manually alongside the embedding model via ADB.
+     * Downloaded automatically during onboarding alongside the embedding model.
      */
     EMBEDDING_GEMMA_SP_MODEL(
         displayName = "EmbeddingGemma SentencePiece model",
         fileName = "sentencepiece.model",
         downloadUrl = "https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/sentencepiece.model",
         approxSizeBytes = 4_500_000L,
-        isRequired = false,
+        // Required — every EmbeddingGemma variant needs this tokeniser to run.
+        isRequired = true,
         preferredForTier = null,
         isGated = true,
     );

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -70,7 +70,10 @@ class ModelDownloadManager @Inject constructor(
         }
         // Auto-queue all required models that aren't yet downloaded
         KernelModel.entries
-            .filter { it.isRequired && !it.isDownloaded(context) }
+            .filter {
+                it.isRequired && !it.isDownloaded(context) &&
+                (!it.isGated || authRepository.getAccessToken() != null)
+            }
             .forEach { model ->
                 Log.i(TAG, "Auto-queuing required model: ${model.displayName}")
                 startDownload(model)
@@ -78,7 +81,10 @@ class ModelDownloadManager @Inject constructor(
         // Auto-queue tier-specific optional models (e.g. E-4B on FLAGSHIP)
         val tier = hardwareProfileDetector.profile.tier
         KernelModel.entries
-            .filter { !it.isRequired && it.preferredForTier == tier && !it.isDownloaded(context) }
+            .filter {
+                !it.isRequired && it.preferredForTier == tier && !it.isDownloaded(context) &&
+                (!it.isGated || authRepository.getAccessToken() != null)
+            }
             .forEach { model ->
                 Log.i(TAG, "Auto-queuing ${model.displayName} for tier ${tier.name}")
                 startDownload(model)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -83,8 +83,6 @@ class ModelDownloadManager @Inject constructor(
                 Log.i(TAG, "Auto-queuing ${model.displayName} for tier ${tier.name}")
                 startDownload(model)
             }
-        // EmbeddingGemma and its SentencePiece model are gated on HuggingFace — user must push
-        // them manually via ADB. Do not auto-queue them here.
     }
 
     // -------------------------------------------------------------------------

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -249,6 +249,28 @@ private fun ChatContent(
                                 onCopy = { content -> onCopyMessage(content) },
                             )
                         }
+                        if (state.isLoadingModel) {
+                            item(key = "model-loading-indicator") {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    horizontalArrangement = Arrangement.Center,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(16.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        text = "Loading model…",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
                     }
                     // Scroll-to-bottom button — fades in/out when content exists below the viewport.
                     val scrollBtnAlpha by animateFloatAsState(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -386,8 +386,14 @@ class ChatViewModel @Inject constructor(
         _inputText.value = ""
         val convId = conversationId ?: return
 
+        // Synchronous flag set — collapses the TOCTOU window before coroutine dispatch
+        if (!inferenceEngine.isReady.value) {
+            _isLoadingModel.value = true
+        }
+
         viewModelScope.launch {
-            val userMsgId = UUID.randomUUID().toString()
+            try {
+                val userMsgId = UUID.randomUUID().toString()
             val userMessage = ChatMessage(
                 id = userMsgId,
                 role = ChatMessage.Role.USER,
@@ -441,12 +447,7 @@ class ChatViewModel @Inject constructor(
 
             // Lazy-init Gemma-4 if not yet loaded.
             if (!inferenceEngine.isReady.value) {
-                _isLoadingModel.value = true
-                try {
-                    initGemma4()
-                } finally {
-                    _isLoadingModel.value = false
-                }
+                initGemma4()
                 if (!inferenceEngine.isReady.value) {
                     // Model still not ready (e.g. file absent) — tell the user and bail.
                     appendAssistantMessage(convId, "Still loading the AI model, please try again in a moment.")
@@ -624,6 +625,9 @@ class ChatViewModel @Inject constructor(
                 activeStreamingContent = StringBuilder()
                 activeStreamingThinking = StringBuilder()
             }
+        } finally {
+            _isLoadingModel.value = false
+        }
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -392,8 +392,14 @@ class ChatViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            // Hoisted so the streaming section (outside the try/finally) can read them.
+            var assistantMsgId = ""
+            var accumulatedContent = StringBuilder()
+            var accumulatedThinking = StringBuilder()
+            var prompt = ""
+
             try {
-                val userMsgId = UUID.randomUUID().toString()
+            val userMsgId = UUID.randomUUID().toString()
             val userMessage = ChatMessage(
                 id = userMsgId,
                 role = ChatMessage.Role.USER,
@@ -454,9 +460,10 @@ class ChatViewModel @Inject constructor(
                     return@launch
                 }
             }
+            // _isLoadingModel is always cleared by the outer finally block below.
 
             // 2. Gemma-4 streaming inference path.
-            val assistantMsgId = UUID.randomUUID().toString()
+            assistantMsgId = UUID.randomUUID().toString()
             val streamingPlaceholder = ChatMessage(
                 id = assistantMsgId,
                 role = ChatMessage.Role.ASSISTANT,
@@ -465,8 +472,8 @@ class ChatViewModel @Inject constructor(
             )
             _messages.update { it + streamingPlaceholder }
 
-            var accumulatedContent = StringBuilder()
-            var accumulatedThinking = StringBuilder()
+            accumulatedContent = StringBuilder()
+            accumulatedThinking = StringBuilder()
 
             // Register active streaming state so cancel/onCleared can flush to Room.
             activeStreamingMsgId = assistantMsgId
@@ -503,7 +510,13 @@ class ChatViewModel @Inject constructor(
                 estimatedTokensUsed += ragTokenCost
             }
 
-            val prompt = if (ragContext.isNotBlank()) "$ragContext\n\n$text" else text
+            prompt = if (ragContext.isNotBlank()) "$ragContext\n\n$text" else text
+
+            } finally {
+                // Reset the loading spinner on every exit path from the pre-inference block —
+                // skill early-returns, model-not-ready bail-outs, and the normal fall-through.
+                _isLoadingModel.value = false
+            }
 
             try {
                 inferenceEngine.generate(prompt).collect { result ->
@@ -625,9 +638,6 @@ class ChatViewModel @Inject constructor(
                 activeStreamingContent = StringBuilder()
                 activeStreamingThinking = StringBuilder()
             }
-        } finally {
-            _isLoadingModel.value = false
-        }
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -31,6 +31,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -100,7 +102,13 @@ class ChatViewModel @Inject constructor(
      */
     private var titleIsPlaceholder = false
 
-    private data class EngineState(val isReady: Boolean, val isGenerating: Boolean)
+    /** True while Gemma-4 is being lazily initialised in response to a [sendMessage] call. */
+    private val _isLoadingModel = MutableStateFlow(false)
+
+    /** Ensures at most one concurrent Gemma-4 initialisation attempt. */
+    private val gemma4InitMutex = Mutex()
+
+    private data class GenerationState(val isGenerating: Boolean, val isLoadingModel: Boolean)
     private data class InputState(
         val messages: List<ChatMessage>,
         val inputText: String,
@@ -108,10 +116,10 @@ class ChatViewModel @Inject constructor(
         val conversationTitle: String?,
     )
 
-    private val engineState = combine(
-        inferenceEngine.isReady,
+    private val generationState = combine(
         inferenceEngine.isGenerating,
-    ) { isReady, isGenerating -> EngineState(isReady, isGenerating) }
+        _isLoadingModel,
+    ) { isGenerating, isLoadingModel -> GenerationState(isGenerating, isLoadingModel) }
 
     private val inputState = combine(
         _messages,
@@ -121,10 +129,10 @@ class ChatViewModel @Inject constructor(
     ) { messages, inputText, error, title -> InputState(messages, inputText, error, title) }
 
     val uiState: StateFlow<ChatUiState> = combine(
-        engineState,
+        generationState,
         downloadManager.downloadStates,
         inputState,
-    ) { engine, downloadStates, input ->
+    ) { generation, downloadStates, input ->
         val allRequired = KernelModel.entries.filter { it.isRequired }
         val allDownloaded = allRequired.all { downloadStates[it] is DownloadState.Downloaded }
 
@@ -141,14 +149,14 @@ class ChatViewModel @Inject constructor(
                 }
                 ChatUiState.ModelsNotReady(isDownloading = anyDownloading, modelProgress = progress)
             }
-            !engine.isReady -> ChatUiState.Loading
             else -> ChatUiState.Ready(
                 conversationId = conversationId ?: "",
                 conversationTitle = input.conversationTitle,
                 messages = input.messages,
-                isGenerating = engine.isGenerating,
+                isGenerating = generation.isGenerating,
                 inputText = input.inputText,
                 error = input.error,
+                isLoadingModel = generation.isLoadingModel,
             )
         }
     }.stateIn(
@@ -159,7 +167,8 @@ class ChatViewModel @Inject constructor(
 
     init {
         viewModelScope.launch { initializeConversation() }
-        viewModelScope.launch { initEngineWhenReady() }
+        viewModelScope.launch { initFunctionGemmaRouter() }  // eager, fast
+        // Gemma-4 loads lazily on first sendMessage() that needs it
     }
 
     private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
@@ -261,63 +270,75 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
-     * Waits until all required models are present on disk, then initialises the inference
-     * engine with the preferred conversation model.
+     * Eagerly initialises [FunctionGemmaRouter] from `init {}` so skill commands are ready
+     * before the user types anything.
      *
-     * Uses [ModelDownloadManager.getModelPath] (file-existence check) rather than the
-     * [ModelDownloadManager.downloadStates] StateFlow so that models pushed manually via ADB
-     * are recognised immediately, independent of WorkManager task state.
-     *
-     * Terminates after the first successful initialisation — the engine stays loaded for the
-     * lifetime of the ViewModel.
+     * Waits for [KernelModel.FUNCTION_GEMMA_270M] to be on disk (handles the case where the
+     * model is currently being downloaded when the chat opens). If the model is absent and not
+     * downloading, logs a warning and returns without blocking.
+     * Non-fatal if initialisation throws.
      */
-    private suspend fun initEngineWhenReady() {
-        // Wait until the StateFlow reports all required models as Downloaded.
-        // The initial value of downloadStates already reflects file existence, so this
-        // fires immediately when models are already on disk.
+    private suspend fun initFunctionGemmaRouter() {
+        // Wait until FunctionGemma transitions out of Downloading state, or bail immediately
+        // if it's NotDownloaded / Error (never been fetched).
         downloadManager.downloadStates
             .filter { states ->
-                KernelModel.entries.filter { it.isRequired }
-                    .all { states[it] is DownloadState.Downloaded }
+                val state = states[KernelModel.FUNCTION_GEMMA_270M]
+                state is DownloadState.Downloaded ||
+                    state is DownloadState.NotDownloaded ||
+                    state is DownloadState.Error
             }
             .first()
 
-        if (inferenceEngine.isReady.value) return
-
-        val preferred = downloadManager.preferredConversationModel()
-        // Use getModelPath (file-existence) — WorkManager state may disagree with reality
-        // e.g. a worker is RUNNING for a model that was already pushed via ADB.
-        val modelPath = downloadManager.getModelPath(preferred) ?: return
-        activeModel = preferred
-        try {
-            // Load user-configured settings so context window and sampler params reach the engine.
-            val settings = modelSettingsRepository.getSettings(preferred.modelId)
-            // Initialize with a prompt that omits backend (not yet known).
-            inferenceEngine.initialize(ModelConfig(
-                modelPath = modelPath,
-                systemPrompt = buildSystemPrompt(),
-                maxTokens = settings.contextWindowSize,
-                temperature = settings.temperature,
-                topP = settings.topP,
-            ))
-            estimatedTokensUsed = 0
-            // Rebuild and push system prompt now that activeBackend is resolved — this
-            // corrects the [Runtime] backend field which was null during initialize().
-            inferenceEngine.updateSystemPrompt(buildSystemPrompt())
-        } catch (e: Exception) {
-            _error.value = "Failed to load model: ${e.message}"
-        }
-
-        // Initialise FunctionGemmaRouter in parallel — non-fatal if model is absent.
         val routerPath = downloadManager.getModelPath(KernelModel.FUNCTION_GEMMA_270M)
-        if (routerPath != null) {
-            try {
-                functionGemmaRouter.initialize(routerPath, buildSkillContext())
-            } catch (e: Exception) {
-                Log.w("KernelAI", "FunctionGemmaRouter: init failed (non-fatal): ${e.message}", e)
-            }
-        } else {
+        if (routerPath == null) {
             Log.i("KernelAI", "FunctionGemmaRouter: model not downloaded — intent routing disabled")
+            return
+        }
+        try {
+            functionGemmaRouter.initialize(routerPath, buildSkillContext())
+            Log.i("KernelAI", "FunctionGemmaRouter initialized successfully")
+        } catch (e: Exception) {
+            Log.w("KernelAI", "FunctionGemmaRouter: init failed (non-fatal): ${e.message}", e)
+        }
+    }
+
+    /**
+     * Lazily initialises the Gemma-4 [InferenceEngine] on the first [sendMessage] that
+     * routes to the streaming path.
+     *
+     * Uses [gemma4InitMutex] to guarantee idempotency: if called concurrently the second
+     * caller waits for the first to finish, then finds [InferenceEngine.isReady] already
+     * true and returns immediately.
+     *
+     * Only waits for the preferred conversation model to be on disk via
+     * [ModelDownloadManager.getModelPath] (file-existence check) — does NOT block on the
+     * [ModelDownloadManager.downloadStates] flow so that manually ADB-pushed models are
+     * recognised immediately.
+     */
+    private suspend fun initGemma4() {
+        gemma4InitMutex.withLock {
+            if (inferenceEngine.isReady.value) return
+
+            val preferred = downloadManager.preferredConversationModel()
+            val modelPath = downloadManager.getModelPath(preferred) ?: return
+            activeModel = preferred
+            try {
+                val settings = modelSettingsRepository.getSettings(preferred.modelId)
+                inferenceEngine.initialize(ModelConfig(
+                    modelPath = modelPath,
+                    systemPrompt = buildSystemPrompt(),
+                    maxTokens = settings.contextWindowSize,
+                    temperature = settings.temperature,
+                    topP = settings.topP,
+                ))
+                estimatedTokensUsed = 0
+                // Rebuild system prompt now that activeBackend is resolved (backend field
+                // was null during initialize()).
+                inferenceEngine.updateSystemPrompt(buildSystemPrompt())
+            } catch (e: Exception) {
+                _error.value = "Failed to load model: ${e.message}"
+            }
         }
     }
 
@@ -360,7 +381,7 @@ class ChatViewModel @Inject constructor(
 
     fun sendMessage() {
         val text = _inputText.value.trim()
-        if (text.isBlank() || inferenceEngine.isGenerating.value) return
+        if (text.isBlank() || inferenceEngine.isGenerating.value || _isLoadingModel.value) return
 
         _inputText.value = ""
         val convId = conversationId ?: return
@@ -415,6 +436,21 @@ class ChatViewModel @Inject constructor(
                 is FunctionGemmaRouter.RouteDecision.PlainConversation,
                 is FunctionGemmaRouter.RouteDecision.RouterNotReady -> {
                     // fall through to Gemma-4
+                }
+            }
+
+            // Lazy-init Gemma-4 if not yet loaded.
+            if (!inferenceEngine.isReady.value) {
+                _isLoadingModel.value = true
+                try {
+                    initGemma4()
+                } finally {
+                    _isLoadingModel.value = false
+                }
+                if (!inferenceEngine.isReady.value) {
+                    // Model still not ready (e.g. file absent) — tell the user and bail.
+                    appendAssistantMessage(convId, "Still loading the AI model, please try again in a moment.")
+                    return@launch
                 }
             }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -13,6 +13,7 @@ sealed interface ChatUiState {
         val isGenerating: Boolean,
         val inputText: String,
         val error: String?,
+        val isLoadingModel: Boolean = false,
     ) : ChatUiState
 
     /** Models need to be downloaded before chatting. */

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -31,11 +31,17 @@ class OnboardingViewModel @Inject constructor(
         if (hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP) KernelModel.GEMMA_4_E4B
         else KernelModel.GEMMA_4_E2B
 
+    /** The EmbeddingGemma variant appropriate for this device — SM8550 on FLAGSHIP, generic otherwise. */
+    val preferredEmbeddingModel: KernelModel =
+        if (hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP) KernelModel.EMBEDDING_GEMMA_300M_SM8550
+        else KernelModel.EMBEDDING_GEMMA_300M
+
     data class OnboardingUiState(
         val isAuthenticated: Boolean = false,
         val username: String? = null,
         val gemmaDownloadState: DownloadState = DownloadState.NotDownloaded,
         val routerDownloadState: DownloadState = DownloadState.NotDownloaded,
+        val embeddingDownloadState: DownloadState = DownloadState.NotDownloaded,
     ) {
         val overallProgress: Float
             get() {
@@ -49,18 +55,26 @@ class OnboardingViewModel @Inject constructor(
                     is DownloadState.Downloaded -> 1f
                     else -> 0f
                 }
-                // FunctionGemma is ~289MB, Gemma-4 E2B is ~2.4GB — weight accordingly
-                return (gemmaP * 0.89f) + (routerP * 0.11f)
+                val embeddingP = when (embeddingDownloadState) {
+                    is DownloadState.Downloading -> embeddingDownloadState.progress
+                    is DownloadState.Downloaded -> 1f
+                    else -> 0f
+                }
+                // Gemma-4 ~3.4GB, EmbeddingGemma ~350MB, FunctionGemma ~289MB → weights ~83%, 9%, 8%
+                return (gemmaP * 0.83f) + (embeddingP * 0.09f) + (routerP * 0.08f)
             }
         val allDownloaded: Boolean
             get() = gemmaDownloadState is DownloadState.Downloaded &&
-                    routerDownloadState is DownloadState.Downloaded
+                    routerDownloadState is DownloadState.Downloaded &&
+                    embeddingDownloadState is DownloadState.Downloaded
         val anyError: Boolean
             get() = gemmaDownloadState is DownloadState.Error ||
-                    routerDownloadState is DownloadState.Error
+                    routerDownloadState is DownloadState.Error ||
+                    embeddingDownloadState is DownloadState.Error
         val isDownloading: Boolean
             get() = gemmaDownloadState is DownloadState.Downloading ||
-                    routerDownloadState is DownloadState.Downloading
+                    routerDownloadState is DownloadState.Downloading ||
+                    embeddingDownloadState is DownloadState.Downloading
     }
 
     val uiState: StateFlow<OnboardingUiState> = combine(
@@ -73,6 +87,7 @@ class OnboardingViewModel @Inject constructor(
             username = username,
             gemmaDownloadState = downloadStates[preferredGemmaModel] ?: DownloadState.NotDownloaded,
             routerDownloadState = downloadStates[KernelModel.FUNCTION_GEMMA_270M] ?: DownloadState.NotDownloaded,
+            embeddingDownloadState = downloadStates[preferredEmbeddingModel] ?: DownloadState.NotDownloaded,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -119,6 +134,10 @@ class OnboardingViewModel @Inject constructor(
      *
      * Always queues [KernelModel.FUNCTION_GEMMA_270M] alongside the primary model so that
      * [com.kernel.ai.core.inference.FunctionGemmaRouter] can initialise correctly and skills fire.
+     *
+     * When downloading the preferred Gemma-4 model, also queues the hardware-appropriate
+     * EmbeddingGemma variant and its SentencePiece tokeniser so the RAG pipeline is ready.
+     * (Auth is already confirmed above — both embedding models are gated.)
      */
     fun startDownload(model: KernelModel) {
         if (model.isGated && !uiState.value.isAuthenticated) {
@@ -129,6 +148,12 @@ class OnboardingViewModel @Inject constructor(
         // FunctionGemma is always required and never gated — queue alongside any Gemma-4 download
         if (model != KernelModel.FUNCTION_GEMMA_270M) {
             modelDownloadManager.startDownload(KernelModel.FUNCTION_GEMMA_270M)
+        }
+        // EmbeddingGemma — queue if we're downloading the preferred Gemma-4 model.
+        // Auth is already confirmed above; SM8550 variant used on FLAGSHIP, generic otherwise.
+        if (model == preferredGemmaModel) {
+            modelDownloadManager.startDownload(preferredEmbeddingModel)
+            modelDownloadManager.startDownload(KernelModel.EMBEDDING_GEMMA_SP_MODEL)
         }
     }
 

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -42,6 +42,7 @@ class OnboardingViewModel @Inject constructor(
         val gemmaDownloadState: DownloadState = DownloadState.NotDownloaded,
         val routerDownloadState: DownloadState = DownloadState.NotDownloaded,
         val embeddingDownloadState: DownloadState = DownloadState.NotDownloaded,
+        val spModelDownloadState: DownloadState = DownloadState.NotDownloaded,
     ) {
         val overallProgress: Float
             get() {
@@ -61,20 +62,24 @@ class OnboardingViewModel @Inject constructor(
                     else -> 0f
                 }
                 // Gemma-4 ~3.4GB, EmbeddingGemma ~350MB, FunctionGemma ~289MB → weights ~83%, 9%, 8%
+                // SP model is ~4.5 MB — negligible weight, excluded from progress calculation
                 return (gemmaP * 0.83f) + (embeddingP * 0.09f) + (routerP * 0.08f)
             }
         val allDownloaded: Boolean
             get() = gemmaDownloadState is DownloadState.Downloaded &&
                     routerDownloadState is DownloadState.Downloaded &&
-                    embeddingDownloadState is DownloadState.Downloaded
+                    embeddingDownloadState is DownloadState.Downloaded &&
+                    spModelDownloadState is DownloadState.Downloaded
         val anyError: Boolean
             get() = gemmaDownloadState is DownloadState.Error ||
                     routerDownloadState is DownloadState.Error ||
-                    embeddingDownloadState is DownloadState.Error
+                    embeddingDownloadState is DownloadState.Error ||
+                    spModelDownloadState is DownloadState.Error
         val isDownloading: Boolean
             get() = gemmaDownloadState is DownloadState.Downloading ||
                     routerDownloadState is DownloadState.Downloading ||
-                    embeddingDownloadState is DownloadState.Downloading
+                    embeddingDownloadState is DownloadState.Downloading ||
+                    spModelDownloadState is DownloadState.Downloading
     }
 
     val uiState: StateFlow<OnboardingUiState> = combine(
@@ -88,6 +93,7 @@ class OnboardingViewModel @Inject constructor(
             gemmaDownloadState = downloadStates[preferredGemmaModel] ?: DownloadState.NotDownloaded,
             routerDownloadState = downloadStates[KernelModel.FUNCTION_GEMMA_270M] ?: DownloadState.NotDownloaded,
             embeddingDownloadState = downloadStates[preferredEmbeddingModel] ?: DownloadState.NotDownloaded,
+            spModelDownloadState = downloadStates[KernelModel.EMBEDDING_GEMMA_SP_MODEL] ?: DownloadState.NotDownloaded,
         )
     }.stateIn(
         scope = viewModelScope,


### PR DESCRIPTION
## Summary

Two commits that fix the model loading architecture and ensure all required models are auto-downloaded.

### Commit 1 — Lazy Gemma-4, eager FunctionGemma router
- Split `initEngineWhenReady()` into `initFunctionGemmaRouter()` (eager, runs on chat open) and `initGemma4()` (lazy, runs on first `sendMessage()` that needs it)
- FunctionGemma spins up immediately → skill commands fire without waiting for a 3.4 GB model
- Gemma-4 only loads when a message routes to `PlainConversation` or `RouterNotReady`
- Added `isLoadingModel` state + `CircularProgressIndicator` + "Loading model…" label in chat UI while Gemma-4 initialises
- `initGemma4()` is Mutex-guarded for idempotency (no double-init on concurrent sends)

### Commit 2 — All required models auto-download
- `FUNCTION_GEMMA_270M`: `isRequired = false → true` (public, no auth, 289 MB — always needed for intent routing)
- `EMBEDDING_GEMMA_300M`: `isRequired = false → true` (gated, queued after HF sign-in — memory/RAG won't work without it)
- `EMBEDDING_GEMMA_SP_MODEL`: `isRequired = false → true` (gated tokeniser, tiny 4.5 MB, always needed alongside EmbeddingGemma)
- `EMBEDDING_GEMMA_300M_SM8550`: `preferredForTier = null → FLAGSHIP` (auto-queued on S23 Ultra, same pattern as E4B)
- `OnboardingViewModel`: queues EmbeddingGemma + SP model alongside Gemma-4 download; adds `embeddingDownloadState` to `OnboardingUiState`; updates `allDownloaded`, `anyError`, `isDownloading`, progress weights (83% Gemma / 9% Embedding / 8% Router)
- Removed stale ADB-only comment from `ModelDownloadManager`

## Testing on S23 Ultra
- [ ] Open chat — FunctionGemma loads immediately, Gemma-4 does NOT load
- [ ] Send a skill command (e.g. "turn on torch") — executes via FunctionGemma, no Gemma-4 needed
- [ ] Send a conversational message — "Loading model…" spinner appears, Gemma-4 loads once, responds
- [ ] Second message — no spinner (Gemma-4 already loaded)
- [ ] Fresh install — onboarding downloads Gemma-4 + FunctionGemma + EmbeddingGemma + SP model sequentially
- [ ] Progress bar reflects all 3 models (83/9/8 weighting)

## Pre-existing failure
`LatexConversionTest > nested fractions are handled` in `:feature:chat` was already failing on `main` before these changes — unrelated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>