### PR TITLE
feat: contact aliases — map relationship names to contacts for make_call (#355)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -24,6 +24,7 @@ import com.kernel.ai.feature.chat.ActionsScreen
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
+import com.kernel.ai.feature.settings.ContactAliasesScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelManagementScreen
 import com.kernel.ai.feature.settings.ModelSettingsScreen
@@ -40,6 +41,7 @@ private const val ROUTE_MEMORY = "settings/memory"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management"
 private const val ROUTE_ABOUT = "settings/about"
+private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
 
@@ -205,6 +207,9 @@ fun KernelNavHost() {
                     onNavigateToAbout = {
                         navController.navigate(ROUTE_ABOUT)
                     },
+                    onNavigateToContactAliases = {
+                        navController.navigate(ROUTE_CONTACT_ALIASES)
+                    },
                 )
             }
 
@@ -240,6 +245,12 @@ fun KernelNavHost() {
                     buildType = com.kernel.ai.BuildConfig.BUILD_TYPE,
                     gitSha = com.kernel.ai.BuildConfig.GIT_SHA,
                     buildTimestamp = com.kernel.ai.BuildConfig.BUILD_TIMESTAMP,
+                )
+            }
+
+            composable(ROUTE_CONTACT_ALIASES) {
+                ContactAliasesScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
         }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ContactAliasRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ContactAliasRepository.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.core.memory
