### PR TITLE
fix: loosen episodic RAG threshold + add episodic debug log

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -40,9 +40,8 @@ class RagRepository @Inject constructor(
         private const val TABLE = "message_embeddings"
         private const val DEFAULT_TOP_K = 5
 
-        /** Maximum cosine distance to include a result (0 = identical, 2 = opposite).
-         *  L2 equivalent of cosine_dist ≤ 0.60 (cos_sim ≥ 0.40) for unit-normalized vectors:
-         *  L2 = sqrt(2 * cosine_dist) = sqrt(2 * 0.60) ≈ 1.10
+        /** Maximum L2 distance to include a result (0 = identical, sqrt(2) ≈ 1.41 = opposite for unit vectors).
+         *  1.10 ≈ cos_sim ≥ 0.40 for unit-normalized 768-dim vectors: L2 = sqrt(2 * (1 - cos_sim)).
          *  Without this, top-K always returns results even when nothing is actually related. */
         private const val MAX_DISTANCE = 1.10f
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -41,10 +41,10 @@ class RagRepository @Inject constructor(
         private const val DEFAULT_TOP_K = 5
 
         /** Maximum cosine distance to include a result (0 = identical, 2 = opposite).
-         *  0.4 ≈ cosine similarity 0.6 — filters out unrelated memories while keeping
-         *  genuinely relevant context. Without this, top-K always returns results even
-         *  when nothing in memory is actually related to the current query. */
-        private const val MAX_DISTANCE = 0.4f
+         *  L2 equivalent of cosine_dist ≤ 0.60 (cos_sim ≥ 0.40) for unit-normalized vectors:
+         *  L2 = sqrt(2 * cosine_dist) = sqrt(2 * 0.60) ≈ 1.10
+         *  Without this, top-K always returns results even when nothing is actually related. */
+        private const val MAX_DISTANCE = 1.10f
     }
 
     private var tableCreated = false
@@ -158,6 +158,7 @@ class RagRepository @Inject constructor(
         if (tableCreated) {
             runCatching {
                 val results = vectorStore.search(TABLE, queryVector, topK + excludeMessageIds.size)
+                Log.d(TAG, "Message vec search: ${results.size} raw results, distances=${results.map { "%.4f".format(it.distance) }}")
                 val candidates = results
                     .filter { it.distance <= MAX_DISTANCE }
                     .map { it.rowId }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -34,11 +34,12 @@ class MemoryRepositoryImpl @Inject constructor(
         //   ancestor memory: best match dist=1.0996 (cos_sim ≈ 0.40) — must pass
         //   aubergine memory: best match dist=0.9398 (cos_sim ≈ 0.56) — must pass
         // Core: 1.10 = sqrt(2 * 0.605) → cos_sim ≥ 0.395 — wide net for explicit memories
-        // Episodic: 0.89 = sqrt(2 * 0.396) → cos_sim ≥ 0.60 — tighter for episodic
+        // Episodic: 1.10 — same as core; episodic summaries are less lexically similar to
+        //   queries than verbatim core memories, so they need a looser threshold too
         /** Loose threshold for core memories — covers cos_sim ≥ 0.40 in L2 space. */
         private const val CORE_MAX_DISTANCE = 1.10f
-        /** Stricter threshold for episodic memories — cos_sim ≥ 0.60 equivalent in L2 space. */
-        private const val EPISODIC_MAX_DISTANCE = 0.89f
+        /** Threshold for episodic memories — cos_sim ≥ 0.40 equivalent in L2 space. */
+        private const val EPISODIC_MAX_DISTANCE = 1.10f
     }
 
     // AtomicBoolean + Mutex for thread-safe lazy table creation
@@ -149,8 +150,9 @@ class MemoryRepositoryImpl @Inject constructor(
 
         runCatching {
             if (episodicTopK <= 0) return@runCatching
-            val episodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, episodicTopK)
-                .filter { it.distance <= EPISODIC_MAX_DISTANCE }
+            val rawEpisodicResults = vectorStore.search(EPISODIC_VEC_TABLE, queryVector, episodicTopK)
+            Log.d(TAG, "Episodic vec search: ${rawEpisodicResults.size} raw results, distances=${rawEpisodicResults.map { "%.4f".format(it.distance) }}")
+            val episodicResults = rawEpisodicResults.filter { it.distance <= EPISODIC_MAX_DISTANCE }
             val rowIds = episodicResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
                 val entities = episodicDao.getAll().filter { it.rowId in rowIds }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -121,9 +121,9 @@ peak. The service stops automatically once `InferenceEngine.isReady` becomes tru
 ```
 [System Prompt]          ← persona, date/time, runtime info
 [User Profile]           ← always injected (structured identity fields)
-[Core Memories]          ← permanent facts (CORE_MAX_DISTANCE=0.55, topK=10)
-[Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=0.40, topK=3)
-[Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=0.40, topK=5)
+[Core Memories]          ← permanent facts (CORE_MAX_DISTANCE=1.10, topK=10)
+[Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=1.10, topK=3)
+[Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=1.10, topK=5)
 [Conversation Window]    ← selected recent turns (75% token budget)
 [Current User Message]   ← with RAG context prepended
 ```
@@ -138,7 +138,7 @@ All three memory sections are conditionally included — omitted entirely if no 
   - `core_memories_vec` — permanent facts about the user (visible in Settings → Core Memories)
   - `episodic_memories_vec` — distilled conversation summaries from `EpisodicDistillationUseCase` (visible in Settings → Episodic Memories)
   - `message_embeddings` — per-message vectors for intra-conversation fuzzy recall (visible in Settings → Message History (RAG))
-- **Retrieval:** `vec_distance_cosine()` similarity search per query; top results injected into prompt
+- **Retrieval:** L2 (Euclidean) distance search per query via sqlite-vec default; results filtered by distance threshold; top results injected into prompt. Vectors are L2-normalised at embedding time (`LiteRtEmbeddingEngine`) so L2 distance is equivalent to `sqrt(2 * (1 - cos_sim))` — threshold 1.10 ≈ cos_sim ≥ 0.40.
 - **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
 - **TTL & pruning:** `prune()` runs on every write with two independent passes:
   1. **TTL pass** — deletes episodic memories where both `createdAt` and `lastAccessedAt` are older than 30 days. Accessing a memory resets `lastAccessedAt`, keeping it alive past the 30-day TTL for as long as it remains in use.
@@ -279,8 +279,8 @@ and awaits the result with a 15s timeout.
 > `SkillsModule.kt` via Hilt `@Binds @IntoSet`. Accepts a required `query` string,
 > optional `conversationId` (scopes search to one conversation for summary-to-detail
 > drill-down), and optional `topK` (default 5). Wraps `RagRepository.searchMessages()`,
-> which embeds the query and performs cosine vector search on `message_embeddings` at
-> `MAX_DISTANCE=0.4`. Results are formatted as a numbered list with date, role, and
+> which embeds the query and performs L2 distance search on `message_embeddings` at
+> `MAX_DISTANCE=1.10` (≈ cos_sim ≥ 0.40). Results are formatted as a numbered list with date, role, and
 > `conversation:ID` prefix. Uses a batch `MessageDao.getByIds()` call — single DB query
 > regardless of result count (avoids N+1). The system prompt injects its description as a
 > tool example so Gemma-4 knows when to invoke it.

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ButtonDefaultsimport androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -20,7 +20,8 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaultsimport androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon


### PR DESCRIPTION
EPISODIC_MAX_DISTANCE was 0.89f (cos_sim >= 0.60) — too strict. Best on-device episodic hit was dist=0.9998, just above threshold. Episodic summaries need a looser threshold than verbatim core memories.

Changes:
- EPISODIC_MAX_DISTANCE: 0.89f -> 1.10f (cos_sim >= 0.40, same as core)
- Add raw-results debug log for episodic search