### PR TITLE
fix: add PM alarm examples and 24h conversion note (#335, #336)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -26,6 +26,7 @@ class RunIntentSkill @Inject constructor(
         "Perform a native Android device action. Use for flashlight control, sending email, " +
             "sending SMS, setting an alarm (supports optional day name for tomorrow/weekday alarms), " +
             "setting a countdown timer, or creating a calendar event. " +
+            "For alarms: hours is 24h format (0-23) — 10pm=22, 9pm=21, 8pm=20, 1pm=13, 12pm=12, 12am=0. " +
             "For calendar events, date accepts YYYY-MM-DD or relative terms like 'tomorrow', 'next wednesday'."
 
     override val schema = SkillSchema(
@@ -53,9 +54,14 @@ class RunIntentSkill @Inject constructor(
         "Send email:      <|tool_call>call:run_intent{intent_name:${STR}send_email${STR},subject:${STR}Subject${STR},body:${STR}Body${STR}}<tool_call|>",
         "Send SMS:        <|tool_call>call:run_intent{intent_name:${STR}send_sms${STR},message:${STR}Hello${STR}}<tool_call|>",
         "Set alarm 7:30:        <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR}}<tool_call|>",
+        "Set alarm 10pm (22:00): <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}22${STR},minutes:${STR}0${STR}}<tool_call|>",
+        "Set alarm 9pm (21:00):  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}21${STR},minutes:${STR}0${STR}}<tool_call|>",
+        "Remind me at 9am:       <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}0${STR}}<tool_call|>",
+        "Remind me at 09:05:     <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}5${STR}}<tool_call|>",
         "Set alarm with label:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR},label:${STR}Wake Up${STR}}<tool_call|>",
         "Set alarm tomorrow 8am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}8${STR},minutes:${STR}0${STR},day:${STR}tomorrow${STR}}<tool_call|>",
         "Set alarm next monday:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}0${STR},day:${STR}monday${STR}}<tool_call|>",
+        "Set alarm 20 April 9am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}0${STR},day:${STR}20 April${STR}}<tool_call|>",
         "Set timer 3 min: <|tool_call>call:run_intent{intent_name:${STR}set_timer${STR},duration_seconds:${STR}180${STR}}<tool_call|>",
         "Add calendar event: <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Team lunch${STR},date:${STR}2026-04-15${STR},time:${STR}12:30${STR}}<tool_call|>",
         "Add all-day event:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Conference${STR},date:${STR}2026-04-20${STR}}<tool_call|>",

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -256,6 +256,12 @@ This means the model only needs two function names; new native intents are added
 > `resolveTime` applies a three-step pre-processor: (1) strip extra trailing digits, (2) pad
 > single-digit minutes (`9:0` → `9:00`), (3) expand bare hour+meridiem (`10pm` → `10:00pm`).
 > Order is critical — padding must precede format-string matching (#319, #320, #321).
+>
+> **Alarm `hours` parameter is 24h format (0–23):** The model must convert PM times — 10pm=22,
+> 9pm=21, 8pm=20, 1pm=13, 12pm=12, 12am=0. The skill description and alarm rule both explicitly
+> state this conversion. Examples added for `"Set alarm 10pm"` (hours:22) and
+> `"Remind me at 09:05"` (hours:9,minutes:5) so the model doesn't rely on implicit conversion
+> (#335, #336).
 
 **Registered JS skills (`run_js`):**
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -262,6 +262,7 @@ class ChatViewModel @Inject constructor(
                         "Alarm rule: whenever the user says 'set alarm', 'set an alarm', 'alarm for', 'alarm at', 'wake me up at', " +
                         "or 'remind me at [specific clock time]' (e.g. 'remind me at 9am', 'remind me at 09:05') — " +
                         "you MUST call run_intent with intent_name=set_alarm. " +
+                        "HOURS MUST BE 24h FORMAT (0-23): 10pm=22, 9pm=21, 8pm=20, 7pm=19, 6pm=18, 1pm=13, 12pm=12, 12am=0. " +
                         "NEVER output text like 'I\\'ve set an alarm', 'alarm set for', or any alarm confirmation without a tool call token first — " +
                         "the ONLY correct response to an alarm request is the tool call token and nothing else. " +
                         "NOTE: 'remind me in X minutes' is a timer (set_timer), NOT an alarm. " +


### PR DESCRIPTION
## Summary

Fixes TC-DT2 ("remind me at" fires timer) and TC-DT3 (10pm → wrong hours) from #333 round 5 testing.

## Changes

### `RunIntentSkill.kt`
- Add `Set alarm 10pm (22:00)` example → `hours:22` — model now has PM reference
- Add `Set alarm 9pm (21:00)` example → `hours:21`
- Add `Remind me at 9am` example → `set_alarm, hours:9` — fixes DT2 where model fired `set_timer` instead
- Add `Remind me at 09:05` example → `set_alarm, hours:9, minutes:5`
- Add `Set alarm 20 April 9am` example → `day:"20 April"` — fixes TC-DT1 garbled day string
- Description updated: "hours is 24h format (0-23) — 10pm=22, 9pm=21, 8pm=20, 1pm=13, 12pm=12, 12am=0"

### `ChatViewModel.kt`
- Alarm rule now contains explicit 24h conversion table in the system prompt reinforcement

### `SPECIFICATION.md`
- Alarm `hours` 24h requirement documented with PM conversion examples

## Closes

Closes #335 
Closes #336