### PR TITLE
fix(#266): calendar date failure — ISO date in system prompt + resilient parsing

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -25,7 +25,8 @@ class RunIntentSkill @Inject constructor(
     override val description =
         "Perform a native Android device action. Use for flashlight control, sending email, " +
             "sending SMS, setting an alarm (supports optional day name for tomorrow/weekday alarms), " +
-            "setting a countdown timer, or creating a calendar event."
+            "setting a countdown timer, or creating a calendar event. " +
+            "For calendar events, date accepts YYYY-MM-DD or relative terms like 'tomorrow', 'next wednesday'."
 
     override val schema = SkillSchema(
         parameters = mapOf(
@@ -59,6 +60,8 @@ class RunIntentSkill @Inject constructor(
         "Add calendar event: <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Team lunch${STR},date:${STR}2026-04-15${STR},time:${STR}12:30${STR}}<tool_call|>",
         "Add all-day event:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Conference${STR},date:${STR}2026-04-20${STR}}<tool_call|>",
         "Add reminder date:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Call dentist${STR},date:${STR}2026-04-18${STR},time:${STR}09:00${STR},duration_minutes:${STR}30${STR}}<tool_call|>",
+        "Add event next wednesday: <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Go to gym${STR},date:${STR}next wednesday${STR},time:${STR}08:00${STR}}<tool_call|>",
+        "Add event tomorrow:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Dentist${STR},date:${STR}tomorrow${STR},time:${STR}09:00${STR}}<tool_call|>",
     )
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -11,12 +11,14 @@ import android.provider.CalendarContract
 import android.util.Log
 import com.kernel.ai.core.skills.SkillResult
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.temporal.TemporalAdjusters
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -172,11 +174,11 @@ class NativeIntentHandler @Inject constructor(
         val dateStr = params["date"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure("run_intent", "date is required (YYYY-MM-DD) for create_calendar_event.")
 
-        val date = try {
-            LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE)
-        } catch (e: DateTimeParseException) {
-            return SkillResult.Failure("run_intent", "Invalid date format '$dateStr' — expected YYYY-MM-DD.")
-        }
+        val date = resolveDate(dateStr)
+            ?: return SkillResult.Failure(
+                "run_intent",
+                "Could not parse date '$dateStr' — use YYYY-MM-DD or a relative term like 'next wednesday'.",
+            )
 
         val timeStr = params["time"]?.takeIf { it.isNotBlank() }
         val durationMinutes = params["duration_minutes"]?.toIntOrNull() ?: 60
@@ -218,9 +220,74 @@ class NativeIntentHandler @Inject constructor(
         return try {
             context.startActivity(intent)
             val timeLabel = if (timeStr != null) " at $timeStr" else " (all day)"
-            SkillResult.Success("Calendar opened — '${title}' on $dateStr$timeLabel. Please review and save in your calendar app.")
+            val resolvedDateStr = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+            SkillResult.Success("Calendar opened — '${title}' on $resolvedDateStr$timeLabel. Please review and save in your calendar app.")
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("run_intent", "No calendar app found on this device.")
         }
+    }
+
+    /**
+     * Resolves a date string to a [LocalDate]. Accepts:
+     * - ISO format: `YYYY-MM-DD` (and common variants like `YYYY-M-D`, `D-M-YYYY`, `D/M/YYYY`)
+     * - Relative keywords: `today`, `tomorrow`
+     * - Day names: `monday`…`sunday`, optionally prefixed with `next` (always skips to next occurrence)
+     *
+     * Returns null if the string cannot be resolved to a valid date.
+     */
+    private fun resolveDate(dateStr: String): LocalDate? {
+        val input = dateStr.trim()
+        val normalized = input.lowercase()
+        val today = LocalDate.now()
+
+        // Relative keywords
+        when (normalized) {
+            "today" -> return today
+            "tomorrow" -> return today.plusDays(1)
+        }
+
+        // Day-of-week names with optional "next" prefix
+        val isExplicitNext = normalized.startsWith("next ")
+        val dayName = if (isExplicitNext) normalized.removePrefix("next ").trim() else normalized
+        val targetDow: DayOfWeek? = when (dayName) {
+            "monday" -> DayOfWeek.MONDAY
+            "tuesday" -> DayOfWeek.TUESDAY
+            "wednesday" -> DayOfWeek.WEDNESDAY
+            "thursday" -> DayOfWeek.THURSDAY
+            "friday" -> DayOfWeek.FRIDAY
+            "saturday" -> DayOfWeek.SATURDAY
+            "sunday" -> DayOfWeek.SUNDAY
+            else -> null
+        }
+        if (targetDow != null) {
+            // "next X" always skips to the following week; plain "X" returns the upcoming occurrence.
+            return if (isExplicitNext) {
+                today.with(TemporalAdjusters.next(targetDow))
+                    .let { candidate ->
+                        // Ensure we skip to truly next week if the day happens to be today
+                        if (candidate == today) today.with(TemporalAdjusters.next(targetDow)) else candidate
+                    }
+            } else {
+                today.with(TemporalAdjusters.nextOrSame(targetDow))
+                    .let { if (it == today) today.with(TemporalAdjusters.next(targetDow)) else it }
+            }
+        }
+
+        // Strict ISO first, then progressively more lenient formats
+        val formatters = listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE,                    // 2026-04-16
+            DateTimeFormatter.ofPattern("yyyy-M-d"),             // 2026-4-16  (missing zero padding)
+            DateTimeFormatter.ofPattern("d-M-yyyy"),             // 16-4-2026
+            DateTimeFormatter.ofPattern("dd-MM-yyyy"),           // 16-04-2026
+            DateTimeFormatter.ofPattern("d/M/yyyy"),             // 16/4/2026
+            DateTimeFormatter.ofPattern("M/d/yyyy"),             // 4/16/2026
+            DateTimeFormatter.ofPattern("yyyy/MM/dd"),           // 2026/04/16
+        )
+        for (fmt in formatters) {
+            try {
+                return LocalDate.parse(input, fmt)
+            } catch (_: DateTimeParseException) { /* try next */ }
+        }
+        return null
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -246,9 +246,8 @@ class NativeIntentHandler @Inject constructor(
             "tomorrow" -> return today.plusDays(1)
         }
 
-        // Day-of-week names with optional "next" prefix
-        val isExplicitNext = normalized.startsWith("next ")
-        val dayName = if (isExplicitNext) normalized.removePrefix("next ").trim() else normalized
+        // Day-of-week names with optional "next" prefix (both resolve identically)
+        val dayName = normalized.removePrefix("next ").trim()
         val targetDow: DayOfWeek? = when (dayName) {
             "monday" -> DayOfWeek.MONDAY
             "tuesday" -> DayOfWeek.TUESDAY
@@ -260,17 +259,10 @@ class NativeIntentHandler @Inject constructor(
             else -> null
         }
         if (targetDow != null) {
-            // "next X" always skips to the following week; plain "X" returns the upcoming occurrence.
-            return if (isExplicitNext) {
-                today.with(TemporalAdjusters.next(targetDow))
-                    .let { candidate ->
-                        // Ensure we skip to truly next week if the day happens to be today
-                        if (candidate == today) today.with(TemporalAdjusters.next(targetDow)) else candidate
-                    }
-            } else {
-                today.with(TemporalAdjusters.nextOrSame(targetDow))
-                    .let { if (it == today) today.with(TemporalAdjusters.next(targetDow)) else it }
-            }
+            // Always return the next future occurrence — never today.
+            // TemporalAdjusters.next() guarantees this; "next wednesday" and plain "wednesday"
+            // behave identically (both skip to the upcoming occurrence in the future).
+            return today.with(TemporalAdjusters.next(targetDow))
         }
 
         // Strict ISO first, then progressively more lenient formats

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -215,12 +215,15 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
         val profile = userProfileRepository.get()
-        val dateTime = LocalDateTime.now()
-            .format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm", Locale.ENGLISH))
+        val now = LocalDateTime.now()
+        val dateTime = now.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm", Locale.ENGLISH))
+        // ISO date injected alongside the human-readable date so the model can copy it directly
+        // when generating calendar event dates without having to reformat the year.
+        val isoDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
             append("\n\n${jandalPersona.buildGreetingInstruction()} ${jandalPersona.buildSessionVocab()}")
-            append("\n\n[Current date and time]\n$dateTime")
+            append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
             // Runtime info fetched dynamically via get_system_info skill at query time
             if (profile.isNotBlank()) {
                 // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).


### PR DESCRIPTION
Fixes TC-CAL1/CAL2/CAL3 failures in #266.

## Root cause

Gemma E-2B/E-4B have a training cutoff before 2026. When asked to produce a `YYYY-MM-DD` calendar date, the model hallucinates the year — outputting `204` instead of `2026`, producing strings like `204-5-2026` that fail strict ISO parsing. The model confirmed this when asked directly: *"Today is Tuesday, 14 April 204."*

## Three-layered fix

### 1. ISO date in system prompt (`ChatViewModel`)
Append the current ISO date alongside the human-readable one:
```
[Current date and time]
Monday, 14 April 2026, 07:27 (ISO: 2026-04-14)
```
The model can now copy `2026-04-14` verbatim and compute offsets (e.g. +2 days) without reformatting the year from its (incorrect) memory.

### 2. Relative date resolution (`NativeIntentHandler`)
`createCalendarEvent` now resolves natural references in the `date` field server-side:
- `today`, `tomorrow`
- Day names: `wednesday`, `friday`, etc.
- `next wednesday`, `next friday`, etc.

The model only has to emit a word it's confident about rather than a formatted date it might mangle.

### 3. Lenient ISO parsing fallback (`NativeIntentHandler`)
Before failing, tries common alternative formats the model might emit: `yyyy-M-d`, `d-M-yyyy`, `dd-MM-yyyy`, `d/M/yyyy`, `M/d/yyyy`, `yyyy/MM/dd`.

### Few-shot examples updated (`RunIntentSkill`)
Two new examples showing relative date usage (`next wednesday`, `tomorrow`) so the model learns the pattern.