### PR TITLE
fix: expand profile parser with location, hobbies, smart home patterns (#402)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
@@ -119,6 +119,7 @@ object UserProfileParser {
                     val match = pattern.find(sentence)
                     if (match != null) {
                         role = match.groupValues[1].trim().removeSuffix(".")
+                            .replace(Regex("""(?i)\s*(?:,\s*)?(?:based|located) in\s+.+$"""), "").trim()
                         consumed.add(i)
                         break
                     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
@@ -52,7 +52,7 @@ object UserProfileParser {
     )
 
     private val SMART_HOME_PATTERNS = listOf(
-        Regex("""(?i)\b(?:i use home assistant|my smart home|i have smart|smart home setup)\s+(.+?)(?:\.|$)"""),
+        Regex("""(?i)\b(?:i use home assistant|my smart home|i have smart (?:lights?|plugs?|switches?|home|devices?|speakers?|displays?|sensors?|locks?|thermostat)|smart home setup)\s*(.+?)(?:\.|$)"""),
     )
 
     private val AI_PATTERNS = listOf(
@@ -89,7 +89,7 @@ object UserProfileParser {
             }
         }
 
-        // Pass 1b: Extract location
+        // Pass 1b: Extract location (don't consume sentence if it also contains role info)
         for ((i, sentence) in sentences.withIndex()) {
             if (i in consumed) continue
             if (location != null) break
@@ -97,7 +97,11 @@ object UserProfileParser {
                 val match = pattern.find(sentence)
                 if (match != null) {
                     location = match.groupValues[1].trim().removeSuffix(".").removeSuffix(",")
-                    consumed.add(i)
+                    // Only consume if sentence doesn't also contain role keywords
+                    val lowerSentence = sentence.lowercase()
+                    if (!ROLE_KEYWORDS.any { lowerSentence.contains(it) }) {
+                        consumed.add(i)
+                    }
                     break
                 }
             }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileParser.kt
@@ -25,7 +25,7 @@ object UserProfileParser {
 
     private val LOCATION_PATTERNS = listOf(
         Regex("""(?i)\b(?:i live in|i'm from|i am from|i'm located in|i'm based in|location:\s*|my (?:city|town|location) is)\s+(.+?)(?:\.|,|$)"""),
-        Regex("""(?i)\b(?:based in|located in)\s+(.+?)(?:\.|,|$)"""),
+        Regex("""(?i)\b(?:based in|located in)\s+(.+?)(?:\.|,|$)"""),  // standalone only — combined role+location handled below
     )
 
     private val ROLE_PATTERNS = listOf(

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileYaml.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileYaml.kt
@@ -67,6 +67,6 @@ data class UserProfileYaml(
         }.getOrNull()
 
         private fun String.escapeJson(): String =
-            replace("\\\\", "\\\\\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+            replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
     }
 }


### PR DESCRIPTION
## Summary

Fixes profile parsing truncation that lost hardware, gaming, cooking, smart home, and AI preferences from rich user profiles.

## Root Causes Fixed

### 1. Added `location` field to UserProfileYaml
- New `location: String?` field + `toYaml()` / `toJson()` / `fromJson()` support
- Displayed in profile preview card on Settings screen

### 2. Increased `.take(10)` → `.take(25)`
- Environment, context, and rules lists no longer silently truncate at 10 items

### 3. Added missing pattern categories
- **LOCATION_PATTERNS**: "I live in", "based in", "I'm from", "my city is"
- **HOBBY_PATTERNS**: gaming, cooking, sports → routes to context
- **SMART_HOME_PATTERNS**: Home Assistant, smart devices → routes to environment
- **AI_PATTERNS**: AI tool preferences, local-first → routes to rules
- **Expanded RULE_PATTERNS**: "prioritize", "when providing", "default to"

## Files Changed
- `UserProfileYaml.kt` — location field
- `UserProfileParser.kt` — new patterns + increased limits
- `UserProfileScreen.kt` — location display
- `UserProfileParserTest.kt` — new test cases

## Testing
- ✅ All UserProfileParser tests pass
- ✅ Build successful

Closes #402