### PR TITLE
fix: QuickIntentRouter param extraction + find_nearby regex bugs (#373)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -153,7 +153,7 @@ class QuickIntentRouter(
                 """(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)(?:\s+(?:and\s+)?(\d+)\s*(minutes?|mins?|seconds?|secs?|m|s))?""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> parseTimerDuration(match) },
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
         ),
         IntentPattern(
             intentName = "set_timer",
@@ -161,7 +161,7 @@ class QuickIntentRouter(
                 """(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> parseTimerDuration(match) },
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
         ),
         // "5 minute timer"
         IntentPattern(
@@ -170,7 +170,7 @@ class QuickIntentRouter(
                 """(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)\s+timer""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> parseTimerDuration(match) },
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
         ),
 
         // ── Do Not Disturb ──
@@ -416,15 +416,53 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "navigate_to",
             regex = Regex(
-                """(?:navigate|directions?|drive|take\s+me|get\s+me)\s+to\s+(.+)""",
+                """(?:navigate|directions?|drive|take\s+me|get\s+me)(?:\s+to)?\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("destination" to match.groupValues[1].trim()) },
         ),
+        // ── Find Nearby (most specific first to avoid greedy mis-capture) ──
+        // "find me nearby cafes" — verb + me + nearby + query
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
-                """(?:find|show\s+me|look\s+for|search\s+for)\s+(.+?)\s+(?:near(?:by|(?:\s+me)?)|close\s+by|around\s+(?:here|me))""",
+                """(?:find|show|get)\s+me\s+nearby\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
+        // "find me cafes nearby" — verb + me + query + location marker
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|show|get)\s+me\s+(.+?)\s+(?:near(?:by|\s+me)|close\s+by|around\s+(?:here|me))""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
+        // "locate nearest pharmacy" — verb + (the)? + nearest + query
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|show\s+me|search\s+for|look\s+for|locate)\s+(?:the\s+)?nearest\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
+        // "find nearby restaurants" — verb + nearby + query (no "me")
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|search\s+for|look\s+for|locate)\s+nearby\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
+        // "find cafes nearby" / "show me petrol stations close by" — general pattern
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|show\s+me|look\s+for|search\s+for|locate)\s+(.+?)\s+(?:near(?:by|\s+me)|close\s+by|around\s+(?:here|me))""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
@@ -546,15 +584,20 @@ class QuickIntentRouter(
             params["hours"] = hours.toString()
             params["minutes"] = minutes.toString()
 
-            // Check for "tomorrow" in surrounding text
-            if (cleaned.contains("tomorrow")) {
-                params["label"] = "TOMORROW"
+            // Extract day name (today, tomorrow, weekday names including abbreviations)
+            val dayRegex = Regex(
+                """\b(today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun)\b""",
+                RegexOption.IGNORE_CASE,
+            )
+            val dayMatch = dayRegex.find(cleaned)
+            if (dayMatch != null) {
+                params["day"] = normalizeDayName(dayMatch.groupValues[1].lowercase())
             }
 
             return params
         }
 
-        fun parseTimerDuration(match: MatchResult): Map<String, String> {
+        fun parseTimerDuration(match: MatchResult, input: String = ""): Map<String, String> {
             val amount1 = match.groupValues[1].toIntOrNull() ?: 0
             val unit1 = normalizeTimeUnit(match.groupValues[2])
 
@@ -567,7 +610,25 @@ class QuickIntentRouter(
                 totalSeconds += toSeconds(amount2, unit2)
             }
 
-            return mapOf("duration_seconds" to totalSeconds.toString())
+            val params = mutableMapOf("duration_seconds" to totalSeconds.toString())
+
+            // Extract label from "called X", "named X", "labeled X", "labelled X"
+            val labelRegex = Regex("""(?:called|named|label(?:l?)ed)\s+(.+)$""", RegexOption.IGNORE_CASE)
+            val labelMatch = labelRegex.find(input)
+            if (labelMatch != null) {
+                params["label"] = labelMatch.groupValues[1].trim()
+            }
+
+            // Also handle "N unit timer for X" where "for" is a label keyword after "timer"
+            if (!params.containsKey("label")) {
+                val timerForRegex = Regex("""timer\s+for\s+([a-zA-Z].+)$""", RegexOption.IGNORE_CASE)
+                val timerForMatch = timerForRegex.find(input)
+                if (timerForMatch != null) {
+                    params["label"] = timerForMatch.groupValues[1].trim()
+                }
+            }
+
+            return params
         }
 
         private fun normalizeTimeUnit(unit: String): String = when {
@@ -582,6 +643,17 @@ class QuickIntentRouter(
             "minutes" -> amount * 60
             "seconds" -> amount
             else -> amount * 60
+        }
+
+        private fun normalizeDayName(day: String): String = when (day) {
+            "mon" -> "monday"
+            "tue", "tues" -> "tuesday"
+            "wed" -> "wednesday"
+            "thu", "thur", "thurs" -> "thursday"
+            "fri" -> "friday"
+            "sat" -> "saturday"
+            "sun" -> "sunday"
+            else -> day
         }
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -159,17 +159,22 @@ class NativeIntentHandler @Inject constructor(
         val (hours, minutes) = timePair
         val day = params["day"]?.trim()?.lowercase()
         val isTomorrow = day == "tomorrow"
+        val weekdays = setOf("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+        val isWeekday = day in weekdays
 
         // NOTE: AlarmClock.EXTRA_DAYS is intentionally NOT used here.
         // EXTRA_DAYS creates a repeating weekly alarm, not a one-time future alarm.
         // The clock app opens pre-filled with the time; the user confirms the date.
         //
-        // For "tomorrow" alarms we prefix EXTRA_MESSAGE with "TOMORROW:" so the label is
-        // visible in the clock app, reminding the user to verify the date before confirming.
+        // For "tomorrow" or weekday alarms we prefix EXTRA_MESSAGE with the day name so
+        // the label is visible in the clock app, reminding the user to verify the date.
         val baseLabel = params["label"]?.takeIf { it.isNotBlank() }
+        val dayDisplay = day?.replaceFirstChar { it.uppercase() }
         val messageLabel = when {
             isTomorrow && baseLabel != null -> "TOMORROW: $baseLabel"
             isTomorrow -> "TOMORROW"
+            isWeekday && baseLabel != null -> "$dayDisplay: $baseLabel"
+            isWeekday -> dayDisplay
             else -> baseLabel
         }
 
@@ -186,11 +191,13 @@ class NativeIntentHandler @Inject constructor(
             context.startActivity(intent)
             val dayLabel = day?.takeIf { it.isNotBlank() }
                 ?.let { " for ${it.replaceFirstChar { c -> c.uppercase() }}" } ?: ""
-            val tomorrowWarning = if (isTomorrow) {
-                " ⚠ Your clock app schedules by time only — please verify the date is set to tomorrow before confirming."
-            } else ""
+            val dayWarning = when {
+                isTomorrow -> " ⚠ Your clock app schedules by time only — please verify the date is set to tomorrow before confirming."
+                isWeekday -> " ⚠ Your clock app schedules by time only — please verify the date is set to $dayDisplay before confirming."
+                else -> ""
+            }
             SkillResult.Success(
-                "Clock app opened — alarm$dayLabel at %02d:%02d. Please confirm in your clock app.$tomorrowWarning"
+                "Clock app opened — alarm$dayLabel at %02d:%02d. Please confirm in your clock app.$dayWarning"
                     .format(hours, minutes)
             )
         } catch (e: ActivityNotFoundException) {
@@ -456,7 +463,7 @@ class NativeIntentHandler @Inject constructor(
     private fun findNearby(params: Map<String, String>): SkillResult {
         val query = params["query"] ?: return SkillResult.Failure("find_nearby", "No search query provided")
         return try {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("geo:0,0?q=${Uri.encode("$query near me")}")).apply {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("geo:0,0?q=${Uri.encode(query)}")).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
             context.startActivity(intent)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -234,6 +234,23 @@ class QuickIntentRouterTest {
             assertEquals(expectedMinutes, intent.params["minutes"], "minutes for '$input'")
         }
 
+        @ParameterizedTest(name = "Regex+day: \"{0}\" → hours={1}, minutes={2}, day={3}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#alarmWithDayRegexPhrases")
+        fun `should match via regex with correct params and day`(
+            input: String,
+            expectedHours: String,
+            expectedMinutes: String,
+            expectedDay: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "set_alarm", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedHours, intent.params["hours"], "hours for '$input'")
+            assertEquals(expectedMinutes, intent.params["minutes"], "minutes for '$input'")
+            assertEquals(expectedDay, intent.params["day"], "day for '$input'")
+        }
+
         @ParameterizedTest(name = "Classifier: \"{0}\"")
         @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#alarmClassifierPhrases")
         fun `should match via classifier`(input: String) {
@@ -263,6 +280,21 @@ class QuickIntentRouterTest {
 
             val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
             assertEquals(expectedSeconds, intent.params["duration_seconds"], "seconds for '$input'")
+        }
+
+        @ParameterizedTest(name = "Regex+label: \"{0}\" → {1}s, label={2}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#timerWithLabelRegexPhrases")
+        fun `should match via regex with correct duration and label`(
+            input: String,
+            expectedSeconds: String,
+            expectedLabel: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "set_timer", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedSeconds, intent.params["duration_seconds"], "seconds for '$input'")
+            assertEquals(expectedLabel, intent.params["label"], "label for '$input'")
         }
 
         @ParameterizedTest(name = "Classifier: \"{0}\"")
@@ -1026,6 +1058,16 @@ class QuickIntentRouterTest {
             Arguments.of("alarm me for the morning"),
         )
 
+        @JvmStatic
+        fun alarmWithDayRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("set an alarm for 10pm thursday", "22", "0", "thursday"),
+            Arguments.of("set alarm for 7am monday", "7", "0", "monday"),
+            Arguments.of("wake me up at 6am tomorrow", "6", "0", "tomorrow"),
+            Arguments.of("alarm for 8pm friday", "20", "0", "friday"),
+            Arguments.of("set alarm for 9am sat", "9", "0", "saturday"),
+            Arguments.of("set an alarm for 7:30am wed", "7", "30", "wednesday"),
+        )
+
         // ── Timer ─────────────────────────────────────────────────────────────
 
         @JvmStatic
@@ -1049,6 +1091,16 @@ class QuickIntentRouterTest {
             Arguments.of("start counting down"),
             Arguments.of("I need a countdown"),
             Arguments.of("count down from 10"),
+        )
+
+        @JvmStatic
+        fun timerWithLabelRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("set a 2 minute timer called egg", "120", "egg"),
+            Arguments.of("5 minute timer called pasta", "300", "pasta"),
+            Arguments.of("set timer for 10 minutes named study", "600", "study"),
+            Arguments.of("set a timer for 30 seconds labeled workout", "30", "workout"),
+            Arguments.of("start a timer for 3 minutes labelled tea", "180", "tea"),
+            Arguments.of("5 minute timer for eggs", "300", "eggs"),
         )
 
         // ── DND ───────────────────────────────────────────────────────────────
@@ -1317,6 +1369,10 @@ class QuickIntentRouterTest {
             Arguments.of("drive to work", "work"),
             Arguments.of("get me to the hospital", "the hospital"),
             Arguments.of("navigate to the nearest petrol station", "the nearest petrol station"),
+            Arguments.of("navigate home", "home"),
+            Arguments.of("drive home", "home"),
+            Arguments.of("take me home", "home"),
+            Arguments.of("directions home", "home"),
         )
 
         @JvmStatic
@@ -1332,6 +1388,12 @@ class QuickIntentRouterTest {
             Arguments.of("show me petrol stations close by", "petrol stations"),
             Arguments.of("search for restaurants nearby", "restaurants"),
             Arguments.of("look for pharmacies near me", "pharmacies"),
+            Arguments.of("find me nearby cafes", "cafes"),
+            Arguments.of("find me nearby mcdonalds", "mcdonalds"),
+            Arguments.of("show me nearby gas stations", "gas stations"),
+            Arguments.of("find nearby restaurants", "restaurants"),
+            Arguments.of("locate nearest pharmacy", "pharmacy"),
+            Arguments.of("find me cafes nearby", "cafes"),
         )
 
         @JvmStatic


### PR DESCRIPTION
Fixes #373

## Changes
- **find_nearby regex** — captures actual query item instead of 'me'; removed redundant ' near me' append in NativeIntentHandler
- **Timer label** — extracts labels from 'called X', 'named X', 'labeled X' patterns  
- **Alarm day** — extracts weekday names (monday-sunday) and 'today'/'tomorrow' into day param
- **navigate_to** — 'to' keyword now optional ('navigate home' works)

## Test results from device testing (#368)
| Before | After |
|--------|-------|
| 'find me nearby cafes' → 'me near me' | → searches 'cafes' |
| '2 min timer called egg' → no label | → label 'egg' applied |
| 'alarm 10pm thursday' → ignores day | → 'thursday' in day param |
| 'navigate home' → no match | → matches navigate_to |