### PR TITLE
docs: update specification, roadmap, and README for #372

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 
 * **The Brain:** **Gemma-4 E-4B/E-2B** runs resident on GPU via LiteRT — always loaded, always ready. A lightweight **`QuickIntentRouter`** (pure Kotlin regex, zero memory) handles instant device actions (<5ms). Complex queries go straight to Gemma-4 for full reasoning with native tool calling.
 * **The Memory:** A local **RAG (Retrieval-Augmented Generation)** system using **sqlite-vec** and **EmbeddingGemma-300M**. The assistant remembers personal facts, preferences, and conversation history across sessions with zero data leaving the device. Episodic distillation consolidates each conversation into long-term memories.
-* **The Action:** A modular skill framework. **Tier 2** native Kotlin actions execute instantly (torch, timer, DND, bluetooth). **Tier 3** complex skills (weather, calendar, email) are handled by the resident Gemma-4 model via its native JSON tool-call format. Community-extensible **WebAssembly** skills run sandboxed via **Chicory** for safe extensibility.
+* **The Action:** A modular skill framework. **Tier 2** native Kotlin actions execute instantly (torch, timer, DND, bluetooth). **Tier 3** complex skills (weather, calendar, email) are handled by the resident Gemma-4 model via LiteRT-LM's native `@Tool` annotations with SDK constrained decoding. Community-extensible **WebAssembly** skills run sandboxed via **Chicory** for safe extensibility.
 
 ## Tech Stack
 
@@ -19,7 +19,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 | Inference | Google AI Edge (LiteRT + LiteRT-LM) |
 | Reasoning | Gemma-4 E-4B / E-2B (INT4 quantized, GPU resident) |
 | Quick Actions | `QuickIntentRouter` (Kotlin regex, zero memory) |
-| Complex Tool Calling | Gemma-4 native JSON tool-call format |
+| Complex Tool Calling | LiteRT-LM native `@Tool` annotations + constrained decoding |
 | Embeddings | EmbeddingGemma-300M (768-dim) |
 | Vector Search | sqlite-vec (NDK) |
 | Wasm Runtime | Chicory (pure JVM) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,14 +150,15 @@ The architectural foundation that determines tool call accuracy and response qua
 
 | Sub-Issue | Title | Status | Priority |
 |-----------|-------|--------|----------|
