### PR TITLE
fix: add <queries> for alarm/timer intents — Android 11+ package visibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,21 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Location permissions for GetWeatherSkill GPS fallback -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required on some OEM clock apps that still check this deprecated permission -->
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+
+    <!--
+        Android 11+ package visibility: declare which implicit intents we resolve
+        so that PackageManager.resolveActivity() returns non-null for these actions.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SET_ALARM" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SET_TIMER" />
+        </intent>
+    </queries>
 
     <application
         android:name=".KernelAIApplication"


### PR DESCRIPTION
## Root cause

On Android 11+ (API 30+) `PackageManager.resolveActivity()` returns `null` for **implicit intents** unless the action is declared in a `<queries>` block in the manifest.

PR #257 added a `resolveActivity()` guard before launching alarm/timer intents. But without `<queries>`, it **always** returns null — so every alarm and timer call hits "No clock app found" regardless of whether a clock app is installed.

## Fix

- Add `<queries>` block with `android.intent.action.SET_ALARM` and `android.intent.action.SET_TIMER`
- Add `com.android.alarm.permission.SET_ALARM` — deprecated since API 19 but some OEM clock apps (Samsung, Xiaomi) still check it

## One-file change

`app/src/main/AndroidManifest.xml` only — no Kotlin changes needed.

## Testing

- Set alarm for 6am → Clock app opens ✅
- Set timer for 5 minutes → Countdown starts ✅
- Device without clock app → "No clock app found" (unchanged) ✅

Fixes TC11-R, TC12-R, TC-T1..TC-T4 in #259