### PR TITLE
fix: expandable think bubble + logcat thinking token count (#489)

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -179,6 +179,7 @@ class LiteRtInferenceEngine @Inject constructor(
         _isGenerating.value = true
         val start = System.currentTimeMillis()
         var firstTokenMs: Long = -1
+        var thinkingCharCount = 0
 
         try {
             conv.sendMessageAsync(
@@ -188,6 +189,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     // Route thinking tokens separately (Gemma thinking mode)
                     val thinkingText = message.channels["thought"]
                     if (!thinkingText.isNullOrEmpty()) {
+                        thinkingCharCount += thinkingText.length
                         trySend(GenerationResult.Thinking(thinkingText))
                     }
 
@@ -203,6 +205,9 @@ class LiteRtInferenceEngine @Inject constructor(
 
                 override fun onDone() {
                     val durationMs = System.currentTimeMillis() - start
+                    if (thinkingCharCount > 0) {
+                        Log.d("KernelAI", "Thinking tokens: $thinkingCharCount chars")
+                    }
                     Log.i(TAG, "Generation complete: total=${durationMs}ms, TTFT=${firstTokenMs}ms [backend=${_activeBackend.value}]")
                     _isGenerating.value = false
                     trySend(GenerationResult.Complete(durationMs = durationMs))

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -412,14 +412,43 @@ private fun MessageBubble(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
     ) {
-        // Thinking text (collapsed, italics)
+        // Thinking bubble — expandable, shows chain-of-thought content when tapped
         if (showThinkingProcess && !message.thinkingText.isNullOrBlank()) {
-            Text(
-                text = "Thinking…",
-                style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
-                color = MaterialTheme.colorScheme.outline,
-                modifier = Modifier.padding(bottom = 2.dp),
-            )
+            var expanded by rememberSaveable { mutableStateOf(false) }
+            Column(modifier = Modifier.padding(bottom = 4.dp)) {
+                Row(
+                    modifier = Modifier.clickable { expanded = !expanded },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Thinking…",
+                        style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (expanded) "Collapse thinking" else "Expand thinking",
+                        tint = MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+                AnimatedVisibility(visible = expanded) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .widthIn(max = 320.dp),
+                    ) {
+                        Text(
+                            text = message.thinkingText!!,
+                            style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(8.dp),
+                        )
+                    }
+                }
+            }
         }
 
         // Tool call chip (shown above message bubble for assistant messages)


### PR DESCRIPTION
Restores PR #495 (accidentally closed by force push). Fixes think bubble to show actual chain-of-thought content (was showing static 'Thinking…' label). Adds logcat token count in LiteRtInferenceEngine.

Closes #489