### PR TITLE
fix: email body keyword extraction + save_memory verbatim content (#447 #448)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -133,7 +133,7 @@ class KernelAIToolSet @Inject constructor(
 
     @Tool(description = "Save an important fact or preference to the user's long-term memory. Use when the user says 'remember', 'save', 'note that', or 'don't forget'")
     fun saveMemory(
-        @ToolParam(description = "The content to remember, written as a clear factual statement") content: String,
+        @ToolParam(description = "The exact fact or preference to save, verbatim as the user stated it — NOT a meta-summary or description of what they said. Example: 'Nick prefers dark mode' or 'Nick\\'s dog is called Biscuit'. Never write 'The user wants to remember X'.") content: String,
     ): Map<String, String> {
         toolCalledInThisTurn = true
         lastToolName = "save_memory"

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -626,17 +626,21 @@ class QuickIntentRouter(
                 params
             },
         ),
-        // "send an email to John about meeting" / "email John about the project"
+        // "send an email to John about meeting" / "email John with body Please review"
         IntentPattern(
             intentName = "send_email",
             regex = Regex(
-                """^(?:send\s+(?:an?\s+)?email|email)\s+(?:to\s+)?(.+?)(?:\s+(?:about|regarding|re|subject)\s+(.+))?$""",
+                """^(?:send\s+(?:an?\s+)?email|email)\s+(?:to\s+)?(.+?)""" +
+                    """(?:\s+(?:about|regarding|re|subject:?)\s+(.+?))?""" +
+                    """(?:\s+(?:body|message|saying|containing)\s+(.+))?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
                 val params = mutableMapOf("contact" to match.groupValues[1].trim())
                 val subject = match.groupValues[2].trim()
+                val body = match.groupValues[3].trim()
                 if (subject.isNotBlank()) params["subject"] = subject
+                if (body.isNotBlank()) params["body"] = body
                 params
             },
         ),

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -35,7 +35,7 @@ class SaveMemorySkill @Inject constructor(
         parameters = mapOf(
             "content" to SkillParameter(
                 type = "string",
-                description = "The fact or preference to remember, written as a clear statement."
+                description = "The exact fact or preference to remember, verbatim as the user stated it — NOT a meta-summary. e.g. 'Nick prefers dark mode', never 'User wants to save a preference'."
             )
         ),
         required = listOf("content"),
@@ -45,7 +45,9 @@ class SaveMemorySkill @Inject constructor(
 save_memory: Save an important fact or preference to the user's long-term memory.
 
 Parameters:
-- content (required, string): The fact to save as a clear statement.
+- content (required, string): The exact fact verbatim as the user stated it — NOT a meta-description.
+  CORRECT: "Nick's cat is called Whiskers"
+  WRONG:   "The user wants to remember the name of their cat"
 
 Memory rule: whenever the user says 'remember', 'save', 'note that', 'don't forget',
 'keep that in mind', 'save it', 'save that', 'remember that', or asks you to keep
@@ -72,7 +74,7 @@ Do NOT ask what to save — always infer and call the tool.
                     embeddingVector = vector,
                 )
                 Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
-                SkillResult.Success("✓ Saved to memory.")
+                SkillResult.Success("✓ Saved: \"${content.take(100)}\".")
             } catch (e: Exception) {
                 Log.e(TAG, "SaveMemorySkill failed", e)
                 SkillResult.Failure(name, e.message ?: "Failed to save memory")


### PR DESCRIPTION
## Summary

Fixes two P2 bugs identified in #427 device testing.

### #447 — Email regex missing body keyword

**Before:** `email John about meeting notes` → only `subject` extracted; no way to pass body content via Tier 2  
**After:** `email John about Meeting Notes with body Please review the agenda` → `subject` + `body` both extracted

Added `body|message|saying|containing` keyword group as group 3 in `send_email` regex. Existing `about|regarding|re|subject` group for subject unchanged.

### #448 — save_memory stores meta-summaries instead of actual content

**Before:** model called `save_memory(content: "The user wants to remember something")`  
**After:** `@ToolParam` description now explicitly forbids meta-descriptions with correct/wrong examples; `SkillResult.Success` echoes actual saved content so model can confirm naturally

## Changes
- `QuickIntentRouter.kt` — extend `send_email` regex; emit `body` param in extractor
- `KernelAIToolSet.kt` — `@ToolParam` for `saveMemory` content forbids meta-summaries
- `SaveMemorySkill.kt` — SkillSchema description updated; success message echoes saved content

Closes #447  
Closes #448