### PR TITLE
fix: weather quick router using wrong intent name (get_weather → get_weather_gps)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -530,7 +530,7 @@ class QuickIntentRouter(
 
         // ── Weather ──
         IntentPattern(
-            intentName = "get_weather",
+            intentName = "get_weather_gps",
             regex = Regex(
                 """(?:what(?:'s| is)\s+(?:the\s+)?weather(?:\s+(?:like|today|tonight|now|outside|currently))?|how(?:'s|\s+is)\s+(?:the\s+)?weather(?:\s+(?:today|tonight|now|outside))?|weather\s+(?:today|tonight|now|outside|forecast|this\s+week))\s*$""",
                 RegexOption.IGNORE_CASE,

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
@@ -37,9 +37,9 @@ class QuickIntentRouterSmokeTest {
             Arguments.of("what day is it", "get_time"),
             Arguments.of("what's today's date", "get_time"),
 
-            // get_weather
-            Arguments.of("what's the weather", "get_weather"),
-            Arguments.of("weather today", "get_weather"),
+            // get_weather_gps
+            Arguments.of("what's the weather", "get_weather_gps"),
+            Arguments.of("weather today", "get_weather_gps"),
 
             // set_alarm
             Arguments.of("set an alarm for 7am", "set_alarm"),


### PR DESCRIPTION
## Problem

'What's the weather' was reaching the LLM and triggering a clarification question instead of just fetching GPS weather.

## Root Cause

Phase 4 added a `get_weather` pattern to `QuickIntentRouter`. On a router match, `ChatViewModel` calls `skillRegistry.get(intentName)`. But `GetWeatherSkill` is registered as `"get_weather_gps"` (its `override val name`), so the lookup returned null.

Fallback path: `run_intent` with `intent_name="get_weather"` → `NativeIntentHandler` has no `get_weather` case → failure injected into system context → LLM asked for clarification.

## Fix

Change `intentName = "get_weather"` → `intentName = "get_weather_gps"` so the direct skill lookup hits `GetWeatherSkill` with empty params (GPS mode).

Updated smoke tests to assert `get_weather_gps`.