### PR TITLE
fix: search_memory routing, save_memory embedding, forecast default days

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -48,7 +48,8 @@ class RunJsSkill @Inject constructor(
             "forecast_days" to SkillParameter(
                 type = "integer",
                 description = "For get-weather-city only: number of forecast days (1–7). " +
-                    "Omit for current weather.",
+                    "Omit for current weather. When the user asks for a forecast without " +
+                    "specifying a number of days, use 3.",
             ),
         ),
         required = listOf("skill_name", "query"),
@@ -61,6 +62,7 @@ class RunJsSkill @Inject constructor(
         "Weather (current, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}Auckland${strToken}}<tool_call|>",
         "Weather (forecast 3 days, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}Auckland${strToken},forecast_days:${strToken}3${strToken}}<tool_call|>",
         "Weather (tomorrow, named city): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}London${strToken},forecast_days:${strToken}1${strToken}}<tool_call|>",
+        "Weather (forecast no days specified — default 3): <|tool_call>call:run_js{skill_name:${strToken}get-weather-city${strToken},query:${strToken}Sydney${strToken},forecast_days:${strToken}3${strToken}}<tool_call|>",
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.skills.natives
 
 import android.util.Log
+import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.Skill
 import com.kernel.ai.core.skills.SkillCall
@@ -16,12 +17,12 @@ private const val TAG = "KernelAI"
 
 /**
  * Skill that saves an important fact or preference to the user's long-term core memory.
- * Persists via [MemoryRepository.addCoreMemory] without requiring an embedding vector
- * (the repository accepts null — the background embedding pipeline handles it asynchronously).
+ * Embeds the content synchronously so the vector is immediately available for search.
  */
 @Singleton
 class SaveMemorySkill @Inject constructor(
     private val memoryRepository: MemoryRepository,
+    private val embeddingEngine: EmbeddingEngine,
 ) : Skill {
 
     override val name = "save_memory"
@@ -43,15 +44,19 @@ class SaveMemorySkill @Inject constructor(
     override suspend fun execute(call: SkillCall): SkillResult {
         val content = call.arguments["content"]
             ?: return SkillResult.Failure(name, "Missing 'content' argument")
-        return withContext(Dispatchers.Default) {
+        return withContext(Dispatchers.IO) {
             try {
+                val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
+                if (vector == null) {
+                    Log.w(TAG, "SaveMemorySkill: embedding engine not ready — saving without vector")
+                }
                 memoryRepository.addCoreMemory(
                     content = content,
                     source = "agent",
-                    embeddingVector = null,
+                    embeddingVector = vector,
                 )
-                Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
-                SkillResult.Success("Got it — I'll remember that.")
+                Log.d(TAG, "SaveMemorySkill: stored core memory (vector=${vector != null}) — '${content.take(60)}'")
+                SkillResult.Success("✓ Saved to memory.")
             } catch (e: Exception) {
                 Log.e(TAG, "SaveMemorySkill failed", e)
                 SkillResult.Failure(name, e.message ?: "Failed to save memory")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
@@ -48,7 +48,9 @@ class SearchMemorySkill @Inject constructor(
         parameters = mapOf(
             "query" to SkillParameter(
                 type = "string",
-                description = "The topic or phrase to search for in saved memories and past messages."
+                description = "The topic or phrase to search for in saved memories and past messages. " +
+                    "Replace first-person pronouns with the user's actual name if known from their profile " +
+                    "(e.g. 'my ancestor' → 'Nick\\'s ancestor', 'my job' → 'Nick\\'s job')."
             ),
             "conversationId" to SkillParameter(
                 type = "string",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -248,9 +248,11 @@ class ChatViewModel @Inject constructor(
                         "No-argument format: <|tool_call>call:FUNCTION_NAME{}<tool_call|>\n" +
                         "With-argument format: <|tool_call>call:FUNCTION_NAME{param:<|\"|>value<|\"|>}<tool_call|>\n\n" +
                         "Memory rule: whenever the user says 'remember', 'save', 'don't forget', 'save it', 'save that', 'remember that', or asks you to keep something in mind, " +
-                        "you MUST immediately call save_memory — never just say 'got it' or acknowledge without using the tool. " +
+                        "you MUST immediately call save_memory — NEVER output 'Got it', 'I'll remember that', 'I've already saved that', or any confirmation text without a tool call token. " +
                         "If the user says 'save it' or 'remember that', infer what 'it'/'that' refers to from the recent conversation and use that as the content. " +
                         "Do NOT ask the user what they want to save — always infer from context and call the tool.\n" +
+                        "Recall rule: whenever the user asks what you remember about something, asks you to recall a fact, or uses words like 'recall', 'do you remember', 'what do you know about', or 'remind me' — " +
+                        "you MUST call search_memory first before answering. Never answer from your own knowledge without calling the tool first.\n" +
                         "Alarm rule: whenever the user asks to set an alarm for a specific time, " +
                         "you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set' or confirm it without using the tool. " +
                         "If the user specifies a day (e.g. 'tomorrow', 'next Monday', 'on Friday'), include day=<day_name> in the call — " +


### PR DESCRIPTION
## Round 3 bug fixes

Addresses three issues reported in #266 testing (TC-SM1, save_memory hallucination, forecast inconsistency).

### Changes

#### `SaveMemorySkill` — fix embedding (root cause of TC-SM1)
- Inject `EmbeddingEngine` and call `embed(content)` synchronously before `addCoreMemory`
- Previously memories were saved with `embeddingVector = null` — the vector table was never written, making all saved memories invisible to vector search
- Graceful fallback: if engine not ready, saves without vector (logged as warning) rather than failing
- Change success message `"Got it — I'll remember that."` → `"✓ Saved to memory."` to break model's pattern-matched hallucination of this phrase

#### `ChatViewModel` — add Recall rule + strengthen Memory rule
- **Memory rule**: change from "never just say 'got it'" to explicit NEVER list: 'Got it', 'I'll remember that', 'I've already saved that' — targets specific phrases the model hallucinates
- **Recall rule** (new): when user asks to recall/remember/who is/remind me, model MUST call `search_memory` first — fixes model answering from its own weights instead of memory

#### `RunJsSkill` — forecast default days
- `forecast_days` description now states: "When the user asks for a forecast without specifying a number of days, use 3"
- Add new example: Weather (forecast no days specified — default 3) with forecast_days=3
- Fixes inconsistent routing when user says 'And the forecast' or 'Give me the forecast for Sydney' without an explicit day count

### Root causes
- TC-SM1 'No memories found': `addCoreMemory(embeddingVector = null)` never writes to `CORE_VEC_TABLE`. Vector search over empty table returns no results. No background pipeline existed.
- save_memory hallucination: success message matched natural model output; model generated confirmation without tool call
- Forecast routing: model only passed `forecast_days` when user said 'next N days'; vague 'forecast' requests omitted the param, defaulting to current weather
