### PR TITLE
docs: update README and ROADMAP for Phase 3 progress

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ All changes go through a PR — direct pushes to `main` are blocked by branch pr
 1. **Implement** on a feature branch (`feat/`, `fix/`, `docs/` prefix)
 2. **Open PR** targeting `main` — title should reference the issue number (e.g. `fix: enable episodic RAG (#233)`)
 3. **CI must pass** — "Build & Test" check is required before merge
+4. **Unit tests** — significant new logic (parsers, use cases, repositories, ViewModels) should include unit tests. Use JUnit 5 + MockK. See `core/skills/src/test/` and `core/memory/src/test/` for examples. Copilot code-reviewer will flag missing coverage on critical paths.
 4. **Code review** — run the Copilot code-reviewer agent on the PR
 5. **Address findings:**
    - **Major issues** (bugs, logic errors, data loss risk, crashes) → fix on the branch, then run a scoped re-review on the fix commits only

--- a/README.md
+++ b/README.md
@@ -44,25 +44,29 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 📊 **Runtime info** — shows active model, backend (GPU/NPU/CPU), and device tier in chat
 - ⚡ **Quick Actions tab** — instant device commands (torch, timer, DND, bluetooth) via zero-overhead Kotlin pattern matcher
 - 💭 **Episodic memory distillation** — Gemma-4 summarises each conversation into long-term memories
+- 🔧 **Native skills** — alarms, timers, SMS, email, torch, calendar events, weather (GPS + city), Wikipedia
+- 🔍 **search_memory** — semantic search across core + episodic memories on demand
+- 🔎 **Tool call debugging** — expand any tool call chip to see request/result, tap to copy
 
 ### Coming Soon
 - 🗣️ **Voice + text input** — tap-to-talk with auto-stop *(Phase 3)*
-- 🔧 **Full native skills** — Alarms, SMS, Email, Media Control, Notes, Weather *(Phase 3)*
+- 📝 **Notes & reminders** — Room DB local storage *(Phase 3)*
+- 🗺️ **Maps & navigation** — `navigate_to` / nearby search *(Phase 3)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
-- ⚡ **Semantic cache** — instant responses for repeated knowledge queries, bypassing main LLM *(Phase 4)*
+- ⚡ **Semantic cache** — instant responses for repeated knowledge queries *(Phase 4)*
 - 🪪 **Self-healing identity** — structured user profile, LLM-managed via Dreaming cycle *(Phase 4)*
-- 🧩 **Wasm skill store** — community-extensible plugins (Rust → Wasm) with sandboxed execution *(Phase 4)*
-- 🏠 **Home Assistant** — smart home control via Wasm skill *(Phase 4)*
-- 📱 **8GB device optimisation** — dynamic weight loading/unloading, E2B fallback *(Phase 5)*
-- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 5)*
+- 🧩 **Wasm skill store** — community-extensible plugins with sandboxed execution *(Phase 5)*
+- 🏠 **Home Assistant / Google Home** — smart home control *(Phase 5)*
+- 📱 **8GB device optimisation** — dynamic weight loading/unloading, E2B fallback *(Phase 6)*
+- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 3)*
 
 ## Roadmap
 
 | Phase | Description | Status |
 |-------|-------------|--------|
 | 1 | Core LiteRT-LM integration + GPU/NPU acceleration + Chat UI | ✅ |
