### PR TITLE
feat: topK setting + thinking display toggle (#342/#343 partial)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -337,7 +337,7 @@ class LiteRtInferenceEngine @Inject constructor(
     ): ConversationConfig {
         // NPU uses hardware sampler — setting SamplerConfig causes a crash
         val samplerConfig = if (backendType == BackendType.NPU) null else SamplerConfig(
-            topK = 40,
+            topK = config.topK,
             topP = config.topP.toDouble(),
             temperature = config.temperature.toDouble(),
         )

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -48,6 +48,7 @@ enum class IdentityTier {
  * @param systemPrompt Optional system instruction prepended to every conversation.
  * @param temperature Sampling temperature (0.1-2.0). Higher = more creative. Default 1.0.
  * @param topP Nucleus sampling threshold (0.0-1.0). Default 0.95.
+ * @param topK Top-K candidates for sampling. Ignored on NPU (hardware sampler). Default 40.
  * @param toolProvider Optional [ToolProvider] wrapping a [ToolSet] for native SDK tool calling.
  */
 data class ModelConfig(
@@ -57,5 +58,6 @@ data class ModelConfig(
     val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
     val temperature: Float = 1.0f,
     val topP: Float = 0.95f,
+    val topK: Int = 40,
     val toolProvider: ToolProvider? = null,
 )

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/12.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/12.json
@@ -1,0 +1,476 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "2394774d362c9f89a1b8cb6a3ce35ade",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2394774d362c9f89a1b8cb6a3ce35ade')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -33,7 +33,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -122,6 +122,14 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_10_11 = object : Migration(10, 11) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE user_profile ADD COLUMN structuredJson TEXT DEFAULT NULL")
+            }
+        }
+
+        /** Adds topK and showThinkingProcess columns to model_settings (#342/#343). */
+        val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE model_settings ADD COLUMN topK INTEGER NOT NULL DEFAULT 40")
+                db.execSQL("ALTER TABLE model_settings ADD COLUMN showThinkingProcess INTEGER NOT NULL DEFAULT 1")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -54,6 +54,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_8_9,
                     KernelDatabase.MIGRATION_9_10,
                     KernelDatabase.MIGRATION_10_11,
+                    KernelDatabase.MIGRATION_11_12,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
@@ -16,5 +16,9 @@ data class ModelSettingsEntity(
     val contextWindowSize: Int,
     val temperature: Float,
     val topP: Float,
+    /** Top-K candidates to sample from. Ignored when backend is NPU (hardware sampler). */
+    val topK: Int = 40,
+    /** Whether to display the model's internal reasoning (thinking tokens) in the chat UI. */
+    val showThinkingProcess: Boolean = true,
     val updatedAt: Long = System.currentTimeMillis(),
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
@@ -36,6 +36,8 @@ class ModelSettingsRepositoryImpl @Inject constructor(
             contextWindowSize = defaultContextWindow,
             temperature = 1.0f,
             topP = 0.95f,
+            topK = 40,
+            showThinkingProcess = true,
             updatedAt = System.currentTimeMillis(),
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -256,6 +256,7 @@ private fun ChatContent(
                             MessageBubble(
                                 message = message,
                                 onCopy = { content -> onCopyMessage(content) },
+                                showThinkingProcess = state.showThinkingProcess,
                             )
                         }
                         if (state.isLoadingModel) {
@@ -378,6 +379,7 @@ private fun ChatContent(
 private fun MessageBubble(
     message: ChatMessage,
     onCopy: (String) -> Unit,
+    showThinkingProcess: Boolean = true,
 ) {
     val isUser = message.role == ChatMessage.Role.USER
     val bubbleColor = if (isUser) {
@@ -403,7 +405,7 @@ private fun MessageBubble(
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
     ) {
         // Thinking text (collapsed, italics)
-        if (!message.thinkingText.isNullOrBlank()) {
+        if (showThinkingProcess && !message.thinkingText.isNullOrBlank()) {
             Text(
                 text = "Thinking…",
                 style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -121,6 +121,7 @@ class ChatViewModel @Inject constructor(
 
     /** True while Gemma-4 is being lazily initialised in response to a [sendMessage] call. */
     private val _isLoadingModel = MutableStateFlow(false)
+    private val _showThinkingProcess = MutableStateFlow(true)
 
     /** Ensures at most one concurrent Gemma-4 initialisation attempt. */
     private val gemma4InitMutex = Mutex()
@@ -156,7 +157,8 @@ class ChatViewModel @Inject constructor(
         engineState,
         downloadManager.downloadStates,
         inputState,
-    ) { engine, downloadStates, input ->
+        _showThinkingProcess,
+    ) { engine, downloadStates, input, showThinking ->
         val allDownloaded = downloadManager.areRequiredModelsDownloaded()
         val tier = downloadManager.deviceTier
         val displayModels: List<KernelModel> = if (tier == HardwareTier.FLAGSHIP) {
@@ -188,6 +190,7 @@ class ChatViewModel @Inject constructor(
                 inputText = input.inputText,
                 error = input.error,
                 isLoadingModel = engine.isLoadingModel,
+                showThinkingProcess = showThinking,
             )
         }
     }.stateIn(
@@ -380,12 +383,14 @@ class ChatViewModel @Inject constructor(
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 activeContextWindowSize = settings.contextWindowSize
+                _showThinkingProcess.value = settings.showThinkingProcess
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
                     maxTokens = settings.contextWindowSize,
                     temperature = settings.temperature,
                     topP = settings.topP,
+                    topK = settings.topK,
                     toolProvider = toolProvider,
                 ))
                 estimatedTokensUsed = 0
@@ -423,12 +428,14 @@ class ChatViewModel @Inject constructor(
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 activeContextWindowSize = settings.contextWindowSize
+                _showThinkingProcess.value = settings.showThinkingProcess
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
                     maxTokens = settings.contextWindowSize,
                     temperature = settings.temperature,
                     topP = settings.topP,
+                    topK = settings.topK,
                     toolProvider = toolProvider,
                 ))
                 estimatedTokensUsed = 0

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -14,6 +14,8 @@ sealed interface ChatUiState {
         val inputText: String,
         val error: String?,
         val isLoadingModel: Boolean = false,
+        /** Whether to show the model's thinking process tokens in the chat UI. */
+        val showThinkingProcess: Boolean = true,
     ) : ChatUiState
 
     /** Models need to be downloaded before chatting. */

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -92,6 +94,7 @@ fun ModelSettingsScreen(
                 ModelCard(
                     modelName = "Gemma 4 E-4B",
                     settings = settings,
+                    isThinkingCapable = true,
                     onSettingsChanged = viewModel::updateE4bSettings,
                     onReset = viewModel::resetE4bToDefaults,
                 )
@@ -134,6 +137,7 @@ fun ModelSettingsScreen(
 private fun ModelCard(
     modelName: String,
     settings: ModelSettingsEntity,
+    isThinkingCapable: Boolean = false,
     onSettingsChanged: (ModelSettingsEntity) -> Unit,
     onReset: () -> Unit,
 ) {
@@ -194,6 +198,44 @@ private fun ModelCard(
                 onSettingsChanged(settings.copy(topP = (newVal * 20).roundToInt() / 20f))
             },
         )
+
+        // Top-K
+        SliderRow(
+            label = "Top-K",
+            valueLabel = "${settings.topK}",
+            value = settings.topK.toFloat(),
+            valueRange = 1f..100f,
+            steps = 98,
+            isInteger = true,
+            onValueChangeFinished = { newVal ->
+                onSettingsChanged(settings.copy(topK = newVal.roundToInt()))
+            },
+        )
+
+        // Thinking toggle — only shown for models that produce thinking tokens (E-4B)
+        if (isThinkingCapable) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Show thinking process",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "Display the model's internal reasoning in chat",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = settings.showThinkingProcess,
+                    onCheckedChange = { onSettingsChanged(settings.copy(showThinkingProcess = it)) },
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
## Summary

Implements configurable topK sampling and a soft thinking display toggle.

### #342 — topK setting (fully implemented)
- Added `topK: Int = 40` to `ModelSettingsEntity` with Room migration 11→12
- Added `topK` field to `ModelConfig` data class
- `LiteRtInferenceEngine` now reads `topK` from `ModelConfig` instead of hardcoded 40
- Both `ChatViewModel` init paths (`initFastActions` + `initGemma4`) pass `topK` from settings
- `ModelSettingsScreen`: topK slider (range 1–100) for both E-2B and E-4B

### #343 — Thinking display toggle (soft, UI-only)
- Added `showThinkingProcess: Boolean = true` to `ModelSettingsEntity`
- `ChatViewModel` exposes `_showThinkingProcess: MutableStateFlow<Boolean>` loaded from settings at model init
- `ChatUiState.Ready` includes `showThinkingProcess` field
- `ChatScreen.MessageBubble` conditionally shows thinking label based on this flag
- `ModelSettingsScreen`: 'Show thinking process' toggle visible only on E-4B card (`isThinkingCapable = true`)

> **Note**: True thinking budget/enable control is parked — LiteRT-LM 0.10.0 SDK has no `ThinkingConfig` API. Thinking mode is model-driven (Gemma-4 decides). This toggle only controls whether the UI renders the thinking tokens that are already captured.

### DB change
Room version 11 → 12. Migration adds `topK INTEGER DEFAULT 40` and `showThinkingProcess INTEGER DEFAULT 1` to `model_settings` table.

Closes #342
Partial #343 (budget control pending SDK support)