### PR TITLE
feat: date-specific alarms via AlarmManager.setExact

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,10 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- Required on some OEM clock apps that still check this deprecated permission -->
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+    <!-- Exact alarm scheduling for date-specific alarms (#327) -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <!-- Re-schedule alarms after device reboot (#327) -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Contact lookup for SMS, email, and call by name -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <!-- Required to read/write the Do Not Disturb (interruption filter) policy -->
@@ -98,6 +102,20 @@
             android:name="com.kernel.ai.core.inference.InferenceLoadingService"
             android:foregroundServiceType="specialUse"
             android:exported="false" />
+
+        <!-- Fires when a scheduled exact alarm triggers (#327) -->
+        <receiver
+            android:name=".alarm.AlarmBroadcastReceiver"
+            android:exported="false" />
+
+        <!-- Re-schedules exact alarms after device reboot (#327) -->
+        <receiver
+            android:name=".alarm.BootCompletedReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <property
             android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
             android:value="On-device AI model inference loading via LiteRT GPU" />

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
@@ -1,0 +1,54 @@
+package com.kernel.ai.alarm
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+
+class AlarmBroadcastReceiver : BroadcastReceiver() {
+    companion object {
+        const val EXTRA_LABEL = "alarm_label"
+        const val EXTRA_ALARM_ID = "alarm_id"
+        const val NOTIFICATION_CHANNEL_ID = "kernel_alarm"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val label = intent.getStringExtra(EXTRA_LABEL) ?: "Alarm"
+        val alarmId = intent.getStringExtra(EXTRA_ALARM_ID) ?: return
+
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Alarms",
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Kernel AI alarm notifications"
+            enableVibration(true)
+            setSound(
+                RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM),
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ALARM)
+                    .build(),
+            )
+        }
+        notificationManager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_idle_alarm)
+            .setContentTitle("Alarm")
+            .setContentText(label)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setAutoCancel(true)
+            .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM))
+            .setVibrate(longArrayOf(0, 500, 200, 500))
+            .build()
+
+        notificationManager.notify(alarmId.hashCode(), notification)
+    }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
@@ -1,0 +1,52 @@
+package com.kernel.ai.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class BootCompletedReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var scheduledAlarmDao: ScheduledAlarmDao
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val alarmManager = context.getSystemService(AlarmManager::class.java)
+                val now = System.currentTimeMillis()
+                val unfiredAlarms = scheduledAlarmDao.getUnfiredFuture(now)
+
+                unfiredAlarms.forEach { alarm ->
+                    val alarmIntent = Intent(context, AlarmBroadcastReceiver::class.java).apply {
+                        putExtra(AlarmBroadcastReceiver.EXTRA_LABEL, alarm.label ?: "Alarm")
+                        putExtra(AlarmBroadcastReceiver.EXTRA_ALARM_ID, alarm.id)
+                    }
+                    val pendingIntent = PendingIntent.getBroadcast(
+                        context,
+                        alarm.id.hashCode(),
+                        alarmIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                    )
+                    alarmManager.setExactAndAllowWhileIdle(
+                        AlarmManager.RTC_WAKEUP,
+                        alarm.triggerAtMillis,
+                        pendingIntent,
+                    )
+                }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -12,6 +12,7 @@ import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
@@ -20,6 +21,7 @@ import com.kernel.ai.core.memory.entity.MessageEmbeddingEntity
 import com.kernel.ai.core.memory.entity.MessageEntity
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.entity.QuickActionEntity
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.memory.entity.UserProfileEntity
 
 @Database(
@@ -32,8 +34,9 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         CoreMemoryEntity::class,
         ModelSettingsEntity::class,
         QuickActionEntity::class,
+        ScheduledAlarmEntity::class,
     ],
-    version = 12,
+    version = 13,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -48,6 +51,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun coreMemoryDao(): CoreMemoryDao
     abstract fun modelSettingsDao(): ModelSettingsDao
     abstract fun quickActionDao(): QuickActionDao
+    abstract fun scheduledAlarmDao(): ScheduledAlarmDao
 
     companion object {
         /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
@@ -130,6 +134,23 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE model_settings ADD COLUMN topK INTEGER NOT NULL DEFAULT 40")
                 db.execSQL("ALTER TABLE model_settings ADD COLUMN showThinkingProcess INTEGER NOT NULL DEFAULT 1")
+            }
+        }
+
+        /** Creates scheduled_alarms table for exact AlarmManager scheduling (#327). */
+        val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS scheduled_alarms (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        triggerAtMillis INTEGER NOT NULL,
+                        label TEXT,
+                        createdAt INTEGER NOT NULL,
+                        fired INTEGER NOT NULL DEFAULT 0
+                    )
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.MemoryRepositoryImpl
@@ -55,6 +56,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_9_10,
                     KernelDatabase.MIGRATION_10_11,
                     KernelDatabase.MIGRATION_11_12,
