### PR TITLE
fix: hallucination retry (C2) + DirectReply skill audit (#487 #471)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/LoadSkillSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/LoadSkillSkill.kt
@@ -49,6 +49,7 @@ class LoadSkillSkill @Inject constructor(
     // load_skill's own fullInstructions are always embedded in the system prompt — no need
     // to load them lazily. This just returns the standard default.
 
+    // Success: instruction context for LLM — not user-facing
     override suspend fun execute(call: SkillCall): SkillResult {
         val skillName = call.arguments["skill_name"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure(name, "Missing required parameter: skill_name.")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -208,6 +208,7 @@ class RunIntentSkill @Inject constructor(
         examples.forEach { appendLine("  $it") }
     }
 
+    // Success: action result — delegates to NativeIntentHandler; LLM narration appropriate
     override suspend fun execute(call: SkillCall): SkillResult {
         val intentName = call.arguments["intent_name"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure(name, "Missing required parameter: intent_name.")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunJsSkill.kt
@@ -63,6 +63,7 @@ class RunJsSkill @Inject constructor(
         "Weather tomorrow → runJs(skillName=\"get-weather-city\", query=\"London\", forecastDays=\"1\")",
     )
 
+    // Success: JS skill output requires LLM synthesis (e.g. Wikipedia summaries)
     override suspend fun execute(call: SkillCall): SkillResult {
         val skillName = call.arguments["skill_name"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure(name, "Missing required parameter: skill_name.")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetSystemInfoSkill.kt
@@ -72,6 +72,7 @@ class GetSystemInfoSkill @Inject constructor(
                 }
 
                 Log.d(TAG, "GetSystemInfoSkill executed successfully")
+                // DirectReply: structured data — hardware stats, RAM, battery percentage
                 SkillResult.DirectReply(info.trim())
             } catch (e: Exception) {
                 Log.e(TAG, "GetSystemInfoSkill failed", e)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -412,6 +412,7 @@ class GetWeatherSkill @Inject constructor(
         }.trimEnd()
 
         Log.d(TAG, "GetWeatherSkill: fetched weather for $locationLabel")
+        // DirectReply: structured data — numeric temperature/humidity/wind values
         return SkillResult.DirectReply(text)
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherUnifiedSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherUnifiedSkill.kt
@@ -58,6 +58,7 @@ class GetWeatherUnifiedSkill @Inject constructor(
         required = emptyList(),
     )
 
+    // DirectReply: delegates to GetWeatherSkill which returns DirectReply for all weather data
     override suspend fun execute(call: SkillCall): SkillResult =
         weatherSkill.execute(SkillCall(weatherSkill.name, call.arguments))
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -74,6 +74,7 @@ Do NOT ask what to save — always infer and call the tool.
                     embeddingVector = vector,
                 )
                 Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
+                // Success: action result — LLM narration appropriate
                 SkillResult.Success("✓ Saved: \"${content.take(100)}\".")
             } catch (e: Exception) {
                 Log.e(TAG, "SaveMemorySkill failed", e)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SearchMemorySkill.kt
@@ -111,6 +111,7 @@ After calling searchMemory, incorporate its result into your reply naturally.
                 )
 
                 if (memoryResults.isEmpty() && messageResults.isEmpty()) {
+                    // Success: action result — LLM narration appropriate
                     return@withContext SkillResult.Success("No memories found matching '$query'.")
                 }
 
@@ -137,7 +138,8 @@ After calling searchMemory, incorporate its result into your reply naturally.
                     }
                 }
 
-                SkillResult.Success(sb.toString().trimEnd())
+                // DirectReply: structured list data — bypasses LLM to preserve dates/indices
+                SkillResult.DirectReply(sb.toString().trimEnd())
             } catch (e: Exception) {
                 Log.e(TAG, "SearchMemorySkill failed", e)
                 SkillResult.Failure(name, e.message ?: "Failed to search memories")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -119,6 +119,9 @@ class ChatViewModel @Inject constructor(
      */
     private var titleIsPlaceholder = false
 
+    /** C2 (#487): per-turn flag — true once the hallucination retry has been attempted. */
+    private var hallucinationRetryAttempted = false
+
     /** True while Gemma-4 is being lazily initialised in response to a [sendMessage] call. */
     private val _isLoadingModel = MutableStateFlow(false)
 
@@ -762,7 +765,14 @@ class ChatViewModel @Inject constructor(
 
             try {
                 kernelAIToolSet.resetTurnState()
-            inferenceEngine.generate(prompt).collect { result ->
+                hallucinationRetryAttempted = false
+                var currentPrompt = prompt
+                var needsHallucinationRetry: Boolean
+
+            do {
+                needsHallucinationRetry = false
+
+            inferenceEngine.generate(currentPrompt).collect { result ->
                     when (result) {
                         is GenerationResult.Token -> {
                             accumulatedContent.append(result.text)
@@ -846,14 +856,39 @@ class ChatViewModel @Inject constructor(
                                 // native tool calls and forcing a replay drops prior turns from the
                                 // tight history budget, causing context amnesia (#446).
                             } else {
-                                // Normal text response — but first check for hallucinated tool
-                                // confirmations. If the model claims to have saved/added/created
-                                // something without actually calling a tool, replace its response
-                                // with an honest failure message rather than surfacing false data.
-                                val displayContent = if (looksLikeToolConfirmation(fullContent)) {
+                                val isHallucination = looksLikeToolConfirmation(fullContent)
+
+                                // C2 (#487): Single automatic retry before falling to C1 failure.
+                                // If the model hallucinated a tool confirmation and we haven't
+                                // retried yet, prepend a correction and re-run inference — unless
+                                // the context window is already >75% full.
+                                if (isHallucination && !hallucinationRetryAttempted) {
+                                    hallucinationRetryAttempted = true
+                                    val budgetOk = estimatedTokensUsed <= (activeContextWindowSize * 0.75).toInt()
+                                    if (budgetOk) {
+                                        Log.w("KernelAI", "hallucination_retry_attempted")
+                                        needsHallucinationRetry = true
+                                        currentPrompt = HALLUCINATION_RETRY_CORRECTION + "\n\n" + prompt
+                                        // Reset streaming state for the retry pass
+                                        accumulatedContent = StringBuilder()
+                                        accumulatedThinking = StringBuilder()
+                                        activeStreamingContent = accumulatedContent
+                                        activeStreamingThinking = accumulatedThinking
+                                        _messages.update { msgs ->
+                                            msgs.map { if (it.id == assistantMsgId) it.copy(content = "", isStreaming = true) else it }
+                                        }
+                                        return@collect
+                                    }
+                                    // Token budget >75% — skip retry, fall through to C1 failure
+                                }
+
+                                // Normal text or C1 hallucination failure
+                                val displayContent = if (isHallucination) {
+                                    if (currentPrompt !== prompt) Log.w("KernelAI", "hallucination_retry_failed")
                                     Log.w("KernelAI", "Hallucination guard triggered — model confirmed action without tool call")
                                     "I wasn't able to complete that action — please try again, or try phrasing it differently."
                                 } else {
+                                    if (currentPrompt !== prompt) Log.d("KernelAI", "hallucination_retry_succeeded")
                                     fullContent
                                 }
                                 _messages.update { msgs ->
@@ -901,6 +936,8 @@ class ChatViewModel @Inject constructor(
                         }
                     }
                 }
+            } while (needsHallucinationRetry)
+
             } catch (e: Exception) {
                 _messages.update { msgs ->
                     msgs.map { msg ->
@@ -1174,6 +1211,12 @@ class ChatViewModel @Inject constructor(
     private fun looksLikeToolConfirmation(response: String): Boolean =
         com.kernel.ai.feature.chat.looksLikeToolConfirmation(response)
 }
+
+/** C2 correction prepended to the prompt when a hallucination retry is attempted (#487). */
+private const val HALLUCINATION_RETRY_CORRECTION =
+    "[System: Your previous response was blocked. It appeared to describe performing an action " +
+    "without actually calling the required tool function. You MUST call the appropriate tool — " +
+    "do not narrate results. If the tool is unavailable, say so honestly.]"
 
 private fun formatBytes(bytes: Long): String = when {
     bytes >= 1_073_741_824L -> "%.1f GB".format(bytes / 1_073_741_824.0)


### PR DESCRIPTION
## Summary

**C2 Hallucination Retry (#487)**
- Added `hallucinationRetryAttempted` per-turn state field, reset at each turn start
- When `looksLikeToolConfirmation()` triggers and retry not yet attempted:
  - Check token budget (>75% context usage → skip to C1 failure)
  - Prepend correction prompt instructing model to call the tool properly
  - Re-run inference via do-while loop around `generate().collect`
  - Reset streaming state for clean retry output
- Logging: `hallucination_retry_attempted` / `succeeded` / `failed`
- Second hallucination goes straight to C1 failure (no infinite loop)

**DirectReply Skill Audit (#471)**
- `SearchMemorySkill`: `Success` → `DirectReply` for structured list results (dates, indices). Empty-result path stays `Success` for LLM narration.
- `GetWeatherSkill`, `GetSystemInfoSkill`, `GetWeatherUnifiedSkill`: already `DirectReply` ✓ — annotated with rationale comments
- `SaveMemorySkill`: keep `Success` ✓ — action result, LLM narration appropriate
- `RunIntentSkill`, `RunJsSkill`, `LoadSkillSkill`: keep `Success` ✓ — annotated
- QIR fast-path verified: `appendAssistantMessageWithToolCall()` already called for DirectReply, tool chip appears correctly

## Tests
- `:feature:chat:test` — all pass (1 pre-existing LaTeX test failure unrelated)
- `:core:skills:test` — all pass

Closes #487
Closes #471