-| [#341](https://github.com/NickMonrad/kernel-ai-assistant/issues/341) | Lazy skill loading (`load_skill` pattern) — refactor monolithic system prompt to on-demand skill instructions | ⬜ Pending | 🔴 High |
+| [#341](https://github.com/NickMonrad/kernel-ai-assistant/issues/341) | Lazy skill loading (`load_skill` pattern) — refactor monolithic system prompt to on-demand skill instructions | ✅ Done | 🔴 High |
+| [#372](https://github.com/NickMonrad/kernel-ai-assistant/issues/372) | Native SDK tool calling — migrate from custom `<\|tool_call\>` tokens to LiteRT-LM `@Tool` annotations with constrained decoding | ✅ Done | 🔴 High |
 | [#342](https://github.com/NickMonrad/kernel-ai-assistant/issues/342) | Model settings — add topK, fix temp 1.0/0.7 conflict, task-aware presets | ⬜ Pending | 🟡 Medium |
 | [#343](https://github.com/NickMonrad/kernel-ai-assistant/issues/343) | Thinking budget configuration — toggle + budget for Gemma-4 think mode | ⬜ Pending | 🟡 Medium |
 | [#231](https://github.com/NickMonrad/kernel-ai-assistant/issues/231) | NPU fallback — QTI Snapdragon device detection fix | ⬜ Pending | 🟡 Medium |
 | [#301](https://github.com/NickMonrad/kernel-ai-assistant/issues/301) | Switch vec0 tables to `distance_metric=cosine` | ⬜ Pending | 🟢 Low |
 | [#230](https://github.com/NickMonrad/kernel-ai-assistant/issues/230) | Review `safeTokenCount()` token alignment logic | ⬜ Pending | 🟢 Low |
 
-> **Key insight (from #340 analysis):** Our system prompt injects ~500+ tokens of tool rules on every turn. AI Edge Gallery uses ~100 tokens + loads skill instructions on demand via `load_skill`. This attention dilution is the root cause of prompt-induced errors like the 1pm=13 bug (#336). Issue #341 is the single most impactful architecture improvement.
+> **Key insight (from #340 analysis):** Our system prompt previously injected ~500+ tokens of tool rules on every turn. Issues #341 (lazy loading) and #372 (native SDK tool calling) resolved this: the prompt now carries ~100 tokens of skill names, and the SDK handles tool declaration generation + constrained decoding for guaranteed well-formed calls.
 
 ---
 
@@ -248,15 +249,16 @@ Lower-priority skill additions — third-party integrations and local utilities.
 
 ---
 
-### Tier 2: QuickIntentRouter (not yet started)
+### Tier 2: QuickIntentRouter
 
 | Task | Status | Notes |
 |------|--------|-------|
-| `QuickIntentRouter` — Kotlin regex matcher | ⬜ Pending | Zero memory, <5ms, deterministic |
-| Wire real OS actions in `KernelAIToolSet` | ⬜ Pending | Timer, battery, DND |
-| Refactor Actions tab to use `QuickIntentRouter` | ⬜ Pending | Remove FunctionGemmaRouter |
+| `QuickIntentRouter` — Kotlin regex matcher | ✅ Done | Zero memory, <5ms, deterministic — PR #365 |
+| Wire real OS actions in `NativeIntentHandler` | ✅ Done | 21+ intents: alarm, timer, torch, DND, BT, email, SMS, calendar |
+| Refactor Actions tab to use `QuickIntentRouter` | ✅ Done | PR #366 |
 | Quick Actions tab UI (#221) | ✅ Done | FAB, bottom sheet, Room persistence |
 | Bottom nav bar (Chats / Actions) | ✅ Done | PR #221 |
+| Actions tab FallThrough → LLM bridge | ⬜ Pending | #373 — unmatched queries dead-end instead of routing to chat |
 
 ### Known Issues / Decisions
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -184,26 +184,44 @@ If no pattern matches → query falls through to Tier 3 (Gemma-4).
 
 ### 4.2 Tier 3: E4B Native Tool Calling
 
-Gemma-4 emits tool call tokens in its native format when it determines a tool should be used:
+Gemma-4 uses LiteRT-LM's native `@Tool`/`@ToolParam` SDK annotations for tool calling.
+The SDK auto-discovers annotated methods on `KernelAIToolSet`, generates tool declarations
+for the model, applies **constrained decoding** to guarantee well-formed JSON calls, invokes
+the matching method, and feeds the return value back as a tool response.
 
+This mirrors Google AI Edge Gallery's `AgentTools` pattern and replaces the earlier custom
+`<|tool_call>` control token format (removed in #372).
+
+**SDK wiring (in `LiteRtInferenceEngine`):**
+```kotlin
+// Enable constrained decoding before creating conversation
+ExperimentalFlags.enableConversationConstrainedDecoding = true
+engine.createConversation(ConversationConfig(
+    tools = listOf(toolProvider),  // ToolProvider wraps KernelAIToolSet
+    systemInstruction = systemPrompt,
+    ...
+))
+ExperimentalFlags.enableConversationConstrainedDecoding = false
 ```
-<|tool_call>call:run_intent{intent_name:<|"|>set_alarm<|"|>,hours:<|"|>7<|"|>,minutes:<|"|>30<|"|>}<tool_call|>
-```
 
-`ChatViewModel.extractNativeToolCall()` detects this token pattern in the streamed output,
-extracts the function name and key-value params, looks up the skill in `SkillRegistry`,
-and calls `Skill.execute(call)`. Tool definitions and concrete `<|tool_call>` examples are
-injected into the system prompt via `SkillRegistry.buildNativeDeclarations()`.
+> **Lazy skill loading (#341, #372):** The system prompt injects only skill names +
+> one-line descriptions (~100 tokens). When the model needs to use a skill, it first
+> calls `loadSkill()` to retrieve full parameter docs, examples, and enforcement rules
+> on demand. This keeps the baseline prompt compact and improves tool call accuracy.
 
-> **Planned: Lazy skill loading (#341):** The current approach injects all tool definitions
-> (~500+ tokens) into every turn's system prompt, diluting attention. A planned refactor will
-> adopt AI Edge Gallery's pattern: inject only skill names + one-line descriptions, then load
-> full instructions on-demand via a `load_skill` tool call. This reduces baseline prompt to
-> ~100 tokens and should improve tool call accuracy.
+**KernelAIToolSet gateway (5 tools):**
 
-> **Format note:** String values are wrapped in `<|"|>` tokens (Gemma-4's string delimiter).
-> In Kotlin source, the token is split to avoid triggering the compiler:
-> `"<|" + "\"" + "|>"`. The tool call block is bounded by `<|tool_call>` … `<tool_call|>`.
+| Gateway | Tool method | Dispatcher | Use for |
+|---------|------------|-----------|---------|
+| Meta | `loadSkill(skillName)` | `LoadSkillSkill` | Load full instructions before using any tool |
+| Native | `runIntent(intentName, parameters)` | `NativeIntentHandler.kt` | Android OS intents (alarm, timer, email, SMS, torch, calendar) |
+| WebView JS | `runJs(skillName, query, forecastDays)` | `JsSkillRunner.kt` | JS skills in `assets/skills/` (weather, Wikipedia) |
+| Memory | `saveMemory(content)` | `SaveMemorySkill` | Store facts to long-term memory |
+| Memory | `searchMemory(query)` | `SearchMemorySkill` | Semantic search across memories |
+
+Each `@Tool` method delegates to the matching `Skill.execute()` via `SkillRegistry`, bridging
+the SDK's synchronous callback with `runBlocking` (acceptable since the SDK already blocks its
+inference loop waiting for the tool result).
 
 **Skill interface:**
 ```kotlin
@@ -211,22 +229,16 @@ interface Skill {
     val name: String
     val description: String
     val schema: SkillSchema           // parameter definitions + required list
-    val examples: List<String>        // optional concrete <|tool_call> examples injected into prompt
+    val examples: List<String>        // native tool call examples for system prompt
+    val fullInstructions: String      // complete docs returned by loadSkill()
     suspend fun execute(call: SkillCall): SkillResult
 }
 ```
 
-**Two-gateway architecture (post #247):**
-
-All Tier 3 tool calls funnel through exactly **two** skill names:
-
-| Gateway | Skill name | Dispatcher | Use for |
-|---------|-----------|-----------|---------|
-| Native | `run_intent` | `NativeIntentHandler.kt` | Any Android OS intent (alarm, timer, email, SMS, torch, calendar, maps) |
-| WebView JS | `run_js` | `JsSkillRunner.kt` | JS skills in `assets/skills/<name>/index.html` (weather, Wikipedia, etc.) |
-
-This means the model only needs two function names; new native intents are added by extending
-`NativeIntentHandler` and new JS skills by dropping an `index.html` into `assets/skills/`.
+**Response handling:** The SDK handles tool calls transparently during `generate()`.
+`KernelAIToolSet` tracks turn state (`wasToolCalled()`, `lastToolName()`, `lastToolResult()`)
+so `ChatViewModel` can attach tool call metadata to the UI. A `ToolCallExtractor` text-parsing
+fallback exists for edge cases where the model emits raw JSON outside the SDK path.
 
 **Registered `run_intent` intents:**
 


### PR DESCRIPTION
Post-merge documentation updates for #372 native tool calling migration.

- **SPECIFICATION.md**: Replace custom `<|tool_call>` format docs with native SDK `@Tool` annotation pattern, constrained decoding, 5-tool KernelAIToolSet gateway table
- **ROADMAP.md**: Mark #341 and #372 as done, update Tier 2 QuickIntentRouter status, update key insight note  
- **README.md**: Update tech stack table and Brain-Memory-Action description