### PR TITLE
feat: Token strategy + Structured profile + FAB consistency (#367, #374)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -131,6 +131,9 @@ fun KernelNavHost() {
                             val encoded = Uri.encode(query)
                             navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded")
                         },
+                        onNewConversation = {
+                            navController.navigate(ROUTE_CHAT)
+                        },
                     )
                 }
             }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -12,7 +12,8 @@ import javax.inject.Singleton
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
 private const val KEY_TRUTHS_SEEDED = "truths_seeded"
-private const val SESSION_VOCAB_COUNT = 4
+private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
+private const val SESSION_VOCAB_COUNT = 2
 
 /**
  * Provides Jandal's dynamic personality elements: time-aware greetings, a randomised
@@ -71,14 +72,22 @@ class JandalPersona @Inject constructor(
     }
 
     /**
-     * Picks [SESSION_VOCAB_COUNT] random entries from the vocab pool and returns a
-     * compact prompt hint so the model can weave them in naturally.
+     * Picks [SESSION_VOCAB_COUNT] entries from the vocab pool with LRU cooldown
+     * (avoids repeating the same phrases across sessions) and returns a compact
+     * prompt hint so the model can weave them in naturally.
      * Returns empty string if the vocab file failed to load.
      */
     fun buildSessionVocab(): String {
         if (vocabPool.isEmpty()) return ""
-        val picked = vocabPool.shuffled().take(SESSION_VOCAB_COUNT)
-        val entries = picked.joinToString(", ") { "\"${it.phrase}\" (${it.meaning})" }
+        val lastUsed = prefs.getString(KEY_LAST_VOCAB_INDICES, "")
+            ?.split(",")
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toSet() ?: emptySet()
+        // Prefer indices not recently used; fall back to full pool if all were used
+        val candidates = vocabPool.indices.filter { it !in lastUsed }.ifEmpty { vocabPool.indices.toList() }
+        val picked = candidates.shuffled().take(SESSION_VOCAB_COUNT)
+        prefs.edit().putString(KEY_LAST_VOCAB_INDICES, picked.joinToString(",")).apply()
+        val entries = picked.map { vocabPool[it] }.joinToString(", ") { "\"${it.phrase}\" (${it.meaning})" }
         return "You may naturally use some of these Kiwi expressions where they fit: $entries."
     }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -6,26 +6,38 @@ import com.google.ai.edge.litertlm.ToolProvider
 /** Jandal's default system prompt. Injected into every new conversation. */
 const val DEFAULT_SYSTEM_PROMPT =
     "You are Jandal — a capable, on-device AI assistant with a genuine Kiwi character. " +
-        "You're direct, warm, and dry-humoured without trying too hard. You don't say " +
-        "\"certainly!\", \"absolutely!\", or \"great question\" — you just get on with it. " +
-        "You run entirely on-device, so the user's data never leaves their phone. " +
+        "You're direct, warm, and dry-humoured without trying too hard. " +
+        "You run entirely on-device — the user's data never leaves their phone. " +
         "Keep responses concise unless the user asks for detail. " +
-        "When you use Kiwi expressions, they should feel natural, not forced. " +
-        "You are culturally and spiritually Kiwi — from Aotearoa New Zealand. " +
-        "You are named after the NZ word for flip-flops: jandals — simple, unpretentious, practical. " +
-        "You were born from Kiwi culture: laid-back, direct, and no-nonsense. " +
-        "When asked where you are from, what your culture is, or why you are called Jandal, " +
-        "own your Kiwi identity with pride — never say you are \"just code\" or that you have no culture. " +
-        "IMPORTANT — language rules: You are New Zealand, NOT Australian. " +
-        "NEVER use Australian phrases. Prohibited examples: 'fair dinkum', 'G\\'day', 'no worries mate'. " +
-        "NEVER refer to New Zealand as 'down under' — that is an Australian term. " +
-        "Always refer to the country as 'New Zealand' or 'Aotearoa'."
+        "You are culturally Kiwi — from Aotearoa New Zealand. Named after jandals: simple, practical, unpretentious. " +
+        "Own your Kiwi identity with pride — never say you are 'just code'. " +
+        "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +
+        "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'."
+
+/**
+ * Minimal identity for tool-only execution (Actions tab).
+ * Omits cultural details and language rules to save tokens.
+ */
+const val MINIMAL_SYSTEM_PROMPT =
+    "You are Jandal — a concise, on-device AI assistant from Aotearoa New Zealand. " +
+        "Be direct and brief. Report results only."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000
 
 /** Sampler defaults for CPU/GPU backends. NPU requires null samplerConfig. */
 val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature = 0.7)
