### PR TITLE
fix: tighten @Tool descriptions to prevent wrong tool selection

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -3,7 +3,22 @@ package com.kernel.ai.core.inference
 import com.google.ai.edge.litertlm.SamplerConfig
 import com.google.ai.edge.litertlm.ToolProvider
 
-/** Jandal's default system prompt. Injected into every new conversation. */
+/**
+ * Jandal's default system prompt. Injected into every new conversation.
+ *
+ * ## ⚠️ Two-tier skill gateway — do NOT advertise specific tool call syntax here
+ * The model discovers how to use skills via the `loadSkill` gateway (see [KernelAIToolSet]):
+ *   1. Model sees only tool *names* + short *descriptions* from `@Tool` annotations.
+ *   2. Model calls `loadSkill("<skill>")` → receives full parameter instructions at runtime.
+ *   3. Model calls the actual tool with correct parameters.
+ *
+ * Never put raw call syntax like `runJs(skillName="query-wikipedia")` in this prompt.
+ * Doing so bypasses step 2 and causes the model to skip `loadSkill`, breaking the lazy
+ * loading design and potentially inflating every conversation's token cost.
+ *
+ * Behavioural rules and IMPORTANT directives are safe to add here.
+ * Skill routing specifics belong in the `@Tool` description or in the skill's loadSkill payload.
+ */
 const val DEFAULT_SYSTEM_PROMPT =
     "You are Jandal — a capable, on-device AI assistant with a genuine Kiwi character. " +
         "You're direct, warm, and dry-humoured without trying too hard. " +

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -14,7 +14,8 @@ const val DEFAULT_SYSTEM_PROMPT =
         "Own your Kiwi identity with pride — never say you are 'just code'. " +
         "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +
         "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
-        "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information."
+        "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
+        "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally."
 
 /**
  * Minimal identity for tool-only execution (Actions tab).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -16,7 +16,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
-        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information (e.g. Wikipedia, weather, time), call the appropriate tool — do NOT fabricate a response as if you had. For Wikipedia lookups use runJs(skillName=\"query-wikipedia\")."
+        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had."
 
 /**
  * Minimal identity for tool-only execution (Actions tab).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -15,7 +15,8 @@ const val DEFAULT_SYSTEM_PROMPT =
         "Language rules: You are New Zealand, NOT Australian. Never use Australian phrases like 'fair dinkum' or 'G'day'. " +
         "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
-        "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally."
+        "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
+        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information (e.g. Wikipedia, weather, time), call the appropriate tool — do NOT fabricate a response as if you had. For Wikipedia lookups use runJs(skillName=\"query-wikipedia\")."
 
 /**
  * Minimal identity for tool-only execution (Actions tab).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -30,7 +30,7 @@ const val MINIMAL_SYSTEM_PROMPT =
 const val DEFAULT_MAX_TOKENS = 8000
 
 /** Sampler defaults for CPU/GPU backends. NPU requires null samplerConfig. */
