### PR TITLE
feat: alarms CRUD — create, edit, toggle enabled (#479)

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/18.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/18.json
@@ -1,0 +1,631 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "38ae1935e6802b5ba334b89d51898b7e",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '38ae1935e6802b5ba334b89d51898b7e')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -45,7 +45,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -203,6 +203,13 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_13_14 = object : Migration(13, 14) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("CREATE TABLE IF NOT EXISTS `contact_aliases` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))")
+            }
+        }
+
+        /** Adds enabled flag to scheduled_alarms for per-alarm toggle (#479). */
+        val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -64,6 +64,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_14_15,
                     KernelDatabase.MIGRATION_15_16,
                     KernelDatabase.MIGRATION_16_17,
+                    KernelDatabase.MIGRATION_17_18,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -27,4 +27,7 @@ interface ScheduledAlarmDao {
 
     @Query("DELETE FROM scheduled_alarms WHERE id = :id")
     suspend fun delete(id: String)
+
+    @Query("UPDATE scheduled_alarms SET enabled = :enabled WHERE id = :id")
+    suspend fun setEnabled(id: String, enabled: Boolean)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -10,4 +10,5 @@ data class ScheduledAlarmEntity(
     val label: String?,
     val createdAt: Long,
     val fired: Boolean = false,
+    val enabled: Boolean = true,
 )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -1,38 +1,55 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -44,6 +61,8 @@ fun ScheduledAlarmsScreen(
 ) {
     val alarms by viewModel.alarms.collectAsStateWithLifecycle()
     var pendingCancel by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var editingAlarm by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var showCreateDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -55,6 +74,11 @@ fun ScheduledAlarmsScreen(
                     }
                 },
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Create alarm")
+            }
         },
     ) { innerPadding ->
         if (alarms.isEmpty()) {
@@ -72,7 +96,7 @@ fun ScheduledAlarmsScreen(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "Alarms scheduled via Jandal for a specific date appear here. You can cancel them before they fire.",
+                    text = "Alarms scheduled via Jandal for a specific date appear here. You can also create alarms here using the + button.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -84,11 +108,38 @@ fun ScheduledAlarmsScreen(
                     .padding(innerPadding),
             ) {
                 items(alarms, key = { it.id }) { alarm ->
-                    AlarmRow(alarm = alarm, onCancel = { pendingCancel = alarm })
+                    AlarmRow(
+                        alarm = alarm,
+                        onTap = { editingAlarm = alarm },
+                        onCancel = { pendingCancel = alarm },
+                        onToggle = { viewModel.toggleEnabled(alarm) },
+                    )
                     HorizontalDivider()
                 }
             }
         }
+    }
+
+    if (showCreateDialog) {
+        AlarmCreateEditDialog(
+            existingAlarm = null,
+            onConfirm = { triggerAtMillis, label ->
+                viewModel.scheduleAlarm(triggerAtMillis, label)
+                showCreateDialog = false
+            },
+            onDismiss = { showCreateDialog = false },
+        )
+    }
+
+    editingAlarm?.let { alarm ->
+        AlarmCreateEditDialog(
+            existingAlarm = alarm,
+            onConfirm = { triggerAtMillis, label ->
+                viewModel.editAlarm(alarm, triggerAtMillis, label)
+                editingAlarm = null
+            },
+            onDismiss = { editingAlarm = null },
+        )
     }
 
     pendingCancel?.let { alarm ->
@@ -115,29 +166,170 @@ fun ScheduledAlarmsScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlarmCreateEditDialog(
+    existingAlarm: ScheduledAlarmEntity?,
+    onConfirm: (triggerAtMillis: Long, label: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isEdit = existingAlarm != null
+
+    val defaultTrigger = remember {
+        if (existingAlarm != null) {
+            Instant.ofEpochMilli(existingAlarm.triggerAtMillis)
+        } else {
+            LocalDate.now().plusDays(1).atTime(8, 0)
+                .atZone(ZoneId.systemDefault()).toInstant()
+        }
+    }
+    val defaultZdt = defaultTrigger.atZone(ZoneId.systemDefault())
+
+    var label by remember { mutableStateOf(existingAlarm?.label ?: "") }
+
+    // Step: "date" → "time" → "confirm"
+    var step by remember { mutableStateOf("date") }
+
+    val dateState = rememberDatePickerState(
+        initialSelectedDateMillis = defaultZdt.toLocalDate()
+            .atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+    )
+    val timeState = rememberTimePickerState(
+        initialHour = defaultZdt.hour,
+        initialMinute = defaultZdt.minute,
+        is24Hour = false,
+    )
+
+    when (step) {
+        "date" -> {
+            DatePickerDialog(
+                onDismissRequest = onDismiss,
+                confirmButton = {
+                    TextButton(
+                        onClick = { step = "time" },
+                        enabled = dateState.selectedDateMillis != null,
+                    ) { Text("Next") }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                },
+            ) {
+                DatePicker(state = dateState)
+            }
+        }
+        "time" -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text(if (isEdit) "Edit alarm time" else "Set time") },
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        TimePicker(state = timeState)
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { step = "label" }) { Text("Next") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { step = "date" }) { Text("Back") }
+                },
+            )
+        }
+        "label" -> {
+            val selectedDateUtcMillis = dateState.selectedDateMillis ?: return
+            val triggerAtMillis = remember(selectedDateUtcMillis, timeState.hour, timeState.minute) {
+                // selectedDateMillis is midnight UTC — convert to local date then apply local time
+                val localDate = Instant.ofEpochMilli(selectedDateUtcMillis)
+                    .atZone(ZoneId.of("UTC")).toLocalDate()
+                localDate.atTime(LocalTime.of(timeState.hour, timeState.minute))
+                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            }
+            val formatted = remember(triggerAtMillis) {
+                DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
+                    .withZone(ZoneId.systemDefault())
+                    .format(Instant.ofEpochMilli(triggerAtMillis))
+            }
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                title = { Text(if (isEdit) "Edit alarm" else "New alarm") },
+                text = {
+                    Column {
+                        Text(
+                            text = formatted,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        OutlinedTextField(
+                            value = label,
+                            onValueChange = { label = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            placeholder = { Text("Label (optional)") },
+                            singleLine = true,
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { onConfirm(triggerAtMillis, label.takeIf { it.isNotBlank() }) }) {
+                        Text(if (isEdit) "Save" else "Set alarm")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { step = "time" }) { Text("Back") }
+                },
+            )
+        }
+    }
+}
+
 @Composable
 private fun AlarmRow(
     alarm: ScheduledAlarmEntity,
+    onTap: () -> Unit,
     onCancel: () -> Unit,
+    onToggle: () -> Unit,
 ) {
     val formatted = remember(alarm.triggerAtMillis) {
         Instant.ofEpochMilli(alarm.triggerAtMillis)
             .let { DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma").withZone(ZoneId.systemDefault()).format(it) }
     }
+    val dimAlpha = if (alarm.enabled) 1f else 0.4f
     ListItem(
-        headlineContent = { Text(alarm.label ?: "Alarm") },
-        supportingContent = { Text(formatted) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onTap),
+        headlineContent = {
+            Text(
+                text = alarm.label ?: "Alarm",
+                textDecoration = if (alarm.enabled) null else TextDecoration.LineThrough,
+                modifier = Modifier.alpha(dimAlpha),
+            )
+        },
+        supportingContent = {
+            Text(
+                text = formatted,
+                modifier = Modifier.alpha(dimAlpha),
+            )
+        },
         leadingContent = {
             Icon(
                 Icons.Default.Alarm,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
+                tint = if (alarm.enabled) MaterialTheme.colorScheme.primary
+                       else MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         trailingContent = {
-            IconButton(onClick = onCancel) {
-                Icon(Icons.Default.Delete, contentDescription = "Cancel alarm")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(
+                    checked = alarm.enabled,
+                    onCheckedChange = { onToggle() },
+                )
+                IconButton(onClick = onCancel) {
+                    Icon(Icons.Default.Delete, contentDescription = "Cancel alarm")
+                }
             }
         },
     )
 }
+

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,30 +30,88 @@ class ScheduledAlarmsViewModel @Inject constructor(
             .map { list -> list.filter { it.triggerAtMillis > System.currentTimeMillis() } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    fun scheduleAlarm(triggerAtMillis: Long, label: String?) {
+        viewModelScope.launch {
+            val alarmId = UUID.randomUUID().toString()
+            val entity = ScheduledAlarmEntity(
+                id = alarmId,
+                triggerAtMillis = triggerAtMillis,
+                label = label?.takeIf { it.isNotBlank() },
+                createdAt = System.currentTimeMillis(),
+                enabled = true,
+            )
+            dao.insert(entity)
+            scheduleAlarmBroadcast(entity)
+        }
+    }
+
+    fun editAlarm(alarm: ScheduledAlarmEntity, newTriggerAtMillis: Long, newLabel: String?) {
+        viewModelScope.launch {
+            cancelAlarmBroadcast(alarm)
+            val updated = alarm.copy(
+                triggerAtMillis = newTriggerAtMillis,
+                label = newLabel?.takeIf { it.isNotBlank() },
+            )
+            dao.insert(updated)
+            if (updated.enabled) scheduleAlarmBroadcast(updated)
+        }
+    }
+
+    fun toggleEnabled(alarm: ScheduledAlarmEntity) {
+        viewModelScope.launch {
+            val newEnabled = !alarm.enabled
+            dao.setEnabled(alarm.id, newEnabled)
+            if (newEnabled) {
+                scheduleAlarmBroadcast(alarm.copy(enabled = true))
+            } else {
+                cancelAlarmBroadcast(alarm)
+            }
+        }
+    }
+
     fun cancelAlarm(alarm: ScheduledAlarmEntity) {
         viewModelScope.launch {
-            // Cancel the pending AlarmManager broadcast.
-            // Intent must include the same extras used when the alarm was scheduled
-            // so that PendingIntent.filterEquals() finds a match.
-            val alarmManager = context.getSystemService(AlarmManager::class.java)
-            val broadcastIntent = Intent().apply {
-                component = android.content.ComponentName(
-                    context.packageName,
-                    "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-                )
-                putExtra("alarm_label", alarm.label ?: "Alarm")
-                putExtra("alarm_id", alarm.id)
-            }
-            val pendingIntent = PendingIntent.getBroadcast(
-                context,
-                alarm.id.hashCode(),
-                broadcastIntent,
-                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
-            )
-            pendingIntent?.let { alarmManager.cancel(it) }
-
-            // Remove from DB
+            cancelAlarmBroadcast(alarm)
             dao.delete(alarm.id)
         }
     }
+
+    private fun scheduleAlarmBroadcast(alarm: ScheduledAlarmEntity) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        val broadcastIntent = Intent().apply {
+            component = android.content.ComponentName(
+                context.packageName,
+                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
+            )
+            putExtra("alarm_label", alarm.label ?: "Alarm")
+            putExtra("alarm_id", alarm.id)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            alarm.id.hashCode(),
+            broadcastIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, alarm.triggerAtMillis, pendingIntent)
+    }
+
+    private fun cancelAlarmBroadcast(alarm: ScheduledAlarmEntity) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        val broadcastIntent = Intent().apply {
+            component = android.content.ComponentName(
+                context.packageName,
+                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
+            )
+            putExtra("alarm_label", alarm.label ?: "Alarm")
+            putExtra("alarm_id", alarm.id)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            alarm.id.hashCode(),
+            broadcastIntent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+        pendingIntent?.let { alarmManager.cancel(it) }
+    }
 }
+


### PR DESCRIPTION
Closes #479

## Changes
- Add `enabled` field to `ScheduledAlarmEntity` (DB migration 17→18)
- `ScheduledAlarmDao.setEnabled()` toggle query
- `ScheduledAlarmsViewModel`: `scheduleAlarm()`, `editAlarm()`, `toggleEnabled()` + private AlarmManager helpers
- FAB + `AlarmCreateEditDialog` (date → time → label) in `ScheduledAlarmsScreen`
- Tap row to edit, Switch to toggle enabled/disabled
- Empty state hint updated