### PR TITLE
fix: declare ACCESS_NOTIFICATION_POLICY and expose DND skill (#384)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <!-- Contact lookup for SMS, email, and call by name -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!-- Required to read/write the Do Not Disturb (interruption filter) policy -->
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
     <!--
         Android 11+ package visibility: declare which implicit intents we resolve

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -67,10 +67,10 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Execute a native Android device action such as toggling the flashlight, setting an alarm or timer, sending email/SMS, or creating a calendar event")
+    @Tool(description = "Execute a native Android device action such as toggling the flashlight, setting an alarm or timer, sending email/SMS, creating a calendar event, or toggling Do Not Disturb")
     fun runIntent(
-        @ToolParam(description = "The intent action: toggle_flashlight_on, toggle_flashlight_off, send_email, send_sms, set_alarm, set_timer, create_calendar_event") intentName: String,
-        @ToolParam(description = "Additional parameters as key:value pairs in JSON. For set_alarm: {\"time\":\"10pm\"} or {\"time\":\"7:30am\",\"day\":\"monday\",\"label\":\"Wake up\"}. For set_timer: {\"duration_seconds\":\"180\"}. For send_email: {\"subject\":\"Hi\",\"body\":\"Text\"}. For create_calendar_event: {\"title\":\"Meeting\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}") parameters: String,
+        @ToolParam(description = "The intent action: toggle_flashlight_on, toggle_flashlight_off, send_email, send_sms, set_alarm, set_timer, create_calendar_event, toggle_dnd_on, toggle_dnd_off") intentName: String,
+        @ToolParam(description = "Additional parameters as key:value pairs in JSON. For set_alarm: {\"time\":\"10pm\"} or {\"time\":\"7:30am\",\"day\":\"monday\",\"label\":\"Wake up\"}. For set_timer: {\"duration_seconds\":\"180\"}. For send_email: {\"subject\":\"Hi\",\"body\":\"Text\"}. For create_calendar_event: {\"title\":\"Meeting\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}. For toggle_dnd_on/off: {}") parameters: String,
     ): Map<String, String> {
         toolCalledInThisTurn = true
         lastToolName = "run_intent"

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -25,7 +25,7 @@ class RunIntentSkill @Inject constructor(
     override val description =
         "Perform a native Android device action. Use for flashlight control, sending email, " +
             "sending SMS, setting an alarm (supports optional day name for tomorrow/weekday alarms), " +
-            "setting a countdown timer, or creating a calendar event. " +
+            "setting a countdown timer, creating a calendar event, or toggling Do Not Disturb mode. " +
             "For alarms: pass the time exactly as the user said it using the 'time' parameter (e.g. time:\"10pm\", time:\"9:30am\", time:\"22:00\"). " +
             "For calendar events, date accepts YYYY-MM-DD or relative terms like 'tomorrow', 'next wednesday'."
 
@@ -42,6 +42,8 @@ class RunIntentSkill @Inject constructor(
                     "set_alarm",
                     "set_timer",
                     "create_calendar_event",
+                    "toggle_dnd_on",
+                    "toggle_dnd_off",
                 ),
             ),
         ),
@@ -55,6 +57,8 @@ class RunIntentSkill @Inject constructor(
         "Set alarm Monday 7am → runIntent(intentName=\"set_alarm\", parameters='{\"time\":\"7am\",\"day\":\"monday\"}')",
         "Set timer 3min → runIntent(intentName=\"set_timer\", parameters='{\"duration_seconds\":\"180\"}')",
         "Calendar event → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Lunch\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}')",
+        "Turn on DND → runIntent(intentName=\"toggle_dnd_on\", parameters=\"{}\")",
+        "Turn off DND → runIntent(intentName=\"toggle_dnd_off\", parameters=\"{}\")",
     )
 
     override val fullInstructions: String = buildString {
@@ -63,7 +67,7 @@ class RunIntentSkill @Inject constructor(
         appendLine("Parameters (pass as JSON in the 'parameters' argument):")
         appendLine("- intent_name (required, string): The action to perform.")
         appendLine("  Options: toggle_flashlight_on, toggle_flashlight_off, send_email, send_sms,")
-        appendLine("           set_alarm, set_timer, create_calendar_event")
+        appendLine("           set_alarm, set_timer, create_calendar_event, toggle_dnd_on, toggle_dnd_off")
         appendLine("- time (string): Pass exactly as user said — e.g. \"10pm\", \"9:30am\", \"22:00\"")
         appendLine("- day (string): Optional day name — e.g. \"tomorrow\", \"monday\", \"next friday\"")
         appendLine("- label (string): Optional alarm label")
@@ -89,6 +93,12 @@ class RunIntentSkill @Inject constructor(
         appendLine("Resolve relative dates (tomorrow, next Friday) to YYYY-MM-DD. Pass time as HH:MM.")
         appendLine("NEVER confirm event was created without calling the tool.")
         appendLine("'remind me in X minutes/seconds' is set_timer, NOT create_calendar_event.")
+        appendLine()
+        appendLine("DND rule: 'turn on do not disturb', 'enable DND', 'silence notifications' →")
+        appendLine("runIntent with intentName=toggle_dnd_on.")
+        appendLine("'turn off do not disturb', 'disable DND', 'allow notifications again' →")
+        appendLine("runIntent with intentName=toggle_dnd_off.")
+        appendLine("If the app needs permission, it will open the settings page automatically.")
         appendLine()
         appendLine("Examples:")
         examples.forEach { appendLine("  $it") }


### PR DESCRIPTION
## Problem
"Turn on do not disturb" fails because:
1. `ACCESS_NOTIFICATION_POLICY` permission is not declared in `AndroidManifest.xml`, so Android rejects the `setInterruptionFilter()` call at runtime.
2. `toggle_dnd_on` / `toggle_dnd_off` are not listed in `RunIntentSkill.schema.enum` or any tool description — the model has no way to discover the DND capability.

## What was already correct
`NativeIntentHandler.setDoNotDisturb()` already:
- Checks `isNotificationPolicyAccessGranted`
- Opens `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` if access not granted
- Calls `setInterruptionFilter(INTERRUPTION_FILTER_NONE/ALL)` when granted

## Fix
1. **AndroidManifest.xml** — added `<uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />`
2. **RunIntentSkill** — added `toggle_dnd_on` and `toggle_dnd_off` to schema enum, skill description, examples list, and fullInstructions (including DND trigger phrases rule)
3. **KernelAIToolSet** — updated `runIntent` `@Tool` description and `intentName` `@ToolParam` to include DND actions

Closes #384