### PR TITLE
fix: add alarm rule to system prompt to prevent hallucination

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -248,7 +248,9 @@ class ChatViewModel @Inject constructor(
                         "No-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\n" +
                         "With-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n" +
                         "Memory rule: whenever the user says 'remember', 'save', 'don't forget', or asks you to keep something in mind, " +
-                        "you MUST call save_memory — never just say 'got it' or acknowledge without using the tool.\n\n" +
+                        "you MUST call save_memory — never just say 'got it' or acknowledge without using the tool.\n" +
+                        "Alarm rule: whenever the user asks to set an alarm for a specific time, " +
+                        "you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set' or confirm it without using the tool.\n\n" +
                         nativeDeclarations
                 )
             }


### PR DESCRIPTION
## Problem

The model has a strong training bias toward verbally confirming alarm requests (mimicking Siri/Google) without calling any tool. Timer works because the tool call example is sufficient for a less-biased intent, but `set_alarm` gets overridden by the model's priors.

## Fix

Add an explicit `Alarm rule` to the `[Tool Use]` section of the system prompt, identical in pattern to the existing `Memory rule`:

```
Alarm rule: whenever the user asks to set an alarm for a specific time,
you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set'
or confirm it without using the tool.
```

## One-line change

`ChatViewModel.kt` system prompt only.

## Testing

- "Set an alarm for 6:30am" → Clock app opens ✅
- "Set an alarm for 6am for the gym" → Clock app opens with label ✅
- Timer still works ✅

Fixes TC11-R, TC12-R in #259