### PR TITLE
fix: calendar reliability — stop retry loop + graceful fallthrough

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -173,6 +173,41 @@ class QuickIntentRouter(
             paramExtractor = { match, input -> parseTimerDuration(match, input) },
         ),
 
+        // ── Calendar ──
+        // "add/create/schedule/set up a [dentist/gym/meeting/event] [for/on] [date] [at time]"
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """(?:add|create|schedule|put|book)\s+(?:a\s+|an\s+)?(?:calendar\s+)?(?:event|appointment|meeting|entry|invite|session|booking)\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+        ),
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """(?:set\s+up|schedule)\s+(?:a\s+|an\s+)?meeting\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+        ),
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """block\s+(?:out\s+)?(?:time\s+)?(?:on\s+(?:my\s+)?calendar\b|(?:this|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|week|morning|afternoon|evening)\b|tomorrow\b)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+        ),
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """put\s+.{3,40}\s+(?:in|on|into)\s+(?:my\s+)?calendar\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+        ),
+
         // ── Do Not Disturb ──
         IntentPattern(
             intentName = "toggle_dnd_on",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -178,7 +178,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "create_calendar_event",
             regex = Regex(
-                """(?:add|create|schedule|put|book)\s+(?:a\s+|an\s+)?(?:calendar\s+)?(?:event|appointment|meeting|entry|invite|session|booking)\b""",
+                """(?:add|create|schedule|put|book|set)\s+(?:a\s+|an\s+)?(?:calendar\s+)?(?:event|appointment|meeting|entry|invite|session|booking)\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, raw -> mapOf("raw_query" to raw) },


### PR DESCRIPTION
## Summary

Addresses calendar failures from device testing (issue 427): 4-5 visible retry messages and LLM narrating bad date math.

## Root causes fixed

1. **Retry loop (RunIntentSkill)** — line 182 told LLM to convert relative dates to YYYY-MM-DD. Small model repeatedly failed date math. Fix: removed instruction; LLM passes dates verbatim; NativeIntentHandler.resolveDate() handles everything natively.

2. **Empty-params failure loop (ChatViewModel)** — QuickIntentRouter matched calendar phrase with no title; immediate execution failed with title required then looped. Fix: check title.isNullOrBlank() and fall through to E4B with a structured hint instead of immediately executing.

3. **Time display cosmetic (NativeIntentHandler)** — success message showed '1600' for 4pm. Now resolves via resolveTime() and formats as HH:mm.

4. **Calendar regex patterns (QuickIntentRouter)** — added 4 IntentPattern entries for common calendar phrases, all extracting raw_query only and falling through to E4B for param extraction.