-| 2 | sqlite-vec + EmbeddingGemma for local RAG + memory, UI polish, model selection | 🔄 |
-| 3 | FunctionGemma intent router + Native Skills + Voice I/O + episodic distillation + Brand refresh (Jandal AI) | ⬜ |
+| 2 | sqlite-vec + EmbeddingGemma for local RAG + memory, UI polish, model selection | ✅ |
+| 3 | Native Skills + episodic distillation + search_memory + Brand refresh (Jandal AI) | 🔄 |
 | 4 | Dreaming Engine (WorkManager overnight cycle) + Semantic Cache + Self-Healing Identity System | ⬜ |
 | 5 | Chicory Wasm runtime + GitHub Skill Store | ⬜ |
 | 6 | 8GB device optimization (dynamic weight loading) | ⬜ |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,7 +150,7 @@ User Input (voice/text)
 | Jandal cultural identity — knows his own NZ/Kiwi culture ([#264](https://github.com/NickMonrad/kernel-ai-assistant/issues/264)) | ✅ Done | PR #268 — Kiwi identity + cultural facts injected into `DEFAULT_SYSTEM_PROMPT` in `ModelConfig.kt` |
 | Review UI patterns ([#71](https://github.com/NickMonrad/kernel-ai-assistant/issues/71)) | ⬜ Pending | Audit and refine UI patterns across the app |
 | Copy chat content ([#78](https://github.com/NickMonrad/kernel-ai-assistant/issues/78)) | ✅ Done | — |
-| Copy tool call content for debugging ([#260](https://github.com/NickMonrad/kernel-ai-assistant/issues/260)) | ⬜ Pending | Tap-to-copy on tool call chip; full message copy should exclude tool call block |
+| Copy tool call content for debugging ([#260](https://github.com/NickMonrad/kernel-ai-assistant/issues/260)) | ✅ Done | PR #325/#326 — copy icon in expanded tool call chip; copies `[Tool: name]\nRequest\nResult` |
 | Skill discoverability UI ([#261](https://github.com/NickMonrad/kernel-ai-assistant/issues/261)) | ⬜ Pending | Settings screen listing skills with enable/disable toggles + config navigation (run_intents non-disableable) |
 
 ### Resident Agent — Tier 2: QuickIntentRouter
@@ -181,7 +181,7 @@ User Input (voice/text)
 | `send_sms` via `run_intent` | ✅ Done | `ACTION_SENDTO smsto:`; message pre-filled (#247) |
 | **Rich tool result UI** ([#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222)) | ⬜ Pending | Replace 🔧 debug chip with weather card, confirmation chips, list cards per skill type |
 | **`set_do_not_disturb`** | ⬜ Pending | `NotificationManager.setInterruptionFilter()` |
-| **`create_calendar_event`** ([#265](https://github.com/NickMonrad/kernel-ai-assistant/issues/265)) | ⬜ Pending | `CalendarContract.Events.CONTENT_URI` insert intent; opens edit screen for user to confirm/add attendees |
+| **`create_calendar_event`** ([#265](https://github.com/NickMonrad/kernel-ai-assistant/issues/265)) | ✅ Done | PR #309 — `CalendarContract ACTION_INSERT` edit screen; `resolveDate` + `resolveTime` with natural language format support (PR #325) |
 | **Maps & location intents** ([#258](https://github.com/NickMonrad/kernel-ai-assistant/issues/258)) | ⬜ Pending | `navigate_to` → `geo:` intent; `open_in_maps` → Maps app; JS skill for nearby search (Phase 5) |
 | **`send_sms` / `send_email` recipient from contacts** ([#256](https://github.com/NickMonrad/kernel-ai-assistant/issues/256)) | ⬜ Pending | `READ_CONTACTS` + `ContactsContract` lookup before composing |
 | **Weather forecast** ([#255](https://github.com/NickMonrad/kernel-ai-assistant/issues/255)) | ✅ Done | PR #269 (JS skill), PR #274 (native GPS skill). Both skills support `forecast_days` 1–7 with emoji + min/max temps |
@@ -198,6 +198,8 @@ User Input (voice/text)
 | Message embedding stats in Memory screen ([#164](https://github.com/NickMonrad/kernel-ai-assistant/issues/164)) | ✅ Done | — |
 | Bulk delete core memories ([#110](https://github.com/NickMonrad/kernel-ai-assistant/issues/110)) | ✅ Done | — |
 | Memory tool gaps: save_memory triggers + search_memory skill ([#223](https://github.com/NickMonrad/kernel-ai-assistant/issues/223)) / ([#236](https://github.com/NickMonrad/kernel-ai-assistant/issues/236)) | ✅ Done | save_memory trigger enforced via hard rule in system prompt (PR #257); `search_memory` native skill with cross-conversation RAG search (PR #270) |
+| search_memory quality — short entry filter ([#323](https://github.com/NickMonrad/kernel-ai-assistant/issues/323)) | ✅ Done | PR #326 — `MIN_EPISODIC_CONTENT_LENGTH = 20` filters short distillation hallucinations at save and search time |
+| Prevent model using stale weather from memory ([#322](https://github.com/NickMonrad/kernel-ai-assistant/issues/322)) | ✅ Done | PR #326 — "ALWAYS call tool, never use memory" added to both weather tool descriptions |
 
 ### Voice Interface
 
@@ -329,25 +331,40 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#163](https://github.com/NickMonrad/kernel-ai-assistant/issues/163) | message_embeddings_vec orphan cleanup on conversation delete | Phase 3 | ✅ Done |
 | [#164](https://github.com/NickMonrad/kernel-ai-assistant/issues/164) | Message embedding stats in Memory screen | Phase 3 | ✅ Done |
 | [#165](https://github.com/NickMonrad/kernel-ai-assistant/issues/165) | Episodic memory distillation on conversation close | Phase 3 | ✅ Done |
-| [#229](https://github.com/NickMonrad/kernel-ai-assistant/issues/229) | Cannot copy tool call output | Phase 3 | Superseded by [#260](https://github.com/NickMonrad/kernel-ai-assistant/issues/260) |
-| [#236](https://github.com/NickMonrad/kernel-ai-assistant/issues/236) | Cross-conversation search_memory skill | Phase 3 | ⬜ Pending — see #223 |
+| [#229](https://github.com/NickMonrad/kernel-ai-assistant/issues/229) | Cannot copy tool call output | Phase 3 | ✅ Done — PR #325/#326 |
+| [#236](https://github.com/NickMonrad/kernel-ai-assistant/issues/236) | Cross-conversation search_memory skill | Phase 3 | ✅ Done — PR #270 |
 | [#239](https://github.com/NickMonrad/kernel-ai-assistant/issues/239) | JS skill execution layer (WebView gateway) | Phase 3 | ✅ Done — #247/#251 |
-| [#240](https://github.com/NickMonrad/kernel-ai-assistant/issues/240) | Unit tests for extractToolCallJson / tryExecuteToolCall | Phase 3 | ⬜ Pending |
+| [#240](https://github.com/NickMonrad/kernel-ai-assistant/issues/240) | Unit tests for extractToolCallJson / tryExecuteToolCall | Phase 3 | ✅ Done — PR #318 (`ToolCallExtractor` + `SkillExecutorTest`, 28 tests) |
 | [#248](https://github.com/NickMonrad/kernel-ai-assistant/issues/248) | "Morena" used at wrong time of day | Phase 3 | ✅ Fixed — #252 |
 | [#250](https://github.com/NickMonrad/kernel-ai-assistant/issues/250) | Wrong emoji on chat background | Phase 3 | ✅ Fixed — #252 |
 | [#253](https://github.com/NickMonrad/kernel-ai-assistant/issues/253) | set_timer intent | Phase 3 | ✅ Done — #257/#262 |
 | [#254](https://github.com/NickMonrad/kernel-ai-assistant/issues/254) | GPS weather location name (Nominatim) | Phase 3 | ✅ Done — #257 |
-| [#255](https://github.com/NickMonrad/kernel-ai-assistant/issues/255) | Weather forecast for tomorrow / next N days | Phase 3 | ⬜ Pending |
+| [#255](https://github.com/NickMonrad/kernel-ai-assistant/issues/255) | Weather forecast for tomorrow / next N days | Phase 3 | ✅ Done — PR #269/#274 |
 | [#256](https://github.com/NickMonrad/kernel-ai-assistant/issues/256) | SMS/email — pre-populate recipient from contact name | Phase 3 | ⬜ Pending |
 | [#258](https://github.com/NickMonrad/kernel-ai-assistant/issues/258) | Maps & location skills (navigate, open, find nearby) | Phase 3/5 | ⬜ Pending — native intents Phase 3; JS nearby search Phase 5 |
-| [#260](https://github.com/NickMonrad/kernel-ai-assistant/issues/260) | Copy tool call content for debugging | Phase 3 | ⬜ Pending |
+| [#260](https://github.com/NickMonrad/kernel-ai-assistant/issues/260) | Copy tool call content for debugging | Phase 3 | ✅ Done — PR #325/#326 |
 | [#261](https://github.com/NickMonrad/kernel-ai-assistant/issues/261) | Skill discoverability UI | Phase 3 | ⬜ Pending |
 | [#264](https://github.com/NickMonrad/kernel-ai-assistant/issues/264) | Jandal doesn't know his own culture | Phase 3 | ✅ Done (PR #268) |
-| [#265](https://github.com/NickMonrad/kernel-ai-assistant/issues/265) | Calendar event intent | Phase 3 | ⬜ Pending |
+| [#265](https://github.com/NickMonrad/kernel-ai-assistant/issues/265) | Calendar event intent | Phase 3 | ✅ Done — PR #309 |
 | [#230](https://github.com/NickMonrad/kernel-ai-assistant/issues/230) | Review `safeTokenCount()` token alignment logic | Phase 3 (technical debt) | ⬜ Open — workaround already in place, needs comment/doc clarity |
 | [#231](https://github.com/NickMonrad/kernel-ai-assistant/issues/231) | NPU fallback rejects QTI Snapdragon devices | Phase 3 (device compat) | ⬜ Open — high priority bug, partial-match fix needed |
 | [#232](https://github.com/NickMonrad/kernel-ai-assistant/issues/232) | Chicory WASM performance design constraint | Phase 5 | ⬜ Open — design note, guides skill authoring guidelines |
 | [#272](https://github.com/NickMonrad/kernel-ai-assistant/issues/272) | GPS weather routing — model always used JS skill | Phase 3 | ✅ Done (PR #274) |
+| [#301](https://github.com/NickMonrad/kernel-ai-assistant/issues/301) | isFirstReply derivation from actual conversation state | Phase 3 | ✅ Done — PR #310 |
+| [#311](https://github.com/NickMonrad/kernel-ai-assistant/issues/311) | Home Assistant integration skill | Phase 3/5 | ⬜ Pending |
+| [#312](https://github.com/NickMonrad/kernel-ai-assistant/issues/312) | Google Home integration skill | Phase 3/5 | ⬜ Pending |
+| [#313](https://github.com/NickMonrad/kernel-ai-assistant/issues/313) | DuckDuckGo web search skill | Phase 3/5 | ⬜ Pending |
+| [#314](https://github.com/NickMonrad/kernel-ai-assistant/issues/314) | Donetick task integration | Phase 3/5 | ⬜ Pending |
+| [#315](https://github.com/NickMonrad/kernel-ai-assistant/issues/315) | Personal notes, reminders, shopping list — Room DB MVP | Phase 3 | ⬜ Pending |
+| [#316](https://github.com/NickMonrad/kernel-ai-assistant/issues/316) | Plex media skill | Phase 3/5 | ⬜ Pending |
+| [#317](https://github.com/NickMonrad/kernel-ai-assistant/issues/317) | Send calendar invites to contacts | Phase 3 | ⬜ Pending |
+| [#319](https://github.com/NickMonrad/kernel-ai-assistant/issues/319) | resolveDate fails on natural date formats | Phase 3 (bug) | ✅ Done — PR #325 |
+| [#320](https://github.com/NickMonrad/kernel-ai-assistant/issues/320) | resolveTime single-digit minute padding | Phase 3 (bug) | ✅ Done — PR #325 |
+| [#321](https://github.com/NickMonrad/kernel-ai-assistant/issues/321) | Alarm AM/PM no-colon format (`10pm` → `01:00`) | Phase 3 (bug) | ✅ Done — PR #325 |
+| [#322](https://github.com/NickMonrad/kernel-ai-assistant/issues/322) | Model uses stale weather from memory instead of tool | Phase 3 (bug) | ✅ Done — PR #326 |
+| [#323](https://github.com/NickMonrad/kernel-ai-assistant/issues/323) | search_memory returns low-quality short fragments | Phase 3 (bug) | ✅ Done — PR #326 |
+| [#324](https://github.com/NickMonrad/kernel-ai-assistant/issues/324) | Tomorrow alarm sets for today | Phase 3 (bug) | ⚠ Partial — PR #326 warning label; full fix tracked in #327 |
+| [#327](https://github.com/NickMonrad/kernel-ai-assistant/issues/327) | Full date-specific alarm via `AlarmManager.setExact()` | Phase 3 | ⬜ Pending — needs permission, BroadcastReceiver, persistence |
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -151,7 +151,11 @@ On conversation close, `EpisodicDistillationUseCase` uses Gemma-4 to summarise t
 into 3–5 episodic memory sentences, stored in `episodic_memories_vec`. This runs fire-and-forget
 on `Dispatchers.IO` from `ChatViewModel.onCleared()`.
 
----
+**Quality filter:** `MIN_SENTENCE_LENGTH = 20` characters is applied to distilled sentences
+before embedding. Sentences shorter than 20 chars (e.g. "Yes.", "OK.") are discarded at write
+time. A matching `MIN_EPISODIC_CONTENT_LENGTH = 20` filter in `MemoryRepositoryImpl.searchMemories()`
+also drops pre-existing short entries from search results, preventing low-signal fragments from
+surfacing in `search_memory` responses (#323).
 
 ## 4. Skill & Tool Framework
 
@@ -228,6 +232,7 @@ This means the model only needs two function names; new native intents are added
 | `send_sms` | SMS composer | `ACTION_SENDTO` + `smsto:` | ✅ |
 | `set_alarm` | Set alarm | `AlarmClock.ACTION_SET_ALARM` | ✅ |
 | `set_timer` | Countdown timer | `AlarmClock.ACTION_SET_TIMER` | ✅ |
+| `create_calendar_event` | Add calendar event | `ACTION_INSERT` + `CONTENT_URI` | ✅ |
 
 > **Package visibility (Android 11+):** `ACTION_SET_ALARM` and `ACTION_SET_TIMER` are declared
 > in a `<queries>` block in `AndroidManifest.xml` so `PackageManager.resolveActivity()` returns
@@ -238,6 +243,19 @@ This means the model only needs two function names; new native intents are added
 > "Alarm rule" forcing `run_intent` for alarm requests (#263), matching the pattern used for
 > `save_memory`. The model's Siri/Google training bias would otherwise cause it to verbally
 > confirm alarms without ever calling the tool.
+
+> **`set_alarm` tomorrow limitation:** `ACTION_SET_ALARM` has no date parameter — only hour and
+> minute. When the model passes `day: "tomorrow"`, `NativeIntentHandler` prefixes the alarm
+> label with "TOMORROW:" and returns a ⚠ warning in the success message. A full date-specific
+> alarm (#327) requires `AlarmManager.setExact()` + BroadcastReceiver + BOOT_COMPLETED receiver
+> and is tracked as a separate feature.
+
+> **`resolveDate` / `resolveTime` natural language parsing:** `NativeIntentHandler` normalises
+> free-text date/time before passing to `SimpleDateFormat`. `resolveDate` handles formats like
+> `"tomorrow"`, `"next Friday"`, `"June 15"`, `"15th June"`, `"15/06/2025"`, `"2025-06-15"`.
+> `resolveTime` applies a three-step pre-processor: (1) strip extra trailing digits, (2) pad
+> single-digit minutes (`9:0` → `9:00`), (3) expand bare hour+meridiem (`10pm` → `10:00pm`).
+> Order is critical — padding must precede format-string matching (#319, #320, #321).
 
 **Registered JS skills (`run_js`):**
 
@@ -288,6 +306,8 @@ and awaits the result with a 15s timeout.
 **System prompt `[Tool Use]` rules (enforced in `ChatViewModel.buildSystemPrompt()`):**
 - Memory rule: user says "remember", "save", "don't forget", "can you remember", or "make a note of" → MUST call `save_memory`
 - Alarm rule: user asks to set an alarm → MUST call `run_intent{intent_name: set_alarm}`
+- Weather rule: `GetWeatherSkill` description includes "ALWAYS call this tool, never use memory" to prevent Gemma-4 from serving stale weather from episodic memory instead of fetching fresh data (#322)
+- JS tool rule: `RunJsSkill` description similarly includes "ALWAYS call this tool, never use memory" (#322)
 
 ### 4.4 Extensible Skills (WebAssembly — Phase 5)
 
@@ -325,6 +345,12 @@ Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime
 - **Voice:** Tap-to-toggle with auto-stop on silence (future: "Hey Jandal" wake word)
 - **Skill results:** Inline rich cards in the conversation stream
 - **Persona:** Friendly, concise, dry-humoured Kiwi — see §7 for full identity details
+
+**Tool call debugging chip (`ToolCallChip`):** Tool calls appear as collapsible chips in the
+chat stream. Tapping expands to show the full request JSON and result string. An icon button
+copies `[Tool: name]\nRequest: <json>\nResult: <result>` to the clipboard via
+`LocalClipboardManager` (Compose API — no system service boilerplate). Added in PR #325
+closing #229 and #260.
 
 ---
 

--- a/docs/adb-testing.md
+++ b/docs/adb-testing.md
@@ -98,7 +98,7 @@ I HardwareProfileDetector: Hardware profile: tier=FLAGSHIP, ram=12 GB,
 I ModelDownloadManager: Auto-queuing Gemma 4 E-4B for tier FLAGSHIP
 I ModelDownloadManager: Enqueuing download for Gemma 4 E-4B
 
-# After E-4B + FunctionGemma + E-2B downloads complete (~6 GB total):
+# After E-4B + E-2B downloads complete (~5 GB total):
 
 I LiteRtInferenceEngine: Initializing engine — model: .../gemma-4-E4B-it.litertlm,
     backend: NPU, tier: FLAGSHIP


### PR DESCRIPTION
## What

Updates README and ROADMAP.md to reflect the actual Phase 3 progress.

### README
- Moves native skills (alarms, timers, SMS, email, weather, Wikipedia, calendar, search_memory, tool call copy) from "Coming Soon" to "Features"
- Updates Phase 2 → ✅, Phase 3 → 🔄
- Removes FunctionGemma reference from Phase 3
- Slims Coming Soon to genuinely pending items

### ROADMAP.md
- Fixes statuses for #229, #236, #240, #255, #260, #265 → ✅
- Adds new issues #311–317 (skill ideas from triage)
- Adds #319–327 (bugs from round 3 testing, all resolved)

No code changes.