### PR TITLE
fix: refine MINIMAL_SYSTEM_PROMPT + anaphora context retention (#491)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -179,6 +179,7 @@ class LiteRtInferenceEngine @Inject constructor(
         _isGenerating.value = true
         val start = System.currentTimeMillis()
         var firstTokenMs: Long = -1
+        var thinkingCharCount = 0
 
         try {
             conv.sendMessageAsync(
@@ -188,6 +189,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     // Route thinking tokens separately (Gemma thinking mode)
                     val thinkingText = message.channels["thought"]
                     if (!thinkingText.isNullOrEmpty()) {
+                        thinkingCharCount += thinkingText.length
                         trySend(GenerationResult.Thinking(thinkingText))
                     }
 
@@ -203,6 +205,9 @@ class LiteRtInferenceEngine @Inject constructor(
 
                 override fun onDone() {
                     val durationMs = System.currentTimeMillis() - start
+                    if (thinkingCharCount > 0) {
+                        Log.d("KernelAI", "Thinking tokens: $thinkingCharCount chars")
+                    }
                     Log.i(TAG, "Generation complete: total=${durationMs}ms, TTFT=${firstTokenMs}ms [backend=${_activeBackend.value}]")
                     _isGenerating.value = false
                     trySend(GenerationResult.Complete(durationMs = durationMs))

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -35,13 +35,23 @@ const val DEFAULT_SYSTEM_PROMPT =
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called."
 
 /**
- * Minimal identity for tool-only execution (Actions tab).
- * Omits cultural details and language rules to save tokens.
+ * Minimal identity for tool-only execution (Actions tab and tool-routed chat queries).
+ *
+ * Omits Kiwi cultural rules and language directives to save ~200 tokens.
+ * Keeps greeting flexibility so "Hi" / "Kia ora" still feel natural.
+ * Retains the two safety IMPORTANT directives so tool-call hygiene is maintained
+ * even on the fast path.
  */
 const val MINIMAL_SYSTEM_PROMPT =
     "You are Jandal — a concise, on-device AI assistant from Aotearoa New Zealand. " +
-        "Be direct and brief. Report results only. " +
-        "When solving mathematical problems or deriving equations, show complete step-by-step working."
+        "Be direct and brief. If this is the opening message, greet the user naturally — " +
+        "\"Kia ora\", \"Hi\", or \"Hello\" are all fine. " +
+        "When solving mathematical problems or deriving equations, show complete step-by-step " +
+        "working; for simple arithmetic, remain concise. " +
+        "IMPORTANT: When a [System:] context block confirms a completed action, do NOT call any " +
+        "tools — simply acknowledge the result naturally. " +
+        "IMPORTANT: When the user asks you to save or remember something, you MUST call the " +
+        "saveMemory tool — NEVER confirm that you saved something without the tool having been called."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -412,14 +412,43 @@ private fun MessageBubble(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
     ) {
-        // Thinking text (collapsed, italics)
+        // Thinking bubble — expandable, shows chain-of-thought content when tapped
         if (showThinkingProcess && !message.thinkingText.isNullOrBlank()) {
-            Text(
-                text = "Thinking…",
-                style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
-                color = MaterialTheme.colorScheme.outline,
-                modifier = Modifier.padding(bottom = 2.dp),
-            )
+            var expanded by rememberSaveable { mutableStateOf(false) }
+            Column(modifier = Modifier.padding(bottom = 4.dp)) {
+                Row(
+                    modifier = Modifier.clickable { expanded = !expanded },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Thinking…",
+                        style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (expanded) "Collapse thinking" else "Expand thinking",
+                        tint = MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+                AnimatedVisibility(visible = expanded) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .widthIn(max = 320.dp),
+                    ) {
+                        Text(
+                            text = message.thinkingText!!,
+                            style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(8.dp),
+                        )
+                    }
+                }
+            }
         }
 
         // Tool call chip (shown above message bubble for assistant messages)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -708,6 +708,21 @@ class ChatViewModel @Inject constructor(
             val effectiveRagContext = if (isToolQuery) "" else ragContext
             val effectiveRagTokenCost = if (isToolQuery) 0 else ragTokenCost
 
+            // Anaphora handling (#491): tool queries with "save that", "look it up", etc. need
+            // the previous turn to resolve what "that/it/this" refers to. Inject the last
+            // user+assistant pair as a lightweight context block — still no RAG or personality.
+            val anaphoraContext: String = if (isToolQuery && looksLikeAnaphora(text)) {
+                val priorMessages = _messages.value.dropLast(2) // exclude just-added user + placeholder
+                val lastPair = priorMessages.takeLast(2)
+                if (lastPair.isEmpty()) "" else buildString {
+                    append("[Context: previous exchange]\n")
+                    for (msg in lastPair) {
+                        val speaker = if (msg.role == ChatMessage.Role.USER) "User" else "Jandal"
+                        append("$speaker: ${msg.content}\n")
+                    }
+                }.trimEnd()
+            } else ""
+
             if (needsHistoryReplay || proactiveReset) {
                 needsHistoryReplay = false
                 val allMessages = _messages.value.dropLast(2) // exclude just-added user + placeholder
@@ -728,6 +743,7 @@ class ChatViewModel @Inject constructor(
 
             prompt = buildString {
                 if (effectiveRagContext.isNotBlank()) append("$effectiveRagContext\n\n")
+                if (anaphoraContext.isNotBlank()) append("$anaphoraContext\n\n")
                 if (systemContext != null) append("$systemContext\n\n")
                 // Greeting instruction injected per-turn so turn 1 says "Kia ora" and
                 // subsequent turns explicitly suppress greetings — without invalidating the KV cache.
@@ -1145,6 +1161,25 @@ class ChatViewModel @Inject constructor(
                 lower.contains(keyword)
             }
         }
+    }
+
+    /**
+     * Returns true if [text] contains an anaphoric reference — i.e. the user says "that",
+     * "this", "it", "the above", or similar, implying they need the previous turn's content
+     * to resolve the referent (#491).
+     *
+     * Used alongside [looksLikeToolQuery] to decide whether to inject the last conversation
+     * pair as lightweight context even when full RAG is stripped.
+     */
+    private fun looksLikeAnaphora(text: String): Boolean {
+        val lower = text.lowercase().trim()
+        return Regex(
+            """^(save|remember|store|add|note|keep)\s+(that|this|it)\b|
+               \b(look|search|find|check)\s+(that|it|this)\s+(up|out)\b|
+               ^(what|how|why|when|where)\s+(is|was|were|did)\s+(that|it|this)\b|
+               \bthat\b|\bthe above\b|\bthe previous\b""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.COMMENTS),
+        ).containsMatchIn(lower)
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #491

Two related improvements to the tool-query fast path introduced in PR #483.

---

### 1. Refined `MINIMAL_SYSTEM_PROMPT`

**Before:** The minimal prompt had no personality instructions, no greeting guidance, and was missing the critical tool-call IMPORTANT directives — so anaphoric tool queries could silently mis-behave (e.g. confirm a save without calling `saveMemory`).

**After:**
- Greeting flexibility: `"Kia ora"`, `"Hi"`, or `"Hello"` are all explicitly allowed — no more robotic first responses on the fast path.
- Kiwi cultural rules dropped (no more `"never say G'day"`, `"own your Kiwi identity"`) — these ~60 tokens caused Australianisms to bleed through without providing value on tool-only turns.
- Both safety IMPORTANT directives retained: `[System:]` action acknowledgement rule + `saveMemory` must-call rule.

---

### 2. Anaphora detection + last-turn context injection

**Problem:** Queries like `"save that"`, `"look it up"`, `"what was that?"` fire `isToolQuery = true`, which strips RAG + history. But the model has no context for what "that" refers to, so it either hallucinates or fails.

**Fix:**
- Added `looksLikeAnaphora(text)` helper using a COMMENTS-mode regex matching:
  - `save/remember/store/add/note/keep that/this/it`
  - `look/search/find/check that/it/this up/out`
  - `what/how/why/when/where is/was/were/did that/it/this`
  - bare `that`, `the above`, `the previous`
- When `isToolQuery && looksLikeAnaphora()`:
  - Still uses `IdentityTier.MINIMAL` (saves personality tokens)
  - Still skips full RAG injection
  - BUT prepends the last 2 messages (1 user + 1 assistant pair) as a `[Context: previous exchange]` block so the model can resolve the referent

Token cost: ~50–150 tokens for the prior exchange vs ~1000 for full RAG + personality — a good trade.