+
+/**
+ * Controls how much of the Jandal identity is injected into the system prompt.
+ * Reduces token usage on paths where full personality isn't needed.
+ */
+enum class IdentityTier {
+    /** Full identity + greeting + vocab. Used for Chat conversations. */
+    FULL,
+    /** Name and style only (~25 tokens). Used for Actions tab tool execution. */
+    MINIMAL,
+}
 
 /**
  * Configuration used when loading a model into [InferenceEngine].

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/10.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/10.json
@@ -1,0 +1,459 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "c2347c13a2e17dbf97b0d1016f286768",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c2347c13a2e17dbf97b0d1016f286768')"
+    ]
+  }
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/11.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/11.json
@@ -1,0 +1,464 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "6343bfa623a500a22320cd0a59451740",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6343bfa623a500a22320cd0a59451740')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -33,7 +33,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
     ],
-    version = 10,
+    version = 11,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -115,6 +115,13 @@ abstract class KernelDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE core_memories ADD COLUMN category TEXT NOT NULL DEFAULT 'user'")
                 // Reclassify existing jandal_persona entries as agent_identity
                 db.execSQL("UPDATE core_memories SET category = 'agent_identity' WHERE source = 'jandal_persona'")
+            }
+        }
+
+        /** Adds structuredJson column to user_profile for structured YAML profile (#374). */
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE user_profile ADD COLUMN structuredJson TEXT DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -33,7 +33,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
     ],
