### PR TITLE
fix: FAB UI consistency — both FABs now SmallFloatingActionButton (#394)

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -129,7 +128,11 @@ fun ConversationListScreen(
                     ) {
                         Icon(Icons.Default.Bolt, contentDescription = "Quick action")
                     }
-                    FloatingActionButton(onClick = onNewConversation) {
+                    SmallFloatingActionButton(
+                        onClick = onNewConversation,
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ) {
                         Icon(Icons.Default.Add, contentDescription = "New conversation")
                     }
                 }


### PR DESCRIPTION
Both conversation list FABs (Quick Actions bolt + New Conversation add) are now `SmallFloatingActionButton` for visual consistency. Previously the New Conversation button was the larger `FloatingActionButton` (56dp) while the Quick Actions button next to it was already `SmallFloatingActionButton` (40dp). Also removed unused `FloatingActionButton` import.