### PR TITLE
fix: scale context window budgets to user-configured token limit

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
@@ -3,10 +3,9 @@ package com.kernel.ai.core.inference
 /**
  * Manages context window budget for LiteRT-LM conversations.
  *
- * LiteRT-LM Gemma-4 E2B/E4B has an 8192-token context window. After a reset
- * (cancel, restore from Room), prior conversation turns must be re-injected
- * so the model has context. This class estimates token usage and selects
- * which turns to include within the available budget.
+ * After a reset (cancel, restore from Room), prior conversation turns must be re-injected
+ * so the model has context. This class estimates token usage and selects which turns to
+ * include within the available budget, scaled to the active context window size.
  *
  * Token estimation uses a conservative 3 chars/token heuristic to account
  * for code, punctuation, and non-English text.
@@ -14,9 +13,6 @@ package com.kernel.ai.core.inference
 class ContextWindowManager {
 
     companion object {
-        /** Gemma-4 E2B/E4B default context length. */
-        const val MAX_CONTEXT_TOKENS = 8192
-
         /** Reserved for the model's generated response. */
         const val RESPONSE_RESERVE = 1024
 
@@ -24,14 +20,18 @@ class ContextWindowManager {
         const val SYSTEM_OVERHEAD = 2048
 
         /**
-         * Token budget allocated for episodic RAG context within [SYSTEM_OVERHEAD].
-         * Passed to [com.kernel.ai.core.memory.rag.RagRepository.getRelevantContext] as
-         * `maxTokens` to keep retrieved memories within a predictable slice of the budget.
+         * Tokens available for conversation history given [contextWindowSize].
+         * Clamped to zero so callers never receive a negative budget.
          */
-        const val EPISODIC_BUDGET = 400
+        fun historyBudget(contextWindowSize: Int): Int =
+            (contextWindowSize - RESPONSE_RESERVE - SYSTEM_OVERHEAD).coerceAtLeast(0)
 
-        /** Tokens available for conversation history replay. */
-        const val HISTORY_BUDGET = MAX_CONTEXT_TOKENS - RESPONSE_RESERVE - SYSTEM_OVERHEAD // 5120
+        /**
+         * Token budget for RAG context block, scaled to [contextWindowSize].
+         * 5% of the window, clamped to [200, 600] tokens.
+         */
+        fun episodicBudget(contextWindowSize: Int): Int =
+            (contextWindowSize * 0.05).toInt().coerceIn(200, 600)
 
         private const val CHARS_PER_TOKEN = 3
     }
