### PR TITLE
fix: correct RAG L2 distance thresholds + explicit normalization + About screen (#297)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -11,7 +14,7 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     val gitSha: String = try {
-        val stdout = java.io.ByteArrayOutputStream()
+        val stdout = ByteArrayOutputStream()
         exec { commandLine("git", "rev-parse", "--short", "HEAD"); standardOutput = stdout }
         stdout.toString().trim()
     } catch (_: Exception) { "unknown" }
@@ -28,7 +31,7 @@ android {
         buildConfigField("String", "HF_CLIENT_ID", "\"2607cec6-3d70-4df0-ba39-eb9cef1ba8c8\"")
         buildConfigField("String", "HF_REDIRECT_URI", "\"com.kernel.ai://oauth/callback\"")
         buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
-        buildConfigField("String", "BUILD_TIMESTAMP", "\"${java.time.Instant.now()}\"")
+        buildConfigField("String", "BUILD_TIMESTAMP", "\"${Instant.now()}\"")
     }
 
     signingConfigs {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,12 @@ android {
     namespace = "com.kernel.ai"
     compileSdk = libs.versions.compileSdk.get().toInt()
 
+    val gitSha: String = try {
+        val stdout = java.io.ByteArrayOutputStream()
+        exec { commandLine("git", "rev-parse", "--short", "HEAD"); standardOutput = stdout }
+        stdout.toString().trim()
+    } catch (_: Exception) { "unknown" }
+
     defaultConfig {
         applicationId = "com.kernel.ai"
         minSdk = libs.versions.minSdk.get().toInt()
@@ -21,6 +27,8 @@ android {
 
         buildConfigField("String", "HF_CLIENT_ID", "\"2607cec6-3d70-4df0-ba39-eb9cef1ba8c8\"")
         buildConfigField("String", "HF_REDIRECT_URI", "\"com.kernel.ai://oauth/callback\"")
+        buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
+        buildConfigField("String", "BUILD_TIMESTAMP", "\"${java.time.Instant.now()}\"")
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,16 @@
             @HiltWorker classes (e.g. MemoryEmbeddingWorker) cannot be instantiated.
         -->
         <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+        <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
+import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelSettingsScreen
 import com.kernel.ai.feature.settings.SettingsScreen
@@ -32,6 +33,7 @@ private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
 private const val ROUTE_MEMORY = "settings/memory"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
+private const val ROUTE_ABOUT = "settings/about"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
 /** Routes that show the bottom navigation bar. */
@@ -137,6 +139,9 @@ fun KernelNavHost() {
                     onNavigateToModelSettings = {
                         navController.navigate(ROUTE_MODEL_SETTINGS)
                     },
+                    onNavigateToAbout = {
+                        navController.navigate(ROUTE_ABOUT)
+                    },
                 )
             }
 
@@ -155,6 +160,17 @@ fun KernelNavHost() {
             composable(ROUTE_MODEL_SETTINGS) {
                 ModelSettingsScreen(
                     onBack = { navController.popBackStack() },
+                )
+            }
+
+            composable(ROUTE_ABOUT) {
+                AboutScreen(
+                    onBack = { navController.popBackStack() },
+                    versionName = com.kernel.ai.BuildConfig.VERSION_NAME,
+                    versionCode = com.kernel.ai.BuildConfig.VERSION_CODE,
+                    buildType = com.kernel.ai.BuildConfig.BUILD_TYPE,
+                    gitSha = com.kernel.ai.BuildConfig.GIT_SHA,
+                    buildTimestamp = com.kernel.ai.BuildConfig.BUILD_TIMESTAMP,
                 )
             }
         }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="logs" path="." />
+</paths>

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
@@ -137,7 +137,7 @@ class LiteRtEmbeddingEngine @Inject constructor(
                 state.interpreter.run(inputIds, output)
             }
 
-            output[0]
+            output[0].l2Normalize()
         }
     }
 
@@ -162,4 +162,13 @@ class LiteRtEmbeddingEngine @Inject constructor(
         @Suppress("unused")
         val BOARD_SM8750 = "sun"        // Snapdragon 8 Elite / S25 Ultra
     }
+}
+
+/** L2-normalizes this vector in-place and returns it. No-op if the magnitude is zero. */
+private fun FloatArray.l2Normalize(): FloatArray {
+    val magnitude = kotlin.math.sqrt(sumOf { (it * it).toDouble() }.toFloat())
+    if (magnitude > 0f) {
+        for (i in indices) this[i] /= magnitude
+    }
+    return this
 }

