### PR TITLE
fix: correct jandal emoji and morena time-awareness (fixes #248, #250)

### DIFF
--- a/core/inference/src/main/assets/jandal_vocab.json
+++ b/core/inference/src/main/assets/jandal_vocab.json
@@ -40,10 +40,6 @@
     "meaning": "hello or thank you (Maori greeting)"
   },
   {
-    "phrase": "morena",
-    "meaning": "good morning (Maori)"
-  },
-  {
     "phrase": "ka pai",
     "meaning": "good job, well done (Maori)"
   },

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -47,13 +47,20 @@ class JandalPersona @Inject constructor(
     }
 
     /**
-     * Returns a time-appropriate greeting.
-     * - 05:00-11:59 -> "Morena!" (good morning in Maori)
-     * - All other hours -> "Kia ora!"
+     * Returns an explicit time-aware instruction about when Morena is appropriate.
+     * This replaces the bare greeting word injection so the model understands the
+     * time constraint rather than treating "Morena!" as a general-purpose greeting.
+     *
+     * - 05:00-11:59 → permit Morena, explain it means good morning
+     * - All other hours → explicitly forbid Morena, direct model to use Kia ora
      */
-    fun getGreeting(): String {
+    fun buildGreetingInstruction(): String {
         val hour = LocalTime.now().hour
-        return if (hour in 5..11) "Morena!" else "Kia ora!"
+        return if (hour in 5..11) {
+            "It is morning. You may greet with 'Morena' (good morning in Māori) where natural."
+        } else {
+            "Do not say 'Morena' — it means good morning and it is not morning. Greet with 'Kia ora' instead."
+        }
     }
 
     /**

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -548,7 +548,7 @@ private fun EmptyConversationHint(modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text = "\uD83E\uDEF4",
+                text = "\uD83E\uDE74",
                 style = MaterialTheme.typography.displayMedium,
             )
             Text(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -219,7 +219,7 @@ class ChatViewModel @Inject constructor(
             .format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm", Locale.ENGLISH))
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
-            append("\n\n${jandalPersona.getGreeting()} ${jandalPersona.buildSessionVocab()}")
+            append("\n\n${jandalPersona.buildGreetingInstruction()} ${jandalPersona.buildSessionVocab()}")
             append("\n\n[Current date and time]\n$dateTime")
             // Runtime info fetched dynamically via get_system_info skill at query time
             if (profile.isNotBlank()) {


### PR DESCRIPTION
Two quick UI/personality bug fixes.

## #250 — Incorrect emoji
The chat background hint was showing the wrong emoji. Fixed the Unicode escape: `\uD83E\uDEF4` (U+226F4, invalid emoji) → `\uD83E\uDE74` (U+1FA74 🩴 thong sandal).

## #248 — Morena used outside morning hours
Root cause: two independent issues both contributed:
1. `getGreeting()` injected `"Morena!"` as an example word into the system prompt. The model treated it as a general-purpose greeting rather than morning-specific.
2. `"morena"` was in `jandal_vocab.json` random pool and could appear in the system prompt at any hour.

**Fixes:**
- Replaced `getGreeting()` with `buildGreetingInstruction()` — returns an explicit directive ("Do not say Morena — it is not morning") instead of a bare example word.
- Removed `morena` from `jandal_vocab.json`; it is handled by the greeting instruction and must not randomly appear in afternoon/evening prompts.

Fixes #248, fixes #250