### PR TITLE
feat(#305): add Cancel and Save & Restart App buttons to Model Settings

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.feature.settings
 
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -35,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -44,6 +48,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import kotlin.math.roundToInt
+import kotlin.system.exitProcess
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +57,7 @@ fun ModelSettingsScreen(
     viewModel: ModelSettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     Scaffold(
         topBar = {
@@ -89,6 +95,36 @@ fun ModelSettingsScreen(
                     onSettingsChanged = viewModel::updateE4bSettings,
                     onReset = viewModel::resetE4bToDefaults,
                 )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            // Screen-level actions: Cancel discards drafts; Save & Restart persists and cold-starts.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = {
+                        viewModel.cancelChanges()
+                        onBack()
+                    },
+                    enabled = uiState.hasUnsavedChanges && !uiState.isSaving,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        viewModel.saveSettings { restartApp(context) }
+                    },
+                    enabled = uiState.hasUnsavedChanges && !uiState.isSaving,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(if (uiState.isSaving) "Saving…" else "Save & Restart App")
+                }
             }
         }
     }
@@ -283,4 +319,11 @@ private fun ModelSettingsScreenPreview() {
             onReset = {},
         )
     }
+}
+
+private fun restartApp(context: android.content.Context) {
+    val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+        ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+    if (intent != null) context.startActivity(intent)
+    exitProcess(0)
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -325,5 +325,8 @@ private fun restartApp(context: android.content.Context) {
     val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
         ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK) }
     if (intent != null) context.startActivity(intent)
+    // Brief pause to let Android register the new activity and allow Room's WAL checkpoint
+    // to flush before the process terminates.
+    Thread.sleep(200)
     exitProcess(0)
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsViewModel.kt
@@ -3,9 +3,9 @@ package com.kernel.ai.feature.settings
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
-import com.kernel.ai.core.inference.download.KernelModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,10 +20,17 @@ class ModelSettingsViewModel @Inject constructor(
 ) : ViewModel() {
 
     data class ModelSettingsUiState(
+        /** Current draft values shown in the UI. Not persisted until [saveSettings] is called. */
         val e2bSettings: ModelSettingsEntity? = null,
         val e4bSettings: ModelSettingsEntity? = null,
+        /** Last-persisted snapshot — used to detect unsaved changes and to revert on Cancel. */
+        val persistedE2b: ModelSettingsEntity? = null,
+        val persistedE4b: ModelSettingsEntity? = null,
         val isSaving: Boolean = false,
-    )
+    ) {
+        val hasUnsavedChanges: Boolean
+            get() = e2bSettings != persistedE2b || e4bSettings != persistedE4b
+    }
 
     private val _uiState = MutableStateFlow(ModelSettingsUiState())
     val uiState: StateFlow<ModelSettingsUiState> = _uiState.asStateFlow()
@@ -36,40 +43,77 @@ class ModelSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val e2b = modelSettingsRepository.getSettings(MODEL_ID_E2B)
             val e4b = modelSettingsRepository.getSettings(MODEL_ID_E4B)
-            _uiState.update { it.copy(e2bSettings = e2b, e4bSettings = e4b) }
+            _uiState.update {
+                it.copy(
+                    e2bSettings = e2b,
+                    e4bSettings = e4b,
+                    persistedE2b = e2b,
+                    persistedE4b = e4b,
+                )
+            }
         }
     }
 
+    /** Updates the E-2B draft. Not persisted until [saveSettings] is called. */
     fun updateE2bSettings(settings: ModelSettingsEntity) {
         _uiState.update { it.copy(e2bSettings = settings) }
-        saveSettings(settings)
     }
 
+    /** Updates the E-4B draft. Not persisted until [saveSettings] is called. */
     fun updateE4bSettings(settings: ModelSettingsEntity) {
         _uiState.update { it.copy(e4bSettings = settings) }
-        saveSettings(settings)
     }
 
