### PR TITLE
feat: Phase 5 — re-enable Actions tab + dual FABs + auto-open sheet (#361)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -47,15 +47,18 @@ fun KernelNavHost() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
+    // destination.route returns the template (e.g. "actions?openSheet={openSheet}"),
+    // so strip the query string when matching base routes.
+    val currentBaseRoute = currentRoute?.substringBefore('?')
 
     Scaffold(
         bottomBar = {
-            if (currentRoute in BOTTOM_NAV_ROUTES) {
+            if (currentBaseRoute in BOTTOM_NAV_ROUTES) {
                 NavigationBar {
                     NavigationBarItem(
-                        selected = currentRoute == ROUTE_LIST,
+                        selected = currentBaseRoute == ROUTE_LIST,
                         onClick = {
-                            if (currentRoute != ROUTE_LIST) {
+                            if (currentBaseRoute != ROUTE_LIST) {
                                 navController.navigate(ROUTE_LIST) {
                                     popUpTo(ROUTE_LIST) { inclusive = true }
                                     launchSingleTop = true
@@ -66,9 +69,9 @@ fun KernelNavHost() {
                         label = { Text("Chats") },
                     )
                     NavigationBarItem(
-                        selected = currentRoute == ROUTE_ACTIONS,
+                        selected = currentBaseRoute == ROUTE_ACTIONS,
                         onClick = {
-                            if (currentRoute != ROUTE_ACTIONS) {
+                            if (currentBaseRoute != ROUTE_ACTIONS) {
                                 navController.navigate(ROUTE_ACTIONS) {
                                     popUpTo(ROUTE_LIST) { saveState = true }
                                     launchSingleTop = true

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.navigation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -18,6 +19,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.kernel.ai.feature.chat.ActionsScreen
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
@@ -28,6 +30,7 @@ import com.kernel.ai.feature.settings.UserProfileScreen
 
 private const val ROUTE_LIST = "conversation_list"
 private const val ROUTE_ACTIONS = "actions"
+private const val ROUTE_ACTIONS_OPEN = "actions?openSheet=true"
 private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
@@ -37,7 +40,7 @@ private const val ROUTE_ABOUT = "settings/about"
 private const val ARG_CONVERSATION_ID = "conversationId"
 
 /** Routes that show the bottom navigation bar. */
-private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST)
+private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
 
 @Composable
 fun KernelNavHost() {
@@ -62,7 +65,20 @@ fun KernelNavHost() {
                         icon = { Icon(Icons.Default.ChatBubble, contentDescription = null) },
                         label = { Text("Chats") },
                     )
-                    // Actions tab hidden pending #361 (Actions tab re-enable + dual FABs)
+                    NavigationBarItem(
+                        selected = currentRoute == ROUTE_ACTIONS,
+                        onClick = {
+                            if (currentRoute != ROUTE_ACTIONS) {
+                                navController.navigate(ROUTE_ACTIONS) {
+                                    popUpTo(ROUTE_LIST) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                        },
+                        icon = { Icon(Icons.Default.Bolt, contentDescription = null) },
+                        label = { Text("Actions") },
+                    )
                 }
             }
         },
@@ -82,6 +98,12 @@ fun KernelNavHost() {
                         onNewConversation = {
                             navController.navigate(ROUTE_CHAT)
                         },
+                        onNavigateToActions = {
+                            navController.navigate(ROUTE_ACTIONS_OPEN) {
+                                popUpTo(ROUTE_LIST) { saveState = true }
+                                launchSingleTop = true
+                            }
+                        },
                         onNavigateToSettings = {
                             navController.navigate(ROUTE_SETTINGS)
                         },
@@ -89,7 +111,16 @@ fun KernelNavHost() {
                 }
             }
 
-// Actions screen hidden pending #361 (Actions tab re-enable + dual FABs)
+            composable(
+                route = "$ROUTE_ACTIONS?openSheet={openSheet}",
+                arguments = listOf(navArgument("openSheet") {
+                    type = NavType.BoolType
+                    defaultValue = false
+                }),
+            ) { backStackEntry ->
+                val openSheet = backStackEntry.arguments?.getBoolean("openSheet") ?: false
+                ActionsScreen(autoOpenSheet = openSheet)
+            }
 
             // New conversation (no conversationId arg)
             composable(ROUTE_CHAT) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -72,7 +72,9 @@ fun ActionsScreen(
     var showClearConfirmation by rememberSaveable { mutableStateOf(false) }
 
     // Auto-open the quick action sheet when navigated here via the FAB shortcut.
-    LaunchedEffect(autoOpenSheet) {
+    // LaunchedEffect(Unit) ensures this runs once on initial composition only —
+    // avoids re-opening the sheet on recomposition or after process death/restore.
+    LaunchedEffect(Unit) {
         if (autoOpenSheet) showBottomSheet = true
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -61,6 +61,7 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActionsScreen(
+    autoOpenSheet: Boolean = false,
     viewModel: ActionsViewModel = hiltViewModel(),
 ) {
     val actions by viewModel.actions.collectAsStateWithLifecycle()
@@ -69,6 +70,11 @@ fun ActionsScreen(
 
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
     var showClearConfirmation by rememberSaveable { mutableStateOf(false) }
+
+    // Auto-open the quick action sheet when navigated here via the FAB shortcut.
+    LaunchedEffect(autoOpenSheet) {
+        if (autoOpenSheet) showBottomSheet = true
+    }
 
     Scaffold(
         topBar = {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.chat
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Search
@@ -56,6 +58,7 @@ import java.util.Locale
 fun ConversationListScreen(
     onOpenConversation: (String) -> Unit,
     onNewConversation: () -> Unit,
+    onNavigateToActions: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
@@ -113,8 +116,20 @@ fun ConversationListScreen(
         },
         floatingActionButton = {
             if (!isInSelectionMode) {
-                FloatingActionButton(onClick = onNewConversation) {
-                    Icon(Icons.Default.Add, contentDescription = "New conversation")
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalAlignment = Alignment.End,
+                ) {
+                    FloatingActionButton(
+                        onClick = onNavigateToActions,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ) {
+                        Icon(Icons.Default.Bolt, contentDescription = "Quick action")
+                    }
+                    FloatingActionButton(onClick = onNewConversation) {
+                        Icon(Icons.Default.Add, contentDescription = "New conversation")
+                    }
                 }
             }
         },

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -134,10 +135,14 @@ fun ConversationListScreen(
             }
         },
     ) { innerPadding ->
+        // Apply only top padding to the Column so the search bar clears the TopAppBar.
+        // Bottom padding (FAB zone) is applied as LazyColumn contentPadding instead — this
+        // prevents a large blank panel above the nav bar while still letting the last item
+        // scroll above the FABs.
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
+                .padding(top = innerPadding.calculateTopPadding()),
         ) {
             // Search bar — hidden in selection mode
             if (!isInSelectionMode) {
@@ -194,6 +199,7 @@ fun ConversationListScreen(
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                 ) {
                     items(conversations, key = { it.id }) { conversation ->
                         Box {


### PR DESCRIPTION
## Summary

Phase 5 of the QuickIntentRouter roadmap: re-enables the Actions tab and adds dual FABs to the Chats screen with direct sheet open on the Actions tab.

## Changes

### `KernelNavHost.kt`
- Added `ROUTE_ACTIONS` to `BOTTOM_NAV_ROUTES`
- Added Actions `NavigationBarItem` (Bolt icon)
- Registered route as `actions?openSheet={openSheet}` (BoolType, default `false`) so the sheet can be auto-triggered via nav arg
- Tab nav: `ROUTE_ACTIONS` → `openSheet=false`; FAB shortcut: `ROUTE_ACTIONS_OPEN` → `openSheet=true`

### `ConversationListScreen.kt`
- Added `onNavigateToActions: () -> Unit = {}` parameter
- Dual FABs: ⚡ Quick Action (secondary container colour) stacked above ➕ New Conversation; both hidden in selection mode

### `ActionsScreen.kt`
- Added `autoOpenSheet: Boolean = false` parameter
- `LaunchedEffect(autoOpenSheet)` auto-opens `QuickActionBottomSheet` when arriving via FAB shortcut
- Future: same entry point can trigger voice input

## UX flow

```
Chats tab → tap ⚡ FAB
  → navigate to Actions tab (openSheet=true)
  → QuickActionBottomSheet opens immediately with keyboard focus
  → user types "turn on flashlight" → skill executes
```

Closes #361
