### PR TITLE
fix(#293): hide Actions tab + stop loading FunctionGemmaRouter

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -3,7 +3,6 @@ package com.kernel.ai.navigation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -19,7 +18,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.kernel.ai.feature.chat.ActionsScreen
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.MemoryScreen
@@ -37,7 +35,7 @@ private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
 /** Routes that show the bottom navigation bar. */
-private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
+private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST)
 
 @Composable
 fun KernelNavHost() {
@@ -62,20 +60,7 @@ fun KernelNavHost() {
                         icon = { Icon(Icons.Default.ChatBubble, contentDescription = null) },
                         label = { Text("Chats") },
                     )
-                    NavigationBarItem(
-                        selected = currentRoute == ROUTE_ACTIONS,
-                        onClick = {
-                            if (currentRoute != ROUTE_ACTIONS) {
-                                navController.navigate(ROUTE_ACTIONS) {
-                                    popUpTo(ROUTE_LIST) { saveState = true }
-                                    launchSingleTop = true
-                                    restoreState = true
-                                }
-                            }
-                        },
-                        icon = { Icon(Icons.Default.Bolt, contentDescription = null) },
-                        label = { Text("Actions") },
-                    )
+                    // Actions tab hidden pending #220 (fast intent layer / FunctionGemmaRouter replacement)
                 }
             }
         },
@@ -102,11 +87,7 @@ fun KernelNavHost() {
                 }
             }
 
-            composable(ROUTE_ACTIONS) {
-                Box(modifier = Modifier.padding(innerPadding)) {
-                    ActionsScreen()
-                }
-            }
+            // Actions screen hidden pending #220 (fast intent layer / FunctionGemmaRouter replacement)
 
             // New conversation (no conversationId arg)
             composable(ROUTE_CHAT) {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -57,14 +57,19 @@ enum class KernelModel(
         isGated = false,
     ),
 
+    /**
+     * Not currently used — FunctionGemmaRouter has been superseded by the native Gemma 4
+     * control-token tool-calling path (#242). Kept in the catalogue (not required) so the
+     * enum reference in FunctionGemmaRouter/ActionsViewModel compiles; will be wired back in
+     * when the fast intent layer (#220) is implemented.
+     */
     FUNCTION_GEMMA_270M(
         displayName = "FunctionGemma 270M (intent router)",
         fileName = "mobile_actions_q8_ekv1024.litertlm",
         downloadUrl = "https://huggingface.co/litert-community/functiongemma-270m-ft-mobile-actions/resolve/main/mobile_actions_q8_ekv1024.litertlm",
         approxSizeBytes = 303_000_000L, // ~289 MB
-        // Required — powers the intent router (FunctionGemmaRouter) so skills fire on every device.
-        // HuggingFace repo is gated — requires sign-in to download.
-        isRequired = true,
+        // Not required until #220 (fast intent layer) is implemented.
+        isRequired = false,
         preferredForTier = null,
         isGated = true,
     ),

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.inference.ContextWindowManager
 import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.EmbeddingEngine
-import com.kernel.ai.core.inference.FunctionGemmaRouter
 import com.kernel.ai.core.inference.GenerationResult
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.inference.JandalPersona
@@ -67,7 +66,6 @@ class ChatViewModel @Inject constructor(
     private val modelSettingsRepository: ModelSettingsRepository,
     private val skillRegistry: SkillRegistry,
     private val skillExecutor: SkillExecutor,
-    private val functionGemmaRouter: FunctionGemmaRouter,
     private val kernelAIToolSet: KernelAIToolSet,
     private val embeddingEngine: EmbeddingEngine,
     private val jandalPersona: JandalPersona,
@@ -198,7 +196,6 @@ class ChatViewModel @Inject constructor(
             // FG's 289MB on CPU is enough to tip OOM during GPU init.
             // Once E4B is stable, FG loads in ~0.4s with no memory pressure.
             initEngineWhenReady()
-            initFunctionGemmaRouter()
         }
     }
 
@@ -375,40 +372,6 @@ class ChatViewModel @Inject constructor(
             } catch (e: Exception) {
                 _error.value = "Failed to load model: ${e.message}"
             }
-        }
-    }
-
-    /**
-     * Eagerly initialises [FunctionGemmaRouter] from `init {}` so skill commands are ready
-     * before the user types anything.
-     *
-     * Waits for [KernelModel.FUNCTION_GEMMA_270M] to be on disk (handles the case where the
-     * model is currently being downloaded when the chat opens). If the model is absent and not
-     * downloading, logs a warning and returns without blocking.
-     * Non-fatal if initialisation throws.
-     */
-    private suspend fun initFunctionGemmaRouter() {
-        // Wait until FunctionGemma transitions out of Downloading state, or bail immediately
-        // if it's NotDownloaded / Error (never been fetched).
-        downloadManager.downloadStates
-            .filter { states ->
-                val state = states[KernelModel.FUNCTION_GEMMA_270M]
-                state is DownloadState.Downloaded ||
-                    state is DownloadState.NotDownloaded ||
-                    state is DownloadState.Error
-            }
-            .first()
-
-        val routerPath = downloadManager.getModelPath(KernelModel.FUNCTION_GEMMA_270M)
-        if (routerPath == null) {
-            Log.i("KernelAI", "FunctionGemmaRouter: model not downloaded — intent routing disabled")
-            return
-        }
-        try {
-            functionGemmaRouter.initialize(routerPath)
-            Log.i("KernelAI", "FunctionGemmaRouter initialized successfully")
-        } catch (e: Exception) {
-            Log.w("KernelAI", "FunctionGemmaRouter: init failed (non-fatal): ${e.message}", e)
         }
     }
 
@@ -1044,9 +1007,6 @@ class ChatViewModel @Inject constructor(
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }
-        CoroutineScope(LlmDispatcher).launch {
-            functionGemmaRouter.release()
-        }
     }
 }
 


### PR DESCRIPTION
Closes #293

## What

Stopgap cleanup now that `FunctionGemmaRouter` has been superseded by native Gemma 4 control-token tool calling (#242).

## Changes

**`KernelNavHost`** — Actions tab removed from bottom nav and composable route removed. `ROUTE_ACTIONS` constant and all source files (`ActionsScreen`, `ActionsViewModel`, `FunctionGemmaRouter`) are **retained** as the reference implementation for #220.

**`ChatViewModel`** — removed `FunctionGemmaRouter` injection, `initFunctionGemmaRouter()` call + body, and `release()` in `onCleared`. Saves ~289 MB RAM on every app launch and removes the misleading `FunctionGemmaRouter initialized successfully` log line.

**`KernelModel`** — `FUNCTION_GEMMA_270M.isRequired = false` so `mobile_actions_q8_ekv1024.litertlm` is not auto-downloaded on fresh install.

## Not changed

- `FunctionGemmaRouter.kt` — retained for #220
- `ActionsViewModel.kt` — retained for #220
- `ActionsScreen.kt` — retained for #220