@@ -45,7 +45,7 @@ class ContextWindowManager {
      */
     fun selectHistory(
         turns: List<Pair<String, String>>,
-        budget: Int = HISTORY_BUDGET,
+        budget: Int,
     ): List<Pair<String, String>> {
         var remaining = budget
         val result = ArrayDeque<Pair<String, String>>()
@@ -96,9 +96,9 @@ class ContextWindowManager {
         return result
     }
 
-    /** Fraction of [HISTORY_BUDGET] consumed by [turns]. Values > 1.0 indicate overflow. */
-    fun historyFillFraction(turns: List<Pair<String, String>>): Float {
+    /** Fraction of [historyBudget] consumed by [turns]. Values > 1.0 indicate overflow. */
+    fun historyFillFraction(turns: List<Pair<String, String>>, contextWindowSize: Int): Float {
         val used = turns.sumOf { estimateTokens(it.first) + estimateTokens(it.second) }
-        return used.toFloat() / HISTORY_BUDGET
+        return used.toFloat() / historyBudget(contextWindowSize)
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -96,7 +96,7 @@ class RagRepository @Inject constructor(
         conversationId: String,
         topK: Int = DEFAULT_TOP_K,
         excludeMessageIds: Set<String> = emptySet(),
-        maxTokens: Int = ContextWindowManager.EPISODIC_BUDGET,
+        maxTokens: Int = ContextWindowManager.episodicBudget(4096),
     ): String = withContext(Dispatchers.IO) {
         val queryVector = embeddingEngine.embed(query)
         if (queryVector.isEmpty()) return@withContext ""

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -88,7 +88,8 @@ class RagRepository @Inject constructor(
      *   conversation summaries) are cross-conversation by design.
      * @param excludeMessageIds Message IDs to exclude (e.g. the current turn's user message).
      * @param maxTokens Maximum token budget for the returned context block (estimated at chars/3).
-     *   Results are truncated to fit within the budget. Defaults to [ContextWindowManager.EPISODIC_BUDGET].
+     *   Results are truncated to fit within the budget. Scaled to the active context window via
+     *   [ContextWindowManager.episodicBudget] — callers should pass that value explicitly.
      */
     suspend fun getRelevantContext(
         query: String,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -80,6 +80,7 @@ class ChatViewModel @Inject constructor(
     private val _conversationTitle = MutableStateFlow<String?>(null)
     private var conversationId: String? = null
     private val contextWindowManager = ContextWindowManager()
+    private var activeContextWindowSize: Int = 4096
     private val truthsSeedingMutex = Mutex()
 
     /** Tracks the timestamp of the last episodic distillation for the current conversation. */
@@ -359,6 +360,7 @@ class ChatViewModel @Inject constructor(
                 Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
+                activeContextWindowSize = settings.contextWindowSize
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
@@ -401,6 +403,7 @@ class ChatViewModel @Inject constructor(
                 Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
+                activeContextWindowSize = settings.contextWindowSize
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
@@ -533,13 +536,13 @@ class ChatViewModel @Inject constructor(
             val ragContext = ragRepository.getRelevantContext(
                 query = text,
                 conversationId = convId,
-                maxTokens = ContextWindowManager.EPISODIC_BUDGET,
+                maxTokens = ContextWindowManager.episodicBudget(activeContextWindowSize),
             )
             val ragTokenCost = contextWindowManager.estimateTokens(ragContext)
 
             // Proactive context reset: if we're at ~75% of the token budget, reset
             // the conversation and replay history to avoid LiteRT locking up.
-            val tokenBudget = ContextWindowManager.MAX_CONTEXT_TOKENS
+            val tokenBudget = activeContextWindowSize
             val proactiveReset = estimatedTokensUsed > (tokenBudget * 0.75).toInt()
 
             if (needsHistoryReplay || proactiveReset) {
@@ -548,7 +551,7 @@ class ChatViewModel @Inject constructor(
                 val turns = contextWindowManager.extractTurns(
                     allMessages.map { it.content to (it.role == ChatMessage.Role.USER) }
                 )
-                val selected = contextWindowManager.selectHistory(turns)
+                val selected = contextWindowManager.selectHistory(turns, ContextWindowManager.historyBudget(activeContextWindowSize))
                 // Inject history into the system prompt so Gemma treats it as background context.
                 val systemPromptWithHistory = buildSystemPrompt(selected)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -117,14 +117,15 @@ private fun ModelCard(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Context Window — steps of 500 to avoid exact powers-of-2 (4096, 8192)
-        // which trigger a GPU reshape alignment bug on some Adreno GPUs.
+        // Context window — steps of 500. Minimum 4000 to ensure non-negative history budget
+        // (fixed overhead is RESPONSE_RESERVE=1024 + SYSTEM_OVERHEAD=2048 = 3072 tokens).
+        // Avoids exact powers-of-2 (4096, 8192) which trigger a GPU reshape alignment bug.
         SliderRow(
             label = "Context window",
             valueLabel = "${settings.contextWindowSize} tokens",
             value = settings.contextWindowSize.toFloat(),
-            valueRange = 2000f..32000f,
-            steps = ((32000 - 2000) / 500) - 1,
+            valueRange = 4000f..32000f,
+            steps = ((32000 - 4000) / 500) - 1,
             isInteger = true,
             onValueChangeFinished = { newVal ->
                 val snapped = (newVal / 500).roundToInt() * 500


### PR DESCRIPTION
## Problem

All token budget calculations in `ContextWindowManager` and `ChatViewModel` were hardcoded against 8192 tokens regardless of the user's model settings. With a custom context window (e.g. 4000 tokens):

- Proactive reset fired at 75% × 8192 = **6144 tokens** — well past the 4000-token KV-cache limit
- `selectHistory` used a fixed 5120-token history budget — larger than the entire context window
- RAG episodic budget was a fixed 400 tokens regardless of window size

This caused generation to stall or get cancelled mid-response when a non-default context window was set.

## Changes

- **`ContextWindowManager`**: Replace `MAX_CONTEXT_TOKENS` / `HISTORY_BUDGET` / `EPISODIC_BUDGET` constants with `historyBudget(contextWindowSize)` and `episodicBudget(contextWindowSize)` helper functions. `selectHistory()` now requires an explicit budget. `historyFillFraction()` takes a `contextWindowSize` parameter.
- **`ChatViewModel`**: Store `activeContextWindowSize` (default 4096) when the engine initialises; use it for the proactive reset threshold, `selectHistory` budget, and RAG episodic budget.
- **`ModelSettingsScreen`**: Raise context window slider minimum from **2000 → 4000**. Fixed overhead (`RESPONSE_RESERVE=1024` + `SYSTEM_OVERHEAD=2048`) totals 3072 tokens — any value below 4000 produces a zero or negative history budget.
- **`RagRepository`**: Update kdoc to reflect that `maxTokens` should come from `ContextWindowManager.episodicBudget()`.

## Budget values at key context window sizes

| Context window | History budget | Episodic RAG budget |
|---|---|---|
| 4000 (min) | 928 tokens | 200 tokens |
| 4096 (default low-RAM) | 1024 tokens | 204 tokens |
| 8000 (near-default flagship) | 4928 tokens | 400 tokens |
| 16000 | 12928 tokens | 600 tokens (cap) |