### PR TITLE
fix: skip E2B on FLAGSHIP, disable broken SM8550 embedding variant

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
@@ -1,7 +1,6 @@
 package com.kernel.ai.core.inference
 
 import android.content.Context
-import android.os.Build
 import android.util.Log
 import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.isDownloaded
@@ -20,9 +19,9 @@ import javax.inject.Singleton
 /**
  * EmbeddingEngine backed by EmbeddingGemma-300M running via the TFLite Interpreter.
  *
- * Model selection priority:
- *   1. SM8550-optimised model (Snapdragon 8 Gen 2 / S23 Ultra) when [Build.BOARD] == "kalama"
- *   2. Generic mixed-precision model (GPU delegate, all devices)
+ * Model selection: generic mixed-precision model (GPU delegate, all devices).
+ * The SM8550-optimised variant was disabled due to LiteRT format incompatibility
+ * (DISPATCH_OP custom op requires Qualcomm AI Engine delegate which is not bundled).
  *
  * Tokenisation: pure-Kotlin [SentencePieceTokenizer] parsing the bundled `sentencepiece.model`.
  *
@@ -46,6 +45,17 @@ class LiteRtEmbeddingEngine @Inject constructor(
     private var _state: State? = null
     private val lock = Any()
 
+    init {
+        // Clean up the SM8550 variant — disabled due to LiteRT format incompatibility.
+        // Remove this once the upstream issue is resolved and the model is re-enabled.
+        KernelModel.EMBEDDING_GEMMA_300M_SM8550.localFile(context).let { f ->
+            if (f.exists()) {
+                f.delete()
+                Log.i(TAG, "Deleted broken SM8550 embedding variant: ${f.name}")
+            }
+        }
+    }
+
     override val dimensions: Int get() = synchronized(lock) { _state?.dimensions ?: 0 }
 
     private fun ensureState(): State? {
@@ -62,11 +72,10 @@ class LiteRtEmbeddingEngine @Inject constructor(
         }
     }
 
-    /** Ordered list of model files to try — SM8550 first, generic fallback. */
-    private fun modelFileCandidates(): List<File> = buildList {
-        if (isSm8550()) add(KernelModel.EMBEDDING_GEMMA_300M_SM8550.localFile(context))
-        add(KernelModel.EMBEDDING_GEMMA_300M.localFile(context))
-    }.filter { it.exists() }
+    /** Only the generic model is used — the SM8550 variant was disabled (LiteRT format incompatibility). */
+    private fun modelFileCandidates(): List<File> = listOf(
+        KernelModel.EMBEDDING_GEMMA_300M.localFile(context)
+    ).filter { it.exists() }
 
     /**
      * Try each candidate in order, returning the first that initialises successfully.
@@ -99,12 +108,6 @@ class LiteRtEmbeddingEngine @Inject constructor(
         Log.e(TAG, "All EmbeddingGemma model candidates failed")
         return null
     }
-
-    /**
-     * Returns true when running on Snapdragon 8 Gen 2 (SM8550).
-     * Board code: "kalama" (Qualcomm's internal name for SM8550).
-     */
-    private fun isSm8550(): Boolean = Build.BOARD.equals("kalama", ignoreCase = true)
 
     override suspend fun embed(text: String): FloatArray = withContext(Dispatchers.IO) {
         val state = ensureState() ?: return@withContext FloatArray(0)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
@@ -6,7 +6,10 @@ import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.isDownloaded
 import com.kernel.ai.core.inference.download.localFile
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.tensorflow.lite.Interpreter
 import java.io.File
@@ -46,9 +49,10 @@ class LiteRtEmbeddingEngine @Inject constructor(
     private val lock = Any()
 
     init {
-        // Clean up the SM8550 variant — disabled due to LiteRT format incompatibility.
-        // Remove this once the upstream issue is resolved and the model is re-enabled.
-        KernelModel.EMBEDDING_GEMMA_300M_SM8550.localFile(context).let { f ->
+        // Clean up the SM8550 variant on a background thread — disabled due to LiteRT format
+        // incompatibility. Remove once the upstream issue is resolved and model is re-enabled.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            val f = KernelModel.EMBEDDING_GEMMA_300M_SM8550.localFile(context)
             if (f.exists()) {
                 f.delete()
                 Log.i(TAG, "Deleted broken SM8550 embedding variant: ${f.name}")

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -100,18 +100,16 @@ enum class KernelModel(
     ),
 
     /**
-     * EmbeddingGemma-300M — Qualcomm SM8550 (Snapdragon 8 Gen 2 / S23 Ultra) optimised build.
-     * Uses Hexagon NPU for faster embedding inference. Auto-queued on FLAGSHIP devices.
+     * SM8550 optimised variant — currently disabled due to LiteRT "Unsupported file format" error
+     * on device. Keep isRequired=false and preferredForTier=null until upstream fix is available.
      */
     EMBEDDING_GEMMA_300M_SM8550(
         displayName = "EmbeddingGemma 300M (SM8550)",
         fileName = "embeddinggemma-300M_seq512_mixed-precision.qualcomm.sm8550.tflite",
         downloadUrl = "https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq512_mixed-precision.qualcomm.sm8550.tflite",
         approxSizeBytes = 350_000_000L,
-        // Not globally required — falls back to EMBEDDING_GEMMA_300M on non-flagship devices.
-        // preferredForTier = FLAGSHIP causes ModelDownloadManager to auto-queue it on S23 Ultra etc.
         isRequired = false,
-        preferredForTier = HardwareTier.FLAGSHIP,
+        preferredForTier = null,
         isGated = true,
     ),
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -11,6 +11,7 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -68,18 +69,21 @@ class ModelDownloadManager @Inject constructor(
         KernelModel.entries.forEach { model ->
             scope.launch { observeWorkInfo(model) }
         }
+        val tier = hardwareProfileDetector.profile.tier  // hoist BEFORE the required-model loop
         // Auto-queue all required models that aren't yet downloaded
         KernelModel.entries
             .filter {
                 it.isRequired && !it.isDownloaded(context) &&
-                (!it.isGated || authRepository.getAccessToken() != null)
+                (!it.isGated || authRepository.getAccessToken() != null) &&
+                // On FLAGSHIP, skip E2B — E4B is auto-queued below as the tier-preferred model
+                !(it == KernelModel.GEMMA_4_E2B && tier == HardwareTier.FLAGSHIP)
             }
             .forEach { model ->
                 Log.i(TAG, "Auto-queuing required model: ${model.displayName}")
                 startDownload(model)
             }
         // Auto-queue tier-specific optional models (e.g. E-4B on FLAGSHIP)
-        val tier = hardwareProfileDetector.profile.tier
+        // NOTE: tier is already declared above
         KernelModel.entries
             .filter {
                 !it.isRequired && it.preferredForTier == tier && !it.isDownloaded(context) &&
@@ -160,11 +164,22 @@ class ModelDownloadManager @Inject constructor(
         return if (model.isDownloaded(context)) model.localFile(context).absolutePath else null
     }
 
-    /** True when all [KernelModel.isRequired] models are present on disk. */
-    fun areRequiredModelsDownloaded(): Boolean =
-        KernelModel.entries
-            .filter { it.isRequired }
+    /** True when all models required for this device tier are present on disk. */
+    fun areRequiredModelsDownloaded(): Boolean {
+        val tier = hardwareProfileDetector.profile.tier
+        // On FLAGSHIP, either E4B or E2B satisfies the conversation model requirement
+        val conversationModelReady = when (tier) {
+            HardwareTier.FLAGSHIP ->
+                KernelModel.GEMMA_4_E4B.isDownloaded(context) ||
+                KernelModel.GEMMA_4_E2B.isDownloaded(context)
+            else -> KernelModel.GEMMA_4_E2B.isDownloaded(context)
+        }
+        // All other required models must be present
+        val otherRequiredReady = KernelModel.entries
+            .filter { it.isRequired && it != KernelModel.GEMMA_4_E2B }
             .all { it.isDownloaded(context) }
+        return conversationModelReady && otherRequiredReady
+    }
 
     /**
      * Returns the best available conversation model.

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -64,6 +64,8 @@ class ModelDownloadManager @Inject constructor(
 
     val downloadStates: StateFlow<Map<KernelModel, DownloadState>> = _downloadStates.asStateFlow()
 
+    val deviceTier: HardwareTier get() = hardwareProfileDetector.profile.tier
+
     init {
         // Resume observing any in-progress workers that survived a process restart
         KernelModel.entries.forEach { model ->

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -133,8 +133,8 @@ class ChatViewModel @Inject constructor(
         downloadManager.downloadStates,
         inputState,
     ) { generation, downloadStates, input ->
+        val allDownloaded = downloadManager.areRequiredModelsDownloaded()
         val allRequired = KernelModel.entries.filter { it.isRequired }
-        val allDownloaded = allRequired.all { downloadStates[it] is DownloadState.Downloaded }
 
         when {
             !allDownloaded -> {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -14,6 +14,7 @@ import com.kernel.ai.core.inference.ModelConfig
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.memory.rag.RagRepository
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
@@ -134,12 +135,18 @@ class ChatViewModel @Inject constructor(
         inputState,
     ) { generation, downloadStates, input ->
         val allDownloaded = downloadManager.areRequiredModelsDownloaded()
-        val allRequired = KernelModel.entries.filter { it.isRequired }
+        val tier = downloadManager.deviceTier
+        val displayModels: List<KernelModel> = if (tier == HardwareTier.FLAGSHIP) {
+            KernelModel.entries.filter { it.isRequired && it != KernelModel.GEMMA_4_E2B } +
+                KernelModel.GEMMA_4_E4B
+        } else {
+            KernelModel.entries.filter { it.isRequired }
+        }
 
         when {
             !allDownloaded -> {
-                val anyDownloading = allRequired.any { downloadStates[it] is DownloadState.Downloading }
-                val progress = allRequired.map { model ->
+                val anyDownloading = displayModels.any { downloadStates[it] is DownloadState.Downloading }
+                val progress = displayModels.map { model ->
                     ModelDownloadProgress(
                         model = model,
                         displayName = model.displayName,

--- a/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/kernel/ai/feature/onboarding/OnboardingViewModel.kt
@@ -31,10 +31,8 @@ class OnboardingViewModel @Inject constructor(
         if (hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP) KernelModel.GEMMA_4_E4B
         else KernelModel.GEMMA_4_E2B
 
-    /** The EmbeddingGemma variant appropriate for this device — SM8550 on FLAGSHIP, generic otherwise. */
-    val preferredEmbeddingModel: KernelModel =
-        if (hardwareProfileDetector.profile.tier == HardwareTier.FLAGSHIP) KernelModel.EMBEDDING_GEMMA_300M_SM8550
-        else KernelModel.EMBEDDING_GEMMA_300M
+    /** Always use the generic EmbeddingGemma — SM8550 variant is currently broken (LiteRT format error). */
+    val preferredEmbeddingModel: KernelModel = KernelModel.EMBEDDING_GEMMA_300M
 
     data class OnboardingUiState(
         val isAuthenticated: Boolean = false,


### PR DESCRIPTION
Two bugs found during device testing:

**Bug 1 — E2B downloading on FLAGSHIP (S23 Ultra)**
`GEMMA_4_E2B.isRequired = true` causes it to be auto-queued in `ModelDownloadManager.init` on all devices when an HF token is present. On FLAGSHIP, E4B is *also* queued via the tier-optional loop — but E2B is smaller and finishes first, so the user ends up with E2B loaded. Fix: skip E2B in the required-model loop on FLAGSHIP tier. `areRequiredModelsDownloaded()` updated to accept E4B OR E2B on FLAGSHIP.

**Bug 2 — SM8550 EmbeddingGemma 'Unsupported file format'**
PR #202 added `EMBEDDING_GEMMA_300M_SM8550.preferredForTier = HardwareTier.FLAGSHIP`, causing it to auto-download and be selected on S23 Ultra. The file fails to load with `INVALID_ARGUMENT: Unsupported file format`. Disabled by setting `preferredForTier = null` and hardcoding `preferredEmbeddingModel` to the generic variant until the upstream issue is resolved.

Closes #204