### PR TITLE
fix: hallucination guard + QIR expansion + context stripping (#438, #481)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -835,6 +835,17 @@ class QuickIntentRouter(
             },
         ),
 
+        // ── System Info ──
+        // "show my device info" / "what are my device specs" / "show system info"
+        IntentPattern(
+            intentName = "get_system_info",
+            regex = Regex(
+                """(?:show|get|what(?:'s|\s+are)?)\s+(?:my\s+)?(?:device\s+(?:info|specs|details)|system\s+info(?:rmation)?)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+
         // ── Lists ──
         IntentPattern(
             intentName = "add_to_list",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -849,6 +849,52 @@ class QuickIntentRouter(
                 )
             },
         ),
+        // "put milk on my shopping list" / "put eggs on the grocery list"
+        IntentPattern(
+            intentName = "add_to_list",
+            regex = Regex(
+                """put\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to match.groupValues[1].trim(),
+                    "list_name" to match.groupValues[2].trim(),
+                )
+            },
+        ),
+        // "create a groceries list" / "make a new shopping list" / "start a meal plan list"
+        IntentPattern(
+            intentName = "create_list",
+            regex = Regex(
+                """(?:create|make|start|new)\s+(?:a\s+|an\s+|my\s+|new\s+)?(.+?)\s+list""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+        ),
+        // "remove milk from my shopping list" / "take eggs off the grocery list"
+        IntentPattern(
+            intentName = "remove_from_list",
+            regex = Regex(
+                """(?:remove|delete|take|cross off)\s+(.+?)\s+(?:from|off)\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to match.groupValues[1].trim(),
+                    "list_name" to match.groupValues[2].trim(),
+                )
+            },
+        ),
+        // "what's on my shopping list" / "show me my grocery list" / "read out my to-do list"
+        IntentPattern(
+            intentName = "get_list_items",
+            regex = Regex(
+                """(?:what(?:'s|\s+is)\s+on|show(?:\s+me)?|read(?:\s+out)?|get|list)\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+        ),
 
         // ── Save Memory ──
         // Pattern: "save [to/that/...] memory that X" / "save this to memory: X"
@@ -869,14 +915,26 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
         ),
-        // Pattern: "note that X" / "make a note that X"
+        // Pattern: "note that X" / "make a note that X" / "don't forget that X"
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:note|don't forget|don't forget)\s+(?:that\s+)?[:\-–]?\s*(.+)""",
+                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
+        ),
+        // Pattern: "my X is Y" — captures personal facts like "my dog's name is Biscuit"
+        // Anchored to start of message and requires "my" to reduce false positives.
+        IntentPattern(
+            intentName = "save_memory",
+            regex = Regex(
+                """^my\s+(.{3,60})\s+is\s+(.{1,100})$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, raw ->
+                mapOf("content" to raw.trim())
+            },
         ),
 
         // ── Smart Home (MUST BE LAST — most generic) ──

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
@@ -72,7 +72,7 @@ class GetSystemInfoSkill @Inject constructor(
                 }
 
                 Log.d(TAG, "GetSystemInfoSkill executed successfully")
-                SkillResult.Success(info.trim())
+                SkillResult.DirectReply(info.trim())
             } catch (e: Exception) {
                 Log.e(TAG, "GetSystemInfoSkill failed", e)
                 SkillResult.Failure(name, e.message ?: "Failed to retrieve system info")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -696,6 +696,18 @@ class ChatViewModel @Inject constructor(
             val tokenBudget = activeContextWindowSize
             val proactiveReset = estimatedTokensUsed > (tokenBudget * 0.75).toInt()
 
+            // Context stripping for tool-routable queries (#438, #481).
+            // When the router had a best-guess intent (FallThrough with non-null bestGuess)
+            // or the query matches known tool-trigger keywords, strip the Jandal personality
+            // and RAG context to free ~1000 tokens for tool-call reasoning. These queries
+            // don't benefit from episodic memory or cultural tone — they need clear headspace.
+            val isToolQuery = (routeResult is QuickIntentRouter.RouteResult.FallThrough &&
+                routeResult.bestGuess != null) ||
+                looksLikeToolQuery(text)
+            val effectiveIdentityTier = if (isToolQuery) IdentityTier.MINIMAL else IdentityTier.FULL
+            val effectiveRagContext = if (isToolQuery) "" else ragContext
+            val effectiveRagTokenCost = if (isToolQuery) 0 else ragTokenCost
+
             if (needsHistoryReplay || proactiveReset) {
                 needsHistoryReplay = false
                 val allMessages = _messages.value.dropLast(2) // exclude just-added user + placeholder
@@ -704,22 +716,25 @@ class ChatViewModel @Inject constructor(
                 )
                 val selected = contextWindowManager.selectHistory(turns, ContextWindowManager.historyBudget(activeContextWindowSize))
                 // Inject history into the system prompt so Gemma treats it as background context.
-                val systemPromptWithHistory = buildSystemPrompt(selected, isFirstReply = isFirstReply)
+                val systemPromptWithHistory = buildSystemPrompt(selected, isFirstReply = isFirstReply, identityTier = effectiveIdentityTier)
                 inferenceEngine.updateSystemPrompt(systemPromptWithHistory)
                 // Re-baseline from selected history, then add the RAG cost for this turn.
                 estimatedTokensUsed = selected.sumOf {
                     contextWindowManager.estimateTokens(it.first) + contextWindowManager.estimateTokens(it.second)
-                } + ragTokenCost
+                } + effectiveRagTokenCost
             } else {
-                estimatedTokensUsed += ragTokenCost
+                estimatedTokensUsed += effectiveRagTokenCost
             }
 
             prompt = buildString {
-                if (ragContext.isNotBlank()) append("$ragContext\n\n")
+                if (effectiveRagContext.isNotBlank()) append("$effectiveRagContext\n\n")
                 if (systemContext != null) append("$systemContext\n\n")
                 // Greeting instruction injected per-turn so turn 1 says "Kia ora" and
                 // subsequent turns explicitly suppress greetings — without invalidating the KV cache.
-                append("[System: ${jandalPersona.buildGreetingInstruction(isFirstReply)}]\n\n")
+                // Suppressed entirely for tool queries to keep the prompt focused.
+                if (!isToolQuery) {
+                    append("[System: ${jandalPersona.buildGreetingInstruction(isFirstReply)}]\n\n")
+                }
                 append(text)
             }
 
@@ -815,14 +830,23 @@ class ChatViewModel @Inject constructor(
                                 // native tool calls and forcing a replay drops prior turns from the
                                 // tight history budget, causing context amnesia (#446).
                             } else {
-                                // Normal text response — write corrected content to UI state
-                                _messages.update { msgs ->
-                                    msgs.map { if (it.id == assistantMsgId) it.copy(content = fullContent, isStreaming = false) else it }
+                                // Normal text response — but first check for hallucinated tool
+                                // confirmations. If the model claims to have saved/added/created
+                                // something without actually calling a tool, replace its response
+                                // with an honest failure message rather than surfacing false data.
+                                val displayContent = if (looksLikeToolConfirmation(fullContent)) {
+                                    Log.w("KernelAI", "Hallucination guard triggered — model confirmed action without tool call")
+                                    "I wasn't able to complete that action — please try again, or try phrasing it differently."
+                                } else {
+                                    fullContent
                                 }
-                                val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", fullContent, thinking)
-                                ragRepository.indexMessage(savedAssistantMsgId, convId, fullContent)
+                                _messages.update { msgs ->
+                                    msgs.map { if (it.id == assistantMsgId) it.copy(content = displayContent, isStreaming = false) else it }
+                                }
+                                val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", displayContent, thinking)
+                                ragRepository.indexMessage(savedAssistantMsgId, convId, displayContent)
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
-                                    contextWindowManager.estimateTokens(fullContent)
+                                    contextWindowManager.estimateTokens(displayContent)
                             }
 
                             // Clear streaming tracking now that the message is fully persisted.
@@ -1094,6 +1118,36 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
+     * Returns true if [query] looks like a tool-routable request that doesn't benefit from
+     * the full Jandal personality or episodic RAG context (#438, #481).
+     *
+     * Used to switch to [IdentityTier.MINIMAL] and skip RAG injection for device-action
+     * and tool-calling queries, freeing ~1000 tokens for tool-call reasoning.
+     */
+    private fun looksLikeToolQuery(query: String): Boolean {
+        val lower = query.lowercase().trim()
+        val toolKeywords = listOf(
+            "save", "remember", "note that", "don't forget", "store",
+            "add to", "put on", "put in", "add .+ to .+ list",
+            "create .+ list", "make .+ list", "remove from", "delete from",
+            "what's on my", "show my", "read my .+ list",
+            "set alarm", "set a timer", "set timer", "remind me",
+            "send email", "send sms", "send a text", "call ",
+            "search wikipedia", "look up", "wikipedia",
+            "turn on", "turn off", "toggle", "open app",
+            "play ", "navigate to", "directions to",
+            "what time", "what's the time", "battery", "get battery",
+        )
+        return toolKeywords.any { keyword ->
+            if (keyword.contains(Regex("[.+*?]"))) {
+                Regex(keyword, RegexOption.IGNORE_CASE).containsMatchIn(lower)
+            } else {
+                lower.contains(keyword)
+            }
+        }
+    }
+
+    /**
      * Corrects digit-truncated numbers in a model response when a [System:] skill context was
      * injected. E.g. model reads "Battery is at 92%" from context but outputs "9%" — a known
      * Gemma-4 generation artefact. Only corrects percentage values to avoid false positives.
@@ -1118,6 +1172,33 @@ class ChatViewModel @Inject constructor(
             }
         }
         return corrected
+    }
+
+    /**
+     * Returns true if [response] looks like the model confirmed a tool action without
+     * actually calling any tool — the classic Gemma-4 hallucination pattern.
+     *
+     * Matches phrases the model uses when it believes it completed an action:
+     * "I've saved that", "Added milk to your list", "Done!", "Memory saved" etc.
+     * Only checked when [wasToolCalled] is false to avoid false positives.
+     *
+     * On a positive match the caller should replace the response with an honest
+     * failure message rather than surfacing fabricated confirmation to the user.
+     */
+    private fun looksLikeToolConfirmation(response: String): Boolean {
+        val lower = response.lowercase()
+        // Past-tense action completions when no tool was called
+        val actionPhrases = listOf(
+            "i've saved", "i have saved", "saved that", "saved to memory", "saved to your memory",
+            "memory saved", "noted that", "i'll remember", "i've noted",
+            "added to your", "added that to", "added it to",
+            "i've added", "i have added", "item added",
+            "created your", "i've created", "list created", "created a new",
+            "set an alarm", "alarm set", "timer set", "i've set",
+            "turned on", "turned off", "toggled",
+            "done!", "all done", "got it, i've", "sure thing",
+        )
+        return actionPhrases.any { lower.contains(it) }
     }
 }
 


### PR DESCRIPTION
Implements the top-3 P0 items from the Opus 4.6 skill hallucination analysis in #481.

## C1 — Hallucination detection guard
`looksLikeToolConfirmation()` detects when Gemma generates fake tool confirmations (`wasToolCalled() == false` but response says "I've saved that" / "Added to your list"). On detection, replaces the hallucinated response with an honest failure message. Logged at WARN.

This is the safety net — catches hallucinations that slip past all other mitigations.

## D1 — Expanded QuickIntentRouter patterns
Intercepts list/memory ops **before they reach E4B** so the hallucination problem doesn't arise:
- `add_to_list`: added `put X on my Y list` variant
- `create_list`: new — `create/make/start/new X list`
- `remove_from_list`: new — `remove/delete/take/cross off X from Y list`
- `get_list_items`: new — `what's on/show me/read my X list`
- `save_memory`: added `don't forget` + `my X is Y` natural phrasing

## B1 — Context stripping for tool-routable queries
When a query is classified as tool-routable, switches to `IdentityTier.MINIMAL` + skips RAG injection, freeing ~1000 tokens for tool-call reasoning. Directly addresses #438.

Closes #438