### PR TITLE
fix(#289,#290): ban Australian phrases and limit greeting to first reply

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -47,20 +47,22 @@ class JandalPersona @Inject constructor(
     }
 
     /**
-     * Returns an explicit time-aware instruction about when Morena is appropriate.
-     * This replaces the bare greeting word injection so the model understands the
-     * time constraint rather than treating "Morena!" as a general-purpose greeting.
+     * Returns an explicit time-aware instruction about when Morena is appropriate,
+     * plus a hard rule to only greet once per conversation.
      *
-     * - 05:00-11:59 → permit Morena, explain it means good morning
-     * - All other hours → explicitly forbid Morena, direct model to use Kia ora
+     * - 05:00-11:59 → permit Morena on the first reply only
+     * - All other hours → explicitly forbid Morena, allow Kia ora on first reply only
      */
     fun buildGreetingInstruction(): String {
         val hour = LocalTime.now().hour
-        return if (hour in 5..11) {
-            "It is morning. You may greet with 'Morena' (good morning in Māori) where natural."
+        val greetWord = if (hour in 5..11) {
+            "You may open your FIRST reply with 'Morena' (good morning in Māori)."
         } else {
-            "Do not say 'Morena' — it means good morning and it is not morning. Greet with 'Kia ora' instead."
+            "Do not say 'Morena' — it is not morning. You may open your FIRST reply with 'Kia ora'."
         }
+        return "$greetWord " +
+            "After the first reply, do NOT start messages with a greeting — it sounds robotic. " +
+            "Use the user's name occasionally for warmth, not as a prefix on every response."
     }
 
     /**

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -47,22 +47,27 @@ class JandalPersona @Inject constructor(
     }
 
     /**
-     * Returns an explicit time-aware instruction about when Morena is appropriate,
-     * plus a hard rule to only greet once per conversation.
+     * Returns an explicit time-aware greeting instruction tailored to whether this is the
+     * first reply in the conversation or a follow-up.
      *
-     * - 05:00-11:59 → permit Morena on the first reply only
-     * - All other hours → explicitly forbid Morena, allow Kia ora on first reply only
+     * @param isFirstReply true when there is no prior conversation history (i.e. turn 1).
+     *
+     * - First reply + morning (05:00–11:59) → open with Morena
+     * - First reply + other hours → open with Kia ora
+     * - Follow-up reply → explicitly forbid any greeting opener
      */
-    fun buildGreetingInstruction(): String {
+    fun buildGreetingInstruction(isFirstReply: Boolean): String {
+        if (!isFirstReply) {
+            return "Do NOT start this reply with a greeting — you already greeted the user earlier in the conversation. " +
+                "Use the user's name occasionally for warmth, not as a prefix on every response."
+        }
         val hour = LocalTime.now().hour
         val greetWord = if (hour in 5..11) {
-            "You may open your FIRST reply with 'Morena' (good morning in Māori)."
+            "Open your reply with 'Morena' (good morning in Māori)."
         } else {
-            "Do not say 'Morena' — it is not morning. You may open your FIRST reply with 'Kia ora'."
+            "Do not say 'Morena' — it is not morning. Open your reply with 'Kia ora'."
         }
-        return "$greetWord " +
-            "After the first reply, do NOT start messages with a greeting — it sounds robotic. " +
-            "Use the user's name occasionally for warmth, not as a prefix on every response."
+        return "$greetWord Use the user's name occasionally for warmth, not as a prefix on every response."
     }
 
     /**

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -17,7 +17,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "When asked where you are from, what your culture is, or why you are called Jandal, " +
         "own your Kiwi identity with pride — never say you are \"just code\" or that you have no culture. " +
         "IMPORTANT — language rules: You are New Zealand, NOT Australian. " +
-        "NEVER use Australian phrases such as 'fair dinkum', 'G'day', or 'no worries mate' in an Australian context. " +
+        "NEVER use Australian phrases. Prohibited examples: 'fair dinkum', 'G\\'day', 'no worries mate'. " +
         "NEVER refer to New Zealand as 'down under' — that is an Australian term. " +
         "Always refer to the country as 'New Zealand' or 'Aotearoa'."
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -15,7 +15,11 @@ const val DEFAULT_SYSTEM_PROMPT =
         "You are named after the NZ word for flip-flops: jandals — simple, unpretentious, practical. " +
         "You were born from Kiwi culture: laid-back, direct, and no-nonsense. " +
         "When asked where you are from, what your culture is, or why you are called Jandal, " +
-        "own your Kiwi identity with pride — never say you are \"just code\" or that you have no culture."
+        "own your Kiwi identity with pride — never say you are \"just code\" or that you have no culture. " +
+        "IMPORTANT — language rules: You are New Zealand, NOT Australian. " +
+        "NEVER use Australian phrases such as 'fair dinkum', 'G'day', or 'no worries mate' in an Australian context. " +
+        "NEVER refer to New Zealand as 'down under' — that is an Australian term. " +
+        "Always refer to the country as 'New Zealand' or 'Aotearoa'."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -222,7 +222,7 @@ class ChatViewModel @Inject constructor(
         val isoDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
-            append("\n\n${jandalPersona.buildGreetingInstruction()} ${jandalPersona.buildSessionVocab()}")
+            append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = historyTurns.isEmpty())} ${jandalPersona.buildSessionVocab()}")
             append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
             // Runtime info fetched dynamically via get_system_info skill at query time
             if (profile.isNotBlank()) {


### PR DESCRIPTION
## Changes

### #289 — Australian phrases leaking into Jandal's responses
- Added explicit prohibition in `DEFAULT_SYSTEM_PROMPT`: never use 'fair dinkum', 'G'day', or 'down under'
- Clarifies NZ is always referred to as 'New Zealand' or 'Aotearoa', never 'down under'

### #290 — Jandal greets on almost every reply
- Reworked `buildGreetingInstruction()` to limit greeting to the **first reply only**
- Subsequent replies must not open with a greeting (Morena/Kia ora)
- Suppresses overuse of user's name as a per-message prefix

Closes #289
Closes #290