### PR TITLE
fix: strengthen alarm tool rule + filter short messages from search_memory

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -39,6 +39,10 @@ class RagRepository @Inject constructor(
         private const val TAG = "RagRepository"
         private const val TABLE = "message_embeddings"
         private const val DEFAULT_TOP_K = 5
+        /** Minimum message content length to surface in search results.
+         *  Prevents short conversational acknowledgements ("Choice bro", "The above")
+         *  from polluting search_memory responses. */
+        private const val MIN_MESSAGE_CONTENT_LENGTH = 20
 
         /** Maximum L2 distance to include a result (0 = identical, sqrt(2) ≈ 1.41 = opposite for unit vectors).
          *  1.10 ≈ cos_sim ≥ 0.40 for unit-normalized 768-dim vectors: L2 = sqrt(2 * (1 - cos_sim)).
@@ -252,6 +256,7 @@ class RagRepository @Inject constructor(
 
             entities.mapNotNull { entity ->
                 val msg = fetchedMessages[entity.messageId] ?: return@mapNotNull null
+                if (msg.content.length < MIN_MESSAGE_CONTENT_LENGTH) return@mapNotNull null
                 MessageSearchResult(
                     role = msg.role,
                     content = msg.content,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -257,12 +257,17 @@ class ChatViewModel @Inject constructor(
                         "you MUST immediately call save_memory — NEVER output 'Got it', 'I'll remember that', 'I've already saved that', or any confirmation text without a tool call token. " +
                         "If the user says 'save it' or 'remember that', infer what 'it'/'that' refers to from the recent conversation and use that as the content. " +
                         "Do NOT ask the user what they want to save — always infer from context and call the tool.\n" +
-                        "Recall rule: whenever the user asks what you remember about something, asks you to recall a fact, or uses words like 'recall', 'do you remember', 'what do you know about', or 'remind me' — " +
+                        "Recall rule: whenever the user asks what you remember about something, asks you to recall a fact, or uses words like 'recall', 'do you remember', 'what do you know about', or 'remind me about' — " +
                         "you MUST call search_memory first before answering. Never answer from your own knowledge without calling the tool first.\n" +
-                        "Alarm rule: whenever the user asks to set an alarm for a specific time, " +
-                        "you MUST call run_intent with intent_name=set_alarm — NEVER say 'alarm set' or confirm it without using the tool. " +
-                        "If the user specifies a day (e.g. 'tomorrow', 'next Monday', 'on Friday'), include day=<day_name> in the call — " +
-                        "pass the day exactly as the user said it (e.g. day='tomorrow', day='monday').\n" +
+                        "Alarm rule: whenever the user says 'set alarm', 'set an alarm', 'alarm for', 'alarm at', 'wake me up at', " +
+                        "or 'remind me at [specific clock time]' (e.g. 'remind me at 9am', 'remind me at 09:05') — " +
+                        "you MUST call run_intent with intent_name=set_alarm. " +
+                        "NEVER output text like 'I\\'ve set an alarm', 'alarm set for', or any alarm confirmation without a tool call token first — " +
+                        "the ONLY correct response to an alarm request is the tool call token and nothing else. " +
+                        "NOTE: 'remind me in X minutes' is a timer (set_timer), NOT an alarm. " +
+                        "'Remind me at [specific time]' is an alarm (set_alarm). " +
+                        "If the user specifies a day (e.g. 'tomorrow', 'next Monday', '20 April'), include day=<day_value> in the call — " +
+                        "pass the day exactly as the user said it (e.g. day=<|\"|>tomorrow<|\"|>, day=<|\"|>monday<|\"|>).\n" +
                         "Calendar rule: whenever the user says 'add a calendar entry', 'create a calendar event', 'add an event', " +
                         "'add a reminder for [topic] on [date]', or 'schedule [topic] on [date]' — you MUST call run_intent with " +
                         "intent_name=create_calendar_event. Resolve any relative date (e.g. 'tomorrow', 'next Friday') to an absolute " +


### PR DESCRIPTION
## What

Two fixes from round 4 testing (#328).

### Fix 1: Alarm tool rule — `ChatViewModel` (closes #331)

The model was verbally confirming alarm requests without ever calling `run_intent`. Root causes:
- Trigger phrase too narrow (`"set an alarm for a specific time"` missed `"Set alarm for 10pm"`, `"Remind me at 09:05"`)
- `"remind me"` in the Recall rule was too broad — alarm-like phrases could trigger `search_memory` instead

Changes:
- Expand alarm trigger phrases: `set alarm`, `alarm for`, `alarm at`, `wake me up at`, `remind me at [clock time]`
- Add explicit negative: `NEVER output verbal alarm confirmation without a tool call token`
- Clarify ambiguity: `"remind me at [time]"` = alarm; `"remind me in X minutes"` = timer
- Fix Recall rule: `"remind me"` → `"remind me about"` to stop it catching alarm phrases

### Fix 2: `search_memory` message quality — `RagRepository` (closes #330)

`"Choice bro"` (10 chars) and `"The above"` (9 chars) were appearing in `search_memory` results. The existing `MIN_EPISODIC_CONTENT_LENGTH = 20` filter only covered episodic results. Added matching `MIN_MESSAGE_CONTENT_LENGTH = 20` in `searchMessages()` to filter short messages at result time.