### PR TITLE
feat(skills): run_js gateway + WebView JS skill bridge (Phase 2 of #247)

### DIFF
--- a/core/skills/src/main/assets/skills/get-weather/index.html
+++ b/core/skills/src/main/assets/skills/get-weather/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+/**
+ * Kernel AI — get-weather JS skill
+ * Compatible with Google AI Edge Gallery's ai_edge_gallery_get_result() contract.
+ *
+ * Args: { location: string }  (city name — GPS not available from JS skills)
+ * Returns: Plain-text current weather for the requested city.
+ *
+ * Note: For GPS-based weather, the native GetWeatherSkill (Kotlin) is preferred.
+ * This JS skill is for named-city lookups when invoked via run_js.
+ */
+async function ai_edge_gallery_get_result(data) {
+    const location = (data.location || data.city || "").trim();
+    if (!location) return "No location provided. Try 'weather in Auckland'.";
+
+    // Geocoding
+    const geoResp = await fetch(
+        "https://geocoding-api.open-meteo.com/v1/search?name=" +
+        encodeURIComponent(location) + "&count=1&language=en&format=json"
+    );
+    if (!geoResp.ok) return "Geocoding failed for: " + location;
+
+    const geoData = await geoResp.json();
+    const results = geoData && geoData.results;
+    if (!results || results.length === 0) {
+        return "Couldn't find location: " + location;
+    }
+
+    const place = results[0];
+    const lat = place.latitude;
+    const lon = place.longitude;
+    const displayName = place.name + (place.country_code ? ", " + place.country_code : "");
+
+    // Weather fetch
+    const weatherResp = await fetch(
+        "https://api.open-meteo.com/v1/forecast" +
+        "?latitude=" + lat + "&longitude=" + lon +
+        "&current=temperature_2m,apparent_temperature,relative_humidity_2m," +
+        "weather_code,wind_speed_10m,precipitation_probability" +
+        "&wind_speed_unit=ms"
+    );
+    if (!weatherResp.ok) return "Weather API failed for: " + displayName;
+
+    const w = await weatherResp.json();
+    const c = w.current;
+    const wmoDescriptions = {
+        0:"Clear sky",1:"Mainly clear",2:"Partly cloudy",3:"Overcast",
+        45:"Fog",48:"Fog",51:"Drizzle",53:"Drizzle",55:"Drizzle",
+        61:"Rain",63:"Rain",65:"Rain",71:"Snow",73:"Snow",75:"Snow",
+        80:"Rain showers",81:"Rain showers",82:"Rain showers",
+        95:"Thunderstorm",96:"Thunderstorm with hail",99:"Thunderstorm with hail"
+    };
+    const desc = wmoDescriptions[c.weather_code] || "Unknown";
+
+    return "Weather in " + displayName + ": " + desc + ".\n" +
+        "Temperature: " + c.temperature_2m.toFixed(1) + "°C" +
+        " (feels like " + c.apparent_temperature.toFixed(1) + "°C).\n" +
+        "Humidity: " + c.relative_humidity_2m + "%.\n" +
+        "Wind: " + c.wind_speed_10m.toFixed(1) + " m/s.\n" +
+        "Precipitation chance: " + c.precipitation_probability + "%.";
+}
+</script>
+</body>
+</html>

--- a/core/skills/src/main/assets/skills/query-wikipedia/index.html
+++ b/core/skills/src/main/assets/skills/query-wikipedia/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+/**
+ * Kernel AI — query-wikipedia JS skill
+ * Compatible with Google AI Edge Gallery's ai_edge_gallery_get_result() contract.
+ *
+ * Args: { query: string }
+ * Returns: A plain-text Wikipedia summary for the query.
+ */
+async function ai_edge_gallery_get_result(data) {
+    const query = (data.query || data.topic || data.search || "").trim();
+    if (!query) return "No search query provided.";
+
+    const encoded = encodeURIComponent(query);
+
+    // Try direct summary endpoint first
+    const summaryResp = await fetch(
+        "https://en.wikipedia.org/api/rest_v1/page/summary/" + encoded
+    );
+
+    if (summaryResp.ok) {
+        const json = await summaryResp.json();
+        const title = json.title || query;
+        const extract = json.extract || "";
+        const pageUrl = (json.content_urls && json.content_urls.desktop)
+            ? json.content_urls.desktop.page : "";
+
+        if (!extract) return "Wikipedia has no summary for: " + query;
+
+        const trimmed = extract.length > 900
+            ? extract.substring(0, 900) + "..."
+            : extract;
+
+        return title + "\n\n" + trimmed + (pageUrl ? "\n\nRead more: " + pageUrl : "");
+    }
+
+    // Fallback: search API
+    const searchResp = await fetch(
+        "https://en.wikipedia.org/w/api.php?action=query&list=search" +
+        "&srsearch=" + encoded + "&format=json&origin=*&srlimit=3"
+    );
+
+    if (!searchResp.ok) return "Wikipedia search failed for: " + query;
+
+    const searchData = await searchResp.json();
+    const results = searchData && searchData.query && searchData.query.search;
+
+    if (!results || results.length === 0) {
+        return "No Wikipedia results found for: " + query;
+    }
+
+    return "Wikipedia results for '" + query + "':\n" +
+        results.map(function(r) {
+            return "• " + r.title + ": " + r.snippet.replace(/<[^>]+>/g, "");
+        }).join("\n");
+}
+</script>
+</body>
+</html>

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -1,0 +1,70 @@
+package com.kernel.ai.core.skills
+
+import android.util.Log
+import com.kernel.ai.core.skills.js.JsSkillRunner
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Gateway skill that mirrors Google AI Edge Gallery's `run_js` pattern.
+ *
+ * Executes a JavaScript skill loaded from `assets/skills/<skill_name>/index.html`.
+ * Each JS skill exposes `async function ai_edge_gallery_get_result(args)` which is
+ * called by [JsSkillRunner] via a hidden WebView.
+ *
+ * Built-in JS skills bundled with the app:
+ *   - query-wikipedia  Search Wikipedia and return a plain-text summary
+ *   - get-weather      Fetch weather for a named city via open-meteo (no GPS needed)
+ *
+ * Phase 3 (future): user-loadable skills from URLs — prerequisite for #177.
+ */
+@Singleton
+class RunJsSkill @Inject constructor(
+    private val runner: JsSkillRunner,
+) : Skill {
+
+    override val name = "run_js"
+    override val description =
+        "Run a built-in JavaScript skill by name. Use for web queries like Wikipedia " +
+            "lookups or city weather when GPS is not needed."
+
+    override val schema = SkillSchema(
+        parameters = mapOf(
+            "skill_name" to SkillParameter(
+                type = "string",
+                description = "The JS skill to run.",
+                enum = listOf("query-wikipedia", "get-weather"),
+            ),
+            "query" to SkillParameter(
+                type = "string",
+                description = "The search query or input for the skill.",
+            ),
+        ),
+        required = listOf("skill_name", "query"),
+    )
+
+    private val strToken = "<|" + "\"" + "|>"
+
+    override val examples: List<String> = listOf(
+        "Wikipedia: <|tool_call>call:run_js{skill_name:${strToken}query-wikipedia${strToken},query:${strToken}New Zealand${strToken}}<tool_call|>",
+        "Weather:   <|tool_call>call:run_js{skill_name:${strToken}get-weather${strToken},query:${strToken}Auckland${strToken}}<tool_call|>",
+    )
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        val skillName = call.arguments["skill_name"]?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure(name, "Missing required parameter: skill_name.")
+        val args = call.arguments - "skill_name"
+
+        Log.d(TAG, "RunJsSkill: executing skill=$skillName args=$args")
+
+        return try {
+            val result = runner.execute(skillName, args)
+            SkillResult.Success(result)
+        } catch (e: Exception) {
+            Log.e(TAG, "RunJsSkill: skill=$skillName failed", e)
+            SkillResult.Failure(name, "JS skill '$skillName' failed: ${e.message}")
+        }
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -28,4 +28,8 @@ abstract class SkillsModule {
     @Binds
     @IntoSet
     abstract fun bindRunIntentSkill(skill: RunIntentSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindRunJsSkill(skill: RunJsSkill): Skill
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/js/JsSkillRunner.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/js/JsSkillRunner.kt
@@ -1,0 +1,122 @@
+package com.kernel.ai.core.skills.js
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+private const val TIMEOUT_MS = 15_000L
+private const val BRIDGE_NAME = "Android"
+
+/**
+ * Executes a JavaScript skill packaged in `assets/skills/<skillName>/index.html`.
+ *
+ * Mirrors Google AI Edge Gallery's JS skill execution model:
+ *  1. The skill's HTML file is loaded into a hidden WebView.
+ *  2. `ai_edge_gallery_get_result(args)` is called asynchronously via JS injection.
+ *  3. The skill calls `Android.onResult(json)` back to the native bridge.
+ *  4. The result is returned as a String to the calling coroutine.
+ *
+ * WebView must be created on the main thread; the coroutine suspends on the main
+ * dispatcher so the message loop can process WebView callbacks without blocking.
+ *
+ * Security note: `allowUniversalAccessFromFileURLs` is enabled so that skills
+ * loaded from `file://android_asset` can make HTTPS network calls (e.g., Wikipedia).
+ * This is acceptable because the skill assets are bundled with the app and are trusted.
+ */
+@Singleton
+class JsSkillRunner @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    @SuppressLint("SetJavaScriptEnabled")
+    suspend fun execute(skillName: String, args: Map<String, String>): String =
+        withContext(Dispatchers.Main) {
+            val deferred = CompletableDeferred<String>()
+            val webView = WebView(context)
+            try {
+                webView.settings.apply {
+                    javaScriptEnabled = true
+                    allowFileAccessFromFileURLs = true
+                    @Suppress("DEPRECATION")
+                    allowUniversalAccessFromFileURLs = true
+                    mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                    cacheMode = WebSettings.LOAD_NO_CACHE
+                }
+                webView.addJavascriptInterface(ResultBridge(deferred), BRIDGE_NAME)
+
+                val argsJson = JSONObject(args as Map<*, *>).toString()
+
+                webView.webViewClient = object : WebViewClient() {
+                    private var callInjected = false
+
+                    override fun onPageFinished(view: WebView, url: String) {
+                        if (callInjected || deferred.isCompleted || url == "about:blank") return
+                        callInjected = true
+                        val js = """
+                            (async () => {
+                                try {
+                                    const result = await ai_edge_gallery_get_result($argsJson);
+                                    $BRIDGE_NAME.onResult(JSON.stringify({success:true,result:String(result)}));
+                                } catch(e) {
+                                    $BRIDGE_NAME.onResult(JSON.stringify({success:false,error:String(e)}));
+                                }
+                            })();
+                        """.trimIndent()
+                        view.evaluateJavascript(js, null)
+                    }
+
+                    override fun onReceivedError(
+                        view: WebView,
+                        request: WebResourceRequest?,
+                        error: WebResourceError?,
+                    ) {
+                        if (!deferred.isCompleted) {
+                            deferred.completeExceptionally(
+                                Exception("WebView load error: ${error?.description}")
+                            )
+                        }
+                    }
+                }
+
+                webView.loadUrl("file:///android_asset/skills/$skillName/index.html")
+                Log.d(TAG, "JsSkillRunner: loading skill=$skillName args=$args")
+
+                withTimeoutOrNull(TIMEOUT_MS) { deferred.await() }
+                    ?: throw Exception("JS skill '$skillName' timed out after ${TIMEOUT_MS / 1000}s")
+            } finally {
+                webView.destroy()
+            }
+        }
+
+    private class ResultBridge(private val deferred: CompletableDeferred<String>) {
+        @JavascriptInterface
+        fun onResult(jsonResult: String) {
+            if (deferred.isCompleted) return
+            try {
+                val obj = JSONObject(jsonResult)
+                if (obj.optBoolean("success", false)) {
+                    deferred.complete(obj.optString("result", ""))
+                } else {
+                    deferred.completeExceptionally(Exception(obj.optString("error", "Unknown JS error")))
+                }
+            } catch (e: Exception) {
+                deferred.completeExceptionally(e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Phase 2 of the Gallery architecture refactor (#247): the `run_js` WebView gateway.

## What this adds

### `JsSkillRunner.kt`
Hidden WebView executor that mirrors AI Edge Gallery's JS skill execution model:
1. Loads `assets/skills/<skill_name>/index.html` into a hidden WebView
2. Calls `ai_edge_gallery_get_result(args)` asynchronously via JS injection
3. Skill calls `Android.onResult(json)` back via `JavascriptInterface`
4. Result returned to the calling coroutine (15s timeout)

WebView runs on main thread; coroutine **suspends** (does not block) waiting for callbacks.

### `RunJsSkill.kt`
The `run_js` gateway skill registered in Hilt. Built-in skills shown in system prompt.

### JS skill assets
- `assets/skills/query-wikipedia/index.html` — Wikipedia REST summary + search fallback
- `assets/skills/get-weather/index.html` — Open-Meteo weather for named cities

## Security
- `allowUniversalAccessFromFileURLs` enabled only for app-bundled trusted skill assets
- Email recipient intentionally omitted from `run_intent` send_email (prompt-injection guard)

## Phase 3 (future — #177)
- Load skills from user-supplied URLs (SKILL.md parser)
- Skill manager UI
- Dynamic `run_js` skill list (not hardcoded enum)

Closes #247 | Related: #177, #34