### PR TITLE
fix(tools): tool calling not working — fix system prompt + add flashlight skills

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
@@ -17,6 +17,45 @@ class SkillRegistry @Inject constructor(
 
     fun allSkills(): List<Skill> = registry.values.toList()
 
+
+    /**
+     * Generates a human-readable, native-token-format list of available tools for injection
+     * into the Gemma 4 system prompt. Each entry shows the exact <|tool_call> syntax the
+     * model must emit — with a concrete usage example using real function names.
+     */
+    fun buildNativeDeclarations(): String {
+        if (registry.isEmpty()) return ""
+        val strToken = "<|" + "\"" + "|>"
+        val sb = StringBuilder("Available tools — use the EXACT function name shown:\n\n")
+        registry.values.sortedBy { it.name }.forEach { skill ->
+            sb.append("• ${skill.name}: ${skill.description}\n")
+            val exampleArgs = if (skill.schema.parameters.isEmpty()) {
+                ""
+            } else {
+                skill.schema.parameters.entries.mapIndexed { i, (k, v) ->
+                    val exVal = when {
+                        !v.enum.isNullOrEmpty() -> "$strToken${v.enum!!.first()}$strToken"
+                        v.type == "integer" || v.type == "number" -> "0"
+                        else -> "${strToken}value$strToken"
+                    }
+                    "$k:$exVal"
+                }.joinToString(",")
+            }
+            sb.append("  Call: <|tool_call>call:${skill.name}{$exampleArgs}<tool_call|>\n")
+            if (skill.schema.parameters.isNotEmpty()) {
+                skill.schema.required.forEach { req ->
+                    val p = skill.schema.parameters[req]
+                    if (p != null) {
+                        val enumNote = if (!p.enum.isNullOrEmpty()) " [${p.enum!!.joinToString("/")}]" else ""
+                        sb.append("  $req (${p.type}$enumNote): ${p.description}\n")
+                    }
+                }
+            }
+            sb.append("\n")
+        }
+        return sb.toString().trimEnd()
+    }
+
     /** Generates the function_declarations JSON array for FunctionGemma's system prompt. */
     fun buildFunctionDeclarationsJson(): String {
         val declarations = org.json.JSONArray()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.core.skills
 import com.kernel.ai.core.skills.natives.GetSystemInfoSkill
 import com.kernel.ai.core.skills.natives.GetWeatherSkill
 import com.kernel.ai.core.skills.natives.SaveMemorySkill
+import com.kernel.ai.core.skills.natives.TurnOffFlashlightSkill
+import com.kernel.ai.core.skills.natives.TurnOnFlashlightSkill
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -24,4 +26,12 @@ abstract class SkillsModule {
     @Binds
     @IntoSet
     abstract fun bindGetWeatherSkill(skill: GetWeatherSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindTurnOnFlashlightSkill(skill: TurnOnFlashlightSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindTurnOffFlashlightSkill(skill: TurnOffFlashlightSkill): Skill
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/TurnOffFlashlightSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/TurnOffFlashlightSkill.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.skills.natives
+
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.util.Log
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+@Singleton
+class TurnOffFlashlightSkill @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : Skill {
+
+    override val name = "turn_off_flashlight"
+    override val description =
+        "Turns the device torch/flashlight off. Use when user says 'turn off torch', 'turn off flashlight', or 'torch off'."
+    override val schema = SkillSchema()
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        return setTorch(false)
+    }
+
+    private fun setTorch(enabled: Boolean): SkillResult {
+        return try {
+            val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            val cameraId = cameraManager.cameraIdList.firstOrNull { id ->
+                cameraManager.getCameraCharacteristics(id)
+                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+            }
+            if (cameraId != null) {
+                cameraManager.setTorchMode(cameraId, enabled)
+                SkillResult.Success("Torch turned off.")
+            } else {
+                SkillResult.Failure(name, "No flash unit found on this device.")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "TurnOffFlashlightSkill failed", e)
+            SkillResult.Failure(name, e.message ?: "Unknown error")
+        }
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/TurnOnFlashlightSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/TurnOnFlashlightSkill.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.skills.natives
+
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.util.Log
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+@Singleton
+class TurnOnFlashlightSkill @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : Skill {
+
+    override val name = "turn_on_flashlight"
+    override val description =
+        "Turns the device torch/flashlight on. Use when user says 'turn on torch', 'turn on flashlight', or 'torch on'."
+    override val schema = SkillSchema()
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        return setTorch(true)
+    }
+
+    private fun setTorch(enabled: Boolean): SkillResult {
+        return try {
+            val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+            val cameraId = cameraManager.cameraIdList.firstOrNull { id ->
+                cameraManager.getCameraCharacteristics(id)
+                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+            }
+            if (cameraId != null) {
+                cameraManager.setTorchMode(cameraId, enabled)
+                SkillResult.Success("Torch turned on.")
+            } else {
+                SkillResult.Failure(name, "No flash unit found on this device.")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "TurnOnFlashlightSkill failed", e)
+            SkillResult.Failure(name, e.message ?: "Unknown error")
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -239,9 +239,9 @@ class ChatViewModel @Inject constructor(
                 }
                 append("[End of previous conversation context]")
             }
-            val skillDeclarations = skillRegistry.buildFunctionDeclarationsJson()
-            if (skillDeclarations != "[]") {
-                append("\n\n[Tool Use]\nWhen you need to call a tool, output ONLY the native call token — no prose before or after.\nString args: <|tool_call>call:tool_name{param:<|\"|>value<|\"|>}<tool_call|>\nNumeric args: <|tool_call>call:tool_name{count:3}<tool_call|>\nNEVER say you called a tool without emitting the call token. NEVER fabricate a result.\n\nAvailable tools:\n$skillDeclarations")
+            val nativeDeclarations = skillRegistry.buildNativeDeclarations()
+            if (nativeDeclarations.isNotBlank()) {
+                append("\n\n[Tool Use]\nWhen you need to perform a device action, output ONLY a tool call token with NO text before or after.\nUse the exact function name from the list below.\n\nNo-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\nWith-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n$nativeDeclarations")
             }
         }
     }
@@ -894,18 +894,28 @@ class ChatViewModel @Inject constructor(
         val endIdx = text.indexOf(endTag, innerStart)
         if (endIdx < 0) return null
 
-        val inner = text.substring(innerStart, endIdx).trim() // "call:name{args}"
+        // inner = "call:name{args}" or "call:name" (no braces for no-arg tools)
+        val inner = text.substring(innerStart, endIdx).trim()
         if (!inner.startsWith("call:")) return null
 
-        val braceIdx = inner.indexOf('{')
-        if (braceIdx < 0) return null
+        val afterCall = inner.substring("call:".length)
+        val braceIdx = afterCall.indexOf('{')
 
-        val rawName = inner.substring("call:".length, braceIdx).trim()
-        val argsBlock = inner.substring(braceIdx + 1, inner.lastIndexOf('}')).trim()
-        val snakeName = camelToSnake(rawName)
-
+        val rawName: String
         val argsJson = org.json.JSONObject()
-        if (argsBlock.isNotBlank()) parseNativeArgs(argsBlock, argsJson)
+        if (braceIdx < 0) {
+            rawName = afterCall.trim()
+        } else {
+            rawName = afterCall.substring(0, braceIdx).trim()
+            val lastBrace = afterCall.lastIndexOf('}')
+            if (lastBrace > braceIdx) {
+                val argsBlock = afterCall.substring(braceIdx + 1, lastBrace).trim()
+                if (argsBlock.isNotBlank()) parseNativeArgs(argsBlock, argsJson)
+            }
+        }
+
+        if (rawName.isBlank()) return null
+        val snakeName = camelToSnake(rawName)
 
         return org.json.JSONObject()
             .put("name", snakeName)


### PR DESCRIPTION
## Problem
Tool calls were leaking raw `<|tool_call>call:tool_nameparam:...` tokens to the user instead of executing.

### Root cause analysis

**Bug 1 — System prompt used `tool_name` as a literal placeholder**
The model copied `tool_name` verbatim from the format examples instead of substituting a real function name. The old instruction was too abstract.

**Bug 2 — Tool declarations in OpenAI JSON schema format**
The model received a JSON schema (`buildFunctionDeclarationsJson()`) but had no example showing how to map that schema to native `<|tool_call>` token syntax.

**Bug 3 — `turn_on_flashlight` / `turn_off_flashlight` not registered as Skills**
These only existed in `KernelAIToolSet` (the LiteRT ToolSet API path, which is unconnected). Even with the correct format, `SkillExecutor` would return `UnknownSkill` → `tryExecuteToolCall` returns null → raw tokens displayed.

**Bug 4 — `extractNativeToolCall` returned null for no-argument tools**
`braceIdx < 0` was an early return, but no-arg tools can legitimately omit braces.

## Fixes

### `TurnOnFlashlightSkill.kt` + `TurnOffFlashlightSkill.kt` (NEW)
Two new `Skill` implementations wrapping `camera2` torch API, registered in `SkillsModule`. Names: `turn_on_flashlight`, `turn_off_flashlight` (no parameters needed).

### `SkillRegistry.buildNativeDeclarations()`
New method generating a human-readable list in native token format — shows the model **exactly** what to output for each skill, with concrete usage examples and real function names.

### `ChatViewModel.buildSystemPrompt()`
Replaces `buildFunctionDeclarationsJson()` with `buildNativeDeclarations()`. Updated tool instruction to:
- Explicitly say "use the exact function name from the list below"
- Show both no-arg and with-arg formats with concrete syntax

### `ChatViewModel.extractNativeToolCall()`
Handles missing braces — for no-arg tools the model may emit `<|tool_call>call:turn_on_flashlight{}<tool_call|>` or even without braces entirely.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>