### PR TITLE
fix: correct digit-truncated percentages from Tier 2 skill results

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -740,9 +740,9 @@ class ChatViewModel @Inject constructor(
                                     contextWindowManager.estimateTokens(resultContent)
                                 needsHistoryReplay = true
                             } else {
-                                // Normal text response
+                                // Normal text response — write corrected content to UI state
                                 _messages.update { msgs ->
-                                    msgs.map { if (it.id == assistantMsgId) it.copy(isStreaming = false) else it }
+                                    msgs.map { if (it.id == assistantMsgId) it.copy(content = fullContent, isStreaming = false) else it }
                                 }
                                 val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", fullContent, thinking)
                                 ragRepository.indexMessage(savedAssistantMsgId, convId, fullContent)
@@ -1017,7 +1017,7 @@ class ChatViewModel @Inject constructor(
         Regex("""\d+""").findAll(systemContext).forEach { match ->
             val expected = match.value
             if (expected.length < 2) return@forEach         // single digits can't be truncated
-            if (corrected.contains(expected)) return@forEach // already present — no fix needed
+            if (corrected.contains("$expected%")) return@forEach // already present as percentage — no fix needed
             // Only repair percentage values — safe, avoids false-positives on other numbers
             corrected = corrected.replace(Regex("""(\d+)%""")) { pctMatch ->
                 val found = pctMatch.groupValues[1]

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1013,15 +1013,20 @@ class ChatViewModel @Inject constructor(
      */
     private fun correctSkillNumbers(response: String, systemContext: String?): String {
         if (systemContext == null) return response
+        // Snapshot original percentage tokens so later loop iterations can't re-correct
+        // a token that was already fixed by a prior iteration (chain-correction guard).
+        val originalPctTokens = Regex("""(\d+)%""").findAll(response).map { it.groupValues[1] }.toSet()
+        val expectedNumbers = Regex("""\d+""").findAll(systemContext).map { it.value }
+            .filter { it.length >= 2 }
+            .toList()
         var corrected = response
-        Regex("""\d+""").findAll(systemContext).forEach { match ->
-            val expected = match.value
-            if (expected.length < 2) return@forEach         // single digits can't be truncated
-            if (corrected.contains("$expected%")) return@forEach // already present as percentage — no fix needed
-            // Only repair percentage values — safe, avoids false-positives on other numbers
+        expectedNumbers.forEach { expected ->
+            if (corrected.contains("$expected%")) return@forEach // full percentage already present
             corrected = corrected.replace(Regex("""(\d+)%""")) { pctMatch ->
                 val found = pctMatch.groupValues[1]
-                if (expected.startsWith(found) && found.length < expected.length) "$expected%"
+                // Only repair tokens that existed in the original response (not already corrected)
+                // and where the model's output is a strict prefix of the expected value.
+                if (found in originalPctTokens && expected.startsWith(found) && found.length < expected.length) "$expected%"
                 else pctMatch.value
             }
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -683,7 +683,7 @@ class ChatViewModel @Inject constructor(
                         }
 
                         is GenerationResult.Complete -> {
-                            val fullContent = accumulatedContent.toString()
+                            val fullContent = correctSkillNumbers(accumulatedContent.toString(), systemContext)
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
 
                             // With native SDK tool calling, tool execution happens
@@ -1004,6 +1004,28 @@ class ChatViewModel @Inject constructor(
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }
+    }
+
+    /**
+     * Corrects digit-truncated numbers in a model response when a [System:] skill context was
+     * injected. E.g. model reads "Battery is at 92%" from context but outputs "9%" — a known
+     * Gemma-4 generation artefact. Only corrects percentage values to avoid false positives.
+     */
+    private fun correctSkillNumbers(response: String, systemContext: String?): String {
+        if (systemContext == null) return response
+        var corrected = response
+        Regex("""\d+""").findAll(systemContext).forEach { match ->
+            val expected = match.value
+            if (expected.length < 2) return@forEach         // single digits can't be truncated
+            if (corrected.contains(expected)) return@forEach // already present — no fix needed
+            // Only repair percentage values — safe, avoids false-positives on other numbers
+            corrected = corrected.replace(Regex("""(\d+)%""")) { pctMatch ->
+                val found = pctMatch.groupValues[1]
+                if (expected.startsWith(found) && found.length < expected.length) "$expected%"
+                else pctMatch.value
+            }
+        }
+        return corrected
     }
 }
 


### PR DESCRIPTION
## Problem

Gemma-4 occasionally drops digits when echoing numbers from injected `[System:]` context. Battery at 92% was reported as 9%.

- SkillResult.Success correctly returns `"Battery is at 92% and charging"`
- systemContext: `[System: get_battery — Battery is at 92% and charging]`
- Model response: `"Your battery is at 9% and it's charging."`

## Fix

Add `correctSkillNumbers(response, systemContext)` called at `GenerationResult.Complete`. Extracts multi-digit numbers from `systemContext`, then for any that are absent from the model response, repairs truncated `\d+%` values where the found value is a strict prefix of the expected:

- `"9%"` when expected `"92"` → corrected to `"92%"` ✓
- `"19%"` when expected `"92"` → not corrected (not a prefix) ✓  
- `"92%"` already present → skipped ✓
- Non-percentage numbers → not touched ✓

## Safety

- Only activates when `systemContext != null` (Tier 2 skill results only)
- Only repairs `\d+%` patterns — no risk of corrupting other text
- Only corrects when expected value is absent AND found is a strict prefix
- No-op when model output is already correct

Closes #385