### PR TITLE
fix: exempt maths from conciseness rule to improve equation output (#371)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -9,6 +9,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "You're direct, warm, and dry-humoured without trying too hard. " +
         "You run entirely on-device — the user's data never leaves their phone. " +
         "Keep responses concise unless the user asks for detail. " +
+        "For maths or equations, show full working — never truncate calculations. " +
         "You are culturally Kiwi — from Aotearoa New Zealand. Named after jandals: simple, practical, unpretentious. " +
         "Own your Kiwi identity with pride — never say you are 'just code'. " +
         "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -9,7 +9,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "You're direct, warm, and dry-humoured without trying too hard. " +
         "You run entirely on-device — the user's data never leaves their phone. " +
         "Keep responses concise unless the user asks for detail. " +
-        "For maths or equations, show full working — never truncate calculations. " +
+        "When solving mathematical problems or deriving equations, show complete step-by-step working; for simple arithmetic, remain concise. " +
         "You are culturally Kiwi — from Aotearoa New Zealand. Named after jandals: simple, practical, unpretentious. " +
         "Own your Kiwi identity with pride — never say you are 'just code'. " +
         "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +
@@ -21,7 +21,8 @@ const val DEFAULT_SYSTEM_PROMPT =
  */
 const val MINIMAL_SYSTEM_PROMPT =
     "You are Jandal — a concise, on-device AI assistant from Aotearoa New Zealand. " +
-        "Be direct and brief. Report results only."
+        "Be direct and brief. Report results only. " +
+        "When solving mathematical problems or deriving equations, show complete step-by-step working."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000


### PR DESCRIPTION
## Problem
Issue #371 reports that the model outputs garbled/truncated LaTeX and equations. The system prompt contains:

> "Keep responses concise unless the user asks for detail."

This instruction, while correct for conversational responses, could cause the model to truncate mathematical working — especially for multi-step equations or LaTeX expressions that are inherently verbose.

## Context
- PR #382 reduced context usage by 62% (now merged), giving more token budget for math
- PR #341 (lazy skill loading) is merged — full context is available for non-tool turns

## Fix
Added "For maths or equations, show full working — never truncate calculations." immediately after the conciseness rule in `DEFAULT_SYSTEM_PROMPT`. This creates an explicit carve-out so the model knows mathematical output is not subject to the brevity instruction.

Note: Some LaTeX rendering issues may remain as an on-device quantised model capability ceiling — if garbled output persists after this change, that issue is beyond prompt-level fixes.

Closes #371