### PR TITLE
feat: nav drawer with Lists/Alarms + Lists MVP CRUD (#459, #469)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -4,16 +4,29 @@ import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.ChatBubble
+import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -25,6 +38,7 @@ import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.ContactAliasesScreen
+import com.kernel.ai.feature.settings.ListItemsScreen
 import com.kernel.ai.feature.settings.ListsScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelManagementScreen
@@ -32,6 +46,7 @@ import com.kernel.ai.feature.settings.ModelSettingsScreen
 import com.kernel.ai.feature.settings.ScheduledAlarmsScreen
 import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
+import kotlinx.coroutines.launch
 
 private const val ROUTE_LIST = "conversation_list"
 private const val ROUTE_ACTIONS = "actions"
@@ -45,7 +60,9 @@ private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management"
 private const val ROUTE_ABOUT = "settings/about"
 private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
 private const val ROUTE_SCHEDULED_ALARMS = "settings/scheduled_alarms"
-private const val ROUTE_LISTS = "settings/lists"
+private const val ROUTE_LISTS = "lists"
+private const val ROUTE_LIST_ITEMS = "lists/{listName}"
+private const val ARG_LIST_NAME = "listName"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
 
@@ -57,223 +74,274 @@ fun KernelNavHost() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
-    // destination.route returns the template (e.g. "actions?openSheet={openSheet}"),
-    // so strip the query string when matching base routes.
     val currentBaseRoute = currentRoute?.substringBefore('?')
 
-    Scaffold(
-        bottomBar = {
-            if (currentBaseRoute in BOTTOM_NAV_ROUTES) {
-                NavigationBar {
-                    NavigationBarItem(
-                        selected = currentBaseRoute == ROUTE_LIST,
-                        onClick = {
-                            if (currentBaseRoute != ROUTE_LIST) {
-                                navController.navigate(ROUTE_LIST) {
-                                    popUpTo(ROUTE_LIST) { inclusive = true }
-                                    launchSingleTop = true
-                                }
-                            }
-                        },
-                        icon = { Icon(Icons.Default.ChatBubble, contentDescription = null) },
-                        label = { Text("Chats") },
-                    )
-                    NavigationBarItem(
-                        selected = currentBaseRoute == ROUTE_ACTIONS,
-                        onClick = {
-                            if (currentBaseRoute != ROUTE_ACTIONS) {
-                                navController.navigate(ROUTE_ACTIONS) {
-                                    popUpTo(ROUTE_LIST) { saveState = true }
-                                    launchSingleTop = true
-                                    restoreState = true
-                                }
-                            }
-                        },
-                        icon = { Icon(Icons.Default.Bolt, contentDescription = null) },
-                        label = { Text("Actions") },
-                    )
-                }
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val coroutineScope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        // Only allow swipe-to-open on main bottom-nav screens
+        gesturesEnabled = currentBaseRoute in BOTTOM_NAV_ROUTES,
+        drawerContent = {
+            ModalDrawerSheet {
+                Text(
+                    text = "Jandal",
+                    style = androidx.compose.material3.MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(horizontal = 28.dp, vertical = 16.dp),
+                )
+                HorizontalDivider()
+                androidx.compose.foundation.layout.Spacer(modifier = Modifier.padding(4.dp))
+                NavigationDrawerItem(
+                    label = { Text("Lists") },
+                    icon = { Icon(Icons.Default.Checklist, contentDescription = null) },
+                    selected = currentBaseRoute == ROUTE_LISTS,
+                    onClick = {
+                        coroutineScope.launch { drawerState.close() }
+                        navController.navigate(ROUTE_LISTS) {
+                            launchSingleTop = true
+                        }
+                    },
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                )
+                NavigationDrawerItem(
+                    label = { Text("Scheduled Alarms") },
+                    icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                    selected = currentBaseRoute == ROUTE_SCHEDULED_ALARMS,
+                    onClick = {
+                        coroutineScope.launch { drawerState.close() }
+                        navController.navigate(ROUTE_SCHEDULED_ALARMS) {
+                            launchSingleTop = true
+                        }
+                    },
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                )
             }
         },
-    ) { innerPadding ->
-        // Only apply bottom nav padding to routes that show the nav bar.
-        // Chat/settings screens handle their own padding via their own Scaffold.
-        NavHost(
-            navController = navController,
-            startDestination = ROUTE_LIST,
-        ) {
-            composable(ROUTE_LIST) {
-                Box(modifier = Modifier.padding(innerPadding)) {
-                    ConversationListScreen(
-                        onOpenConversation = { id ->
-                            navController.navigate("$ROUTE_CHAT/$id")
-                        },
+    ) {
+        Scaffold(
+            bottomBar = {
+                if (currentBaseRoute in BOTTOM_NAV_ROUTES) {
+                    NavigationBar {
+                        NavigationBarItem(
+                            selected = currentBaseRoute == ROUTE_LIST,
+                            onClick = {
+                                if (currentBaseRoute != ROUTE_LIST) {
+                                    navController.navigate(ROUTE_LIST) {
+                                        popUpTo(ROUTE_LIST) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                }
+                            },
+                            icon = { Icon(Icons.Default.ChatBubble, contentDescription = null) },
+                            label = { Text("Chats") },
+                        )
+                        NavigationBarItem(
+                            selected = currentBaseRoute == ROUTE_ACTIONS,
+                            onClick = {
+                                if (currentBaseRoute != ROUTE_ACTIONS) {
+                                    navController.navigate(ROUTE_ACTIONS) {
+                                        popUpTo(ROUTE_LIST) { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                }
+                            },
+                            icon = { Icon(Icons.Default.Bolt, contentDescription = null) },
+                            label = { Text("Actions") },
+                        )
+                    }
+                }
+            },
+        ) { innerPadding ->
+            NavHost(
+                navController = navController,
+                startDestination = ROUTE_LIST,
+            ) {
+                composable(ROUTE_LIST) {
+                    Box(modifier = Modifier.padding(innerPadding)) {
+                        ConversationListScreen(
+                            onOpenConversation = { id ->
+                                navController.navigate("$ROUTE_CHAT/$id")
+                            },
+                            onNewConversation = {
+                                navController.navigate(ROUTE_CHAT)
+                            },
+                            onNavigateToActions = {
+                                navController.navigate(ROUTE_ACTIONS_OPEN) {
+                                    popUpTo(ROUTE_LIST) { saveState = true }
+                                    launchSingleTop = true
+                                }
+                            },
+                            onNavigateToSettings = {
+                                navController.navigate(ROUTE_SETTINGS)
+                            },
+                            onOpenDrawer = {
+                                coroutineScope.launch { drawerState.open() }
+                            },
+                        )
+                    }
+                }
+
+                composable(
+                    route = "$ROUTE_ACTIONS?openSheet={openSheet}",
+                    arguments = listOf(navArgument("openSheet") {
+                        type = NavType.BoolType
+                        defaultValue = false
+                    }),
+                ) { backStackEntry ->
+                    val openSheet = backStackEntry.arguments?.getBoolean("openSheet") ?: false
+                    Box(modifier = Modifier.padding(innerPadding)) {
+                        ActionsScreen(
+                            autoOpenSheet = openSheet,
+                            onNavigateToChat = { query ->
+                                val encoded = Uri.encode(query)
+                                navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded")
+                            },
+                            onNewConversation = {
+                                navController.navigate(ROUTE_CHAT)
+                            },
+                            onOpenDrawer = {
+                                coroutineScope.launch { drawerState.open() }
+                            },
+                        )
+                    }
+                }
+
+                composable(
+                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}",
+                    arguments = listOf(navArgument(ARG_INITIAL_QUERY) {
+                        type = NavType.StringType
+                        defaultValue = ""
+                        nullable = false
+                    }),
+                ) { backStackEntry ->
+                    val initialQuery = backStackEntry.arguments?.getString(ARG_INITIAL_QUERY)
+                        ?.takeIf { it.isNotBlank() }
+                    ChatScreen(
+                        conversationId = null,
+                        initialQuery = initialQuery,
+                        onBack = { navController.popBackStack() },
                         onNewConversation = {
-                            navController.navigate(ROUTE_CHAT)
-                        },
-                        onNavigateToActions = {
-                            navController.navigate(ROUTE_ACTIONS_OPEN) {
-                                popUpTo(ROUTE_LIST) { saveState = true }
-                                launchSingleTop = true
+                            navController.navigate(ROUTE_CHAT) {
+                                popUpTo(ROUTE_CHAT) { inclusive = true }
                             }
                         },
-                        onNavigateToSettings = {
-                            navController.navigate(ROUTE_SETTINGS)
+                        onNavigateToList = {
+                            navController.navigate(ROUTE_LIST) {
+                                popUpTo(ROUTE_LIST) { inclusive = true }
+                            }
                         },
                     )
                 }
-            }
 
-            composable(
-                route = "$ROUTE_ACTIONS?openSheet={openSheet}",
-                arguments = listOf(navArgument("openSheet") {
-                    type = NavType.BoolType
-                    defaultValue = false
-                }),
-            ) { backStackEntry ->
-                val openSheet = backStackEntry.arguments?.getBoolean("openSheet") ?: false
-                Box(modifier = Modifier.padding(innerPadding)) {
-                    ActionsScreen(
-                        autoOpenSheet = openSheet,
-                        onNavigateToChat = { query ->
-                            val encoded = Uri.encode(query)
-                            navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded")
-                        },
+                composable(
+                    route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
+                    arguments = listOf(navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType }),
+                ) { backStackEntry ->
+                    val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
+                    ChatScreen(
+                        conversationId = conversationId,
+                        onBack = { navController.popBackStack() },
                         onNewConversation = {
                             navController.navigate(ROUTE_CHAT)
                         },
+                        onNavigateToList = {
+                            navController.popBackStack()
+                        },
                     )
                 }
-            }
 
-            // New conversation (no conversationId arg), optionally with a pre-filled query
-            // from the Actions tab FallThrough bridge.
-            composable(
-                route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}",
-                arguments = listOf(navArgument(ARG_INITIAL_QUERY) {
-                    type = NavType.StringType
-                    defaultValue = ""
-                    nullable = false
-                }),
-            ) { backStackEntry ->
-                val initialQuery = backStackEntry.arguments?.getString(ARG_INITIAL_QUERY)
-                    ?.takeIf { it.isNotBlank() }
-                ChatScreen(
-                    conversationId = null,
-                    initialQuery = initialQuery,
-                    onBack = { navController.popBackStack() },
-                    onNewConversation = {
-                        navController.navigate(ROUTE_CHAT) {
-                            popUpTo(ROUTE_CHAT) { inclusive = true }
-                        }
-                    },
-                    onNavigateToList = {
-                        navController.navigate(ROUTE_LIST) {
-                            popUpTo(ROUTE_LIST) { inclusive = true }
-                        }
-                    },
-                )
-            }
+                composable(ROUTE_SETTINGS) {
+                    SettingsScreen(
+                        onBack = { navController.popBackStack() },
+                        onNavigateToUserProfile = {
+                            navController.navigate(ROUTE_USER_PROFILE)
+                        },
+                        onNavigateToMemory = {
+                            navController.navigate(ROUTE_MEMORY)
+                        },
+                        onNavigateToModelSettings = {
+                            navController.navigate(ROUTE_MODEL_SETTINGS)
+                        },
+                        onNavigateToModelManagement = {
+                            navController.navigate(ROUTE_MODEL_MANAGEMENT)
+                        },
+                        onNavigateToAbout = {
+                            navController.navigate(ROUTE_ABOUT)
+                        },
+                        onNavigateToContactAliases = {
+                            navController.navigate(ROUTE_CONTACT_ALIASES)
+                        },
+                    )
+                }
 
-            // Existing conversation
-            composable(
-                route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
-                arguments = listOf(navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType }),
-            ) { backStackEntry ->
-                val conversationId = backStackEntry.arguments?.getString(ARG_CONVERSATION_ID)
-                ChatScreen(
-                    conversationId = conversationId,
-                    onBack = { navController.popBackStack() },
-                    onNewConversation = {
-                        navController.navigate(ROUTE_CHAT)
-                    },
-                    onNavigateToList = {
-                        navController.popBackStack()
-                    },
-                )
-            }
+                composable(ROUTE_USER_PROFILE) {
+                    UserProfileScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_SETTINGS) {
-                SettingsScreen(
-                    onBack = { navController.popBackStack() },
-                    onNavigateToUserProfile = {
-                        navController.navigate(ROUTE_USER_PROFILE)
-                    },
-                    onNavigateToMemory = {
-                        navController.navigate(ROUTE_MEMORY)
-                    },
-                    onNavigateToModelSettings = {
-                        navController.navigate(ROUTE_MODEL_SETTINGS)
-                    },
-                    onNavigateToModelManagement = {
-                        navController.navigate(ROUTE_MODEL_MANAGEMENT)
-                    },
-                    onNavigateToAbout = {
-                        navController.navigate(ROUTE_ABOUT)
-                    },
-                    onNavigateToContactAliases = {
-                        navController.navigate(ROUTE_CONTACT_ALIASES)
-                    },
-                    onNavigateToScheduledAlarms = {
-                        navController.navigate(ROUTE_SCHEDULED_ALARMS)
-                    },
-                    onNavigateToLists = {
-                        navController.navigate(ROUTE_LISTS)
-                    },
-                )
-            }
+                composable(ROUTE_MEMORY) {
+                    MemoryScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_USER_PROFILE) {
-                UserProfileScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
+                composable(ROUTE_MODEL_SETTINGS) {
+                    ModelSettingsScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_MEMORY) {
-                MemoryScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
+                composable(ROUTE_MODEL_MANAGEMENT) {
+                    ModelManagementScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_MODEL_SETTINGS) {
-                ModelSettingsScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
+                composable(ROUTE_ABOUT) {
+                    AboutScreen(
+                        onBack = { navController.popBackStack() },
+                        versionName = com.kernel.ai.BuildConfig.VERSION_NAME,
+                        versionCode = com.kernel.ai.BuildConfig.VERSION_CODE,
+                        buildType = com.kernel.ai.BuildConfig.BUILD_TYPE,
+                        gitSha = com.kernel.ai.BuildConfig.GIT_SHA,
+                        buildTimestamp = com.kernel.ai.BuildConfig.BUILD_TIMESTAMP,
+                    )
+                }
 
-            composable(ROUTE_MODEL_MANAGEMENT) {
-                ModelManagementScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
+                composable(ROUTE_CONTACT_ALIASES) {
+                    ContactAliasesScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_ABOUT) {
-                AboutScreen(
-                    onBack = { navController.popBackStack() },
-                    versionName = com.kernel.ai.BuildConfig.VERSION_NAME,
-                    versionCode = com.kernel.ai.BuildConfig.VERSION_CODE,
-                    buildType = com.kernel.ai.BuildConfig.BUILD_TYPE,
-                    gitSha = com.kernel.ai.BuildConfig.GIT_SHA,
-                    buildTimestamp = com.kernel.ai.BuildConfig.BUILD_TIMESTAMP,
-                )
-            }
+                composable(ROUTE_SCHEDULED_ALARMS) {
+                    ScheduledAlarmsScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
 
-            composable(ROUTE_CONTACT_ALIASES) {
-                ContactAliasesScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
+                composable(ROUTE_LISTS) {
+                    ListsScreen(
+                        onBack = { navController.popBackStack() },
+                        onOpenList = { listName ->
+                            navController.navigate("lists/$listName")
+                        },
+                    )
+                }
 
-            composable(ROUTE_SCHEDULED_ALARMS) {
-                ScheduledAlarmsScreen(
-                    onBack = { navController.popBackStack() },
-                )
-            }
-
-            composable(ROUTE_LISTS) {
-                ListsScreen(
-                    onBack = { navController.popBackStack() },
-                )
+                composable(
+                    route = ROUTE_LIST_ITEMS,
+                    arguments = listOf(navArgument(ARG_LIST_NAME) { type = NavType.StringType }),
+                ) { backStackEntry ->
+                    val listName = backStackEntry.arguments?.getString(ARG_LIST_NAME) ?: return@composable
+                    ListItemsScreen(
+                        listName = listName,
+                        onBack = { navController.popBackStack() },
+                    )
+                }
             }
         }
     }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/16.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/16.json
@@ -1,0 +1,595 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "0bf77e078ea074305f98fb02aab31d00",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0bf77e078ea074305f98fb02aab31d00')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
@@ -42,6 +42,10 @@ interface ListItemDao {
     @Query("DELETE FROM list_items WHERE listName = :listName AND checked = 1")
     suspend fun deleteChecked(listName: String)
 
+    /** Remove a single item by id. */
+    @Query("DELETE FROM list_items WHERE id = :id")
+    suspend fun deleteItem(id: Long)
+
     /** Remove the entire list. */
     @Query("DELETE FROM list_items WHERE listName = :listName")
     suspend fun deleteList(listName: String)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
@@ -1,5 +1,24 @@
 package com.kernel.ai.core.skills
 
+/**
+ * Result returned by a [Skill] after execution.
+ *
+ * ## Choosing between [Success] and [DirectReply]
+ *
+ * | Variant | When to use | LLM invoked? |
+ * |---------|-------------|--------------|
+ * | [DirectReply] | Skill returns **structured or numeric data** (weather readings, search results, sensor values, lists). Output is already complete — LLM rephrasing risks corrupting numbers/units. | ❌ Shown verbatim |
+ * | [Success] | Skill performs an **action** and the LLM should narrate the outcome naturally (e.g. toggle flashlight, set alarm, save memory). Conversational wrapping adds value. | ✅ Injected as system context |
+ *
+ * ### Example — why this matters
+ * `GetWeatherSkill` originally returned [Success], which injected the formatted string
+ * as `[System: ...]` context. The LLM then summarised it and corrupted `16.6°C` → `6.6°C`.
+ * Switching to [DirectReply] fixed this by bypassing the LLM entirely.
+ *
+ * ### UI behaviour
+ * Both [Success] and [DirectReply] display an intent chip in the chat UI via [ToolCallInfo].
+ * [DirectReply] uses `appendAssistantMessageWithToolCall()` in `ChatViewModel`.
+ */
 sealed class SkillResult {
     /** Skill ran successfully. [content] is injected back into the conversation as system context
      *  so the LLM can produce a natural conversational wrapper around it. */

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AlertDialog
@@ -67,6 +68,7 @@ fun ActionsScreen(
     autoOpenSheet: Boolean = false,
     onNavigateToChat: (query: String) -> Unit = {},
     onNewConversation: () -> Unit = {},
+    onOpenDrawer: () -> Unit = {},
     viewModel: ActionsViewModel = hiltViewModel(),
 ) {
     val actions by viewModel.actions.collectAsStateWithLifecycle()
@@ -96,6 +98,11 @@ fun ActionsScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Actions") },
+                navigationIcon = {
+                    IconButton(onClick = onOpenDrawer) {
+                        Icon(Icons.Default.Menu, contentDescription = "Menu")
+                    }
+                },
                 actions = {
                     if (actions.isNotEmpty()) {
                         IconButton(onClick = { showClearConfirmation = true }) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
@@ -61,6 +62,7 @@ fun ConversationListScreen(
     onNewConversation: () -> Unit,
     onNavigateToActions: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    onOpenDrawer: () -> Unit = {},
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
@@ -87,6 +89,13 @@ fun ConversationListScreen(
                         Text("${selectedConversationIds.size} / ${conversations.size} selected")
                     } else {
                         Text("Jandal")
+                    }
+                },
+                navigationIcon = {
+                    if (!isInSelectionMode) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = "Menu")
+                        }
                     }
                 },
                 actions = {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -1,0 +1,283 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ListItemEntity
+import androidx.compose.material3.AlertDialog
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListItemsScreen(
+    listName: String,
+    onBack: () -> Unit = {},
+    viewModel: ListsViewModel = hiltViewModel(),
+) {
+    val grouped by viewModel.groupedItems.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.itemSearchQuery.collectAsStateWithLifecycle()
+    val allItems = grouped[listName] ?: emptyList()
+
+    // Split active vs completed
+    val activeItems = allItems.filter { !it.checked }
+    val completedItems = allItems.filter { it.checked }
+
+    // Apply search filter
+    val filteredActive = if (searchQuery.isBlank()) activeItems
+    else activeItems.filter { it.item.contains(searchQuery, ignoreCase = true) }
+    val filteredCompleted = if (searchQuery.isBlank()) completedItems
+    else completedItems.filter { it.item.contains(searchQuery, ignoreCase = true) }
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var completedExpanded by rememberSaveable { mutableStateOf(false) }
+
+    // Clear item search when leaving the screen
+    DisposableEffect(Unit) {
+        onDispose { viewModel.clearItemSearchQuery() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(listName.replaceFirstChar { it.uppercase() }) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (completedItems.isNotEmpty()) {
+                        TextButton(onClick = { viewModel.clearChecked(listName) }) {
+                            Text("Clear done")
+                        }
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add item")
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Search bar
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = viewModel::setItemSearchQuery,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = { Text("Search items") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = viewModel::clearItemSearchQuery) {
+                            Icon(Icons.Default.Close, contentDescription = "Clear")
+                        }
+                    }
+                },
+                singleLine = true,
+            )
+
+            if (allItems.isEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(modifier = Modifier.height(32.dp))
+                    Text(
+                        text = "No items yet.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Tap + to add an item, or ask Jandal.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    // Active items
+                    items(filteredActive, key = { it.id }) { item ->
+                        ListItemRow(
+                            item = item,
+                            onToggle = { viewModel.toggleChecked(item) },
+                            onDelete = { viewModel.deleteItem(item.id) },
+                        )
+                        HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                    }
+
+                    // Completed section header (only if there are completed items)
+                    if (completedItems.isNotEmpty()) {
+                        item(key = "completed_header") {
+                            ListItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                headlineContent = {
+                                    Text(
+                                        "Completed (${completedItems.size})",
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                },
+                                trailingContent = {
+                                    IconButton(onClick = { completedExpanded = !completedExpanded }) {
+                                        Icon(
+                                            if (completedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                            contentDescription = if (completedExpanded) "Collapse" else "Expand",
+                                        )
+                                    }
+                                },
+                            )
+                            HorizontalDivider()
+                        }
+                    }
+
+                    // Completed items (collapsible)
+                    if (completedExpanded) {
+                        items(filteredCompleted, key = { "done_${it.id}" }) { item ->
+                            ListItemRow(
+                                item = item,
+                                onToggle = { viewModel.toggleChecked(item) },
+                                onDelete = { viewModel.deleteItem(item.id) },
+                            )
+                            HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(88.dp)) } // FAB clearance
+                }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AddItemDialog(
+            onConfirm = { text ->
+                showAddDialog = false
+                viewModel.addItem(listName, text)
+            },
+            onDismiss = { showAddDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun ListItemRow(
+    item: ListItemEntity,
+    onToggle: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = item.item,
+                style = if (item.checked) {
+                    MaterialTheme.typography.bodyLarge.copy(
+                        textDecoration = TextDecoration.LineThrough,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    MaterialTheme.typography.bodyLarge
+                },
+            )
+        },
+        leadingContent = {
+            Checkbox(
+                checked = item.checked,
+                onCheckedChange = { onToggle() },
+            )
+        },
+        trailingContent = {
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Delete item",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun AddItemDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add item") },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                placeholder = { Text("Item name") },
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(text) },
+                enabled = text.isNotBlank(),
+            ) { Text("Add") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -1,43 +1,66 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material3.Checkbox
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kernel.ai.core.memory.entity.ListItemEntity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListsScreen(
     onBack: () -> Unit = {},
+    onOpenList: (String) -> Unit = {},
     viewModel: ListsViewModel = hiltViewModel(),
 ) {
-    val grouped by viewModel.groupedItems.collectAsStateWithLifecycle()
+    val listNames by viewModel.listNames.collectAsStateWithLifecycle()
+    val itemCounts by viewModel.itemCounts.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.listSearchQuery.collectAsStateWithLifecycle()
+
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var pendingDeleteList by remember { mutableStateOf<String?>(null) }
+
+    val filtered = if (searchQuery.isBlank()) listNames
+    else listNames.filter { it.contains(searchQuery, ignoreCase = true) }
 
     Scaffold(
         topBar = {
@@ -50,121 +73,167 @@ fun ListsScreen(
                 },
             )
         },
-    ) { innerPadding ->
-        if (grouped.isEmpty()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(16.dp),
-            ) {
-                Spacer(modifier = Modifier.height(32.dp))
-                Text(
-                    text = "No lists yet.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Ask Jandal to add something to a list — e.g. \"Add milk to my shopping list\".",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Create list")
             }
-        } else {
-            LazyColumn(
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Search bar
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = viewModel::setListSearchQuery,
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
-            ) {
-                grouped.forEach { (listName, items) ->
-                    item(key = "header_$listName") {
-                        ListSectionHeader(
-                            listName = listName,
-                            hasChecked = items.any { it.checked },
-                            onClearChecked = { viewModel.clearChecked(listName) },
-                            onDeleteList = { viewModel.deleteList(listName) },
-                        )
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = { Text("Search lists") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.setListSearchQuery("") }) {
+                            Icon(Icons.Default.Close, contentDescription = "Clear")
+                        }
                     }
-                    items(items, key = { it.id }) { listItem ->
-                        ListItemRow(
-                            item = listItem,
-                            onToggle = { viewModel.toggleChecked(listItem) },
-                        )
-                        HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
-                    }
-                    item(key = "spacer_$listName") {
+                },
+                singleLine = true,
+            )
+
+            if (filtered.isEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(modifier = Modifier.height(32.dp))
+                    Text(
+                        text = if (listNames.isEmpty()) "No lists yet." else "No lists match \"$searchQuery\".",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (listNames.isEmpty()) {
                         Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Tap + to create a list, or ask Jandal — e.g. \"Add milk to my shopping list\".",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(filtered, key = { it }) { listName ->
+                        val count = itemCounts[listName] ?: 0
+                        ListItem(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onOpenList(listName) },
+                            headlineContent = {
+                                Text(listName.replaceFirstChar { it.uppercase() })
+                            },
+                            supportingContent = {
+                                Text("$count item${if (count == 1) "" else "s"}")
+                            },
+                            leadingContent = {
+                                Icon(
+                                    Icons.Default.Checklist,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            },
+                            trailingContent = {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(0.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    IconButton(onClick = { pendingDeleteList = listName }) {
+                                        Icon(
+                                            Icons.Default.Delete,
+                                            contentDescription = "Delete list",
+                                            tint = MaterialTheme.colorScheme.error,
+                                        )
+                                    }
+                                    Icon(Icons.Default.ChevronRight, contentDescription = null)
+                                }
+                            },
+                        )
+                        HorizontalDivider()
                     }
                 }
             }
         }
     }
+
+    // Create list dialog
+    if (showCreateDialog) {
+        CreateListDialog(
+            onConfirm = { name ->
+                showCreateDialog = false
+                if (name.isNotBlank()) onOpenList(name.trim())
+            },
+            onDismiss = { showCreateDialog = false },
+        )
+    }
+
+    // Delete confirmation dialog
+    pendingDeleteList?.let { listName ->
+        val count = itemCounts[listName] ?: 0
+        AlertDialog(
+            onDismissRequest = { pendingDeleteList = null },
+            title = { Text("Delete \"${listName.replaceFirstChar { it.uppercase() }}\"?") },
+            text = {
+                if (count > 0) Text("This will permanently delete $count item${if (count == 1) "" else "s"}.")
+                else Text("The list is empty and will be deleted.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteList(listName)
+                        pendingDeleteList = null
+                    },
+                ) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteList = null }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 @Composable
-private fun ListSectionHeader(
-    listName: String,
-    hasChecked: Boolean,
-    onClearChecked: () -> Unit,
-    onDeleteList: () -> Unit,
+private fun CreateListDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
 ) {
-    ListItem(
-        headlineContent = {
-            Text(
-                text = listName.replaceFirstChar { it.uppercase() },
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary,
+    var name by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New list") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                placeholder = { Text("List name") },
+                singleLine = true,
             )
         },
-        leadingContent = {
-            Icon(
-                Icons.Default.Checklist,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name) },
+                enabled = name.isNotBlank(),
+            ) { Text("Create") }
         },
-        trailingContent = {
-            if (hasChecked) {
-                TextButton(onClick = onClearChecked) { Text("Clear done") }
-            } else {
-                IconButton(onClick = onDeleteList) {
-                    Icon(
-                        Icons.Default.Delete,
-                        contentDescription = "Delete list",
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
-        },
-    )
-    HorizontalDivider()
-}
-
-@Composable
-private fun ListItemRow(
-    item: ListItemEntity,
-    onToggle: () -> Unit,
-) {
-    ListItem(
-        headlineContent = {
-            Text(
-                text = item.item,
-                style = if (item.checked) {
-                    MaterialTheme.typography.bodyLarge.copy(
-                        textDecoration = TextDecoration.LineThrough,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else {
-                    MaterialTheme.typography.bodyLarge
-                },
-            )
-        },
-        leadingContent = {
-            Checkbox(
-                checked = item.checked,
-                onCheckedChange = { onToggle() },
-            )
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -17,16 +19,51 @@ class ListsViewModel @Inject constructor(
     private val dao: ListItemDao,
 ) : ViewModel() {
 
-    /** All items grouped by list name, ordered for display. */
+    /** All items grouped by list name — used by the drill-in item screen. */
     val groupedItems: StateFlow<Map<String, List<ListItemEntity>>> =
         dao.observeAll()
             .map { items -> items.groupBy { it.listName } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
+    /** Distinct list names, alphabetical — for the overview screen. */
+    val listNames: StateFlow<List<String>> =
+        dao.observeAllLists()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Item counts keyed by list name — shown in the overview. */
+    val itemCounts: StateFlow<Map<String, Int>> =
+        dao.observeAll()
+            .map { items -> items.groupBy { it.listName }.mapValues { it.value.size } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    /** Search query for the list overview screen. */
+    private val _listSearchQuery = MutableStateFlow("")
+    val listSearchQuery: StateFlow<String> = _listSearchQuery.asStateFlow()
+
+    /** Search query for the drill-in item screen. */
+    private val _itemSearchQuery = MutableStateFlow("")
+    val itemSearchQuery: StateFlow<String> = _itemSearchQuery.asStateFlow()
+
+    fun setListSearchQuery(q: String) { _listSearchQuery.value = q }
+    fun setItemSearchQuery(q: String) { _itemSearchQuery.value = q }
+    fun clearItemSearchQuery() { _itemSearchQuery.value = "" }
+
     fun toggleChecked(item: ListItemEntity) {
         viewModelScope.launch {
             if (item.checked) dao.markUnchecked(item.id) else dao.markChecked(item.id)
         }
+    }
+
+    fun addItem(listName: String, itemText: String) {
+        val trimmed = itemText.trim()
+        if (trimmed.isBlank()) return
+        viewModelScope.launch {
+            dao.insert(ListItemEntity(listName = listName, item = trimmed))
+        }
+    }
+
+    fun deleteItem(id: Long) {
+        viewModelScope.launch { dao.deleteItem(id) }
     }
 
     fun clearChecked(listName: String) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Alarm
-import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
@@ -62,8 +60,6 @@ fun SettingsScreen(
     onNavigateToModelManagement: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
     onNavigateToContactAliases: () -> Unit = {},
-    onNavigateToScheduledAlarms: () -> Unit = {},
-    onNavigateToLists: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -177,30 +173,6 @@ fun SettingsScreen(
                 headlineContent = { Text("People & Contacts") },
                 supportingContent = { Text("Map nicknames to contacts for calling") },
                 leadingContent = { Icon(Icons.Default.People, contentDescription = null) },
-                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
-            )
-            HorizontalDivider()
-
-            // ── Scheduled Alarms ─────────────────────────────────────────────
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onNavigateToScheduledAlarms() },
-                headlineContent = { Text("Scheduled Alarms") },
-                supportingContent = { Text("View and cancel upcoming alarms set by Jandal") },
-                leadingContent = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
-            )
-            HorizontalDivider()
-
-            // ── Lists ─────────────────────────────────────────────────────────
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onNavigateToLists() },
-                headlineContent = { Text("Lists") },
-                supportingContent = { Text("Shopping lists, to-do lists and more") },
-                leadingContent = { Icon(Icons.Default.Checklist, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()


### PR DESCRIPTION
## Summary

Implements navigation drawer and Lists MVP as described in #459 and #469.

### Navigation Drawer (#459)
- `ModalNavigationDrawer` wraps the outer Scaffold in `KernelNavHost`
- **Lists** and **Scheduled Alarms** accessible from the drawer
- Gesture-open only works on Chats/Actions tabs (`BOTTOM_NAV_ROUTES` gate)
- Hamburger icon added to `ConversationListScreen` and `ActionsScreen` (hidden during multi-select mode)
- Removed Lists + Scheduled Alarms `ListItem` rows from `SettingsScreen` — navigation is now drawer-only

### Lists MVP (#469)
- **`ListsScreen`** rewritten as list-of-lists overview: search bar, FAB to create new list, item count per list, delete confirmation dialog
- **`ListItemsScreen`** (new): drill-in view for a single list — active/completed sections, collapsible completed section (collapsed by default), check-off toggles, per-item delete, search, FAB to add item
- **`ListsViewModel`** extended: `listNames`, `itemCounts` flows, `addItem`, `deleteItem`
- **`ListItemDao`**: added `deleteItem(id: Long)`
- New route: `ROUTE_LIST_ITEMS = "lists/{listName}"` (moved out of settings sub-tree)

### Also includes
- `SkillResult.DirectReply` KDoc (forward-ported from PR #467 base)

Closes #459
Closes #469