+
+import com.kernel.ai.core.memory.dao.ContactAliasDao
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ContactAliasRepository @Inject constructor(private val dao: ContactAliasDao) {
+    fun getAllAliases(): Flow<List<ContactAliasEntity>> = dao.getAllAliases()
+
+    suspend fun getByAlias(alias: String): ContactAliasEntity? =
+        dao.getByAlias(alias.trim().lowercase())
+
+    suspend fun addAlias(
+        alias: String,
+        displayName: String,
+        contactId: String,
+        phoneNumber: String,
+    ) {
+        dao.insert(ContactAliasEntity(alias.trim().lowercase(), displayName, contactId, phoneNumber))
+    }
+
+    suspend fun deleteAlias(alias: String) = dao.delete(alias.trim().lowercase())
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ContactAliasRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ContactAliasRepository.kt
@@ -10,8 +10,13 @@ import javax.inject.Singleton
 class ContactAliasRepository @Inject constructor(private val dao: ContactAliasDao) {
     fun getAllAliases(): Flow<List<ContactAliasEntity>> = dao.getAllAliases()
 
+    private fun normalise(alias: String): String =
+        alias.trim().lowercase()
+            .removePrefix("my ").removePrefix("the ")
+            .trim()
+
     suspend fun getByAlias(alias: String): ContactAliasEntity? =
-        dao.getByAlias(alias.trim().lowercase())
+        dao.getByAlias(normalise(alias))
 
     suspend fun addAlias(
         alias: String,
@@ -19,8 +24,8 @@ class ContactAliasRepository @Inject constructor(private val dao: ContactAliasDa
         contactId: String,
         phoneNumber: String,
     ) {
-        dao.insert(ContactAliasEntity(alias.trim().lowercase(), displayName, contactId, phoneNumber))
+        dao.insert(ContactAliasEntity(normalise(alias), displayName, contactId, phoneNumber))
     }
 
-    suspend fun deleteAlias(alias: String) = dao.delete(alias.trim().lowercase())
+    suspend fun deleteAlias(alias: String) = dao.delete(normalise(alias))
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.kernel.ai.core.memory.dao.ContactAliasDao
 import com.kernel.ai.core.memory.dao.ConversationDao
 import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
@@ -14,6 +15,7 @@ import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ConversationEntity
 import com.kernel.ai.core.memory.entity.CoreMemoryEntity
 import com.kernel.ai.core.memory.entity.EpisodicMemoryEntity
@@ -35,8 +37,9 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ModelSettingsEntity::class,
         QuickActionEntity::class,
         ScheduledAlarmEntity::class,
+        ContactAliasEntity::class,
     ],
-    version = 13,
+    version = 14,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -52,6 +55,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun modelSettingsDao(): ModelSettingsDao
     abstract fun quickActionDao(): QuickActionDao
     abstract fun scheduledAlarmDao(): ScheduledAlarmDao
+    abstract fun contactAliasDao(): ContactAliasDao
 
     companion object {
         /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
@@ -151,6 +155,13 @@ abstract class KernelDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Creates contact_aliases table for relationship-name to contact mapping (#355). */
+        val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE TABLE IF NOT EXISTS `contact_aliases` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.core.memory
 
 import android.content.Context
 import androidx.room.Room
+import com.kernel.ai.core.memory.dao.ContactAliasDao
 import com.kernel.ai.core.memory.dao.ConversationDao
 import com.kernel.ai.core.memory.dao.CoreMemoryDao
 import com.kernel.ai.core.memory.dao.EpisodicMemoryDao
@@ -57,6 +58,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_10_11,
                     KernelDatabase.MIGRATION_11_12,
                     KernelDatabase.MIGRATION_12_13,
+                    KernelDatabase.MIGRATION_13_14,
                 )
                 .build()
 
@@ -86,5 +88,13 @@ abstract class MemoryModule {
 
         @Provides
         fun provideScheduledAlarmDao(db: KernelDatabase): ScheduledAlarmDao = db.scheduledAlarmDao()
+
+        @Provides
+        fun provideContactAliasDao(db: KernelDatabase): ContactAliasDao = db.contactAliasDao()
+
+        @Provides
+        @Singleton
+        fun provideContactAliasRepository(dao: ContactAliasDao): ContactAliasRepository =
+            ContactAliasRepository(dao)
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ContactAliasDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ContactAliasDao.kt
@@ -1,0 +1,23 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ContactAliasDao {
+    @Query("SELECT * FROM contact_aliases ORDER BY alias ASC")
+    fun getAllAliases(): Flow<List<ContactAliasEntity>>
+
+    @Query("SELECT * FROM contact_aliases WHERE alias = :alias LIMIT 1")
+    suspend fun getByAlias(alias: String): ContactAliasEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(alias: ContactAliasEntity)
+
+    @Query("DELETE FROM contact_aliases WHERE alias = :alias")
+    suspend fun delete(alias: String)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ContactAliasEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ContactAliasEntity.kt
@@ -1,0 +1,12 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "contact_aliases")
+data class ContactAliasEntity(
+    @PrimaryKey val alias: String,      // lowercase, trimmed — e.g. "mum", "wife"
+    val displayName: String,            // UI display — e.g. "Margaret Smith"
+    val contactId: String,              // Android ContactsContract ID
+    val phoneNumber: String,            // cached phone number
+)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -627,8 +627,12 @@ class NativeIntentHandler @Inject constructor(
 
     private fun makeCall(params: Map<String, String>): SkillResult {
         val contact = params["contact"] ?: return SkillResult.Failure("make_call", "No contact specified")
+        // If the input looks like a phone number (digits, +, spaces, dashes), dial it directly.
+        val looksLikeNumber = contact.replace(Regex("[\\s\\-().+]"), "").all { it.isDigit() } &&
+            contact.replace(Regex("[\\s\\-().+]"), "").isNotEmpty()
         val phoneNumber = resolveContactNumber(contact)
-            ?: return SkillResult.Failure(
+            ?: if (looksLikeNumber) contact
+            else return SkillResult.Failure(
                 "make_call",
                 "Couldn't find a contact for '$contact'. You can add them in Settings → People & Contacts.",
             )

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -18,6 +18,7 @@ import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.provider.Settings
 import android.util.Log
+import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.skills.SkillResult
@@ -75,6 +76,7 @@ private const val TAG = "KernelAI"
 class NativeIntentHandler @Inject constructor(
     @ApplicationContext private val context: Context,
     private val scheduledAlarmDao: ScheduledAlarmDao,
+    private val contactAliasRepository: ContactAliasRepository,
 ) {
 
     fun handle(intentName: String, params: Map<String, String>): SkillResult {
@@ -625,7 +627,11 @@ class NativeIntentHandler @Inject constructor(
 
     private fun makeCall(params: Map<String, String>): SkillResult {
         val contact = params["contact"] ?: return SkillResult.Failure("make_call", "No contact specified")
-        val phoneNumber = resolveContactNumber(contact) ?: contact
+        val phoneNumber = resolveContactNumber(contact)
+            ?: return SkillResult.Failure(
+                "make_call",
+                "Couldn't find a contact for '$contact'. You can add them in Settings → People & Contacts.",
+            )
         return try {
             val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:${Uri.encode(phoneNumber)}")).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -638,6 +644,17 @@ class NativeIntentHandler @Inject constructor(
     }
 
     private fun resolveContactNumber(name: String): String? {
+        // 1. Alias check — strip common prefixes, normalise, look up in DB
+        val normalised = name.trim().lowercase()
+            .removePrefix("my ").removePrefix("the ")
+            .trim()
+        val aliasMatch = runBlocking { contactAliasRepository.getByAlias(normalised) }
+        if (aliasMatch != null) {
+            Log.d(TAG, "Alias resolved: '$name' → '${aliasMatch.displayName}' (${aliasMatch.phoneNumber})")
+            return aliasMatch.phoneNumber
+        }
+
+        // 2. Fall through to ContactsContract fuzzy search
         return try {
             val uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
             val projection = arrayOf(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesScreen.kt
@@ -1,0 +1,240 @@
+package com.kernel.ai.feature.settings
+
+import android.content.ContentUris
+import android.provider.ContactsContract
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactAliasesScreen(
+    onBack: () -> Unit = {},
+    viewModel: ContactAliasesViewModel = hiltViewModel(),
+) {
+    val aliases by viewModel.aliases.collectAsStateWithLifecycle()
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("People & Contacts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add alias")
+            }
+        },
+    ) { innerPadding ->
+        if (aliases.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp),
+            ) {
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "No aliases yet.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Tap + to map a nickname (e.g. \"mum\") to a contact so Jandal can call them by name.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                items(aliases, key = { it.alias }) { entity ->
+                    AliasRow(entity = entity, onDelete = { viewModel.deleteAlias(entity.alias) })
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AddAliasDialog(
+            onDismiss = { showAddDialog = false },
+            onSave = { alias, displayName, contactId, phoneNumber ->
+                viewModel.addAlias(alias, displayName, contactId, phoneNumber)
+                showAddDialog = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun AliasRow(
+    entity: ContactAliasEntity,
+    onDelete: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text("\"${entity.alias}\" → ${entity.displayName}")
+        },
+        supportingContent = {
+            Text(entity.phoneNumber, style = MaterialTheme.typography.bodySmall)
+        },
+        trailingContent = {
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Close, contentDescription = "Delete alias")
+            }
+        },
+    )
+}
+
+@Composable
+private fun AddAliasDialog(
+    onDismiss: () -> Unit,
+    onSave: (alias: String, displayName: String, contactId: String, phoneNumber: String) -> Unit,
+) {
+    val context = LocalContext.current
+    var aliasText by remember { mutableStateOf("") }
+    var selectedDisplayName by remember { mutableStateOf<String?>(null) }
+    var selectedContactId by remember { mutableStateOf<String?>(null) }
+    var selectedPhoneNumber by remember { mutableStateOf<String?>(null) }
+
+    val contactPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickContact(),
+    ) { contactUri ->
+        if (contactUri == null) return@rememberLauncherForActivityResult
+        // Resolve display name + phone number from the contact URI
+        val contactId = ContentUris.parseId(contactUri).toString()
+        var displayName: String? = null
+        var phoneNumber: String? = null
+
+        context.contentResolver.query(
+            contactUri,
+            arrayOf(ContactsContract.Contacts.DISPLAY_NAME),
+            null, null, null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                displayName = cursor.getString(
+                    cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)
+                )
+            }
+        }
+
+        context.contentResolver.query(
+            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+            arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER),
+            "${ContactsContract.CommonDataKinds.Phone.CONTACT_ID} = ?",
+            arrayOf(contactId),
+            null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                phoneNumber = cursor.getString(
+                    cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)
+                )
+            }
+        }
+
+        if (displayName != null && phoneNumber != null) {
+            selectedDisplayName = displayName
+            selectedContactId = contactId
+            selectedPhoneNumber = phoneNumber
+        }
+    }
+
+    val canSave = aliasText.isNotBlank() && selectedContactId != null
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add contact alias") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = aliasText,
+                    onValueChange = { aliasText = it },
+                    label = { Text("What do you call them?") },
+                    placeholder = { Text("e.g. mum, wife, boss") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Button(
+                    onClick = { contactPickerLauncher.launch(null) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Pick contact")
+                }
+                if (selectedDisplayName != null) {
+                    Text(
+                        text = "Selected: $selectedDisplayName (${selectedPhoneNumber})",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSave(
+                        aliasText,
+                        selectedDisplayName ?: "",
+                        selectedContactId ?: "",
+                        selectedPhoneNumber ?: "",
+                    )
+                },
+                enabled = canSave,
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesScreen.kt
@@ -188,7 +188,7 @@ private fun AddAliasDialog(
         }
     }
 
-    val canSave = aliasText.isNotBlank() && selectedContactId != null
+    val canSave = aliasText.isNotBlank() && selectedContactId != null && selectedPhoneNumber != null
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ContactAliasesViewModel.kt
@@ -1,0 +1,29 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ContactAliasesViewModel @Inject constructor(
+    private val repository: ContactAliasRepository,
+) : ViewModel() {
+
+    val aliases: StateFlow<List<ContactAliasEntity>> = repository.getAllAliases()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun deleteAlias(alias: String) {
+        viewModelScope.launch { repository.deleteAlias(alias) }
+    }
+
+    fun addAlias(alias: String, displayName: String, contactId: String, phoneNumber: String) {
+        viewModelScope.launch { repository.addAlias(alias, displayName, contactId, phoneNumber) }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
@@ -56,6 +57,7 @@ fun SettingsScreen(
     onNavigateToModelSettings: () -> Unit = {},
     onNavigateToModelManagement: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
+    onNavigateToContactAliases: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -152,6 +154,18 @@ fun SettingsScreen(
                 headlineContent = { Text("Memory") },
                 supportingContent = { Text("Manage stored memories") },
                 leadingContent = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            // ── People & Contacts ─────────────────────────────────────────────
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToContactAliases() },
+                headlineContent = { Text("People & Contacts") },
+                supportingContent = { Text("Map nicknames to contacts for calling") },
+                leadingContent = { Icon(Icons.Default.People, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()


### PR DESCRIPTION
## Summary

Implements #355 — Contact Aliases, allowing users to map relationship nicknames (e.g. "mum", "wife", "boss") to real contacts so that `make_call` can resolve them.

## Changes

### Data layer (Room v13→v14)
- **`ContactAliasEntity`** — new `contact_aliases` table
- **`ContactAliasDao`** — CRUD operations with Flow for the list
- **`KernelDatabase`** — bumped to v14, added entity + DAO + `MIGRATION_13_14`
- **`MemoryModule`** — wires `ContactAliasDao` and `ContactAliasRepository` via Hilt

### Repository
- **`ContactAliasRepository`** — `@Singleton`, normalises alias (trim + lowercase) before all DB calls

### Settings UI
- **`ContactAliasesViewModel`** — exposes `StateFlow<List<ContactAliasEntity>>`, `addAlias`, `deleteAlias`
- **`ContactAliasesScreen`** — LazyColumn of alias rows with delete (✕), FAB to open add-alias `AlertDialog` with `OutlinedTextField` + system `PickContact` launcher
- **`SettingsScreen`** — new "People & Contacts" row
- **`KernelNavHost`** — new `settings/contact_aliases` destination

### NativeIntentHandler
- Injected `ContactAliasRepository`
- `resolveContactNumber()` checks alias DB first (strips "my "/"the " prefixes), falls through to `ContactsContract` fuzzy search if no alias found
- `makeCall()` returns `SkillResult.Failure` with helpful Settings pointer when contact can't be resolved

## Testing
No build run per instructions. Patterns verified against `ScheduledAlarmDao`/`ScheduledAlarmEntity`/`MIGRATION_12_13` and existing settings screens.