### PR TITLE
feat: SMS/email contact resolution + calendar attendees (#256 #317)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -207,6 +207,15 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
         ),
+        // "invite Sarah to my Friday dinner" / "invite John and Sarah to the team meeting"
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """^invite\s+.+\s+to\s+(?:my\s+|the\s+|a\s+|an\s+)?.{3,}""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+        ),
 
         // ── Do Not Disturb ──
         IntentPattern(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -84,6 +84,7 @@ class RunIntentSkill @Inject constructor(
         "Flashlight off → runIntent(intentName=\"toggle_flashlight_off\", parameters=\"{}\")",
         // Communication
         "Send email → runIntent(intentName=\"send_email\", parameters='{\"subject\":\"Hi\",\"body\":\"Text\"}')",
+        "Send email to John → runIntent(intentName=\"send_email\", parameters='{\"contact\":\"John\",\"subject\":\"Hi\",\"body\":\"Text\"}')",
         "Send SMS → runIntent(intentName=\"send_sms\", parameters='{\"contact\":\"Mom\",\"message\":\"On my way\"}')",
         "Call Dad → runIntent(intentName=\"make_call\", parameters='{\"contact\":\"Dad\"}')",
         // Scheduling
@@ -93,6 +94,7 @@ class RunIntentSkill @Inject constructor(
         "Set timer 3min → runIntent(intentName=\"set_timer\", parameters='{\"duration_seconds\":\"180\"}')",
         "Calendar event (explicit date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Lunch\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}')",
         "Calendar event (relative date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Cancel MightyApe\",\"date\":\"next thursday\",\"time\":\"16:00\"}')",
+        "Calendar with attendees → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Dinner\",\"date\":\"friday\",\"time\":\"19:00\",\"attendees\":\"Sarah,John\"}')",
         // System toggles
         "Turn on DND → runIntent(intentName=\"toggle_dnd_on\", parameters=\"{}\")",
         "Enable Wi-Fi → runIntent(intentName=\"toggle_wifi\", parameters='{\"state\":\"on\"}')",
@@ -126,14 +128,14 @@ class RunIntentSkill @Inject constructor(
         appendLine("  toggle_flashlight_on, toggle_flashlight_off — No params")
         appendLine()
         appendLine("COMMUNICATION:")
-        appendLine("  send_email — params: subject, body")
+        appendLine("  send_email — params: contact (optional, name to resolve email from contacts), subject, body")
         appendLine("  send_sms — params: contact, message")
         appendLine("  make_call — params: contact")
         appendLine()
         appendLine("SCHEDULING:")
         appendLine("  set_alarm — params: time (\"10pm\", \"9:30am\"), day (optional: \"tomorrow\", \"monday\"), label (optional)")
         appendLine("  set_timer — params: duration_seconds (\"180\" for 3 min), label (optional)")
-        appendLine("  create_calendar_event — params: title, date (pass relative terms as-is: \"tomorrow\", \"next thursday\", \"this friday\"; or YYYY-MM-DD for explicit dates), time (HH:MM), duration_minutes (optional), description (optional)")
+        appendLine("  create_calendar_event — params: title, date (pass relative terms as-is: \"tomorrow\", \"next thursday\", \"this friday\"; or YYYY-MM-DD for explicit dates), time (HH:MM), duration_minutes (optional), description (optional), attendees (optional, comma-separated contact names)")
         appendLine()
         appendLine("SYSTEM TOGGLES:")
         appendLine("  toggle_dnd_on, toggle_dnd_off — No params")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -136,10 +136,13 @@ class NativeIntentHandler @Inject constructor(
     // ── Email ─────────────────────────────────────────────────────────────────
 
     private fun sendEmail(params: Map<String, String>): SkillResult {
-        // SECURITY: do NOT populate EXTRA_EMAIL from LLM output — recipient must be chosen by user
-        // in the mail app to prevent prompt-injection exfiltration.
+        // Resolve recipient from on-device contacts only (never from raw LLM text).
+        // Only pre-populate if exactly one match is found — avoids wrong-recipient risk.
+        val contact = params["contact"]
+        val resolvedEmail = contact?.let { resolveContactEmail(it) }
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "message/rfc822"
+            if (resolvedEmail != null) putExtra(Intent.EXTRA_EMAIL, arrayOf(resolvedEmail))
             putExtra(Intent.EXTRA_SUBJECT, params["subject"] ?: "")
             putExtra(Intent.EXTRA_TEXT, params["body"] ?: "")
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -147,7 +150,8 @@ class NativeIntentHandler @Inject constructor(
         context.startActivity(Intent.createChooser(intent, "Send email").apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         })
-        return SkillResult.Success("Email composer opened.")
+        val recipientLabel = resolvedEmail?.let { " to $it" } ?: ""
+        return SkillResult.Success("Email composer opened$recipientLabel.")
     }
 
     // ── SMS ───────────────────────────────────────────────────────────────────
@@ -342,6 +346,13 @@ class NativeIntentHandler @Inject constructor(
             params["description"]?.takeIf { it.isNotBlank() }?.let {
                 putExtra(CalendarContract.Events.DESCRIPTION, it)
             }
+            // Attendees: resolve each name to email from contacts; skip unresolvable names
+            val attendeeEmails = params["attendees"]
+                ?.split(",")
+                ?.mapNotNull { it.trim().takeIf { n -> n.isNotBlank() }?.let { n -> resolveContactEmail(n) } }
+                ?.joinToString(",")
+                ?.takeIf { it.isNotBlank() }
+            if (attendeeEmails != null) putExtra(Intent.EXTRA_EMAIL, attendeeEmails)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
@@ -352,7 +363,8 @@ class NativeIntentHandler @Inject constructor(
             context.startActivity(intent)
             val timeLabel = if (timeStr != null) " at $timeStr" else " (all day)"
             val resolvedDateStr = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
-            SkillResult.Success("Calendar opened — '${title}' on $resolvedDateStr$timeLabel. Please review and save in your calendar app.")
+            val attendeesLabel = params["attendees"]?.takeIf { it.isNotBlank() }?.let { " with $it" } ?: ""
+            SkillResult.Success("Calendar opened — '${title}' on $resolvedDateStr$timeLabel$attendeesLabel. Please review and save in your calendar app.")
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("run_intent", "No calendar app found on this device.")
         }
@@ -658,7 +670,7 @@ class NativeIntentHandler @Inject constructor(
             return aliasMatch.phoneNumber
         }
 
-        // 2. Fall through to ContactsContract fuzzy search
+        // 2. ContactsContract fuzzy search — only pre-populate if unique match
         return try {
             val uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
             val projection = arrayOf(
@@ -668,14 +680,14 @@ class NativeIntentHandler @Inject constructor(
             val selection = "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} LIKE ?"
             val selectionArgs = arrayOf("%$name%")
             context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
-                if (cursor.moveToFirst()) {
-                    val number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
-                    val displayName = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME))
-                    Log.d(TAG, "Contact resolved: '$name' → '$displayName' ($number)")
-                    number
-                } else {
-                    Log.d(TAG, "Contact not found for '$name'")
-                    null
+                val matches = mutableListOf<String>()
+                while (cursor.moveToNext()) {
+                    matches += cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
+                }
+                when (matches.size) {
+                    0 -> { Log.d(TAG, "Contact not found for '$name'"); null }
+                    1 -> { Log.d(TAG, "Contact resolved: '$name' → ${matches[0]}"); matches[0] }
+                    else -> { Log.d(TAG, "Multiple contacts match '$name' — not pre-populating"); null }
                 }
             }
         } catch (e: SecurityException) {
@@ -683,6 +695,39 @@ class NativeIntentHandler @Inject constructor(
             null
         } catch (e: Exception) {
             Log.w(TAG, "Contact lookup failed for '$name'", e)
+            null
+        }
+    }
+
+    /** Resolves a contact name to an email address. Only pre-populates on unique match. */
+    private fun resolveContactEmail(name: String): String? {
+        return try {
+            val uri = ContactsContract.CommonDataKinds.Email.CONTENT_URI
+            val projection = arrayOf(
+                ContactsContract.CommonDataKinds.Email.ADDRESS,
+                ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY,
+            )
+            val selection = "${ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY} LIKE ?"
+            val selectionArgs = arrayOf("%$name%")
+            context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
+                val matches = mutableListOf<String>()
+                while (cursor.moveToNext()) {
+                    val address = cursor.getString(
+                        cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS)
+                    )
+                    if (!address.isNullOrBlank()) matches += address
+                }
+                when (matches.size) {
+                    0 -> { Log.d(TAG, "No email found for '$name'"); null }
+                    1 -> { Log.d(TAG, "Email resolved: '$name' → ${matches[0]}"); matches[0] }
+                    else -> { Log.d(TAG, "Multiple emails match '$name' — not pre-populating"); null }
+                }
+            }
+        } catch (e: SecurityException) {
+            Log.w(TAG, "READ_CONTACTS permission not granted — cannot resolve email for '$name'", e)
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "Email lookup failed for '$name'", e)
             null
         }
     }


### PR DESCRIPTION
## Summary

Two related features sharing the same contacts resolution infrastructure.

---

### #256 — SMS/email contact pre-population

**SMS** was already resolving contacts but used the first match regardless of ambiguity. **Email** had no resolution at all (previous security comment was overly broad — resolving from on-device contacts is safe; only raw LLM text is unsafe).

**Changes:**
- `resolveContactNumber()`: changed from "first match" to **uniqueness check** — returns the number only if exactly 1 contact matches. Multiple matches → `null` (blank `smsto:` URI). Prevents calling/texting the wrong person.
- `resolveContactEmail()`: **new method** — same uniqueness logic, queries `CommonDataKinds.Email` by display name. Falls back silently on `SecurityException` (no READ_CONTACTS permission).
- `sendEmail()`: resolves `contact` param to email from on-device contacts; pre-populates `EXTRA_EMAIL` if unique match; blank if no match or ambiguous.

**Behaviour:**
| Scenario | Result |
|---|---|
| "Email John" — 1 John in contacts | Pre-populated |
| "Email John" — 2 Johns in contacts | Blank (user picks) |
| "Email John" — no John in contacts | Blank |
| READ_CONTACTS denied | Blank (silent fallback) |

---

### #317 — Calendar attendees

**Changes:**
- `createCalendarEvent()`: reads `attendees` param (comma-separated names), resolves each to email via `resolveContactEmail()`, emits `Intent.EXTRA_EMAIL`. Unresolvable names skipped silently.
- Success message includes attendees label.
- `QuickIntentRouter`: new `invite X to event` pattern routes to `create_calendar_event`.
- `RunIntentSkill`: `send_email` contact param documented; `create_calendar_event` attendees param documented + example added.

**Example:** "Invite Sarah to my Friday dinner" → routes to Tier 2 → LLM emits `attendees: "Sarah"` → resolved to Sarah's email → `EXTRA_EMAIL` pre-filled in calendar app.

---

## Files changed
- `NativeIntentHandler.kt` — resolveContactNumber uniqueness fix; resolveContactEmail new; sendEmail recipient resolution; createCalendarEvent attendees
- `RunIntentSkill.kt` — updated docs + examples
- `QuickIntentRouter.kt` — invite pattern added

Closes #256  
Closes #317