### PR TITLE
fix(#216/#219): GPU alignment guard, Quick Actions tab, Resident Agent architecture

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,24 +31,44 @@ An Android-native, **local-first AI assistant** with zero cloud dependencies. Al
 
 ## Architecture
 
-### Brain — Model Cascade
+### Brain — Resident Agent (Three-Tier)
 
-Three models with a cascading strategy:
+The architecture uses a three-tier Resident Agent pattern — FunctionGemma is **deprecated** and no longer loaded at startup:
+
+```
+User input
+    │
+    ▼
+┌─────────────────────────────┐
+│  Tier 2: QuickIntentRouter  │  ← Pure Kotlin regex, ~0MB, <5ms (⬜ pending)
+│  Torch / Timer / DND etc.   │    Deterministic matching for ~8 simple actions
+└────────┬────────────────────┘
+         │ no match
+         ▼
+┌─────────────────────────────┐
+│  Tier 3: Gemma-4 E-4B/E-2B │  ← Resident on GPU, TTFT ~2.3s
+│  Native JSON tool calling   │    Complex NLU + tool calling via SkillExecutor
+│  + RAG memory context       │    Confirmed working: weather, save_memory, get_system_info
+└─────────────────────────────┘
+```
+
+**Model inventory:**
 
 | Model | Role | Size | Loading |
 |-------|------|------|---------|
-| FunctionGemma-270M-FT-Mobile-Actions | Intent router (always-hot) | 289MB | Loaded at splash screen (~1-2s) |
-| Gemma-4 E-4B (Performance) / E-2B (Compat) | Reasoning | ~1.5-2.5GB | Lazy-loaded on first complex query |
-| EmbeddingGemma-300M | Semantic embeddings | <200MB | Loaded when RAG pipeline activates |
+| Gemma-4 E-4B (Performance) / E-2B (Compat) | Resident reasoning + tool calling | ~3.4GB | Eager at startup — E4B-first to guarantee full GPU headroom |
+| EmbeddingGemma-300M | Semantic embeddings (RAG) | <200MB | Lazy — loads on first RAG-triggering query |
+| FunctionGemma-270M | ~~Intent router~~ **Deprecated** | 289MB | Not loaded at startup; class retained for future reference |
 
-- All models use **quantized weights** (INT4/INT8) via LiteRT with GPU + NPU delegates
-- FunctionGemma runs on **CPU via XNNPACK** (4 threads, ~154 tk/s) — always ready
-- **Model Manager** handles warm-up/teardown: never hold EmbeddingGemma + Gemma-4 simultaneously on 8GB devices
+- All models use **quantized weights** (INT4/INT8) via LiteRT
+- E4B runs on **GPU (OpenCL / Adreno 740)** — loaded first with full memory headroom
+- `safeTokenCount()` guard: nudges powers-of-2 down ~2.4% to avoid LiteRT `reshape::Eval` buffer-alignment bug on Adreno (4096→4000, 8192→8000)
+- **E4B-first loading:** E4B initialises on GPU before FunctionGemma is considered — prevents lmkd OOM during ~20s GPU kernel compilation peak
 - Backend fallback chain: NPU → GPU → CPU
 
 ### Memory — Local RAG
 
-**Short-term (session):** LiteRT-LM KV Cache — 4,096 tokens (Performance) / 2,048 tokens (Compatibility). At 80% capacity, the reasoning model generates a recursive summary injected back into the prompt.
+**Short-term (session):** LiteRT-LM KV Cache — 4,000 tokens (Performance) / 2,000 tokens (Compatibility). At 80% capacity, the reasoning model generates a recursive summary injected back into the prompt.
 
 **Long-term (semantic):** sqlite-vec (compiled via NDK for arm64-v8a) with Room entities. Every user query triggers cosine-similarity search via `vec_distance_cosine()`; top 3–5 memory fragments prepended to system prompt. EmbeddingGemma-300M generates 768-dim vectors (256-dim on 8GB tier via Matryoshka reduction).
 
@@ -71,14 +91,16 @@ Three models with a cascading strategy:
 ### Architecture
 - **Kotlin is the host language.** All orchestration, OS integration, and JNI bridges are Kotlin/JVM. Wasm is guest-only.
 - **No external LLM APIs.** Never introduce network calls to cloud inference endpoints; all model inference must go through LiteRT.
-- **Contract-first skill development.** Define the JSON schema for every skill before writing logic. The schema is the source of truth for both FunctionGemma (routing) and the Kotlin/Wasm implementation (execution). Any skill change starts with a version bump in the manifest.
-- **Context window is managed, not truncated.** When approaching the token limit, trigger recursive summarization — do not simply drop history.
+- **Contract-first skill development.** Define the JSON schema (`SkillSchema`) for every skill before writing logic. The schema is injected into the system prompt via `SkillRegistry.buildFunctionDeclarationsJson()` so E4B knows available tools. Any skill change starts with a version bump in the manifest.
+- **Context window is managed, not truncated.** When approaching the token limit, trigger recursive summarisation — do not simply drop history.
+- **FunctionGemma is deprecated.** Do not load FunctionGemma at startup or wire new features to it. All intent routing goes through `QuickIntentRouter` (Tier 2) or Gemma-4 E4B native tool calling (Tier 3).
 
 ### Performance & Safety
-- **Dedicated LLM Dispatcher.** All inference runs on a custom coroutine dispatcher (dedicated thread pool), never `Dispatchers.Main`. Keep UI responsive while NPU is saturated.
-- **Hallucination guardrails.** Always validate FunctionGemma's output against the skill registry schema. If malformed, retry once with the error fed back to the model. If still invalid, fall back to a text response from Gemma-4.
+- **Dedicated LLM Dispatcher.** All inference runs on a custom coroutine dispatcher (dedicated thread pool), never `Dispatchers.Main`. Keep UI responsive while GPU is saturated.
+- **E4B tool call validation.** `tryExecuteToolCall()` in `ChatViewModel` parses E4B JSON output and dispatches to `SkillExecutor`. If the skill name is unknown or JSON is malformed, fall through to plain text response — do not crash.
 - **Verify quantization.** Use LiteRT Metadata Extractor to confirm models are actually running at the expected bit-depth. An accidental FP32 model will OOM on 8GB devices.
 - **LeakCanary from day one.** Integrate early to catch model weight leaks — weights that linger after a conversation closes.
+- **`gemma4InitMutex`** guards all E4B init paths — both `initEngineWhenReady()` and `initGemma4()` must hold this lock to prevent concurrent double-init and GPU engine orphaning.
 
 ### Security
 - **Explicit Intents only.** When triggering native Android actions (SMS, email, etc.), never use implicit intents that could be intercepted by other apps.
@@ -86,9 +108,9 @@ Three models with a cascading strategy:
 - **Domain-scoped network access.** Wasm skills needing HTTP get domain-specific bridge functions (e.g., `fetchHomeAssistant(path)`) with URL validation against an allowlist — never a generic `fetch()`.
 
 ### Cold Start Strategy
-- Splash screen loads FunctionGemma (~1-2s) — simple commands work immediately
-- Gemma-4 lazy-loads on first complex query ("Thinking..." indicator shown)
-- EmbeddingGemma loads on first RAG-triggering query
+- E4B loads eagerly on GPU at startup (~20s first boot, ~2s with kernel cache) — all features available immediately once ready
+- EmbeddingGemma loads lazily on first RAG-triggering query
+- "Thinking…" indicator shown while E4B is initialising
 
 ## UI/UX
 
@@ -246,8 +268,8 @@ The script verifies SHA256 hashes after download. Models directory: `models/` (g
 
 ## Implementation Phases
 
-1. Core LiteRT-LM integration with GPU/NPU acceleration for Gemma-4
-2. sqlite-vec + EmbeddingGemma for local semantic search (RAG)
-3. FunctionGemma Intent Router + initial Native Skills + Voice I/O
+1. ✅ Core LiteRT-LM integration with GPU/NPU acceleration for Gemma-4
+2. ✅ sqlite-vec + EmbeddingGemma for local semantic search (RAG)
+3. 🔄 Resident Agent Architecture: QuickIntentRouter (Tier 2) + E4B native tool calling (Tier 3) + Voice I/O — **top priority: #222 (baseline skills + rich UI), #223 (memory tools)**
 4. Chicory Wasm Runtime + GitHub-based Skill Store
 5. 8GB device optimization (dynamic weight loading/unloading)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A high-performance, **local-first** intelligent agent for Android. All inference
 
 ## How It Works
 
-The app operates on a **Brain–Memory–Action** triad:
+The app operates on a **Brain–Memory–Action** triad using a three-tier Resident Agent Architecture:
 
-* **The Brain:** A three-model cascade that adapts to your hardware. **FunctionGemma** (270M) handles instant intent routing, while **Gemma-4 E-4B/E-2B** is loaded on-demand for complex reasoning — delivering flagship-class AI on 8–12GB devices.
-* **The Memory:** A local **RAG (Retrieval-Augmented Generation)** system using **sqlite-vec** and **EmbeddingGemma-300M**. The assistant remembers personal facts, preferences, and conversation history across sessions with zero data leaving the device.
-* **The Action:** A modular skill framework. Native **Kotlin** skills handle high-privilege OS integrations (SMS, device controls, media). Community-extensible **WebAssembly** skills run in a sandboxed **Chicory** runtime for safe extensibility.
+* **The Brain:** **Gemma-4 E-4B/E-2B** runs resident on GPU via LiteRT — always loaded, always ready. A lightweight **`QuickIntentRouter`** (pure Kotlin regex, zero memory) handles instant device actions (<5ms). Complex queries go straight to Gemma-4 for full reasoning with native tool calling.
+* **The Memory:** A local **RAG (Retrieval-Augmented Generation)** system using **sqlite-vec** and **EmbeddingGemma-300M**. The assistant remembers personal facts, preferences, and conversation history across sessions with zero data leaving the device. Episodic distillation consolidates each conversation into long-term memories.
+* **The Action:** A modular skill framework. **Tier 2** native Kotlin actions execute instantly (torch, timer, DND, bluetooth). **Tier 3** complex skills (weather, calendar, email) are handled by the resident Gemma-4 model via its native JSON tool-call format. Community-extensible **WebAssembly** skills run sandboxed via **Chicory** for safe extensibility.
 
 ## Tech Stack
 
@@ -17,8 +17,9 @@ The app operates on a **Brain–Memory–Action** triad:
 | Language | Kotlin |
 | UI | Jetpack Compose, Material 3 Dynamic Color |
 | Inference | Google AI Edge (LiteRT + LiteRT-LM) |
-| Reasoning | Gemma-4 E-4B / E-2B (INT4 quantized) |
-| Intent Router | FunctionGemma-270M (Mobile Actions fine-tune) |
+| Reasoning | Gemma-4 E-4B / E-2B (INT4 quantized, GPU resident) |
+| Quick Actions | `QuickIntentRouter` (Kotlin regex, zero memory) |
+| Complex Tool Calling | Gemma-4 native JSON tool-call format |
 | Embeddings | EmbeddingGemma-300M (768-dim) |
 | Vector Search | sqlite-vec (NDK) |
 | Wasm Runtime | Chicory (pure JVM) |
@@ -29,7 +30,7 @@ The app operates on a **Brain–Memory–Action** triad:
 ## Features
 
 ### Delivered
-- 🧠 **On-device reasoning** — Gemma-4 running on GPU/NPU via LiteRT, no internet required
+- 🧠 **On-device reasoning** — Gemma-4 E-4B running on GPU via LiteRT, no internet required
 - 💾 **Persistent memory** — RAG-powered recall across conversations using sqlite-vec semantic search
 - 🔒 **100% private** — No cloud APIs, no telemetry, all data stays on device
 - 💬 **Full markdown rendering** — headings, bold, italic, inline code, code blocks, tables, links, lists
@@ -41,16 +42,19 @@ The app operates on a **Brain–Memory–Action** triad:
 - 🎬 **Fun loading screens** — 13 themed animated narratives
 - 🖼️ **Context window management** — structured prompt assembly with KV cache management and recursive summarisation
 - 📊 **Runtime info** — shows active model, backend (GPU/NPU/CPU), and device tier in chat
+- ⚡ **Quick Actions tab** — instant device commands (torch, timer, DND, bluetooth) via zero-overhead Kotlin pattern matcher
+- 💭 **Episodic memory distillation** — Gemma-4 summarises each conversation into long-term memories
 
 ### Coming Soon
 - 🗣️ **Voice + text input** — tap-to-talk with auto-stop *(Phase 3)*
-- 🔧 **Native skills** — Flashlight, DND, Bluetooth, Alarms, SMS, Email, Media Control, Notes *(Phase 3)*
-- 💭 **Episodic memory distillation** — Gemma-4 summarises each conversation into long-term memories *(Phase 3)*
+- 🔧 **Full native skills** — Alarms, SMS, Email, Media Control, Notes, Weather *(Phase 3)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
 - ⚡ **Semantic cache** — instant responses for repeated knowledge queries, bypassing main LLM *(Phase 4)*
 - 🪪 **Self-healing identity** — structured user profile, LLM-managed via Dreaming cycle *(Phase 4)*
-- 🧩 **Wasm skill store** — community-extensible plugins (Rust → Wasm) with sandboxed execution *(Phase 5)*
-- 🏠 **Home Assistant** — smart home control via Wasm skill *(Phase 5)*
+- 🧩 **Wasm skill store** — community-extensible plugins (Rust → Wasm) with sandboxed execution *(Phase 4)*
+- 🏠 **Home Assistant** — smart home control via Wasm skill *(Phase 4)*
+- 📱 **8GB device optimisation** — dynamic weight loading/unloading, E2B fallback *(Phase 5)*
+- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 5)*
 
 ## Roadmap
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <!-- Foreground service for download progress notification -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- Notification permission (required on API 33+; minSdk=35 so always required) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Location permissions for GetWeatherSkill GPS fallback -->
@@ -44,6 +45,15 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+
+        <!-- Foreground service to keep process alive during GPU model init -->
+        <service
+            android:name="com.kernel.ai.core.inference.InferenceLoadingService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
+        <property
+            android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+            android:value="On-device AI model inference loading via LiteRT GPU" />
 
         <!--
             AppAuth redirect receiver — handles com.kernel.ai://oauth/callback (release).

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -2,7 +2,9 @@ package com.kernel.ai
 
 import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.content.ContextCompat
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -33,7 +35,10 @@ class MainActivity : ComponentActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
-        requestLocationPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED) {
+            requestLocationPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
         setContent {
             KernelAITheme {
                 KernelNavHost()

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -24,12 +24,16 @@ class MainActivity : ComponentActivity() {
     private val requestNotificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
 
+    private val requestLocationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
+        requestLocationPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
         setContent {
             KernelAITheme {
                 KernelNavHost()

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -1,11 +1,24 @@
 package com.kernel.ai.navigation
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.ChatBubble
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.kernel.ai.feature.chat.ActionsScreen
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.MemoryScreen
@@ -14,6 +27,7 @@ import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
 
 private const val ROUTE_LIST = "conversation_list"
+private const val ROUTE_ACTIONS = "actions"
 private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
@@ -21,95 +35,141 @@ private const val ROUTE_MEMORY = "settings/memory"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
+/** Routes that show the bottom navigation bar. */
+private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
+
 @Composable
 fun KernelNavHost() {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
 
-    NavHost(
-        navController = navController,
-        startDestination = ROUTE_LIST,
-    ) {
-        composable(ROUTE_LIST) {
-            ConversationListScreen(
-                onOpenConversation = { id ->
-                    navController.navigate("$ROUTE_CHAT/$id")
-                },
-                onNewConversation = {
-                    navController.navigate(ROUTE_CHAT)
-                },
-                onNavigateToSettings = {
-                    navController.navigate(ROUTE_SETTINGS)
-                },
-            )
-        }
+    Scaffold(
+        bottomBar = {
+            if (currentRoute in BOTTOM_NAV_ROUTES) {
+                NavigationBar {
+                    NavigationBarItem(
+                        selected = currentRoute == ROUTE_LIST,
+                        onClick = {
+                            if (currentRoute != ROUTE_LIST) {
+                                navController.navigate(ROUTE_LIST) {
+                                    popUpTo(ROUTE_LIST) { inclusive = true }
+                                    launchSingleTop = true
+                                }
+                            }
+                        },
+                        icon = { Icon(Icons.Default.ChatBubble, contentDescription = null) },
+                        label = { Text("Chats") },
+                    )
+                    NavigationBarItem(
+                        selected = currentRoute == ROUTE_ACTIONS,
+                        onClick = {
+                            if (currentRoute != ROUTE_ACTIONS) {
+                                navController.navigate(ROUTE_ACTIONS) {
+                                    popUpTo(ROUTE_LIST) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                        },
+                        icon = { Icon(Icons.Default.Bolt, contentDescription = null) },
+                        label = { Text("Actions") },
+                    )
+                }
+            }
+        },
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = ROUTE_LIST,
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            composable(ROUTE_LIST) {
+                ConversationListScreen(
+                    onOpenConversation = { id ->
+                        navController.navigate("$ROUTE_CHAT/$id")
+                    },
+                    onNewConversation = {
+                        navController.navigate(ROUTE_CHAT)
+                    },
+                    onNavigateToSettings = {
+                        navController.navigate(ROUTE_SETTINGS)
+                    },
+                )
+            }
 
-        // New conversation (no conversationId arg)
-        composable(ROUTE_CHAT) {
-            ChatScreen(
-                conversationId = null,
-                onBack = { navController.popBackStack() },
-                onNewConversation = {
-                    navController.navigate(ROUTE_CHAT) {
-                        popUpTo(ROUTE_CHAT) { inclusive = true }
-                    }
-                },
-                onNavigateToList = {
-                    navController.navigate(ROUTE_LIST) {
-                        popUpTo(ROUTE_LIST) { inclusive = true }
-                    }
-                },
-            )
-        }
+            composable(ROUTE_ACTIONS) {
+                ActionsScreen()
+            }
 
-        // Existing conversation
-        composable(
-            route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
-            arguments = listOf(navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType }),
-        ) { backStackEntry ->
-            val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
-            ChatScreen(
-                conversationId = conversationId,
-                onBack = { navController.popBackStack() },
-                onNewConversation = {
-                    navController.navigate(ROUTE_CHAT)
-                },
-                onNavigateToList = {
-                    navController.popBackStack()
-                },
-            )
-        }
+            // New conversation (no conversationId arg)
+            composable(ROUTE_CHAT) {
+                ChatScreen(
+                    conversationId = null,
+                    onBack = { navController.popBackStack() },
+                    onNewConversation = {
+                        navController.navigate(ROUTE_CHAT) {
+                            popUpTo(ROUTE_CHAT) { inclusive = true }
+                        }
+                    },
+                    onNavigateToList = {
+                        navController.navigate(ROUTE_LIST) {
+                            popUpTo(ROUTE_LIST) { inclusive = true }
+                        }
+                    },
+                )
+            }
 
-        composable(ROUTE_SETTINGS) {
-            SettingsScreen(
-                onBack = { navController.popBackStack() },
-                onNavigateToUserProfile = {
-                    navController.navigate(ROUTE_USER_PROFILE)
-                },
-                onNavigateToMemory = {
-                    navController.navigate(ROUTE_MEMORY)
-                },
-                onNavigateToModelSettings = {
-                    navController.navigate(ROUTE_MODEL_SETTINGS)
-                },
-            )
-        }
+            // Existing conversation
+            composable(
+                route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
+                arguments = listOf(navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType }),
+            ) { backStackEntry ->
+                val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
+                ChatScreen(
+                    conversationId = conversationId,
+                    onBack = { navController.popBackStack() },
+                    onNewConversation = {
+                        navController.navigate(ROUTE_CHAT)
+                    },
+                    onNavigateToList = {
+                        navController.popBackStack()
+                    },
+                )
+            }
 
-        composable(ROUTE_USER_PROFILE) {
-            UserProfileScreen(
-                onBack = { navController.popBackStack() },
-            )
-        }
+            composable(ROUTE_SETTINGS) {
+                SettingsScreen(
+                    onBack = { navController.popBackStack() },
+                    onNavigateToUserProfile = {
+                        navController.navigate(ROUTE_USER_PROFILE)
+                    },
+                    onNavigateToMemory = {
+                        navController.navigate(ROUTE_MEMORY)
+                    },
+                    onNavigateToModelSettings = {
+                        navController.navigate(ROUTE_MODEL_SETTINGS)
+                    },
+                )
+            }
 
-        composable(ROUTE_MEMORY) {
-            MemoryScreen(
-                onBack = { navController.popBackStack() },
-            )
-        }
+            composable(ROUTE_USER_PROFILE) {
+                UserProfileScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
 
-        composable(ROUTE_MODEL_SETTINGS) {
-            ModelSettingsScreen(
-                onBack = { navController.popBackStack() },
-            )
+            composable(ROUTE_MEMORY) {
+                MemoryScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+
+            composable(ROUTE_MODEL_SETTINGS) {
+                ModelSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.navigation
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
@@ -79,27 +80,32 @@ fun KernelNavHost() {
             }
         },
     ) { innerPadding ->
+        // Only apply bottom nav padding to routes that show the nav bar.
+        // Chat/settings screens handle their own padding via their own Scaffold.
         NavHost(
             navController = navController,
             startDestination = ROUTE_LIST,
-            modifier = Modifier.padding(innerPadding),
         ) {
             composable(ROUTE_LIST) {
-                ConversationListScreen(
-                    onOpenConversation = { id ->
-                        navController.navigate("$ROUTE_CHAT/$id")
-                    },
-                    onNewConversation = {
-                        navController.navigate(ROUTE_CHAT)
-                    },
-                    onNavigateToSettings = {
-                        navController.navigate(ROUTE_SETTINGS)
-                    },
-                )
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    ConversationListScreen(
+                        onOpenConversation = { id ->
+                            navController.navigate("$ROUTE_CHAT/$id")
+                        },
+                        onNewConversation = {
+                            navController.navigate(ROUTE_CHAT)
+                        },
+                        onNavigateToSettings = {
+                            navController.navigate(ROUTE_SETTINGS)
+                        },
+                    )
+                }
             }
 
             composable(ROUTE_ACTIONS) {
-                ActionsScreen()
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    ActionsScreen()
+                }
             }
 
             // New conversation (no conversationId arg)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/FunctionGemmaRouter.kt
@@ -14,6 +14,8 @@ import com.google.ai.edge.litertlm.tool
 import com.kernel.ai.core.inference.hardware.HardwareProfileDetector
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -66,52 +68,51 @@ class FunctionGemmaRouter @Inject constructor(
     private val _isReady = MutableStateFlow(false)
     val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
 
+    /** Prevents concurrent double-init from ChatViewModel + ActionsViewModel. */
+    private val initMutex = Mutex()
+
     /**
-     * Initialises FunctionGemma on [LlmDispatcher].
-     *
-     * Always forces CPU/XNNPACK backend — FunctionGemma-270M is the always-hot router and
-     * must not compete with the main model on GPU/NPU resources.
-     *
-     * Tools are registered via [KernelAIToolSet] through the SDK's native `ToolProvider`
-     * mechanism — the model sees the tool declarations directly with no system-prompt hacking.
-     *
-     * @param functionGemmaPath Absolute path to the `.litertlm` model file on disk.
+     * Initialises FunctionGemma on [LlmDispatcher]. Idempotent — if already ready,
+     * returns immediately without re-loading. Protected by [initMutex] so concurrent
+     * calls from [ActionsViewModel] and [ChatViewModel] serialize safely.
      */
     suspend fun initialize(functionGemmaPath: String) {
-        withContext(LlmDispatcher) {
-            _isReady.value = false
-            // Close any previously-held resources before re-initialising to avoid native memory leaks.
-            try { conversation?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev conv: ${e.message}") }
-            try { engine?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev engine: ${e.message}") }
-            conversation = null
-            engine = null
-            try {
-                Log.i(TAG, "FunctionGemmaRouter: initialising from $functionGemmaPath")
-
-                val engineConfig = EngineConfig(
-                    modelPath = functionGemmaPath,
-                    backend = BackendType.CPU.toBackend(context),
-                    maxNumTokens = MAX_TOKENS,
-                )
-                val eng = Engine(engineConfig)
-                eng.initialize()
-
-                val toolProvider = tool(toolSet)
-                val samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.0)
-                val convConfig = ConversationConfig(
-                    samplerConfig = samplerConfig,
-                    systemInstruction = buildSystemPrompt(),
-                    tools = listOf(toolProvider),
-                )
-                val conv = eng.createConversation(convConfig)
-
-                engine = eng
-                conversation = conv
-                _isReady.value = true
-                Log.i(TAG, "FunctionGemmaRouter: ready (CPU/XNNPACK, maxTokens=$MAX_TOKENS)")
-            } catch (e: Exception) {
-                Log.e(TAG, "FunctionGemmaRouter: initialisation failed — ${e.message}", e)
+        initMutex.withLock {
+            if (_isReady.value) return
+            withContext(LlmDispatcher) {
                 _isReady.value = false
+                try { conversation?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev conv: ${e.message}") }
+                try { engine?.close() } catch (e: Exception) { Log.w(TAG, "FunctionGemmaRouter: close prev engine: ${e.message}") }
+                conversation = null
+                engine = null
+                try {
+                    Log.i(TAG, "FunctionGemmaRouter: initialising from $functionGemmaPath")
+
+                    val engineConfig = EngineConfig(
+                        modelPath = functionGemmaPath,
+                        backend = BackendType.CPU.toBackend(context),
+                        maxNumTokens = MAX_TOKENS,
+                    )
+                    val eng = Engine(engineConfig)
+                    eng.initialize()
+
+                    val toolProvider = tool(toolSet)
+                    val samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.0)
+                    val convConfig = ConversationConfig(
+                        samplerConfig = samplerConfig,
+                        systemInstruction = buildSystemPrompt(),
+                        tools = listOf(toolProvider),
+                    )
+                    val conv = eng.createConversation(convConfig)
+
+                    engine = eng
+                    conversation = conv
+                    _isReady.value = true
+                    Log.i(TAG, "FunctionGemmaRouter: ready (CPU/XNNPACK, maxTokens=$MAX_TOKENS)")
+                } catch (e: Exception) {
+                    Log.e(TAG, "FunctionGemmaRouter: initialisation failed — ${e.message}", e)
+                    _isReady.value = false
+                }
             }
         }
     }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceLoadingService.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceLoadingService.kt
@@ -1,0 +1,80 @@
+package com.kernel.ai.core.inference
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import android.util.Log
+
+/**
+ * Foreground service that keeps the process at high OOM priority during
+ * GPU model initialisation.
+ *
+ * Without this, Samsung's lmkd demotes the app to oom_score_adj 700 (cached)
+ * during the ~20s GPU init, then kills it because of memory watermark pressure
+ * from the 1-3GB GPU allocation.
+ *
+ * Start before [LiteRtInferenceEngine.initialize], stop after it returns.
+ */
+class InferenceLoadingService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        ensureNotificationChannel()
+        val notification = buildNotification()
+        startForeground(
+            NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+        )
+        Log.i(TAG, "Foreground inference service started — process OOM priority elevated")
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(TAG, "Foreground inference service stopped")
+    }
+
+    private fun buildNotification(): Notification =
+        Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle("Loading AI model…")
+            .setContentText("Preparing on-device inference engine")
+            .setSmallIcon(android.R.drawable.ic_popup_sync)
+            .setOngoing(true)
+            .build()
+
+    private fun ensureNotificationChannel() {
+        val nm = getSystemService(NotificationManager::class.java)
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Model Loading",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Shown while the AI model initialises on GPU" }
+        nm.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val TAG = "InferenceLoadingService"
+        private const val CHANNEL_ID = "kernel_inference_loading"
+        private const val NOTIFICATION_ID = 9001
+
+        fun start(context: Context) {
+            context.startForegroundService(
+                Intent(context, InferenceLoadingService::class.java),
+            )
+        }
+
+        fun stop(context: Context) {
+            context.stopService(
+                Intent(context, InferenceLoadingService::class.java),
+            )
+        }
+    }
+}

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -79,12 +79,15 @@ class LiteRtInferenceEngine @Inject constructor(
             val resolvedConfig = if (config.backendType == BackendType.AUTO) {
                 config.copy(
                     backendType = profile.recommendedBackend,
-                    maxTokens = config.maxTokens.coerceAtMost(profile.recommendedMaxTokens),
+                    maxTokens = safeTokenCount(config.maxTokens.coerceAtMost(profile.recommendedMaxTokens)),
                 )
-            } else config
+            } else {
+                config.copy(maxTokens = safeTokenCount(config.maxTokens))
+            }
 
             Log.i(TAG, "Initializing engine — model: ${resolvedConfig.modelPath}, " +
-                "backend: ${resolvedConfig.backendType}, tier: ${profile.tier}")
+                "backend: ${resolvedConfig.backendType}, tier: ${profile.tier}, " +
+                "maxTokens: ${resolvedConfig.maxTokens} (requested: ${config.maxTokens})")
 
             // Sanity-check quantization before spending 10-30s initializing.
             QuantizationVerifier.verify(
@@ -92,14 +95,22 @@ class LiteRtInferenceEngine @Inject constructor(
                 expectedBytes = estimateExpectedBytes(resolvedConfig.modelPath),
             )
 
-            val (eng, backendType) = createEngineWithFallback(resolvedConfig)
-            engine = eng
-            conversation = eng.createConversation(buildConversationConfig(backendType, resolvedConfig))
-            currentConfig = resolvedConfig
-            _activeBackend.value = backendType
-            _isReady.value = true
+            // Start foreground service to keep process at high OOM priority during
+            // the ~20s GPU model load. Without this Samsung lmkd demotes the process
+            // to oom_score_adj 700 (cached) and kills it for memory watermark reasons.
+            InferenceLoadingService.start(context)
+            try {
+                val (eng, backendType) = createEngineWithFallback(resolvedConfig)
+                engine = eng
+                conversation = eng.createConversation(buildConversationConfig(backendType, resolvedConfig))
+                currentConfig = resolvedConfig
+                _activeBackend.value = backendType
+                _isReady.value = true
 
-            Log.i(TAG, "Engine ready — backend: $backendType, maxTokens: ${resolvedConfig.maxTokens}")
+                Log.i(TAG, "Engine ready — backend: $backendType, maxTokens: ${resolvedConfig.maxTokens}")
+            } finally {
+                InferenceLoadingService.stop(context)
+            }
         }
     }
 
@@ -294,6 +305,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     modelPath = config.modelPath,
                     backend = backendType.toBackend(context),
                     maxNumTokens = config.maxTokens,
+                    cacheDir = context.cacheDir.absolutePath,
                 )
                 val eng = Engine(engineConfig)
                 eng.initialize()
@@ -348,5 +360,24 @@ class LiteRtInferenceEngine @Inject constructor(
         return com.kernel.ai.core.inference.download.KernelModel.entries
             .firstOrNull { it.fileName == fileName }
             ?.approxSizeBytes ?: 0L
+    }
+
+    companion object {
+        /**
+         * Avoids exact powers-of-2 token counts that trigger a buffer-alignment bug
+         * in LiteRT's GPU `reshape::Eval` operation (observed on Adreno 740 / SM8550).
+         * Nudges e.g. 4096→4000, 8192→8000 while leaving non-power-of-2 values untouched.
+         */
+        internal fun safeTokenCount(tokens: Int): Int {
+            if (tokens <= 0) return tokens
+            // Check if tokens is an exact power of 2
+            if (tokens and (tokens - 1) == 0) {
+                val safe = (tokens * 125) / 128  // ~97.6% — e.g. 4096→4000, 8192→8000
+                Log.w("LiteRtInferenceEngine",
+                    "Adjusted maxTokens from $tokens to $safe (avoid GPU reshape alignment bug)")
+                return safe
+            }
+            return tokens
+        }
     }
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -11,7 +11,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "Keep responses short unless asked for detail."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
-const val DEFAULT_MAX_TOKENS = 8192
+const val DEFAULT_MAX_TOKENS = 8000
 
 /** Sampler defaults for CPU/GPU backends. NPU requires null samplerConfig. */
 val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature = 0.7)

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -38,7 +38,8 @@ enum class KernelModel(
         isRequired = true,
         /** Suitable for all hardware tiers. */
         preferredForTier = null,
-        isGated = true,
+        // Ungated since Apr 2026 — no auth token required.
+        isGated = false,
     ),
 
     /**
@@ -52,7 +53,8 @@ enum class KernelModel(
         approxSizeBytes = 3_654_467_584L, // 3.4 GB
         isRequired = false,
         preferredForTier = HardwareTier.FLAGSHIP,
-        isGated = true,
+        // Ungated since Apr 2026 — no auth token required.
+        isGated = false,
     ),
 
     FUNCTION_GEMMA_270M(

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/hardware/HardwareProfileDetector.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/hardware/HardwareProfileDetector.kt
@@ -49,9 +49,9 @@ class HardwareProfileDetector @Inject constructor(
         }
 
         val recommendedMaxTokens = when (tier) {
-            HardwareTier.FLAGSHIP -> 8192
-            HardwareTier.MID_RANGE -> 2048
-            HardwareTier.LOW_POWER -> 1024
+            HardwareTier.FLAGSHIP -> 4000
+            HardwareTier.MID_RANGE -> 2000
+            HardwareTier.LOW_POWER -> 1000
         }
 
         val profile = HardwareProfile(

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/8.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/8.json
@@ -1,0 +1,441 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "d6407bcb752d021e2c19042ed90c00df",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd6407bcb752d021e2c19042ed90c00df')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
+import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
@@ -18,6 +19,7 @@ import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
 import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
 import com.kernel.ai.core.memory.entity.MessageEntity
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+import com.kernel.ai.core.memory.entity.QuickActionEntity
 import com.kernel.ai.core.memory.entity.UserProfileEntity
 
 @Database(
@@ -29,8 +31,9 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         EpisodicMemoryEntity::class,
         CoreMemoryEntity::class,
         ModelSettingsEntity::class,
+        QuickActionEntity::class,
     ],
-    version = 7,
+    version = 8,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -44,6 +47,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun episodicMemoryDao(): EpisodicMemoryDao
     abstract fun coreMemoryDao(): CoreMemoryDao
     abstract fun modelSettingsDao(): ModelSettingsDao
+    abstract fun quickActionDao(): QuickActionDao
 
     companion object {
         /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
@@ -76,6 +80,24 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_6_7 = object : Migration(6, 7) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE messages ADD COLUMN toolCallJson TEXT DEFAULT NULL")
+            }
+        }
+
+        /** Creates quick_actions table for FunctionGemma action history (#actions). */
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS quick_actions (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        userQuery TEXT NOT NULL,
+                        skillName TEXT DEFAULT NULL,
+                        resultText TEXT NOT NULL,
+                        isSuccess INTEGER NOT NULL,
+                        timestamp INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -8,6 +8,7 @@ import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
+import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.MemoryRepositoryImpl
@@ -45,7 +46,12 @@ abstract class MemoryModule {
         @Singleton
         fun provideKernelDatabase(@ApplicationContext context: Context): KernelDatabase =
             Room.databaseBuilder(context, KernelDatabase::class.java, "kernel_db")
-                .addMigrations(KernelDatabase.MIGRATION_4_5, KernelDatabase.MIGRATION_5_6, KernelDatabase.MIGRATION_6_7)
+                .addMigrations(
+                    KernelDatabase.MIGRATION_4_5,
+                    KernelDatabase.MIGRATION_5_6,
+                    KernelDatabase.MIGRATION_6_7,
+                    KernelDatabase.MIGRATION_7_8,
+                )
                 .build()
 
         @Provides
@@ -68,5 +74,8 @@ abstract class MemoryModule {
 
         @Provides
         fun provideModelSettingsDao(db: KernelDatabase): ModelSettingsDao = db.modelSettingsDao()
+
+        @Provides
+        fun provideQuickActionDao(db: KernelDatabase): QuickActionDao = db.quickActionDao()
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/QuickActionDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/QuickActionDao.kt
@@ -1,0 +1,24 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.QuickActionEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface QuickActionDao {
+
+    @Query("SELECT * FROM quick_actions ORDER BY timestamp DESC")
+    fun observeAll(): Flow<List<QuickActionEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(action: QuickActionEntity)
+
+    @Query("DELETE FROM quick_actions WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM quick_actions")
+    suspend fun deleteAll()
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/QuickActionEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/QuickActionEntity.kt
@@ -1,0 +1,24 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+/**
+ * Persists the history of quick-action commands executed via FunctionGemma.
+ *
+ * Each row represents a single user query → FunctionGemma inference → tool execution cycle.
+ */
+@Entity(tableName = "quick_actions")
+data class QuickActionEntity(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    /** The raw text the user typed (e.g. "turn on flashlight"). */
+    val userQuery: String,
+    /** Name of the skill/tool that was invoked, if any. Null when no tool was triggered. */
+    val skillName: String? = null,
+    /** The final response shown to the user. */
+    val resultText: String,
+    /** Whether the action completed successfully. */
+    val isSuccess: Boolean,
+    val timestamp: Long = System.currentTimeMillis(),
+)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,15 +158,24 @@ User Input (voice/text)
 | Quick Actions tab UI (#221) | ✅ Done | History list, FAB (⚡), bottom sheet input, Room persistence |
 | Bottom nav bar (Chats / Actions) | ✅ Done | PR #221 |
 
-### Resident Agent — Tier 3: E4B Native Tool Calling
+### 🔥 TOP PRIORITY — Resident Agent — Tier 3: E4B Baseline Skills + Rich UI ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222))
 
 | Task | Status | Notes |
 |------|--------|-------|
 | E4B native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ✅ Done | `tryExecuteToolCall()` + `SkillExecutor` pipeline; tool schemas injected via `buildSystemPrompt()` |
 | Tool system prompt injection | ✅ Done | `SkillRegistry.buildFunctionDeclarationsJson()` injected into system prompt at init and on every model reload |
-| GetSystemInfo native skill ([#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86)) | ✅ Done | Runtime device/model/backend info via callable skill |
-| Weather skill — Open-Meteo + GPS | ✅ Done | GPS (`current`) or city geocoding → Open-Meteo API; no API key required; falls back to named city gracefully |
-| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⚠️ Partial | Skill class exists; Room persistence wiring incomplete |
+| `get_system_info` skill | ✅ Done | Runtime device/model/backend info |
+| `get_weather` skill — Open-Meteo + GPS | ✅ Done | GPS or city geocoding → Open-Meteo; no API key; confirmed working |
+| `save_memory` skill | ✅ Done | Persists to `MemoryRepository.addCoreMemory`; confirmed working |
+| **Rich tool result UI** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Replace 🔧 debug chip with weather card, confirmation chips, list cards per skill type |
+| **Weather card + GPS display name fix** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Reverse-geocode GPS coords → suburb/city name; WMO emoji; visual card |
+| **`set_timer` / `set_alarm`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Wire to `AlarmClock.ACTION_SET_TIMER` / `ACTION_SET_ALARM` |
+| **`set_flashlight`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | `CameraManager.setTorchMode()` |
+| **`set_do_not_disturb`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | `NotificationManager.setInterruptionFilter()` |
+| **`send_email` / `send_sms` / `create_contact`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Intent-based dispatch |
+| **`create_calendar_event` / `show_map_location`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Intent-based dispatch |
+| **`add_to_shopping_list`** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Room-backed local list with list card UI |
+| **WiFi / Bluetooth / Airplane / Hotspot toggles** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Settings intent fallbacks where direct API removed |
 | Gated model download handling ([#38](https://github.com/NickMonrad/kernel-ai-assistant/issues/38)) | ⬜ Pending | HuggingFace token flow |
 
 ### Memory & Distillation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -162,11 +162,11 @@ User Input (voice/text)
 
 | Task | Status | Notes |
 |------|--------|-------|
-| E4B native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ⬜ Pending | `tryExecuteToolCall()` + `SkillExecutor` pipeline exists — needs system prompt engineering |
-| Tool system prompt injection | ⬜ Pending | Inject `SkillRegistry` schemas into system prompt so E4B knows available tools |
+| E4B native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ✅ Done | `tryExecuteToolCall()` + `SkillExecutor` pipeline; tool schemas injected via `buildSystemPrompt()` |
+| Tool system prompt injection | ✅ Done | `SkillRegistry.buildFunctionDeclarationsJson()` injected into system prompt at init and on every model reload |
 | GetSystemInfo native skill ([#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86)) | ✅ Done | Runtime device/model/backend info via callable skill |
-| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⬜ Pending | Agent-initiated memory persistence |
-| Weather skill (location + API) | ⬜ Pending | Location permission done (#221); needs real weather API |
+| Weather skill — Open-Meteo + GPS | ✅ Done | GPS (`current`) or city geocoding → Open-Meteo API; no API key required; falls back to named city gracefully |
+| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⚠️ Partial | Skill class exists; Room persistence wiring incomplete |
 | Gated model download handling ([#38](https://github.com/NickMonrad/kernel-ai-assistant/issues/38)) | ⬜ Pending | HuggingFace token flow |
 
 ### Memory & Distillation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kernel AI Assistant — Roadmap
 
-> **Last updated:** 2026-04-11
+> **Last updated:** 2026-04-13
 >
 > This is the living roadmap for Kernel AI. It tracks what's been built, what's next,
 > and what's planned. If you have ideas, [open an issue](https://github.com/NickMonrad/kernel-ai-assistant/issues/new)
@@ -20,7 +20,8 @@
 | **Inference** | LiteRT + LiteRT-LM |
 | **Chat model** | Gemma-4 E-4B / E-2B |
 | **Embeddings** | EmbeddingGemma-300M (SentencePiece + TFLite) |
-| **Intent router** | FunctionGemma-270M-FT-Mobile-Actions |
+| **Intent router (simple)** | `QuickIntentRouter` (Kotlin regex, zero memory, <5ms) |
+| **Intent router (complex)** | Gemma-4 native JSON tool-call format |
 | **Vector search** | sqlite-vec 0.1.9 via bundled SQLite 3.49.2 |
 | **Wasm runtime** | Chicory (pure JVM) |
 | **Test device** | Samsung Galaxy S23 Ultra (SD 8 Gen 2, 12GB RAM) |
@@ -39,10 +40,13 @@ Working chat app with Gemma-4 running entirely on-device.
 | Chat UI (streaming tokens, thinking mode, conversations) | ✅ Done | #7, #8 |
 | Hardware tier detection (Flagship/Mid/Compat) | ✅ Done | #8 |
 | ADB device testing on S23 Ultra | ✅ Done | — |
+| GPU alignment guard (`safeTokenCount`) — avoids LiteRT reshape::Eval bug at powers-of-2 token counts | ✅ Done | #221 |
+| GPU kernel cache (serialized OpenCL kernels) | ✅ Done | #221 |
+| Foreground service OOM protection during GPU init | ✅ Done | #221 |
 
 ---
 
-## Phase 2: Local Semantic Memory (RAG) 🔄 In Progress
+## Phase 2: Local Semantic Memory (RAG) ✅ Complete
 
 The assistant remembers facts across sessions using on-device vector search, with a
 tri-tiered memory architecture inspired by the
@@ -101,65 +105,94 @@ tri-tiered memory architecture inspired by the
 
 ---
 
-## Phase 3: Brand + FunctionGemma Intent Router + Native Skills
+## Phase 3: Resident Agent Architecture + Native Skills 🔄 In Progress
 
-Brand refresh to Jandal AI, FunctionGemma for fast intent routing, native skills, and voice.
+> **Architecture pivot (Apr 2026):** FunctionGemma-270M has been deprecated from the
+> startup sequence. Its 289MB footprint causes lmkd to terminate the process during
+> Gemma-4's GPU kernel compilation peak (~4–5GB transient). After exhaustive testing (#219),
+> the architecture was redesigned to a three-tier **Resident Agent** pattern (#220).
 
-| Task | Status | Notes |
-|------|--------|-------|
-| Brand pass: Jandal AI ([#21](https://github.com/NickMonrad/kernel-ai-assistant/issues/21)) | ⬜ Pending | App name, package rename `com.kernel.ai` → `com.jandal.ai`, Kiwi persona, Fern Green palette |
-| Fun loading screens v2 ([#96](https://github.com/NickMonrad/kernel-ai-assistant/issues/96)) | ⬜ Pending | Dark AMOLED background, bigger text, per-phase icons, expanded Kiwi-themed messages — bundle with brand pass |
-| Gated model download handling ([#38](https://github.com/NickMonrad/kernel-ai-assistant/issues/38)) | ⬜ Pending | HuggingFace token flow, graceful error for 401/403 gated models |
-| Review UI patterns ([#71](https://github.com/NickMonrad/kernel-ai-assistant/issues/71)) | ⬜ Pending | Audit and refine UI patterns across the app |
-| Copy chat content ([#78](https://github.com/NickMonrad/kernel-ai-assistant/issues/78)) | ⬜ Pending | Copy individual messages or entire conversations |
-| Live mode ([#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64)) | ⬜ Pending | Real-time streaming / continuous interaction mode |
-| Episodic memory distillation ([#165](https://github.com/NickMonrad/kernel-ai-assistant/issues/165)) | ⬜ Pending | Gemma-4 distils each conversation into 3–5 episodic memory sentences on conversation close. Populates `episodic_memories_vec`. No WorkManager needed — triggered inline. |
-| Message embedding stats in Memory screen ([#164](https://github.com/NickMonrad/kernel-ai-assistant/issues/164)) | ⬜ Pending | Show indexed message count and conversation count in Memory screen so RAG activity is visible during testing. |
-| Fix: message_embeddings_vec orphan cleanup on conversation delete ([#163](https://github.com/NickMonrad/kernel-ai-assistant/issues/163)) | ⬜ Pending | Clean up vec entries when conversation deleted. |
-
-### Phase 3 continued: FunctionGemma Intent Router + Native Skills
-
-FunctionGemma routes user intents to native Android actions without loading the large model.
-
-| Task | Status | Notes |
-|------|--------|-------|
-| FunctionGemma integration | ⬜ Pending | Pre-fine-tuned LiteRT model, ~154 tk/s on CPU |
-| Gemma 4 native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ⬜ Pending | Leverage Gemma 4's built-in function calling instead of separate FunctionGemma |
-| GetSystemInfo native skill ([#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86)) | ⬜ Pending | Runtime device/model/backend info via callable skill, replaces static `[Runtime]` block |
-| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⬜ Pending | Agent-initiated `addEpisodicMemory()` / `addCoreMemory()` — model decides what to remember |
-| Skill registry + JSON schema generation | ⬜ Pending | Uses LiteRT-LM's `@Tool`/`@ToolParam` annotations |
-| Native skills (8+ Kotlin skills) | ⬜ Pending | Flashlight, DND, Bluetooth, Alarms, SMS, Notes, Media |
-| Model cascade orchestrator | ⬜ Pending | FunctionGemma → skill exec OR escalate to Gemma-4 |
-| Model settings UI ([#46](https://github.com/NickMonrad/kernel-ai-assistant/issues/46)) | ⬜ Pending | Full model management UI (download, delete, info) |
-| Permission handling | ⬜ Pending | Per-skill runtime permissions with graceful degradation |
-
-### Phase 3: Voice Interface
-
-| Task | Status | Notes |
-|------|--------|-------|
-| Voice input/output | ⬜ Pending | Android `SpeechRecognizer` + `TextToSpeech` |
-| "Hey Jandal" wake word ([#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65)) | ⬜ Pending | Always-listening wake word trigger |
-
-### Model Cascade Architecture
+### Three-Tier Intent Architecture
 
 ```
 User Input (voice/text)
     │
     ▼
-┌─────────────────────────┐
-│  FunctionGemma-270M-IT  │  ← Always loaded (~135MB), near-instant
-│  "Intent Router"        │
-└────────┬────────────────┘
+┌─────────────────────────────┐
+│  Tier 1: Wake Word          │  ← Always-on, ~0MB (future: Picovoice Porcupine)
+│  "Hey Jandal"               │
+└────────┬────────────────────┘
          │
-    ┌────┴─────────────────────────────┐
-    │                                  │
-    ▼ (high confidence)                ▼ (low confidence / complex)
-┌──────────────┐              ┌──────────────────────┐
-│ Native Skill │              │ Gemma-4 E-4B/E-2B    │
-│ or Wasm Skill│              │ + RAG memory context  │
-│ (direct exec)│              └──────────────────────┘
-└──────────────┘
+         ▼
+┌─────────────────────────────┐
+│  Tier 2: QuickIntentRouter  │  ← Pure Kotlin regex, ~0MB, <5ms
+│  Torch / Timer / DND /      │    Deterministic matching for ~8 simple actions
+│  Bluetooth / WiFi / Time /  │    No ML model, no GPU, instantly available
+│  Battery / Alarm            │
+└────────┬────────────────────┘
+         │ no match
+         ▼
+┌─────────────────────────────┐
+│  Tier 3: Gemma-4 E-4B/E-2B │  ← Resident on GPU, TTFT ~2.3s
+│  Native tool calling        │    Complex NLU: weather, calendar, email,
+│  + RAG memory context       │    multi-step reasoning, conversation
+└─────────────────────────────┘
 ```
+
+### Brand & Polish
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Brand pass: Jandal AI ([#21](https://github.com/NickMonrad/kernel-ai-assistant/issues/21)) | ⬜ Pending | App name, Kiwi persona, Fern Green palette |
+| Fun loading screens v2 ([#96](https://github.com/NickMonrad/kernel-ai-assistant/issues/96)) | ⬜ Pending | Dark AMOLED background, bigger text, per-phase icons |
+| Review UI patterns ([#71](https://github.com/NickMonrad/kernel-ai-assistant/issues/71)) | ⬜ Pending | Audit and refine UI patterns across the app |
+| Copy chat content ([#78](https://github.com/NickMonrad/kernel-ai-assistant/issues/78)) | ⬜ Pending | Copy individual messages or entire conversations |
+
+### Resident Agent — Tier 2: QuickIntentRouter
+
+| Task | Status | Notes |
+|------|--------|-------|
+| `QuickIntentRouter` — Kotlin regex matcher | ⬜ Pending | Zero memory, <5ms, deterministic. Replaces FunctionGemma for simple actions |
+| Wire real OS actions in `KernelAIToolSet` | ⬜ Pending | `setTimer` → `AlarmClock.ACTION_SET_TIMER` + `EXTRA_SKIP_UI`; battery → `BatteryManager`; DND → `NotificationManager` |
+| Refactor Actions tab to use `QuickIntentRouter` | ⬜ Pending | Remove `FunctionGemmaRouter` dependency from `ActionsViewModel` |
+| Quick Actions tab UI (#221) | ✅ Done | History list, FAB (⚡), bottom sheet input, Room persistence |
+| Bottom nav bar (Chats / Actions) | ✅ Done | PR #221 |
+
+### Resident Agent — Tier 3: E4B Native Tool Calling
+
+| Task | Status | Notes |
+|------|--------|-------|
+| E4B native tool calling ([#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84)) | ⬜ Pending | `tryExecuteToolCall()` + `SkillExecutor` pipeline exists — needs system prompt engineering |
+| Tool system prompt injection | ⬜ Pending | Inject `SkillRegistry` schemas into system prompt so E4B knows available tools |
+| GetSystemInfo native skill ([#86](https://github.com/NickMonrad/kernel-ai-assistant/issues/86)) | ✅ Done | Runtime device/model/backend info via callable skill |
+| SaveMemory native skill ([#103](https://github.com/NickMonrad/kernel-ai-assistant/issues/103)) | ⬜ Pending | Agent-initiated memory persistence |
+| Weather skill (location + API) | ⬜ Pending | Location permission done (#221); needs real weather API |
+| Gated model download handling ([#38](https://github.com/NickMonrad/kernel-ai-assistant/issues/38)) | ⬜ Pending | HuggingFace token flow |
+
+### Memory & Distillation
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Episodic memory distillation ([#165](https://github.com/NickMonrad/kernel-ai-assistant/issues/165)) | ✅ Done | Gemma-4 distils conversations into episodic memories on close |
+| Fix: message_embeddings_vec orphan cleanup ([#163](https://github.com/NickMonrad/kernel-ai-assistant/issues/163)) | ⬜ Pending | Clean up vec entries when conversation deleted |
+| Message embedding stats in Memory screen ([#164](https://github.com/NickMonrad/kernel-ai-assistant/issues/164)) | ⬜ Pending | Show indexed message / conversation count |
+| Bulk delete core memories ([#110](https://github.com/NickMonrad/kernel-ai-assistant/issues/110)) | ⬜ Pending | Multi-select + delete in Memory screen |
+
+### Voice Interface
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Voice input (push-to-talk) | ⬜ Pending | Android `SpeechRecognizer` + `TextToSpeech` |
+| Live mode ([#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64)) | ⬜ Pending | Real-time streaming / continuous interaction mode |
+| "Hey Jandal" wake word ([#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65)) | ⬜ Pending | Always-on local detection (Picovoice Porcupine) → `QuickIntentRouter` → E4B |
+
+### Known Issues / Decisions
+
+| Issue | Description |
+|-------|-------------|
+| [#218](https://github.com/NickMonrad/kernel-ai-assistant/issues/218) | FunctionGemma limited scope — only ~6 actions, parameter extraction unreliable |
+| [#219](https://github.com/NickMonrad/kernel-ai-assistant/issues/219) | FG + E4B cannot coexist during GPU init — 289MB causes lmkd OOM |
+| [#220](https://github.com/NickMonrad/kernel-ai-assistant/issues/220) | Resident Agent Architecture — approved design |
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -193,14 +193,14 @@ interface Skill {
 
 | Skill name | Description | Status |
 |------------|-------------|--------|
-| `get_weather` | Current weather for a location | ⚠️ Placeholder (needs weather API) |
+| `get_weather` | Current weather via Open-Meteo (free, no API key). Uses device GPS (`current`) or geocodes a city name. Returns temp, feels-like, humidity, wind speed, precipitation chance. | ✅ Wired |
 | `get_system_info` | Device/model/backend/battery stats | ✅ Wired |
 | `save_memory` | Persist a note/fact to Room | ⚠️ Partial |
 | `set_timer` | Set a countdown timer | ⚠️ Needs AlarmManager wire-up |
 | `run_intent` | OS intent dispatch (SET_ALARM, SEND_EMAIL, etc.) | ✅ Wired |
 
-Tool definitions are injected into the system prompt so Gemma-4 knows available tools and
-expected output format.
+Tool definitions (name, description, parameter schema) are injected into the system prompt via
+`SkillRegistry.buildFunctionDeclarationsJson()` so Gemma-4 knows available tools and expected output format.
 
 ### 4.3 Extensible Skills (WebAssembly)
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,0 +1,290 @@
+# Technical Specification: Jandal AI — Local-First Android AI Assistant
+
+> **Last updated:** 2026-04-13
+>
+> This is the authoritative technical specification for Jandal AI. For feature status and
+> delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
+
+---
+
+## 1. Executive Summary
+
+Jandal AI is a privacy-centric, on-device mobile assistant for Android. All inference runs
+entirely on-device via Google AI Edge (LiteRT) — no cloud APIs, no telemetry, no data
+leaving the device. The system uses a **Resident Agent Architecture** with three tiers of
+intent routing, a local RAG memory pipeline, and a modular skill framework for extensibility.
+
+**Design principles:**
+- Local-first: all inference, memory, and skill execution on-device
+- Resident model: Gemma-4 stays loaded on GPU — no cold-start per query
+- Deterministic fast path: simple device actions handled by regex (<5ms), not ML
+- Context-window managed: recursive summarisation, never truncate history
+- Security-first: explicit intents only, Wasm sandboxing, no prompt-injection exfiltration
+
+---
+
+## 2. System Architecture
+
+The assistant is built on a **Brain–Memory–Action** triad, orchestrated centrally in Kotlin.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     User Input (text/voice)               │
+└────────────────────────────┬─────────────────────────────┘
+                             │
+                    ┌────────▼────────┐
+                    │  Tier 1          │  Wake word (future: Picovoice Porcupine)
+                    │  "Hey Jandal"   │  Always-on, ~0MB, triggers Tier 2
+                    └────────┬────────┘
+                             │
+                    ┌────────▼────────┐
+                    │  Tier 2          │  QuickIntentRouter (Kotlin regex)
+                    │  Fast Actions   │  ~0MB, <5ms — torch, timer, alarm,
+                    │                 │  DND, bluetooth, wifi, time, battery
+                    └────────┬────────┘
+                             │ no match
+                    ┌────────▼────────┐
+                    │  Tier 3          │  Gemma-4 E-4B / E-2B on GPU
+                    │  Deep Reasoning │  RAG context + native tool calling
+                    │                 │  TTFT ~2.3s, resident in memory
+                    └─────────────────┘
+```
+
+### 2.1 Module Structure
+
+```
+:app                  Entry point, Hilt DI, navigation, splash screen
+:core:inference       LiteRtInferenceEngine, ModelConfig, LlmDispatcher, hardware tier detection
+:core:memory          sqlite-vec JNI bridge, EmbeddingGemma, RAG pipeline, Room entities
+:core:skills          SkillRegistry, SkillExecutor, QuickIntentRouter, native Kotlin skills
+:core:wasm            Chicory Wasm host runtime, bridge functions, resource limiting
+:core:ui              Shared Compose components, Material 3 theme
+:feature:chat         ChatScreen, ChatViewModel, ActionsScreen, ActionsViewModel
+:feature:settings     Memory management, model settings, persona config
+:feature:onboarding   First-launch model download flow
+```
+
+### 2.2 Model Inventory
+
+| Model | Role | Size | Backend | Loading |
+|-------|------|------|---------|---------|
+| Gemma-4 E-4B | Reasoning, tool calling | ~3.4GB | GPU (OpenCL) | Eager at startup |
+| Gemma-4 E-2B | Reasoning (8GB devices) | ~1.5GB | GPU (OpenCL) | Eager at startup |
+| EmbeddingGemma-300M | Semantic embeddings (768-dim) | <200MB | CPU | Lazy on first RAG query |
+
+> **FunctionGemma-270M deprecated (Apr 2026):** Its 289MB footprint causes lmkd to
+> terminate the process during Gemma-4's GPU kernel compilation peak (~4–5GB transient).
+> After testing 5 loading strategies (#219), simple device actions were migrated to a
+> zero-memory `QuickIntentRouter`; complex tool calls use Gemma-4 natively (#218, #219, #220).
+
+### 2.3 Hardware Tiering
+
+| Component | Performance Tier (12GB+ RAM) | Compatibility Tier (8GB RAM) |
+|-----------|------------------------------|------------------------------|
+| Reasoning | Gemma-4 E-4B | Gemma-4 E-2B |
+| Embeddings | EmbeddingGemma-300M (768-dim) | EmbeddingGemma-300M (256-dim Matryoshka) |
+| GPU backend | OpenCL (Adreno 740) | OpenCL |
+| Context window | 4,000 tokens | 2,000 tokens |
+| RAM (resident) | ~3.4GB (E4B) + ~200MB (EG) | ~1.5GB (E2B) + ~200MB (EG) |
+
+> **Token alignment guard:** Exact powers of 2 (4096, 8192) are avoided for `maxNumTokens`.
+> `safeTokenCount()` nudges values down by ~2.4% (e.g. 4096→4000) to prevent a LiteRT GPU
+> `reshape::Eval` buffer-alignment bug on Adreno GPUs.
+
+### 2.4 LlmDispatcher
+
+All LiteRT operations run on a single-threaded `LlmDispatcher` (`Executors.newSingleThreadExecutor`,
+thread name `llm-inference`). This prevents concurrent native API calls on the non-thread-safe
+LiteRT engine. All coroutines doing inference use `withContext(LlmDispatcher)`.
+
+### 2.5 GPU OOM Protection
+
+`InferenceLoadingService` is a foreground service (`FOREGROUND_SERVICE_TYPE_SPECIAL_USE`) that
+starts during Gemma-4 GPU initialisation (~20s). It keeps `oom_score_adj` at 0, preventing
+Samsung lmkd from demoting the process to cached (adj ~700) during the GPU kernel compilation
+peak. The service stops automatically once `InferenceEngine.isReady` becomes true.
+
+---
+
+## 3. Memory Architecture
+
+### 3.1 Short-Term (Session) Memory
+
+- **Implementation:** LiteRT-LM KV Cache
+- **Window:** 4,000 tokens (Performance) / 2,000 tokens (Compatibility)
+- **Proactive reset:** At ~75% capacity, `ChatViewModel` injects history-aware system prompt
+  and resets the conversation, preserving selected turns
+- **Token estimation:** `ContextWindowManager.estimateTokens()` (~4 chars/token heuristic)
+
+### 3.2 Prompt Assembly Order
+
+```
+[System Prompt]          ← persona, date/time, runtime info
+[User Profile]           ← always injected (structured identity fields)
+[Core Memories]          ← retrieved by RAG (CORE_MAX_DISTANCE=0.55, topK=10)
+[Episodic Memories]      ← retrieved by RAG (top 3–5 by cosine similarity)
+[Conversation Window]    ← selected recent turns (75% token budget)
+[Current User Message]   ← with RAG context prepended
+```
+
+### 3.3 Long-Term (Semantic) Memory
+
+- **Vector store:** sqlite-vec (compiled via NDK for arm64-v8a), bundled as `libkernelvec.so`
+- **Embedding model:** EmbeddingGemma-300M — 768-dim vectors (256-dim on 8GB via Matryoshka)
+- **Two vec0 tables:** `episodic_memories_vec` (conversation summaries) and `core_memories_vec` (permanent facts)
+- **Retrieval:** `vec_distance_cosine()` similarity search per query; top results injected into prompt
+- **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
+
+### 3.4 Episodic Distillation
+
+On conversation close, `EpisodicDistillationUseCase` uses Gemma-4 to summarise the conversation
+into 3–5 episodic memory sentences, stored in `episodic_memories_vec`. This runs fire-and-forget
+on `Dispatchers.IO` from `ChatViewModel.onCleared()`.
+
+---
+
+## 4. Skill & Tool Framework
+
+### 4.1 Tier 2: QuickIntentRouter
+
+A pure-Kotlin regex/keyword matcher with zero ML overhead. Deterministically maps user input
+to one of ~8 supported device actions. Executes the matched action directly via Android OS APIs.
+
+| Pattern | Action | OS API |
+|---------|--------|--------|
+| "turn on/off torch/flashlight" | Torch toggle | `CameraManager.setTorchMode()` |
+| "set a timer for X minutes" | Timer | `AlarmClock.ACTION_SET_TIMER` + `EXTRA_SKIP_UI` |
+| "set an alarm for X:XX" | Alarm | `AlarmClock.ACTION_SET_ALARM` |
+| "turn on/off do not disturb/dnd" | DND | `NotificationManager.setInterruptionFilter()` |
+| "turn on/off bluetooth" | Bluetooth | `BluetoothAdapter.enable()/disable()` |
+| "turn on/off wifi" | Wi-Fi | `WifiManager.setWifiEnabled()` |
+| "what time is it / what's the date" | Time/Date | `LocalDateTime.now()` |
+| "battery level / how much battery" | Battery | `BatteryManager.getIntProperty()` |
+
+If no pattern matches → query falls through to Tier 3 (Gemma-4).
+
+**Design constraints:**
+- No ML model loaded — available at ~0ms from app start
+- Deterministic: same input always produces same result
+- Testable: pure function, no Android dependencies in unit tests (via interface)
+
+### 4.2 Tier 3: E4B Native Tool Calling
+
+Gemma-4 emits JSON function-call blocks when it determines a tool should be used:
+```json
+{"name": "get_weather", "arguments": {"location": "Auckland"}}
+```
+
+`ChatViewModel.tryExecuteToolCall()` detects this pattern in the model's output, hands it to
+`SkillExecutor`, which parses the JSON, looks up the skill in `SkillRegistry`, validates required
+parameters, and calls `Skill.execute(call)`.
+
+**Skill interface:**
+```kotlin
+interface Skill {
+    val name: String
+    val description: String
+    val schema: SkillSchema       // JSON Schema for parameter validation
+    suspend fun execute(call: SkillCall): SkillResult
+}
+```
+
+**Registered skills:**
+
+| Skill name | Description | Status |
+|------------|-------------|--------|
+| `get_weather` | Current weather for a location | ⚠️ Placeholder (needs weather API) |
+| `get_system_info` | Device/model/backend/battery stats | ✅ Wired |
+| `save_memory` | Persist a note/fact to Room | ⚠️ Partial |
+| `set_timer` | Set a countdown timer | ⚠️ Needs AlarmManager wire-up |
+| `run_intent` | OS intent dispatch (SET_ALARM, SEND_EMAIL, etc.) | ✅ Wired |
+
+Tool definitions are injected into the system prompt so Gemma-4 knows available tools and
+expected output format.
+
+### 4.3 Extensible Skills (WebAssembly)
+
+Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime, v1.0+).
+
+- **Sandboxing:** Wasm modules have no direct OS access; all capabilities via explicit Kotlin bridge functions
+- **Resource limits:** 5s wall-clock timeout (coroutine), 16MB memory cap, 1MB output limit
+- **Authoring:** Rust → Wasm via `wasm-pack` / `cargo-component`
+- **Network:** Domain-scoped bridge functions only (e.g. `fetchHomeAssistant(path)` with URL allowlist) — never a generic `fetch()`
+- **Sideloading:** Import section audit + mandatory "Accept Risk" dialog for unsigned skills
+
+---
+
+## 5. Security & Trust Model
+
+| Area | Requirement |
+|------|-------------|
+| **Intents** | Explicit intents only — never implicit intents for SMS, email, etc. |
+| **Wasm sandboxing** | Non-negotiable: no direct OS capabilities in Wasm modules |
+| **Network in Wasm** | Domain-scoped bridge functions with URL allowlist validation |
+| **Email exfiltration guard** | `EXTRA_EMAIL` never populated from LLM output — user enters recipient manually |
+| **Prompt injection** | FunctionGemma output always validated against SkillRegistry schema before execution |
+| **Sideloaded skills** | Wasm import section audited; user must acknowledge "Accept Risk" |
+| **LeakCanary** | Integrated from day one — model weight leaks caught early |
+
+---
+
+## 6. UI/UX
+
+- **Framework:** Jetpack Compose, Material 3 Dynamic Color
+- **Theme:** Dark default (AMOLED-friendly), supports light/dark toggle
+- **Navigation:** Bottom nav bar — Chats tab (conversations list) + Actions tab (quick commands)
+- **Chat:** Streaming token display, thinking mode indicator, markdown rendering, multi-conversation
+- **Actions tab:** History list, FAB (⚡) for new commands, bottom sheet input, Room-persisted history
+- **Voice:** Tap-to-toggle with auto-stop on silence (future: "Hey Jandal" wake word)
+- **Skill results:** Inline rich cards in the conversation stream
+- **Persona:** Friendly, concise, slightly playful (Kiwi-flavoured) — future: configurable
+
+---
+
+## 7. Development Prerequisites
+
+| Requirement | Detail |
+|-------------|--------|
+| Machine RAM | 32GB minimum (LiteRT builds + Android Emulator) |
+| Android Studio | Ladybug (2024.2.1) or newer |
+| Android NDK | Required for sqlite-vec JNI bridge |
+| JDK | 21 (Homebrew OpenJDK) |
+| Min SDK | API 35 (Android 15) |
+| Target SDK | 36 |
+| Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16) |
+
+**Backend note:** `Build.SOC_MANUFACTURER` on S23 Ultra returns `"QTI"` (not `"Qualcomm"`),
+so `hasQualcommNpu = false` and the backend falls through to GPU (OpenCL / Adreno 740).
+The NPU path requires `"Qualcomm"` string match — this is a known device quirk.
+
+---
+
+## 8. Build & Test
+
+```bash
+./gradlew assembleDebug              # Build debug APK
+./gradlew test                       # Unit tests (JUnit 5 + MockK)
+./gradlew testDebugUnitTest          # Unit tests, debug variant only
+./gradlew connectedDebugAndroidTest  # Compose UI tests (requires connected device)
+./gradlew lint                       # Android lint
+./gradlew installDebug               # Build + install on connected device
+./gradlew :core:inference:test       # Single-module test
+```
+
+**CI:** Runs lint + unit tests + debug build. No real model inference in CI — `InferenceEngine`
+is behind an interface and mocked in all tests. Models (~3GB) are never downloaded in CI.
+
+---
+
+## 9. Roadmap Summary
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 1 | Core LiteRT-LM chat + GPU/NPU + GPU alignment fixes + OOM protection | ✅ Complete |
+| 2 | sqlite-vec RAG + EmbeddingGemma + episodic distillation + memory UI | ✅ Complete |
+| 3 | Resident Agent Architecture: QuickIntentRouter + E4B tool calling + Voice I/O | 🔄 In Progress |
+| 4 | Dreaming Engine (overnight distillation) + Semantic Cache + Self-Healing Identity | ⬜ Planned |
+| 5 | Chicory Wasm Runtime + GitHub Skill Store | ⬜ Planned |
+| 6 | 8GB device optimisation (dynamic weight loading, E2B auto-select) + wake word | ⬜ Planned |
+
+See [`ROADMAP.md`](./ROADMAP.md) for full task-level detail.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -1,0 +1,400 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.QuickActionEntity
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActionsScreen(
+    viewModel: ActionsViewModel = hiltViewModel(),
+) {
+    val actions by viewModel.actions.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+
+    var showBottomSheet by rememberSaveable { mutableStateOf(false) }
+    var showClearConfirmation by rememberSaveable { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Actions") },
+                actions = {
+                    if (actions.isNotEmpty()) {
+                        IconButton(onClick = { showClearConfirmation = true }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Clear history")
+                        }
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showBottomSheet = true },
+            ) {
+                Icon(Icons.Default.Bolt, contentDescription = "Run quick action")
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Loading/executing indicator
+            AnimatedVisibility(
+                visible = uiState != ActionsViewModel.UiState.Idle,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = when (uiState) {
+                            is ActionsViewModel.UiState.LoadingModel -> "Loading actions model…"
+                            is ActionsViewModel.UiState.Executing -> "Running action…"
+                            else -> ""
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+
+            // Error banner
+            error?.let { errorMessage ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.Error,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = errorMessage,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = { viewModel.clearError() }) {
+                            Icon(
+                                Icons.Default.Clear,
+                                contentDescription = "Dismiss",
+                                tint = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Action history or empty state
+            if (actions.isEmpty() && uiState == ActionsViewModel.UiState.Idle) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("⚡", style = MaterialTheme.typography.displayMedium)
+                        Text(
+                            text = "No actions yet",
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                        Text(
+                            text = "Tap ⚡ to run a quick command",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        horizontal = 16.dp,
+                        vertical = 8.dp,
+                    ),
+                ) {
+                    items(actions, key = { it.id }) { action ->
+                        ActionHistoryCard(
+                            action = action,
+                            onDelete = { viewModel.deleteAction(action.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // Bottom sheet for quick command input
+    if (showBottomSheet) {
+        QuickActionBottomSheet(
+            uiState = uiState,
+            onDismiss = { showBottomSheet = false },
+            onSubmit = { query ->
+                viewModel.executeAction(query)
+                showBottomSheet = false
+            },
+        )
+    }
+
+    // Clear history confirmation
+    if (showClearConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirmation = false },
+            title = { Text("Clear action history?") },
+            text = { Text("All quick action history will be permanently deleted.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.clearHistory()
+                        showClearConfirmation = false
+                    }
+                ) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirmation = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun QuickActionBottomSheet(
+    uiState: ActionsViewModel.UiState,
+    onDismiss: () -> Unit,
+    onSubmit: (String) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    var inputText by rememberSaveable { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+        ) {
+            Text(
+                text = "Quick Action",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Type a command like \"turn on flashlight\" or \"set timer for 5 minutes\"",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { inputText = it },
+                placeholder = { Text("What do you want to do?") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                trailingIcon = {
+                    val isLoading = uiState != ActionsViewModel.UiState.Idle
+                    if (isLoading) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    } else {
+                        IconButton(
+                            onClick = {
+                                if (inputText.isNotBlank()) {
+                                    val query = inputText.trim()
+                                    inputText = ""
+                                    scope.launch { sheetState.hide() }
+                                    onSubmit(query)
+                                }
+                            },
+                            enabled = inputText.isNotBlank(),
+                        ) {
+                            Icon(Icons.Default.Send, contentDescription = "Send")
+                        }
+                    }
+                },
+            )
+
+            if (uiState == ActionsViewModel.UiState.LoadingModel) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Loading actions model…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionHistoryCard(
+    action: QuickActionEntity,
+    onDelete: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (action.isSuccess) {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            } else {
+                MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+            },
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+        ) {
+            // Header: icon + query + delete
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = if (action.isSuccess) Icons.Default.CheckCircle else Icons.Default.Error,
+                    contentDescription = null,
+                    tint = if (action.isSuccess) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = action.userQuery,
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    action.skillName?.let { name ->
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+
+            // Result text
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = action.resultText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            // Timestamp
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = formatActionTimestamp(action.timestamp),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+private fun formatActionTimestamp(millis: Long): String {
+    val sdf = SimpleDateFormat("MMM d, h:mm a", Locale.getDefault())
+    return sdf.format(Date(millis))
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -67,7 +67,8 @@ class ActionsViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                // 1. Lazy-load FunctionGemma if not yet ready
+                // FG is loaded eagerly at app start by ChatViewModel (CPU, ~0.4s).
+                // If not ready yet, lazy-load it here.
                 if (!functionGemmaRouter.isReady.value) {
                     _uiState.value = UiState.LoadingModel
                     val modelPath = downloadManager.getModelPath(KernelModel.FUNCTION_GEMMA_270M)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -1,0 +1,160 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.FunctionGemmaRouter
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.memory.dao.QuickActionDao
+import com.kernel.ai.core.memory.entity.QuickActionEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val TAG = "KernelAI"
+
+/**
+ * Manages the Actions tab: lazy FunctionGemma initialisation, command execution,
+ * and action-history persistence.
+ *
+ * FunctionGemma is NOT loaded at startup — it initialises on the first user action
+ * to avoid OOM when the main Gemma-4 model is already resident on GPU.
+ */
+@HiltViewModel
+class ActionsViewModel @Inject constructor(
+    private val functionGemmaRouter: FunctionGemmaRouter,
+    private val downloadManager: ModelDownloadManager,
+    private val quickActionDao: QuickActionDao,
+) : ViewModel() {
+
+    // ── Action history ──────────────────────────────────────────────────────
+
+    val actions: StateFlow<List<QuickActionEntity>> = quickActionDao.observeAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // ── Loading / execution state ───────────────────────────────────────────
+
+    sealed interface UiState {
+        object Idle : UiState
+        object LoadingModel : UiState
+        object Executing : UiState
+    }
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    /** Last error message to show in the UI. Cleared on next action. */
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    // ── Public API ──────────────────────────────────────────────────────────
+
+    /**
+     * Executes a quick-action command.
+     *
+     * If FunctionGemma hasn't been loaded yet, it is initialised lazily first.
+     * The result is persisted to the action history via Room.
+     */
+    fun executeAction(query: String) {
+        if (query.isBlank()) return
+        _error.value = null
+
+        viewModelScope.launch {
+            try {
+                // 1. Lazy-load FunctionGemma if not yet ready
+                if (!functionGemmaRouter.isReady.value) {
+                    _uiState.value = UiState.LoadingModel
+                    val modelPath = downloadManager.getModelPath(KernelModel.FUNCTION_GEMMA_270M)
+                    if (modelPath == null) {
+                        _error.value = "FunctionGemma model not downloaded. Please download it in Settings → Models."
+                        _uiState.value = UiState.Idle
+                        return@launch
+                    }
+                    Log.i(TAG, "ActionsViewModel: lazy-loading FunctionGemma from $modelPath")
+                    functionGemmaRouter.initialize(modelPath)
+                    if (!functionGemmaRouter.isReady.value) {
+                        _error.value = "Failed to load the actions model. Try again."
+                        _uiState.value = UiState.Idle
+                        return@launch
+                    }
+                }
+
+                // 2. Execute the command
+                _uiState.value = UiState.Executing
+                val result = functionGemmaRouter.handle(query)
+
+                // 3. Persist result
+                val entity = when (result) {
+                    is FunctionGemmaRouter.HandleResult.ToolHandled -> QuickActionEntity(
+                        userQuery = query,
+                        skillName = extractSkillName(result.response),
+                        resultText = result.response,
+                        isSuccess = true,
+                    )
+                    is FunctionGemmaRouter.HandleResult.PlainResponse -> QuickActionEntity(
+                        userQuery = query,
+                        skillName = null,
+                        resultText = result.response.ifEmpty { "No matching action found." },
+                        isSuccess = result.response.isNotEmpty(),
+                    )
+                    is FunctionGemmaRouter.HandleResult.NotReady -> QuickActionEntity(
+                        userQuery = query,
+                        skillName = null,
+                        resultText = "Actions model not ready.",
+                        isSuccess = false,
+                    )
+                }
+                quickActionDao.insert(entity)
+            } catch (e: Exception) {
+                Log.e(TAG, "ActionsViewModel: executeAction failed — ${e.message}", e)
+                _error.value = e.message ?: "Unknown error"
+                // Persist the failure
+                quickActionDao.insert(
+                    QuickActionEntity(
+                        userQuery = query,
+                        resultText = "Error: ${e.message ?: "Unknown"}",
+                        isSuccess = false,
+                    )
+                )
+            } finally {
+                _uiState.value = UiState.Idle
+            }
+        }
+    }
+
+    fun deleteAction(id: String) {
+        viewModelScope.launch { quickActionDao.deleteById(id) }
+    }
+
+    fun clearHistory() {
+        viewModelScope.launch { quickActionDao.deleteAll() }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Do NOT release FunctionGemmaRouter here — it's a @Singleton shared with ChatViewModel.
+        // The router's resources are managed at the application scope.
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Best-effort skill name extraction from the tool response.
+     * FunctionGemma responses often start with the tool name or contain it.
+     */
+    private fun extractSkillName(response: String): String? {
+        // The KernelAIToolSet logs the tool name; we can't access it from here.
+        // Return null — the UI will show a generic action icon.
+        return null
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -33,6 +33,7 @@ import com.kernel.ai.feature.chat.model.ToolCallInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -45,6 +46,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -187,10 +189,13 @@ class ChatViewModel @Inject constructor(
 
     init {
         viewModelScope.launch { initializeConversation() }
-        // FunctionGemma disabled — loading 289MB alongside E4B GPU init causes OOM.
-        // TODO: re-enable once lazy load-on-demand (after E4B is ready) is implemented.
-        // viewModelScope.launch { initFunctionGemmaRouter() }
-        viewModelScope.launch { initEngineWhenReady() }       // eager, shows loading screen
+        viewModelScope.launch {
+            // E4B first — GPU compilation needs every byte of headroom.
+            // FG's 289MB on CPU is enough to tip OOM during GPU init.
+            // Once E4B is stable, FG loads in ~0.4s with no memory pressure.
+            initEngineWhenReady()
+            initFunctionGemmaRouter()
+        }
     }
 
     private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
@@ -310,6 +315,8 @@ class ChatViewModel @Inject constructor(
         activeModel = preferred
         try {
             // Release EmbeddingGemma before loading Gemma-4 to free memory.
+            // FunctionGemma stays resident — it's only 289MB on CPU and loaded
+            // sequentially before E4B, so no OOM risk.
             embeddingEngine.close()
             System.gc()
             Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
@@ -384,7 +391,6 @@ class ChatViewModel @Inject constructor(
             val modelPath = downloadManager.getModelPath(preferred) ?: return
             activeModel = preferred
             try {
-                // Release EmbeddingGemma before loading Gemma-4 to free memory.
                 embeddingEngine.close()
                 System.gc()
                 Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -296,11 +296,12 @@ class ChatViewModel @Inject constructor(
      *
      * Waits for all required models to be on disk, then loads the preferred
      * conversation model with a visible loading screen ([ChatUiState.Loading]).
-     * Releases FunctionGemma + EmbeddingGemma before GPU init to maximise
-     * available memory for the large conversation model.
+     *
+     * Protected by [gemma4InitMutex] — the same lock used by [initGemma4] — so a concurrent
+     * [sendMessage] call during the ~20s GPU init cannot race here, double-close
+     * EmbeddingGemma, or orphan the GPU engine allocation.
      */
     private suspend fun initEngineWhenReady() {
-        // Wait until all required models are on disk.
         downloadManager.downloadStates
             .filter { states ->
                 KernelModel.entries.filter { it.isRequired }
@@ -308,31 +309,30 @@ class ChatViewModel @Inject constructor(
             }
             .first()
 
-        if (inferenceEngine.isReady.value) return
+        gemma4InitMutex.withLock {
+            if (inferenceEngine.isReady.value) return
 
-        val preferred = downloadManager.preferredConversationModel()
-        val modelPath = downloadManager.getModelPath(preferred) ?: return
-        activeModel = preferred
-        try {
-            // Release EmbeddingGemma before loading Gemma-4 to free memory.
-            // FunctionGemma stays resident — it's only 289MB on CPU and loaded
-            // sequentially before E4B, so no OOM risk.
-            embeddingEngine.close()
-            System.gc()
-            Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
+            val preferred = downloadManager.preferredConversationModel()
+            val modelPath = downloadManager.getModelPath(preferred) ?: return
+            activeModel = preferred
+            try {
+                embeddingEngine.close()
+                System.gc()
+                Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
 
-            val settings = modelSettingsRepository.getSettings(preferred.modelId)
-            inferenceEngine.initialize(ModelConfig(
-                modelPath = modelPath,
-                systemPrompt = buildSystemPrompt(),
-                maxTokens = settings.contextWindowSize,
-                temperature = settings.temperature,
-                topP = settings.topP,
-            ))
-            estimatedTokensUsed = 0
-            inferenceEngine.updateSystemPrompt(buildSystemPrompt())
-        } catch (e: Exception) {
-            _error.value = "Failed to load model: ${e.message}"
+                val settings = modelSettingsRepository.getSettings(preferred.modelId)
+                inferenceEngine.initialize(ModelConfig(
+                    modelPath = modelPath,
+                    systemPrompt = buildSystemPrompt(),
+                    maxTokens = settings.contextWindowSize,
+                    temperature = settings.temperature,
+                    topP = settings.topP,
+                ))
+                estimatedTokensUsed = 0
+                inferenceEngine.updateSystemPrompt(buildSystemPrompt())
+            } catch (e: Exception) {
+                _error.value = "Failed to load model: ${e.message}"
+            }
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -114,7 +114,11 @@ class ChatViewModel @Inject constructor(
     /** Ensures at most one concurrent Gemma-4 initialisation attempt. */
     private val gemma4InitMutex = Mutex()
 
-    private data class GenerationState(val isGenerating: Boolean, val isLoadingModel: Boolean)
+    private data class EngineState(
+        val isReady: Boolean,
+        val isGenerating: Boolean,
+        val isLoadingModel: Boolean,
+    )
     private data class InputState(
         val messages: List<ChatMessage>,
         val inputText: String,
@@ -122,10 +126,13 @@ class ChatViewModel @Inject constructor(
         val conversationTitle: String?,
     )
 
-    private val generationState = combine(
+    private val engineState = combine(
+        inferenceEngine.isReady,
         inferenceEngine.isGenerating,
         _isLoadingModel,
-    ) { isGenerating, isLoadingModel -> GenerationState(isGenerating, isLoadingModel) }
+    ) { isReady, isGenerating, isLoadingModel ->
+        EngineState(isReady, isGenerating, isLoadingModel)
+    }
 
     private val inputState = combine(
         _messages,
@@ -135,10 +142,10 @@ class ChatViewModel @Inject constructor(
     ) { messages, inputText, error, title -> InputState(messages, inputText, error, title) }
 
     val uiState: StateFlow<ChatUiState> = combine(
-        generationState,
+        engineState,
         downloadManager.downloadStates,
         inputState,
-    ) { generation, downloadStates, input ->
+    ) { engine, downloadStates, input ->
         val allDownloaded = downloadManager.areRequiredModelsDownloaded()
         val tier = downloadManager.deviceTier
         val displayModels: List<KernelModel> = if (tier == HardwareTier.FLAGSHIP) {
@@ -161,14 +168,15 @@ class ChatViewModel @Inject constructor(
                 }
                 ChatUiState.ModelsNotReady(isDownloading = anyDownloading, modelProgress = progress)
             }
+            !engine.isReady -> ChatUiState.Loading
             else -> ChatUiState.Ready(
                 conversationId = conversationId ?: "",
                 conversationTitle = input.conversationTitle,
                 messages = input.messages,
-                isGenerating = generation.isGenerating,
+                isGenerating = engine.isGenerating,
                 inputText = input.inputText,
                 error = input.error,
-                isLoadingModel = generation.isLoadingModel,
+                isLoadingModel = engine.isLoadingModel,
             )
         }
     }.stateIn(
@@ -179,8 +187,10 @@ class ChatViewModel @Inject constructor(
 
     init {
         viewModelScope.launch { initializeConversation() }
-        viewModelScope.launch { initFunctionGemmaRouter() }  // eager, fast
-        // Gemma-4 loads lazily on first sendMessage() that needs it
+        // FunctionGemma disabled — loading 289MB alongside E4B GPU init causes OOM.
+        // TODO: re-enable once lazy load-on-demand (after E4B is ready) is implemented.
+        // viewModelScope.launch { initFunctionGemmaRouter() }
+        viewModelScope.launch { initEngineWhenReady() }       // eager, shows loading screen
     }
 
     private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
@@ -273,7 +283,50 @@ class ChatViewModel @Inject constructor(
         }
         // else: new conversation, both flags stay false (defaults)
 
-        // Engine init is handled reactively by initEngineWhenReady().
+        // Engine init is handled eagerly by initEngineWhenReady() — shows loading screen.
+    }
+
+    /**
+     * Eagerly initialises the Gemma-4 [InferenceEngine] at startup.
+     *
+     * Waits for all required models to be on disk, then loads the preferred
+     * conversation model with a visible loading screen ([ChatUiState.Loading]).
+     * Releases FunctionGemma + EmbeddingGemma before GPU init to maximise
+     * available memory for the large conversation model.
+     */
+    private suspend fun initEngineWhenReady() {
+        // Wait until all required models are on disk.
+        downloadManager.downloadStates
+            .filter { states ->
+                KernelModel.entries.filter { it.isRequired }
+                    .all { states[it] is DownloadState.Downloaded }
+            }
+            .first()
+
+        if (inferenceEngine.isReady.value) return
+
+        val preferred = downloadManager.preferredConversationModel()
+        val modelPath = downloadManager.getModelPath(preferred) ?: return
+        activeModel = preferred
+        try {
+            // Release EmbeddingGemma before loading Gemma-4 to free memory.
+            embeddingEngine.close()
+            System.gc()
+            Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
+
+            val settings = modelSettingsRepository.getSettings(preferred.modelId)
+            inferenceEngine.initialize(ModelConfig(
+                modelPath = modelPath,
+                systemPrompt = buildSystemPrompt(),
+                maxTokens = settings.contextWindowSize,
+                temperature = settings.temperature,
+                topP = settings.topP,
+            ))
+            estimatedTokensUsed = 0
+            inferenceEngine.updateSystemPrompt(buildSystemPrompt())
+        } catch (e: Exception) {
+            _error.value = "Failed to load model: ${e.message}"
+        }
     }
 
     /**
@@ -331,13 +384,10 @@ class ChatViewModel @Inject constructor(
             val modelPath = downloadManager.getModelPath(preferred) ?: return
             activeModel = preferred
             try {
-                // Release FunctionGemma + EmbeddingGemma before loading Gemma-4 to free memory.
-                // Edge Gallery only keeps one model in memory; holding multiple models during
-                // GPU init causes Samsung's lmkd to kill the process.
-                functionGemmaRouter.release()
+                // Release EmbeddingGemma before loading Gemma-4 to free memory.
                 embeddingEngine.close()
                 System.gc()
-                Log.i("KernelAI", "Released FunctionGemma + EmbeddingGemma for Gemma-4 GPU init")
+                Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 inferenceEngine.initialize(ModelConfig(
@@ -435,22 +485,9 @@ class ChatViewModel @Inject constructor(
                 Log.d("KernelAI", "Set placeholder title for $convId: \"$placeholder\"")
             }
 
-            // 1. Route via FunctionGemma — SDK calls @Tool methods natively.
-            //    ToolHandled  → a skill ran, display response, skip Gemma-4.
-            //    PlainResponse → FunctionGemma answered without a tool, fall through to Gemma-4
-            //                    so the user gets a high-quality conversational response.
-            //    NotReady     → router not initialised, fall through to Gemma-4.
-            when (val result = functionGemmaRouter.handle(text)) {
-                is FunctionGemmaRouter.HandleResult.ToolHandled -> {
-                    appendAssistantMessage(convId, result.response)
-                    needsHistoryReplay = true
-                    return@launch
-                }
-                is FunctionGemmaRouter.HandleResult.PlainResponse,
-                is FunctionGemmaRouter.HandleResult.NotReady -> {
-                    // fall through to Gemma-4
-                }
-            }
+            // FunctionGemma routing disabled — concurrent loading causes OOM during
+            // E4B GPU init. All queries go directly to Gemma-4 for now.
+            // TODO: re-enable with lazy load-on-demand after Gemma-4 is ready.
 
             // Lazy-init Gemma-4 if not yet loaded.
             if (!inferenceEngine.isReady.value) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -117,16 +117,17 @@ private fun ModelCard(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Context Window
+        // Context Window — steps of 500 to avoid exact powers-of-2 (4096, 8192)
+        // which trigger a GPU reshape alignment bug on some Adreno GPUs.
         SliderRow(
             label = "Context window",
             valueLabel = "${settings.contextWindowSize} tokens",
             value = settings.contextWindowSize.toFloat(),
-            valueRange = 2048f..32768f,
-            steps = ((32768 - 2048) / 1024) - 1,
+            valueRange = 2000f..32000f,
+            steps = ((32000 - 2000) / 500) - 1,
             isInteger = true,
             onValueChangeFinished = { newVal ->
-                val snapped = (newVal / 1024).roundToInt() * 1024
+                val snapped = (newVal / 500).roundToInt() * 500
                 onSettingsChanged(settings.copy(contextWindowSize = snapped))
             },
         )
@@ -270,7 +271,7 @@ private fun ModelSettingsScreenPreview() {
     MaterialTheme {
         val sampleSettings = ModelSettingsEntity(
             modelId = "gemma_4_e2b",
-            contextWindowSize = 4096,
+            contextWindowSize = 4000,
             temperature = 1.0f,
             topP = 0.95f,
         )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -141,15 +141,56 @@ fun SettingsScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B) },
-                headlineContent = { Text("E2B — Gemma 4 E-2B") },
-                supportingContent = { Text("2.4 GB · Efficient, runs on all devices") },
+                    .clickable {
+                        if (uiState.e2bDownloaded) {
+                            viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B)
+                        } else {
+                            scope.launch {
+                                snackbarHostState.showSnackbar("E2B not downloaded")
+                            }
+                        }
+                    },
+                headlineContent = {
+                    Text(
+                        text = "E2B — Gemma 4 E-2B",
+                        color = if (uiState.e2bDownloaded)
+                            MaterialTheme.colorScheme.onSurface
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                supportingContent = {
+                    Text(
+                        text = if (uiState.e2bDownloaded) "2.4 GB · Efficient, runs on all devices"
+                               else "Not downloaded · 2.4 GB",
+                        color = if (uiState.e2bDownloaded)
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        else
+                            MaterialTheme.colorScheme.error,
+                    )
+                },
                 leadingContent = {
                     RadioButton(
                         selected = uiState.preferredModel == KernelModel.GEMMA_4_E2B,
-                        onClick = { viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B) },
+                        onClick = {
+                            if (uiState.e2bDownloaded) {
+                                viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B)
+                            } else {
+                                scope.launch {
+                                    snackbarHostState.showSnackbar("E2B not downloaded")
+                                }
+                            }
+                        },
+                        enabled = uiState.e2bDownloaded,
                     )
                 },
+                trailingContent = if (!uiState.e2bDownloaded) {
+                    {
+                        TextButton(onClick = { viewModel.downloadModel(KernelModel.GEMMA_4_E2B) }) {
+                            Text("Download")
+                        }
+                    }
+                } else null,
             )
 
             // E4B option
@@ -161,7 +202,7 @@ fun SettingsScreen(
                             viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
                         } else {
                             scope.launch {
-                                snackbarHostState.showSnackbar("E4B not downloaded — using E2B")
+                                snackbarHostState.showSnackbar("E4B not downloaded")
                             }
                         }
                     },
@@ -177,7 +218,7 @@ fun SettingsScreen(
                 supportingContent = {
                     Text(
                         text = if (uiState.e4bDownloaded) "3.4 GB · Higher quality, flagship devices"
-                               else "Not downloaded",
+                               else "Not downloaded · 3.4 GB",
                         color = if (uiState.e4bDownloaded)
                             MaterialTheme.colorScheme.onSurfaceVariant
                         else
@@ -192,13 +233,20 @@ fun SettingsScreen(
                                 viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
                             } else {
                                 scope.launch {
-                                    snackbarHostState.showSnackbar("E4B not downloaded — using E2B")
+                                    snackbarHostState.showSnackbar("E4B not downloaded")
                                 }
                             }
                         },
                         enabled = uiState.e4bDownloaded,
                     )
                 },
+                trailingContent = if (!uiState.e4bDownloaded) {
+                    {
+                        TextButton(onClick = { viewModel.downloadModel(KernelModel.GEMMA_4_E4B) }) {
+                            Text("Download")
+                        }
+                    }
+                } else null,
             )
 
             HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsViewModel.kt
@@ -35,6 +35,7 @@ class SettingsViewModel @Inject constructor(
         val activeBackend: String = "",
         val activeTier: String = "",
         val preferredModel: KernelModel? = null,   // null = auto
+        val e2bDownloaded: Boolean = false,
         val e4bDownloaded: Boolean = false,
         /** True when a valid HF token is stored. */
         val hfAuthenticated: Boolean = false,
@@ -50,6 +51,7 @@ class SettingsViewModel @Inject constructor(
     ) { preferredModel, downloadStates, hfAuthenticated, hfUsername ->
         val profile = hardwareProfileDetector.profile
         val e4bDownloaded = downloadStates[KernelModel.GEMMA_4_E4B] is DownloadState.Downloaded
+        val e2bDownloaded = downloadStates[KernelModel.GEMMA_4_E2B] is DownloadState.Downloaded
 
         fun isDownloadedInStates(model: KernelModel) = downloadStates[model] is DownloadState.Downloaded
 
@@ -67,6 +69,7 @@ class SettingsViewModel @Inject constructor(
             activeBackend = profile.recommendedBackend.name,
             activeTier = profile.tier.name,
             preferredModel = preferredModel,
+            e2bDownloaded = e2bDownloaded,
             e4bDownloaded = e4bDownloaded,
             hfAuthenticated = hfAuthenticated,
             hfUsername = hfUsername,
@@ -106,6 +109,11 @@ class SettingsViewModel @Inject constructor(
                 _saveError.tryEmit("Couldn't save preference — please try again")
             }
         }
+    }
+
+    fun downloadModel(model: KernelModel) {
+        modelDownloadManager.startDownload(model)
+        _saveSuccess.tryEmit("Downloading ${model.displayName}…")
     }
 
     /** Signs the user out of HuggingFace and clears the stored token. */

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,7 @@
-***
+> **This document has moved.**  
+> The authoritative technical specification is now at **[docs/SPECIFICATION.md](docs/SPECIFICATION.md)**.
 
-# Technical Specification: Jandal AI — Local-First Android AI Assistant ("Project Gemma-Mobile")
+
 
 ## 1. Executive Summary
 This document outlines the architecture for a privacy-centric, on-device mobile assistant. By leveraging the Google AI Edge (LiteRT) ecosystem and the Gemma-4 family of models, the assistant provides reasoning, memory retrieval, and device actions without relying on cloud APIs. The system uses a tiered hardware approach to ensure performance across a wide range of Android devices while maintaining a modular "Skill" framework for extensibility.

--- a/specification.md
+++ b/specification.md
@@ -20,9 +20,12 @@ The assistant is built on a "Brain-Memory-Action" triad, managed by a central Or
 | Component | Performance Tier (12GB+ RAM) | Compatibility Tier (8GB RAM) |
 | :--- | :--- | :--- |
 | **Reasoning Model** | Gemma-4 E-4B (4.0B params) | Gemma-4 E-2B (2.0B params) |
-| **Embedding Model** | EmbeddingGemma-300M | Gecko-110m-en |
-| **Action Model** | FunctionGemma-270M | FunctionGemma-270M |
-| **RAM Utilization** | ~3.5GB - 4.0GB | ~1.8GB - 2.2GB |
+| **Embedding Model** | EmbeddingGemma-300M | EmbeddingGemma-300M |
+| **Intent Routing (simple)** | `QuickIntentRouter` (Kotlin regex, zero RAM) | `QuickIntentRouter` (Kotlin regex, zero RAM) |
+| **Intent Routing (complex)** | Gemma-4 E-4B native tool calling | Gemma-4 E-2B native tool calling |
+| **RAM Utilization** | ~3.4GB (E4B GPU) | ~1.5GB (E2B GPU) |
+
+> **Note (Apr 2026):** FunctionGemma-270M has been deprecated from the startup sequence. Its 289MB footprint causes lmkd to terminate the process during Gemma-4's GPU kernel compilation peak (~4–5GB transient). Simple device actions (torch, timer, alarm, DND, bluetooth, wifi) are now handled by a zero-overhead Kotlin `QuickIntentRouter`; complex tool calls (weather, calendar, email) are handled by the resident Gemma-4 model via its native `{"name": ..., "arguments": {...}}` JSON tool-call format. See issues #218, #219, #220.
 
 ---
 
@@ -33,8 +36,8 @@ The assistant utilizes a hybrid memory system to maintain long-term facts and sh
 
 ### 3.1 Short-Term (Session) Memory
 * **Implementation:** Managed via the LiteRT-LM KV Cache.
-* **Window:** 4,096 tokens (Performance) / 2,048 tokens (Compatibility).
-* **Summarization:** When the window reaches 80% capacity, the system triggers the 2B/4B model to generate a recursive summary, which is then injected into the prompt to preserve context while freeing tokens.
+* **Window:** 4,000 tokens (Performance) / 2,000 tokens (Compatibility). **Note:** Exact powers of 2 (4096, 8192) are avoided — a `safeTokenCount()` guard nudges values down by ~2.4% to prevent a LiteRT GPU `reshape::Eval` buffer-alignment bug on Adreno GPUs.
+* **Summarization:** When the window reaches ~75% capacity, the system triggers the resident model to generate a recursive summary, which is then injected into the prompt to preserve context while freeing tokens.
 
 ### 3.2 Long-Term (Semantic) Memory
 * **Database:** SQLite with the **VSS (Vector Similarity Search)** extension.
@@ -46,14 +49,30 @@ The assistant utilizes a hybrid memory system to maintain long-term facts and sh
 ## 4. Skill & Tool Framework
 To ensure the assistant can perform tasks, it uses a decoupled skill registry.
 
-### 4.1 Native Skills (Kotlin/JVM)
-High-performance, high-privilege tasks integrated directly with the Android OS:
-* **Android Actions:** Flashlight, DND, Bluetooth, Alarm/Timer management.
-* **Communication:** Drafting emails (ACTION_SEND) and background SMS (SEND_SMS).
-* **Local Productivity:** Integration with Google Keep via Intents for note-taking and shopping lists.
-* **Media Control:** MediaSession API hooks for controlling local players like Plexamp.
+### 4.1 Native Skills — Tier 2: Quick Intent Router
+Zero-overhead deterministic matching for simple device actions. A pure-Kotlin `QuickIntentRouter` uses regex/keyword patterns to match user input without loading any ML model. Matched actions execute directly via OS APIs. Latency: <5ms from text to action.
 
-### 4.2 Extensible Skills (WebAssembly)
+**Supported actions:**
+* Flashlight on/off (`CameraManager.setTorchMode`)
+* Timer (`AlarmClock.ACTION_SET_TIMER`)
+* Alarm (`AlarmClock.ACTION_SET_ALARM`)
+* Do Not Disturb toggle (`NotificationManager.setInterruptionFilter`)
+* Bluetooth / Wi-Fi toggle
+* Get current time / date
+* Battery level (`BatteryManager`)
+
+If no pattern matches, the query falls through to Tier 3 (Gemma-4 reasoning).
+
+### 4.2 Native Skills — Tier 3: E4B Tool Calling
+The resident Gemma-4 model handles complex tool calls requiring NLU and reasoning. When the model outputs a JSON function-call block (`{"name": "skill_name", "arguments": {...}}`), `SkillExecutor` parses it and dispatches to the registered `Skill` implementation. This enables multi-step reasoning before action execution.
+
+**Supported skills (via `SkillRegistry`):**
+* `get_weather` — geolocation + weather API
+* `get_system_info` — battery, connectivity, device stats
+* `save_memory` — persist notes/facts to Room
+* `set_timer`, `run_intent` — OS action delegation
+
+### 4.3 Extensible Skills (WebAssembly)
 
 For community-driven and logic-heavy extensions, the system supports a **Wasm (WebAssembly)** runtime (via Extism or Wasmtime JNI).
 * **Role:** Specialized logic like recipe parsing (e.g., RecipeTin Eats), data transformation, or web scrapers.
@@ -86,8 +105,8 @@ For community-driven and logic-heavy extensions, the system supports a **Wasm (W
 ---
 
 ## 8. Implementation Roadmap
-1.  **Phase 1:** Core LiteRT-LM integration with GPU/NPU acceleration for Gemma-4. Backlog polish: active model/backend/tier display in Settings (#59); user-controlled E2B/E4B model selection persisted via DataStore (#60).
-2.  **Phase 2:** Deployment of sqlite-vec and EmbeddingGemma-300M for local semantic search and RAG.
-3.  **Phase 3:** FunctionGemma intent router + Native Skills + full Voice I/O. Includes **Live Mode** (#64) — real-time offline voice conversation via Silero VAD endpointing → Gemma-4 audio tensor input → Sherpa-ONNX/Piper TTS → barge-in, 28s rolling buffer, <1.5s time-to-first-audio. Includes **"Hey Jandal" wake word** (#65) — always-on local detection via openWakeWord (ONNX Runtime) + VoiceInteractionService with 3s ring buffer handoff to Live Mode pipeline.
-4.  **Phase 4:** Integration of the Chicory Wasm Runtime and the GitHub-based Skill Store.
-5.  **Phase 5:** Optimization for 8GB devices (dynamic loading/unloading of weights).
+1. **Phase 1 ✅:** Core LiteRT-LM integration with GPU/NPU acceleration for Gemma-4. E4B loads on GPU (TTFT ~2.3s). GPU kernel cache, foreground service OOM protection, safe token-count alignment guard.
+2. **Phase 2 ✅:** sqlite-vec + EmbeddingGemma-300M for local semantic search and RAG. Episodic distillation, context window management.
+3. **Phase 3 (In Progress):** Resident Agent Architecture — deprecate FunctionGemma, build `QuickIntentRouter` for simple actions, enable Gemma-4 native tool calling for complex queries. Voice I/O (push-to-talk). Native skills: Flashlight, DND, Bluetooth, Alarm/Timer, Weather, Notes.
+4. **Phase 4:** Chicory Wasm Runtime + GitHub-based Skill Store. Community-extensible sandboxed skills.
+5. **Phase 5:** 8GB device optimisation (dynamic loading/unloading of weights, E2B fallback). **"Hey Jandal" wake word** (#65) — always-on local detection → `QuickIntentRouter` → E4B for complex follow-up.


### PR DESCRIPTION
## Summary

Fixes Gemma-4 E4B GPU crashes and adds the Quick Actions tab. Lays groundwork for the Resident Agent Architecture (#220).

Closes #216

## Changes

### GPU OOM & Alignment Fixes
- **`safeTokenCount()`** in `LiteRtInferenceEngine`: nudges token counts away from exact powers of 2 (4096→4000, 8192→8000) to avoid a LiteRT GPU `reshape::Eval` buffer-alignment bug on Adreno GPUs
- **`InferenceLoadingService`**: foreground service that keeps `oom_score_adj` at 0 during the ~20s GPU kernel compilation peak
- **GPU kernel cache**: `EngineConfig.cacheDir` set so compiled OpenCL kernels are serialized — subsequent loads skip recompilation
- **E4B-first sequential loading**: `ChatViewModel.init` now loads E4B on GPU first (full memory headroom), then loads FunctionGemma on CPU after — prevents lmkd OOM during GPU init
- **Token defaults updated** to non-power-of-2: FLAGSHIP=4000, MID_RANGE=2000, LOW_POWER=1000
- **Slider steps** changed from 1024 to 500 to avoid snapping to power-of-2 values

### Quick Actions Tab
- New **`ActionsScreen`** + **`ActionsViewModel`**: Actions history list, FAB (⚡), bottom sheet command input
- New **`QuickActionEntity`** + **`QuickActionDao`**: Room persistence for action history
- Room database **migration v7→v8**
- **Bottom nav bar** (Chats / Actions) added to `KernelNavHost`
- `innerPadding` scoped only to list/actions routes — prevents phantom padding below chat input

### Other
- Location permission (`ACCESS_COARSE_LOCATION`) requested at launch for weather skill
- `specification.md` updated: hardware tiering table, token window note, skills architecture, roadmap Phases 1–5

## Testing
- E4B loads on GPU at 4000 tokens (TTFT ~2367ms) on S23 Ultra
- Quick Actions tab shows history, FAB, bottom sheet input
- Foreground service starts during GPU init, stops when ready
- Bottom nav with correct padding (no phantom space below chat input)
- FunctionGemma still wired to Actions tab — will be replaced with `QuickIntentRouter` in next PR (#220 Phase 3)

## Related Issues
- Closes #216
- References #218, #219, #220 (Resident Agent Architecture)
