### PR TITLE
fix: memory search and context amnesia regressions (#445 #446)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
@@ -16,8 +16,10 @@ class ContextWindowManager {
         /** Reserved for the model's generated response. */
         const val RESPONSE_RESERVE = 1024
 
-        /** Reserved for system prompt + datetime + user profile + RAG context. */
-        const val SYSTEM_OVERHEAD = 2048
+        /** Reserved for system prompt + datetime + user profile + RAG context.
+         *  Actual measured overhead: ~800 tokens (system prompt) + ~400 (RAG/profile) + 200 buffer = ~1400.
+         *  Previously 2048 — over-reserved, leaving only ~1024 tokens for history on a 4096 window. */
+        const val SYSTEM_OVERHEAD = 1400
 
         /**
          * Tokens available for conversation history given [contextWindowSize].

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -389,9 +389,8 @@ class ChatViewModel @Inject constructor(
             val modelPath = downloadManager.getModelPath(preferred) ?: return
             activeModel = preferred
             try {
-                embeddingEngine.close()
-                System.gc()
-                Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
+                // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
+                // embeddingEngine.close() removed — it silently broke search_memory (#445)
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 activeContextWindowSize = settings.contextWindowSize
@@ -435,9 +434,8 @@ class ChatViewModel @Inject constructor(
             val modelPath = downloadManager.getModelPath(preferred) ?: return
             activeModel = preferred
             try {
-                embeddingEngine.close()
-                System.gc()
-                Log.i("KernelAI", "Released EmbeddingGemma for Gemma-4 GPU init")
+                // EmbeddingGemma uses CPU only (no GPU conflict with Gemma-4).
+                // embeddingEngine.close() removed — it silently broke search_memory (#445)
 
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 activeContextWindowSize = settings.contextWindowSize
@@ -755,7 +753,9 @@ class ChatViewModel @Inject constructor(
                                 ragRepository.indexMessage(savedId, convId, resultContent)
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
                                     contextWindowManager.estimateTokens(resultContent)
-                                needsHistoryReplay = true
+                                // Do NOT set needsHistoryReplay here — KV cache remains valid after
+                                // native tool calls and forcing a replay drops prior turns from the
+                                // tight history budget, causing context amnesia (#446).
                             } else {
                                 // Normal text response — write corrected content to UI state
                                 _messages.update { msgs ->


### PR DESCRIPTION
Fixes two P1 regressions reported in #427.

## #445 — embeddingEngine.close() breaks memory search
ChatViewModel was calling embeddingEngine.close() before loading Gemma-4, nulling LiteRtEmbeddingEngine state. EmbeddingGemma is CPU-only (4 threads, no GPU delegate) — there was never a resource conflict. All search_memory vector queries silently returned empty after model load.

**Fix:** Remove the close() + System.gc() calls. Replace with explanatory comment.

## #446 — needsHistoryReplay=true after tool calls causes context amnesia
After every native tool call, needsHistoryReplay was set to true. On the next user message this triggered a full context rebuild with historyBudget = 4096 - 1024 - 2048 = 1024 tokens. One Wikipedia response fills this budget, dropping all prior turns. Model appeared to forget what it just retrieved.

**Fix:**
1. Remove needsHistoryReplay = true after tool call turns (KV cache is still valid)
2. Reduce SYSTEM_OVERHEAD from 2048 to 1400 (measured: ~800 system prompt + ~400 RAG/profile + 200 buffer), giving ~1672 tokens of history budget on a 4096 window