### PR TITLE
fix: add androidx.hilt:hilt-compiler KSP processor for @HiltWorker

### DIFF
--- a/core/memory/build.gradle.kts
+++ b/core/memory/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
 
     implementation(libs.work.runtime.ktx)
     implementation(libs.hilt.work)
+    ksp(libs.hilt.work.compiler)
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,7 @@ tflite-gpu = { group = "org.tensorflow", name = "tensorflow-lite-gpu", version.r
 # WorkManager
 work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
 
 # Coroutines
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutinesTest" }


### PR DESCRIPTION
## Root cause

`MemoryEmbeddingWorker` is annotated `@HiltWorker` but `androidx.hilt:hilt-compiler` (the KSP processor that generates the worker factory) was never added to `:core:memory`.

`libs.hilt.compiler` in the version catalog is `com.google.dagger:hilt-compiler` — this processes `@HiltAndroidApp`/`@HiltViewModel` etc., but **does not** process `@HiltWorker`. That requires the separate `androidx.hilt:hilt-compiler` processor.

Without it, `MemoryEmbeddingWorker_HiltModules` is never generated → `HiltWorkerFactory.workerFactories` has no entry for the worker → falls back to reflection → `NoSuchMethodException`.

## Fix

Add `androidx.hilt:hilt-compiler` to the version catalog and wire it as `ksp(libs.hilt.work.compiler)` in `:core:memory`.

## Note

This is a separate (and the actual) root cause from the `WorkManagerInitializer` race fixed in #292. Both fixes are needed:
- #292 ensures `HiltWorkerFactory` is registered with WorkManager
- This PR ensures the generated factory for `MemoryEmbeddingWorker` actually exists