### PR TITLE
fix: weather numbers corrupted by LLM rephrasing, no intent chip (#466)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -183,6 +183,7 @@ class KernelAIToolSet @Inject constructor(
             }
             when (result) {
                 is SkillResult.Success -> mapOf("result" to result.content)
+                is SkillResult.DirectReply -> mapOf("result" to result.content)
                 is SkillResult.Failure -> mapOf("error" to result.error)
                 is SkillResult.ParseError -> mapOf("error" to "Parse error: ${result.reason}")
                 is SkillResult.UnknownSkill -> mapOf("error" to "Unknown skill: ${result.skillName}")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
@@ -1,8 +1,13 @@
 package com.kernel.ai.core.skills
 
 sealed class SkillResult {
-    /** Skill ran successfully. [content] is injected back into the conversation. */
+    /** Skill ran successfully. [content] is injected back into the conversation as system context
+     *  so the LLM can produce a natural conversational wrapper around it. */
     data class Success(val content: String) : SkillResult()
+    /** Skill ran successfully and [content] should be shown to the user verbatim — the LLM is
+     *  bypassed entirely. Use for skills that return structured data (e.g. weather readings,
+     *  sensor values) where LLM rephrasing risks corrupting numbers or units. */
+    data class DirectReply(val content: String) : SkillResult()
     /** Skill not found in registry. */
     data class UnknownSkill(val skillName: String) : SkillResult()
     /** Skill found but execution failed. */

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -245,7 +245,7 @@ class GetWeatherSkill @Inject constructor(
         }.trimEnd()
 
         Log.d(TAG, "GetWeatherSkill: fetched ${len}-day forecast for $locationLabel")
-        return SkillResult.Success(text)
+        return SkillResult.DirectReply(text)
     }
 
     private fun formatForecastDate(dateStr: String): String {
@@ -317,7 +317,7 @@ class GetWeatherSkill @Inject constructor(
         }
 
         Log.d(TAG, "GetWeatherSkill: fetched weather for $locationLabel")
-        return SkillResult.Success(text)
+        return SkillResult.DirectReply(text)
     }
 
     // ── WMO code → description / emoji ───────────────────────────────────────

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -169,6 +169,12 @@ class ActionsViewModel @Inject constructor(
         skillName: String,
         result: SkillResult,
     ): QuickActionEntity = when (result) {
+        is SkillResult.DirectReply -> QuickActionEntity(
+            userQuery = query,
+            skillName = skillName,
+            resultText = result.content,
+            isSuccess = true,
+        )
         is SkillResult.Success -> QuickActionEntity(
             userQuery = query,
             skillName = skillName,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -476,6 +476,43 @@ class ChatViewModel @Inject constructor(
         ragRepository.indexMessage(savedId, convId, content)
     }
 
+    /** Like [appendAssistantMessage] but also attaches a [ToolCallInfo] chip so the UI shows
+     *  which skill produced the reply. Used by the DirectReply path (QuickIntentRouter skills
+     *  that bypass the LLM). */
+    private suspend fun appendAssistantMessageWithToolCall(
+        convId: String,
+        content: String,
+        skillName: String,
+        requestJson: String,
+        isSuccess: Boolean,
+    ) {
+        val msgId = UUID.randomUUID().toString()
+        val toolCall = ToolCallInfo(
+            skillName = skillName,
+            requestJson = requestJson,
+            resultText = content,
+            isSuccess = isSuccess,
+        )
+        val msg = ChatMessage(
+            id = msgId,
+            role = ChatMessage.Role.ASSISTANT,
+            content = content,
+            toolCall = toolCall,
+        )
+        _messages.update { it + msg }
+        val toolCallJsonStr = org.json.JSONObject().apply {
+            put("skillName", toolCall.skillName)
+            put("requestJson", toolCall.requestJson)
+            put("resultText", toolCall.resultText)
+            put("isSuccess", toolCall.isSuccess)
+        }.toString()
+        val savedId = conversationRepository.addMessage(
+            convId, "assistant", content,
+            toolCallJson = toolCallJsonStr,
+        )
+        ragRepository.indexMessage(savedId, convId, content)
+    }
+
     fun retryDownload(model: KernelModel) {
         downloadManager.startDownload(model, force = false)
     }
@@ -581,6 +618,18 @@ class ChatViewModel @Inject constructor(
                 if (skill != null) {
                     val skillResult = skill.execute(SkillCall(skill.name, callParams))
                     when (skillResult) {
+                        is com.kernel.ai.core.skills.SkillResult.DirectReply -> {
+                            // Skill produced a complete, self-contained reply — show it verbatim
+                            // and bypass the LLM entirely to avoid number/unit corruption.
+                            appendAssistantMessageWithToolCall(
+                                convId = convId,
+                                content = skillResult.content,
+                                skillName = matchedIntent.intentName,
+                                requestJson = callParams.toString(),
+                                isSuccess = true,
+                            )
+                            return@launch
+                        }
                         is com.kernel.ai.core.skills.SkillResult.Success -> {
                             systemContext = "[System: ${matchedIntent.intentName} — ${skillResult.content}]"
                             // E4B not loaded yet: show action result directly and skip the wrapper.
@@ -972,6 +1021,18 @@ class ChatViewModel @Inject constructor(
         val result = skillExecutor.execute(extracted)
         return when (result) {
             is SkillResult.Success -> {
+                val skillName = try {
+                    org.json.JSONObject(extracted).optString("name", "unknown")
+                } catch (e: Exception) { "unknown" }
+                val toolCall = ToolCallInfo(
+                    skillName = skillName,
+                    requestJson = extracted,
+                    resultText = result.content,
+                    isSuccess = true,
+                )
+                Pair(toolCall, result.content)
+            }
+        is SkillResult.DirectReply -> {
                 val skillName = try {
                     org.json.JSONObject(extracted).optString("name", "unknown")
                 } catch (e: Exception) { "unknown" }


### PR DESCRIPTION
Fixes #466

## Bugs fixed

### 1. Temperature mangled (16.6°C → 6.6°C)
`GetWeatherSkill` returned `SkillResult.Success`, which injects the result as `[System: ...]` context and lets the LLM produce a conversational wrapper. The LLM mis-read the formatted temperature string.

### 2. No intent chip visible
The QuickIntentRouter skill dispatch path never created a `ToolCallInfo`, so no badge appeared in the chat UI.

## Fix

**New `SkillResult.DirectReply`** — sealed variant that bypasses the LLM entirely. Content is shown verbatim. Appropriate for structured sensor/API data where number fidelity matters more than conversational tone.

- `GetWeatherSkill` (current + forecast) returns `DirectReply` instead of `Success`
- `ChatViewModel`: `DirectReply` path calls new `appendAssistantMessageWithToolCall()` — shows content directly **and** attaches a `ToolCallInfo` chip so the intent badge is visible
- `KernelAIToolSet` / `ActionsViewModel`: exhaustive `when()` for new variant (treated same as `Success`)