-    version = 9,
+    version = 10,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -106,6 +106,15 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE core_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("ALTER TABLE episodic_memories ADD COLUMN vectorized INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        /** Adds category column to core_memories for NZ knowledge separation (#367). */
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN category TEXT NOT NULL DEFAULT 'user'")
+                // Reclassify existing jandal_persona entries as agent_identity
+                db.execSQL("UPDATE core_memories SET category = 'agent_identity' WHERE source = 'jandal_persona'")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -52,6 +52,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_6_7,
                     KernelDatabase.MIGRATION_7_8,
                     KernelDatabase.MIGRATION_8_9,
+                    KernelDatabase.MIGRATION_9_10,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -53,6 +53,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_7_8,
                     KernelDatabase.MIGRATION_8_9,
                     KernelDatabase.MIGRATION_9_10,
+                    KernelDatabase.MIGRATION_10_11,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
@@ -14,4 +14,6 @@ data class CoreMemoryEntity(
     val accessCount: Int = 0,
     val source: String,  // "user" or "dreaming"
     val vectorized: Boolean = false,
+    /** Separates user facts from agent identity (NZ knowledge). Default "user" for backward compat. */
+    val category: String = "user",
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/UserProfileEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/UserProfileEntity.kt
@@ -7,12 +7,15 @@ import androidx.room.PrimaryKey
  * Singleton user profile injected into every LLM system prompt.
  *
  * Only one row ever exists (id = 1). The [profileText] is a free-form narrative
- * block written/edited by the user (or eventually auto-updated by the Dreaming Engine).
- * Kept under ~500 tokens (~2,000 chars) so it fits comfortably in the context budget.
+ * block written/edited by the user. The [structuredJson] column holds a
+ * [com.kernel.ai.core.memory.profile.UserProfileYaml] serialised as JSON,
+ * derived from the free-text by heuristic parsing (and optionally refined by LLM).
  */
 @Entity(tableName = "user_profile")
 data class UserProfileEntity(
     @PrimaryKey val id: Int = 1,
     val profileText: String,
     val updatedAt: Long,
+    /** JSON-serialised UserProfileYaml; null until first parse. */
+    val structuredJson: String? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
@@ -1,0 +1,132 @@
+package com.kernel.ai.core.memory.profile
+
+/**
+ * Heuristic parser that extracts structured profile fields from free-text.
+ *
+ * This is a fast, deterministic first pass. An optional background LLM pass
+ * can refine the results later (#374 Phase 2b).
+ *
+ * Patterns recognised:
+ * - Name: "My name is X", "I'm X", "I am X", "Name: X", "Call me X"
+ * - Role: "I'm a/an X", "I work as X", "Role: X", "I am a X developer/engineer/..."
+ * - Environment: "I use X", "I have X", "running X", device/OS/tool mentions
+ * - Rules: "I prefer X", "I like X", "always X", "never X", "don't X"
+ * - Context: Sentences that don't match the above but contain useful info
+ */
+object UserProfileParser {
+
+    private val NAME_PATTERNS = listOf(
+        Regex("""(?i)\b(?:my name is|i'm|i am|call me|name:\s*)\s*([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)?)"""),
+    )
+
+    private val ROLE_PATTERNS = listOf(
+        Regex("""(?i)\b(?:i'm an?|i am an?|i work as an?|role:\s*)\s+(.+?)(?:\.|$)"""),
+    )
+
+    private val ROLE_KEYWORDS = setOf(
+        "developer", "engineer", "designer", "manager", "analyst", "architect",
+        "consultant", "student", "researcher", "programmer", "admin", "devops",
+        "writer", "teacher", "professional", "specialist",
+    )
+
+    private val ENVIRONMENT_PATTERNS = listOf(
+        Regex("""(?i)\b(?:i use|i have|i run|i'm (?:on|using)|running|device:\s*)\s+(.+?)(?:\.|$)"""),
+    )
+
+    private val RULE_PATTERNS = listOf(
+        Regex("""(?i)\b(?:i prefer|i like|i want|always|never|don'?t|please)\s+(.+?)(?:\.|$)"""),
+    )
+
+    fun parse(freeText: String): UserProfileYaml {
+        if (freeText.isBlank()) return UserProfileYaml()
+
+        var name: String? = null
+        var role: String? = null
+        val environment = mutableListOf<String>()
+        val context = mutableListOf<String>()
+        val rules = mutableListOf<String>()
+
+        // Split into sentences
+        val sentences = freeText.split(Regex("""(?<=[.!?])\s+|\n+"""))
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+
+        val consumed = mutableSetOf<Int>()
+
+        // Pass 1: Extract name
+        for ((i, sentence) in sentences.withIndex()) {
+            if (name != null) break
+            for (pattern in NAME_PATTERNS) {
+                val match = pattern.find(sentence)
+                if (match != null) {
+                    name = match.groupValues[1].trim()
+                    consumed.add(i)
+                    break
+                }
+            }
+        }
+
+        // Pass 2: Extract role
+        for ((i, sentence) in sentences.withIndex()) {
+            if (i in consumed) continue
+            if (role != null) break
+            // Check if sentence mentions a role keyword
+            val lowerSentence = sentence.lowercase()
+            val hasRoleKeyword = ROLE_KEYWORDS.any { lowerSentence.contains(it) }
+            if (hasRoleKeyword) {
+                for (pattern in ROLE_PATTERNS) {
+                    val match = pattern.find(sentence)
+                    if (match != null) {
+                        role = match.groupValues[1].trim().removeSuffix(".")
+                        consumed.add(i)
+                        break
+                    }
+                }
+            }
+        }
+
+        // Pass 3: Extract environment and rules
+        for ((i, sentence) in sentences.withIndex()) {
+            if (i in consumed) continue
+            var matched = false
+
+            for (pattern in RULE_PATTERNS) {
+                val match = pattern.find(sentence)
+                if (match != null) {
+                    rules.add(sentence.trim().removeSuffix("."))
+                    consumed.add(i)
+                    matched = true
+                    break
+                }
+            }
+            if (matched) continue
+
+            for (pattern in ENVIRONMENT_PATTERNS) {
+                val match = pattern.find(sentence)
+                if (match != null) {
+                    environment.add(match.groupValues[1].trim().removeSuffix("."))
+                    consumed.add(i)
+                    matched = true
+                    break
+                }
+            }
+            if (matched) continue
+        }
+
+        // Pass 4: Everything else goes to context
+        for ((i, sentence) in sentences.withIndex()) {
+            if (i in consumed) continue
+            if (sentence.length > 5) {
+                context.add(sentence.trim().removeSuffix("."))
+            }
+        }
+
+        return UserProfileYaml(
+            name = name,
+            role = role,
+            environment = environment.take(10),
+            context = context.take(10),
+            rules = rules.take(10),
+        )
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileYaml.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileYaml.kt
@@ -1,0 +1,68 @@
+package com.kernel.ai.core.memory.profile
+
+/**
+ * Structured representation of the user profile, derived from free-text.
+ * Injected into the system prompt as compact YAML for token efficiency.
+ */
+data class UserProfileYaml(
+    val name: String? = null,
+    val role: String? = null,
+    val environment: List<String> = emptyList(),
+    val context: List<String> = emptyList(),
+    val rules: List<String> = emptyList(),
+) {
+    /** Render as compact YAML block for system prompt injection. */
+    fun toYaml(): String = buildString {
+        name?.let { appendLine("name: $it") }
+        role?.let { appendLine("role: $it") }
+        if (environment.isNotEmpty()) {
+            appendLine("environment:")
+            environment.forEach { appendLine("  - $it") }
+        }
+        if (context.isNotEmpty()) {
+            appendLine("context:")
+            context.forEach { appendLine("  - $it") }
+        }
+        if (rules.isNotEmpty()) {
+            appendLine("rules:")
+            rules.forEach { appendLine("  - $it") }
+        }
+    }.trimEnd()
+
+    fun isEmpty(): Boolean =
+        name == null && role == null && environment.isEmpty() && context.isEmpty() && rules.isEmpty()
+
+    fun toJson(): String = buildString {
+        append("{")
+        val parts = mutableListOf<String>()
+        name?.let { parts.add("\"name\":\"${it.escapeJson()}\"") }
+        role?.let { parts.add("\"role\":\"${it.escapeJson()}\"") }
+        if (environment.isNotEmpty()) parts.add("\"environment\":[${environment.joinToString(",") { "\"${it.escapeJson()}\"" }}]")
+        if (context.isNotEmpty()) parts.add("\"context\":[${context.joinToString(",") { "\"${it.escapeJson()}\"" }}]")
+        if (rules.isNotEmpty()) parts.add("\"rules\":[${rules.joinToString(",") { "\"${it.escapeJson()}\"" }}]")
+        append(parts.joinToString(","))
+        append("}")
+    }
+
+    companion object {
+        fun fromJson(text: String): UserProfileYaml? = runCatching {
+            val obj = org.json.JSONObject(text)
+            UserProfileYaml(
+                name = obj.optString("name").ifEmpty { null },
+                role = obj.optString("role").ifEmpty { null },
+                environment = obj.optJSONArray("environment")?.let { arr ->
+                    (0 until arr.length()).map { arr.getString(it) }
+                } ?: emptyList(),
+                context = obj.optJSONArray("context")?.let { arr ->
+                    (0 until arr.length()).map { arr.getString(it) }
+                } ?: emptyList(),
+                rules = obj.optJSONArray("rules")?.let { arr ->
+                    (0 until arr.length()).map { arr.getString(it) }
+                } ?: emptyList(),
+            )
+        }.getOrNull()
+
+        private fun String.escapeJson(): String =
+            replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -8,16 +8,17 @@ interface MemoryRepository {
     /** Store a volatile, conversation-scoped memory. */
     suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
-    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray): String
+    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray, category: String = "user"): String
     /** Backfill vector for an existing core memory that was saved without one (used by MemoryEmbeddingWorker). */
     suspend fun backfillCoreVector(rowId: Long, vector: FloatArray)
     /** Backfill vector for an existing episodic memory that was saved without one (used by MemoryEmbeddingWorker). */
     suspend fun backfillEpisodicVector(rowId: Long, vector: FloatArray)
