### PR TITLE
fix: align DEFAULT_SAMPLER_CONFIG to Google Gemma 4 default (temperature 1.0)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -46,8 +46,12 @@ const val MINIMAL_SYSTEM_PROMPT =
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000
 
-/** Sampler defaults for CPU/GPU backends. NPU requires null samplerConfig. */
-val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 64, topP = 0.95, temperature = 0.7)
+/**
+ * Reference sampler defaults matching Google's Gemma 4 E4B model card.
+ * Actual runtime values come from [ModelSettingsEntity] (user-configurable, defaults to 1.0/0.95/64).
+ * NPU backend ignores SamplerConfig entirely (hardware sampler used instead).
+ */
+val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 64, topP = 0.95f, temperature = 1.0f)
 
 /**
  * Controls how much of the Jandal identity is injected into the system prompt.

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -51,7 +51,7 @@ const val DEFAULT_MAX_TOKENS = 8000
  * Actual runtime values come from [ModelSettingsEntity] (user-configurable, defaults to 1.0/0.95/64).
  * NPU backend ignores SamplerConfig entirely (hardware sampler used instead).
  */
-val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 64, topP = 0.95f, temperature = 1.0f)
+val DEFAULT_SAMPLER_CONFIG = SamplerConfig(topK = 64, topP = 0.95, temperature = 1.0)
 
 /**
  * Controls how much of the Jandal identity is injected into the system prompt.


### PR DESCRIPTION
## Problem\n`DEFAULT_SAMPLER_CONFIG` in `ModelConfig.kt` had `temperature = 0.7` which is inconsistent with Google's Gemma 4 E4B model card default of `1.0`.\n\n## Root Cause\nThis constant is **dead code** — it is never referenced at runtime. Actual inference temperature comes from `ModelSettingsRepository.getSettings()` which correctly defaults to `1.0f`. The stale value was confusing and flagged during a hallucination analysis audit (#481).\n\n## Fix\n- Updated constant to `temperature = 1.0f` (matching Google defaults)\n- Added KDoc clarifying the constant is a reference/documentation value, not used in runtime inference path\n\nRelates to #481, #489