-val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 40, topP = 0.95, temperature = 0.7)
+val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 64, topP = 0.95, temperature = 0.7)
 
 /**
  * Controls how much of the Jandal identity is injected into the system prompt.
@@ -52,7 +52,7 @@ enum class IdentityTier {
  * @param systemPrompt Optional system instruction prepended to every conversation.
  * @param temperature Sampling temperature (0.1-2.0). Higher = more creative. Default 1.0.
  * @param topP Nucleus sampling threshold (0.0-1.0). Default 0.95.
- * @param topK Top-K candidates for sampling. Ignored on NPU (hardware sampler). Default 40.
+ * @param topK Top-K candidates for sampling. Ignored on NPU (hardware sampler). Default 64 (Gemma 4 model card).
  * @param thinkingEnabled Whether to enable the model's thinking (chain-of-thought) channel.
  *   When false, the `thought` channel is omitted from [ConversationConfig], preventing the
  *   model from generating reasoning tokens — saving compute time and context window space.
@@ -65,7 +65,7 @@ data class ModelConfig(
     val systemPrompt: String? = DEFAULT_SYSTEM_PROMPT,
     val temperature: Float = 1.0f,
     val topP: Float = 0.95f,
-    val topK: Int = 40,
+    val topK: Int = 64,
     val thinkingEnabled: Boolean = true,
     val toolProvider: ToolProvider? = null,
 )

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -117,7 +117,7 @@ class KernelAIToolSet @Inject constructor(
 
     @Tool(description = "Get current weather conditions or a multi-day weather forecast for a location. ONLY for weather, temperature, precipitation, wind, or climate queries. NOT for date, time, day-of-week, calendar, or general knowledge questions.")
     fun getWeather(
-        @ToolParam(description = "Optional location/city name (e.g., \"Brisbane\" or \"Murrumba Downs, QLD, Australia\"). If provided, uses this location. If omitted, uses device GPS") location: String,
+        @ToolParam(description = "Optional location/city name. ONLY provide if the user explicitly names a place (e.g. 'in Brisbane') or says 'at home'. Leave blank for all other weather queries — device GPS will be used automatically and is more accurate than profile location.") location: String,
         @ToolParam(description = "Optional number of forecast days (1-7). Omit for current conditions only") forecastDays: String,
     ): Map<String, String> {
         toolCalledInThisTurn = true

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -67,7 +67,7 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Execute a native Android device action: flashlight, alarms, timers, calendar events, email, SMS, calls, Do Not Disturb, volume, Wi-Fi, Bluetooth, airplane mode, hotspot, media playback (local/YouTube/Spotify/Netflix/Plex), navigation, app launching, and info queries")
+    @Tool(description = "Execute a native Android device action: flashlight, alarms, timers, calendar events, email, SMS, phone calls, Do Not Disturb, volume, Wi-Fi, Bluetooth, airplane mode, hotspot, media playback (local/YouTube/Spotify/Netflix/Plex), navigation, app launching, battery status, current time, and current date. NOT for weather, web search, memory recall, or general knowledge questions.")
     fun runIntent(
         @ToolParam(description = "The intent action: toggle_flashlight_on, toggle_flashlight_off, send_email, send_sms, make_call, set_alarm, set_timer, create_calendar_event, toggle_dnd_on, toggle_dnd_off, toggle_wifi, toggle_bluetooth, toggle_airplane_mode, toggle_hotspot, set_volume, play_media, play_media_album, play_media_playlist, play_youtube, play_spotify, play_netflix, play_plex, navigate_to, find_nearby, open_app, get_battery, get_time, get_date") intentName: String,
         @ToolParam(description = "Additional parameters as key:value pairs in JSON. For set_alarm: {\"time\":\"10pm\"} or {\"time\":\"7:30am\",\"day\":\"monday\",\"label\":\"Wake up\"}. For set_timer: {\"duration_seconds\":\"180\"}. For send_email: {\"subject\":\"Hi\",\"body\":\"Text\"}. For send_sms: {\"contact\":\"Mom\",\"message\":\"Text\"}. For make_call: {\"contact\":\"Dad\"}. For create_calendar_event: {\"title\":\"Meeting\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}. For set_volume: {\"value\":\"50\",\"is_percent\":\"true\"}. For play_media: {\"query\":\"Song Name\",\"artist\":\"Artist\"}. For play_plex: {\"title\":\"Movie Name\"}. For navigate_to: {\"destination\":\"airport\"}. For toggle_wifi/bluetooth/airplane_mode/hotspot: {\"state\":\"on\"}. For open_app: {\"app_name\":\"Spotify\"}. For toggle_dnd/flashlight/get_battery/get_time/get_date: {}") parameters: String,
@@ -89,7 +89,7 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Run a built-in JavaScript skill. Use skill_name 'get-weather-city' for weather by city name, 'query-wikipedia' for Wikipedia search. For GPS weather use run_intent with get_weather_gps instead")
+    @Tool(description = "Run a built-in JavaScript skill. Use 'query-wikipedia' for Wikipedia or encyclopedia lookups. DO NOT use for weather — use the getWeather tool instead.")
     fun runJs(
         @ToolParam(description = "The JS skill to run: 'get-weather-city' or 'query-wikipedia'") skillName: String,
         @ToolParam(description = "The search query or input (city name for weather, topic for Wikipedia)") query: String,
@@ -109,7 +109,7 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Get current weather or forecast. If user's location is known from their profile, pass it as location parameter. Otherwise uses device GPS")
+    @Tool(description = "Get current weather conditions or a multi-day weather forecast for a location. ONLY for weather, temperature, precipitation, wind, or climate queries. NOT for date, time, day-of-week, calendar, or general knowledge questions.")
     fun getWeather(
         @ToolParam(description = "Optional location/city name (e.g., \"Brisbane\" or \"Murrumba Downs, QLD, Australia\"). If provided, uses this location. If omitted, uses device GPS") location: String,
         @ToolParam(description = "Optional number of forecast days (1-7). Omit for current conditions only") forecastDays: String,
@@ -131,7 +131,7 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Save an important fact or preference to the user's long-term memory. Use when the user says 'remember', 'save', 'note that', or 'don't forget'")
+    @Tool(description = "Save an important fact or preference to the user's long-term memory. Use when the user says 'remember', 'save', 'note that', or 'don't forget'. NOT for calendar events, alarms, reminders, timers, or to-do items — use runIntent for those.")
     fun saveMemory(
         @ToolParam(description = "The exact fact or preference to save, verbatim as the user stated it — NOT a meta-summary or description of what they said. Example: 'Nick prefers dark mode' or 'Nick\\'s dog is called Biscuit'. Never write 'The user wants to remember X'.") content: String,
     ): Map<String, String> {
@@ -143,7 +143,7 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Search saved memories and past conversation history for information about a topic. Use when the user asks what you remember, wants to recall a fact, or asks about past conversations")
+    @Tool(description = "Search saved memories and past conversation history for information about a topic. Use when the user asks what you remember, wants to recall a fact, or asks about past conversations. NOT for web search, Wikipedia, weather, or any real-time information.")
     fun searchMemory(
         @ToolParam(description = "What to search for in saved memories and past messages") query: String,
     ): Map<String, String> {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -31,6 +31,12 @@ private const val TAG = "KernelAI"
  * ## Lazy injection
  * [SkillRegistry] is injected lazily to break the circular dependency:
  * SkillRegistry → Set<Skill> (includes LoadSkillSkill) → SkillRegistry.
+ *
+ * ## ⚠️ System prompt constraint
+ * Because the model only learns skill parameters via `loadSkill`, the system prompt
+ * ([DEFAULT_SYSTEM_PROMPT] in ModelConfig) must never contain raw tool call syntax
+ * (e.g. `runJs(skillName="query-wikipedia")`). That would cause the model to skip
+ * step 2 entirely. Behavioural rules are fine; skill invocation recipes are not.
  */
 @Singleton
 class KernelAIToolSet @Inject constructor(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -31,22 +31,22 @@ class GetWeatherSkill @Inject constructor(
 
     override val name = "get_weather_gps"
     override val description =
-        "Get current weather or a multi-day forecast. Can use device GPS or a specified location. " +
-            "If the user's location is known from their profile, pass it in the location parameter. " +
-            "Otherwise, uses device GPS as fallback. " +
+        "Get current weather or a multi-day forecast. Uses device GPS by default — only pass a " +
+            "location if the user explicitly names a place or says 'at home'. " +
+            "Profile location is a fallback only when GPS is unavailable. " +
             "ALWAYS call this tool for any weather question — never use weather data from memory, it is stale."
     override val examples = listOf(
         "Current location weather → get_weather_gps()",
         "GPS location 3-day forecast → get_weather_gps(forecast_days=\"3\")",
         "Weather in Brisbane → get_weather_gps(location=\"Brisbane\")",
-        "Forecast for user's profile location → get_weather_gps(location=\"Murrumba Downs, QLD, Australia\")",
+        "Weather at home → get_weather_gps(location=\"Murrumba Downs, QLD, Australia\")",
     )
 
     override val schema = SkillSchema(
         parameters = mapOf(
             "location" to SkillParameter(
                 type = "string",
-                description = "Optional location/city name (e.g., \"Brisbane\" or \"Murrumba Downs, QLD, Australia\"). If provided, uses geocoding to fetch weather for this location. If not provided, uses device GPS.",
+                description = "Optional location/city name. Only provide if the user explicitly names a place or says 'at home'. Leave blank to use device GPS — GPS is always preferred and more accurate than profile location.",
             ),
             "forecast_days" to SkillParameter(
                 type = "integer",


### PR DESCRIPTION
## Summary

Addresses Pattern D from the codebase consistency audit — vague `@Tool` descriptions causing the model to select the wrong tool.

## Changes

| Tool | Problem | Fix |
|------|---------|-----|
| `getWeather` | Too broad — "forecast" implied future days, causing day-of-week questions to route here | Scoped to weather/temperature/precipitation/wind only. Added explicit NOT for date/time/day-of-week/calendar |
| `runIntent` | "info queries" too vague — overlapped with weather/memory/web | Replaced with explicit list (battery, time, date). Added NOT for weather/web/memory |
| `runJs` | Referenced stale `get_weather_gps` run_intent routing that no longer applies | Removed weather references entirely — all weather routes to `getWeather` |
| `saveMemory` | "note that" overlapped with to-do/reminder creation | Added NOT for calendar events/alarms/reminders/timers/to-do items |
| `searchMemory` | Could be confused with web search or Wikipedia | Added NOT for web/Wikipedia/weather/real-time information |

Also adds a system prompt guard to prevent double-execution after QuickIntentRouter skill success:
> When a [System:] context block confirms a completed action, do NOT call any tools — simply acknowledge the result naturally.

## Expected impact

- Likely resolves #453 (intelligence regression — date/weather misrouting)
- Eliminates the class of bugs where "what day is it" triggers `get_weather`
- Prevents E4B from re-running an intent that the router already handled
