### PR TITLE
fix: add READ_CONTACTS permission for SMS/call contact resolution

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- Required on some OEM clock apps that still check this deprecated permission -->
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+    <!-- Contact lookup for SMS, email, and call by name -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
 
     <!--
         Android 11+ package visibility: declare which implicit intents we resolve

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -29,6 +29,9 @@ class MainActivity : ComponentActivity() {
     private val requestLocationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
 
+    private val requestContactsPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -38,6 +41,10 @@ class MainActivity : ComponentActivity() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
             requestLocationPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            requestContactsPermission.launch(Manifest.permission.READ_CONTACTS)
         }
         setContent {
             KernelAITheme {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -597,9 +597,18 @@ class NativeIntentHandler @Inject constructor(
             val selectionArgs = arrayOf("%$name%")
             context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
                 if (cursor.moveToFirst()) {
-                    cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
-                } else null
+                    val number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+                    val displayName = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME))
+                    Log.d(TAG, "Contact resolved: '$name' → '$displayName' ($number)")
+                    number
+                } else {
+                    Log.d(TAG, "Contact not found for '$name'")
+                    null
+                }
             }
+        } catch (e: SecurityException) {
+            Log.w(TAG, "READ_CONTACTS permission not granted — cannot resolve '$name'", e)
+            null
         } catch (e: Exception) {
             Log.w(TAG, "Contact lookup failed for '$name'", e)
             null


### PR DESCRIPTION
Contact lookup via `resolveContactNumber()` was silently failing because `READ_CONTACTS` was never declared. Names like "Laurelle Kerr" were passed as the phone number instead of being resolved.

### Changes
- `AndroidManifest.xml`: Added `READ_CONTACTS` permission
- `MainActivity.kt`: Runtime permission request (same pattern as location)
- `NativeIntentHandler.kt`: Explicit `SecurityException` catch + success/not-found debug logs

Found during #380 testing.