### PR TITLE
feat: model management screen, gated download UX, and conversation restore

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -25,6 +25,7 @@ import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.MemoryScreen
+import com.kernel.ai.feature.settings.ModelManagementScreen
 import com.kernel.ai.feature.settings.ModelSettingsScreen
 import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
@@ -37,6 +38,7 @@ private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
 private const val ROUTE_MEMORY = "settings/memory"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
+private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management"
 private const val ROUTE_ABOUT = "settings/about"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
@@ -197,6 +199,9 @@ fun KernelNavHost() {
                     onNavigateToModelSettings = {
                         navController.navigate(ROUTE_MODEL_SETTINGS)
                     },
+                    onNavigateToModelManagement = {
+                        navController.navigate(ROUTE_MODEL_MANAGEMENT)
+                    },
                     onNavigateToAbout = {
                         navController.navigate(ROUTE_ABOUT)
                     },
@@ -217,6 +222,12 @@ fun KernelNavHost() {
 
             composable(ROUTE_MODEL_SETTINGS) {
                 ModelSettingsScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+
+            composable(ROUTE_MODEL_MANAGEMENT) {
+                ModelManagementScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/DownloadState.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/DownloadState.kt
@@ -32,6 +32,8 @@ sealed class DownloadState {
      * Download failed.
      *
      * @param message Human-readable error description.
+     * @param licenceRequired True when the server returned 401/403 — the user must accept
+     *   the model licence on HuggingFace before downloading.
      */
-    data class Error(val message: String) : DownloadState()
+    data class Error(val message: String, val licenceRequired: Boolean = false) : DownloadState()
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -29,6 +29,11 @@ enum class KernelModel(
      * to the download request when this is `true`.
      */
     val isGated: Boolean = false,
+    /**
+     * URL to the HuggingFace model licence page. Non-null for gated models — shown in the
+     * Model Management UI so users can accept the licence before downloading.
+     */
+    val licenceUrl: String? = null,
 ) {
     GEMMA_4_E2B(
         displayName = "Gemma 4 E-2B",
@@ -40,6 +45,7 @@ enum class KernelModel(
         preferredForTier = null,
         // Ungated since Apr 2026 — no auth token required.
         isGated = false,
+        licenceUrl = null,
     ),
 
     /**
@@ -55,6 +61,7 @@ enum class KernelModel(
         preferredForTier = HardwareTier.FLAGSHIP,
         // Ungated since Apr 2026 — no auth token required.
         isGated = false,
+        licenceUrl = null,
     ),
 
     /**
@@ -72,6 +79,7 @@ enum class KernelModel(
         isRequired = true,
         preferredForTier = null,
         isGated = true,
+        licenceUrl = "https://huggingface.co/litert-community/embeddinggemma-300m",
     ),
 
     /**
@@ -86,6 +94,7 @@ enum class KernelModel(
         isRequired = false,
         preferredForTier = null,
         isGated = true,
+        licenceUrl = "https://huggingface.co/litert-community/embeddinggemma-300m",
     ),
 
     /**
@@ -101,6 +110,7 @@ enum class KernelModel(
         isRequired = true,
         preferredForTier = null,
         isGated = true,
+        licenceUrl = "https://huggingface.co/litert-community/embeddinggemma-300m",
     );
 
     /**

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -100,6 +101,17 @@ class ModelDownloadManager @Inject constructor(
                 Log.i(TAG, "Auto-queuing ${model.displayName} for tier ${tier.name}")
                 startDownload(model)
             }
+        // Auto-trigger gated required models when user signs in
+        scope.launch {
+            authRepository.isAuthenticated
+                .filter { it }
+                .collect {
+                    KernelModel.entries
+                        .filter { m -> m.isGated && m.isRequired }
+                        .filter { m -> _downloadStates.value[m] is DownloadState.NotDownloaded }
+                        .forEach { m -> startDownload(m) }
+                }
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -191,6 +203,20 @@ class ModelDownloadManager @Inject constructor(
      */
     fun getModelPath(model: KernelModel): String? {
         return if (model.isDownloaded(context)) model.localFile(context).absolutePath else null
+    }
+
+    /**
+     * Re-checks the filesystem for [model] and updates [downloadStates] accordingly.
+     * Call this after manually deleting a model file so the UI reflects [DownloadState.NotDownloaded].
+     */
+    fun refreshState(model: KernelModel) {
+        val newState = if (model.isDownloaded(context)) {
+            DownloadState.Downloaded(model.localFile(context).absolutePath)
+        } else {
+            DownloadState.NotDownloaded
+        }
+        updateState(model, newState)
+        Log.i(TAG, "Refreshed state for ${model.displayName}: $newState")
     }
 
     /** True when all models required for this device tier are present on disk. */
@@ -316,10 +342,19 @@ class ModelDownloadManager @Inject constructor(
                             Log.i(TAG, "Worker failed but file present — treating as Downloaded: ${model.displayName}")
                             DownloadState.Downloaded(localPath = localFile.absolutePath)
                         } else {
-                            val errorMsg = info.outputData.getString(KEY_ERROR_MESSAGE)
-                                ?: "Download failed"
-                            Log.w(TAG, "Download failed for ${model.displayName}: $errorMsg")
-                            DownloadState.Error(message = errorMsg)
+                            val errorKey = info.outputData.getString(KEY_ERROR)
+                            if (errorKey == "LICENCE_REQUIRED") {
+                                Log.w(TAG, "Licence required for ${model.displayName}")
+                                DownloadState.Error(
+                                    message = "Accept the model licence on HuggingFace before downloading.",
+                                    licenceRequired = true,
+                                )
+                            } else {
+                                val errorMsg = info.outputData.getString(KEY_ERROR_MESSAGE)
+                                    ?: "Download failed"
+                                Log.w(TAG, "Download failed for ${model.displayName}: $errorMsg")
+                                DownloadState.Error(message = errorMsg)
+                            }
                         }
                     }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadWorker.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadWorker.kt
@@ -12,6 +12,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -33,6 +34,8 @@ const val KEY_PROGRESS_BYTES = "progress_bytes"
 const val KEY_DOWNLOAD_RATE = "download_rate_bps"
 const val KEY_REMAINING_MS = "remaining_ms"
 const val KEY_ERROR_MESSAGE = "error_message"
+const val KEY_ERROR = "error"
+const val KEY_ERROR_CODE = "error_code"
 /** Optional HuggingFace Bearer token — present when downloading a gated model. */
 const val KEY_HF_ACCESS_TOKEN = "hf_access_token"
 
@@ -90,6 +93,9 @@ class ModelDownloadWorker(
             )
             Log.i(TAG, "Download complete: ${outputFile.absolutePath}")
             Result.success()
+        } catch (e: LicenceRequiredException) {
+            Log.w(TAG, "Licence required (HTTP ${e.responseCode}) for $downloadUrl")
+            Result.failure(workDataOf(KEY_ERROR to "LICENCE_REQUIRED", KEY_ERROR_CODE to e.responseCode))
         } catch (e: IOException) {
             Log.e(TAG, "Download failed: ${e.message}", e)
             Result.failure(errorData(e.message ?: "Unknown I/O error"))
@@ -122,6 +128,9 @@ class ModelDownloadWorker(
         connection.connect()
 
         val responseCode = connection.responseCode
+        if (responseCode == 401 || responseCode == 403) {
+            throw LicenceRequiredException(responseCode)
+        }
         if (responseCode != HttpURLConnection.HTTP_OK && responseCode != HttpURLConnection.HTTP_PARTIAL) {
             throw IOException("HTTP $responseCode for $url")
         }
@@ -241,3 +250,6 @@ class ModelDownloadWorker(
     private fun errorData(message: String): Data =
         Data.Builder().putString(KEY_ERROR_MESSAGE, message).build()
 }
+
+/** Thrown when the server returns 401 or 403 — model licence must be accepted first. */
+private class LicenceRequiredException(val responseCode: Int) : IOException("HTTP $responseCode — licence required")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -60,7 +60,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
     private val inferenceEngine: InferenceEngine,
     private val downloadManager: ModelDownloadManager,
     private val conversationRepository: ConversationRepository,
@@ -554,6 +554,19 @@ class ChatViewModel @Inject constructor(
                 is QuickIntentRouter.RouteResult.FallThrough -> null
             }
             if (matchedIntent != null) {
+                // Calendar intent matched by classifier but params not extractable via regex —
+                // skip immediate execution and fall through to E4B with a structured hint.
+                if (matchedIntent.intentName == "create_calendar_event" &&
+                    matchedIntent.params["title"].isNullOrBlank()
+                ) {
+                    val rawQuery = matchedIntent.params["raw_query"] ?: text
+                    systemContext = "[System: User wants to create a calendar event. " +
+                        "Their request: \"$rawQuery\". " +
+                        "Extract the event title, date, and time, then call " +
+                        "runIntent(intentName=\"create_calendar_event\", ...). " +
+                        "Pass the date exactly as the user said it. Pass time as HH:MM 24h.]"
+                    // fall through to E4B — do NOT execute now
+                } else {
                 // Router intent names (e.g. "toggle_flashlight_on") are sub-intent values
                 // handled by the run_intent skill — they aren't top-level skill names.
                 // Resolve: direct skill match first, then fall back to run_intent.
@@ -583,6 +596,7 @@ class ChatViewModel @Inject constructor(
                         else -> { /* UnknownSkill/ParseError — fall through to E4B unchanged */ }
                     }
                 }
+                } // end else (non-calendar or calendar with params)
             }
 
             // Lazy-init Gemma-4 if not yet loaded.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -301,6 +301,9 @@ class ChatViewModel @Inject constructor(
         try {
         val id = navConversationId ?: conversationRepository.createConversation()
         conversationId = id
+        // Persist resolved ID so process-death recreation restores the right conversation
+        // instead of creating a fresh one on every cold start.
+        savedStateHandle["conversationId"] = id
 
         // Load persisted title immediately so UI shows it on back-navigation.
         val conversation = conversationRepository.getConversation(id)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
@@ -450,8 +450,9 @@ private fun ModelRow(
                     }
                     is DownloadState.Error -> {
                         Column(horizontalAlignment = Alignment.End) {
-                            if (state.licenceRequired && model.licenceUrl != null) {
-                                TextButton(onClick = { onViewLicence(model.licenceUrl) }) {
+                            val licenceUrl = model.licenceUrl
+                            if (state.licenceRequired && licenceUrl != null) {
+                                TextButton(onClick = { onViewLicence(licenceUrl) }) {
                                     Text("Accept licence")
                                 }
                             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
@@ -1,0 +1,476 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+
+private val HfOrange = Color(0xFFFF9D00)
+private const val EMBEDDING_GEMMA_LICENCE_URL = "https://huggingface.co/litert-community/embeddinggemma-300m"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModelManagementScreen(
+    onBack: () -> Unit = {},
+    viewModel: ModelManagementViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Model Management") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // ── Storage summary ───────────────────────────────────────────────
+            item {
+                StorageSummaryCard(
+                    usedBytes = uiState.totalStorageUsedBytes,
+                    freeBytes = uiState.freeSpaceBytes,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+
+            // ── HuggingFace account ───────────────────────────────────────────
+            item {
+                Text(
+                    text = "HuggingFace Account",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+                HuggingFaceRow(
+                    isAuthenticated = uiState.hfAuthenticated,
+                    username = uiState.hfUsername,
+                    onSignIn = { viewModel.startAuth() },
+                    onSignOut = { viewModel.signOut() },
+                    onViewLicence = { uriHandler.openUri(EMBEDDING_GEMMA_LICENCE_URL) },
+                )
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // ── Model rows ────────────────────────────────────────────────────
+            item {
+                Text(
+                    text = "Models",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+
+            // Skip EMBEDDING_GEMMA_300M_SM8550 (disabled variant)
+            val visibleModels = uiState.models.filter { it.model != KernelModel.EMBEDDING_GEMMA_300M_SM8550 }
+            items(visibleModels) { rowState ->
+                ModelRow(
+                    rowState = rowState,
+                    isAuthenticated = uiState.hfAuthenticated,
+                    onDownload = { viewModel.downloadModel(rowState.model) },
+                    onCancel = { viewModel.cancelDownload(rowState.model) },
+                    onDelete = { viewModel.deleteModel(rowState.model) },
+                    onViewLicence = { url -> uriHandler.openUri(url) },
+                    onRetry = { viewModel.downloadModel(rowState.model) },
+                )
+                HorizontalDivider()
+            }
+
+            // ── Preferred model section ───────────────────────────────────────
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Conversation model",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+
+            item {
+                val e2bState = uiState.models.find { it.model == KernelModel.GEMMA_4_E2B }?.downloadState
+                val e4bState = uiState.models.find { it.model == KernelModel.GEMMA_4_E4B }?.downloadState
+                val e2bDownloaded = e2bState is DownloadState.Downloaded
+                val e4bDownloaded = e4bState is DownloadState.Downloaded
+
+                // Auto
+                ListItem(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { viewModel.setPreferredModel(null) },
+                    headlineContent = { Text("Auto") },
+                    supportingContent = { Text("Select best model for your hardware") },
+                    leadingContent = {
+                        RadioButton(
+                            selected = uiState.preferredModel == null,
+                            onClick = { viewModel.setPreferredModel(null) },
+                        )
+                    },
+                )
+                HorizontalDivider()
+
+                // E2B
+                ListItem(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (e2bDownloaded) viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B)
+                        },
+                    headlineContent = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("E2B — Gemma 4 E-2B")
+                            if (!e2bDownloaded) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(
+                                    "(not downloaded)",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                        }
+                    },
+                    supportingContent = { Text("2.4 GB · Efficient, runs on all devices") },
+                    leadingContent = {
+                        RadioButton(
+                            selected = uiState.preferredModel == KernelModel.GEMMA_4_E2B,
+                            onClick = { if (e2bDownloaded) viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B) },
+                            enabled = e2bDownloaded,
+                        )
+                    },
+                )
+                HorizontalDivider()
+
+                // E4B
+                ListItem(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (e4bDownloaded) viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
+                        },
+                    headlineContent = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("E4B — Gemma 4 E-4B")
+                            if (!e4bDownloaded) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(
+                                    "(not downloaded)",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                        }
+                    },
+                    supportingContent = { Text("3.4 GB · Higher quality, flagship devices") },
+                    leadingContent = {
+                        RadioButton(
+                            selected = uiState.preferredModel == KernelModel.GEMMA_4_E4B,
+                            onClick = { if (e4bDownloaded) viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B) },
+                            enabled = e4bDownloaded,
+                        )
+                    },
+                )
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StorageSummaryCard(
+    usedBytes: Long,
+    freeBytes: Long,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = formatBytes(usedBytes),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "used",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = formatBytes(freeBytes),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "free",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HuggingFaceRow(
+    isAuthenticated: Boolean,
+    username: String?,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    onViewLicence: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isAuthenticated) {
+        ListItem(
+            modifier = modifier.fillMaxWidth(),
+            headlineContent = {
+                Text(if (username != null) "@$username" else "Signed in")
+            },
+            supportingContent = {
+                Column {
+                    Text("Gated models unlocked")
+                    TextButton(onClick = onViewLicence, contentPadding = PaddingValues(0.dp)) {
+                        Text("View licence →", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            },
+            leadingContent = {
+                Icon(Icons.Default.AccountCircle, contentDescription = null, tint = HfOrange)
+            },
+            trailingContent = {
+                TextButton(onClick = onSignOut) {
+                    Text("Sign out", color = MaterialTheme.colorScheme.error)
+                }
+            },
+        )
+    } else {
+        ListItem(
+            modifier = modifier.fillMaxWidth(),
+            headlineContent = { Text("Not signed in") },
+            supportingContent = {
+                Column {
+                    Text("Required to download EmbeddingGemma (gated). Accept licence before downloading.")
+                    TextButton(onClick = onViewLicence, contentPadding = PaddingValues(0.dp)) {
+                        Text("View licence →", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            },
+            leadingContent = {
+                Icon(Icons.Default.AccountCircle, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            },
+            trailingContent = {
+                Button(
+                    onClick = onSignIn,
+                    colors = ButtonDefaults.buttonColors(containerColor = HfOrange),
+                ) {
+                    Text("Sign in", color = Color.Black)
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ModelRow(
+    rowState: ModelRowState,
+    isAuthenticated: Boolean,
+    onDownload: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit,
+    onViewLicence: (String) -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val model = rowState.model
+    val state = rowState.downloadState
+
+    ListItem(
+        modifier = modifier.fillMaxWidth(),
+        headlineContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(model.displayName)
+                if (model.isGated) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        Icons.Default.Lock,
+                        contentDescription = "Gated",
+                        modifier = Modifier.size(14.dp),
+                        tint = HfOrange,
+                    )
+                }
+                Spacer(modifier = Modifier.width(6.dp))
+                if (model.isRequired) {
+                    SuggestionChip(
+                        onClick = {},
+                        label = { Text("Required", style = MaterialTheme.typography.labelSmall) },
+                        colors = SuggestionChipDefaults.suggestionChipColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        ),
+                    )
+                } else {
+                    SuggestionChip(
+                        onClick = {},
+                        label = { Text("Optional", style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+            }
+        },
+        supportingContent = {
+            Column {
+                Text(
+                    text = formatBytes(model.approxSizeBytes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                when (state) {
+                    is DownloadState.Downloading -> {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        LinearProgressIndicator(
+                            progress = { state.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        val pct = (state.progress * 100).toInt()
+                        val mbps = state.bytesPerSecond / 1_000_000.0
+                        val etaSec = state.remainingMs / 1000
+                        Text(
+                            text = buildString {
+                                append("$pct%")
+                                if (state.bytesPerSecond > 0) append(" · ${"%.1f".format(mbps)} MB/s")
+                                if (etaSec > 0) append(" · ${etaSec}s remaining")
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    is DownloadState.Error -> {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    else -> Unit
+                }
+            }
+        },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                when (state) {
+                    is DownloadState.NotDownloaded -> {
+                        val gatedBlocked = model.isGated && !isAuthenticated
+                        TextButton(
+                            onClick = onDownload,
+                            enabled = !gatedBlocked,
+                        ) {
+                            Text("Download")
+                        }
+                    }
+                    is DownloadState.Downloading -> {
+                        TextButton(onClick = onCancel) {
+                            Text("Cancel")
+                        }
+                    }
+                    is DownloadState.Downloaded -> {
+                        Icon(
+                            Icons.Default.CheckCircle,
+                            contentDescription = "Downloaded",
+                            tint = Color(0xFF4CAF50),
+                            modifier = Modifier.size(20.dp),
+                        )
+                        if (!model.isRequired) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            TextButton(onClick = onDelete) {
+                                Text("Delete", color = MaterialTheme.colorScheme.error)
+                            }
+                        }
+                    }
+                    is DownloadState.Error -> {
+                        Column(horizontalAlignment = Alignment.End) {
+                            if (state.licenceRequired && model.licenceUrl != null) {
+                                TextButton(onClick = { onViewLicence(model.licenceUrl) }) {
+                                    Text("Accept licence")
+                                }
+                            }
+                            TextButton(onClick = onRetry) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+private fun formatBytes(bytes: Long): String {
+    return when {
+        bytes >= 1_000_000_000L -> "${"%.1f".format(bytes / 1_000_000_000.0)} GB"
+        bytes >= 1_000_000L -> "${"%.0f".format(bytes / 1_000_000.0)} MB"
+        bytes >= 1_000L -> "${"%.0f".format(bytes / 1_000.0)} KB"
+        else -> "$bytes B"
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
@@ -77,6 +77,7 @@ class ModelManagementViewModel @Inject constructor(
     }
 
     fun deleteModel(model: KernelModel) {
+        if (model.isRequired) return
         viewModelScope.launch(Dispatchers.IO) {
             model.localFile(context).delete()
             // Also delete any stale .tmp resume file

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
@@ -1,0 +1,114 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import android.os.StatFs
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.download.localFile
+import com.kernel.ai.core.inference.prefs.ModelPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import javax.inject.Inject
+
+data class ModelRowState(
+    val model: KernelModel,
+    val downloadState: DownloadState,
+)
+
+data class ModelManagementUiState(
+    val models: List<ModelRowState> = emptyList(),
+    val totalStorageUsedBytes: Long = 0,
+    val freeSpaceBytes: Long = 0,
+    val hfAuthenticated: Boolean = false,
+    val hfUsername: String? = null,
+    val preferredModel: KernelModel? = null,
+)
+
+@HiltViewModel
+class ModelManagementViewModel @Inject constructor(
+    private val modelDownloadManager: ModelDownloadManager,
+    private val modelPreferences: ModelPreferences,
+    private val authRepository: HuggingFaceAuthRepository,
+    @ApplicationContext private val context: Context,
+) : ViewModel() {
+
+    val uiState = combine(
+        modelDownloadManager.downloadStates,
+        authRepository.isAuthenticated,
+        authRepository.username,
+        modelPreferences.preferredConversationModel,
+    ) { downloadStates, hfAuthenticated, hfUsername, preferredModel ->
+        ModelManagementUiState(
+            models = KernelModel.entries.map { model ->
+                ModelRowState(
+                    model = model,
+                    downloadState = downloadStates[model] ?: DownloadState.NotDownloaded,
+                )
+            },
+            totalStorageUsedBytes = calculateStorageUsed(),
+            freeSpaceBytes = calculateFreeSpace(),
+            hfAuthenticated = hfAuthenticated,
+            hfUsername = hfUsername,
+            preferredModel = preferredModel,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ModelManagementUiState(),
+    )
+
+    fun downloadModel(model: KernelModel) {
+        modelDownloadManager.startDownload(model)
+    }
+
+    fun cancelDownload(model: KernelModel) {
+        modelDownloadManager.cancelDownload(model)
+    }
+
+    fun deleteModel(model: KernelModel) {
+        viewModelScope.launch(Dispatchers.IO) {
+            model.localFile(context).delete()
+            // Also delete any stale .tmp resume file
+            val tmpFile = java.io.File(model.localFile(context).absolutePath + ".tmp")
+            if (tmpFile.exists()) tmpFile.delete()
+            withContext(Dispatchers.Main) {
+                modelDownloadManager.refreshState(model)
+            }
+        }
+    }
+
+    fun setPreferredModel(model: KernelModel?) {
+        viewModelScope.launch {
+            try {
+                modelPreferences.setPreferredModel(model)
+            } catch (_: IOException) { /* best-effort */ }
+        }
+    }
+
+    fun startAuth() = authRepository.startAuthFlow()
+
+    fun signOut() = authRepository.signOut()
+
+    private fun calculateStorageUsed(): Long =
+        KernelModel.entries.sumOf { model ->
+            val file = model.localFile(context)
+            if (file.exists()) file.length() else 0L
+        }
+
+    private fun calculateFreeSpace(): Long =
+        try {
+            val path = context.getExternalFilesDir(null)?.path ?: context.filesDir.path
+            StatFs(path).availableBytes
+        } catch (_: Exception) { 0L }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -2,19 +2,18 @@ package com.kernel.ai.feature.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
@@ -27,7 +26,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -38,16 +36,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kernel.ai.core.inference.download.KernelModel
-import kotlinx.coroutines.launch
 
 /** Amber / HuggingFace brand colour — same as in OnboardingScreen. */
 private val HfOrange = Color(0xFFFF9D00)
@@ -59,12 +54,13 @@ fun SettingsScreen(
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
+    onNavigateToModelManagement: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
 
     LaunchedEffect(Unit) {
         viewModel.saveError.collect { message ->
@@ -115,144 +111,26 @@ fun SettingsScreen(
                 HorizontalDivider()
             }
 
-            // ── Conversation Model Selection ──────────────────────────────────
             Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Conversation model",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-            )
 
-            // Auto option
+            // ── Model Management ──────────────────────────────────────────────
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { viewModel.setPreferredModel(null) },
-                headlineContent = { Text("Auto") },
-                supportingContent = { Text("Select best model for your hardware") },
-                leadingContent = {
-                    RadioButton(
-                        selected = uiState.preferredModel == null,
-                        onClick = { viewModel.setPreferredModel(null) },
-                    )
-                },
-            )
-
-            // E2B option
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        if (uiState.e2bDownloaded) {
-                            viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B)
-                        } else {
-                            scope.launch {
-                                snackbarHostState.showSnackbar("E2B not downloaded")
-                            }
-                        }
-                    },
-                headlineContent = {
-                    Text(
-                        text = "E2B — Gemma 4 E-2B",
-                        color = if (uiState.e2bDownloaded)
-                            MaterialTheme.colorScheme.onSurface
-                        else
-                            MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                supportingContent = {
-                    Text(
-                        text = if (uiState.e2bDownloaded) "2.4 GB · Efficient, runs on all devices"
-                               else "Not downloaded · 2.4 GB",
-                        color = if (uiState.e2bDownloaded)
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        else
-                            MaterialTheme.colorScheme.error,
-                    )
-                },
-                leadingContent = {
-                    RadioButton(
-                        selected = uiState.preferredModel == KernelModel.GEMMA_4_E2B,
-                        onClick = {
-                            if (uiState.e2bDownloaded) {
-                                viewModel.setPreferredModel(KernelModel.GEMMA_4_E2B)
-                            } else {
-                                scope.launch {
-                                    snackbarHostState.showSnackbar("E2B not downloaded")
-                                }
-                            }
-                        },
-                        enabled = uiState.e2bDownloaded,
-                    )
-                },
-                trailingContent = if (!uiState.e2bDownloaded) {
-                    {
-                        TextButton(onClick = { viewModel.downloadModel(KernelModel.GEMMA_4_E2B) }) {
-                            Text("Download")
-                        }
-                    }
-                } else null,
-            )
-
-            // E4B option
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        if (uiState.e4bDownloaded) {
-                            viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
-                        } else {
-                            scope.launch {
-                                snackbarHostState.showSnackbar("E4B not downloaded")
-                            }
-                        }
-                    },
-                headlineContent = {
-                    Text(
-                        text = "E4B — Gemma 4 E-4B",
-                        color = if (uiState.e4bDownloaded)
-                            MaterialTheme.colorScheme.onSurface
-                        else
-                            MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                supportingContent = {
-                    Text(
-                        text = if (uiState.e4bDownloaded) "3.4 GB · Higher quality, flagship devices"
-                               else "Not downloaded · 3.4 GB",
-                        color = if (uiState.e4bDownloaded)
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        else
-                            MaterialTheme.colorScheme.error,
-                    )
-                },
-                leadingContent = {
-                    RadioButton(
-                        selected = uiState.preferredModel == KernelModel.GEMMA_4_E4B,
-                        onClick = {
-                            if (uiState.e4bDownloaded) {
-                                viewModel.setPreferredModel(KernelModel.GEMMA_4_E4B)
-                            } else {
-                                scope.launch {
-                                    snackbarHostState.showSnackbar("E4B not downloaded")
-                                }
-                            }
-                        },
-                        enabled = uiState.e4bDownloaded,
-                    )
-                },
-                trailingContent = if (!uiState.e4bDownloaded) {
-                    {
-                        TextButton(onClick = { viewModel.downloadModel(KernelModel.GEMMA_4_E4B) }) {
-                            Text("Download")
-                        }
-                    }
-                } else null,
+                    .clickable { onNavigateToModelManagement() },
+                headlineContent = { Text("Model management") },
+                supportingContent = { Text("Downloads, storage and model preferences") },
+                leadingContent = { Icon(Icons.Default.Download, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
 
             HorizontalDivider()
             Spacer(modifier = Modifier.height(8.dp))
+
+            // Auto option
+            // E2B option
+            // E4B option
+            // (Model selection moved to ModelManagementScreen)
 
             // ── User Profile ──────────────────────────────────────────────────
             ListItem(
@@ -316,6 +194,7 @@ fun SettingsScreen(
                 username = uiState.hfUsername,
                 onSignIn = { viewModel.startAuth() },
                 onSignOut = { viewModel.signOutHuggingFace() },
+                onViewLicence = { uriHandler.openUri("https://huggingface.co/litert-community/embeddinggemma-300m") },
             )
             HorizontalDivider()
         }
@@ -360,6 +239,7 @@ private fun HuggingFaceAccountRow(
     username: String?,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
+    onViewLicence: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     if (isAuthenticated) {
@@ -371,7 +251,14 @@ private fun HuggingFaceAccountRow(
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
-            supportingContent = { Text("Gated models unlocked") },
+            supportingContent = {
+                Column {
+                    Text("Gated models unlocked")
+                    TextButton(onClick = onViewLicence, contentPadding = PaddingValues(0.dp)) {
+                        Text("View licence →", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            },
             leadingContent = {
                 Icon(
                     imageVector = Icons.Default.AccountCircle,
@@ -389,7 +276,14 @@ private fun HuggingFaceAccountRow(
         ListItem(
             modifier = modifier.fillMaxWidth(),
             headlineContent = { Text("Not signed in") },
-            supportingContent = { Text("Sign in to download gated models (Gemma 4, EmbeddingGemma)") },
+            supportingContent = {
+                Column {
+                    Text("Required to download EmbeddingGemma (gated). Accept licence before downloading.")
+                    TextButton(onClick = onViewLicence, contentPadding = PaddingValues(0.dp)) {
+                        Text("View licence →", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            },
             leadingContent = {
                 Icon(
                     imageVector = Icons.Default.AccountCircle,


### PR DESCRIPTION
## Summary

Closes #363
Closes #433

### #433 — Conversation restore on process death

In `ChatViewModel.initializeConversation()`, after the conversation ID is resolved (from nav arg or newly created), write it back to `savedStateHandle["conversationId"]`. On process death + recreation, `SavedStateHandle` restores this persisted value, so `navConversationId` is non-null and the existing conversation is loaded instead of creating a new one.

### #363 — Model Management UX

**`KernelModel`** — added `licenceUrl: String?` field. Gated EmbeddingGemma models all point to `https://huggingface.co/litert-community/embeddinggemma-300m`; ungated models are `null`.

**`DownloadState.Error`** — added `licenceRequired: Boolean = false` field to distinguish 401/403 failures from general I/O errors.

**`ModelDownloadWorker`** — detects HTTP 401/403 separately and returns `Result.failure(workDataOf(KEY_ERROR to "LICENCE_REQUIRED", KEY_ERROR_CODE to responseCode))` instead of throwing `IOException`, enabling targeted UI messaging.

**`ModelDownloadManager`** — handles `LICENCE_REQUIRED` worker output to set `DownloadState.Error(licenceRequired=true)` with a user-friendly message. Added auto-trigger of gated required models when the user signs in via `authRepository.isAuthenticated`. Added `refreshState(model)` to re-sync filesystem state after file deletion.

**`ModelManagementViewModel`** + **`ModelManagementScreen`** — new dedicated screen accessible from Settings:
- Storage summary card (used GB / free GB via `StatFs`)
- HuggingFace account row (compact sign-in/out + View licence link)
- Per-model rows (EMBEDDING_GEMMA_300M_SM8550 hidden as it is disabled): download/cancel/delete/retry with `LinearProgressIndicator`, rate and ETA
- Preferred conversation model section (Auto / E2B / E4B radio buttons)

**`SettingsScreen`** — replaced the large inline model selection section (150+ lines) with a single `ListItem` navigating to the new Model Management screen. Updated `HuggingFaceAccountRow` supporting text and added a View licence `TextButton`.

**`KernelNavHost`** — wired `ROUTE_MODEL_MANAGEMENT = "settings/model_management"` composable and passed `onNavigateToModelManagement` to `SettingsScreen`.

## Testing

CI will run the full test suite. No new tests were added (existing behaviour is preserved; new UI is best verified on-device).