### PR TITLE
fix: embed all core memory save paths, add WorkManager backfill (#284)

### DIFF
--- a/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
+++ b/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
@@ -3,6 +3,11 @@ package com.kernel.ai
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.kernel.ai.core.memory.worker.MemoryEmbeddingWorker
+import com.kernel.ai.core.memory.worker.WORK_NAME_BACKFILL
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -22,4 +27,13 @@ class KernelAIApplication : Application(), Configuration.Provider {
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        WorkManager.getInstance(this).enqueueUniqueWork(
+            WORK_NAME_BACKFILL,
+            ExistingWorkPolicy.KEEP,
+            OneTimeWorkRequestBuilder<MemoryEmbeddingWorker>().build(),
+        )
+    }
 }

--- a/core/memory/build.gradle.kts
+++ b/core/memory/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
+    implementation(libs.work.runtime.ktx)
+    implementation(libs.hilt.work)
+
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -33,7 +33,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -98,6 +98,14 @@ abstract class KernelDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Adds vectorized column to core_memories and episodic_memories (#284). */
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE episodic_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -51,6 +51,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_5_6,
                     KernelDatabase.MIGRATION_6_7,
                     KernelDatabase.MIGRATION_7_8,
+                    KernelDatabase.MIGRATION_8_9,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -71,4 +71,10 @@ interface CoreMemoryDao {
 
     @Query("SELECT rowId FROM core_memories WHERE id = :id LIMIT 1")
     suspend fun getRowIdById(id: String): Long?
+
+    @Query("SELECT * FROM core_memories WHERE vectorized = 0")
+    suspend fun getUnvectorized(): List<CoreMemoryEntity>
+
+    @Query("UPDATE core_memories SET vectorized = 1 WHERE rowId = :rowId")
+    suspend fun markVectorized(rowId: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -79,4 +79,10 @@ interface EpisodicMemoryDao {
         if (rowId != null) deleteById(id)
         return rowId
     }
+
+    @Query("SELECT * FROM episodic_memories WHERE vectorized = 0")
+    suspend fun getUnvectorized(): List<EpisodicMemoryEntity>
+
+    @Query("UPDATE episodic_memories SET vectorized = 1 WHERE rowId = :rowId")
+    suspend fun markVectorized(rowId: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
@@ -13,4 +13,5 @@ data class CoreMemoryEntity(
     val lastAccessedAt: Long,
     val accessCount: Int = 0,
     val source: String,  // "user" or "dreaming"
+    val vectorized: Boolean = false,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
@@ -14,4 +14,5 @@ data class EpisodicMemoryEntity(
     val accessCount: Int = 0,
     // NOTE: defaults to 0 (not createdAt) due to SQLite migration constraint
     val lastAccessedAt: Long = 0,
+    val vectorized: Boolean = false,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -9,6 +9,10 @@ interface MemoryRepository {
     suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
     suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray): String
+    /** Backfill vector for an existing core memory that was saved without one (used by MemoryEmbeddingWorker). */
+    suspend fun backfillCoreVector(rowId: Long, vector: FloatArray)
+    /** Backfill vector for an existing episodic memory that was saved without one (used by MemoryEmbeddingWorker). */
+    suspend fun backfillEpisodicVector(rowId: Long, vector: FloatArray)
     /** Search BOTH tiers; core ranked above episodic. */
     suspend fun searchMemories(
         queryVector: FloatArray,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -6,9 +6,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface MemoryRepository {
     /** Store a volatile, conversation-scoped memory. */
-    suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray? = null): String
+    suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
-    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray? = null): String
+    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray): String
     /** Search BOTH tiers; core ranked above episodic. */
     suspend fun searchMemories(
         queryVector: FloatArray,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -52,12 +52,13 @@ class MemoryRepositoryImpl @Inject constructor(
             conversationId = conversationId,
             content = content,
             createdAt = now,
-            vectorized = true,
+            vectorized = false,
         )
         val rowId = episodicDao.insert(entity)
         if (rowId > 0) {
             ensureEpisodicVecTable(embeddingVector.size)
             vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, embeddingVector)
+            episodicDao.markVectorized(rowId)
         }
         prune()
         Log.d(TAG, "Added episodic memory id=$id rowId=$rowId")
@@ -77,16 +78,29 @@ class MemoryRepositoryImpl @Inject constructor(
             createdAt = now,
             lastAccessedAt = now,
             source = source,
-            vectorized = true,
+            vectorized = false,
         )
         val rowId = coreDao.insert(entity)
         if (rowId > 0) {
             ensureCoreVecTable(embeddingVector.size)
             vectorStore.upsert(CORE_VEC_TABLE, rowId, embeddingVector)
+            coreDao.markVectorized(rowId)
         }
         prune()
         Log.d(TAG, "Added core memory id=$id rowId=$rowId source=$source")
         return id
+    }
+
+    override suspend fun backfillCoreVector(rowId: Long, vector: FloatArray) {
+        ensureCoreVecTable(vector.size)
+        vectorStore.upsert(CORE_VEC_TABLE, rowId, vector)
+        coreDao.markVectorized(rowId)
+    }
+
+    override suspend fun backfillEpisodicVector(rowId: Long, vector: FloatArray) {
+        ensureEpisodicVecTable(vector.size)
+        vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, vector)
+        episodicDao.markVectorized(rowId)
     }
 
     // Remove flag-guards: persisted vec tables must be searched after app restart.

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -178,7 +178,7 @@ class MemoryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray?) {
-        coreDao.updateContent(id, newContent)
+        // update vec first; only write content if vec succeeds (matches updateEpisodicMemory pattern)
         if (newVector != null) {
             val rowId = coreDao.getRowIdById(id)
             if (rowId != null && rowId > 0) {
@@ -186,6 +186,7 @@ class MemoryRepositoryImpl @Inject constructor(
                 vectorStore.upsert(CORE_VEC_TABLE, rowId, newVector)
             }
         }
+        coreDao.updateContent(id, newContent)
         Log.d(TAG, "Updated core memory id=$id")
     }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -43,7 +43,7 @@ class MemoryRepositoryImpl @Inject constructor(
     override suspend fun addEpisodicMemory(
         conversationId: String,
         content: String,
-        embeddingVector: FloatArray?,
+        embeddingVector: FloatArray,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -52,9 +52,10 @@ class MemoryRepositoryImpl @Inject constructor(
             conversationId = conversationId,
             content = content,
             createdAt = now,
+            vectorized = true,
         )
         val rowId = episodicDao.insert(entity)
-        if (embeddingVector != null && rowId > 0) {
+        if (rowId > 0) {
             ensureEpisodicVecTable(embeddingVector.size)
             vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, embeddingVector)
         }
@@ -66,7 +67,7 @@ class MemoryRepositoryImpl @Inject constructor(
     override suspend fun addCoreMemory(
         content: String,
         source: String,
-        embeddingVector: FloatArray?,
+        embeddingVector: FloatArray,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -76,9 +77,10 @@ class MemoryRepositoryImpl @Inject constructor(
             createdAt = now,
             lastAccessedAt = now,
             source = source,
+            vectorized = true,
         )
         val rowId = coreDao.insert(entity)
-        if (embeddingVector != null && rowId > 0) {
+        if (rowId > 0) {
             ensureCoreVecTable(embeddingVector.size)
             vectorStore.upsert(CORE_VEC_TABLE, rowId, embeddingVector)
         }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
@@ -1,0 +1,72 @@
+package com.kernel.ai.core.memory.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.memory.dao.CoreMemoryDao
+import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
+import com.kernel.ai.core.memory.vector.VectorStore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val TAG = "MemoryEmbeddingWorker"
+const val WORK_NAME_BACKFILL = "memory_embedding_backfill"
+
+@HiltWorker
+class MemoryEmbeddingWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val embeddingEngine: EmbeddingEngine,
+    private val coreMemoryDao: CoreMemoryDao,
+    private val episodicMemoryDao: EpisodicMemoryDao,
+    private val vectorStore: VectorStore,
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        private const val CORE_VEC_TABLE = "core_memories_vec"
+        private const val EPISODIC_VEC_TABLE = "episodic_memories_vec"
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            var backfilled = 0
+
+            // Backfill core memories
+            val unvectorizedCore = coreMemoryDao.getUnvectorized()
+            for (entity in unvectorizedCore) {
+                val vector = embeddingEngine.embed(entity.content)
+                if (vector.isEmpty()) {
+                    Log.w(TAG, "Embedding engine not ready — skipping core memory rowId=${entity.rowId}")
+                    continue
+                }
+                vectorStore.upsert(CORE_VEC_TABLE, entity.rowId, vector)
+                coreMemoryDao.markVectorized(entity.rowId)
+                backfilled++
+            }
+
+            // Backfill episodic memories
+            val unvectorizedEpisodic = episodicMemoryDao.getUnvectorized()
+            for (entity in unvectorizedEpisodic) {
+                val vector = embeddingEngine.embed(entity.content)
+                if (vector.isEmpty()) {
+                    Log.w(TAG, "Embedding engine not ready — skipping episodic memory rowId=${entity.rowId}")
+                    continue
+                }
+                vectorStore.upsert(EPISODIC_VEC_TABLE, entity.rowId, vector)
+                episodicMemoryDao.markVectorized(entity.rowId)
+                backfilled++
+            }
+
+            Log.i(TAG, "Memory backfill complete — $backfilled memories vectorized")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Memory backfill failed", e)
+            Result.retry()
+        }
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
@@ -8,7 +8,7 @@ import androidx.work.WorkerParameters
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
-import com.kernel.ai.core.memory.vector.VectorStore
+import com.kernel.ai.core.memory.repository.MemoryRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +17,16 @@ import kotlinx.coroutines.withContext
 private const val TAG = "MemoryEmbeddingWorker"
 const val WORK_NAME_BACKFILL = "memory_embedding_backfill"
 
+/**
+ * WorkManager [CoroutineWorker] that backfills embedding vectors for any core or episodic
+ * memories saved before vector embedding was made mandatory.
+ *
+ * Enqueued as a one-time unique work at app startup (ExistingWorkPolicy.KEEP), so it runs
+ * once after an upgrade and is a no-op on subsequent launches once all memories are vectorized.
+ *
+ * Future extension: schedule as a PeriodicWorkRequest with charging + idle constraints
+ * for nightly re-embedding (e.g. after a model upgrade) or episodic distillation.
+ */
 @HiltWorker
 class MemoryEmbeddingWorker @AssistedInject constructor(
     @Assisted context: Context,
@@ -24,19 +34,13 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
     private val embeddingEngine: EmbeddingEngine,
     private val coreMemoryDao: CoreMemoryDao,
     private val episodicMemoryDao: EpisodicMemoryDao,
-    private val vectorStore: VectorStore,
+    private val memoryRepository: MemoryRepository,
 ) : CoroutineWorker(context, params) {
-
-    companion object {
-        private const val CORE_VEC_TABLE = "core_memories_vec"
-        private const val EPISODIC_VEC_TABLE = "episodic_memories_vec"
-    }
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
             var backfilled = 0
 
-            // Backfill core memories
             val unvectorizedCore = coreMemoryDao.getUnvectorized()
             for (entity in unvectorizedCore) {
                 val vector = embeddingEngine.embed(entity.content)
@@ -44,12 +48,10 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
                     Log.w(TAG, "Embedding engine not ready — skipping core memory rowId=${entity.rowId}")
                     continue
                 }
-                vectorStore.upsert(CORE_VEC_TABLE, entity.rowId, vector)
-                coreMemoryDao.markVectorized(entity.rowId)
+                memoryRepository.backfillCoreVector(entity.rowId, vector)
                 backfilled++
             }
 
-            // Backfill episodic memories
             val unvectorizedEpisodic = episodicMemoryDao.getUnvectorized()
             for (entity in unvectorizedEpisodic) {
                 val vector = embeddingEngine.embed(entity.content)
@@ -57,8 +59,7 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
                     Log.w(TAG, "Embedding engine not ready — skipping episodic memory rowId=${entity.rowId}")
                     continue
                 }
-                vectorStore.upsert(EPISODIC_VEC_TABLE, entity.rowId, vector)
-                episodicMemoryDao.markVectorized(entity.rowId)
+                memoryRepository.backfillEpisodicVector(entity.rowId, vector)
                 backfilled++
             }
 
@@ -70,3 +71,4 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
         }
     }
 }
+

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
@@ -49,18 +49,6 @@ class MemoryRepositoryImplTest {
     // ─────────────────────────────── addEpisodicMemory ───────────────────────────────
 
     @Test
-    fun `addEpisodicMemory without embedding — inserts entity, no vec upsert`() = runTest {
-        coEvery { episodicDao.insert(any()) } returns 1L
-        stubPrune()
-
-        val id = repository.addEpisodicMemory("conv-1", "test content")
-
-        assertTrue(id.isNotBlank(), "Returned ID should not be blank")
-        coVerify(exactly = 1) { episodicDao.insert(any()) }
-        verify(exactly = 0) { vectorStore.upsert(any(), any(), any()) }
-    }
-
-    @Test
     fun `addEpisodicMemory with embedding — inserts entity AND upserts to vec table`() = runTest {
         coEvery { episodicDao.insert(any()) } returns 42L
         every { vectorStore.createTable(any(), any()) } just Runs
@@ -100,18 +88,6 @@ class MemoryRepositoryImplTest {
     }
 
     // ─────────────────────────────── addCoreMemory ───────────────────────────────────
-
-    @Test
-    fun `addCoreMemory without embedding — inserts entity, no vec upsert`() = runTest {
-        coEvery { coreDao.insert(any()) } returns 1L
-        stubPrune()
-
-        val id = repository.addCoreMemory("user preference content")
-
-        assertTrue(id.isNotBlank(), "Returned ID should not be blank")
-        coVerify(exactly = 1) { coreDao.insert(any()) }
-        verify(exactly = 0) { vectorStore.upsert(any(), any(), any()) }
-    }
 
     @Test
     fun `addCoreMemory with embedding — inserts entity AND upserts to vec`() = runTest {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -47,15 +47,16 @@ class SaveMemorySkill @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
-                if (vector == null) {
-                    Log.w(TAG, "SaveMemorySkill: embedding engine not ready — saving without vector")
-                }
+                    ?: run {
+                        Log.w(TAG, "SaveMemorySkill: embedding engine not ready, skipping")
+                        return@withContext SkillResult.Failure(name, "Embedding engine not ready")
+                    }
                 memoryRepository.addCoreMemory(
                     content = content,
                     source = "agent",
                     embeddingVector = vector,
                 )
-                Log.d(TAG, "SaveMemorySkill: stored core memory (vector=${vector != null}) — '${content.take(60)}'")
+                Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
                 SkillResult.Success("✓ Saved to memory.")
             } catch (e: Exception) {
                 Log.e(TAG, "SaveMemorySkill failed", e)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -206,7 +206,9 @@ class ChatViewModel @Inject constructor(
         truthsSeedingMutex.withLock {
             if (jandalPersona.isTruthsSeeded) return
             jandalPersona.truths.forEach { truth ->
-                memoryRepository.addCoreMemory(truth, source = "jandal_persona")
+                val vector = embeddingEngine.embed(truth).takeIf { it.isNotEmpty() }
+                    ?: return@forEach  // skip if engine not ready
+                memoryRepository.addCoreMemory(truth, source = "jandal_persona", embeddingVector = vector)
             }
             jandalPersona.markTruthsSeeded()
             Log.i("ChatViewModel", "Seeded ${jandalPersona.truths.size} Kiwi truths into core memory")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -256,7 +256,14 @@ class MemoryViewModel @Inject constructor(
         }
         viewModelScope.launch {
             try {
-                memoryRepository.addCoreMemory(content = text, source = "user")
+                val vector = withContext(Dispatchers.Default) {
+                    embeddingEngine.embed(text)
+                }.takeIf { it.isNotEmpty() } ?: run {
+                    Log.w("KernelAI", "addCoreMemory: embedding engine not ready, aborting")
+                    _isSubmitting.value = false
+                    return@launch
+                }
+                memoryRepository.addCoreMemory(content = text, source = "user", embeddingVector = vector)
                 dismissAddDialog()
             } finally {
                 _isSubmitting.value = false

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -85,6 +85,7 @@ class MemoryViewModelTest {
 
     @Test
     fun `addCoreMemory calls repository with trimmed text`() = runTest {
+        every { embeddingEngine.embed(any()) } returns floatArrayOf(0.1f, 0.2f)
         coEvery { memoryRepository.addCoreMemory(any(), any(), any()) } returns "id-1"
 
         viewModel.openAddDialog()
@@ -93,7 +94,11 @@ class MemoryViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            memoryRepository.addCoreMemory(content = "remember this", source = "user")
+            memoryRepository.addCoreMemory(
+                content = "remember this",
+                source = "user",
+                embeddingVector = floatArrayOf(0.1f, 0.2f),
+            )
         }
     }
 
@@ -101,6 +106,18 @@ class MemoryViewModelTest {
     fun `addCoreMemory does not call repository when text is blank`() = runTest {
         viewModel.openAddDialog()
         viewModel.onAddDialogTextChange("   ")
+        viewModel.addCoreMemory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { memoryRepository.addCoreMemory(any(), any(), any()) }
+    }
+
+    @Test
+    fun `addCoreMemory does not call repository when embedding engine returns empty`() = runTest {
+        every { embeddingEngine.embed(any()) } returns floatArrayOf()
+
+        viewModel.openAddDialog()
+        viewModel.onAddDialogTextChange("some text")
         viewModel.addCoreMemory()
         testDispatcher.scheduler.advanceUntilIdle()
 


### PR DESCRIPTION
Closes #284

## Summary

Fixes all remaining `addCoreMemory` / `addEpisodicMemory` callers that were saving memories without embedding vectors, adds a `vectorized` tracking flag to Room entities, and implements a WorkManager backfill worker to fix existing orphaned (unvectorized) memories.

## Changes

### Entities
- `CoreMemoryEntity` — add `vectorized: Boolean = false`
- `EpisodicMemoryEntity` — add `vectorized: Boolean = false`

### DAOs
- `CoreMemoryDao` — add `getUnvectorized()` and `markVectorized(rowId)`
- `EpisodicMemoryDao` — add `getUnvectorized()` and `markVectorized(rowId)`

### Database
- Bump version 8 → 9 with `MIGRATION_8_9` adding `vectorized INTEGER NOT NULL DEFAULT 0` to both tables
- Register migration in `MemoryModule`

### Repository
- `MemoryRepository` — make `embeddingVector` non-nullable on both `addEpisodicMemory` and `addCoreMemory`
- `MemoryRepositoryImpl` — always upsert vector, remove null-guard, set `vectorized = true` on entity construction

### New Worker
- `MemoryEmbeddingWorker` (`@HiltWorker`) — backfills existing unvectorized core and episodic memories at startup
- Add `work-runtime-ktx` + `hilt-work` to `core/memory/build.gradle.kts`
- Enqueue with `ExistingWorkPolicy.KEEP` in `KernelAIApplication.onCreate()`

### Callers fixed
- `ChatViewModel.seedKiwiTruthsIfNeeded()` — embed each truth before saving
- `MemoryViewModel.addCoreMemory()` — embed before saving; abort if engine not ready
- `SaveMemorySkill` — inject `EmbeddingEngine`, embed before `addCoreMemory`

### Tests
- `MemoryRepositoryImplTest` — remove "without embedding" tests (no longer valid); keep with-embedding tests
- `MemoryViewModelTest` — add `embeddingEngine.embed()` mock; add test for engine-not-ready abort path
