### PR TITLE
fix: FunctionGemma MAX_TOKENS 256→1024 (ekv1024 model)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -199,7 +199,11 @@ Do not add any explanation or extra text.
     """.trimIndent()
 
     private companion object {
-        /** Token budget for the router — 256 is sufficient for a compact JSON function call. */
-        private const val MAX_TOKENS = 256
+        /**
+         * Token budget for the router. The model file is the `ekv1024` variant, compiled with
+         * a 1024-token KV cache — match that here. 256 was too small for the system prompt +
+         * function declarations, causing "Input token ids are too long" on every inference call.
+         */
+        private const val MAX_TOKENS = 1024
     }
 }


### PR DESCRIPTION
## Root cause

FunctionGemma was initialised with `maxNumTokens = 256`, but the model file is the `ekv1024` variant compiled with a 1024-token KV cache. The system prompt + skill declarations JSON already exceeds 256 tokens, so every single routing call failed with:

```
Input token ids are too long. Exceeding the maximum number of tokens allowed: 319 >= 256
```

This caused `route()` to always throw, always return `RouterNotReady`, which routed every message to Gemma-4 lazy-load — triggering the 'Loading model…' spinner and then crashing when Gemma-4 wasn't ready.

## Fix
`MAX_TOKENS = 256 → 1024` — matches the KV cache the model was compiled with.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>