### PR TITLE
fix: bundle TC test failures — set_alarm, set_timer, wikipedia, GPS location, save_memory

### DIFF
--- a/core/skills/src/main/assets/skills/query-wikipedia/index.html
+++ b/core/skills/src/main/assets/skills/query-wikipedia/index.html
@@ -8,6 +8,10 @@
  *
  * Args: { query: string }
  * Returns: A plain-text Wikipedia summary for the query.
+ *
+ * Strategy:
+ *  1. Try direct summary endpoint (works for exact article titles)
+ *  2. If that 404s, search for top result then fetch its full summary
  */
 async function ai_edge_gallery_get_result(data) {
     const query = (data.query || data.topic || data.search || "").trim();
@@ -15,46 +19,43 @@ async function ai_edge_gallery_get_result(data) {
 
     const encoded = encodeURIComponent(query);
 
-    // Try direct summary endpoint first
+    // 1. Try direct summary lookup
     const summaryResp = await fetch(
         "https://en.wikipedia.org/api/rest_v1/page/summary/" + encoded
     );
-
     if (summaryResp.ok) {
-        const json = await summaryResp.json();
-        const title = json.title || query;
-        const extract = json.extract || "";
-        const pageUrl = (json.content_urls && json.content_urls.desktop)
-            ? json.content_urls.desktop.page : "";
-
-        if (!extract) return "Wikipedia has no summary for: " + query;
-
-        const trimmed = extract.length > 900
-            ? extract.substring(0, 900) + "..."
-            : extract;
-
-        return title + "\n\n" + trimmed + (pageUrl ? "\n\nRead more: " + pageUrl : "");
+        return formatSummary(await summaryResp.json());
     }
 
-    // Fallback: search API
+    // 2. Search for top result, then fetch its summary
     const searchResp = await fetch(
         "https://en.wikipedia.org/w/api.php?action=query&list=search" +
-        "&srsearch=" + encoded + "&format=json&origin=*&srlimit=3"
+        "&srsearch=" + encoded + "&format=json&origin=*&srlimit=1"
     );
-
     if (!searchResp.ok) return "Wikipedia search failed for: " + query;
 
     const searchData = await searchResp.json();
     const results = searchData && searchData.query && searchData.query.search;
+    if (!results || results.length === 0) return "No Wikipedia results found for: " + query;
 
-    if (!results || results.length === 0) {
-        return "No Wikipedia results found for: " + query;
-    }
+    const topTitle = results[0].title;
+    const articleResp = await fetch(
+        "https://en.wikipedia.org/api/rest_v1/page/summary/" + encodeURIComponent(topTitle)
+    );
+    if (!articleResp.ok) return "Couldn't fetch Wikipedia article for: " + topTitle;
 
-    return "Wikipedia results for '" + query + "':\n" +
-        results.map(function(r) {
-            return "• " + r.title + ": " + r.snippet.replace(/<[^>]+>/g, "");
-        }).join("\n");
+    return formatSummary(await articleResp.json());
+}
+
+function formatSummary(json) {
+    const title = json.title || "";
+    const extract = json.extract || "";
+    const pageUrl = json.content_urls && json.content_urls.desktop
+        ? json.content_urls.desktop.page : "";
+
+    if (!extract) return "Wikipedia has no summary for: " + title;
+
+    return title + "\n\n" + extract + (pageUrl ? "\n\nRead more: " + pageUrl : "");
 }
 </script>
 </body>

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -24,7 +24,7 @@ class RunIntentSkill @Inject constructor(
     override val name = "run_intent"
     override val description =
         "Perform a native Android device action. Use for flashlight control, sending email, " +
-            "sending SMS, or setting an alarm."
+            "sending SMS, setting an alarm, or setting a countdown timer."
 
     override val schema = SkillSchema(
         parameters = mapOf(
@@ -37,6 +37,7 @@ class RunIntentSkill @Inject constructor(
                     "send_email",
                     "send_sms",
                     "set_alarm",
+                    "set_timer",
                 ),
             ),
         ),
@@ -49,6 +50,7 @@ class RunIntentSkill @Inject constructor(
         "Send email:      <|tool_call>call:run_intent{intent_name:${STR}send_email${STR},subject:${STR}Subject${STR},body:${STR}Body${STR}}<tool_call|>",
         "Send SMS:        <|tool_call>call:run_intent{intent_name:${STR}send_sms${STR},message:${STR}Hello${STR}}<tool_call|>",
         "Set alarm 7:30:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR}}<tool_call|>",
+        "Set timer 3 min: <|tool_call>call:run_intent{intent_name:${STR}set_timer${STR},duration_seconds:${STR}180${STR}}<tool_call|>",
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -76,7 +76,37 @@ class GetWeatherSkill @Inject constructor(
                 name,
                 "Couldn't get device location. Try asking about a specific city.",
             )
-        return fetchWeather(lat = loc.latitude, lon = loc.longitude, displayName = null)
+        return fetchWeather(lat = loc.latitude, lon = loc.longitude, displayName = reverseGeocode(loc.latitude, loc.longitude))
+    }
+
+    private suspend fun reverseGeocode(lat: Double, lon: Double): String? = withContext(Dispatchers.IO) {
+        try {
+            val url = "https://nominatim.openstreetmap.org/reverse" +
+                "?lat=$lat&lon=$lon&format=json"
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", "KernelAI/1.0 (Android)")
+                .build()
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                val body = response.body?.string() ?: return@withContext null
+                val json = JSONObject(body)
+                val address = json.optJSONObject("address") ?: return@withContext null
+                val city = address.optString("city").takeIf { it.isNotBlank() }
+                    ?: address.optString("town").takeIf { it.isNotBlank() }
+                    ?: address.optString("village").takeIf { it.isNotBlank() }
+                    ?: address.optString("suburb").takeIf { it.isNotBlank() }
+                val country = address.optString("country_code").uppercase().takeIf { it.isNotBlank() }
+                when {
+                    city != null && country != null -> "$city, $country"
+                    city != null -> city
+                    else -> null
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Reverse geocode failed", e)
+            null
+        }
     }
 
     @Suppress("MissingPermission")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.skills.natives
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.hardware.camera2.CameraCharacteristics
@@ -26,6 +27,7 @@ private const val TAG = "KernelAI"
  *   send_email             — ACTION_SEND mail chooser (params: subject, body)
  *   send_sms               — ACTION_SENDTO SMS composer (params: message)
  *   set_alarm              — AlarmClock.ACTION_SET_ALARM (params: hours, minutes, label)
+ *   set_timer              — AlarmClock.ACTION_SET_TIMER (params: duration_seconds, label)
  */
 @Singleton
 class NativeIntentHandler @Inject constructor(
@@ -41,6 +43,7 @@ class NativeIntentHandler @Inject constructor(
                 "send_email" -> sendEmail(params)
                 "send_sms" -> sendSms(params)
                 "set_alarm" -> setAlarm(params)
+                "set_timer" -> setTimer(params)
                 else -> SkillResult.Failure("run_intent", "Unknown intent: $intentName")
             }
         } catch (e: Exception) {
@@ -105,7 +108,45 @@ class NativeIntentHandler @Inject constructor(
             }
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
-        context.startActivity(intent)
-        return SkillResult.Success("Alarm set for %02d:%02d.".format(hours, minutes))
+        if (context.packageManager.resolveActivity(intent, 0) == null) {
+            return SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
+        }
+        return try {
+            context.startActivity(intent)
+            SkillResult.Success("Alarm set for %02d:%02d.".format(hours, minutes))
+        } catch (e: ActivityNotFoundException) {
+            SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
+        }
+    }
+
+    // ── Timer ─────────────────────────────────────────────────────────────────
+
+    private fun setTimer(params: Map<String, String>): SkillResult {
+        val seconds = params["duration_seconds"]?.toIntOrNull()
+            ?: return SkillResult.Failure("run_intent", "duration_seconds is required and must be an integer.")
+        val intent = Intent(AlarmClock.ACTION_SET_TIMER).apply {
+            putExtra(AlarmClock.EXTRA_LENGTH, seconds)
+            putExtra(AlarmClock.EXTRA_SKIP_UI, false)
+            params["label"]?.takeIf { it.isNotBlank() }?.let {
+                putExtra(AlarmClock.EXTRA_MESSAGE, it)
+            }
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        if (context.packageManager.resolveActivity(intent, 0) == null) {
+            return SkillResult.Failure("run_intent", "No clock app found to set a timer.")
+        }
+        return try {
+            context.startActivity(intent)
+            val mins = seconds / 60
+            val secs = seconds % 60
+            val label = when {
+                mins > 0 && secs > 0 -> "$mins min $secs sec"
+                mins > 0 -> "$mins minute${if (mins != 1) "s" else ""}"
+                else -> "$seconds seconds"
+            }
+            SkillResult.Success("Timer set for $label.")
+        } catch (e: ActivityNotFoundException) {
+            SkillResult.Failure("run_intent", "No clock app found to set a timer.")
+        }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -247,8 +247,8 @@ class ChatViewModel @Inject constructor(
                         "Use the exact function name from the list below.\n\n" +
                         "No-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\n" +
                         "With-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n" +
-                        "Memory rule: whenever the user shares a personal fact, preference, name, or anything worth remembering, " +
-                        "call save_memory immediately — do NOT just acknowledge without using the tool.\n\n" +
+                        "Memory rule: whenever the user says 'remember', 'save', 'don't forget', or asks you to keep something in mind, " +
+                        "you MUST call save_memory — never just say 'got it' or acknowledge without using the tool.\n\n" +
                         nativeDeclarations
                 )
             }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -241,7 +241,16 @@ class ChatViewModel @Inject constructor(
             }
             val nativeDeclarations = skillRegistry.buildNativeDeclarations()
             if (nativeDeclarations.isNotBlank()) {
-                append("\n\n[Tool Use]\nWhen you need to perform a device action, output ONLY a tool call token with NO text before or after.\nUse the exact function name from the list below.\n\nNo-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\nWith-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n$nativeDeclarations")
+                append(
+                    "\n\n[Tool Use]\n" +
+                        "When you need to perform a device action, output ONLY a tool call token with NO text before or after.\n" +
+                        "Use the exact function name from the list below.\n\n" +
+                        "No-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\n" +
+                        "With-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n" +
+                        "Memory rule: whenever the user shares a personal fact, preference, name, or anything worth remembering, " +
+                        "call save_memory immediately — do NOT just acknowledge without using the tool.\n\n" +
+                        nativeDeclarations
+                )
             }
         }
     }


### PR DESCRIPTION
Bundles fixes for failures found during TC testing (#244).

## Changes

### `set_alarm` — fix silent failure (TC11/TC12)
Previously `startActivity()` would succeed silently even if no clock app could handle the alarm intent, causing Jandal to say "Alarm set" while nothing happened. Now checks `packageManager.resolveActivity()` first and catches `ActivityNotFoundException` — returns an honest failure message if no app is found.

### `set_timer` — new intent (closes #253, TC13-15)
Adds `set_timer` to `NativeIntentHandler` via `AlarmClock.ACTION_SET_TIMER`.
- `duration_seconds` required, `label` optional
- Same safety check as `set_alarm`
- Friendly confirmation: '3 minutes', '1 min 30 sec', etc.
- Added to `RunIntentSkill` enum and examples

### `query-wikipedia` — full article instead of bullet snippets (TC18)
The old search fallback returned bullet-point snippets for multiple results. Now: search finds the top result title, then fetches the full Wikipedia summary article for it. Removes the 900-char truncation — model can summarise naturally.

### `GetWeatherSkill` — GPS reverse geocode (closes #254, TC5)
GPS weather now calls Nominatim to resolve lat/lon to a city name. "Weather in Brisbane, AU" instead of "Weather in -27.25, 153.00". Falls back gracefully to coordinates if Nominatim fails.

### `ChatViewModel` — strengthen `save_memory` proactive instruction
Added explicit rule to the `[Tool Use]` section: *call save_memory immediately when the user shares a personal fact — do NOT just acknowledge without using the tool.*

## Issues raised as separate follow-ups
- #255 — weather forecast for tomorrow/next N days
- #256 — SMS/email pre-populate recipient from contacts

Fixes TC11, TC12, TC13-15, TC18, TC5 from #244 | Closes #253 | Related: #254