### PR TITLE
fix: topK reset-to-defaults regressed to 40 (was never fixed in persistence layer)

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -42,7 +42,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ContactAliasEntity::class,
         ListItemEntity::class,
     ],
-    version = 15,
+    version = 16,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -176,6 +176,13 @@ abstract class KernelDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Corrects topK default from 40 → 64 per Gemma 4 model card. */
+        val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("UPDATE model_settings SET topK = 64 WHERE topK = 40")
             }
         }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -61,6 +61,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_12_13,
                     KernelDatabase.MIGRATION_13_14,
                     KernelDatabase.MIGRATION_14_15,
+                    KernelDatabase.MIGRATION_15_16,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ModelSettingsEntity.kt
@@ -17,7 +17,7 @@ data class ModelSettingsEntity(
     val temperature: Float,
     val topP: Float,
     /** Top-K candidates to sample from. Ignored when backend is NPU (hardware sampler). */
-    val topK: Int = 40,
+    val topK: Int = 64,
     /** Whether to display the model's internal reasoning (thinking tokens) in the chat UI. */
     val showThinkingProcess: Boolean = true,
     val updatedAt: Long = System.currentTimeMillis(),

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ModelSettingsRepositoryImpl.kt
@@ -36,7 +36,7 @@ class ModelSettingsRepositoryImpl @Inject constructor(
             contextWindowSize = defaultContextWindow,
             temperature = 1.0f,
             topP = 0.95f,
-            topK = 40,
+            topK = 64,
             showThinkingProcess = true,
             updatedAt = System.currentTimeMillis(),
         )


### PR DESCRIPTION
## Problem

After #454 changed `ModelConfig.topK` default to 64, hitting **Reset to defaults** in Model Settings immediately reverted topK back to 40.

## Root cause (3 locations)

1. **`ModelSettingsRepositoryImpl.defaultSettings()`** — hardcoded `topK = 40`. This is what `resetToDefaults()` writes to the DB, so every reset undid the fix.

2. **`ModelSettingsEntity.topK: Int = 40`** — Kotlin data class default still 40.

3. **`MIGRATION_11_12` SQL `DEFAULT 40`** — already ran on all existing devices, so every user's DB row has `topK = 40`. Even with fixes 1 & 2, users who never hit reset would still load 40 from their DB.

## Fix

- `defaultSettings()` → `topK = 64`
- `ModelSettingsEntity` default → `topK = 64`
- Added `MIGRATION_15_16`: `UPDATE model_settings SET topK = 64 WHERE topK = 40` — only touches rows still at the old default, preserving any user-set values
- DB version bumped 15 → 16