### PR TITLE
feat: search_memory skill — cross-conversation message history search (#236)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MessageDao.kt
@@ -28,6 +28,9 @@ interface MessageDao {
     @Query("UPDATE messages SET content = :content, thinkingText = :thinkingText WHERE id = :id")
     suspend fun updateContentAndThinking(id: String, content: String, thinkingText: String?)
 
+    @Query("SELECT * FROM messages WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<MessageEntity>
+
     @Query("UPDATE messages SET toolCallJson = :toolCallJson WHERE id = :id")
     suspend fun updateToolCallJson(id: String, toolCallJson: String?)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/MessageSearchResult.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/MessageSearchResult.kt
@@ -1,0 +1,16 @@
+package com.kernel.ai.core.memory.rag
+
+/**
+ * A single message result returned by [RagRepository.searchMessages].
+ *
+ * @param role "user" or "assistant"
+ * @param content The message text.
+ * @param conversationId The conversation this message belongs to.
+ * @param timestamp Unix millis when the message was recorded.
+ */
+data class MessageSearchResult(
+    val role: String,
+    val content: String,
+    val conversationId: String,
+    val timestamp: Long,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -168,10 +168,9 @@ class RagRepository @Inject constructor(
                         .sortedBy { candidates.indexOf(it.rowId) }
                         .take(topK)
 
-                    val messages = filteredEntities.mapNotNull { entity ->
-                        messageDao.getByConversation(entity.conversationId)
-                            .firstOrNull { it.id == entity.messageId }
-                    }
+                    val fetchedMsgIds = filteredEntities.map { it.messageId }
+                    val fetchedMsgMap = messageDao.getByIds(fetchedMsgIds).associateBy { it.id }
+                    val messages = filteredEntities.mapNotNull { fetchedMsgMap[it.messageId] }
 
                     val episodicHeader = "[Episodic Memories — recalled from a past conversation]\n"
                     val episodicFooter = "[End of episodic memories]"
@@ -247,10 +246,11 @@ class RagRepository @Inject constructor(
                 .sortedBy { rawResults.indexOf(it.rowId) }
                 .take(topK)
 
+            val messageIds = entities.map { it.messageId }
+            val fetchedMessages = messageDao.getByIds(messageIds).associateBy { it.id }
+
             entities.mapNotNull { entity ->
-                val msg = messageDao.getByConversation(entity.conversationId)
-                    .firstOrNull { it.id == entity.messageId }
-                    ?: return@mapNotNull null
+                val msg = fetchedMessages[entity.messageId] ?: return@mapNotNull null
                 MessageSearchResult(
                     role = msg.role,
                     content = msg.content,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -141,7 +141,8 @@ class RagRepository @Inject constructor(
             val distilledOverhead = (distilledHeader.length + distilledFooter.length + charsPerToken - 1) / charsPerToken
             var distilledBudget = tokenBudgetRemaining - distilledOverhead
             for (result in distilledResults) {
-                val line = result.content.take(400)
+                val prefix = result.conversationId?.let { "conversation:$it | " } ?: ""
+                val line = "$prefix${result.content.take(400)}"
                 val cost = (line.length + 1 + charsPerToken - 1) / charsPerToken
                 if (distilledBudget - cost < 0) break
                 distilledMemoryLines.add(line)
@@ -210,6 +211,56 @@ class RagRepository @Inject constructor(
                 episodicLines.forEach { appendLine(it) }
                 append("[End of message history]")
             }
+        }
+    }
+
+    /**
+     * Search [message_embeddings] for messages semantically similar to [query].
+     *
+     * @param query Natural-language search query to embed and compare against stored messages.
+     * @param conversationId When provided, restricts results to that conversation (summary-to-detail
+     *   path). When null, searches across all conversations (cross-conversation recall).
+     * @param topK Maximum number of results to return.
+     * @return List of matching messages with role, content, and conversationId; empty if none found
+     *   or if the embedding engine is not ready.
+     */
+    suspend fun searchMessages(
+        query: String,
+        conversationId: String? = null,
+        topK: Int = DEFAULT_TOP_K,
+    ): List<MessageSearchResult> = withContext(Dispatchers.IO) {
+        val queryVector = embeddingEngine.embed(query)
+        if (queryVector.isEmpty()) return@withContext emptyList()
+        if (!tableCreated) return@withContext emptyList()
+
+        runCatching {
+            val rawResults = vectorStore.search(TABLE, queryVector, topK * 2)
+                .filter { it.distance <= MAX_DISTANCE }
+                .map { it.rowId }
+            if (rawResults.isEmpty()) return@runCatching emptyList()
+
+            val entities = if (conversationId != null) {
+                embeddingDao.getByRowIdsForConversation(rawResults, conversationId)
+            } else {
+                embeddingDao.getByRowIds(rawResults)
+            }
+                .sortedBy { rawResults.indexOf(it.rowId) }
+                .take(topK)
+
+            entities.mapNotNull { entity ->
+                val msg = messageDao.getByConversation(entity.conversationId)
+                    .firstOrNull { it.id == entity.messageId }
+                    ?: return@mapNotNull null
+                MessageSearchResult(
+                    role = msg.role,
+                    content = msg.content,
+                    conversationId = entity.conversationId,
+                    timestamp = msg.timestamp,
+                )
+            }
+        }.getOrElse {
+            Log.w(TAG, "searchMessages failed: ${it.message}")
+            emptyList()
         }
     }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -139,6 +139,7 @@ class MemoryRepositoryImpl @Inject constructor(
                             source = "episodic",
                             score = 1f - (distanceMap[entity.rowId] ?: 1f),
                             lastAccessedAt = entity.lastAccessedAt,
+                            conversationId = entity.conversationId,
                         )
                     )
                 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
@@ -6,4 +6,5 @@ data class MemorySearchResult(
     val source: String,       // "episodic" or "core"
     val score: Float,
     val lastAccessedAt: Long = 0L, // populated for core memories; used as tiebreaker when truncating
+    val conversationId: String? = null, // populated for episodic memories; used for summary-to-detail retrieval
 )

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.skills
 import com.kernel.ai.core.skills.natives.GetSystemInfoSkill
 import com.kernel.ai.core.skills.natives.GetWeatherSkill
 import com.kernel.ai.core.skills.natives.SaveMemorySkill
+import com.kernel.ai.core.skills.natives.SearchMemorySkill
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -20,6 +21,10 @@ abstract class SkillsModule {
     @Binds
     @IntoSet
     abstract fun bindSaveMemorySkill(skill: SaveMemorySkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindSearchMemorySkill(skill: SearchMemorySkill): Skill
 
     @Binds
     @IntoSet

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
@@ -1,0 +1,95 @@
+package com.kernel.ai.core.skills.natives
+
+import android.util.Log
+import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillParameter
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Skill that searches the user's cross-conversation message history for content
+ * semantically similar to a query.
+ *
+ * Two usage modes:
+ * - No [conversationId]: cross-conversation search across all past messages.
+ * - With [conversationId]: scoped search within a specific conversation, useful for
+ *   the summary-to-detail path where the model has an episodic summary and wants the
+ *   underlying messages.
+ */
+@Singleton
+class SearchMemorySkill @Inject constructor(
+    private val ragRepository: RagRepository,
+) : Skill {
+
+    override val name = "search_memory"
+    override val description =
+        "Search your saved message history for information about a topic. Use when the user " +
+            "asks what you remember about something, asks you to recall a past conversation, " +
+            "or asks 'what did we discuss about X'. Optionally scope to a specific " +
+            "conversationId from an episodic summary for detail retrieval."
+    override val schema = SkillSchema(
+        parameters = mapOf(
+            "query" to SkillParameter(
+                type = "string",
+                description = "The topic or phrase to search for in past messages."
+            ),
+            "conversationId" to SkillParameter(
+                type = "string",
+                description = "Optional. Restrict search to this conversation ID (from an episodic summary)."
+            ),
+            "topK" to SkillParameter(
+                type = "integer",
+                description = "Maximum number of results to return. Defaults to 5."
+            ),
+        ),
+        required = listOf("query"),
+    )
+
+    override val examples = listOf(
+        "User asks 'what do you remember about my project?' → Call: <|tool_call>call:search_memory{query:<|\"project\"|>}<tool_call|>",
+        "User asks 'what did we decide last week?' → Call: <|tool_call>call:search_memory{query:<|\"decision last week\"|>}<tool_call|>",
+        "Drill into an episodic summary tagged conversation:abc-123 → Call: <|tool_call>call:search_memory{query:<|\"topic\"|>,conversationId:<|\"abc-123\"|>}<tool_call|>",
+    )
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        val query = call.arguments["query"]
+            ?: return SkillResult.Failure(name, "Missing 'query' argument")
+        val conversationId = call.arguments["conversationId"]?.takeIf { it.isNotBlank() }
+        val topK = call.arguments["topK"]?.toIntOrNull()?.coerceIn(1, 20) ?: 5
+
+        return withContext(Dispatchers.Default) {
+            try {
+                val results = ragRepository.searchMessages(query, conversationId, topK)
+                Log.d(TAG, "SearchMemorySkill: query='${query.take(60)}' conversationId=$conversationId → ${results.size} results")
+
+                if (results.isEmpty()) {
+                    return@withContext SkillResult.Success("No memories found matching '$query'.")
+                }
+
+                val fmt = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+                val sb = StringBuilder("Here's what I found in our past conversations:\n\n")
+                results.forEachIndexed { i, result ->
+                    val role = if (result.role == "user") "You" else "Me"
+                    val date = fmt.format(Date(result.timestamp))
+                    sb.appendLine("${i + 1}. [$date — conversation:${result.conversationId.take(8)}]")
+                    sb.appendLine("   $role: ${result.content.take(300)}")
+                }
+                SkillResult.Success(sb.toString().trimEnd())
+            } catch (e: Exception) {
+                Log.e(TAG, "SearchMemorySkill failed", e)
+                SkillResult.Failure(name, e.message ?: "Failed to search memories")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #236 — `search_memory` native Kotlin skill for cross-conversation message history retrieval.

## Changes

### `SearchMemorySkill.kt` (new)
- `name = "search_memory"` registered via Hilt `@IntoSet`
- Parameters: `query` (required), `conversationId` (optional), `topK` (optional, default 5)
- `conversationId = null` → cross-conversation search across all `message_embeddings`
- `conversationId` provided → scoped to that conversation (summary-to-detail path)
- Returns formatted list: role, content excerpt, date, and `conversation:ID` prefix per result

### `RagRepository.searchMessages()` (new method)
- Embeds query, searches `message_embeddings` vector table with `MAX_DISTANCE=0.4`
- Respects optional `conversationId` scope using existing `MessageEmbeddingDao` methods
- Returns `List<MessageSearchResult>` with role, content, conversationId, timestamp

### `MessageSearchResult.kt` (new data class)
- Lightweight result type: `role`, `content`, `conversationId`, `timestamp`

### `MemorySearchResult.conversationId` (new field)
- Nullable `String?`, populated from `EpisodicMemoryEntity.conversationId` for episodic results
- Core memory results leave it `null`

### `RagRepository.getRelevantContext()` updated
- `[Episodic Memories]` lines now prefixed with `conversation:ID |`
- Enables the model to extract a `conversationId` and call `search_memory` with it for detail retrieval

### `SkillsModule.kt` updated
- `bindSearchMemorySkill` added with `@Binds @IntoSet`

## Acceptance Criteria
- [x] `MemorySearchResult.conversationId` populated for episodic results
- [x] `[Episodic Memories]` RAG lines prefixed with `conversation:ID |`
- [x] `search_memory` cross-conversation search (no conversationId)
- [x] `search_memory` scoped search with conversationId (summary-to-detail)
- [x] Model can perform summary-to-detail retrieval in a single follow-up tool call

Closes #236