+    /**
+     * Resets E-2B to hardware-aware defaults and persists them immediately.
+     * A process restart is still required for the inference engine to load the new values.
+     */
     fun resetE2bToDefaults() {
         viewModelScope.launch {
             val defaults = modelSettingsRepository.resetToDefaults(MODEL_ID_E2B)
-            _uiState.update { it.copy(e2bSettings = defaults) }
+            _uiState.update { it.copy(e2bSettings = defaults, persistedE2b = defaults) }
         }
     }
 
+    /**
+     * Resets E-4B to hardware-aware defaults and persists them immediately.
+     * A process restart is still required for the inference engine to load the new values.
+     */
     fun resetE4bToDefaults() {
         viewModelScope.launch {
             val defaults = modelSettingsRepository.resetToDefaults(MODEL_ID_E4B)
-            _uiState.update { it.copy(e4bSettings = defaults) }
+            _uiState.update { it.copy(e4bSettings = defaults, persistedE4b = defaults) }
         }
     }
 
-    private fun saveSettings(entity: ModelSettingsEntity) {
+    /** Reverts all unsaved draft changes back to the last-persisted values. */
+    fun cancelChanges() {
+        _uiState.update { it.copy(e2bSettings = it.persistedE2b, e4bSettings = it.persistedE4b) }
+    }
+
+    /**
+     * Persists both draft settings, then invokes [onSaved].
+     * The caller is responsible for triggering a process restart inside [onSaved].
+     */
+    fun saveSettings(onSaved: () -> Unit) {
         viewModelScope.launch {
+            val draft2b = _uiState.value.e2bSettings ?: return@launch
+            val draft4b = _uiState.value.e4bSettings ?: return@launch
+            _uiState.update { it.copy(isSaving = true) }
             try {
-                modelSettingsRepository.saveSettings(entity)
+                modelSettingsRepository.saveSettings(draft2b)
+                modelSettingsRepository.saveSettings(draft4b)
+                _uiState.update {
+                    it.copy(
+                        isSaving = false,
+                        persistedE2b = draft2b,
+                        persistedE4b = draft4b,
+                    )
+                }
+                onSaved()
             } catch (e: Exception) {
-                Log.e("KernelAI", "ModelSettingsViewModel: failed to save settings", e)
+                Log.e(TAG, "Failed to save settings", e)
+                _uiState.update { it.copy(isSaving = false) }
             }
         }
     }
@@ -77,5 +121,6 @@ class ModelSettingsViewModel @Inject constructor(
     companion object {
         val MODEL_ID_E2B = KernelModel.GEMMA_4_E2B.modelId
         val MODEL_ID_E4B = KernelModel.GEMMA_4_E4B.modelId
+        private const val TAG = "KernelAI"
     }
 }


### PR DESCRIPTION
Closes #305

## What changed

### Problem
Settings were auto-saved on every slider movement, but the inference engine only reads them at startup. Since Android doesn't guarantee a cold start when the user closes the app, there was no reliable way to apply new settings.

### Solution
Switch to a **draft / persisted** model with explicit Save & Restart.

#### `ModelSettingsViewModel`
- `updateE2bSettings` / `updateE4bSettings` now update an in-memory draft only — no database write.
- New `saveSettings(onSaved)` — persists both model drafts, then calls `onSaved` (the restart callback).
- New `cancelChanges()` — resets both drafts to the last-persisted snapshot.
- `UiState.hasUnsavedChanges` — drives button enabled states.
- `resetXxxToDefaults` — unchanged behaviour (persists immediately), but now also updates the persisted snapshot so Cancel after a reset is a no-op.

#### `ModelSettingsScreen`
New button row below both model cards:

| Button | Enabled when | Behaviour |
|---|---|---|
| **Cancel** | unsaved changes exist | Reverts draft → navigates back |
| **Save & Restart App** | unsaved changes exist | Persists → restarts process |

Both disable while `isSaving`. Restart uses `getLaunchIntentForPackage` + `FLAG_ACTIVITY_CLEAR_TASK` + `exitProcess(0)` — no new dependency.

## Acceptance criteria
- [x] Cancel discards in-memory changes and navigates back
- [x] Save & Restart persists settings and force-restarts
- [x] Reset to defaults still works (immediate persist, no Save & Restart required)
- [x] No new dependency added