### PR TITLE
debug: vec search JNI + Kotlin distance logging

### DIFF
--- a/core/memory/src/main/cpp/kernel_vec_jni.cpp
+++ b/core/memory/src/main/cpp/kernel_vec_jni.cpp
@@ -169,7 +169,9 @@ Java_com_kernel_ai_core_memory_vector_VectorStoreJni_search(
     jdoubleArray result = env->NewDoubleArray(0);
 
     int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
-    if (rc == SQLITE_OK) {
+    if (rc != SQLITE_OK) {
+        LOGE("search prepare failed for '%s': %s", table, sqlite3_errmsg(db));
+    } else {
         sqlite3_bind_blob(stmt, 1, queryFloats, dims * sizeof(float), SQLITE_STATIC);
         sqlite3_bind_int(stmt, 2, k);
 
@@ -178,9 +180,11 @@ Java_com_kernel_ai_core_memory_vector_VectorStoreJni_search(
         while (sqlite3_step(stmt) == SQLITE_ROW && count < k) {
             rows[count * 2]     = static_cast<double>(sqlite3_column_int64(stmt, 0));
             rows[count * 2 + 1] = sqlite3_column_double(stmt, 1);
+            LOGI("search '%s': rowid=%.0f dist=%.4f", table, rows[count*2], rows[count*2+1]);
             count++;
         }
         sqlite3_finalize(stmt);
+        LOGI("search '%s': %d results for k=%d dims=%d", table, count, k, (int)dims);
 
         result = env->NewDoubleArray(count * 2);
         if (count > 0) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -113,8 +113,9 @@ class MemoryRepositoryImpl @Inject constructor(
         val results = mutableListOf<MemorySearchResult>()
 
         runCatching {
-            val coreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, coreTopK)
-                .filter { it.distance <= CORE_MAX_DISTANCE }
+            val rawCoreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, coreTopK)
+            Log.d(TAG, "Core vec search: ${rawCoreResults.size} raw results, distances=${rawCoreResults.map { "%.3f".format(it.distance) }}")
+            val coreResults = rawCoreResults.filter { it.distance <= CORE_MAX_DISTANCE }
             val rowIds = coreResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
                 val entities = coreDao.getAll().filter { it.rowId in rowIds }


### PR DESCRIPTION
Adds diagnostic logging to diagnose why `search_memory` always returns 0 results.

**JNI** (`kernel_vec_jni.cpp`):
- Log `sqlite3_prepare_v2` errors (was silently returning empty array)
- Log each returned rowid + distance
- Log total result count per search call

**Kotlin** (`MemoryRepositoryImpl`):
- Log raw result count and distances before distance threshold filter

This will confirm:
1. Whether the JNI query itself fails
2. What actual distances sqlite-vec returns
3. Whether `CORE_MAX_DISTANCE=0.55` is filtering everything out

All 18 core memories have `accessCount=0` — search has never returned a single result.