### PR TITLE
fix(ui): jandal emoji + Kiwi greeting on chat empty state

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -548,11 +548,11 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text = "👋",
+                text = "\uD83E\uDEF4",
                 style = MaterialTheme.typography.displayMedium,
             )
             Text(
-                text = "Hi, I'm Jandal. How can I help?",
+                text = "Kia ora! What can I help with?",
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.padding(top = 8.dp),
             )
@@ -643,7 +643,7 @@ private fun OnboardingContent(
         ) {
             Text(text = "🧠", style = MaterialTheme.typography.displayLarge)
             Text(
-                text = "Welcome to Jandal",
+                text = "Kia ora, welcome to Jandal",
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.padding(top = 16.dp),
             )


### PR DESCRIPTION
The `EmptyConversationHint` composable (shown when no messages exist) had a generic waving hand emoji and generic greeting.

**Changes:**
- `👋` → `🩴` (jandal/flip-flop emoji — matches the name)
- `"Hi, I'm Jandal. How can I help?"` → `"Kia ora! What can I help with?"`
- `"Welcome to Jandal"` → `"Kia ora, welcome to Jandal"` on the model download screen

Not implemented in #241 — that PR only updated the system prompt persona, not the UI strings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>