### PR TITLE
fix: alarm label param + save_memory infer-from-context rule (#277, #279)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -49,7 +49,8 @@ class RunIntentSkill @Inject constructor(
         "Flashlight off:  <|tool_call>call:run_intent{intent_name:${STR}toggle_flashlight_off${STR}}<tool_call|>",
         "Send email:      <|tool_call>call:run_intent{intent_name:${STR}send_email${STR},subject:${STR}Subject${STR},body:${STR}Body${STR}}<tool_call|>",
         "Send SMS:        <|tool_call>call:run_intent{intent_name:${STR}send_sms${STR},message:${STR}Hello${STR}}<tool_call|>",
-        "Set alarm 7:30:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR}}<tool_call|>",
+        "Set alarm 7:30:        <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR}}<tool_call|>",
+        "Set alarm with label:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR},label:${STR}Wake Up${STR}}<tool_call|>",
         "Set timer 3 min: <|tool_call>call:run_intent{intent_name:${STR}set_timer${STR},duration_seconds:${STR}180${STR}}<tool_call|>",
     )
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -247,8 +247,10 @@ class ChatViewModel @Inject constructor(
                         "Use the exact function name from the list below.\n\n" +
                         "No-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\n" +
                         "With-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n" +
-                        "Memory rule: whenever the user says 'remember', 'save', 'don't forget', or asks you to keep something in mind, " +
-                        "you MUST call save_memory — never just say 'got it' or acknowledge without using the tool.\n" +
+                        "Memory rule: whenever the user says 'remember', 'save', 'don't forget', 'save it', 'save that', 'remember that', or asks you to keep something in mind, " +
+                        "you MUST immediately call save_memory — never just say 'got it' or acknowledge without using the tool. " +
+                        "If the user says 'save it' or 'remember that', infer what 'it'/'that' refers to from the recent conversation and use that as the content. " +
+                        "Do NOT ask the user what they want to save — always infer from context and call the tool.\n" +
                         "Alarm rule: whenever the user asks to set an alarm for a specific time, " +
                         "you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set' or confirm it without using the tool.\n\n" +
                         nativeDeclarations


### PR DESCRIPTION
Two prompt/example fixes from Round 2 testing (#266).

## #277 — set_alarm label not passed
Added a second `set_alarm` example to `RunIntentSkill.kt` showing the `label` param:
```
Set alarm with label: call:run_intent{intent_name:"set_alarm",hours:"7",minutes:"30",label:"Wake Up"}
```
The `NativeIntentHandler` already maps `label` → `AlarmClock.EXTRA_MESSAGE` — this was a missing example, not a missing implementation.

## #279 — save_memory asks for clarification on 'save it'
Updated the Memory rule in `ChatViewModel.buildSystemPrompt()` to explicitly instruct the model:
- Trigger phrases now include: `save it`, `save that`, `remember that`
- Model must **infer content from recent context** — never ask the user what to save
- Closes the clarification loop where model said 'What info?' instead of calling the tool

Fixes #277, fixes #279