### PR TITLE
fix: rename weather skills to get_weather_gps and get-weather-city, add GPS forecast (#272)

### DIFF
--- a/core/skills/src/main/assets/skills/get-weather-city/index.html
+++ b/core/skills/src/main/assets/skills/get-weather-city/index.html
@@ -3,7 +3,7 @@
 <body>
 <script>
 /**
- * Kernel AI — get-weather JS skill
+ * Kernel AI — get-weather-city JS skill
  * Compatible with Google AI Edge Gallery's ai_edge_gallery_get_result() contract.
  *
  * Args:

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -29,8 +29,9 @@ class RunJsSkill @Inject constructor(
 
     override val name = "run_js"
     override val description =
-        "Run a built-in JavaScript skill by name. Use for web queries like Wikipedia " +
-            "lookups, city weather (current or forecast). " +
+        "Run a built-in JavaScript skill by name. Use for web queries like Wikipedia lookups " +
+            "or weather for a known city name. " +
+            "For weather at the user's current/GPS location, use the native get_weather skill instead. " +
             "For weather forecasts pass forecast_days (1–7) to get a daily forecast."
 
     override val schema = SkillSchema(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -16,7 +16,7 @@ private const val TAG = "KernelAI"
  *
  * Built-in JS skills bundled with the app:
  *   - query-wikipedia  Search Wikipedia and return a plain-text summary
- *   - get-weather      Fetch current weather or multi-day forecast for a named city
+ *   - get-weather-city Fetch current weather or multi-day forecast for a named city
  *                      via Open-Meteo (no GPS needed).
  *                      Pass forecast_days (1–7) for a daily forecast instead of current.
  *
@@ -29,17 +29,17 @@ class RunJsSkill @Inject constructor(
 
     override val name = "run_js"
     override val description =
-        "Run a built-in JavaScript skill by name. Use for web queries like Wikipedia lookups " +
-            "or weather for a known city name. " +
-            "For weather at the user's current/GPS location, use the native get_weather skill instead. " +
-            "For weather forecasts pass forecast_days (1–7) to get a daily forecast."
+        "Run a built-in JavaScript skill by name. Use skill_name='get-weather-city' for weather " +
+            "with a known city name or forecast by city. " +
+            "For current GPS location weather or GPS-based forecast, use get_weather_gps instead. " +
+            "For forecast, pass forecast_days (1–7)."
 
     override val schema = SkillSchema(
         parameters = mapOf(
             "skill_name" to SkillParameter(
                 type = "string",
                 description = "The JS skill to run.",
-                enum = listOf("query-wikipedia", "get-weather"),
+                enum = listOf("query-wikipedia", "get-weather-city"),
             ),
             "query" to SkillParameter(
                 type = "string",
@@ -47,7 +47,7 @@ class RunJsSkill @Inject constructor(
             ),
             "forecast_days" to SkillParameter(
                 type = "integer",
-                description = "For get-weather only: number of forecast days (1–7). " +
+                description = "For get-weather-city only: number of forecast days (1–7). " +
                     "Omit for current weather.",
             ),
         ),
@@ -58,9 +58,9 @@ class RunJsSkill @Inject constructor(
 
     override val examples: List<String> = listOf(
         "Wikipedia: <|tool_call>call:run_js{skill_name:${strToken}query-wikipedia${strToken},query:${strToken}New Zealand${strToken}}<tool_call|>",
-        "Weather (current): <|tool_call>call:run_js{skill_name:${strToken}get-weather${strToken},query:${strToken}Auckland${strToken}}<tool_call|>",
-        "Weather (forecast 3 days): <|tool_call>call:run_js{skill_name:${strToken}get-weather${strToken},query:${strToken}Auckland${strToken},forecast_days:${strToken}3${strToken}}<tool_call|>",
-        "Weather (tomorrow): <|tool_call>call:run_js{skill_name:${strToken}get-weather${strToken},query:${strToken}London${strToken},forecast_days:${strToken}1${strToken}}<tool_call|>",
+        "Weather (current, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}Auckland${strToken}}<tool_call|>",
+        "Weather (forecast 3 days, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}Auckland${strToken},forecast_days:${strToken}3${strToken}}<tool_call|>",
+        "Weather (tomorrow, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}London${strToken},forecast_days:${strToken}1${strToken}}<tool_call|>",
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -33,6 +33,13 @@ class GetWeatherSkill @Inject constructor(
     override val description =
         "Get current weather conditions for the user's location or a named city. " +
             "Use when the user asks about weather, temperature, rain, forecast, or conditions."
+    private val strToken = "<|" + "\"" + "|>"
+
+    override val examples = listOf(
+        "GPS/current location: <|tool_call>call:get_weather{location:${strToken}current${strToken}}<tool_call|>",
+        "Named city: <|tool_call>call:get_weather{location:${strToken}Auckland${strToken}}<tool_call|>",
+    )
+
     override val schema = SkillSchema(
         parameters = mapOf(
             "location" to SkillParameter(
@@ -121,26 +128,29 @@ class GetWeatherSkill @Inject constructor(
     // ── Geocoding ─────────────────────────────────────────────────────────────
 
     private suspend fun fetchByCity(city: String): SkillResult = withContext(Dispatchers.IO) {
+        val result = geocodeAndFetch(city)
+        if (result != null) return@withContext result
+
+        // Retry with just the first comma-separated component (e.g. "Murrumba Downs, QLD, Australia" → "Murrumba Downs")
+        val simplified = city.substringBefore(",").trim()
+        if (simplified != city) {
+            val retryResult = geocodeAndFetch(simplified)
+            if (retryResult != null) return@withContext retryResult
+        }
+
+        SkillResult.Failure(name, "Couldn't find location '$city'. Try a different city name.")
+    }
+
+    private suspend fun geocodeAndFetch(city: String): SkillResult? = withContext(Dispatchers.IO) {
         val url = "https://geocoding-api.open-meteo.com/v1/search" +
             "?name=${java.net.URLEncoder.encode(city, "UTF-8")}&count=1&language=en&format=json"
         val request = Request.Builder().url(url).build()
         httpClient.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                return@withContext SkillResult.Failure(
-                    name,
-                    "Geocoding API returned ${response.code}.",
-                )
-            }
-            val body = response.body?.string()
-                ?: return@withContext SkillResult.Failure(name, "Empty geocoding response.")
+            if (!response.isSuccessful) return@withContext null
+            val body = response.body?.string() ?: return@withContext null
             val json = JSONObject(body)
             val results = json.optJSONArray("results")
-            if (results == null || results.length() == 0) {
-                return@withContext SkillResult.Failure(
-                    name,
-                    "Couldn't find location '$city'. Try a different city name.",
-                )
-            }
+            if (results == null || results.length() == 0) return@withContext null
             val place = results.getJSONObject(0)
             val lat = place.getDouble("latitude")
             val lon = place.getDouble("longitude")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -159,6 +159,10 @@ class GetWeatherSkill @Inject constructor(
 
         val len = dates.length()
         if (len == 0) return SkillResult.Failure(name, "No forecast data returned.")
+        if (maxTemps.length() != len || minTemps.length() != len ||
+            precip.length() != len || codes.length() != len) {
+            return SkillResult.Failure(name, "Incomplete forecast data (mismatched array lengths).")
+        }
 
         val locationLabel = displayName ?: "GPS location"
         val text = buildString {
@@ -287,7 +291,8 @@ class GetWeatherSkill @Inject constructor(
         66, 67 -> "Freezing rain"
         71, 73, 75 -> "Snow"
         77 -> "Snow grains"
-        80, 81, 82 -> "Rain showers"
+        80, 81 -> "Rain showers"
+        82 -> "Heavy rain showers"
         85, 86 -> "Snow showers"
         95 -> "Thunderstorm"
         96, 99 -> "Thunderstorm with hail"

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -29,37 +29,33 @@ class GetWeatherSkill @Inject constructor(
     private val httpClient: OkHttpClient,
 ) : Skill {
 
-    override val name = "get_weather"
+    override val name = "get_weather_gps"
     override val description =
-        "Get current weather conditions for the user's location or a named city. " +
-            "Use when the user asks about weather, temperature, rain, forecast, or conditions."
+        "Get current weather or a multi-day forecast using the device's GPS location. " +
+            "Use this when the user asks about their current location weather or doesn't specify a city. " +
+            "For weather in a named city, use run_js with skill_name='get-weather-city' instead."
     private val strToken = "<|" + "\"" + "|>"
 
     override val examples = listOf(
-        "GPS/current location: <|tool_call>call:get_weather{location:${strToken}current${strToken}}<tool_call|>",
-        "Named city: <|tool_call>call:get_weather{location:${strToken}Auckland${strToken}}<tool_call|>",
+        "Current location weather: <|tool_call>call:get_weather_gps{}<tool_call|>",
+        "GPS location forecast 3 days: <|tool_call>call:get_weather_gps{forecast_days:${strToken}3${strToken}}<tool_call|>",
     )
 
     override val schema = SkillSchema(
         parameters = mapOf(
-            "location" to SkillParameter(
-                type = "string",
-                description = "City name (e.g. 'Auckland') or 'current' to use device GPS. " +
-                    "Defaults to 'current' if not specified.",
+            "forecast_days" to SkillParameter(
+                type = "integer",
+                description = "Number of forecast days (1–7). Omit for current conditions only.",
             ),
         ),
         required = emptyList(),
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {
-        val location = call.arguments["location"]?.takeIf { it.isNotBlank() } ?: "current"
+        val forecastDays = call.arguments["forecast_days"]?.trim()?.toIntOrNull()?.coerceIn(1, 7) ?: 0
 
         return try {
-            if (location.equals("current", ignoreCase = true)) {
-                fetchByDeviceLocation()
-            } else {
-                fetchByCity(location)
-            }
+            fetchByDeviceLocation(forecastDays)
         } catch (e: Exception) {
             Log.e(TAG, "GetWeatherSkill failed", e)
             SkillResult.Failure(name, "Couldn't fetch weather: ${e.message}")
@@ -68,14 +64,14 @@ class GetWeatherSkill @Inject constructor(
 
     // ── Location ──────────────────────────────────────────────────────────────
 
-    private suspend fun fetchByDeviceLocation(): SkillResult {
+    private suspend fun fetchByDeviceLocation(forecastDays: Int = 0): SkillResult {
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
             != PackageManager.PERMISSION_GRANTED
         ) {
             return SkillResult.Failure(
                 name,
-                "Location permission not granted. Try asking about weather in a specific city, " +
-                    "e.g. 'weather in Auckland'.",
+                "Location permission not granted. Try asking about weather in a specific city " +
+                    "using run_js with skill_name='get-weather-city'.",
             )
         }
         val loc = getLastKnownLocation()
@@ -83,7 +79,12 @@ class GetWeatherSkill @Inject constructor(
                 name,
                 "Couldn't get device location. Try asking about a specific city.",
             )
-        return fetchWeather(lat = loc.latitude, lon = loc.longitude, displayName = reverseGeocode(loc.latitude, loc.longitude))
+        val displayName = reverseGeocode(loc.latitude, loc.longitude)
+        return if (forecastDays > 0) {
+            fetchForecast(lat = loc.latitude, lon = loc.longitude, displayName = displayName, days = forecastDays)
+        } else {
+            fetchWeather(lat = loc.latitude, lon = loc.longitude, displayName = displayName)
+        }
     }
 
     private suspend fun reverseGeocode(lat: Double, lon: Double): String? = withContext(Dispatchers.IO) {
@@ -125,39 +126,76 @@ class GetWeatherSkill @Inject constructor(
                 .addOnFailureListener { cont.resumeWith(Result.success(null)) }
         }
 
-    // ── Geocoding ─────────────────────────────────────────────────────────────
+    // ── Forecast fetch ────────────────────────────────────────────────────────
 
-    private suspend fun fetchByCity(city: String): SkillResult = withContext(Dispatchers.IO) {
-        val result = geocodeAndFetch(city)
-        if (result != null) return@withContext result
-
-        // Retry with just the first comma-separated component (e.g. "Murrumba Downs, QLD, Australia" → "Murrumba Downs")
-        val simplified = city.substringBefore(",").trim()
-        if (simplified != city) {
-            val retryResult = geocodeAndFetch(simplified)
-            if (retryResult != null) return@withContext retryResult
+    private suspend fun fetchForecast(lat: Double, lon: Double, displayName: String?, days: Int): SkillResult =
+        withContext(Dispatchers.IO) {
+            val url = "https://api.open-meteo.com/v1/forecast" +
+                "?latitude=$lat&longitude=$lon" +
+                "&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,weather_code" +
+                "&timezone=auto&forecast_days=$days&wind_speed_unit=ms"
+            val request = Request.Builder().url(url).build()
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    return@withContext SkillResult.Failure(
+                        name,
+                        "Forecast API returned ${response.code}.",
+                    )
+                }
+                val body = response.body?.string()
+                    ?: return@withContext SkillResult.Failure(name, "Empty forecast response.")
+                parseForecastResponse(body, displayName)
+            }
         }
 
-        SkillResult.Failure(name, "Couldn't find location '$city'. Try a different city name.")
+    private fun parseForecastResponse(json: String, displayName: String?): SkillResult {
+        val obj = JSONObject(json)
+        val daily = obj.getJSONObject("daily")
+        val dates = daily.getJSONArray("time")
+        val maxTemps = daily.getJSONArray("temperature_2m_max")
+        val minTemps = daily.getJSONArray("temperature_2m_min")
+        val precip = daily.getJSONArray("precipitation_sum")
+        val codes = daily.getJSONArray("weather_code")
+
+        val len = dates.length()
+        if (len == 0) return SkillResult.Failure(name, "No forecast data returned.")
+
+        val locationLabel = displayName ?: "GPS location"
+        val text = buildString {
+            append("$locationLabel forecast:\n")
+            for (i in 0 until len) {
+                val dateStr = dates.getString(i)          // "YYYY-MM-DD"
+                val formattedDate = formatForecastDate(dateStr)
+                val code = codes.optInt(i, -1)
+                val emoji = wmoEmoji(code)
+                val desc = wmoDescription(code)
+                val high = maxTemps.optDouble(i, Double.NaN)
+                val low = minTemps.optDouble(i, Double.NaN)
+                val rain = precip.optDouble(i, 0.0)
+                val highStr = if (!high.isNaN()) "%.0f°C".format(high) else "?°C"
+                val lowStr = if (!low.isNaN()) "%.0f°C".format(low) else "?°C"
+                val rainStr = "%.0fmm rain".format(rain)
+                append("$formattedDate: $emoji $desc $highStr / $lowStr, $rainStr\n")
+            }
+        }.trimEnd()
+
+        Log.d(TAG, "GetWeatherSkill: fetched ${len}-day forecast for $locationLabel")
+        return SkillResult.Success(text)
     }
 
-    private suspend fun geocodeAndFetch(city: String): SkillResult? = withContext(Dispatchers.IO) {
-        val url = "https://geocoding-api.open-meteo.com/v1/search" +
-            "?name=${java.net.URLEncoder.encode(city, "UTF-8")}&count=1&language=en&format=json"
-        val request = Request.Builder().url(url).build()
-        httpClient.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) return@withContext null
-            val body = response.body?.string() ?: return@withContext null
-            val json = JSONObject(body)
-            val results = json.optJSONArray("results")
-            if (results == null || results.length() == 0) return@withContext null
-            val place = results.getJSONObject(0)
-            val lat = place.getDouble("latitude")
-            val lon = place.getDouble("longitude")
-            val resolvedName = place.optString("name", city)
-            val country = place.optString("country_code", "")
-            val displayName = if (country.isNotBlank()) "$resolvedName, $country" else resolvedName
-            fetchWeather(lat = lat, lon = lon, displayName = displayName)
+    private fun formatForecastDate(dateStr: String): String {
+        return try {
+            val parts = dateStr.split("-")
+            if (parts.size != 3) return dateStr
+            val year = parts[0].toInt()
+            val month = parts[1].toInt() - 1  // 0-based
+            val day = parts[2].toInt()
+            val cal = java.util.Calendar.getInstance().apply { set(year, month, day) }
+            val dayNames = arrayOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+            val monthNames = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+            "${dayNames[cal.get(java.util.Calendar.DAY_OF_WEEK) - 1]} $day ${monthNames[month]}"
+        } catch (e: Exception) {
+            dateStr
         }
     }
 
@@ -217,7 +255,26 @@ class GetWeatherSkill @Inject constructor(
         return SkillResult.Success(text)
     }
 
-    // ── WMO code → description ────────────────────────────────────────────────
+    // ── WMO code → description / emoji ───────────────────────────────────────
+
+    private fun wmoEmoji(code: Int): String = when (code) {
+        0 -> "☀️"
+        1 -> "🌤️"
+        2 -> "⛅"
+        3 -> "☁️"
+        45, 48 -> "🌫️"
+        51, 53 -> "🌦️"
+        55 -> "🌧️"
+        61, 63, 65 -> "🌧️"
+        66, 67 -> "🌧️"
+        71, 73, 75 -> "❄️"
+        77 -> "🌨️"
+        80, 81 -> "🌦️"
+        82 -> "⛈️"
+        85, 86 -> "🌨️"
+        95, 96, 99 -> "⛈️"
+        else -> "🌡️"
+    }
 
     private fun wmoDescription(code: Int): String = when (code) {
         0 -> "Clear sky"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -171,7 +171,7 @@ User Input (voice/text)
 | Tool system prompt injection | ✅ Done | `SkillRegistry.buildNativeDeclarations()` injected into system prompt; concrete `<\|tool_call>` examples per skill |
 | JS skill execution layer — WebView gateway ([#239](https://github.com/NickMonrad/kernel-ai-assistant/issues/239)) | ✅ Done | `JsSkillRunner` + hidden WebView; `run_js` gateway (#247/#251) |
 | `get_system_info` skill | ✅ Done | Runtime device/model/backend info |
-| `get_weather` JS skill — Open-Meteo + GPS | ✅ Done | GPS or city geocoding → Open-Meteo; Nominatim reverse geocode for GPS display name (#257) |
+| `get_weather` JS skill — Open-Meteo + GPS | ✅ Done | Renamed to `get_weather_gps` (native) and `get-weather-city` (JS). GPS skill now supports forecast (#272) |
 | `query_wikipedia` JS skill | ✅ Done | Full article fetch via REST summary API (#257) |
 | `save_memory` skill | ✅ Done | Persists to `MemoryRepository.addCoreMemory`; explicit trigger enforced in system prompt (#257) |
 | `set_alarm` via `run_intent` | ✅ Done | `AlarmClock.ACTION_SET_ALARM`; package visibility fix (#262); hallucination rule (#263) |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-04-13 (revised post-PR #247/#251/#257/#262/#263)
+> **Last updated:** 2026-04-13 (revised post-PR #262/#263/#268/#269/#270)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -243,8 +243,16 @@ This means the model only needs two function names; new native intents are added
 
 | `skill_name` | Location | Status |
 |-------------|----------|--------|
-| `get_weather` | `assets/skills/get-weather/index.html` | ✅ |
+| `get_weather` | `assets/skills/get-weather/index.html` | ✅ (current + forecast) |
 | `query_wikipedia` | `assets/skills/query-wikipedia/index.html` | ✅ |
+
+> **`get_weather` forecast support (PR #269):** Pass `forecast_days` (integer 1–7) for a
+> day-by-day forecast instead of current conditions. When `forecast_days > 0` or
+> `query_type = "forecast"`, the skill calls the Open-Meteo `daily` API
+> (`temperature_2m_max`, `temperature_2m_min`, `precipitation_sum`, `weather_code`,
+> `timezone=auto`) and returns a breakdown with WMO weather emoji (☀️🌤️⛅☁️🌧️❄️⛈️) and
+> min/max temps. Default `forecast_days = 3` when a forecast is requested. A defensive
+> array-length guard prevents crashes on partial API responses.
 
 JS skills expose a single async entry point:
 ```javascript
@@ -259,13 +267,26 @@ and awaits the result with a 15s timeout.
 |------------|-------------|--------|
 | `get_system_info` | Device/model/backend/battery stats | ✅ |
 | `save_memory` | Persist a note/fact to `core_memories_vec` | ✅ (explicit trigger only — see memory rule below) |
+| `search_memory` | Semantic search across `message_embeddings` — cross-conversation by default, or scoped to one conversation | ✅ |
 
 > **save_memory trigger:** Works reliably when the user explicitly says "remember", "save",
-> or "don't forget". Does not activate proactively from implicit personal facts shared in
-> conversation — small model limitation. The system prompt encodes this as a hard rule.
+> "don't forget", "can you remember", or "make a note of". Does not activate proactively from
+> implicit personal facts shared in conversation — small model limitation. The trigger is
+> enforced as a hard `[Tool Use]` rule in `ChatViewModel.buildSystemPrompt()`, not via the
+> skill description.
+
+> **search_memory:** A direct `Skill` implementation (not a gateway skill) registered in
+> `SkillsModule.kt` via Hilt `@Binds @IntoSet`. Accepts a required `query` string,
+> optional `conversationId` (scopes search to one conversation for summary-to-detail
+> drill-down), and optional `topK` (default 5). Wraps `RagRepository.searchMessages()`,
+> which embeds the query and performs cosine vector search on `message_embeddings` at
+> `MAX_DISTANCE=0.4`. Results are formatted as a numbered list with date, role, and
+> `conversation:ID` prefix. Uses a batch `MessageDao.getByIds()` call — single DB query
+> regardless of result count (avoids N+1). The system prompt injects its description as a
+> tool example so Gemma-4 knows when to invoke it.
 
 **System prompt `[Tool Use]` rules (enforced in `ChatViewModel.buildSystemPrompt()`):**
-- Memory rule: user says "remember/save/don't forget" → MUST call `save_memory`
+- Memory rule: user says "remember", "save", "don't forget", "can you remember", or "make a note of" → MUST call `save_memory`
 - Alarm rule: user asks to set an alarm → MUST call `run_intent{intent_name: set_alarm}`
 
 ### 4.4 Extensible Skills (WebAssembly — Phase 5)
@@ -303,11 +324,39 @@ Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime
 - **Actions tab:** History list, FAB (⚡) for new commands, bottom sheet input, Room-persisted history
 - **Voice:** Tap-to-toggle with auto-stop on silence (future: "Hey Jandal" wake word)
 - **Skill results:** Inline rich cards in the conversation stream
-- **Persona:** Friendly, concise, slightly playful (Kiwi-flavoured) — future: configurable
+- **Persona:** Friendly, concise, dry-humoured Kiwi — see §7 for full identity details
 
 ---
 
-## 7. Development Prerequisites
+## 7. Jandal Persona & Cultural Identity
+
+Jandal's character is encoded in `DEFAULT_SYSTEM_PROMPT` in `ModelConfig.kt` (updated PR #268):
+
+```
+"You are Jandal — a capable, on-device AI assistant with a genuine Kiwi character. "
+"You're direct, warm, and dry-humoured without trying too hard. You don't say "
+"\"certainly!\", \"absolutely!\", or \"great question\" — you just get on with it. "
+"You run entirely on-device, so the user's data never leaves their phone. "
+"Keep responses concise unless the user asks for detail. "
+"When you use Kiwi expressions, they should feel natural, not forced. "
+"You are culturally and spiritually Kiwi — from Aotearoa New Zealand. "
+"You are named after the NZ word for flip-flops: jandals — simple, unpretentious, practical. "
+"You were born from Kiwi culture: laid-back, direct, and no-nonsense. "
+"When asked where you are from, what your culture is, or why you are called Jandal, "
+"own your Kiwi identity with pride — never say you are \"just code\" or that you have no culture."
+```
+
+**Key identity rules:**
+- Jandal is culturally and spiritually Kiwi — from Aotearoa New Zealand
+- Named after the NZ word for flip-flops: jandals — simple, unpretentious, practical
+- Born from Kiwi culture: laid-back, direct, no-nonsense
+- When asked about origin, culture, or name → own Kiwi identity with pride; NEVER say "just code" or "I have no culture"
+- Kiwi expressions must feel natural, not forced
+- No hollow affirmations ("certainly!", "absolutely!", "great question!")
+
+---
+
+## 8. Development Prerequisites
 
 | Requirement | Detail |
 |-------------|--------|
@@ -325,7 +374,7 @@ The NPU path requires `"Qualcomm"` string match — this is a known device quirk
 
 ---
 
-## 8. Build & Test
+## 9. Build & Test
 
 ```bash
 ./gradlew assembleDebug              # Build debug APK
@@ -342,7 +391,7 @@ is behind an interface and mocked in all tests. Models (~3GB) are never download
 
 ---
 
-## 9. Roadmap Summary
+## 10. Roadmap Summary
 
 | Phase | Description | Status |
 |-------|-------------|--------|

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -243,10 +243,10 @@ This means the model only needs two function names; new native intents are added
 
 | `skill_name` | Location | Status |
 |-------------|----------|--------|
-| `get_weather` | `assets/skills/get-weather/index.html` | ✅ (current + forecast) |
+| `get-weather-city` | `assets/skills/get-weather-city/index.html` | ✅ (current + forecast) |
 | `query_wikipedia` | `assets/skills/query-wikipedia/index.html` | ✅ |
 
-> **`get_weather` forecast support (PR #269):** Pass `forecast_days` (integer 1–7) for a
+> **`get-weather-city` forecast support (PR #269):** Pass `forecast_days` (integer 1–7) for a
 > day-by-day forecast instead of current conditions. When `forecast_days > 0` or
 > `query_type = "forecast"`, the skill calls the Open-Meteo `daily` API
 > (`temperature_2m_max`, `temperature_2m_min`, `precipitation_sum`, `weather_code`,

--- a/specification.md
+++ b/specification.md
@@ -68,7 +68,8 @@ If no pattern matches, the query falls through to Tier 3 (Gemma-4 reasoning).
 The resident Gemma-4 model handles complex tool calls requiring NLU and reasoning. When the model outputs a JSON function-call block (`{"name": "skill_name", "arguments": {...}}`), `SkillExecutor` parses it and dispatches to the registered `Skill` implementation. This enables multi-step reasoning before action execution.
 
 **Supported skills (via `SkillRegistry`):**
-* `get_weather` — geolocation + weather API
+* `get_weather_gps` — GPS-based current weather + forecast
+* `run_js{get-weather-city}` — named city weather + forecast via Open-Meteo
 * `get_system_info` — battery, connectivity, device stats
 * `save_memory` — persist notes/facts to Room
 * `set_timer`, `run_intent` — OS action delegation


### PR DESCRIPTION
## Summary

Fixes #272 — eliminates model routing ambiguity between the two weather skills by giving each a distinct, unambiguous name.

## Changes

### 1. `GetWeatherSkill.kt` — renamed `get_weather` to `get_weather_gps`
- Skill name changed to `get_weather_gps` so the model can clearly distinguish GPS-based weather from city-based weather
- Description updated: clarifies this is GPS-only, directs named-city queries to `get-weather-city`
- **`location` param removed** — this skill is GPS-only; city lookup was dead code
- **`forecast_days` param added** (optional, int 1-7): triggers multi-day forecast via Open-Meteo daily API
- Added `fetchForecast()` + `parseForecastResponse()`: calls `temperature_2m_max/min`, `precipitation_sum`, `weather_code`, `timezone=auto`
- Added `wmoEmoji()` function (mirrors JS skill WMO_EMOJI map)
- Added `formatForecastDate()` helper for 'Sun 13 Apr' style labels
- Two concrete examples: current GPS + 3-day forecast

### 2. `assets/skills/get-weather/` renamed to `get-weather-city/`
- Folder renamed so the skill name in the asset path matches the new `skill_name` enum value
- Internal comment in `index.html` updated

### 3. `RunJsSkill.kt` — updated to `get-weather-city`
- `enum` list: `'get-weather'` to `'get-weather-city'`
- Description: city weather uses `get-weather-city`, GPS uses `get_weather_gps`
- All 3 weather examples updated to `skill_name='get-weather-city'`

### 4. Docs
- `docs/SPECIFICATION.md`, `docs/ROADMAP.md`, `specification.md` updated

## Before / After routing

| User request | Before | After |
|---|---|---|
| 'What's the weather here?' | `run_js{get-weather}` (wrong) | `get_weather_gps{}` |
| 'Forecast for next 3 days' | `run_js{get-weather}` (wrong) | `get_weather_gps{forecast_days:3}` |
| 'Weather in Auckland' | `run_js{get-weather}` | `run_js{get-weather-city, Auckland}` |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>