### PR TITLE
test: unit tests for ToolCallExtractor and SkillExecutor (#240)

### DIFF
--- a/core/skills/build.gradle.kts
+++ b/core/skills/build.gradle.kts
@@ -22,6 +22,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    testOptions {
+        unitTests.all { it.useJUnitPlatform() }
+    }
 }
 
 dependencies {
@@ -38,4 +42,5 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
+    testImplementation("org.json:json:20240303")
 }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/SkillExecutorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/SkillExecutorTest.kt
@@ -1,0 +1,156 @@
+package com.kernel.ai.core.skills
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SkillExecutorTest {
+
+    private lateinit var registry: SkillRegistry
+    private lateinit var executor: SkillExecutor
+
+    private fun makeSkill(
+        skillName: String,
+        required: List<String> = emptyList(),
+        result: SkillResult = SkillResult.Success("ok"),
+    ): Skill {
+        val skill = mockk<Skill>()
+        io.mockk.every { skill.name } returns skillName
+        io.mockk.every { skill.schema } returns SkillSchema(
+            parameters = required.associateWith {
+                SkillParameter(type = "string", description = it)
+            },
+            required = required,
+        )
+        coEvery { skill.execute(any()) } returns result
+        return skill
+    }
+
+    @BeforeEach
+    fun setUp() {
+        registry = mockk()
+        executor = SkillExecutor(registry)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // parseSkillCall (tested via execute)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class ParseSkillCall {
+
+        @Test
+        fun `pure JSON dispatches to skill and returns Success`() = runTest {
+            val skill = makeSkill("save_memory", required = listOf("content"))
+            io.mockk.every { registry.get("save_memory") } returns skill
+
+            val result = executor.execute("""{"name": "save_memory", "arguments": {"content": "test"}}""")
+
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertEquals("ok", (result as SkillResult.Success).content)
+        }
+
+        @Test
+        fun `markdown fenced JSON is stripped and dispatched`() = runTest {
+            val skill = makeSkill("get_weather")
+            io.mockk.every { registry.get("get_weather") } returns skill
+
+            val result = executor.execute("```json\n{\"name\": \"get_weather\", \"arguments\": {}}\n```")
+
+            assertInstanceOf(SkillResult.Success::class.java, result)
+        }
+
+        @Test
+        fun `empty arguments object is accepted`() = runTest {
+            val skill = makeSkill("get_system_info")
+            io.mockk.every { registry.get("get_system_info") } returns skill
+
+            val result = executor.execute("""{"name": "get_system_info", "arguments": {}}""")
+
+            assertInstanceOf(SkillResult.Success::class.java, result)
+        }
+
+        @Test
+        fun `malformed JSON returns ParseError`() = runTest {
+            val result = executor.execute("not json at all")
+            assertInstanceOf(SkillResult.ParseError::class.java, result)
+        }
+
+        @Test
+        fun `JSON without name field returns ParseError`() = runTest {
+            val result = executor.execute("""{"foo": "bar"}""")
+            assertInstanceOf(SkillResult.ParseError::class.java, result)
+        }
+
+        @Test
+        fun `empty string returns ParseError`() = runTest {
+            val result = executor.execute("")
+            assertInstanceOf(SkillResult.ParseError::class.java, result)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Skill dispatch
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class SkillDispatch {
+
+        @Test
+        fun `unknown skill name returns UnknownSkill`() = runTest {
+            io.mockk.every { registry.get("nonexistent") } returns null
+
+            val result = executor.execute("""{"name": "nonexistent", "arguments": {}}""")
+
+            assertInstanceOf(SkillResult.UnknownSkill::class.java, result)
+            assertEquals("nonexistent", (result as SkillResult.UnknownSkill).skillName)
+        }
+
+        @Test
+        fun `missing required parameter returns ParseError`() = runTest {
+            val skill = makeSkill("save_memory", required = listOf("content"))
+            io.mockk.every { registry.get("save_memory") } returns skill
+
+            // "content" is required but not provided
+            val result = executor.execute("""{"name": "save_memory", "arguments": {}}""")
+
+            assertInstanceOf(SkillResult.ParseError::class.java, result)
+            val error = result as SkillResult.ParseError
+            assertEquals(true, error.reason.contains("content"))
+        }
+
+        @Test
+        fun `skill throwing exception returns Failure`() = runTest {
+            val skill = makeSkill("get_weather")
+            coEvery { skill.execute(any()) } throws RuntimeException("network error")
+            io.mockk.every { registry.get("get_weather") } returns skill
+
+            val result = executor.execute("""{"name": "get_weather", "arguments": {}}""")
+
+            assertInstanceOf(SkillResult.Failure::class.java, result)
+            assertEquals("network error", (result as SkillResult.Failure).error)
+        }
+
+        @Test
+        fun `skill returning Failure is passed through`() = runTest {
+            val skill = makeSkill("get_weather", result = SkillResult.Failure("get_weather", "timeout"))
+            io.mockk.every { registry.get("get_weather") } returns skill
+
+            val result = executor.execute("""{"name": "get_weather", "arguments": {}}""")
+
+            assertInstanceOf(SkillResult.Failure::class.java, result)
+            assertEquals("timeout", (result as SkillResult.Failure).error)
+        }
+
+        @Test
+        fun `normal text response with no JSON returns ParseError - no regression`() = runTest {
+            val result = executor.execute("Kia ora, how can I help?")
+            assertInstanceOf(SkillResult.ParseError::class.java, result)
+        }
+    }
+}

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -64,4 +64,5 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
+    testImplementation("org.json:json:20240303")
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -213,16 +213,16 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private suspend fun buildSystemPrompt(historyTurns: List<Pair<String, String>> = emptyList()): String {
+    private suspend fun buildSystemPrompt(
+        historyTurns: List<Pair<String, String>> = emptyList(),
+        isFirstReply: Boolean = _messages.value.none { it.role == ChatMessage.Role.ASSISTANT },
+    ): String {
         val profile = userProfileRepository.get()
         val now = LocalDateTime.now()
         val dateTime = now.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm", Locale.ENGLISH))
         // ISO date injected alongside the human-readable date so the model can copy it directly
         // when generating calendar event dates without having to reformat the year.
         val isoDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
-        // isFirstReply is true only when no assistant messages have been sent yet in this conversation.
-        // _messages holds the live conversation; historyTurns is only populated on RAG history replay.
-        val isFirstReply = _messages.value.none { it.role == ChatMessage.Role.ASSISTANT } && historyTurns.isEmpty()
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
             append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = isFirstReply)} ${jandalPersona.buildSessionVocab()}")
@@ -522,6 +522,9 @@ class ChatViewModel @Inject constructor(
             // _isLoadingModel is always cleared by the outer finally block below.
 
             // 2. Gemma-4 streaming inference path.
+            // Capture isFirstReply before adding the streaming placeholder — once the placeholder
+            // is in _messages the ASSISTANT check would always return false.
+            val isFirstReply = _messages.value.none { it.role == ChatMessage.Role.ASSISTANT }
             assistantMsgId = UUID.randomUUID().toString()
             val streamingPlaceholder = ChatMessage(
                 id = assistantMsgId,
@@ -559,7 +562,7 @@ class ChatViewModel @Inject constructor(
                 )
                 val selected = contextWindowManager.selectHistory(turns, ContextWindowManager.historyBudget(activeContextWindowSize))
                 // Inject history into the system prompt so Gemma treats it as background context.
-                val systemPromptWithHistory = buildSystemPrompt(selected)
+                val systemPromptWithHistory = buildSystemPrompt(selected, isFirstReply = isFirstReply)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)
                 // Re-baseline from selected history, then add the RAG cost for this turn.
                 estimatedTokensUsed = selected.sumOf {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -220,9 +220,12 @@ class ChatViewModel @Inject constructor(
         // ISO date injected alongside the human-readable date so the model can copy it directly
         // when generating calendar event dates without having to reformat the year.
         val isoDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
+        // isFirstReply is true only when no assistant messages have been sent yet in this conversation.
+        // _messages holds the live conversation; historyTurns is only populated on RAG history replay.
+        val isFirstReply = _messages.value.none { it.role == ChatMessage.Role.ASSISTANT } && historyTurns.isEmpty()
         return buildString {
             append(DEFAULT_SYSTEM_PROMPT)
-            append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = historyTurns.isEmpty())} ${jandalPersona.buildSessionVocab()}")
+            append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = isFirstReply)} ${jandalPersona.buildSessionVocab()}")
             append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
             // Runtime info fetched dynamically via get_system_info skill at query time
             if (profile.isNotBlank()) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -850,7 +850,8 @@ class ChatViewModel @Inject constructor(
     private suspend fun tryExecuteToolCall(raw: String): Pair<ToolCallInfo, String>? {
         // E4B often wraps the JSON tool call in prose. Extract the first valid
         // {"name": ..., "arguments": ...} block from anywhere in the response.
-        val extracted = extractNativeToolCall(raw) ?: extractToolCallJson(raw) ?: return null
+        val extracted = ToolCallExtractor.extractNativeToolCall(raw)
+            ?: ToolCallExtractor.extractToolCallJson(raw) ?: return null
 
         val result = skillExecutor.execute(extracted)
         return when (result) {
@@ -880,119 +881,6 @@ class ChatViewModel @Inject constructor(
     }
 
 
-    /**
-     * Scans [text] for a Gemma 4 native tool call token:
-     *   <|tool_call>call:name{key:<|"|>value<|"|>,key2:numval}<tool_call|>
-     * If found, normalises it to {"name": "name", "arguments": {...}} JSON
-     * so it can be dispatched via the existing [SkillExecutor] path.
-     */
-    private fun extractNativeToolCall(text: String): String? {
-        val startTag = "<|tool_call>"
-        val endTag = "<tool_call|>"
-        val startIdx = text.indexOf(startTag)
-        if (startIdx < 0) return null
-        val innerStart = startIdx + startTag.length
-        val endIdx = text.indexOf(endTag, innerStart)
-        if (endIdx < 0) return null
-
-        // inner = "call:name{args}" or "call:name" (no braces for no-arg tools)
-        val inner = text.substring(innerStart, endIdx).trim()
-        if (!inner.startsWith("call:")) return null
-
-        val afterCall = inner.substring("call:".length)
-        val braceIdx = afterCall.indexOf('{')
-
-        val rawName: String
-        val argsJson = org.json.JSONObject()
-        if (braceIdx < 0) {
-            rawName = afterCall.trim()
-        } else {
-            rawName = afterCall.substring(0, braceIdx).trim()
-            val lastBrace = afterCall.lastIndexOf('}')
-            if (lastBrace > braceIdx) {
-                val argsBlock = afterCall.substring(braceIdx + 1, lastBrace).trim()
-                if (argsBlock.isNotBlank()) parseNativeArgs(argsBlock, argsJson)
-            }
-        }
-
-        if (rawName.isBlank()) return null
-        val snakeName = camelToSnake(rawName)
-
-        return org.json.JSONObject()
-            .put("name", snakeName)
-            .put("arguments", argsJson)
-            .toString()
-    }
-
-    /** Converts camelCase to snake_case for mapping native tool names to SkillRegistry names. */
-    private fun camelToSnake(name: String): String =
-        name.replace(Regex("([A-Z])")) { "_${it.value.lowercase()}" }.trimStart('_')
-
-    /**
-     * Parses the Gemma 4 native arg block, e.g.:
-     *   location:<|"|>London<|"|>,unit:<|"|>celsius<|"|>
-     *   duration:5
-     */
-    private fun parseNativeArgs(raw: String, out: org.json.JSONObject) {
-        val strToken = """<|"|>"""
-        var i = 0
-        while (i < raw.length) {
-            val colonIdx = raw.indexOf(':', i)
-            if (colonIdx < 0) break
-            val key = raw.substring(i, colonIdx).trim()
-            val rest = raw.substring(colonIdx + 1)
-            if (rest.startsWith(strToken)) {
-                val valueStart = strToken.length
-                val valueEnd = rest.indexOf(strToken, valueStart)
-                if (valueEnd < 0) break
-                out.put(key, rest.substring(valueStart, valueEnd))
-                i = colonIdx + 1 + valueEnd + strToken.length
-                if (i < raw.length && raw[i] == ',') i++
-            } else {
-                val commaIdx = rest.indexOf(',')
-                val rawVal = if (commaIdx < 0) rest.trim() else rest.substring(0, commaIdx).trim()
-                out.put(key, rawVal.toLongOrNull() ?: rawVal.toDoubleOrNull() ?: rawVal)
-                i = colonIdx + 1 + (if (commaIdx < 0) rest.length else commaIdx + 1)
-            }
-        }
-    }
-
-    /**
-     * Scans [text] for the first balanced {...} block that contains a "name" key and
-     * can be parsed as a valid skill call JSON. Handles responses where E4B emits the
-     * tool call JSON embedded in conversational prose rather than as a standalone object.
-     */
-    private fun extractToolCallJson(text: String): String? {
-        var i = 0
-        while (i < text.length) {
-            val start = text.indexOf('{', i)
-            if (start == -1) break
-            var depth = 0
-            var j = start
-            var inString = false
-            var escape = false
-            while (j < text.length) {
-                val c = text[j]
-                when {
-                    escape -> escape = false
-                    c == '\\' && inString -> escape = true
-                    c == '"' -> inString = !inString
-                    !inString && c == '{' -> depth++
-                    !inString && c == '}' -> {
-                        depth--
-                        if (depth == 0) {
-                            val candidate = text.substring(start, j + 1)
-                            if (candidate.contains("\"name\"")) return candidate
-                            break
-                        }
-                    }
-                }
-                j++
-            }
-            i = start + 1
-        }
-        return null
-    }
 
     override fun onCleared() {
         super.onCleared()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
@@ -1,0 +1,125 @@
+package com.kernel.ai.feature.chat
+
+/**
+ * Stateless utilities for extracting tool call JSON from raw model output.
+ *
+ * E4B and Gemma 4 emit tool calls in two different formats:
+ *  - Gemma 4 native token:  <|tool_call>call:name{args}<tool_call|>
+ *  - JSON (E4B / FunctionGemma):  {"name": "...", "arguments": {...}} possibly embedded in prose
+ *
+ * Both paths are normalised to the same canonical JSON string so [SkillExecutor] can
+ * dispatch them uniformly.
+ */
+internal object ToolCallExtractor {
+
+    /**
+     * Scans [text] for a Gemma 4 native tool call token:
+     *   <|tool_call>call:name{key:<|"|>value<|"|>,key2:numval}<tool_call|>
+     * If found, normalises it to {"name": "name", "arguments": {...}} JSON.
+     */
+    fun extractNativeToolCall(text: String): String? {
+        val startTag = "<|tool_call>"
+        val endTag = "<tool_call|>"
+        val startIdx = text.indexOf(startTag)
+        if (startIdx < 0) return null
+        val innerStart = startIdx + startTag.length
+        val endIdx = text.indexOf(endTag, innerStart)
+        if (endIdx < 0) return null
+
+        val inner = text.substring(innerStart, endIdx).trim()
+        if (!inner.startsWith("call:")) return null
+
+        val afterCall = inner.substring("call:".length)
+        val braceIdx = afterCall.indexOf('{')
+
+        val rawName: String
+        val argsJson = org.json.JSONObject()
+        if (braceIdx < 0) {
+            rawName = afterCall.trim()
+        } else {
+            rawName = afterCall.substring(0, braceIdx).trim()
+            val lastBrace = afterCall.lastIndexOf('}')
+            if (lastBrace > braceIdx) {
+                val argsBlock = afterCall.substring(braceIdx + 1, lastBrace).trim()
+                if (argsBlock.isNotBlank()) parseNativeArgs(argsBlock, argsJson)
+            }
+        }
+
+        if (rawName.isBlank()) return null
+        val snakeName = camelToSnake(rawName)
+
+        return org.json.JSONObject()
+            .put("name", snakeName)
+            .put("arguments", argsJson)
+            .toString()
+    }
+
+    /**
+     * Scans [text] for the first balanced {...} block that contains a "name" key.
+     * Handles responses where the model emits the tool call JSON embedded in prose.
+     */
+    fun extractToolCallJson(text: String): String? {
+        var i = 0
+        while (i < text.length) {
+            val start = text.indexOf('{', i)
+            if (start == -1) break
+            var depth = 0
+            var j = start
+            var inString = false
+            var escape = false
+            while (j < text.length) {
+                val c = text[j]
+                when {
+                    escape -> escape = false
+                    c == '\\' && inString -> escape = true
+                    c == '"' -> inString = !inString
+                    !inString && c == '{' -> depth++
+                    !inString && c == '}' -> {
+                        depth--
+                        if (depth == 0) {
+                            val candidate = text.substring(start, j + 1)
+                            if (candidate.contains("\"name\"")) return candidate
+                            break
+                        }
+                    }
+                }
+                j++
+            }
+            i = start + 1
+        }
+        return null
+    }
+
+    /** Converts camelCase to snake_case for mapping native tool names to SkillRegistry names. */
+    fun camelToSnake(name: String): String =
+        name.replace(Regex("([A-Z])")) { "_${it.value.lowercase()}" }.trimStart('_')
+
+    /**
+     * Parses the Gemma 4 native arg block, e.g.:
+     *   location:<|"|>London<|"|>,unit:<|"|>celsius<|"|>
+     *   duration:5
+     */
+    internal fun parseNativeArgs(raw: String, out: org.json.JSONObject) {
+        val strToken = """<|"|>"""
+        var i = 0
+        while (i < raw.length) {
+            val colonIdx = raw.indexOf(':', i)
+            if (colonIdx < 0) break
+            val key = raw.substring(i, colonIdx).trim()
+            val rest = raw.substring(colonIdx + 1)
+            if (rest.startsWith(strToken)) {
+                val valueStart = strToken.length
+                val valueEnd = rest.indexOf(strToken, valueStart)
+                if (valueEnd < 0) break
+                out.put(key, rest.substring(valueStart, valueEnd))
+                i = colonIdx + 1 + valueEnd + strToken.length
+                if (i < raw.length && raw[i] == ',') i++
+            } else {
+                val commaIdx = rest.indexOf(',')
+                val rawVal = if (commaIdx < 0) rest.trim() else rest.substring(0, commaIdx).trim()
+                out.put(key, rawVal.toLongOrNull() ?: rawVal.toDoubleOrNull() ?: rawVal)
+                i = colonIdx + 1 + (if (commaIdx < 0) rest.length else commaIdx + 1)
+            }
+        }
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ToolCallExtractorTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ToolCallExtractorTest.kt
@@ -1,0 +1,189 @@
+package com.kernel.ai.feature.chat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.json.JSONObject
+
+class ToolCallExtractorTest {
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // extractToolCallJson
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class ExtractToolCallJson {
+
+        @Test
+        fun `pure JSON response returned unchanged`() {
+            val input = """{"name": "save_memory", "arguments": {"content": "test"}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            val json = JSONObject(result!!)
+            assertEquals("save_memory", json.getString("name"))
+        }
+
+        @Test
+        fun `JSON embedded in prose - extracts inner block`() {
+            val input = """Got it! {"name": "save_memory", "arguments": {"content": "test"}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            assertEquals("save_memory", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `JSON at end of prose`() {
+            val input = """Sure thing, Nick. {"name": "get_weather", "arguments": {}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            assertEquals("get_weather", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `nested braces in arguments`() {
+            val input = """{"name": "x", "arguments": {"data": {"key": "val"}}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            val json = JSONObject(result!!)
+            assertEquals("x", json.getString("name"))
+            assertEquals("val", json.getJSONObject("arguments").getJSONObject("data").getString("key"))
+        }
+
+        @Test
+        fun `escaped quotes inside string value`() {
+            val input = """{"name": "x", "arguments": {"text": "say \"hello\""}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            assertEquals("x", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `multiple JSON blocks - returns first block containing name`() {
+            val input = """{"foo": "bar"} {"name": "save_memory", "arguments": {}} {"name": "other", "arguments": {}}"""
+            val result = ToolCallExtractor.extractToolCallJson(input)
+            assertNotNull(result)
+            assertEquals("save_memory", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `plain text with no JSON returns null`() {
+            assertNull(ToolCallExtractor.extractToolCallJson("Hello mate"))
+        }
+
+        @Test
+        fun `object without name key returns null`() {
+            assertNull(ToolCallExtractor.extractToolCallJson("""{"foo": "bar"}"""))
+        }
+
+        @Test
+        fun `unbalanced braces returns null without crashing`() {
+            assertNull(ToolCallExtractor.extractToolCallJson("""{"name": "x" """))
+        }
+
+        @Test
+        fun `empty string returns null`() {
+            assertNull(ToolCallExtractor.extractToolCallJson(""))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // extractNativeToolCall
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class ExtractNativeToolCall {
+
+        private val STR = "<|\"|>"
+
+        @Test
+        fun `valid native call with string arg is normalised to JSON`() {
+            val input = "<|tool_call>call:get_weather{location:${STR}London${STR}}<tool_call|>"
+            val result = ToolCallExtractor.extractNativeToolCall(input)
+            assertNotNull(result)
+            val json = JSONObject(result!!)
+            assertEquals("get_weather", json.getString("name"))
+            assertEquals("London", json.getJSONObject("arguments").getString("location"))
+        }
+
+        @Test
+        fun `camelCase tool name is converted to snake_case`() {
+            val input = "<|tool_call>call:saveMemory{content:${STR}test${STR}}<tool_call|>"
+            val result = ToolCallExtractor.extractNativeToolCall(input)
+            assertNotNull(result)
+            assertEquals("save_memory", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `no-arg tool call produces empty arguments object`() {
+            val input = "<|tool_call>call:get_system_info<tool_call|>"
+            val result = ToolCallExtractor.extractNativeToolCall(input)
+            assertNotNull(result)
+            val json = JSONObject(result!!)
+            assertEquals("get_system_info", json.getString("name"))
+            assertTrue(json.getJSONObject("arguments").length() == 0)
+        }
+
+        @Test
+        fun `native call embedded in prose is extracted`() {
+            val input = "Let me check. <|tool_call>call:get_weather{location:${STR}Auckland${STR}}<tool_call|> Done."
+            val result = ToolCallExtractor.extractNativeToolCall(input)
+            assertNotNull(result)
+            assertEquals("get_weather", JSONObject(result!!).getString("name"))
+        }
+
+        @Test
+        fun `numeric arg is extracted`() {
+            val input = "<|tool_call>call:set_timer{duration:5}<tool_call|>"
+            val result = ToolCallExtractor.extractNativeToolCall(input)
+            assertNotNull(result)
+            val args = JSONObject(result!!).getJSONObject("arguments")
+            assertEquals(5L, args.getLong("duration"))
+        }
+
+        @Test
+        fun `text with no native token returns null`() {
+            assertNull(ToolCallExtractor.extractNativeToolCall("plain text"))
+        }
+
+        @Test
+        fun `start tag without end tag returns null`() {
+            assertNull(ToolCallExtractor.extractNativeToolCall("<|tool_call>call:get_weather{location:${STR}x${STR}}"))
+        }
+
+        @Test
+        fun `content without call prefix returns null`() {
+            assertNull(ToolCallExtractor.extractNativeToolCall("<|tool_call>get_weather<tool_call|>"))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // camelToSnake
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class CamelToSnake {
+
+        @Test
+        fun `already snake_case is unchanged`() {
+            assertEquals("get_weather", ToolCallExtractor.camelToSnake("get_weather"))
+        }
+
+        @Test
+        fun `camelCase converts correctly`() {
+            assertEquals("save_memory", ToolCallExtractor.camelToSnake("saveMemory"))
+        }
+
+        @Test
+        fun `PascalCase converts correctly`() {
+            assertEquals("get_weather", ToolCallExtractor.camelToSnake("GetWeather"))
+        }
+
+        @Test
+        fun `single word is unchanged`() {
+            assertEquals("weather", ToolCallExtractor.camelToSnake("weather"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #240

- Extracts `extractToolCallJson`, `extractNativeToolCall`, `camelToSnake`, `parseNativeArgs` from `ChatViewModel` into `ToolCallExtractor` object — no behaviour change
- `ChatViewModel` delegates to `ToolCallExtractor`
- **`ToolCallExtractorTest`** — 18 tests: prose embedding, nested braces, escaped quotes, multiple blocks, native tokens, camelCase→snake_case, edge cases
- **`SkillExecutorTest`** — 10 tests: pure JSON, markdown fenced, missing params, unknown skill, exception handling, regression guard
- Adds `org.json:json` test dep to both modules; adds `useJUnitPlatform()` to `core:skills`