### PR TITLE
fix: expand compact time formats in resolveTime ("630am" → "6:30am")

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -732,8 +732,15 @@ class NativeIntentHandler @Inject constructor(
     private fun resolveTime(timeStr: String): LocalTime? {
         val raw = timeStr.trim()
 
+        // 0. Expand compact formats before any other normalisation.
+        //    "630am" → "6:30am", "630" → "6:30", "0630" → "06:30", "1245pm" → "12:45pm"
+        val expanded = Regex("""^(\d{1,2})(\d{2})\s*(am|pm|AM|PM)?$""").replace(raw) { m ->
+            val meridiem = m.groupValues[3]
+            "${m.groupValues[1]}:${m.groupValues[2]}${meridiem}"
+        }
+
         // 1. Strip extra trailing digits after a valid HH:mm prefix (e.g. "18:0000" → "18:00").
-        val stripped = Regex("""^(\d{1,2}:\d{2})\d+(.*)$""").replace(raw) { m ->
+        val stripped = Regex("""^(\d{1,2}:\d{2})\d+(.*)$""").replace(expanded) { m ->
             m.groupValues[1] + m.groupValues[2]
         }
 
@@ -763,7 +770,7 @@ class NativeIntentHandler @Inject constructor(
                 return LocalTime.parse(input, fmt)
             } catch (_: DateTimeParseException) { /* try next */ }
         }
-        Log.w(TAG, "resolveTime: could not parse '$raw' (normalized to '$input')")
+        Log.w(TAG, "resolveTime: could not parse '$raw' (expanded='$expanded', normalized='$input')")
         return null
     }
 }


### PR DESCRIPTION
## Problem

`resolveTime("630am")` returned `null` — the compact 3-digit format had no handler. The alarm silently fell back to the 8:00am default, and the model's confirmation echoed the malformed input as `"6:3000 am"`.

## Fix

Add a step 0 to `resolveTime()` that expands compact formats before the existing normalisation pipeline:

| Input | Expanded |
|-------|---------|
| `630am` | `6:30am` |
| `630` | `6:30` |
| `0630` | `06:30` |
| `1245pm` | `12:45pm` |

The existing steps 1–3 (strip extra digits, pad single-digit minute, insert :00 for bare hour) then handle the expanded string normally.

## Testing

- `"wake me up at 630am"` → alarm set at 06:30, confirmation shows 06:30
- `"set alarm for 930"` → alarm set at 09:30
- `"alarm at 1245pm"` → alarm set at 12:45 PM
- Existing formats unaffected (`"10pm"`, `"9:30am"`, `"22:00"`)

Closes #385