-    /** Search BOTH tiers; core ranked above episodic. */
+    /** Search BOTH tiers; core ranked above episodic. Agent identity memories use separate topK. */
     suspend fun searchMemories(
         queryVector: FloatArray,
         coreTopK: Int = 10,
         episodicTopK: Int = 5,
+        identityTopK: Int = 2,
     ): List<MemorySearchResult>
     /** Delete a specific core memory. */
     suspend fun deleteCoreMemory(id: String)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -80,6 +80,7 @@ class MemoryRepositoryImpl @Inject constructor(
         content: String,
         source: String,
         embeddingVector: FloatArray,
+        category: String,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -90,6 +91,7 @@ class MemoryRepositoryImpl @Inject constructor(
             lastAccessedAt = now,
             source = source,
             vectorized = false,
+            category = category,
         )
         val rowId = coreDao.insert(entity)
         if (rowId > 0) {
@@ -120,18 +122,33 @@ class MemoryRepositoryImpl @Inject constructor(
         queryVector: FloatArray,
         coreTopK: Int,
         episodicTopK: Int,
+        identityTopK: Int,
     ): List<MemorySearchResult> {
         val results = mutableListOf<MemorySearchResult>()
 
         runCatching {
-            val rawCoreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, coreTopK)
+            // Fetch more than needed so we can split by category after filtering
+            val fetchTopK = coreTopK + identityTopK
+            val rawCoreResults = vectorStore.search(CORE_VEC_TABLE, queryVector, fetchTopK)
             Log.d(TAG, "Core vec search: ${rawCoreResults.size} raw results, distances=${rawCoreResults.map { "%.3f".format(it.distance) }}")
             val coreResults = rawCoreResults.filter { it.distance <= CORE_MAX_DISTANCE }
             val rowIds = coreResults.map { it.rowId }
             if (rowIds.isNotEmpty()) {
                 val entities = coreDao.getAll().filter { it.rowId in rowIds }
                 val distanceMap = coreResults.associate { it.rowId to it.distance }
-                entities.forEach { entity ->
+
+                // Split by category and apply separate topK limits
+                val userEntities = entities
+                    .filter { it.category != "agent_identity" }
+                    .sortedBy { distanceMap[it.rowId] ?: Float.MAX_VALUE }
+                    .take(coreTopK)
+                val identityEntities = entities
+                    .filter { it.category == "agent_identity" }
+                    .sortedBy { distanceMap[it.rowId] ?: Float.MAX_VALUE }
+                    .take(identityTopK)
+                val combined = userEntities + identityEntities
+
+                combined.forEach { entity ->
                     results.add(
                         MemorySearchResult(
                             id = entity.id,
@@ -142,11 +159,9 @@ class MemoryRepositoryImpl @Inject constructor(
                         )
                     )
                 }
-                // Update access stats atomically via @Transaction wrapper so Room's
-                // InvalidationTracker fires on commit and observeAll() re-emits.
                 runCatching {
                     val now = System.currentTimeMillis()
-                    coreDao.incrementAccessStatsAndNotify(entities.map { it.id }, now)
+                    coreDao.incrementAccessStatsAndNotify(combined.map { it.id }, now)
                 }.onFailure { Log.w(TAG, "incrementAccessStatsAndNotify failed: ${it.message}") }
             }
         }.onFailure { Log.w(TAG, "Core memory search failed: ${it.message}") }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
@@ -2,6 +2,8 @@ package com.kernel.ai.core.memory.repository
 
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.UserProfileEntity
+import com.kernel.ai.core.memory.profile.UserProfileParser
+import com.kernel.ai.core.memory.profile.UserProfileYaml
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -17,19 +19,32 @@ class UserProfileRepository @Inject constructor(
     /** Observe the current profile text (empty string when not set). */
     fun observe(): Flow<String> = dao.observe().map { it?.profileText ?: "" }
 
+    /** Observe the structured profile (null when not parsed or empty). */
+    fun observeStructured(): Flow<UserProfileYaml?> = dao.observe().map { entity ->
+        entity?.structuredJson?.let { UserProfileYaml.fromJson(it) }
+    }
+
     /** Get the current profile text once (empty string when not set). */
     suspend fun get(): String = dao.get()?.profileText ?: ""
 
+    /** Get the structured profile (null when not yet parsed). */
+    suspend fun getStructured(): UserProfileYaml? =
+        dao.get()?.structuredJson?.let { UserProfileYaml.fromJson(it) }
+
     /**
      * Save [text] as the user profile. Trims to [maxLength] if needed.
+     * Automatically runs heuristic parsing to populate structured fields.
      * Pass an empty string to effectively clear the profile content.
      */
     suspend fun save(text: String) {
         val trimmed = text.take(maxLength)
+        val parsed = UserProfileParser.parse(trimmed)
+        val json = if (parsed.isEmpty()) null else parsed.toJson()
         dao.upsert(
             UserProfileEntity(
                 profileText = trimmed,
                 updatedAt = System.currentTimeMillis(),
+                structuredJson = json,
             )
         )
     }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/profile/UserProfileParserTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/profile/UserProfileParserTest.kt
@@ -1,0 +1,134 @@
+package com.kernel.ai.core.memory.profile
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UserProfileParserTest {
+
+    @Nested
+    inner class NameExtraction {
+        @Test
+        fun `extracts name from 'My name is X'`() {
+            val result = UserProfileParser.parse("My name is Nick. I live in Auckland.")
+            assertEquals("Nick", result.name)
+        }
+
+        @Test
+        fun `extracts name from 'I'm X'`() {
+            val result = UserProfileParser.parse("I'm Nick Monrad. I like coffee.")
+            assertEquals("Nick Monrad", result.name)
+        }
+
+        @Test
+        fun `extracts name from 'Call me X'`() {
+            val result = UserProfileParser.parse("Call me Dave. I prefer dark mode.")
+            assertEquals("Dave", result.name)
+        }
+
+        @Test
+        fun `returns null when no name pattern found`() {
+            val result = UserProfileParser.parse("I use a Samsung S23 Ultra.")
+            assertNull(result.name)
+        }
+    }
+
+    @Nested
+    inner class RoleExtraction {
+        @Test
+        fun `extracts role with developer keyword`() {
+            val result = UserProfileParser.parse("My name is Nick. I'm a Kotlin developer.")
+            assertEquals("Nick", result.name)
+            assertEquals("Kotlin developer", result.role)
+        }
+
+        @Test
+        fun `extracts role with engineer keyword`() {
+            val result = UserProfileParser.parse("I am a software engineer at Google.")
+            assertEquals("software engineer at Google", result.role)
+        }
+    }
+
+    @Nested
+    inner class EnvironmentExtraction {
+        @Test
+        fun `extracts I use patterns`() {
+            val result = UserProfileParser.parse("I use a Samsung S23 Ultra. I use Home Assistant for solar.")
+            assertEquals(2, result.environment.size)
+            assertTrue(result.environment[0].contains("Samsung"))
+        }
+    }
+
+    @Nested
+    inner class RuleExtraction {
+        @Test
+        fun `extracts preference patterns`() {
+            val result = UserProfileParser.parse("I prefer concise answers. Always use dark mode.")
+            assertEquals(2, result.rules.size)
+        }
+    }
+
+    @Nested
+    inner class FullProfile {
+        @Test
+        fun `parses realistic profile`() {
+            val text = """
+                My name is Nick. I'm a Kotlin developer based in Auckland, New Zealand.
+                I use a Samsung S23 Ultra. I use Home Assistant for solar monitoring.
+                I prefer concise code. Never use Java when Kotlin is available.
+                I work on an Android AI assistant called Kernel.
+            """.trimIndent()
+            val result = UserProfileParser.parse(text)
+            assertEquals("Nick", result.name)
+            assertEquals("Kotlin developer based in Auckland, New Zealand", result.role)
+            assertTrue(result.environment.isNotEmpty())
+            assertTrue(result.rules.isNotEmpty())
+        }
+
+        @Test
+        fun `empty text returns empty profile`() {
+            val result = UserProfileParser.parse("")
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class YamlSerialization {
+        @Test
+        fun `toJson produces valid JSON`() {
+            val original = UserProfileYaml(
+                name = "Nick",
+                role = "developer",
+                environment = listOf("Samsung S23"),
+                context = listOf("Works on Kernel AI"),
+                rules = listOf("Prefer concise code"),
+            )
+            val json = original.toJson()
+            assertTrue(json.contains("\"name\":\"Nick\""))
+            assertTrue(json.contains("\"role\":\"developer\""))
+            assertTrue(json.contains("\"environment\":[\"Samsung S23\"]"))
+        }
+
+        @Test
+        fun `toYaml produces compact format`() {
+            val profile = UserProfileYaml(
+                name = "Nick",
+                role = "Kotlin developer",
+                rules = listOf("Prefer concise code"),
+            )
+            val yaml = profile.toYaml()
+            assertTrue(yaml.contains("name: Nick"))
+            assertTrue(yaml.contains("role: Kotlin developer"))
+            assertTrue(yaml.contains("  - Prefer concise code"))
+        }
+
+        @Test
+        fun `empty profile produces empty yaml`() {
+            val profile = UserProfileYaml()
+            assertTrue(profile.isEmpty())
+            assertEquals("", profile.toYaml())
+        }
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -119,14 +119,19 @@ peak. The service stops automatically once `InferenceEngine.isReady` becomes tru
 ### 3.2 Prompt Assembly Order
 
 ```
-[System Prompt]          ← persona, date/time, runtime info
-[User Profile]           ← always injected (structured identity fields)
-[Core Memories]          ← permanent facts (CORE_MAX_DISTANCE=1.10, topK=10)
+[System Prompt]          ← persona (FULL ~200t / MINIMAL ~25t), date/time
+[User Profile]           ← structured YAML injection (name, role, environment, context, rules)
+[Core Memories]          ← permanent facts split by category:
+                           user (topK=8), agent_identity (topK=2)
+                           CORE_MAX_DISTANCE=1.10
 [Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=1.10, topK=3)
 [Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=1.10, topK=5)
 [Conversation Window]    ← selected recent turns (75% token budget)
 [Current User Message]   ← with RAG context prepended
 ```
+
+**Identity tiers:** `IdentityTier.FULL` (Chat) includes greeting, vocab phrases, profile, and history.
+`IdentityTier.MINIMAL` (Actions tab) uses a slim ~25-token prompt with no profile/history.
 
 All three memory sections are conditionally included — omitted entirely if no results meet their distance threshold. Token budget is allocated sequentially: Core → Episodic → Message History.
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -36,6 +37,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -64,6 +66,7 @@ import java.util.Locale
 fun ActionsScreen(
     autoOpenSheet: Boolean = false,
     onNavigateToChat: (query: String) -> Unit = {},
+    onNewConversation: () -> Unit = {},
     viewModel: ActionsViewModel = hiltViewModel(),
 ) {
     val actions by viewModel.actions.collectAsStateWithLifecycle()
@@ -103,10 +106,21 @@ fun ActionsScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { showBottomSheet = true },
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Icon(Icons.Default.Bolt, contentDescription = "Run quick action")
+                SmallFloatingActionButton(
+                    onClick = onNewConversation,
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = "New conversation")
+                }
+                FloatingActionButton(
+                    onClick = { showBottomSheet = true },
+                ) {
+                    Icon(Icons.Default.Bolt, contentDescription = "Run quick action")
+                }
             }
         },
     ) { innerPadding ->

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -8,9 +8,11 @@ import com.kernel.ai.core.inference.ContextWindowManager
 import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.inference.GenerationResult
+import com.kernel.ai.core.inference.IdentityTier
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.inference.JandalPersona
 import com.kernel.ai.core.inference.LlmDispatcher
+import com.kernel.ai.core.inference.MINIMAL_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.ModelConfig
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
@@ -211,7 +213,7 @@ class ChatViewModel @Inject constructor(
             jandalPersona.truths.forEach { truth ->
                 val vector = embeddingEngine.embed(truth).takeIf { it.isNotEmpty() }
                     ?: return@forEach  // skip if engine not ready
-                memoryRepository.addCoreMemory(truth, source = "jandal_persona", embeddingVector = vector)
+                memoryRepository.addCoreMemory(truth, source = "jandal_persona", embeddingVector = vector, category = "agent_identity")
             }
             jandalPersona.markTruthsSeeded()
             Log.i("ChatViewModel", "Seeded ${jandalPersona.truths.size} Kiwi truths into core memory")
@@ -221,6 +223,7 @@ class ChatViewModel @Inject constructor(
     private suspend fun buildSystemPrompt(
         historyTurns: List<Pair<String, String>> = emptyList(),
         isFirstReply: Boolean = _messages.value.none { it.role == ChatMessage.Role.ASSISTANT },
+        identityTier: IdentityTier = IdentityTier.FULL,
     ): String {
         val profile = userProfileRepository.get()
         val now = LocalDateTime.now()
@@ -229,26 +232,36 @@ class ChatViewModel @Inject constructor(
         // when generating calendar event dates without having to reformat the year.
         val isoDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
         return buildString {
-            append(DEFAULT_SYSTEM_PROMPT)
-            append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = isFirstReply)} ${jandalPersona.buildSessionVocab()}")
-            append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
-            // Runtime info fetched dynamically via get_system_info skill at query time
-            if (profile.isNotBlank()) {
-                // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
-                // The original stored profile is never modified — only the injected copy is shortened.
-                val contextWindowSize = activeModel?.let { model ->
-                    modelSettingsRepository.getSettings(model.modelId).contextWindowSize
-                } ?: 4096
-                val maxProfileChars = modelSettingsRepository.getMaxUserProfileChars(contextWindowSize)
-                val injectedProfile = profile.take(maxProfileChars)
-                append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$injectedProfile")
-            }
-            if (historyTurns.isNotEmpty()) {
-                append("\n\n[Previous conversation context]\n")
-                for ((user, assistant) in historyTurns) {
-                    append("User: $user\nAssistant: $assistant\n")
+            when (identityTier) {
+                IdentityTier.FULL -> {
+                    append(DEFAULT_SYSTEM_PROMPT)
+                    append("\n\n${jandalPersona.buildGreetingInstruction(isFirstReply = isFirstReply)} ${jandalPersona.buildSessionVocab()}")
                 }
-                append("[End of previous conversation context]")
+                IdentityTier.MINIMAL -> {
+                    append(MINIMAL_SYSTEM_PROMPT)
+                }
+            }
+            append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
+            // Skip profile and history for minimal (Actions) tier to save tokens
+            if (identityTier == IdentityTier.FULL) {
+                // Runtime info fetched dynamically via get_system_info skill at query time
+                if (profile.isNotBlank()) {
+                    // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
+                    // The original stored profile is never modified — only the injected copy is shortened.
+                    val contextWindowSize = activeModel?.let { model ->
+                        modelSettingsRepository.getSettings(model.modelId).contextWindowSize
+                    } ?: 4096
+                    val maxProfileChars = modelSettingsRepository.getMaxUserProfileChars(contextWindowSize)
+                    val injectedProfile = profile.take(maxProfileChars)
+                    append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$injectedProfile")
+                }
+                if (historyTurns.isNotEmpty()) {
+                    append("\n\n[Previous conversation context]\n")
+                    for ((user, assistant) in historyTurns) {
+                        append("User: $user\nAssistant: $assistant\n")
+                    }
+                    append("[End of previous conversation context]")
+                }
             }
             // Native tool calling pipeline (Google Gallery pattern).
             // Tool declarations are auto-generated by the SDK from @Tool annotations — no need

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -244,16 +244,18 @@ class ChatViewModel @Inject constructor(
             append("\n\n[Current date and time]\n$dateTime (ISO: $isoDate)")
             // Skip profile and history for minimal (Actions) tier to save tokens
             if (identityTier == IdentityTier.FULL) {
-                // Runtime info fetched dynamically via get_system_info skill at query time
-                if (profile.isNotBlank()) {
-                    // Truncate profile to context-window-aware budget (10% of context window, max 3000 chars).
-                    // The original stored profile is never modified — only the injected copy is shortened.
+                // Prefer structured YAML injection (compact, ~200 tokens) over raw text (~750 tokens).
+                val structured = userProfileRepository.getStructured()
+                if (structured != null && !structured.isEmpty()) {
+                    append("\n\n[User Profile]\n${structured.toYaml()}")
+                } else if (profile.isNotBlank()) {
+                    // Fallback to raw text if no structured data yet
                     val contextWindowSize = activeModel?.let { model ->
                         modelSettingsRepository.getSettings(model.modelId).contextWindowSize
                     } ?: 4096
                     val maxProfileChars = modelSettingsRepository.getMaxUserProfileChars(contextWindowSize)
                     val injectedProfile = profile.take(maxProfileChars)
-                    append("\n\nThe following is background context about the user — use it to personalise responses:\n\n[User Profile]\n$injectedProfile")
+                    append("\n\n[User Profile]\n$injectedProfile")
                 }
                 if (historyTurns.isNotEmpty()) {
                     append("\n\n[Previous conversation context]\n")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -25,13 +28,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.profile.UserProfileYaml
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +44,7 @@ fun UserProfileScreen(
     viewModel: UserProfileViewModel = hiltViewModel(),
 ) {
     val savedProfile by viewModel.profileText.collectAsStateWithLifecycle()
+    val structured by viewModel.structuredProfile.collectAsStateWithLifecycle()
 
     // Local edit buffer — initialised from saved value.
     var editText by rememberSaveable(savedProfile) { mutableStateOf(savedProfile) }
@@ -118,7 +123,81 @@ fun UserProfileScreen(
                 }
             }
 
+            // Structured preview — shows parsed fields from the saved profile
+            AnimatedVisibility(visible = structured != null && !structured!!.isEmpty()) {
+                StructuredProfileCard(profile = structured!!)
+            }
+
             Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun StructuredProfileCard(profile: UserProfileYaml) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "Parsed Profile",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            profile.name?.let { FieldRow("Name", it) }
+            profile.role?.let { FieldRow("Role", it) }
+
+            if (profile.environment.isNotEmpty()) {
+                FieldList("Environment", profile.environment)
+            }
+            if (profile.context.isNotEmpty()) {
+                FieldList("Context", profile.context)
+            }
+            if (profile.rules.isNotEmpty()) {
+                FieldList("Preferences", profile.rules)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FieldRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "$label: ",
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun FieldList(label: String, items: List<String>) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        items.forEach { item ->
+            Text(
+                text = "  • $item",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 8.dp),
+            )
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/UserProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.profile.UserProfileYaml
 import com.kernel.ai.core.memory.repository.UserProfileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,6 +23,13 @@ class UserProfileViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = "",
+        )
+
+    val structuredProfile: StateFlow<UserProfileYaml?> = repository.observeStructured()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null,
         )
 
     fun save(text: String) {


### PR DESCRIPTION
## Summary

Bundled implementation of three related items that all touch the system prompt pipeline:

### Token Strategy (#367)
- **Slim system prompt**: `DEFAULT_SYSTEM_PROMPT` reduced from ~377 to ~200 tokens
- **Tiered identity**: `IdentityTier.FULL` (Chat) vs `MINIMAL` (Actions tab, ~25 tokens)
- **Phrase rotation**: Session vocab reduced from 4→2 with LRU cooldown
- **NZ knowledge separation**: Core memories now have `category` field (`user` vs `agent_identity`) with split topK (8 user + 2 identity) so NZ trivia doesn't displace user context in RAG

### Structured User Profile (#374)
- **Data model**: `UserProfileYaml` with name, role, environment, context, rules fields
- **Heuristic parser**: `UserProfileParser` extracts structured data from free-text on save (regex-based, runs instantly)
- **Dual UI**: Structured preview card below free-text editor with AnimatedVisibility
- **YAML injection**: `buildSystemPrompt()` prefers compact YAML (~100-200t) over raw text (~750t)

### FAB Consistency
- Stacked FABs on Actions screen: `SmallFloatingActionButton` (new conversation) above primary ⚡ bolt FAB
- Wired through KernelNavHost navigation

### Token Budget Impact
| Component | Before | After | Saving |
|-----------|--------|-------|--------|
| Identity prompt | ~377t | ~200t | -177t |
| Greeting + vocab | ~130t | ~80t | -50t |
| User profile | ~750t | ~200t | -550t |
| **Total** | ~1,257t | ~480t | **~62% reduction** |

### Database Migrations
- **9→10**: `category TEXT` column on `core_memories` + reclassify `jandal_persona` entries
- **10→11**: `structuredJson TEXT` column on `user_profile`

### Tests
- 13 new unit tests for `UserProfileParser` and `UserProfileYaml`
- Build passes, pre-existing test failures unchanged

Closes #367, closes #374