### PR TITLE
feat(#209): replace JSON schema injection with native LiteRT-LM ToolSet API

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -79,6 +79,11 @@ class FunctionGemmaRouter @Inject constructor(
     suspend fun initialize(functionGemmaPath: String) {
         withContext(LlmDispatcher) {
             _isReady.value = false
+            // Close any previously-held resources before re-initialising to avoid native memory leaks.
+            try { conversation?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev conv: ${e.message}") }
+            try { engine?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev engine: ${e.message}") }
+            conversation = null
+            engine = null
             try {
                 Log.i(TAG, "FunctionGemmaRouter: initialising from $functionGemmaPath")
 
@@ -156,7 +161,7 @@ class FunctionGemmaRouter @Inject constructor(
             when {
                 toolSet.wasToolCalled() -> HandleResult.ToolHandled(raw.ifEmpty { "Done." })
                 raw.isNotEmpty() -> HandleResult.PlainResponse(raw)
-                else -> HandleResult.NotReady
+                else -> HandleResult.PlainResponse("")   // router ready, model returned nothing; fall through to Gemma-4
             }
         } catch (e: Exception) {
             Log.e(TAG, "FunctionGemmaRouter: inference failed — ${e.message}", e)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -46,6 +46,19 @@ class FunctionGemmaRouter @Inject constructor(
     private val hardwareProfileDetector: HardwareProfileDetector,
     private val toolSet: KernelAIToolSet,
 ) {
+    /**
+     * Result of a [handle] call.
+     *
+     * [ToolHandled] — a `@Tool` method was invoked; display [response] to the user.
+     * [PlainResponse] — FunctionGemma responded but called no tool; fall through to Gemma-4.
+     * [NotReady] — router not yet initialised; fall through to Gemma-4.
+     */
+    sealed class HandleResult {
+        data class ToolHandled(val response: String) : HandleResult()
+        data class PlainResponse(val response: String) : HandleResult()
+        object NotReady : HandleResult()
+    }
+
     private var engine: Engine? = null
     private var conversation: com.google.ai.edge.litertlm.Conversation? = null
 
@@ -107,14 +120,15 @@ class FunctionGemmaRouter @Inject constructor(
      *
      * Runs on [LlmDispatcher] — safe to call from any coroutine context.
      */
-    suspend fun handle(userMessage: String): String? = withContext(LlmDispatcher) {
+    suspend fun handle(userMessage: String): HandleResult = withContext(LlmDispatcher) {
         val conv = conversation
         if (conv == null) {
             Log.w(TAG, "FunctionGemmaRouter: handle() called before initialisation — falling back")
-            return@withContext null
+            return@withContext HandleResult.NotReady
         }
 
         try {
+            toolSet.resetTurnState()
             val sb = StringBuilder()
             val latch = CompletableDeferred<Unit>()
 
@@ -138,11 +152,15 @@ class FunctionGemmaRouter @Inject constructor(
             latch.await()
 
             val raw = sb.toString().trim()
-            Log.d(TAG, "FunctionGemmaRouter: response=\"$raw\"")
-            raw.ifEmpty { null }
+            Log.d(TAG, "FunctionGemmaRouter: response=\"$raw\" toolCalled=${toolSet.wasToolCalled()}")
+            when {
+                toolSet.wasToolCalled() -> HandleResult.ToolHandled(raw.ifEmpty { "Done." })
+                raw.isNotEmpty() -> HandleResult.PlainResponse(raw)
+                else -> HandleResult.NotReady
+            }
         } catch (e: Exception) {
             Log.e(TAG, "FunctionGemmaRouter: inference failed — ${e.message}", e)
-            null
+            HandleResult.NotReady
         }
     }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -10,6 +10,7 @@ import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.MessageCallback
 import com.google.ai.edge.litertlm.SamplerConfig
+import com.google.ai.edge.litertlm.tool
 import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
@@ -17,34 +18,34 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "KernelAI"
 
 /**
- * Routes user messages to either a skill or plain conversation using FunctionGemma-270M.
+ * Handles user messages via FunctionGemma-270M using the LiteRT-LM native ToolSet API.
  *
- * FunctionGemma runs on CPU (XNNPACK, 4 threads) and is always-hot — loaded at app start.
+ * FunctionGemma is fine-tuned to use the SDK's `@Tool`/`ToolSet`/`ToolProvider` mechanism.
+ * Tools are registered with [ConversationConfig] so the model genuinely sees them — no
+ * manual JSON schema injection or text-output parsing required.
+ *
+ * FunctionGemma runs on CPU (XNNPACK) and is always-hot — loaded at app start.
  * It never shares its session with the main conversation (isolated Engine + Conversation).
  *
  * Output contract:
- * - Valid JSON object with "name" field → [RouteDecision.SkillCall]
- * - Anything else (including "CONVERSATION") → [RouteDecision.PlainConversation]
- * - Engine not yet initialised → [RouteDecision.RouterNotReady]
+ * - Non-null [String] → final model text response after any tool calls completed internally
+ * - `null`            → router not ready; caller should fall through to Gemma-4
  */
 @Singleton
 class FunctionGemmaRouter @Inject constructor(
     @ApplicationContext private val context: Context,
     @Suppress("UnusedPrivateMember")
     private val hardwareProfileDetector: HardwareProfileDetector,
+    private val toolSet: KernelAIToolSet,
 ) {
-    sealed class RouteDecision {
-        data class SkillCall(val rawJson: String) : RouteDecision()
-        object PlainConversation : RouteDecision()
-        object RouterNotReady : RouteDecision()
-    }
-
     private var engine: Engine? = null
     private var conversation: com.google.ai.edge.litertlm.Conversation? = null
 
@@ -57,11 +58,12 @@ class FunctionGemmaRouter @Inject constructor(
      * Always forces CPU/XNNPACK backend — FunctionGemma-270M is the always-hot router and
      * must not compete with the main model on GPU/NPU resources.
      *
+     * Tools are registered via [KernelAIToolSet] through the SDK's native `ToolProvider`
+     * mechanism — the model sees the tool declarations directly with no system-prompt hacking.
+     *
      * @param functionGemmaPath Absolute path to the `.litertlm` model file on disk.
-     * @param functionDeclarationsJson JSON array of available skill declarations injected
-     *        into the system prompt so the model knows which functions it may call.
      */
-    suspend fun initialize(functionGemmaPath: String, functionDeclarationsJson: String) {
+    suspend fun initialize(functionGemmaPath: String) {
         withContext(LlmDispatcher) {
             _isReady.value = false
             try {
@@ -75,11 +77,12 @@ class FunctionGemmaRouter @Inject constructor(
                 val eng = Engine(engineConfig)
                 eng.initialize()
 
-                val systemInstruction = buildSystemPrompt(functionDeclarationsJson)
+                val toolProvider = tool(toolSet)
                 val samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.0)
                 val convConfig = ConversationConfig(
                     samplerConfig = samplerConfig,
-                    systemInstruction = Contents.of(Content.Text(systemInstruction)),
+                    systemInstruction = buildSystemPrompt(),
+                    tools = listOf(toolProvider),
                 )
                 val conv = eng.createConversation(convConfig)
 
@@ -95,19 +98,20 @@ class FunctionGemmaRouter @Inject constructor(
     }
 
     /**
-     * Routes [userMessage] to a skill call or plain conversation.
+     * Sends [userMessage] to FunctionGemma. The SDK invokes any matching `@Tool` methods
+     * automatically and feeds their results back to the model before generating the final
+     * text reply.
      *
      * Must only be called after [initialize] completes successfully (i.e., [isReady] is true).
-     * If the router is not ready, returns [RouteDecision.RouterNotReady] so the caller can
-     * fall through to Gemma-4.
+     * Returns `null` if the router is not ready — caller should fall through to Gemma-4.
      *
      * Runs on [LlmDispatcher] — safe to call from any coroutine context.
      */
-    suspend fun route(userMessage: String): RouteDecision = withContext(LlmDispatcher) {
+    suspend fun handle(userMessage: String): String? = withContext(LlmDispatcher) {
         val conv = conversation
         if (conv == null) {
-            Log.w(TAG, "FunctionGemmaRouter: route() called before initialisation — falling back")
-            return@withContext RouteDecision.RouterNotReady
+            Log.w(TAG, "FunctionGemmaRouter: handle() called before initialisation — falling back")
+            return@withContext null
         }
 
         try {
@@ -134,11 +138,11 @@ class FunctionGemmaRouter @Inject constructor(
             latch.await()
 
             val raw = sb.toString().trim()
-            Log.d(TAG, "FunctionGemmaRouter: raw output=\"$raw\"")
-            parseRouteDecision(raw)
+            Log.d(TAG, "FunctionGemmaRouter: response=\"$raw\"")
+            raw.ifEmpty { null }
         } catch (e: Exception) {
             Log.e(TAG, "FunctionGemmaRouter: inference failed — ${e.message}", e)
-            RouteDecision.RouterNotReady
+            null
         }
     }
 
@@ -157,52 +161,25 @@ class FunctionGemmaRouter @Inject constructor(
     // -------------------------------------------------------------------------
 
     /**
-     * Parses the raw model output and returns the appropriate [RouteDecision].
-     *
-     * Strips code fences (same pattern as `SkillExecutor.parseSkillCall`) then tries to
-     * deserialise as a JSON object with a non-blank "name" field.
+     * Builds the system instruction matching Edge Gallery's style.
+     * No manual function declarations — those are provided via [ConversationConfig.tools].
      */
-    private fun parseRouteDecision(raw: String): RouteDecision {
-        return try {
-            val cleaned = raw.trim()
-                .removePrefix("```json").removePrefix("```")
-                .removeSuffix("```")
-                .trim()
-            val json = org.json.JSONObject(cleaned)
-            val name = json.optString("name").takeIf { it.isNotBlank() }
-            if (name != null) {
-                Log.d(TAG, "FunctionGemmaRouter: skill call detected — name=$name")
-                RouteDecision.SkillCall(cleaned)
-            } else {
-                Log.d(TAG, "FunctionGemmaRouter: JSON has no 'name' field — plain conversation")
-                RouteDecision.PlainConversation
-            }
-        } catch (e: Exception) {
-            // Not valid JSON — treat as plain conversation (includes "CONVERSATION" literal)
-            Log.d(TAG, "FunctionGemmaRouter: non-JSON output — plain conversation")
-            RouteDecision.PlainConversation
-        }
+    private fun buildSystemPrompt(): Contents {
+        val now = LocalDateTime.now()
+        val dateStr = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+        val dayStr = now.format(DateTimeFormatter.ofPattern("EEEE"))
+        return Contents.of(
+            listOf(
+                Content.Text("You are a model that can do function calling with the following functions"),
+                Content.Text("Current date and time: $dateStr, Day: $dayStr"),
+            ),
+        )
     }
-
-    private fun buildSystemPrompt(functionDeclarationsJson: String): String = """
-You are a function router. Given a user message, decide if it requires a function call or a normal conversation response.
-
-Available functions:
-$functionDeclarationsJson
-
-If the user message requires a function call, respond with ONLY a JSON object:
-{"name": "function_name", "arguments": {"param": "value"}}
-
-If the user message is a normal conversation, respond with ONLY the word: CONVERSATION
-
-Do not add any explanation or extra text.
-    """.trimIndent()
 
     private companion object {
         /**
          * Token budget for the router. The model file is the `ekv1024` variant, compiled with
-         * a 1024-token KV cache — match that here. 256 was too small for the system prompt +
-         * function declarations, causing "Input token ids are too long" on every inference call.
+         * a 1024-token KV cache — match that here.
          */
         private const val MAX_TOKENS = 1024
     }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
@@ -75,7 +75,7 @@ class KernelAIToolSet @Inject constructor(
         @ToolParam(description = "The content to remember") content: String,
     ): Map<String, String> {
         toolCalledInThisTurn = true
-        Log.d(TAG, "ToolSet: saveMemory content=$content")
+        Log.d(TAG, "ToolSet: saveMemory (${content.length} chars)")
         // TODO: wire to Room notes DB
         return mapOf("result" to "Memory saved: $content")
     }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
@@ -1,0 +1,90 @@
+package com.kernel.ai.core.inference
+
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.util.Log
+import com.google.ai.edge.litertlm.Tool
+import com.google.ai.edge.litertlm.ToolParam
+import com.google.ai.edge.litertlm.ToolSet
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Native skill implementations exposed as LiteRT-LM tools.
+ * FunctionGemma calls these directly via the SDK's ToolSet API — no JSON parsing required.
+ *
+ * Each `@Tool`-annotated method is invoked by the SDK when FunctionGemma decides it matches
+ * a user request. The return value is fed back to the model as a tool response before the
+ * model generates its final text reply.
+ */
+@Singleton
+class KernelAIToolSet @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ToolSet {
+
+    @Tool(description = "Turns the device flashlight/torch on")
+    fun turnOnFlashlight(): Map<String, String> {
+        Log.d(TAG, "ToolSet: turnOnFlashlight")
+        return setTorch(true)
+    }
+
+    @Tool(description = "Turns the device flashlight/torch off")
+    fun turnOffFlashlight(): Map<String, String> {
+        Log.d(TAG, "ToolSet: turnOffFlashlight")
+        return setTorch(false)
+    }
+
+    @Tool(description = "Gets the current weather for a location")
+    fun getWeather(
+        @ToolParam(description = "The city or location to get weather for") location: String,
+    ): Map<String, String> {
+        Log.d(TAG, "ToolSet: getWeather location=$location")
+        // TODO: wire to real weather API — return placeholder for now
+        return mapOf("result" to "Weather lookup for $location is not yet available offline.")
+    }
+
+    @Tool(description = "Sets a timer for a specified duration")
+    fun setTimer(
+        @ToolParam(description = "Duration in seconds") seconds: Int,
+    ): Map<String, String> {
+        Log.d(TAG, "ToolSet: setTimer seconds=$seconds")
+        // TODO: wire to Android AlarmManager
+        return mapOf("result" to "Timer set for $seconds seconds.")
+    }
+
+    @Tool(description = "Saves a note or memory for future reference")
+    fun saveMemory(
+        @ToolParam(description = "The content to remember") content: String,
+    ): Map<String, String> {
+        Log.d(TAG, "ToolSet: saveMemory content=$content")
+        // TODO: wire to Room notes DB
+        return mapOf("result" to "Memory saved: $content")
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private fun setTorch(enabled: Boolean): Map<String, String> {
+        return try {
+            val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            val cameraId = cameraManager.cameraIdList.firstOrNull { id ->
+                cameraManager.getCameraCharacteristics(id)
+                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+            }
+            if (cameraId != null) {
+                cameraManager.setTorchMode(cameraId, enabled)
+                mapOf("result" to "success")
+            } else {
+                mapOf("result" to "error", "error" to "No flash unit found on this device")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "setTorch($enabled) failed: ${e.message}", e)
+            mapOf("result" to "error", "error" to (e.message ?: "Unknown error"))
+        }
+    }
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
@@ -26,14 +26,26 @@ class KernelAIToolSet @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : ToolSet {
 
+    @Volatile private var toolCalledInThisTurn = false
+
+    /** Call before each [FunctionGemmaRouter.handle] invocation to reset the tool-called flag. */
+    fun resetTurnState() {
+        toolCalledInThisTurn = false
+    }
+
+    /** Returns true if any `@Tool` method was invoked during the current turn. */
+    fun wasToolCalled(): Boolean = toolCalledInThisTurn
+
     @Tool(description = "Turns the device flashlight/torch on")
     fun turnOnFlashlight(): Map<String, String> {
+        toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: turnOnFlashlight")
         return setTorch(true)
     }
 
     @Tool(description = "Turns the device flashlight/torch off")
     fun turnOffFlashlight(): Map<String, String> {
+        toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: turnOffFlashlight")
         return setTorch(false)
     }
@@ -42,6 +54,7 @@ class KernelAIToolSet @Inject constructor(
     fun getWeather(
         @ToolParam(description = "The city or location to get weather for") location: String,
     ): Map<String, String> {
+        toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: getWeather location=$location")
         // TODO: wire to real weather API — return placeholder for now
         return mapOf("result" to "Weather lookup for $location is not yet available offline.")
@@ -51,6 +64,7 @@ class KernelAIToolSet @Inject constructor(
     fun setTimer(
         @ToolParam(description = "Duration in seconds") seconds: Int,
     ): Map<String, String> {
+        toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: setTimer seconds=$seconds")
         // TODO: wire to Android AlarmManager
         return mapOf("result" to "Timer set for $seconds seconds.")
@@ -60,6 +74,7 @@ class KernelAIToolSet @Inject constructor(
     fun saveMemory(
         @ToolParam(description = "The content to remember") content: String,
     ): Map<String, String> {
+        toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: saveMemory content=$content")
         // TODO: wire to Room notes DB
         return mapOf("result" to "Memory saved: $content")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -210,12 +210,6 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Returns the function_declarations JSON array for FunctionGemma's system prompt.
-     * Used to advertise available skills to the model at inference time.
-     */
-    fun buildSkillContext(): String = skillRegistry.buildFunctionDeclarationsJson()
-
     private suspend fun initializeConversation() {
         val id = navConversationId ?: conversationRepository.createConversation()
         conversationId = id
@@ -303,7 +297,7 @@ class ChatViewModel @Inject constructor(
             return
         }
         try {
-            functionGemmaRouter.initialize(routerPath, buildSkillContext())
+            functionGemmaRouter.initialize(routerPath)
             Log.i("KernelAI", "FunctionGemmaRouter initialized successfully")
         } catch (e: Exception) {
             Log.w("KernelAI", "FunctionGemmaRouter: init failed (non-fatal): ${e.message}", e)
@@ -427,36 +421,14 @@ class ChatViewModel @Inject constructor(
                 Log.d("KernelAI", "Set placeholder title for $convId: \"$placeholder\"")
             }
 
-            // 1. Route via FunctionGemma — fast CPU classifier decides skill vs. conversation.
-            val routeDecision = functionGemmaRouter.route(text)
-            when (routeDecision) {
-                is FunctionGemmaRouter.RouteDecision.SkillCall -> {
-                    val result = skillExecutor.execute(routeDecision.rawJson)
-                    when (result) {
-                        is SkillResult.Success -> {
-                            appendAssistantMessage(convId, result.content)
-                            needsHistoryReplay = true
-                            return@launch
-                        }
-                        is SkillResult.ParseError, is SkillResult.UnknownSkill -> {
-                            Log.w("KernelAI", "Skill routing failed: $result — falling back to Gemma-4")
-                            // fall through to Gemma-4
-                        }
-                        is SkillResult.Failure -> {
-                            appendAssistantMessage(
-                                convId,
-                                "I tried to do that but something went wrong: ${(result as SkillResult.Failure).error}",
-                            )
-                            needsHistoryReplay = true
-                            return@launch
-                        }
-                    }
-                }
-                is FunctionGemmaRouter.RouteDecision.PlainConversation,
-                is FunctionGemmaRouter.RouteDecision.RouterNotReady -> {
-                    // fall through to Gemma-4
-                }
+            // 1. Route via FunctionGemma — SDK calls @Tool methods natively and returns final text.
+            val routerResponse = functionGemmaRouter.handle(text)
+            if (routerResponse != null) {
+                appendAssistantMessage(convId, routerResponse)
+                needsHistoryReplay = true
+                return@launch
             }
+            // null → router not ready or plain conversation; fall through to Gemma-4
 
             // Lazy-init Gemma-4 if not yet loaded.
             if (!inferenceEngine.isReady.value) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -421,14 +421,22 @@ class ChatViewModel @Inject constructor(
                 Log.d("KernelAI", "Set placeholder title for $convId: \"$placeholder\"")
             }
 
-            // 1. Route via FunctionGemma — SDK calls @Tool methods natively and returns final text.
-            val routerResponse = functionGemmaRouter.handle(text)
-            if (routerResponse != null) {
-                appendAssistantMessage(convId, routerResponse)
-                needsHistoryReplay = true
-                return@launch
+            // 1. Route via FunctionGemma — SDK calls @Tool methods natively.
+            //    ToolHandled  → a skill ran, display response, skip Gemma-4.
+            //    PlainResponse → FunctionGemma answered without a tool, fall through to Gemma-4
+            //                    so the user gets a high-quality conversational response.
+            //    NotReady     → router not initialised, fall through to Gemma-4.
+            when (val result = functionGemmaRouter.handle(text)) {
+                is FunctionGemmaRouter.HandleResult.ToolHandled -> {
+                    appendAssistantMessage(convId, result.response)
+                    needsHistoryReplay = true
+                    return@launch
+                }
+                is FunctionGemmaRouter.HandleResult.PlainResponse,
+                is FunctionGemmaRouter.HandleResult.NotReady -> {
+                    // fall through to Gemma-4
+                }
             }
-            // null → router not ready or plain conversation; fall through to Gemma-4
 
             // Lazy-init Gemma-4 if not yet loaded.
             if (!inferenceEngine.isReady.value) {


### PR DESCRIPTION
## Summary

FunctionGemma is fine-tuned to use the SDK's `@Tool`/`@ToolParam`/`ToolSet` mechanism, not manual JSON in the system prompt. The previous approach caused the model to respond _"I don't have a tool for that"_ for every skill call because tools were never registered with the SDK — only described textually.

## Root cause

The old `FunctionGemmaRouter` manually serialised skill schemas into JSON, injected them into the system prompt, then tried to parse the model's text output as JSON. FunctionGemma has no awareness of these injected descriptions as actual callable tools, so it falls back to saying it cannot help.

## What changed

### `core/inference` — new file: `KernelAIToolSet.kt`
- Implements `ToolSet` with `@Tool`-annotated methods for: `turnOnFlashlight`, `turnOffFlashlight`, `getWeather`, `setTimer`, `saveMemory`
- Flashlight uses `CameraManager.setTorchMode` with explicit camera ID lookup
- Weather, timer, and saveMemory have TODO stubs returning placeholders (ready to wire up)
- Injected via Hilt `@Singleton` — placed in `:core:inference` where LiteRT-LM is already a direct dependency

### `core/inference` — rewrite: `FunctionGemmaRouter.kt`
- `initialize(path)` now calls `tool(toolSet)` to create a `ToolProvider`, then passes `listOf(toolProvider)` to `ConversationConfig(tools = ...)`
- System prompt matches Edge Gallery style: _"You are a model that can do function calling with the following functions"_ + current date/time — no manual function declarations
- `route(): RouteDecision` replaced by `handle(): String?` — SDK dispatches tool calls internally; callers receive the final text response (or `null` if not ready)
- Removed: `RouteDecision` sealed class, `parseRouteDecision()`, `buildSystemPrompt(json)`, `functionDeclarationsJson` parameter

### `feature/chat` — update: `ChatViewModel.kt`
- `initFunctionGemmaRouter()`: `initialize(path, buildSkillContext())` → `initialize(path)`
- `sendMessage()`: replaces the `when (routeDecision) { is SkillCall → ... }` block with a single `handle(text)` null-check
- Removed `buildSkillContext()` helper (no longer needed; `SkillRegistry.buildFunctionDeclarationsJson()` still used for Gemma-4 system prompt injection)

## Reference
Edge Gallery implementation studied: `MobileActionsTools.kt`, `MobileActionsTask.kt`, `MobileActionsViewModel.kt`

## Build
- `./gradlew :core:inference:assembleDebug` ✅
- `./gradlew :app:assembleDebug` ✅ (218 tasks, 0 errors)

## Trade-offs / follow-ups
- `getWeather`, `setTimer`, `saveMemory` return stub responses — tracked for future wiring in separate issues
- `SkillExecutor` + `SkillRegistry` remain in `ChatViewModel` for the direct text-command execution path (line ~773) and Gemma-4 system prompt injection — no change needed there