### PR TITLE
fix: search_memory quality, stale weather, tomorrow alarm warning

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -40,6 +40,9 @@ class MemoryRepositoryImpl @Inject constructor(
         private const val CORE_MAX_DISTANCE = 1.10f
         /** Threshold for episodic memories — cos_sim ≥ 0.40 equivalent in L2 space. */
         private const val EPISODIC_MAX_DISTANCE = 1.10f
+        /** Minimum content length for an episodic entry to appear in search results.
+         *  Guards against short model hallucinations ("Nick", "You: Here") polluting results. */
+        private const val MIN_EPISODIC_CONTENT_LENGTH = 20
     }
 
     // AtomicBoolean + Mutex for thread-safe lazy table creation
@@ -155,7 +158,8 @@ class MemoryRepositoryImpl @Inject constructor(
             val episodicResults = rawEpisodicResults.filter { it.distance <= EPISODIC_MAX_DISTANCE }
             val rowIds = episodicResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
-                val entities = episodicDao.getAll().filter { it.rowId in rowIds }
+                val entities = episodicDao.getAll()
+                    .filter { it.rowId in rowIds && it.content.length >= MIN_EPISODIC_CONTENT_LENGTH }
                 val distanceMap = episodicResults.associate { it.rowId to it.distance }
                 entities.forEach { entity ->
                     results.add(

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -28,6 +28,8 @@ class EpisodicDistillationUseCase @Inject constructor(
     companion object {
         private const val TAG = "KernelAI"
         private const val MIN_TURNS = 4
+        /** Minimum character length for a distilled sentence to be worth embedding and storing. */
+        private const val MIN_SENTENCE_LENGTH = 20
         private val LEADING_JUNK = Regex("""^[\s\d]+[.)]\s*|^[-•*]\s*""")
     }
 
@@ -71,7 +73,7 @@ $transcript
 
             val sentences = response.lines()
                 .map { LEADING_JUNK.replace(it.trim(), "") }
-                .filter { it.isNotBlank() }
+                .filter { it.length >= MIN_SENTENCE_LENGTH }
             if (sentences.isEmpty()) {
                 Log.w(TAG, "Episodic distillation: no sentences parsed for $conversationId")
                 return

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -32,7 +32,8 @@ class RunJsSkill @Inject constructor(
         "Run a built-in JavaScript skill by name. Use skill_name='get-weather-city' for weather " +
             "with a known city name or forecast by city. " +
             "For current GPS location weather or GPS-based forecast, use get_weather_gps instead. " +
-            "For forecast, pass forecast_days (1–7)."
+            "For forecast, pass forecast_days (1–7). " +
+            "ALWAYS call this tool for weather — never use weather data from memory, it is stale."
 
     override val schema = SkillSchema(
         parameters = mapOf(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -33,7 +33,8 @@ class GetWeatherSkill @Inject constructor(
     override val description =
         "Get current weather or a multi-day forecast using the device's GPS location. " +
             "Use this when the user asks about their current location weather or doesn't specify a city. " +
-            "For weather in a named city, use run_js with skill_name='get-weather-city' instead."
+            "For weather in a named city, use run_js with skill_name='get-weather-city' instead. " +
+            "ALWAYS call this tool for any weather question — never use weather data from memory, it is stale."
     private val strToken = "<|" + "\"" + "|>"
 
     override val examples = listOf(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -262,51 +262,89 @@ class NativeIntentHandler @Inject constructor(
             return today.with(TemporalAdjusters.next(targetDow))
         }
 
-        // Strict ISO first, then progressively more lenient formats
-        val formatters = listOf(
-            DateTimeFormatter.ISO_LOCAL_DATE,                    // 2026-04-16
-            DateTimeFormatter.ofPattern("yyyy-M-d"),             // 2026-4-16  (missing zero padding)
-            DateTimeFormatter.ofPattern("d-M-yyyy"),             // 16-4-2026
-            DateTimeFormatter.ofPattern("dd-MM-yyyy"),           // 16-04-2026
-            DateTimeFormatter.ofPattern("d/M/yyyy"),             // 16/4/2026
-            DateTimeFormatter.ofPattern("M/d/yyyy"),             // 4/16/2026
-            DateTimeFormatter.ofPattern("yyyy/MM/dd"),           // 2026/04/16
+        // Strict ISO first, then progressively more lenient formats.
+        // Year-defaulting formats (no year in string) use today's year.
+        val today2 = today // capture for use in lambda below
+        val formatters: List<Pair<DateTimeFormatter, ((java.time.temporal.TemporalAccessor) -> LocalDate)?>> = listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE to null,                           // 2026-04-16
+            DateTimeFormatter.ofPattern("yyyy-M-d") to null,                    // 2026-4-16
+            DateTimeFormatter.ofPattern("d-M-yyyy") to null,                    // 16-4-2026
+            DateTimeFormatter.ofPattern("dd-MM-yyyy") to null,                  // 16-04-2026
+            DateTimeFormatter.ofPattern("d/M/yyyy") to null,                    // 16/4/2026
+            DateTimeFormatter.ofPattern("M/d/yyyy") to null,                    // 4/16/2026
+            DateTimeFormatter.ofPattern("yyyy/MM/dd") to null,                  // 2026/04/16
+            DateTimeFormatter.ofPattern("d MMMM yyyy", java.util.Locale.ENGLISH) to null,  // 20 April 2026
+            DateTimeFormatter.ofPattern("d MMM yyyy", java.util.Locale.ENGLISH) to null,   // 20 Apr 2026
+            DateTimeFormatter.ofPattern("MMMM d, yyyy", java.util.Locale.ENGLISH) to null, // April 20, 2026
+            DateTimeFormatter.ofPattern("MMMM d yyyy", java.util.Locale.ENGLISH) to null,  // April 20 2026
+            // No-year variants — default to current year
+            DateTimeFormatter.ofPattern("d MMMM", java.util.Locale.ENGLISH) to
+                { t: java.time.temporal.TemporalAccessor ->
+                    LocalDate.of(today2.year, java.time.Month.from(t), java.time.MonthDay.from(t).dayOfMonth)
+                },
+            DateTimeFormatter.ofPattern("d MMM", java.util.Locale.ENGLISH) to
+                { t: java.time.temporal.TemporalAccessor ->
+                    LocalDate.of(today2.year, java.time.Month.from(t), java.time.MonthDay.from(t).dayOfMonth)
+                },
+            DateTimeFormatter.ofPattern("MMMM d", java.util.Locale.ENGLISH) to
+                { t: java.time.temporal.TemporalAccessor ->
+                    LocalDate.of(today2.year, java.time.Month.from(t), java.time.MonthDay.from(t).dayOfMonth)
+                },
         )
-        for (fmt in formatters) {
+        for ((fmt, resolver) in formatters) {
             try {
-                return LocalDate.parse(input, fmt)
+                val parsed = fmt.parse(input)
+                return resolver?.invoke(parsed) ?: LocalDate.from(parsed)
             } catch (_: DateTimeParseException) { /* try next */ }
+            catch (_: java.time.DateTimeException) { /* try next */ }
         }
         return null
     }
 
     /**
      * Parses a time string from the model into a [LocalTime], trying multiple common formats so
-     * minor model hallucinations (extra zeros, missing padding) don't hard-fail the call.
+     * minor model hallucinations (extra zeros, missing padding, no-colon AM/PM) don't hard-fail.
      *
-     * Pre-processing: strips trailing extra zeros after a valid HH:mm prefix, e.g. "18:0000" → "18:00".
-     * The `HH:mmss` pattern is intentionally NOT used — it would silently misparse "18:1234" as 18:12:34.
+     * Pre-processing (applied in order):
+     *  1. Strip trailing extra digits after HH:mm prefix — "18:0000" → "18:00"
+     *  2. Pad a single-digit minute — "09:0" → "09:00", "9:5" → "9:05"
+     *  3. Insert ":00" into bare hour+meridiem — "10pm" → "10:00pm", "9am" → "9:00am"
      *
      * Tried in order:
      *   HH:mm        — 18:00  (canonical)
      *   H:mm         — 9:00   (no hour padding)
      *   HH:mm:ss     — 18:00:00
-     *   h:mm a       — 6:00 PM (12-hour with AM/PM)
+     *   h:mm a       — 6:00 PM
      *   h:mma        — 6:00PM  (no space)
+     *   hh:mm a      — 06:00 PM
+     *   hh:mma       — 06:00PM
      */
     private fun resolveTime(timeStr: String): LocalTime? {
-        // Strip extra digits after a valid HH:mm or H:mm prefix (e.g. "18:0000" → "18:00").
-        // Regex: optional 1-2 digit hour, colon, exactly 2 minute digits, then any trailing chars.
-        val normalized = Regex("""^(\d{1,2}:\d{2})\d+(.*)$""").replace(timeStr.trim()) { m ->
+        val raw = timeStr.trim()
+
+        // 1. Strip extra trailing digits after a valid HH:mm prefix (e.g. "18:0000" → "18:00").
+        val stripped = Regex("""^(\d{1,2}:\d{2})\d+(.*)$""").replace(raw) { m ->
             m.groupValues[1] + m.groupValues[2]
         }
-        val input = normalized.trim()
+
+        // 2. Pad a single-digit minute value (e.g. "09:0" → "09:00", "9:5" → "9:05").
+        val padded = Regex("""^(\d{1,2}):(\d)(?!\d)(.*)$""").replace(stripped) { m ->
+            "${m.groupValues[1]}:0${m.groupValues[2]}${m.groupValues[3]}"
+        }
+
+        // 3. Insert ":00" for bare hour+meridiem (e.g. "10pm" → "10:00pm", "9 AM" → "9:00 AM").
+        val input = Regex("""^(\d{1,2})\s*(am|pm|AM|PM)$""").replace(padded) { m ->
+            "${m.groupValues[1]}:00${m.groupValues[2]}"
+        }.trim()
+
         val formatters = listOf(
             DateTimeFormatter.ofPattern("HH:mm"),
             DateTimeFormatter.ofPattern("H:mm"),
             DateTimeFormatter.ofPattern("HH:mm:ss"),
             DateTimeFormatter.ofPattern("h:mm a", java.util.Locale.ENGLISH),
             DateTimeFormatter.ofPattern("h:mma", java.util.Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("hh:mm a", java.util.Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("hh:mma", java.util.Locale.ENGLISH),
         )
         for (fmt in formatters) {
             try {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -111,15 +111,26 @@ class NativeIntentHandler @Inject constructor(
     private fun setAlarm(params: Map<String, String>): SkillResult {
         val hours = params["hours"]?.toIntOrNull() ?: 8
         val minutes = params["minutes"]?.toIntOrNull() ?: 0
+        val day = params["day"]?.trim()?.lowercase()
+        val isTomorrow = day == "tomorrow"
+
         // NOTE: AlarmClock.EXTRA_DAYS is intentionally NOT used here.
         // EXTRA_DAYS creates a repeating weekly alarm, not a one-time future alarm.
         // The clock app opens pre-filled with the time; the user confirms the date.
+        //
+        // For "tomorrow" alarms we prefix EXTRA_MESSAGE with "TOMORROW:" so the label is
+        // visible in the clock app, reminding the user to verify the date before confirming.
+        val baseLabel = params["label"]?.takeIf { it.isNotBlank() }
+        val messageLabel = when {
+            isTomorrow && baseLabel != null -> "TOMORROW: $baseLabel"
+            isTomorrow -> "TOMORROW"
+            else -> baseLabel
+        }
+
         val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
             putExtra(AlarmClock.EXTRA_HOUR, hours)
             putExtra(AlarmClock.EXTRA_MINUTES, minutes)
-            params["label"]?.takeIf { it.isNotBlank() }?.let {
-                putExtra(AlarmClock.EXTRA_MESSAGE, it)
-            }
+            messageLabel?.let { putExtra(AlarmClock.EXTRA_MESSAGE, it) }
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         if (context.packageManager.resolveActivity(intent, 0) == null) {
@@ -127,9 +138,15 @@ class NativeIntentHandler @Inject constructor(
         }
         return try {
             context.startActivity(intent)
-            val dayLabel = params["day"]?.takeIf { it.isNotBlank() }
+            val dayLabel = day?.takeIf { it.isNotBlank() }
                 ?.let { " for ${it.replaceFirstChar { c -> c.uppercase() }}" } ?: ""
-            SkillResult.Success("Clock app opened — alarm$dayLabel at %02d:%02d. Please confirm in your clock app.".format(hours, minutes))
+            val tomorrowWarning = if (isTomorrow) {
+                " ⚠ Your clock app schedules by time only — please verify the date is set to tomorrow before confirming."
+            } else ""
+            SkillResult.Success(
+                "Clock app opened — alarm$dayLabel at %02d:%02d. Please confirm in your clock app.$tomorrowWarning"
+                    .format(hours, minutes)
+            )
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -779,6 +779,7 @@ private fun formatEta(remainingMs: Long): String {
 @Composable
 private fun ToolCallChip(toolCall: ToolCallInfo, modifier: Modifier = Modifier) {
     var expanded by remember { mutableStateOf(false) }
+    val clipboardManager = LocalClipboardManager.current
     Surface(
         modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.small,
@@ -818,6 +819,26 @@ private fun ToolCallChip(toolCall: ToolCallInfo, modifier: Modifier = Modifier) 
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    IconButton(
+                        onClick = {
+                            val text = "[Tool: ${toolCall.skillName}]\nRequest: ${toolCall.requestJson}\nResult: ${toolCall.resultText}"
+                            clipboardManager.setText(AnnotatedString(text))
+                        },
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.ContentCopy,
+                            contentDescription = "Copy tool call",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #322, #323, #324

### search_memory quality (#323)
- `EpisodicDistillationUseCase`: filter distilled sentences shorter than 20 chars before embedding/storing — prevents model output like `"Nick"` polluting the episodic index
- `MemoryRepositoryImpl.searchMemories`: secondary content-length filter for entries already in the DB (`MIN_EPISODIC_CONTENT_LENGTH = 20`)

### Weather from memory (#322)
- `GetWeatherSkill` + `RunJsSkill`: appended `ALWAYS call this tool for any weather question — never use weather data from memory, it is stale.` to both tool descriptions

### Tomorrow alarm warning (#324)
- `setAlarm`: detects `day == "tomorrow"`, prefixes `EXTRA_MESSAGE` with `TOMORROW:` so it shows in the clock app label; appends a ⚠ warning to the success response reminding user to verify the date
- Note: `ACTION_SET_ALARM` does not support specific dates — full date-based fix would require `AlarmManager.setExact()` (tracked separately)