### PR TITLE
fix: Actions tab torch not working + FAB hidden behind nav bar

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -122,7 +122,9 @@ fun KernelNavHost() {
                 }),
             ) { backStackEntry ->
                 val openSheet = backStackEntry.arguments?.getBoolean("openSheet") ?: false
-                ActionsScreen(autoOpenSheet = openSheet)
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    ActionsScreen(autoOpenSheet = openSheet)
+                }
             }
 
             // New conversation (no conversationId arg)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -79,9 +79,19 @@ class ActionsViewModel @Inject constructor(
                 }
 
                 val entity = if (intent != null) {
-                    val skill = skillRegistry.get(intent.intentName)
+                    // Router intent names (e.g. "toggle_flashlight_on") are sub-intent values
+                    // passed as the intent_name param to run_intent — they are not skill names.
+                    // Resolve: direct skill name match first, then fall back to run_intent.
+                    val directSkill = skillRegistry.get(intent.intentName)
+                    val (skill, callParams) = when {
+                        directSkill != null -> directSkill to intent.params
+                        else -> {
+                            val runIntent = skillRegistry.get("run_intent")
+                            runIntent to (mapOf("intent_name" to intent.intentName) + intent.params)
+                        }
+                    }
                     if (skill != null) {
-                        val skillResult = skill.execute(SkillCall(intent.intentName, intent.params))
+                        val skillResult = skill.execute(SkillCall(skill.name, callParams))
                         buildEntityFromSkillResult(query, intent.intentName, skillResult)
                     } else {
                         Log.w(TAG, "ActionsViewModel: intent '${intent.intentName}' has no registered skill")


### PR DESCRIPTION
## Root causes

### Torch ("action recognised but not yet implemented")
**ActionsViewModel** was calling `skillRegistry.get(intent.intentName)` — e.g. `skillRegistry.get("toggle_flashlight_on")`. But `toggle_flashlight_on` is not a skill name; it's a parameter value for the `run_intent` skill. The registry returned null → fallback message shown.

**Fix:** resolve direct skill name first; if not found, look up `run_intent` and build params as `{intent_name: intentName, ...extraParams}`.

### FAB hidden behind bottom nav bar
**KernelNavHost** wasn't wrapping `ActionsScreen` in `Box(modifier = Modifier.padding(innerPadding))` like it does for `ConversationListScreen`. This meant the inner Scaffold's FAB was positioned at the very bottom of the full screen, behind the outer nav bar.

**Fix:** wrap `ActionsScreen` in `Box(modifier = Modifier.padding(innerPadding))`.

## Files changed
- `ActionsViewModel.kt` — intent → run_intent resolution
- `KernelNavHost.kt` — Box padding wrapper for ActionsScreen