### PR TITLE
feat(#211): wire KernelAIToolSet into Gemma-4 — tools + runIntent

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.inference
 
 import android.content.Context
+import android.content.Intent
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.util.Log
@@ -78,6 +79,64 @@ class KernelAIToolSet @Inject constructor(
         Log.d(TAG, "ToolSet: saveMemory (${content.length} chars)")
         // TODO: wire to Room notes DB
         return mapOf("result" to "Memory saved: $content")
+    }
+
+    @Tool(description = "Runs an Android system action such as opening settings, setting an alarm, creating a calendar event, or sending an email")
+    fun runIntent(
+        @ToolParam(description = "The action to perform. One of: SET_ALARM, OPEN_WIFI_SETTINGS, OPEN_BLUETOOTH_SETTINGS, CREATE_CALENDAR_EVENT, SEND_EMAIL") action: String,
+        @ToolParam(description = "JSON string of parameters for the action, e.g. '{\"hours\":7,\"minutes\":30,\"message\":\"Wake up\"}' for SET_ALARM") parameters: String,
+    ): Map<String, String> {
+        toolCalledInThisTurn = true
+        Log.d(TAG, "ToolSet: runIntent action=$action params=$parameters")
+        return try {
+            val params = org.json.JSONObject(parameters.ifBlank { "{}" })
+            when (action.uppercase()) {
+                "SET_ALARM" -> {
+                    val intent = Intent(android.provider.AlarmClock.ACTION_SET_ALARM).apply {
+                        putExtra(android.provider.AlarmClock.EXTRA_HOUR, params.optInt("hours", 8))
+                        putExtra(android.provider.AlarmClock.EXTRA_MINUTES, params.optInt("minutes", 0))
+                        params.optString("message").takeIf { it.isNotEmpty() }?.let {
+                            putExtra(android.provider.AlarmClock.EXTRA_MESSAGE, it)
+                        }
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    context.startActivity(intent)
+                    mapOf("result" to "success", "action" to action)
+                }
+                "OPEN_WIFI_SETTINGS" -> {
+                    context.startActivity(Intent(android.provider.Settings.ACTION_WIFI_SETTINGS).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK })
+                    mapOf("result" to "success")
+                }
+                "OPEN_BLUETOOTH_SETTINGS" -> {
+                    context.startActivity(Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK })
+                    mapOf("result" to "success")
+                }
+                "CREATE_CALENDAR_EVENT" -> {
+                    val intent = Intent(Intent.ACTION_INSERT).apply {
+                        data = android.provider.CalendarContract.Events.CONTENT_URI
+                        putExtra(android.provider.CalendarContract.Events.TITLE, params.optString("title", "New Event"))
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    context.startActivity(intent)
+                    mapOf("result" to "success")
+                }
+                "SEND_EMAIL" -> {
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "message/rfc822"
+                        putExtra(Intent.EXTRA_EMAIL, arrayOf(params.optString("to", "")))
+                        putExtra(Intent.EXTRA_SUBJECT, params.optString("subject", ""))
+                        putExtra(Intent.EXTRA_TEXT, params.optString("body", ""))
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    context.startActivity(intent)
+                    mapOf("result" to "success")
+                }
+                else -> mapOf("result" to "error", "error" to "Unknown action: $action")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "runIntent failed: ${e.message}", e)
+            mapOf("result" to "error", "error" to (e.message ?: "Unknown error"))
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/KernelAIToolSet.kt
@@ -84,7 +84,7 @@ class KernelAIToolSet @Inject constructor(
     @Tool(description = "Runs an Android system action such as opening settings, setting an alarm, creating a calendar event, or sending an email")
     fun runIntent(
         @ToolParam(description = "The action to perform. One of: SET_ALARM, OPEN_WIFI_SETTINGS, OPEN_BLUETOOTH_SETTINGS, CREATE_CALENDAR_EVENT, SEND_EMAIL") action: String,
-        @ToolParam(description = "JSON string of parameters for the action, e.g. '{\"hours\":7,\"minutes\":30,\"message\":\"Wake up\"}' for SET_ALARM") parameters: String,
+        @ToolParam(description = "JSON string of parameters. SET_ALARM: {\"hours\":7,\"minutes\":30,\"message\":\"label\"}. CREATE_CALENDAR_EVENT: {\"title\":\"Meeting\",\"startEpochMs\":1234567890000,\"endEpochMs\":1234571490000}. SEND_EMAIL: {\"subject\":\"Hello\",\"body\":\"text\"}") parameters: String,
     ): Map<String, String> {
         toolCalledInThisTurn = true
         Log.d(TAG, "ToolSet: runIntent action=$action params=$parameters")
@@ -115,15 +115,20 @@ class KernelAIToolSet @Inject constructor(
                     val intent = Intent(Intent.ACTION_INSERT).apply {
                         data = android.provider.CalendarContract.Events.CONTENT_URI
                         putExtra(android.provider.CalendarContract.Events.TITLE, params.optString("title", "New Event"))
+                        val startMs = params.optLong("startEpochMs")
+                        if (startMs > 0) putExtra(android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME, startMs)
+                        val endMs = params.optLong("endEpochMs")
+                        if (endMs > 0) putExtra(android.provider.CalendarContract.EXTRA_EVENT_END_TIME, endMs)
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }
                     context.startActivity(intent)
                     mapOf("result" to "success")
                 }
                 "SEND_EMAIL" -> {
+                    // Do NOT populate EXTRA_EMAIL from LLM output to prevent prompt-injection
+                    // exfiltration — the user must enter the recipient themselves in the mail app.
                     val intent = Intent(Intent.ACTION_SEND).apply {
                         type = "message/rfc822"
-                        putExtra(Intent.EXTRA_EMAIL, arrayOf(params.optString("to", "")))
                         putExtra(Intent.EXTRA_SUBJECT, params.optString("subject", ""))
                         putExtra(Intent.EXTRA_TEXT, params.optString("body", ""))
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -13,6 +13,7 @@ import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.MessageCallback
 import com.google.ai.edge.litertlm.SamplerConfig
+import com.google.ai.edge.litertlm.tool
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
@@ -326,9 +327,13 @@ class LiteRtInferenceEngine @Inject constructor(
             ?.takeIf { it.isNotBlank() }
             ?.let { Contents.of(Content.Text(it)) }
 
+        val tools = config.toolSet?.let { listOf(tool(it)) } ?: emptyList()
+
         return ConversationConfig(
             samplerConfig = samplerConfig,
             systemInstruction = systemInstruction,
+            tools = tools,
+            automaticToolCalling = tools.isNotEmpty(),
         )
     }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.inference
 
 import com.google.ai.edge.litertlm.SamplerConfig
+import com.google.ai.edge.litertlm.ToolSet
 
 /** Jandal's default system prompt. Injected into every new conversation. */
 const val DEFAULT_SYSTEM_PROMPT =
@@ -32,4 +33,5 @@ data class ModelConfig(
     val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
     val temperature: Float = 1.0f,
     val topP: Float = 0.95f,
+    val toolSet: ToolSet? = null,
 )

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -26,6 +26,9 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
+        // LiteRT-LM (via core:inference) is compiled with Kotlin metadata 2.3.0.
+        // Skip the strict metadata version check to allow compilation.
+        freeCompilerArgs += "-Xskip-metadata-version-check"
     }
 
     testOptions {
@@ -38,6 +41,9 @@ dependencies {
     implementation(project(":core:inference"))
     implementation(project(":core:memory"))
     implementation(project(":core:skills"))
+
+    // LiteRT-LM — needed to resolve ToolSet supertype of KernelAIToolSet at compile time
+    implementation(libs.litertlm.android)
 
     // Compose
     implementation(platform(libs.compose.bom))

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -510,7 +510,6 @@ class ChatViewModel @Inject constructor(
             }
 
             try {
-                kernelAIToolSet.resetTurnState()
                 inferenceEngine.generate(prompt).collect { result ->
                     when (result) {
                         is GenerationResult.Token -> {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.FunctionGemmaRouter
 import com.kernel.ai.core.inference.GenerationResult
 import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.KernelAIToolSet
 import com.kernel.ai.core.inference.LlmDispatcher
 import com.kernel.ai.core.inference.ModelConfig
 import com.kernel.ai.core.inference.download.DownloadState
@@ -62,6 +63,7 @@ class ChatViewModel @Inject constructor(
     private val skillRegistry: SkillRegistry,
     private val skillExecutor: SkillExecutor,
     private val functionGemmaRouter: FunctionGemmaRouter,
+    private val kernelAIToolSet: KernelAIToolSet,
 ) : ViewModel() {
 
     /** Passed via nav arg; null means "start a new conversation". */
@@ -207,6 +209,7 @@ class ChatViewModel @Inject constructor(
             if (skillDeclarations != "[]") {
                 append("\n\n[Tool Use]\nYou have access to tools. When a user asks for something a tool can help with, output ONLY the following JSON — no explanation, no extra text:\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n\nAvailable tools:\n$skillDeclarations")
             }
+            append("\n\n[Available tools]\nflashlight on/off, set timer, get current time, save memory, set alarm, open settings, create calendar event, send email")
         }
     }
 
@@ -332,6 +335,7 @@ class ChatViewModel @Inject constructor(
                     maxTokens = settings.contextWindowSize,
                     temperature = settings.temperature,
                     topP = settings.topP,
+                    toolSet = kernelAIToolSet,
                 ))
                 estimatedTokensUsed = 0
                 // Rebuild system prompt now that activeBackend is resolved (backend field
@@ -506,6 +510,7 @@ class ChatViewModel @Inject constructor(
             }
 
             try {
+                kernelAIToolSet.resetTurnState()
                 inferenceEngine.generate(prompt).collect { result ->
                     when (result) {
                         is GenerationResult.Token -> {


### PR DESCRIPTION
## Summary

Wires KernelAIToolSet into Gemma-4 via ModelConfig so the main reasoning model has the same tool access as FunctionGemma.

### Changes
- Add toolSet field to ModelConfig
- Wire tools into LiteRtInferenceEngine.buildConversationConfig() with automaticToolCalling=true
- Add runIntent tool to KernelAIToolSet (alarm, WiFi/BT settings, calendar, email)
- Inject KernelAIToolSet into ChatViewModel and pass to ModelConfig
- resetTurnState() before Gemma-4 generation
- Add tool awareness to system prompt

### Build fix
- Add `litertlm-android` direct dep + `-Xskip-metadata-version-check` to `feature:chat` (mirrors `core:inference`; needed because ModelConfig.toolSet exposes ToolSet type to the module)

Closes #211