### PR TITLE
feat: create_calendar_event intent (#265)

### DIFF
--- a/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
+++ b/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
@@ -3,6 +3,11 @@ package com.kernel.ai
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.kernel.ai.core.memory.worker.MemoryEmbeddingWorker
+import com.kernel.ai.core.memory.worker.WORK_NAME_BACKFILL
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -22,4 +27,13 @@ class KernelAIApplication : Application(), Configuration.Provider {
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        WorkManager.getInstance(this).enqueueUniqueWork(
+            WORK_NAME_BACKFILL,
+            ExistingWorkPolicy.KEEP,
+            OneTimeWorkRequestBuilder<MemoryEmbeddingWorker>().build(),
+        )
+    }
 }

--- a/core/memory/build.gradle.kts
+++ b/core/memory/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
+    implementation(libs.work.runtime.ktx)
+    implementation(libs.hilt.work)
+
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -33,7 +33,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -98,6 +98,14 @@ abstract class KernelDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Adds vectorized column to core_memories and episodic_memories (#284). */
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE episodic_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -51,6 +51,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_5_6,
                     KernelDatabase.MIGRATION_6_7,
                     KernelDatabase.MIGRATION_7_8,
+                    KernelDatabase.MIGRATION_8_9,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -71,4 +71,10 @@ interface CoreMemoryDao {
 
     @Query("SELECT rowId FROM core_memories WHERE id = :id LIMIT 1")
     suspend fun getRowIdById(id: String): Long?
+
+    @Query("SELECT * FROM core_memories WHERE vectorized = 0")
+    suspend fun getUnvectorized(): List<CoreMemoryEntity>
+
+    @Query("UPDATE core_memories SET vectorized = 1 WHERE rowId = :rowId")
+    suspend fun markVectorized(rowId: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -79,4 +79,10 @@ interface EpisodicMemoryDao {
         if (rowId != null) deleteById(id)
         return rowId
     }
+
+    @Query("SELECT * FROM episodic_memories WHERE vectorized = 0")
+    suspend fun getUnvectorized(): List<EpisodicMemoryEntity>
+
+    @Query("UPDATE episodic_memories SET vectorized = 1 WHERE rowId = :rowId")
+    suspend fun markVectorized(rowId: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
@@ -13,4 +13,5 @@ data class CoreMemoryEntity(
     val lastAccessedAt: Long,
     val accessCount: Int = 0,
     val source: String,  // "user" or "dreaming"
+    val vectorized: Boolean = false,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/EpisodicMemoryEntity.kt
@@ -14,4 +14,5 @@ data class EpisodicMemoryEntity(
     val accessCount: Int = 0,
     // NOTE: defaults to 0 (not createdAt) due to SQLite migration constraint
     val lastAccessedAt: Long = 0,
+    val vectorized: Boolean = false,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -9,6 +9,10 @@ interface MemoryRepository {
     suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
     suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray): String
+    /** Backfill vector for an existing core memory that was saved without one (used by MemoryEmbeddingWorker). */
+    suspend fun backfillCoreVector(rowId: Long, vector: FloatArray)
+    /** Backfill vector for an existing episodic memory that was saved without one (used by MemoryEmbeddingWorker). */
+    suspend fun backfillEpisodicVector(rowId: Long, vector: FloatArray)
     /** Search BOTH tiers; core ranked above episodic. */
     suspend fun searchMemories(
         queryVector: FloatArray,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -6,9 +6,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface MemoryRepository {
     /** Store a volatile, conversation-scoped memory. */
-    suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray? = null): String
+    suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
-    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray? = null): String
+    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray): String
     /** Search BOTH tiers; core ranked above episodic. */
     suspend fun searchMemories(
         queryVector: FloatArray,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -52,12 +52,13 @@ class MemoryRepositoryImpl @Inject constructor(
             conversationId = conversationId,
             content = content,
             createdAt = now,
-            vectorized = true,
+            vectorized = false,
         )
         val rowId = episodicDao.insert(entity)
         if (rowId > 0) {
             ensureEpisodicVecTable(embeddingVector.size)
             vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, embeddingVector)
+            episodicDao.markVectorized(rowId)
         }
         prune()
         Log.d(TAG, "Added episodic memory id=$id rowId=$rowId")
@@ -77,16 +78,29 @@ class MemoryRepositoryImpl @Inject constructor(
             createdAt = now,
             lastAccessedAt = now,
             source = source,
-            vectorized = true,
+            vectorized = false,
         )
         val rowId = coreDao.insert(entity)
         if (rowId > 0) {
             ensureCoreVecTable(embeddingVector.size)
             vectorStore.upsert(CORE_VEC_TABLE, rowId, embeddingVector)
+            coreDao.markVectorized(rowId)
         }
         prune()
         Log.d(TAG, "Added core memory id=$id rowId=$rowId source=$source")
         return id
+    }
+
+    override suspend fun backfillCoreVector(rowId: Long, vector: FloatArray) {
+        ensureCoreVecTable(vector.size)
+        vectorStore.upsert(CORE_VEC_TABLE, rowId, vector)
+        coreDao.markVectorized(rowId)
+    }
+
+    override suspend fun backfillEpisodicVector(rowId: Long, vector: FloatArray) {
+        ensureEpisodicVecTable(vector.size)
+        vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, vector)
+        episodicDao.markVectorized(rowId)
     }
 
     // Remove flag-guards: persisted vec tables must be searched after app restart.

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -178,7 +178,7 @@ class MemoryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray?) {
-        coreDao.updateContent(id, newContent)
+        // update vec first; only write content if vec succeeds (matches updateEpisodicMemory pattern)
         if (newVector != null) {
             val rowId = coreDao.getRowIdById(id)
             if (rowId != null && rowId > 0) {
@@ -186,6 +186,7 @@ class MemoryRepositoryImpl @Inject constructor(
                 vectorStore.upsert(CORE_VEC_TABLE, rowId, newVector)
             }
         }
+        coreDao.updateContent(id, newContent)
         Log.d(TAG, "Updated core memory id=$id")
     }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -43,7 +43,7 @@ class MemoryRepositoryImpl @Inject constructor(
     override suspend fun addEpisodicMemory(
         conversationId: String,
         content: String,
-        embeddingVector: FloatArray?,
+        embeddingVector: FloatArray,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -52,9 +52,10 @@ class MemoryRepositoryImpl @Inject constructor(
             conversationId = conversationId,
             content = content,
             createdAt = now,
+            vectorized = true,
         )
         val rowId = episodicDao.insert(entity)
-        if (embeddingVector != null && rowId > 0) {
+        if (rowId > 0) {
             ensureEpisodicVecTable(embeddingVector.size)
             vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, embeddingVector)
         }
@@ -66,7 +67,7 @@ class MemoryRepositoryImpl @Inject constructor(
     override suspend fun addCoreMemory(
         content: String,
         source: String,
-        embeddingVector: FloatArray?,
+        embeddingVector: FloatArray,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -76,9 +77,10 @@ class MemoryRepositoryImpl @Inject constructor(
             createdAt = now,
             lastAccessedAt = now,
             source = source,
+            vectorized = true,
         )
         val rowId = coreDao.insert(entity)
-        if (embeddingVector != null && rowId > 0) {
+        if (rowId > 0) {
             ensureCoreVecTable(embeddingVector.size)
             vectorStore.upsert(CORE_VEC_TABLE, rowId, embeddingVector)
         }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
@@ -1,0 +1,72 @@
+package com.kernel.ai.core.memory.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.memory.dao.CoreMemoryDao
+import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
+import com.kernel.ai.core.memory.vector.VectorStore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val TAG = "MemoryEmbeddingWorker"
+const val WORK_NAME_BACKFILL = "memory_embedding_backfill"
+
+@HiltWorker
+class MemoryEmbeddingWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val embeddingEngine: EmbeddingEngine,
+    private val coreMemoryDao: CoreMemoryDao,
+    private val episodicMemoryDao: EpisodicMemoryDao,
+    private val vectorStore: VectorStore,
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        private const val CORE_VEC_TABLE = "core_memories_vec"
+        private const val EPISODIC_VEC_TABLE = "episodic_memories_vec"
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            var backfilled = 0
+
+            // Backfill core memories
+            val unvectorizedCore = coreMemoryDao.getUnvectorized()
+            for (entity in unvectorizedCore) {
+                val vector = embeddingEngine.embed(entity.content)
+                if (vector.isEmpty()) {
+                    Log.w(TAG, "Embedding engine not ready — skipping core memory rowId=${entity.rowId}")
+                    continue
+                }
+                vectorStore.upsert(CORE_VEC_TABLE, entity.rowId, vector)
+                coreMemoryDao.markVectorized(entity.rowId)
+                backfilled++
+            }
+
+            // Backfill episodic memories
+            val unvectorizedEpisodic = episodicMemoryDao.getUnvectorized()
+            for (entity in unvectorizedEpisodic) {
+                val vector = embeddingEngine.embed(entity.content)
+                if (vector.isEmpty()) {
+                    Log.w(TAG, "Embedding engine not ready — skipping episodic memory rowId=${entity.rowId}")
+                    continue
+                }
+                vectorStore.upsert(EPISODIC_VEC_TABLE, entity.rowId, vector)
+                episodicMemoryDao.markVectorized(entity.rowId)
+                backfilled++
+            }
+
+            Log.i(TAG, "Memory backfill complete — $backfilled memories vectorized")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Memory backfill failed", e)
+            Result.retry()
+        }
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/worker/MemoryEmbeddingWorker.kt
@@ -8,7 +8,7 @@ import androidx.work.WorkerParameters
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
-import com.kernel.ai.core.memory.vector.VectorStore
+import com.kernel.ai.core.memory.repository.MemoryRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +17,16 @@ import kotlinx.coroutines.withContext
 private const val TAG = "MemoryEmbeddingWorker"
 const val WORK_NAME_BACKFILL = "memory_embedding_backfill"
 
+/**
+ * WorkManager [CoroutineWorker] that backfills embedding vectors for any core or episodic
+ * memories saved before vector embedding was made mandatory.
+ *
+ * Enqueued as a one-time unique work at app startup (ExistingWorkPolicy.KEEP), so it runs
+ * once after an upgrade and is a no-op on subsequent launches once all memories are vectorized.
+ *
+ * Future extension: schedule as a PeriodicWorkRequest with charging + idle constraints
+ * for nightly re-embedding (e.g. after a model upgrade) or episodic distillation.
+ */
 @HiltWorker
 class MemoryEmbeddingWorker @AssistedInject constructor(
     @Assisted context: Context,
@@ -24,19 +34,13 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
     private val embeddingEngine: EmbeddingEngine,
     private val coreMemoryDao: CoreMemoryDao,
     private val episodicMemoryDao: EpisodicMemoryDao,
-    private val vectorStore: VectorStore,
+    private val memoryRepository: MemoryRepository,
 ) : CoroutineWorker(context, params) {
-
-    companion object {
-        private const val CORE_VEC_TABLE = "core_memories_vec"
-        private const val EPISODIC_VEC_TABLE = "episodic_memories_vec"
-    }
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
             var backfilled = 0
 
-            // Backfill core memories
             val unvectorizedCore = coreMemoryDao.getUnvectorized()
             for (entity in unvectorizedCore) {
                 val vector = embeddingEngine.embed(entity.content)
@@ -44,12 +48,10 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
                     Log.w(TAG, "Embedding engine not ready — skipping core memory rowId=${entity.rowId}")
                     continue
                 }
-                vectorStore.upsert(CORE_VEC_TABLE, entity.rowId, vector)
-                coreMemoryDao.markVectorized(entity.rowId)
+                memoryRepository.backfillCoreVector(entity.rowId, vector)
                 backfilled++
             }
 
-            // Backfill episodic memories
             val unvectorizedEpisodic = episodicMemoryDao.getUnvectorized()
             for (entity in unvectorizedEpisodic) {
                 val vector = embeddingEngine.embed(entity.content)
@@ -57,8 +59,7 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
                     Log.w(TAG, "Embedding engine not ready — skipping episodic memory rowId=${entity.rowId}")
                     continue
                 }
-                vectorStore.upsert(EPISODIC_VEC_TABLE, entity.rowId, vector)
-                episodicMemoryDao.markVectorized(entity.rowId)
+                memoryRepository.backfillEpisodicVector(entity.rowId, vector)
                 backfilled++
             }
 
@@ -70,3 +71,4 @@ class MemoryEmbeddingWorker @AssistedInject constructor(
         }
     }
 }
+

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/MemoryRepositoryImplTest.kt
@@ -49,18 +49,6 @@ class MemoryRepositoryImplTest {
     // ─────────────────────────────── addEpisodicMemory ───────────────────────────────
 
     @Test
-    fun `addEpisodicMemory without embedding — inserts entity, no vec upsert`() = runTest {
-        coEvery { episodicDao.insert(any()) } returns 1L
-        stubPrune()
-
-        val id = repository.addEpisodicMemory("conv-1", "test content")
-
-        assertTrue(id.isNotBlank(), "Returned ID should not be blank")
-        coVerify(exactly = 1) { episodicDao.insert(any()) }
-        verify(exactly = 0) { vectorStore.upsert(any(), any(), any()) }
-    }
-
-    @Test
     fun `addEpisodicMemory with embedding — inserts entity AND upserts to vec table`() = runTest {
         coEvery { episodicDao.insert(any()) } returns 42L
         every { vectorStore.createTable(any(), any()) } just Runs
@@ -100,18 +88,6 @@ class MemoryRepositoryImplTest {
     }
 
     // ─────────────────────────────── addCoreMemory ───────────────────────────────────
-
-    @Test
-    fun `addCoreMemory without embedding — inserts entity, no vec upsert`() = runTest {
-        coEvery { coreDao.insert(any()) } returns 1L
-        stubPrune()
-
-        val id = repository.addCoreMemory("user preference content")
-
-        assertTrue(id.isNotBlank(), "Returned ID should not be blank")
-        coVerify(exactly = 1) { coreDao.insert(any()) }
-        verify(exactly = 0) { vectorStore.upsert(any(), any(), any()) }
-    }
 
     @Test
     fun `addCoreMemory with embedding — inserts entity AND upserts to vec`() = runTest {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -25,7 +25,7 @@ class RunIntentSkill @Inject constructor(
     override val description =
         "Perform a native Android device action. Use for flashlight control, sending email, " +
             "sending SMS, setting an alarm (supports optional day name for tomorrow/weekday alarms), " +
-            "or setting a countdown timer."
+            "setting a countdown timer, or creating a calendar event."
 
     override val schema = SkillSchema(
         parameters = mapOf(
@@ -39,6 +39,7 @@ class RunIntentSkill @Inject constructor(
                     "send_sms",
                     "set_alarm",
                     "set_timer",
+                    "create_calendar_event",
                 ),
             ),
         ),
@@ -55,6 +56,9 @@ class RunIntentSkill @Inject constructor(
         "Set alarm tomorrow 8am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}8${STR},minutes:${STR}0${STR},day:${STR}tomorrow${STR}}<tool_call|>",
         "Set alarm next monday:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}0${STR},day:${STR}monday${STR}}<tool_call|>",
         "Set timer 3 min: <|tool_call>call:run_intent{intent_name:${STR}set_timer${STR},duration_seconds:${STR}180${STR}}<tool_call|>",
+        "Add calendar event: <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Team lunch${STR},date:${STR}2026-04-15${STR},time:${STR}12:30${STR}}<tool_call|>",
+        "Add all-day event:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Conference${STR},date:${STR}2026-04-20${STR}}<tool_call|>",
+        "Add reminder date:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Call dentist${STR},date:${STR}2026-04-18${STR},time:${STR}09:00${STR},duration_minutes:${STR}30${STR}}<tool_call|>",
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -180,6 +180,9 @@ class NativeIntentHandler @Inject constructor(
 
         val timeStr = params["time"]?.takeIf { it.isNotBlank() }
         val durationMinutes = params["duration_minutes"]?.toIntOrNull() ?: 60
+        if (durationMinutes <= 0) {
+            return SkillResult.Failure("run_intent", "duration_minutes must be greater than 0 (received: $durationMinutes).")
+        }
         val zone = ZoneId.systemDefault()
 
         val (beginMillis, endMillis) = if (timeStr != null) {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -7,9 +7,16 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.net.Uri
 import android.provider.AlarmClock
+import android.provider.CalendarContract
 import android.util.Log
 import com.kernel.ai.core.skills.SkillResult
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,12 +29,13 @@ private const val TAG = "KernelAI"
  * [intentName] strings to concrete Android APIs or system Intents.
  *
  * Supported intents:
- *   toggle_flashlight_on   — Camera2 torch on
- *   toggle_flashlight_off  — Camera2 torch off
- *   send_email             — ACTION_SEND mail chooser (params: subject, body)
- *   send_sms               — ACTION_SENDTO SMS composer (params: message)
- *   set_alarm              — AlarmClock.ACTION_SET_ALARM (params: hours, minutes, label)
- *   set_timer              — AlarmClock.ACTION_SET_TIMER (params: duration_seconds, label)
+ *   toggle_flashlight_on    — Camera2 torch on
+ *   toggle_flashlight_off   — Camera2 torch off
+ *   send_email              — ACTION_SEND mail chooser (params: subject, body)
+ *   send_sms                — ACTION_SENDTO SMS composer (params: message)
+ *   set_alarm               — AlarmClock.ACTION_SET_ALARM (params: hours, minutes, label)
+ *   set_timer               — AlarmClock.ACTION_SET_TIMER (params: duration_seconds, label)
+ *   create_calendar_event   — CalendarContract ACTION_INSERT edit screen (params: title, date, time?, duration_minutes?, description?)
  */
 @Singleton
 class NativeIntentHandler @Inject constructor(
@@ -44,6 +52,7 @@ class NativeIntentHandler @Inject constructor(
                 "send_sms" -> sendSms(params)
                 "set_alarm" -> setAlarm(params)
                 "set_timer" -> setTimer(params)
+                "create_calendar_event" -> createCalendarEvent(params)
                 else -> SkillResult.Failure("run_intent", "Unknown intent: $intentName")
             }
         } catch (e: Exception) {
@@ -152,6 +161,63 @@ class NativeIntentHandler @Inject constructor(
             SkillResult.Success("Timer set for $label.")
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("run_intent", "No clock app found to set a timer.")
+        }
+    }
+
+    // ── Calendar ──────────────────────────────────────────────────────────────
+
+    private fun createCalendarEvent(params: Map<String, String>): SkillResult {
+        val title = params["title"]?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("run_intent", "title is required for create_calendar_event.")
+        val dateStr = params["date"]?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("run_intent", "date is required (YYYY-MM-DD) for create_calendar_event.")
+
+        val date = try {
+            LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE)
+        } catch (e: DateTimeParseException) {
+            return SkillResult.Failure("run_intent", "Invalid date format '$dateStr' — expected YYYY-MM-DD.")
+        }
+
+        val timeStr = params["time"]?.takeIf { it.isNotBlank() }
+        val durationMinutes = params["duration_minutes"]?.toIntOrNull() ?: 60
+        val zone = ZoneId.systemDefault()
+
+        val (beginMillis, endMillis) = if (timeStr != null) {
+            val time = try {
+                LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm"))
+            } catch (e: DateTimeParseException) {
+                return SkillResult.Failure("run_intent", "Invalid time format '$timeStr' — expected HH:MM (24h).")
+            }
+            val begin = LocalDateTime.of(date, time).atZone(zone).toInstant().toEpochMilli()
+            val end = begin + durationMinutes * 60_000L
+            begin to end
+        } else {
+            // All-day event: pass midnight-to-midnight in UTC as CalendarContract expects
+            val begin = date.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
+            val end = begin + 24 * 60 * 60_000L
+            begin to end
+        }
+
+        val intent = Intent(Intent.ACTION_INSERT, CalendarContract.Events.CONTENT_URI).apply {
+            putExtra(CalendarContract.Events.TITLE, title)
+            putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, beginMillis)
+            putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endMillis)
+            if (timeStr == null) putExtra(CalendarContract.EXTRA_EVENT_ALL_DAY, true)
+            params["description"]?.takeIf { it.isNotBlank() }?.let {
+                putExtra(CalendarContract.Events.DESCRIPTION, it)
+            }
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+
+        if (context.packageManager.resolveActivity(intent, 0) == null) {
+            return SkillResult.Failure("run_intent", "No calendar app found on this device.")
+        }
+        return try {
+            context.startActivity(intent)
+            val timeLabel = if (timeStr != null) " at $timeStr" else " (all day)"
+            SkillResult.Success("Calendar opened — '${title}' on $dateStr$timeLabel. Please review and save in your calendar app.")
+        } catch (e: ActivityNotFoundException) {
+            SkillResult.Failure("run_intent", "No calendar app found on this device.")
         }
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -47,15 +47,16 @@ class SaveMemorySkill @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
-                if (vector == null) {
-                    Log.w(TAG, "SaveMemorySkill: embedding engine not ready — saving without vector")
-                }
+                    ?: run {
+                        Log.w(TAG, "SaveMemorySkill: embedding engine not ready, skipping")
+                        return@withContext SkillResult.Failure(name, "Embedding engine not ready")
+                    }
                 memoryRepository.addCoreMemory(
                     content = content,
                     source = "agent",
                     embeddingVector = vector,
                 )
-                Log.d(TAG, "SaveMemorySkill: stored core memory (vector=${vector != null}) — '${content.take(60)}'")
+                Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
                 SkillResult.Success("✓ Saved to memory.")
             } catch (e: Exception) {
                 Log.e(TAG, "SaveMemorySkill failed", e)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -206,7 +206,9 @@ class ChatViewModel @Inject constructor(
         truthsSeedingMutex.withLock {
             if (jandalPersona.isTruthsSeeded) return
             jandalPersona.truths.forEach { truth ->
-                memoryRepository.addCoreMemory(truth, source = "jandal_persona")
+                val vector = embeddingEngine.embed(truth).takeIf { it.isNotEmpty() }
+                    ?: return@forEach  // skip if engine not ready
+                memoryRepository.addCoreMemory(truth, source = "jandal_persona", embeddingVector = vector)
             }
             jandalPersona.markTruthsSeeded()
             Log.i("ChatViewModel", "Seeded ${jandalPersona.truths.size} Kiwi truths into core memory")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -258,7 +258,14 @@ class ChatViewModel @Inject constructor(
                         "Alarm rule: whenever the user asks to set an alarm for a specific time, " +
                         "you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set' or confirm it without using the tool. " +
                         "If the user specifies a day (e.g. 'tomorrow', 'next Monday', 'on Friday'), include day=<day_name> in the call — " +
-                        "pass the day exactly as the user said it (e.g. day='tomorrow', day='monday').\n\n" +
+                        "pass the day exactly as the user said it (e.g. day='tomorrow', day='monday').\n" +
+                        "Calendar rule: whenever the user says 'add a calendar entry', 'create a calendar event', 'add an event', " +
+                        "'add a reminder for [topic] on [date]', or 'schedule [topic] on [date]' — you MUST call run_intent with " +
+                        "intent_name=create_calendar_event. Resolve any relative date (e.g. 'tomorrow', 'next Friday') to an absolute " +
+                        "YYYY-MM-DD date before calling. Pass time as HH:MM (24h) if specified; omit it for all-day events. " +
+                        "NEVER confirm the event was created without calling the tool. " +
+                        "IMPORTANT: 'remind me in X minutes/seconds' is a timer (set_timer), NOT a calendar event. " +
+                        "Only use create_calendar_event when the user specifies a future date or a specific clock time on a date.\n\n" +
                         nativeDeclarations
                 )
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MemoryViewModel.kt
@@ -256,7 +256,14 @@ class MemoryViewModel @Inject constructor(
         }
         viewModelScope.launch {
             try {
-                memoryRepository.addCoreMemory(content = text, source = "user")
+                val vector = withContext(Dispatchers.Default) {
+                    embeddingEngine.embed(text)
+                }.takeIf { it.isNotEmpty() } ?: run {
+                    Log.w("KernelAI", "addCoreMemory: embedding engine not ready, aborting")
+                    _isSubmitting.value = false
+                    return@launch
+                }
+                memoryRepository.addCoreMemory(content = text, source = "user", embeddingVector = vector)
                 dismissAddDialog()
             } finally {
                 _isSubmitting.value = false

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -85,6 +85,7 @@ class MemoryViewModelTest {
 
     @Test
     fun `addCoreMemory calls repository with trimmed text`() = runTest {
+        every { embeddingEngine.embed(any()) } returns floatArrayOf(0.1f, 0.2f)
         coEvery { memoryRepository.addCoreMemory(any(), any(), any()) } returns "id-1"
 
         viewModel.openAddDialog()
@@ -93,7 +94,11 @@ class MemoryViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            memoryRepository.addCoreMemory(content = "remember this", source = "user")
+            memoryRepository.addCoreMemory(
+                content = "remember this",
+                source = "user",
+                embeddingVector = floatArrayOf(0.1f, 0.2f),
+            )
         }
     }
 
@@ -101,6 +106,18 @@ class MemoryViewModelTest {
     fun `addCoreMemory does not call repository when text is blank`() = runTest {
         viewModel.openAddDialog()
         viewModel.onAddDialogTextChange("   ")
+        viewModel.addCoreMemory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { memoryRepository.addCoreMemory(any(), any(), any()) }
+    }
+
+    @Test
+    fun `addCoreMemory does not call repository when embedding engine returns empty`() = runTest {
+        every { embeddingEngine.embed(any()) } returns floatArrayOf()
+
+        viewModel.openAddDialog()
+        viewModel.onAddDialogTextChange("some text")
         viewModel.addCoreMemory()
         testDispatcher.scheduler.advanceUntilIdle()
 


### PR DESCRIPTION
Closes #265

## Summary
Adds `create_calendar_event` as a new `run_intent` action, opening the default calendar app edit screen with event details pre-filled.

## Changes

### `NativeIntentHandler`
- New `createCalendarEvent(params)` uses `ACTION_INSERT` + `CalendarContract.Events.CONTENT_URI`
- Opens the calendar **edit screen** (user reviews and saves)
- Timed events (`time=HH:MM`) and all-day events (omit `time`)
- Validates date (`YYYY-MM-DD`) and time (`HH:MM` 24h) with clear error messages
- Params: `title` (required), `date` YYYY-MM-DD (required), `time` HH:MM (optional), `duration_minutes` (optional, default 60), `description` (optional)

### `RunIntentSkill`
- `create_calendar_event` added to `intent_name` enum
- Three new examples: timed event, all-day event, reminder-style

### `ChatViewModel` - Calendar rule
- Routes 'add calendar entry/event', 'schedule X on [date]', 'add reminder for X on [date]' to `create_calendar_event`
- Model resolves relative dates to YYYY-MM-DD before calling
- Explicit disambiguation: 'remind me in X minutes' stays as `set_timer`; 'remind me what I said about X' stays as `search_memory`
- NEVER confirm event created without calling the tool

## Test cases
- `Add a calendar entry for team lunch on Friday at 12:30` - calendar edit screen with title + time pre-filled
- `Create a calendar event for the conference on 20 April` - all-day event
- `Add a reminder for dentist appointment on Thursday at 9am` - calendar (not alarm)
- `Remind me in 5 minutes` - still routes to `set_timer` (regression check)
