### PR TITLE
fix: embedding engine lifecycle + history replay context amnesia (#445, #446)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
@@ -62,7 +62,9 @@ class ContextWindowManager {
             if (remaining < cost) {
                 // If we haven't collected any turns yet, the most recent turn alone exceeds
                 // the budget. Include it truncated so at least one turn of context survives.
-                if (result.isEmpty() && remaining > 0) {
+                // Guard requires remaining >= 2: estimateTokens() has coerceAtLeast(1) so each
+                // half costs minimum 1 token — a budget of 1 would produce 2 tokens (overflow).
+                if (result.isEmpty() && remaining >= 2) {
                     val maxCharsEach = (remaining * CHARS_PER_TOKEN) / 2
                     result.addFirst(turn.first.take(maxCharsEach) to turn.second.take(maxCharsEach))
                 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ContextWindowManager.kt
@@ -44,16 +44,30 @@ class ContextWindowManager {
     /**
      * Returns the most recent (user, assistant) pairs from [turns] that fit
      * within [budget] tokens, in chronological order.
+     *
+     * When the most recent turn alone exceeds [budget] (e.g. a very long tool
+     * result), it is included truncated rather than dropping all history. This
+     * prevents complete context amnesia (#446) when a single large turn fills
+     * the budget.
      */
     fun selectHistory(
         turns: List<Pair<String, String>>,
         budget: Int,
     ): List<Pair<String, String>> {
+        if (turns.isEmpty() || budget <= 0) return emptyList()
         var remaining = budget
         val result = ArrayDeque<Pair<String, String>>()
         for (turn in turns.reversed()) {
             val cost = estimateTokens(turn.first) + estimateTokens(turn.second)
-            if (remaining < cost) break
+            if (remaining < cost) {
+                // If we haven't collected any turns yet, the most recent turn alone exceeds
+                // the budget. Include it truncated so at least one turn of context survives.
+                if (result.isEmpty() && remaining > 0) {
+                    val maxCharsEach = (remaining * CHARS_PER_TOKEN) / 2
+                    result.addFirst(turn.first.take(maxCharsEach) to turn.second.take(maxCharsEach))
+                }
+                break
+            }
             result.addFirst(turn)
             remaining -= cost
         }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtEmbeddingEngine.kt
@@ -142,6 +142,10 @@ class LiteRtEmbeddingEngine @Inject constructor(
     }
 
     override fun close() {
+        // Log at WARN so any unexpected call (e.g. accidental close during Gemma-4 init,
+        // see #445) is immediately visible in logcat. Intentional shutdown calls are fine.
+        Log.w(TAG, "EmbeddingEngine.close() called — interpreter will be nulled. " +
+            "Subsequent embed() calls will re-initialise automatically.")
         synchronized(lock) {
             _state?.interpreter?.close()
             _state = null


### PR DESCRIPTION
## Summary

Fixes two memory-system bugs that were silently degrading the AI assistant experience.

---

### Bug 1 — #445: `embeddingEngine.close()` in `initGemma4` silently breaks memory search

**Root cause:** `embeddingEngine.close()` + `System.gc()` was called in both `initGemma4()` and `initEngineWhenReady()` before loading the Gemma-4 GPU model. EmbeddingGemma runs entirely on CPU — there is no GPU memory conflict. The `close()` call nulled `LiteRtEmbeddingEngine._state`, silently breaking all subsequent `embed()` calls (which returned `FloatArray(0)`), causing every `search_memory` tool query to return empty results with no error.

**Fixes:**
- Removed `embeddingEngine.close()` from both init paths (applied in efc7107).
- **New:** Added `Log.w` in `LiteRtEmbeddingEngine.close()` so any future accidental close is immediately visible in logcat.

---

### Bug 2 — #446: `needsHistoryReplay=true` after tool calls causes context amnesia

**Root cause:** `needsHistoryReplay = true` was set after every native tool call. On the next turn, `selectHistory()` replayed history into the system prompt — but with `SYSTEM_OVERHEAD=2048`, the history budget was only ~1024 tokens on a 4096-token window. A single moderately-long response filled the budget, dropping all earlier conversation context.

**Fixes:**
- Removed `needsHistoryReplay = true` from the native tool-call path — KV cache remains valid after tool calls, no replay needed (applied in efc7107).
- Reduced `SYSTEM_OVERHEAD` from 2048 → 1400 tokens, giving ~1672 tokens for history replay (applied in efc7107).
- **New:** `selectHistory()` now handles the edge case where a single oversized turn (e.g. a very long tool result) would return zero history — the most recent turn is included truncated rather than returning nothing, preventing total context amnesia.

---

## Files changed

- `core/inference/src/.../LiteRtEmbeddingEngine.kt` — defensive warn log in `close()`
- `core/inference/src/.../ContextWindowManager.kt` — truncation fallback in `selectHistory()` for oversized turns

## Compile check

```
./gradlew :core:inference:compileDebugKotlin :feature:chat:compileDebugKotlin --no-daemon -q
# exit 0 ✓
```