### PR TITLE
fix: FunctionGemma isGated = true (HuggingFace repo requires auth)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -61,10 +61,10 @@ enum class KernelModel(
         downloadUrl = "https://huggingface.co/litert-community/functiongemma-270m-ft-mobile-actions/resolve/main/mobile_actions_q8_ekv1024.litertlm",
         approxSizeBytes = 303_000_000L, // ~289 MB
         // Required — powers the intent router (FunctionGemmaRouter) so skills fire on every device.
-        // Public HuggingFace repo — no auth token needed.
+        // HuggingFace repo is gated — requires sign-in to download.
         isRequired = true,
         preferredForTier = null,
-        isGated = false,
+        isGated = true,
     ),
 
     /**


### PR DESCRIPTION
The `litert-community/functiongemma-270m-ft-mobile-actions` repo on HuggingFace returns HTTP 401 without authentication — it is gated. `isGated` was incorrectly set to `false`, causing the download worker to fail immediately with no token attached to the request.

**Fix:** `FUNCTION_GEMMA_270M.isGated = false → true`

The download manager already attaches the Bearer token for gated models, so no other changes needed. After sign-in, FunctionGemma will download correctly alongside Gemma-4 and EmbeddingGemma.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>