### PR TITLE
fix: enable episodic distilled memory retrieval in RAG (#233)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -29,10 +29,10 @@ interface EpisodicMemoryDao {
     @Query("SELECT COUNT(*) FROM episodic_memories")
     fun observeCount(): Flow<Int>
 
-    @Query("SELECT rowId FROM episodic_memories WHERE createdAt < :cutoffMs")
+    @Query("SELECT rowId FROM episodic_memories WHERE createdAt < :cutoffMs AND lastAccessedAt < :cutoffMs")
     suspend fun getRowIdsOlderThan(cutoffMs: Long): List<Long>
 
-    @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoffMs")
+    @Query("DELETE FROM episodic_memories WHERE createdAt < :cutoffMs AND lastAccessedAt < :cutoffMs")
     suspend fun deleteOlderThan(cutoffMs: Long)
 
     @Query("SELECT rowId FROM episodic_memories ORDER BY createdAt ASC LIMIT :count")

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -83,8 +83,10 @@ class RagRepository @Inject constructor(
      * Returns a formatted context block ready to prepend to a prompt, or an
      * empty string when no relevant context is available.
      *
-     * @param conversationId Only episodic (message) memories from this conversation are
-     *   considered, preventing memories from unrelated conversations from leaking in.
+     * @param conversationId Only message history from this conversation is
+     *   considered for the [Message History] section, preventing messages from
+     *   unrelated conversations from leaking in. Episodic memories (distilled
+     *   conversation summaries) are cross-conversation by design.
      * @param excludeMessageIds Message IDs to exclude (e.g. the current turn's user message).
      * @param maxTokens Maximum token budget for the returned context block (estimated at chars/3).
      *   Results are truncated to fit within the budget. Defaults to [ContextWindowManager.EPISODIC_BUDGET].
@@ -134,8 +136,8 @@ class RagRepository @Inject constructor(
                 tokenBudgetRemaining = coreBudget
             }
 
-            val distilledHeader = "[Distilled Memories — summaries of past conversations]\n"
-            val distilledFooter = "[End of distilled memories]"
+            val distilledHeader = "[Episodic Memories — summaries of past conversations]\n"
+            val distilledFooter = "[End of episodic memories]"
             val distilledOverhead = (distilledHeader.length + distilledFooter.length + charsPerToken - 1) / charsPerToken
             var distilledBudget = tokenBudgetRemaining - distilledOverhead
             for (result in distilledResults) {
@@ -198,15 +200,15 @@ class RagRepository @Inject constructor(
             }
             if (distilledMemoryLines.isNotEmpty()) {
                 if (coreMemoryLines.isNotEmpty()) append("\n\n")
-                append("[Distilled Memories — summaries of past conversations]\n")
+                append("[Episodic Memories — summaries of past conversations]\n")
                 distilledMemoryLines.forEach { appendLine(it) }
-                append("[End of distilled memories]")
+                append("[End of episodic memories]")
             }
             if (episodicLines.isNotEmpty()) {
                 if (coreMemoryLines.isNotEmpty() || distilledMemoryLines.isNotEmpty()) append("\n\n")
-                append("[Episodic Memories — recalled from a past conversation]\n")
+                append("[Message History — earlier in this conversation]\n")
                 episodicLines.forEach { appendLine(it) }
-                append("[End of episodic memories]")
+                append("[End of message history]")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -21,7 +21,8 @@ import javax.inject.Singleton
  * - Index each message into the sqlite-vec vector store after it is saved.
  * - Retrieve the most semantically relevant past messages for a given query.
  * - Format retrieved context into a prefix that can be prepended to the user prompt,
- *   merging both core memories and episodic (message) memories.
+ *   merging core memories, distilled episodic conversation summaries, and per-message
+ *   episodic memories.
  *
  * The embedding table is created lazily on first use, once the [EmbeddingEngine] has
  * loaded its model and the embedding dimensions are known.
@@ -105,13 +106,19 @@ class RagRepository @Inject constructor(
         val framingTokenCost = (framingHeader.length + charsPerToken - 1) / charsPerToken
         var tokenBudgetRemaining = maxTokens - framingTokenCost
 
-        // --- Core Memories ---
+        // --- Core + Distilled Episodic Memories ---
         val coreMemoryLines = mutableListOf<String>()
+        val distilledMemoryLines = mutableListOf<String>()
         runCatching {
-            val coreResults = memoryRepository.searchMemories(queryVector, coreTopK = 10, episodicTopK = 0)
+            val allMemoryResults = memoryRepository.searchMemories(queryVector, coreTopK = 10, episodicTopK = 3)
+            val coreResults = allMemoryResults
                 .filter { it.source == "core" }
                 // Primary: semantic relevance. Secondary: recency (recently-accessed facts win ties).
                 .sortedWith(compareByDescending<MemorySearchResult> { it.score }.thenByDescending { it.lastAccessedAt })
+            val distilledResults = allMemoryResults
+                .filter { it.source == "episodic" }
+                .sortedByDescending { it.score }
+
             val coreHeader = "[Core Memories — permanent facts about the user]\n"
             val coreFooter = "[End of core memories]"
             val coreOverhead = (coreHeader.length + coreFooter.length + charsPerToken - 1) / charsPerToken
@@ -126,7 +133,22 @@ class RagRepository @Inject constructor(
             if (coreMemoryLines.isNotEmpty()) {
                 tokenBudgetRemaining = coreBudget
             }
-        }.onFailure { Log.w(TAG, "Core memory retrieval failed: ${it.message}") }
+
+            val distilledHeader = "[Distilled Memories — summaries of past conversations]\n"
+            val distilledFooter = "[End of distilled memories]"
+            val distilledOverhead = (distilledHeader.length + distilledFooter.length + charsPerToken - 1) / charsPerToken
+            var distilledBudget = tokenBudgetRemaining - distilledOverhead
+            for (result in distilledResults) {
+                val line = result.content.take(400)
+                val cost = (line.length + 1 + charsPerToken - 1) / charsPerToken
+                if (distilledBudget - cost < 0) break
+                distilledMemoryLines.add(line)
+                distilledBudget -= cost
+            }
+            if (distilledMemoryLines.isNotEmpty()) {
+                tokenBudgetRemaining = distilledBudget
+            }
+        }.onFailure { Log.w(TAG, "Core/distilled memory retrieval failed: ${it.message}") }
 
         // --- Episodic (message) Memories ---
         val episodicLines = mutableListOf<String>()
@@ -165,7 +187,7 @@ class RagRepository @Inject constructor(
             }.onFailure { Log.w(TAG, "Episodic retrieval failed: ${it.message}") }
         }
 
-        if (coreMemoryLines.isEmpty() && episodicLines.isEmpty()) return@withContext ""
+        if (coreMemoryLines.isEmpty() && distilledMemoryLines.isEmpty() && episodicLines.isEmpty()) return@withContext ""
 
         buildString {
             append(framingHeader)
@@ -174,8 +196,14 @@ class RagRepository @Inject constructor(
                 coreMemoryLines.forEach { appendLine(it) }
                 append("[End of core memories]")
             }
-            if (episodicLines.isNotEmpty()) {
+            if (distilledMemoryLines.isNotEmpty()) {
                 if (coreMemoryLines.isNotEmpty()) append("\n\n")
+                append("[Distilled Memories — summaries of past conversations]\n")
+                distilledMemoryLines.forEach { appendLine(it) }
+                append("[End of distilled memories]")
+            }
+            if (episodicLines.isNotEmpty()) {
+                if (coreMemoryLines.isNotEmpty() || distilledMemoryLines.isNotEmpty()) append("\n\n")
                 append("[Episodic Memories — recalled from a past conversation]\n")
                 episodicLines.forEach { appendLine(it) }
                 append("[End of episodic memories]")

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -138,6 +138,7 @@ class MemoryRepositoryImpl @Inject constructor(
                             content = entity.content,
                             source = "episodic",
                             score = 1f - (distanceMap[entity.rowId] ?: 1f),
+                            lastAccessedAt = entity.lastAccessedAt,
                         )
                     )
                 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -124,7 +124,7 @@ class MemoryRepositoryImpl @Inject constructor(
         }.onFailure { Log.w(TAG, "Core memory search failed: ${it.message}") }
 
         runCatching {
-            if (episodicTopK <= 0) return@runCatching  // skip until Dreaming Engine populates the table
+            if (episodicTopK <= 0) return@runCatching
             val episodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, episodicTopK)
                 .filter { it.distance <= EPISODIC_MAX_DISTANCE }
             val rowIds = episodicResults.map { it.rowId }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -141,7 +141,7 @@ All three memory sections are conditionally included — omitted entirely if no 
 - **Retrieval:** `vec_distance_cosine()` similarity search per query; top results injected into prompt
 - **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
 - **TTL & pruning:** `prune()` runs on every write with two independent passes:
-  1. **TTL pass** — deletes episodic memories where `createdAt` is older than 30 days. Accessing a memory does **not** reset the TTL; it is fixed from creation time.
+  1. **TTL pass** — deletes episodic memories where both `createdAt` and `lastAccessedAt` are older than 30 days. Accessing a memory resets `lastAccessedAt`, keeping it alive past the 30-day TTL for as long as it remains in use.
   2. **LRU overflow pass** — if count still exceeds 500 after TTL pass, evicts the least-recently-accessed entries (ordered by `lastAccessedAt ASC`). `lastAccessedAt` is updated on every RAG retrieval, so frequently recalled memories survive overflow eviction even if old.
   - Core memories: no TTL, capped at 200 entries, evicted by `createdAt` order (no LRU — core memories are considered permanent).
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -140,7 +140,10 @@ All three memory sections are conditionally included — omitted entirely if no 
   - `message_embeddings` — per-message vectors for intra-conversation fuzzy recall (visible in Settings → Message History (RAG))
 - **Retrieval:** `vec_distance_cosine()` similarity search per query; top results injected into prompt
 - **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
-- **TTL & pruning:** Episodic memories pruned on write — 30-day TTL + LRU cap of 500 entries. Core memories capped at 200. `lastAccessedAt` updated on each retrieval to ensure LRU ordering is accurate.
+- **TTL & pruning:** `prune()` runs on every write with two independent passes:
+  1. **TTL pass** — deletes episodic memories where `createdAt` is older than 30 days. Accessing a memory does **not** reset the TTL; it is fixed from creation time.
+  2. **LRU overflow pass** — if count still exceeds 500 after TTL pass, evicts the least-recently-accessed entries (ordered by `lastAccessedAt ASC`). `lastAccessedAt` is updated on every RAG retrieval, so frequently recalled memories survive overflow eviction even if old.
+  - Core memories: no TTL, capped at 200 entries, evicted by `createdAt` order (no LRU — core memories are considered permanent).
 
 ### 3.4 Episodic Distillation
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -121,19 +121,26 @@ peak. The service stops automatically once `InferenceEngine.isReady` becomes tru
 ```
 [System Prompt]          ← persona, date/time, runtime info
 [User Profile]           ← always injected (structured identity fields)
-[Core Memories]          ← retrieved by RAG (CORE_MAX_DISTANCE=0.55, topK=10)
-[Episodic Memories]      ← retrieved by RAG (top 3–5 by cosine similarity)
+[Core Memories]          ← permanent facts (CORE_MAX_DISTANCE=0.55, topK=10)
+[Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=0.40, topK=3)
+[Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=0.40, topK=5)
 [Conversation Window]    ← selected recent turns (75% token budget)
 [Current User Message]   ← with RAG context prepended
 ```
+
+All three memory sections are conditionally included — omitted entirely if no results meet their distance threshold. Token budget is allocated sequentially: Core → Episodic → Message History.
 
 ### 3.3 Long-Term (Semantic) Memory
 
 - **Vector store:** sqlite-vec (compiled via NDK for arm64-v8a), bundled as `libkernelvec.so`
 - **Embedding model:** EmbeddingGemma-300M — 768-dim vectors (256-dim on 8GB via Matryoshka)
-- **Two vec0 tables:** `episodic_memories_vec` (conversation summaries) and `core_memories_vec` (permanent facts)
+- **Three vec0 tables:**
+  - `core_memories_vec` — permanent facts about the user (visible in Settings → Core Memories)
+  - `episodic_memories_vec` — distilled conversation summaries from `EpisodicDistillationUseCase` (visible in Settings → Episodic Memories)
+  - `message_embeddings` — per-message vectors for intra-conversation fuzzy recall (visible in Settings → Message History (RAG))
 - **Retrieval:** `vec_distance_cosine()` similarity search per query; top results injected into prompt
 - **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
+- **TTL & pruning:** Episodic memories pruned on write — 30-day TTL + LRU cap of 500 entries. Core memories capped at 200. `lastAccessedAt` updated on each retrieval to ensure LRU ordering is accurate.
 
 ### 3.4 Episodic Distillation
 


### PR DESCRIPTION
Fixes #233

## What

Distilled conversation summaries written by `EpisodicDistillationUseCase` to `episodic_memories_vec` were never retrieved into RAG prompts because `RagRepository` hardcoded `episodicTopK = 0`. This PR enables retrieval and surfaces them in the prompt alongside core memories and message history.

## Changes

### `RagRepository.kt`
- `searchMemories(episodicTopK = 0)` -> `episodicTopK = 3`
- Results split into `coreResults` (source=`core`) and `distilledResults` (source=`episodic`)
- Distilled summaries rendered as `[Episodic Memories - summaries of past conversations]` with its own token budget slice (up to 400 chars per entry)
- Per-message intra-conversation section renamed from `[Episodic Memories - recalled from a past conversation]` to `[Message History - earlier in this conversation]` - aligns with the 'Message History (RAG)' label in Settings
- Section ordering: Core Memories -> Episodic Memories -> Message History
- Updated KDoc to clarify cross-conversation vs intra-conversation scope

### `MemoryRepositoryImpl.kt`
- Removed stale comment `// skip until Dreaming Engine populates the table` - `EpisodicDistillationUseCase` is live and populating the table

## RAG prompt output (after)
```
[Core Memories - permanent facts about the user]
...
[End of core memories]

[Episodic Memories - summaries of past conversations]   <- was silently empty before this fix
conversation:abc-123 | In a past conversation...
[End of episodic memories]

[Message History - earlier in this conversation]        <- renamed from 'Episodic Memories'
...
[End of message history]
```

## Side effects

- `updateLastAccessedAt()` is now reachable -> LRU eviction in `prune()` works correctly for the first time
- No changes to core memory or message history retrieval behaviour

## Testing
- Close a conversation (triggers distillation)
- Open a new conversation and ask something related to the closed one
- Expect `[Episodic Memories]` block in the RAG prefix logged by `ChatViewModel`