### PR TITLE
feat: adaptive distillation sentence count + sibling expansion in search_memory

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -85,4 +85,7 @@ interface EpisodicMemoryDao {
 
     @Query("UPDATE episodic_memories SET vectorized = 1 WHERE rowId = :rowId")
     suspend fun markVectorized(rowId: Long)
+
+    @Query("SELECT * FROM episodic_memories WHERE conversationId IN (:conversationIds) ORDER BY createdAt DESC")
+    suspend fun getByConversationIds(conversationIds: List<String>): List<EpisodicMemoryEntity>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt
@@ -86,6 +86,7 @@ interface EpisodicMemoryDao {
     @Query("UPDATE episodic_memories SET vectorized = 1 WHERE rowId = :rowId")
     suspend fun markVectorized(rowId: Long)
 
+    // Caller must ensure list is non-empty — Room generates invalid SQL for IN () with empty lists.
     @Query("SELECT * FROM episodic_memories WHERE conversationId IN (:conversationIds) ORDER BY createdAt DESC")
     suspend fun getByConversationIds(conversationIds: List<String>): List<EpisodicMemoryEntity>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.memory.rag
 import android.util.Log
 import com.kernel.ai.core.inference.ContextWindowManager
 import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
@@ -34,6 +35,7 @@ class RagRepository @Inject constructor(
     private val messageDao: MessageDao,
     private val embeddingDao: MessageEmbeddingDao,
     private val memoryRepository: MemoryRepository,
+    private val episodicMemoryDao: EpisodicMemoryDao,
 ) {
     companion object {
         private const val TAG = "RagRepository"
@@ -48,6 +50,10 @@ class RagRepository @Inject constructor(
          *  1.10 ≈ cos_sim ≥ 0.40 for unit-normalized 768-dim vectors: L2 = sqrt(2 * (1 - cos_sim)).
          *  Without this, top-K always returns results even when nothing is actually related. */
         private const val MAX_DISTANCE = 1.10f
+
+        /** Sibling expansion caps for searchCoreAndEpisodic. */
+        private const val SIBLING_MAX_PER_CONVERSATION = 3
+        private const val SIBLING_MAX_CONVERSATIONS = 2
     }
 
     private var tableCreated = false
@@ -287,11 +293,40 @@ class RagRepository @Inject constructor(
         val queryVector = embeddingEngine.embed(query)
         if (queryVector.isEmpty()) return@withContext emptyList()
         runCatching {
-            memoryRepository.searchMemories(
+            val initialResults = memoryRepository.searchMemories(
                 queryVector = queryVector,
                 coreTopK = topK,
                 episodicTopK = topK,
             )
+
+            // Sibling expansion: fetch all episodic entries from the same conversations as
+            // the initial episodic hits, capped to avoid bloating the result set.
+            val episodicHitConversationIds = initialResults
+                .filter { it.source == "episodic" && it.conversationId != null }
+                .mapNotNull { it.conversationId }
+                .distinct()
+                .take(SIBLING_MAX_CONVERSATIONS)
+
+            if (episodicHitConversationIds.isEmpty()) return@runCatching initialResults
+
+            val alreadyReturnedIds = initialResults.map { it.id }.toSet()
+            val siblings = episodicMemoryDao.getByConversationIds(episodicHitConversationIds)
+                .filter { it.id !in alreadyReturnedIds }
+                .groupBy { it.conversationId }
+                .flatMap { (_, entries) -> entries.take(SIBLING_MAX_PER_CONVERSATION) }
+                .map { entity ->
+                    MemorySearchResult(
+                        id = entity.id,
+                        content = entity.content,
+                        source = "episodic",
+                        score = 0f,
+                        lastAccessedAt = entity.lastAccessedAt,
+                        conversationId = entity.conversationId,
+                    )
+                }
+
+            Log.d(TAG, "searchCoreAndEpisodic: ${initialResults.size} initial + ${siblings.size} siblings from ${episodicHitConversationIds.size} conversation(s)")
+            initialResults + siblings
         }.getOrElse {
             Log.w(TAG, "searchCoreAndEpisodic failed: ${it.message}")
             emptyList()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -319,7 +319,7 @@ class RagRepository @Inject constructor(
                         id = entity.id,
                         content = entity.content,
                         source = "episodic",
-                        score = 0f,
+                        score = -0.5f, // below all initial hits (floor is ~-0.10f at max distance)
                         lastAccessedAt = entity.lastAccessedAt,
                         conversationId = entity.conversationId,
                     )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -57,8 +57,14 @@ class EpisodicDistillationUseCase @Inject constructor(
                 "$label: ${msg.content}"
             }
 
+            val sentenceRange = when {
+                messages.size >= 17 -> "6–10 sentences"
+                messages.size >= 9  -> "5–8 sentences"
+                else                -> "3–5 sentences"
+            }
+
             val prompt = """
-Summarise the key facts, preferences, and events from this conversation in 3–5 short sentences. Each sentence should be a standalone fact. Output only the sentences, one per line, with no numbering or bullet points.
+Summarise the key facts, preferences, and events from this conversation in $sentenceRange. Each sentence should be a standalone fact. Output only the sentences, one per line, with no numbering or bullet points.
 
 [CONVERSATION]
 $transcript


### PR DESCRIPTION
## Summary

Implements both parts of issue #418 — two targeted improvements to the episodic memory system.

---

### Part 1 — Adaptive distillation sentence count

**File:** `core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt`

Replaces the fixed `3–5 short sentences` prompt with an adaptive range based on `messages.size`:

| Message count | Sentence range |
|---|---|
| 4–8 | 3–5 sentences |
| 9–16 | 5–8 sentences |
| 17+ | 6–10 sentences |

Short conversations get a tighter summary; long conversations get proportionally more detail.

---

### Part 2 — Sibling expansion in `searchCoreAndEpisodic`

**Files:** `core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt`, `core/memory/src/main/java/com/kernel/ai/core/memory/dao/EpisodicMemoryDao.kt`

After the initial vector search returns episodic hits, a secondary fetch retrieves all episodic entries from the same `conversationId`s. This surfaces related memories that weren't ranked in the top-K but belong to the same conversation thread.

Caps:
- Max **3 siblings** per conversation  
- Max **2 conversations** expanded

The automatic RAG path (`getRelevantContext`) is unchanged — siblings are only added in the explicit `search_memory` path.

New DAO method: `EpisodicMemoryDao.getByConversationIds(ids: List<String>): List<EpisodicMemoryEntity>`

---

Closes #418