### PR TITLE
fix: make quick-action bolt FAB small/secondary on conversation list

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -121,7 +122,7 @@ fun ConversationListScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     horizontalAlignment = Alignment.End,
                 ) {
-                    FloatingActionButton(
+                    SmallFloatingActionButton(
                         onClick = onNavigateToActions,
                         containerColor = MaterialTheme.colorScheme.secondaryContainer,
                         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,


### PR DESCRIPTION
## Summary
Changes the quick-action (bolt) `FloatingActionButton` on the conversation list screen to `SmallFloatingActionButton` with secondary colours, matching the visual hierarchy on the Actions tab.

## What changed
- `ConversationListScreen.kt`: `FloatingActionButton` → `SmallFloatingActionButton` for bolt/quick-action button
- Added `SmallFloatingActionButton` import

## Why
The Actions tab uses a large primary FAB for the bolt (it's the primary action there) and a small secondary FAB for "New conversation". The conversation list was the opposite — both FABs were the same large size, making the hierarchy unclear.

Closes #394

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>