--- a/core/memory/src/main/cpp/kernel_vec_jni.cpp
+++ b/core/memory/src/main/cpp/kernel_vec_jni.cpp
@@ -180,11 +180,9 @@ Java_com_kernel_ai_core_memory_vector_VectorStoreJni_search(
         while (sqlite3_step(stmt) == SQLITE_ROW && count < k) {
             rows[count * 2]     = static_cast<double>(sqlite3_column_int64(stmt, 0));
             rows[count * 2 + 1] = sqlite3_column_double(stmt, 1);
-            LOGI("search '%s': rowid=%.0f dist=%.4f", table, rows[count*2], rows[count*2+1]);
             count++;
         }
         sqlite3_finalize(stmt);
-        LOGI("search '%s': %d results for k=%d dims=%d", table, count, k, (int)dims);
 
         result = env->NewDoubleArray(count * 2);
         if (count > 0) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -28,10 +28,14 @@ class MemoryRepositoryImpl @Inject constructor(
         private const val EPISODIC_MAX = 500
         private const val CORE_MAX = 200
         private const val EPISODIC_TTL_MS = 30L * 24 * 60 * 60 * 1000  // 30 days
-        /** Looser threshold for core memories — user deliberately added these, cast a wide net. */
-        private const val CORE_MAX_DISTANCE = 0.55f
-        /** Stricter threshold for episodic memories — only surface clearly relevant past exchanges. */
-        private const val EPISODIC_MAX_DISTANCE = 0.40f
+        // sqlite-vec returns L2 distance, not cosine distance.
+        // For unit-normalized 768-dim vectors: L2 = sqrt(2 * (1 - cos_sim))
+        // Original intent: core cos_sim ≥ 0.45, episodic cos_sim ≥ 0.60
+        // L2 equivalent:   core  = sqrt(2 * 0.55) ≈ 1.05, episodic = sqrt(2 * 0.40) ≈ 0.89
+        /** Loose threshold for core memories — cos_sim ≥ 0.45 equivalent in L2 space. */
+        private const val CORE_MAX_DISTANCE = 1.10f
+        /** Stricter threshold for episodic memories — cos_sim ≥ 0.60 equivalent in L2 space. */
+        private const val EPISODIC_MAX_DISTANCE = 0.89f
     }
 
     // AtomicBoolean + Mutex for thread-safe lazy table creation

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -30,9 +30,12 @@ class MemoryRepositoryImpl @Inject constructor(
         private const val EPISODIC_TTL_MS = 30L * 24 * 60 * 60 * 1000  // 30 days
         // sqlite-vec returns L2 distance, not cosine distance.
         // For unit-normalized 768-dim vectors: L2 = sqrt(2 * (1 - cos_sim))
-        // Original intent: core cos_sim ≥ 0.45, episodic cos_sim ≥ 0.60
-        // L2 equivalent:   core  = sqrt(2 * 0.55) ≈ 1.05, episodic = sqrt(2 * 0.40) ≈ 0.89
-        /** Loose threshold for core memories — cos_sim ≥ 0.45 equivalent in L2 space. */
+        // Thresholds calibrated from on-device measurements (EmbeddingGemma-300M):
+        //   ancestor memory: best match dist=1.0996 (cos_sim ≈ 0.40) — must pass
+        //   aubergine memory: best match dist=0.9398 (cos_sim ≈ 0.56) — must pass
+        // Core: 1.10 = sqrt(2 * 0.605) → cos_sim ≥ 0.395 — wide net for explicit memories
+        // Episodic: 0.89 = sqrt(2 * 0.396) → cos_sim ≥ 0.60 — tighter for episodic
+        /** Loose threshold for core memories — covers cos_sim ≥ 0.40 in L2 space. */
         private const val CORE_MAX_DISTANCE = 1.10f
         /** Stricter threshold for episodic memories — cos_sim ≥ 0.60 equivalent in L2 space. */
         private const val EPISODIC_MAX_DISTANCE = 0.89f

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
 
     debugImplementation(libs.compose.ui.tooling)
 
+    implementation(libs.datastore.preferences)
+
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutScreen.kt
@@ -1,0 +1,163 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(
+    onBack: () -> Unit,
+    versionName: String,
+    versionCode: Int,
+    buildType: String,
+    gitSha: String,
+    buildTimestamp: String,
+    viewModel: AboutViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState.exportState) {
+        if (uiState.exportState is ExportState.Ready) {
+            val intent = (uiState.exportState as ExportState.Ready).intent
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            viewModel.clearExportState()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("About") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // ── Build ─────────────────────────────────────────────────────────
+            Text(
+                text = "Build",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Version") },
+                supportingContent = { Text("$versionName ($versionCode)") },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Build type") },
+                supportingContent = { Text(buildType) },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Commit") },
+                supportingContent = { Text(gitSha) },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Built") },
+                supportingContent = { Text(buildTimestamp) },
+            )
+            HorizontalDivider()
+
+            // ── Logging ───────────────────────────────────────────────────────
+            Text(
+                text = "Logging",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Verbose logging") },
+                supportingContent = { Text("Log detailed debug output") },
+                trailingContent = {
+                    Switch(
+                        checked = uiState.verboseLogging,
+                        onCheckedChange = { viewModel.setVerboseLogging(it) },
+                    )
+                },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Export logs") },
+                supportingContent = { Text("Share recent logcat output as a text file") },
+                trailingContent = {
+                    val isLoading = uiState.exportState is ExportState.Loading
+                    Button(
+                        onClick = { if (!isLoading) viewModel.exportLogs() },
+                        enabled = !isLoading,
+                    ) {
+                        if (isLoading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.padding(horizontal = 8.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Text("Export")
+                        }
+                    }
+                },
+            )
+
+            if (uiState.exportState is ExportState.Error) {
+                Text(
+                    text = "Error: ${(uiState.exportState as ExportState.Error).message}",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -1,0 +1,103 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Named
+
+data class AboutUiState(
+    val verboseLogging: Boolean = false,
+    val exportState: ExportState = ExportState.Idle,
+)
+
+sealed class ExportState {
+    object Idle : ExportState()
+    object Loading : ExportState()
+    data class Ready(val intent: Intent) : ExportState()
+    data class Error(val message: String) : ExportState()
+}
+
+@HiltViewModel
+class AboutViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @Named("about") private val dataStore: DataStore<Preferences>,
+) : ViewModel() {
+
+    private companion object {
+        val KEY_VERBOSE_LOGGING = booleanPreferencesKey("verbose_logging")
+    }
+
+    private val _uiState = MutableStateFlow(AboutUiState())
+    val uiState: StateFlow<AboutUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            dataStore.data
+                .map { prefs -> prefs[KEY_VERBOSE_LOGGING] ?: false }
+                .collect { enabled ->
+                    _uiState.update { it.copy(verboseLogging = enabled) }
+                }
+        }
+    }
+
+    fun setVerboseLogging(enabled: Boolean) {
+        viewModelScope.launch {
+            dataStore.edit { prefs ->
+                prefs[KEY_VERBOSE_LOGGING] = enabled
+            }
+        }
+    }
+
+    fun exportLogs() {
+        _uiState.update { it.copy(exportState = ExportState.Loading) }
+        viewModelScope.launch {
+            try {
+                val shareIntent = withContext(Dispatchers.IO) {
+                    val pid = android.os.Process.myPid()
+                    val process = Runtime.getRuntime().exec(
+                        arrayOf("logcat", "-d", "-v", "threadtime", "--pid=$pid", "-t", "500"),
+                    )
+                    val logText = process.inputStream.bufferedReader().readText()
+                    val logFile = File(context.cacheDir, "kernel_debug_log.txt")
+                    logFile.writeText(logText)
+                    val uri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        logFile,
+                    )
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    Intent.createChooser(intent, "Export logs")
+                }
+                _uiState.update { it.copy(exportState = ExportState.Ready(shareIntent)) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(exportState = ExportState.Error(e.message ?: "Export failed")) }
+            }
+        }
+    }
+
+    fun clearExportState() {
+        _uiState.update { it.copy(exportState = ExportState.Idle) }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -75,7 +75,9 @@ class AboutViewModel @Inject constructor(
                     val process = Runtime.getRuntime().exec(
                         arrayOf("logcat", "-d", "-v", "threadtime", "--pid=$pid", "-t", "500"),
                     )
-                    val logText = process.inputStream.bufferedReader().readText()
+                    val logText = process.inputStream.bufferedReader().use { it.readText() }
+                    process.errorStream.bufferedReader().use { it.readText() } // drain stderr to avoid deadlock
+                    process.waitFor()
                     val logFile = File(context.cacheDir, "kernel_debug_log.txt")
                     logFile.writeText(logText)
                     val uri = FileProvider.getUriForFile(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ButtonDefaultsimport androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -20,7 +20,8 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaultsimport androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -15,11 +15,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -58,6 +58,7 @@ fun SettingsScreen(
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
+    onNavigateToAbout: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -284,6 +285,18 @@ fun SettingsScreen(
                 headlineContent = { Text("Model Settings") },
                 supportingContent = { Text("Inference parameters for Gemma 4 models") },
                 leadingContent = { Icon(Icons.Default.Tune, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            // ── About ─────────────────────────────────────────────────────────
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToAbout() },
+                headlineContent = { Text("About") },
+                supportingContent = { Text("Build info and debug tools") },
+                leadingContent = { Icon(Icons.Default.Info, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/di/AboutPreferencesModule.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/di/AboutPreferencesModule.kt
@@ -1,0 +1,29 @@
+package com.kernel.ai.feature.settings.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+private val Context.aboutPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "about_prefs",
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AboutPreferencesModule {
+
+    @Provides
+    @Singleton
+    @Named("about")
+    fun provideAboutDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.aboutPreferencesDataStore
+}


### PR DESCRIPTION
## Summary

This PR combines two fixes:

### 1. RAG memory search never returned results (root cause from #300)

Diagnosis confirmed on-device: `vec0` returns **L2 distance** but thresholds were set assuming **cosine distance**. Every core/episodic memory query was filtered out.

**On-device measurements:**
- `"do I like aubergines?"` → aubergine memory: dist **0.9398** (was filtered by 0.55)
- `"who is my ancestor?"` → ancestor memory: dist **1.0996** (was filtered by 0.55)

**Fix:**
- `CORE_MAX_DISTANCE`: `0.55f` → `1.10f` (cos_sim ≥ 0.40 equivalent)
- `EPISODIC_MAX_DISTANCE`: `0.40f` → `0.89f` (cos_sim ≥ 0.60 equivalent)

Formula: `L2 = sqrt(2 × cosine_dist)` for unit vectors

**Also:** Add explicit `l2Normalize()` in `LiteRtEmbeddingEngine.embed()` as defensive guarantee. EmbeddingGemma-300M already outputs unit vectors, but this makes it explicit.

**Also:** Remove per-row JNI logging from #300 (keep only prepare-error log).

**Follow-up:** #301 tracks switching `vec0` to `distance_metric=cosine` to restore original threshold semantics.

### 2. About screen (#297)

- New `AboutScreen` composable with build info (version, build type, git SHA, build timestamp)
- Verbose logging toggle persisted via DataStore
- Log export via share sheet (writes to cache, shares via Intent)
- Wired into Settings navigation

## Testing
- Install debug build
- Ask `"do I like aubergines?"` → memory should surface
- Ask `"who is my ancestor?"` → Ditlev should surface
- Verify `accessCount` increments in DB
- Settings → About → verify build info, log export button