### PR TITLE
feat: wire thinking toggle to LiteRT-LM Channel API (#343)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -13,6 +13,7 @@ import com.google.ai.edge.litertlm.EngineConfig
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.MessageCallback
 import com.google.ai.edge.litertlm.SamplerConfig
+import com.google.ai.edge.litertlm.Channel
 import com.google.ai.edge.litertlm.ExperimentalApi
 import com.google.ai.edge.litertlm.ExperimentalFlags
 import com.google.ai.edge.litertlm.ToolProvider
@@ -347,6 +348,15 @@ class LiteRtInferenceEngine @Inject constructor(
 
         val tools = config.toolProvider?.let { listOf(it) } ?: emptyList()
 
+        // When thinking is enabled, register the thought channel so the model emits
+        // chain-of-thought tokens via message.channels["thought"]. Omitting the channel
+        // disables thinking entirely — the model skips reasoning and responds directly.
+        val channels = if (config.thinkingEnabled) {
+            listOf(Channel("thought", "<|think|>", "<|/think|>"))
+        } else {
+            emptyList()
+        }
+
         // Enable constrained decoding for well-formed tool calls (Google Gallery pattern).
         // Must be set before createConversation() and reset after via resetConstrainedDecodingFlag().
         if (tools.isNotEmpty()) {
@@ -357,6 +367,7 @@ class LiteRtInferenceEngine @Inject constructor(
             samplerConfig = samplerConfig,
             systemInstruction = systemInstruction,
             tools = tools,
+            channels = channels,
         )
     }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -52,6 +52,9 @@ enum class IdentityTier {
  * @param temperature Sampling temperature (0.1-2.0). Higher = more creative. Default 1.0.
  * @param topP Nucleus sampling threshold (0.0-1.0). Default 0.95.
  * @param topK Top-K candidates for sampling. Ignored on NPU (hardware sampler). Default 40.
+ * @param thinkingEnabled Whether to enable the model's thinking (chain-of-thought) channel.
+ *   When false, the `thought` channel is omitted from [ConversationConfig], preventing the
+ *   model from generating reasoning tokens — saving compute time and context window space.
  * @param toolProvider Optional [ToolProvider] wrapping a [ToolSet] for native SDK tool calling.
  */
 data class ModelConfig(
@@ -62,5 +65,6 @@ data class ModelConfig(
     val temperature: Float = 1.0f,
     val topP: Float = 0.95f,
     val topK: Int = 40,
+    val thinkingEnabled: Boolean = true,
     val toolProvider: ToolProvider? = null,
 )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -391,6 +391,7 @@ class ChatViewModel @Inject constructor(
                     temperature = settings.temperature,
                     topP = settings.topP,
                     topK = settings.topK,
+                    thinkingEnabled = settings.showThinkingProcess,
                     toolProvider = toolProvider,
                 ))
                 estimatedTokensUsed = 0
@@ -436,6 +437,7 @@ class ChatViewModel @Inject constructor(
                     temperature = settings.temperature,
                     topP = settings.topP,
                     topK = settings.topK,
+                    thinkingEnabled = settings.showThinkingProcess,
                     toolProvider = toolProvider,
                 ))
                 estimatedTokensUsed = 0

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelSettingsScreen.kt
@@ -221,11 +221,11 @@ private fun ModelCard(
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Show thinking process",
+                        text = "Thinking mode",
                         style = MaterialTheme.typography.bodyMedium,
                     )
                     Text(
-                        text = "Display the model's internal reasoning in chat",
+                        text = "Enable chain-of-thought reasoning. Disabling saves tokens and speeds up responses.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )


### PR DESCRIPTION
## Summary

Connects the existing `showThinkingProcess` UI toggle to the LiteRT-LM inference engine via the **Channel API**. Previously the toggle only hid/showed thinking tokens in the chat UI — the model still generated them. Now, disabling thinking actually prevents the model from generating reasoning tokens.

## What changed

| File | Change |
|------|--------|
| `ModelConfig.kt` | Added `thinkingEnabled: Boolean = true` parameter |
| `LiteRtInferenceEngine.kt` | Import `Channel`, conditionally register `Channel("thought", "<\|think\|>", "<\|/think\|>")` in `buildConversationConfig()` |
| `ChatViewModel.kt` | Pass `settings.showThinkingProcess` → `ModelConfig.thinkingEnabled` at both init sites |
| `ModelSettingsScreen.kt` | Updated label to "Thinking mode" with engine-level description |

## How it works

LiteRT-LM 0.10.0's `ConversationConfig` accepts a `channels: List<Channel>` parameter. Each `Channel(name, startToken, endToken)` declares a named output stream. Gemma 4 uses `<|think|>...<|/think|>` for reasoning.

- **Toggle ON:** `channels = listOf(Channel("thought", "<|think|>", "<|/think|>"))` → model reasons, tokens routed via `message.channels["thought"]`
- **Toggle OFF:** `channels = emptyList()` → model skips reasoning entirely

## Benefits of engine-level control
- ⚡ Faster TTFT (no reasoning phase)
- 📉 Lower token usage (reasoning tokens not generated)
- 🔋 Battery savings on constrained devices

## Testing
- Build passes (`assembleDebug`)
- Requires on-device verification with Gemma 4 E-4B model

Closes #343