### PR TITLE
fix: Kotlin-side time param for alarms, datetime in get_system_info, parser key fix

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -13,8 +13,10 @@ private val STR get() = "<|" + "\"" + "|>"
  * needs to know ONE function name for all device operations. The [NativeIntentHandler] then
  * maps [intent_name] to the concrete Android API or system Intent.
  *
- * Additional params (subject, body, message, hours, minutes, label) are passed alongside
+ * Additional params (time, subject, body, message, label, day) are passed alongside
  * intent_name in the tool call and forwarded to the handler as-is.
+ * For set_alarm, pass `time` as the user said it (e.g. "10pm", "9:30am") — NativeIntentHandler
+ * runs it through resolveTime() so no 12h→24h conversion is needed from the model.
  */
 @Singleton
 class RunIntentSkill @Inject constructor(
@@ -26,7 +28,7 @@ class RunIntentSkill @Inject constructor(
         "Perform a native Android device action. Use for flashlight control, sending email, " +
             "sending SMS, setting an alarm (supports optional day name for tomorrow/weekday alarms), " +
             "setting a countdown timer, or creating a calendar event. " +
-            "For alarms: hours is 24h format (0-23) — 10pm=22, 9pm=21, 8pm=20, 1pm=13, 12pm=12, 12am=0. " +
+            "For alarms: pass the time exactly as the user said it using the 'time' parameter (e.g. time:\"10pm\", time:\"9:30am\", time:\"22:00\"). " +
             "For calendar events, date accepts YYYY-MM-DD or relative terms like 'tomorrow', 'next wednesday'."
 
     override val schema = SkillSchema(
@@ -53,15 +55,15 @@ class RunIntentSkill @Inject constructor(
         "Flashlight off:  <|tool_call>call:run_intent{intent_name:${STR}toggle_flashlight_off${STR}}<tool_call|>",
         "Send email:      <|tool_call>call:run_intent{intent_name:${STR}send_email${STR},subject:${STR}Subject${STR},body:${STR}Body${STR}}<tool_call|>",
         "Send SMS:        <|tool_call>call:run_intent{intent_name:${STR}send_sms${STR},message:${STR}Hello${STR}}<tool_call|>",
-        "Set alarm 7:30:        <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR}}<tool_call|>",
-        "Set alarm 10pm (22:00): <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}22${STR},minutes:${STR}0${STR}}<tool_call|>",
-        "Set alarm 9pm (21:00):  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}21${STR},minutes:${STR}0${STR}}<tool_call|>",
-        "Remind me at 9am:       <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}0${STR}}<tool_call|>",
-        "Remind me at 09:05:     <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}5${STR}}<tool_call|>",
-        "Set alarm with label:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}30${STR},label:${STR}Wake Up${STR}}<tool_call|>",
-        "Set alarm tomorrow 8am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}8${STR},minutes:${STR}0${STR},day:${STR}tomorrow${STR}}<tool_call|>",
-        "Set alarm next monday:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}7${STR},minutes:${STR}0${STR},day:${STR}monday${STR}}<tool_call|>",
-        "Set alarm 20 April 9am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},hours:${STR}9${STR},minutes:${STR}0${STR},day:${STR}20 April${STR}}<tool_call|>",
+        "Set alarm 7:30:         <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}7:30am${STR}}<tool_call|>",
+        "Set alarm 10pm:         <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}10pm${STR}}<tool_call|>",
+        "Set alarm 9:30pm:       <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}9:30pm${STR}}<tool_call|>",
+        "Remind me at 9am:       <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}9am${STR}}<tool_call|>",
+        "Remind me at 09:05:     <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}09:05${STR}}<tool_call|>",
+        "Set alarm with label:   <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}7:30am${STR},label:${STR}Wake Up${STR}}<tool_call|>",
+        "Set alarm tomorrow 8am: <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}8am${STR},day:${STR}tomorrow${STR}}<tool_call|>",
+        "Set alarm next monday:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}7am${STR},day:${STR}monday${STR}}<tool_call|>",
+        "Set alarm Friday 10pm:  <|tool_call>call:run_intent{intent_name:${STR}set_alarm${STR},time:${STR}10pm${STR},day:${STR}friday${STR}}<tool_call|>",
         "Set timer 3 min: <|tool_call>call:run_intent{intent_name:${STR}set_timer${STR},duration_seconds:${STR}180${STR}}<tool_call|>",
         "Add calendar event: <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Team lunch${STR},date:${STR}2026-04-15${STR},time:${STR}12:30${STR}}<tool_call|>",
         "Add all-day event:  <|tool_call>call:run_intent{intent_name:${STR}create_calendar_event${STR},title:${STR}Conference${STR},date:${STR}2026-04-20${STR}}<tool_call|>",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
@@ -15,6 +15,9 @@ import com.kernel.ai.core.skills.SkillSchema
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,7 +36,7 @@ class GetSystemInfoSkill @Inject constructor(
     override val name = "get_system_info"
     override val description =
         "Returns current device and model runtime information including hardware tier, " +
-            "available memory, battery level, and active model."
+            "available memory, battery level, active model, and current date/time."
     override val schema = SkillSchema()
 
     override suspend fun execute(call: SkillCall): SkillResult {
@@ -56,6 +59,8 @@ class GetSystemInfoSkill @Inject constructor(
                 } ?: -1
 
                 val info = buildString {
+                    val now = LocalDateTime.now()
+                    appendLine("Date/time: ${now.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy, HH:mm", Locale.ENGLISH))}")
                     appendLine("Hardware tier: ${profile.tier.name}")
                     appendLine("SoC: ${profile.socManufacturer} ${profile.socModel}".trim())
                     appendLine("Total RAM: ${profile.ramLabel}")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -352,9 +352,11 @@ class NativeIntentHandler @Inject constructor(
             "${m.groupValues[1]}:0${m.groupValues[2]}${m.groupValues[3]}"
         }
 
-        // 3. Insert ":00" for bare hour+meridiem (e.g. "10pm" → "10:00pm", "9 AM" → "9:00 AM").
+        // 3. Insert ":00" for bare hour+meridiem — only for valid 12h range (1-12).
+        //    Reject "13pm" / "0am" here so we don't produce a string that silently fails later.
         val input = Regex("""^(\d{1,2})\s*(am|pm|AM|PM)$""").replace(padded) { m ->
-            "${m.groupValues[1]}:00${m.groupValues[2]}"
+            val h = m.groupValues[1].toIntOrNull() ?: 0
+            if (h in 1..12) "${m.groupValues[1]}:00${m.groupValues[2]}" else m.value
         }.trim()
 
         val formatters = listOf(
@@ -371,6 +373,7 @@ class NativeIntentHandler @Inject constructor(
                 return LocalTime.parse(input, fmt)
             } catch (_: DateTimeParseException) { /* try next */ }
         }
+        Log.w(TAG, "resolveTime: could not parse '$raw' (normalized to '$input')")
         return null
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -111,9 +111,10 @@ class NativeIntentHandler @Inject constructor(
     private fun setAlarm(params: Map<String, String>): SkillResult {
         // Prefer `time` string (e.g. "10pm", "09:05") over raw hours/minutes so the model
         // never has to do 12h→24h conversion — resolveTime() handles it reliably in Kotlin.
-        val (hours, minutes): Pair<Int, Int> = params["time"]?.let { t ->
+        val timePair = params["time"]?.let { t ->
             resolveTime(t)?.let { it.hour to it.minute }
         } ?: ((params["hours"]?.toIntOrNull() ?: 8) to (params["minutes"]?.toIntOrNull() ?: 0))
+        val (hours, minutes) = timePair
         val day = params["day"]?.trim()?.lowercase()
         val isTomorrow = day == "tomorrow"
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -111,9 +111,9 @@ class NativeIntentHandler @Inject constructor(
     private fun setAlarm(params: Map<String, String>): SkillResult {
         // Prefer `time` string (e.g. "10pm", "09:05") over raw hours/minutes so the model
         // never has to do 12h→24h conversion — resolveTime() handles it reliably in Kotlin.
-        val (hours, minutes) = params["time"]?.let { t ->
+        val (hours, minutes): Pair<Int, Int> = params["time"]?.let { t ->
             resolveTime(t)?.let { it.hour to it.minute }
-        } ?: (params["hours"]?.toIntOrNull() ?: 8 to params["minutes"]?.toIntOrNull() ?: 0)
+        } ?: ((params["hours"]?.toIntOrNull() ?: 8) to (params["minutes"]?.toIntOrNull() ?: 0))
         val day = params["day"]?.trim()?.lowercase()
         val isTomorrow = day == "tomorrow"
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -109,8 +109,11 @@ class NativeIntentHandler @Inject constructor(
     // ── Alarm ─────────────────────────────────────────────────────────────────
 
     private fun setAlarm(params: Map<String, String>): SkillResult {
-        val hours = params["hours"]?.toIntOrNull() ?: 8
-        val minutes = params["minutes"]?.toIntOrNull() ?: 0
+        // Prefer `time` string (e.g. "10pm", "09:05") over raw hours/minutes so the model
+        // never has to do 12h→24h conversion — resolveTime() handles it reliably in Kotlin.
+        val (hours, minutes) = params["time"]?.let { t ->
+            resolveTime(t)?.let { it.hour to it.minute }
+        } ?: (params["hours"]?.toIntOrNull() ?: 8 to params["minutes"]?.toIntOrNull() ?: 0)
         val day = params["day"]?.trim()?.lowercase()
         val isTomorrow = day == "tomorrow"
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -262,12 +262,12 @@ class ChatViewModel @Inject constructor(
                         "Alarm rule: whenever the user says 'set alarm', 'set an alarm', 'alarm for', 'alarm at', 'wake me up at', " +
                         "or 'remind me at [specific clock time]' (e.g. 'remind me at 9am', 'remind me at 09:05') — " +
                         "you MUST call run_intent with intent_name=set_alarm. " +
-                        "HOURS MUST BE 24h FORMAT (0-23): 10pm=22, 9pm=21, 8pm=20, 7pm=19, 6pm=18, 1pm=13, 12pm=12, 12am=0. " +
+                        "Pass the time exactly as the user said it using the 'time' parameter (e.g. time=<|\"|>10pm<|\"|>, time=<|\"|>9:30am<|\"|>). " +
                         "NEVER output text like 'I\\'ve set an alarm', 'alarm set for', or any alarm confirmation without a tool call token first — " +
                         "the ONLY correct response to an alarm request is the tool call token and nothing else. " +
                         "NOTE: 'remind me in X minutes' is a timer (set_timer), NOT an alarm. " +
                         "'Remind me at [specific time]' is an alarm (set_alarm). " +
-                        "If the user specifies a day (e.g. 'tomorrow', 'next Monday', '20 April'), include day=<day_value> in the call — " +
+                        "If the user specifies a day (e.g. 'tomorrow', 'next Monday'), include day=<day_value> in the call — " +
                         "pass the day exactly as the user said it (e.g. day=<|\"|>tomorrow<|\"|>, day=<|\"|>monday<|\"|>).\n" +
                         "Calendar rule: whenever the user says 'add a calendar entry', 'create a calendar event', 'add an event', " +
                         "'add a reminder for [topic] on [date]', or 'schedule [topic] on [date]' — you MUST call run_intent with " +

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
@@ -98,17 +98,23 @@ internal object ToolCallExtractor {
      * Parses the Gemma 4 native arg block, e.g.:
      *   location:<|"|>London<|"|>,unit:<|"|>celsius<|"|>
      *   duration:5
+     *
+     * Model occasionally wraps parameter keys in <|"|> delimiters. We strip them from the key
+     * after extraction. Leading commas/whitespace are skipped at the loop level so the key
+     * extraction never includes them.
      */
     internal fun parseNativeArgs(raw: String, out: org.json.JSONObject) {
         val strToken = """<|"|>"""
         var i = 0
         while (i < raw.length) {
+            // Skip commas and whitespace between parameters (root cause of leading-comma key names).
+            while (i < raw.length && (raw[i] == ',' || raw[i] == ' ')) i++
+            if (i >= raw.length) break
+
             val colonIdx = raw.indexOf(':', i)
             if (colonIdx < 0) break
-            // Strip string delimiters and leading commas from key names (model sometimes wraps
-            // keys in <|"|> tokens, e.g. <|"|>forecast_days<|"|>:value).
+            // Strip <|"|> delimiters from key names — model sometimes wraps keys in them.
             val key = raw.substring(i, colonIdx).trim()
-                .trimStart(',')
                 .removePrefix(strToken)
                 .removeSuffix(strToken)
                 .trim()
@@ -117,7 +123,7 @@ internal object ToolCallExtractor {
             if (rest.startsWith(strToken)) {
                 val valueStart = strToken.length
                 val valueEnd = rest.indexOf(strToken, valueStart)
-                if (valueEnd < 0) break
+                if (valueEnd < 0 || valueEnd < valueStart) break
                 out.put(key, rest.substring(valueStart, valueEnd))
                 i = colonIdx + 1 + valueEnd + strToken.length
                 if (i < raw.length && raw[i] == ',') i++

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolCallExtractor.kt
@@ -105,7 +105,14 @@ internal object ToolCallExtractor {
         while (i < raw.length) {
             val colonIdx = raw.indexOf(':', i)
             if (colonIdx < 0) break
+            // Strip string delimiters and leading commas from key names (model sometimes wraps
+            // keys in <|"|> tokens, e.g. <|"|>forecast_days<|"|>:value).
             val key = raw.substring(i, colonIdx).trim()
+                .trimStart(',')
+                .removePrefix(strToken)
+                .removeSuffix(strToken)
+                .trim()
+            if (key.isBlank()) { i = colonIdx + 1; continue }
             val rest = raw.substring(colonIdx + 1)
             if (rest.startsWith(strToken)) {
                 val valueStart = strToken.length


### PR DESCRIPTION
## Summary

Three independent fixes discovered during round 6 testing.

## Fix 1: Kotlin-side alarm time parsing (#336)

**Root cause identified:** Our `1pm=13` entry in the conversion table caused the model to pattern-match `10pm` → (starts with `1`, like `1pm`) → `13`. AI Edge Gallery uses the same model with a clean/minimal prompt and converts correctly. The problem was our prompt, not the model.

**Fix:** Add a `time` string parameter to `set_alarm`. The model now passes `time:"10pm"` and `NativeIntentHandler.resolveTime()` handles the conversion in Kotlin — no math required from the model. Falls back to `hours`/`minutes` for backward compatibility.

All alarm examples updated from `hours:22,minutes:0` → `time:"10pm"`. Confusing 24h conversion table removed from alarm rule and skill description.

## Fix 2: Current date/time in get_system_info

Model calls `get_system_info` when asked "what time is it" (correct instinct, wrong result — no time was in the response). Added `LocalDateTime.now()` formatted as `"EEEE, d MMMM yyyy, HH:mm"` as the first line of the skill output.

## Fix 3: ToolCallExtractor key stripping

Model occasionally wraps parameter *keys* in `<|"|>` delimiters (e.g. `<|"|>forecast_days<|"|>:3`). Parser was not stripping delimiters from keys, only values, causing `forecast_days` to appear as `<|"|>,forecast_days` in parsed args. Added `removePrefix`/`removeSuffix` + `trimStart(,)`.

## Closes

Closes #336