### PR TITLE
test: add QuickIntentRouter smoke tests and helper unit tests (Phase 4 audit)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -293,6 +293,16 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, raw -> extractCalendarHints(raw) },
         ),
+        // "set a dental appointment" / "book a hair appointment" — requires article "a/an" so
+        // bare-noun forms like "add dentist appointment to my calendar" fall through to LLM.
+        IntentPattern(
+            intentName = "create_calendar_event",
+            regex = Regex(
+                """(?:add|create|schedule|put|book|set)\s+(?:a|an)\s+(?:\S+\s+){1,4}?(?:appointment|meeting|event|session|booking)\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, raw -> extractCalendarHints(raw) },
+        ),
 
         // ── Do Not Disturb ──
         IntentPattern(
@@ -522,7 +532,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:what(?:'s| is)\s+(?:the\s+)?weather|how(?:'s|\s+is)\s+(?:the\s+)?weather|weather\s+(?:today|tonight|now|outside|forecast|this\s+week))""",
+                """(?:what(?:'s| is)\s+(?:the\s+)?weather(?:\s+(?:like|today|tonight|now|outside|currently))?|how(?:'s|\s+is)\s+(?:the\s+)?weather(?:\s+(?:today|tonight|now|outside))?|weather\s+(?:today|tonight|now|outside|forecast|this\s+week))\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },


### PR DESCRIPTION
## Summary

Phase 4 audit test suite for `QuickIntentRouter` — three new JUnit5 test files plus the companion-object API they depend on.

## New test files

### `QuickIntentRouterSmokeTest.kt`
30 parameterised cases (2 phrasings × 14 intents) verifying regex routing works end-to-end:
`get_time`, `get_weather`, `set_alarm`, `set_timer`, `cancel_alarm`, `cancel_timer`, `get_battery`, `toggle_dnd_on`, `make_call`, `send_sms`, `create_calendar_event`, `open_app`, `add_to_list`

### `QuickIntentRouterNegativeTest.kt`
5 inputs that must return `null` so they fall through to Gemma E4B:
`"new conversation"`, `"new chat"`, `"what is the capital of France"`, `"tell me about jazz music"`, `"what do you think about that"`

### `QuickIntentRouterHelperTest.kt`
Pure unit tests for companion helpers:
- `resolveTime`: `"5pm" → "17:00"`, `"9:30am" → "09:30"`, `"14:00" → "14:00"`, `"9 o'clock" → "09:00"`
- `resolveDate`: today/tomorrow → ISO date, next Monday → is a Monday
- `parseTimerDuration(String)`: `"5 minutes" → 300`, `"1 hour 30 minutes" → 5400`, `"90 seconds" → 90`

## QuickIntentRouter changes

- `QuickIntent` data class (action + params)
- `matchQuickIntent(String): QuickIntent?` — regex-only companion function for tests
- `internal resolveTime(String): String?` — HH:mm output
- `internal resolveDate(String): String?` — YYYY-MM-DD output
- `parseTimerDuration(String): Int?` — string overload (seconds)
- `get_weather` patterns with `$` anchor (prevents false match on location-specific queries like `"what's the weather in Auckland"`)
- Descriptive-appointment calendar pattern (`"set a dental appointment for 5pm tomorrow" → create_calendar_event`) requiring article `a/an` so bare-noun forms still fall through to LLM

## Test results
`504 tests completed, 5 failed` — all 5 remaining failures are pre-existing (Smart Home TV device casing, DND unmute classifier gap, complex calendar NLU) and are unchanged from the baseline.