### PR TITLE
fix: c4679d1 test failures — time format, day routing, calendar hints, alarm screen

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -28,6 +28,7 @@ import com.kernel.ai.feature.settings.ContactAliasesScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelManagementScreen
 import com.kernel.ai.feature.settings.ModelSettingsScreen
+import com.kernel.ai.feature.settings.ScheduledAlarmsScreen
 import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
 
@@ -42,6 +43,7 @@ private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management"
 private const val ROUTE_ABOUT = "settings/about"
 private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
+private const val ROUTE_SCHEDULED_ALARMS = "settings/scheduled_alarms"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
 
@@ -210,6 +212,9 @@ fun KernelNavHost() {
                     onNavigateToContactAliases = {
                         navController.navigate(ROUTE_CONTACT_ALIASES)
                     },
+                    onNavigateToScheduledAlarms = {
+                        navController.navigate(ROUTE_SCHEDULED_ALARMS)
+                    },
                 )
             }
 
@@ -250,6 +255,12 @@ fun KernelNavHost() {
 
             composable(ROUTE_CONTACT_ALIASES) {
                 ContactAliasesScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+
+            composable(ROUTE_SCHEDULED_ALARMS) {
+                ScheduledAlarmsScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/14.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/14.json
@@ -1,0 +1,553 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "372e41ee330d35566884be93408eaeb0",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '372e41ee330d35566884be93408eaeb0')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -18,6 +18,10 @@ interface ScheduledAlarmDao {
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
     fun observeUnfiredFuture(nowMillis: Long): Flow<List<ScheduledAlarmEntity>>
 
+    /** Observe all unfired alarms with no time filter — callers apply their own time cutoff. */
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 ORDER BY triggerAtMillis ASC")
+    fun observeAllUnfired(): Flow<List<ScheduledAlarmEntity>>
+
     @Query("UPDATE scheduled_alarms SET fired = 1 WHERE id = :id")
     suspend fun markFired(id: String)
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -5,14 +5,18 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ScheduledAlarmDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(alarm: ScheduledAlarmEntity)
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
     suspend fun getUnfiredFuture(nowMillis: Long): List<ScheduledAlarmEntity>
+
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
+    fun observeUnfiredFuture(nowMillis: Long): Flow<List<ScheduledAlarmEntity>>
 
     @Query("UPDATE scheduled_alarms SET fired = 1 WHERE id = :id")
     suspend fun markFired(id: String)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -181,7 +181,7 @@ class QuickIntentRouter(
                 """(?:add|create|schedule|put|book|set)\s+(?:a\s+|an\s+)?(?:calendar\s+)?(?:event|appointment|meeting|entry|invite|session|booking)\b""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
         IntentPattern(
             intentName = "create_calendar_event",
@@ -189,7 +189,7 @@ class QuickIntentRouter(
                 """(?:set\s+up|schedule)\s+(?:a\s+|an\s+)?meeting\b""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
         IntentPattern(
             intentName = "create_calendar_event",
@@ -197,7 +197,7 @@ class QuickIntentRouter(
                 """block\s+(?:out\s+)?(?:time\s+)?(?:on\s+(?:my\s+)?calendar\b|(?:this|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|week|morning|afternoon|evening)\b|tomorrow\b)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
         IntentPattern(
             intentName = "create_calendar_event",
@@ -205,7 +205,7 @@ class QuickIntentRouter(
                 """put\s+.{3,40}\s+(?:in|on|into)\s+(?:my\s+)?calendar\b""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
         // "invite Sarah to my Friday dinner" / "invite John and Sarah to the team meeting"
         IntentPattern(
@@ -214,7 +214,7 @@ class QuickIntentRouter(
                 """^invite\s+.+\s+to\s+(?:my\s+|the\s+|a\s+|an\s+)?.{3,}""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, raw -> mapOf("raw_query" to raw) },
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
 
         // ── Do Not Disturb ──
@@ -262,13 +262,28 @@ class QuickIntentRouter(
         ),
 
         // ── Time / Date ──
+        // query_type drives the response format in NativeIntentHandler.getTime():
+        //   "time"        → just the time (e.g. "It's 7:27 PM")
+        //   "date"        → just the date (e.g. "Today is Thursday, 16 April 2026")
+        //   "day_of_week" → just the weekday name
+        //   "year"        → just the year
+        //   "month"       → just the month name
+        //   "week"        → week number
+        //   (absent)      → full datetime (fallback)
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
-                """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(?:time|date|day)""",
+                """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(time|date|day)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                when (match.groupValues[1].lowercase()) {
+                    "time" -> mapOf("query_type" to "time")
+                    "date" -> mapOf("query_type" to "date")
+                    "day" -> mapOf("query_type" to "day_of_week")
+                    else -> emptyMap()
+                }
+            },
         ),
         IntentPattern(
             intentName = "get_time",
@@ -276,23 +291,44 @@ class QuickIntentRouter(
                 """what\s+time\s+is\s+it""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "time") },
         ),
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
-                """(?:tell|give)\s+me\s+(?:the\s+)?(?:time|date)""",
+                """(?:tell|give)\s+me\s+(?:the\s+)?(time|date)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                when (match.groupValues[1].lowercase()) {
+                    "time" -> mapOf("query_type" to "time")
+                    "date" -> mapOf("query_type" to "date")
+                    else -> emptyMap()
+                }
+            },
         ),
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
-                """what\s+(?:day|date)\s+is\s+(?:it|today)""",
+                """what\s+(day|date)\s+is\s+(?:it|today)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                when (match.groupValues[1].lowercase()) {
+                    "day" -> mapOf("query_type" to "day_of_week")
+                    "date" -> mapOf("query_type" to "date")
+                    else -> emptyMap()
+                }
+            },
+        ),
+        // "what day of the week is it" — explicit pattern so it doesn't fall to LLM
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """what\s+day\s+of\s+the\s+week\s+(?:is\s+it|it\s+is|are\s+we\s+in)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> mapOf("query_type" to "day_of_week") },
         ),
         // Pattern: "what's today's date" / "what is today's date" (must be before broader "what is today")
         IntentPattern(
@@ -301,7 +337,7 @@ class QuickIntentRouter(
                 """what(?:'s| is)\s+today'?s\s+(?:date|day)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "date") },
         ),
         // Pattern: "what is today" / "what's today"
         IntentPattern(
@@ -310,7 +346,7 @@ class QuickIntentRouter(
                 """what(?:'s| is)\s+today""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "date") },
         ),
         // Pattern: "what year is it" / "what year are we in"
         IntentPattern(
@@ -319,7 +355,7 @@ class QuickIntentRouter(
                 """what\s+year\s+(?:is\s+it|are\s+we\s+in|is\s+this)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "year") },
         ),
         // Pattern: "what year is it currently" / "what's the year"
         IntentPattern(
@@ -328,7 +364,7 @@ class QuickIntentRouter(
                 """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?year\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "year") },
         ),
         // Pattern: "is it still Monday" / "is it Monday today" / "is today Monday" / "is it Friday today"
         IntentPattern(
@@ -337,25 +373,37 @@ class QuickIntentRouter(
                 """(?:is\s+it\s+(?:still\s+)?|is\s+today\s+)(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)(?:\s+today)?\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { _, _ -> mapOf("query_type" to "day_of_week") },
         ),
         // Pattern: "what month is it" / "what week is it" / "what month are we in"
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
-                """what\s+(?:month|week)\b\s+(?:is\s+it|are\s+we\s+in|is\s+this)\s*$""",
+                """what\s+(month|week)\b\s+(?:is\s+it|are\s+we\s+in|is\s+this)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                when (match.groupValues[1].lowercase()) {
+                    "month" -> mapOf("query_type" to "month")
+                    "week" -> mapOf("query_type" to "week")
+                    else -> emptyMap()
+                }
+            },
         ),
         // Pattern: "what's the month" / "what's the week"
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
-                """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(?:month|week)\s*$""",
+                """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(month|week)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { _, _ -> emptyMap() },
+            paramExtractor = { match, _ ->
+                when (match.groupValues[1].lowercase()) {
+                    "month" -> mapOf("query_type" to "month")
+                    "week" -> mapOf("query_type" to "week")
+                    else -> emptyMap()
+                }
+            },
         ),
 
         // ── Volume ──
@@ -739,6 +787,28 @@ class QuickIntentRouter(
     // ── Parameter parsing helpers ─────────────────────────────────────────────
 
     companion object {
+        /**
+         * Builds calendar intent params from a raw user query. Always includes `raw_query`.
+         * Attempts to pre-extract a `extracted_title` hint from "for a/an X" phrasing so the
+         * LLM prompt can be made more specific (reducing "title is required" failures).
+         */
+        fun extractCalendarHints(raw: String): Map<String, String> {
+            val params = mutableMapOf("raw_query" to raw)
+            // Match "for a/an X" or "for X" where X doesn't start with a date/time keyword.
+            // Stops before at/from/on/next/this/tomorrow/weekday names/digits.
+            val titleMatch = Regex(
+                """(?:^|\s)for\s+(?:a\s+|an\s+)?([a-zA-Z][a-zA-Z\s]{1,40}?)(?=\s+(?:at|from|on|next|this|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d)|$)""",
+                RegexOption.IGNORE_CASE,
+            ).find(raw)
+            titleMatch?.groupValues?.get(1)?.trim()
+                ?.takeIf { it.isNotBlank() && it.length >= 2 }
+                ?.let { title ->
+                    params["extracted_title"] = title.split(" ")
+                        .joinToString(" ") { w -> w.replaceFirstChar { c -> c.uppercase() } }
+                }
+            return params
+        }
+
         fun parseAlarmTime(raw: String): Map<String, String> {
             val params = mutableMapOf<String, String>()
             val cleaned = raw.lowercase().trim()
@@ -770,6 +840,13 @@ class QuickIntentRouter(
             val dayMatch = dayRegex.find(cleaned)
             if (dayMatch != null) {
                 params["day"] = normalizeDayName(dayMatch.groupValues[1].lowercase())
+            }
+
+            // Extract label from "called X", "named X", "labeled X", "labelled X" — mirrors parseTimerDuration
+            val labelRegex = Regex("""(?:called|named|label(?:l?)ed)\s+(.+)$""", RegexOption.IGNORE_CASE)
+            val labelMatch = labelRegex.find(cleaned)
+            if (labelMatch != null) {
+                params["label"] = labelMatch.groupValues[1].trim()
             }
 
             return params

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -842,8 +842,13 @@ class QuickIntentRouter(
                 params["day"] = normalizeDayName(dayMatch.groupValues[1].lowercase())
             }
 
-            // Extract label from "called X", "named X", "labeled X", "labelled X" — mirrors parseTimerDuration
-            val labelRegex = Regex("""(?:called|named|label(?:l?)ed)\s+(.+)$""", RegexOption.IGNORE_CASE)
+            // Extract label from "called X", "named X", "labeled X", "labelled X" — mirrors parseTimerDuration.
+            // Non-greedy capture with lookahead to stop before time/date keywords so
+            // "alarm called wake up at 7am" extracts "wake up", not "wake up at 7am".
+            val labelRegex = Regex(
+                """(?:called|named|label(?:l?)ed)\s+(.+?)(?=\s+(?:at|on|for|by|from|tomorrow|today|tonight|morning|afternoon|evening|monday|tuesday|wednesday|thursday|friday|saturday|sunday|\d{1,2}(?::\d{2})?\s*(?:am|pm))(?:\s|$)|$)""",
+                RegexOption.IGNORE_CASE,
+            )
             val labelMatch = labelRegex.find(cleaned)
             if (labelMatch != null) {
                 params["label"] = labelMatch.groupValues[1].trim()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -32,6 +32,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.time.temporal.TemporalAdjusters
+import java.time.temporal.WeekFields
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -91,7 +92,7 @@ class NativeIntentHandler @Inject constructor(
                 "set_timer" -> setTimer(params)
                 "create_calendar_event" -> createCalendarEvent(params)
                 "get_battery" -> getBattery()
-                "get_time", "get_date" -> getTime()
+                "get_time", "get_date" -> getTime(params)
                 "toggle_dnd_on" -> setDoNotDisturb(true)
                 "toggle_dnd_off" -> setDoNotDisturb(false)
                 "set_volume" -> setVolume(params)
@@ -325,9 +326,11 @@ class NativeIntentHandler @Inject constructor(
         }
         val zone = ZoneId.systemDefault()
 
+        var resolvedTimeLabel: String? = null
         val (beginMillis, endMillis) = if (timeStr != null) {
             val time = resolveTime(timeStr)
                 ?: return SkillResult.Failure("run_intent", "Invalid time format '$timeStr' — expected HH:MM (24h).")
+            resolvedTimeLabel = time.format(DateTimeFormatter.ofPattern("HH:mm"))
             val begin = LocalDateTime.of(date, time).atZone(zone).toInstant().toEpochMilli()
             val end = begin + durationMinutes * 60_000L
             begin to end
@@ -361,7 +364,7 @@ class NativeIntentHandler @Inject constructor(
         }
         return try {
             context.startActivity(intent)
-            val timeLabel = if (timeStr != null) " at $timeStr" else " (all day)"
+            val timeLabel = if (resolvedTimeLabel != null) " at $resolvedTimeLabel" else " (all day)"
             val resolvedDateStr = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
             val attendeesLabel = params["attendees"]?.takeIf { it.isNotBlank() }?.let { " with $it" } ?: ""
             SkillResult.Success("Calendar opened — '${title}' on $resolvedDateStr$timeLabel$attendeesLabel. Please review and save in your calendar app.")
@@ -382,11 +385,32 @@ class NativeIntentHandler @Inject constructor(
 
     // ── Time / Date ───────────────────────────────────────────────────────────
 
-    private fun getTime(): SkillResult {
+    private fun getTime(params: Map<String, String> = emptyMap()): SkillResult {
         val now = LocalDateTime.now()
-        val time = now.format(DateTimeFormatter.ofPattern("h:mm a"))
-        val date = now.format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
-        return SkillResult.Success("It's $time on $date")
+        return when (params["query_type"]) {
+            "time" -> SkillResult.Success(
+                "It's ${now.format(DateTimeFormatter.ofPattern("h:mm a"))}",
+            )
+            "date" -> SkillResult.Success(
+                "Today is ${now.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy"))}",
+            )
+            "day_of_week" -> SkillResult.Success(
+                "It's ${now.format(DateTimeFormatter.ofPattern("EEEE"))}",
+            )
+            "year" -> SkillResult.Success("It's ${now.year}")
+            "month" -> SkillResult.Success(
+                "It's ${now.format(DateTimeFormatter.ofPattern("MMMM"))}",
+            )
+            "week" -> {
+                val week = now.get(WeekFields.ISO.weekOfWeekBasedYear())
+                SkillResult.Success("It's week $week of ${now.year}")
+            }
+            else -> {
+                val time = now.format(DateTimeFormatter.ofPattern("h:mm a"))
+                val date = now.format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
+                SkillResult.Success("It's $time on $date")
+            }
+        }
     }
 
     // ── Do Not Disturb ────────────────────────────────────────────────────────

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -558,9 +558,11 @@ class ChatViewModel @Inject constructor(
                     matchedIntent.params["title"].isNullOrBlank()
                 ) {
                     val rawQuery = matchedIntent.params["raw_query"] ?: text
+                    val titleHint = matchedIntent.params["extracted_title"]
+                    val titleClause = if (titleHint != null) "The event title is likely \"$titleHint\". " else ""
                     systemContext = "[System: User wants to create a calendar event. " +
                         "Their request: \"$rawQuery\". " +
-                        "Extract the event title, date, and time, then call " +
+                        "${titleClause}Extract the event title, date, and time, then call " +
                         "runIntent(intentName=\"create_calendar_event\", ...). " +
                         "Pass the date exactly as the user said it. Pass time as HH:MM 24h.]"
                     // fall through to E4B — do NOT execute now

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -1,0 +1,143 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Alarm
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScheduledAlarmsScreen(
+    onBack: () -> Unit = {},
+    viewModel: ScheduledAlarmsViewModel = hiltViewModel(),
+) {
+    val alarms by viewModel.alarms.collectAsStateWithLifecycle()
+    var pendingCancel by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Scheduled Alarms") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (alarms.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp),
+            ) {
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "No upcoming alarms.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Alarms scheduled via Jandal for a specific date appear here. You can cancel them before they fire.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                items(alarms, key = { it.id }) { alarm ->
+                    AlarmRow(alarm = alarm, onCancel = { pendingCancel = alarm })
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    pendingCancel?.let { alarm ->
+        AlertDialog(
+            onDismissRequest = { pendingCancel = null },
+            icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+            title = { Text("Cancel alarm?") },
+            text = {
+                val label = alarm.label ?: "Alarm"
+                val formatted = Instant.ofEpochMilli(alarm.triggerAtMillis)
+                    .let { DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma").withZone(ZoneId.systemDefault()).format(it) }
+                Text("Cancel \"$label\" scheduled for $formatted?")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.cancelAlarm(alarm)
+                    pendingCancel = null
+                }) { Text("Cancel alarm") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingCancel = null }) { Text("Keep") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun AlarmRow(
+    alarm: ScheduledAlarmEntity,
+    onCancel: () -> Unit,
+) {
+    val formatted = remember(alarm.triggerAtMillis) {
+        Instant.ofEpochMilli(alarm.triggerAtMillis)
+            .let { DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma").withZone(ZoneId.systemDefault()).format(it) }
+    }
+    ListItem(
+        headlineContent = { Text(alarm.label ?: "Alarm") },
+        supportingContent = { Text(formatted) },
+        leadingContent = {
+            Icon(
+                Icons.Default.Alarm,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        },
+        trailingContent = {
+            IconButton(onClick = onCancel) {
+                Icon(Icons.Default.Delete, contentDescription = "Cancel alarm")
+            }
+        },
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -1,0 +1,52 @@
+package com.kernel.ai.feature.settings
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ScheduledAlarmsViewModel @Inject constructor(
+    private val dao: ScheduledAlarmDao,
+    @ApplicationContext private val context: Context,
+) : ViewModel() {
+
+    val alarms: StateFlow<List<ScheduledAlarmEntity>> =
+        dao.observeUnfiredFuture(System.currentTimeMillis())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun cancelAlarm(alarm: ScheduledAlarmEntity) {
+        viewModelScope.launch {
+            // Cancel the pending AlarmManager broadcast
+            val alarmManager = context.getSystemService(AlarmManager::class.java)
+            val broadcastIntent = Intent().apply {
+                component = android.content.ComponentName(
+                    context.packageName,
+                    "com.kernel.ai.alarm.AlarmBroadcastReceiver",
+                )
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                alarm.id.hashCode(),
+                broadcastIntent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+            )
+            pendingIntent?.let { alarmManager.cancel(it) }
+
+            // Remove from DB
+            dao.delete(alarm.id)
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -23,19 +23,25 @@ class ScheduledAlarmsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
+    // Filter by current time on every emission so past-due alarms disappear immediately
     val alarms: StateFlow<List<ScheduledAlarmEntity>> =
-        dao.observeUnfiredFuture(System.currentTimeMillis())
+        dao.observeAllUnfired()
+            .map { list -> list.filter { it.triggerAtMillis > System.currentTimeMillis() } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun cancelAlarm(alarm: ScheduledAlarmEntity) {
         viewModelScope.launch {
-            // Cancel the pending AlarmManager broadcast
+            // Cancel the pending AlarmManager broadcast.
+            // Intent must include the same extras used when the alarm was scheduled
+            // so that PendingIntent.filterEquals() finds a match.
             val alarmManager = context.getSystemService(AlarmManager::class.java)
             val broadcastIntent = Intent().apply {
                 component = android.content.ComponentName(
                     context.packageName,
                     "com.kernel.ai.alarm.AlarmBroadcastReceiver",
                 )
+                putExtra("alarm_label", alarm.label ?: "Alarm")
+                putExtra("alarm_id", alarm.id)
             }
             val pendingIntent = PendingIntent.getBroadcast(
                 context,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
@@ -58,6 +59,7 @@ fun SettingsScreen(
     onNavigateToModelManagement: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
     onNavigateToContactAliases: () -> Unit = {},
+    onNavigateToScheduledAlarms: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -166,6 +168,18 @@ fun SettingsScreen(
                 headlineContent = { Text("People & Contacts") },
                 supportingContent = { Text("Map nicknames to contacts for calling") },
                 leadingContent = { Icon(Icons.Default.People, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            // ── Scheduled Alarms ─────────────────────────────────────────────
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToScheduledAlarms() },
+                headlineContent = { Text("Scheduled Alarms") },
+                supportingContent = { Text("View and cancel upcoming alarms set by Jandal") },
+                leadingContent = { Icon(Icons.Default.Alarm, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()


### PR DESCRIPTION
## Summary

Fixes all issues identified from c4679d1 device testing reported in #427.

## Fixes

### Fix 1 — "What time is it" response includes full date
`getTime()` now accepts a `query_type` param and returns a focused response:
- `time` → "It's 7:27 PM"
- `date` → "Today is Thursday, 16 April 2026"
- `day_of_week` → "It's Thursday"
- `year`/`month`/`week` → targeted answers

All QuickIntentRouter time/date patterns updated to pass the appropriate `query_type`.

### Fix 2 — "What day of the week is it" called get_weather
Added explicit `what day of the week is it` pattern to QuickIntentRouter routing to `get_time` with `query_type=day_of_week`. Previously fell through to LLM which miscalled `get_weather`.

### Fix 3 — Alarm label not extracted (Pattern B parity fix)
`parseAlarmTime()` now extracts labels via `called/named/labeled` regex, matching the existing behaviour in `parseTimerDuration()`. Fixes "set alarm for 7am called gym" losing the label.

### Fix 4 — Calendar title hint extraction
New `extractCalendarHints()` helper pre-extracts the event title from "for a/an X" phrasing in all calendar `raw_query` patterns. ChatViewModel injects it into the LLM prompt. Fixes "Block this Friday for a review" → title required failure.

### Fix 5 — Calendar success message shows raw "17:000"
`createCalendarEvent()` now tracks the resolved `LocalTime` and formats it as `HH:mm` in the success message instead of echoing the raw LLM `timeStr` param.

### Fix 6 — Scheduled Alarms management screen
New **Settings → Scheduled Alarms** screen backed by the existing `ScheduledAlarmEntity` Room DB:
- Lists all upcoming (unfired) alarms with label and formatted date/time
- Cancel button cancels both the `AlarmManager` `PendingIntent` and deletes the DB row
- Empty state explains what the screen is for
- Added `observeUnfiredFuture()` `Flow` query to `ScheduledAlarmDao`

## Test cases (from #427 build c4679d1)
- [ ] "What time is it" → time only, no date
- [ ] "What day of the week is it" → "It's Thursday", no get_weather call
- [ ] "Set an alarm for 7am called gym" → alarm created with label
- [ ] "Block this Friday for a review" → LLM receives title hint "Review", event created
- [ ] "Set a dental appointment for 5pm tomorrow" → success message shows "17:00" not "17:000"
- [ ] "Set alarm for 9pm tomorrow" → alarm visible and cancellable in Settings → Scheduled Alarms
