### PR TITLE
fix: force get_system_info for date/time queries instead of memory (#395)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -13,7 +13,8 @@ const val DEFAULT_SYSTEM_PROMPT =
         "You are culturally Kiwi — from Aotearoa New Zealand. Named after jandals: simple, practical, unpretentious. " +
         "Own your Kiwi identity with pride — never say you are 'just code'. " +
         "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +
-        "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'."
+        "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
+        "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information."
 
 /**
  * Minimal identity for tool-only execution (Actions tab).

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -250,6 +250,24 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
+        // Pattern: "what is today" / "what's today"
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """what(?:'s| is)\s+today""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        // Pattern: "what's today's date" / "what is today's date"
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """what(?:'s| is)\s+today'?s\s+(?:date|day)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
 
         // ── Volume ──
         IntentPattern(
@@ -400,10 +418,11 @@ class QuickIntentRouter(
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
         ),
         // Open app — "open YouTube" / "launch Spotify"
+        // Excludes timer/countdown phrases that start with "start" to prevent false matches
         IntentPattern(
             intentName = "open_app",
             regex = Regex(
-                """^(?:open|launch|start)\s+(?:the\s+)?(.+?)(?:\s+app)?$""",
+                """^(?:open|launch|start)\s+(?:the\s+)?(?!.*(?:count|timer|alarm))(.+?)(?:\s+app)?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("app_name" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -250,20 +250,20 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
+        // Pattern: "what's today's date" / "what is today's date" (must be before broader "what is today")
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """what(?:'s| is)\s+today'?s\s+(?:date|day)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
         // Pattern: "what is today" / "what's today"
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
                 """what(?:'s| is)\s+today""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { _, _ -> emptyMap() },
-        ),
-        // Pattern: "what's today's date" / "what is today's date"
-        IntentPattern(
-            intentName = "get_time",
-            regex = Regex(
-                """what(?:'s| is)\s+today'?s\s+(?:date|day)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -422,7 +422,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "open_app",
             regex = Regex(
-                """^(?:open|launch|start)\s+(?:the\s+)?(?!.*(?:count|timer|alarm))(.+?)(?:\s+app)?$""",
+                """^(?:open|launch|start)\s+(?:the\s+)?(?!(?:a\s+)?(?:count(?:down|ing)|timer|alarm)\b)(.+?)(?:\s+app)?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("app_name" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
@@ -36,7 +36,8 @@ class GetSystemInfoSkill @Inject constructor(
     override val name = "get_system_info"
     override val description =
         "Returns current device and model runtime information including hardware tier, " +
-            "available memory, battery level, active model, and current date/time."
+            "available memory, battery level, active model, and current date/time. " +
+            "ALWAYS use this tool for current date/time queries — never rely on memory or past conversations."
     override val schema = SkillSchema()
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1264,11 +1264,15 @@ class QuickIntentRouterTest {
             Arguments.of("what date is it today"),
             Arguments.of("tell me the time"),
             Arguments.of("give me the time"),
+            Arguments.of("what is today"),
+            Arguments.of("what's today"),
+            Arguments.of("what's today's date"),
+            Arguments.of("what is today's date"),
+            Arguments.of("what's today's day"),
         )
 
         @JvmStatic
         fun timeClassifierPhrases(): Stream<Arguments> = Stream.of(
-            Arguments.of("what's today's date"),
             Arguments.of("do you know the time"),
             Arguments.of("how late is it"),
             Arguments.of("current date and time"),


### PR DESCRIPTION
## Bug
When the user asks "What is today" or "What's today's date", the model retrieves the date from stale memory/past conversations instead of calling the `get_system_info` tool with `type=datetime`. The response says "The date I have on record from our previous chats is Wednesday, 15 April 207" — wrong year (207 instead of 2026), and sourced from memory instead of live system info.

## Root Causes Fixed
1. **System prompt** didn't instruct the model to prioritize `get_system_info` for date/time queries
2. **QuickIntentRouter** regex patterns missed "what is today" and "what's today's date" variants
3. **open_app regex** was too greedy, matching timer phrases like "start counting down"

## Changes
### ModelConfig.kt
- Added explicit instruction: "For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information."

### GetSystemInfoSkill.kt
- Updated description to emphasize: "ALWAYS use this tool for current date/time queries — never rely on memory or past conversations."

### QuickIntentRouter.kt
- Added 2 new regex patterns:
  - `what(?:'s| is)\s+today` → matches "what is today", "what's today"
  - `what(?:'s| is)\s+today'?s\s+(?:date|day)` → matches "what's today's date", "what is today's date"
- Fixed `open_app` regex to exclude timer/countdown keywords using negative lookahead:
  - Changed from: `^(?:open|launch|start)\s+(?:the\s+)?(.+?)(?:\s+app)?$`
  - Prevents "start counting down" from matching as "open app: counting down"

### QuickIntentRouterTest.kt
- Moved "what's today's date" from `timeClassifierPhrases` to `timeRegexPhrases`
- Added test coverage for "what is today", "what's today", "what is today's date", "what's today's day"

## Testing
✅ All 301 unit tests passing
```
./gradlew :core:skills:testDebugUnitTest --no-daemon
BUILD SUCCESSFUL
```

## Impact
- **QuickIntentRouter** now catches date queries at Tier 2 (<30ms) instead of falling through to E4B (~2s)
- **Model** has clear guidance to never use memory for current date/time
- **Users** get accurate, live date/time from system instead of stale memory

Fixes #395