+                    KernelDatabase.MIGRATION_12_13,
                 )
                 .build()
 
@@ -81,5 +83,8 @@ abstract class MemoryModule {
 
         @Provides
         fun provideQuickActionDao(db: KernelDatabase): QuickActionDao = db.quickActionDao()
+
+        @Provides
+        fun provideScheduledAlarmDao(db: KernelDatabase): ScheduledAlarmDao = db.scheduledAlarmDao()
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+
+@Dao
+interface ScheduledAlarmDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(alarm: ScheduledAlarmEntity)
+
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis")
+    suspend fun getUnfiredFuture(nowMillis: Long): List<ScheduledAlarmEntity>
+
+    @Query("UPDATE scheduled_alarms SET fired = 1 WHERE id = :id")
+    suspend fun markFired(id: String)
+
+    @Query("DELETE FROM scheduled_alarms WHERE id = :id")
+    suspend fun delete(id: String)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -1,0 +1,13 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "scheduled_alarms")
+data class ScheduledAlarmEntity(
+    @PrimaryKey val id: String,
+    val triggerAtMillis: Long,
+    val label: String?,
+    val createdAt: Long,
+    val fired: Boolean = false,
+)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -711,6 +711,8 @@ class QuickIntentRouter(
 
             params["hours"] = hours.toString()
             params["minutes"] = minutes.toString()
+            // Also emit a "time" key in HH:mm format so setAlarm() can use resolveTime()
+            params["time"] = "${hours}:${minutes.toString().padStart(2, '0')}"
 
             // Extract day name (today, tomorrow, weekday names including abbreviations)
             val dayRegex = Regex(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -18,7 +18,6 @@ import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.provider.Settings
 import android.util.Log
-import com.kernel.ai.alarm.AlarmBroadcastReceiver
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.skills.SkillResult
@@ -202,9 +201,13 @@ class NativeIntentHandler @Inject constructor(
             runBlocking { scheduledAlarmDao.insert(alarmEntity) }
 
             val alarmManager = context.getSystemService(AlarmManager::class.java)
-            val alarmIntent = Intent(context, AlarmBroadcastReceiver::class.java).apply {
-                putExtra(AlarmBroadcastReceiver.EXTRA_LABEL, label ?: "Alarm")
-                putExtra(AlarmBroadcastReceiver.EXTRA_ALARM_ID, alarmId)
+            val alarmIntent = Intent().apply {
+                component = android.content.ComponentName(
+                    context.packageName,
+                    "com.kernel.ai.alarm.AlarmBroadcastReceiver",
+                )
+                putExtra("alarm_label", label ?: "Alarm")
+                putExtra("alarm_id", alarmId)
             }
             val pendingIntent = PendingIntent.getBroadcast(
                 context,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.core.skills.natives
 
+import android.app.AlarmManager
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.SearchManager
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -16,9 +18,13 @@ import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.provider.Settings
 import android.util.Log
+import com.kernel.ai.alarm.AlarmBroadcastReceiver
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.skills.SkillResult
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.DayOfWeek
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -26,9 +32,11 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.time.temporal.TemporalAdjusters
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
+import kotlinx.coroutines.runBlocking
 
 private const val TAG = "KernelAI"
 
@@ -67,6 +75,7 @@ private const val TAG = "KernelAI"
 @Singleton
 class NativeIntentHandler @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val scheduledAlarmDao: ScheduledAlarmDao,
 ) {
 
     fun handle(intentName: String, params: Map<String, String>): SkillResult {
@@ -162,31 +171,70 @@ class NativeIntentHandler @Inject constructor(
     // ── Alarm ─────────────────────────────────────────────────────────────────
 
     private fun setAlarm(params: Map<String, String>): SkillResult {
-        // Prefer `time` string (e.g. "10pm", "09:05") over raw hours/minutes so the model
-        // never has to do 12h→24h conversion — resolveTime() handles it reliably in Kotlin.
-        val timePair = params["time"]?.let { t ->
-            resolveTime(t)?.let { it.hour to it.minute }
-        } ?: ((params["hours"]?.toIntOrNull() ?: 8) to (params["minutes"]?.toIntOrNull() ?: 0))
-        val (hours, minutes) = timePair
-        val day = params["day"]?.trim()?.lowercase()
-        val isTomorrow = day == "tomorrow"
-        val weekdays = setOf("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
-        val isWeekday = day in weekdays
+        val timeStr = params["time"]
+            ?: return SkillResult.Failure("run_intent", "No time specified for alarm.")
+        val resolvedTime = resolveTime(timeStr)
+            ?: return SkillResult.Failure("run_intent", "Couldn't parse time: $timeStr")
 
-        // NOTE: AlarmClock.EXTRA_DAYS is intentionally NOT used here.
-        // EXTRA_DAYS creates a repeating weekly alarm, not a one-time future alarm.
-        // The clock app opens pre-filled with the time; the user confirms the date.
-        //
-        // For "tomorrow" or weekday alarms we prefix EXTRA_MESSAGE with the day name so
-        // the label is visible in the clock app, reminding the user to verify the date.
-        val baseLabel = params["label"]?.takeIf { it.isNotBlank() }
+        val label = params["label"]?.takeIf { it.isNotBlank() }
+        val day = params["day"]?.trim()?.takeIf { it.isNotBlank() }
+        val resolvedDate = day?.let { resolveDate(it) }
+
+        if (resolvedDate != null) {
+            // Schedule a real exact alarm via AlarmManager
+            val triggerAt = resolvedDate
+                .atTime(resolvedTime)
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
+
+            if (triggerAt <= System.currentTimeMillis()) {
+                return SkillResult.Failure("run_intent", "That time has already passed.")
+            }
+
+            val alarmId = UUID.randomUUID().toString()
+            val alarmEntity = ScheduledAlarmEntity(
+                id = alarmId,
+                triggerAtMillis = triggerAt,
+                label = label,
+                createdAt = System.currentTimeMillis(),
+            )
+            runBlocking { scheduledAlarmDao.insert(alarmEntity) }
+
+            val alarmManager = context.getSystemService(AlarmManager::class.java)
+            val alarmIntent = Intent(context, AlarmBroadcastReceiver::class.java).apply {
+                putExtra(AlarmBroadcastReceiver.EXTRA_LABEL, label ?: "Alarm")
+                putExtra(AlarmBroadcastReceiver.EXTRA_ALARM_ID, alarmId)
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                alarmId.hashCode(),
+                alarmIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+
+            val formatter = DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
+                .withZone(ZoneId.systemDefault())
+            val formattedTime = formatter.format(Instant.ofEpochMilli(triggerAt))
+            return SkillResult.Success(
+                "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
+            )
+        }
+
+        // No date resolved — fall back to clock app intent (existing behaviour)
+        val (hours, minutes) = resolvedTime.hour to resolvedTime.minute
         val dayDisplay = day?.replaceFirstChar { it.uppercase() }
+        val isWeekday = day?.lowercase() in setOf(
+            "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"
+        )
+        val isTomorrow = day?.lowercase() == "tomorrow"
         val messageLabel = when {
-            isTomorrow && baseLabel != null -> "TOMORROW: $baseLabel"
+            isTomorrow && label != null -> "TOMORROW: $label"
             isTomorrow -> "TOMORROW"
-            isWeekday && baseLabel != null -> "$dayDisplay: $baseLabel"
+            isWeekday && label != null -> "$dayDisplay: $label"
             isWeekday -> dayDisplay
-            else -> baseLabel
+            else -> label
         }
 
         val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {


### PR DESCRIPTION
## Summary

Implements programmatic one-off alarm scheduling when the user specifies a date+time (e.g. "set alarm for tomorrow at 7am"). Closes #327.

## Changes

### Permissions & Manifest
- Added `USE_EXACT_ALARM` permission for `AlarmManager.setExactAndAllowWhileIdle`
- Added `RECEIVE_BOOT_COMPLETED` permission for alarm re-scheduling after reboot
- Registered `AlarmBroadcastReceiver` and `BootCompletedReceiver`

### Room / Database
- New `ScheduledAlarmEntity` + `scheduled_alarms` table
- New `ScheduledAlarmDao` (insert, getUnfiredFuture, markFired, delete)
- `KernelDatabase` bumped to v13 with `MIGRATION_12_13`
- `MemoryModule` wired with `provideScheduledAlarmDao`

### Alarm Infrastructure
- `AlarmBroadcastReceiver`: fires a high-priority `CATEGORY_ALARM` notification with alarm sound + vibration
- `BootCompletedReceiver` (`@AndroidEntryPoint`): re-schedules all unfired future alarms after device reboot

### NativeIntentHandler
- Injected `ScheduledAlarmDao` into constructor
- `setAlarm()`: when `day` param resolves to a `LocalDate`, schedules a real exact alarm via `AlarmManager.setExactAndAllowWhileIdle`, persists to Room, and returns a formatted confirmation (e.g. *"Alarm set for Wed 2 Jul at 7:00am"*)
- Falls back to `AlarmClock.ACTION_SET_ALARM` intent when no date is given (time-only alarms)