### PR TITLE
feat: ADB skill regression harness + chat_input wiring (20/20 passing)

### DIFF
--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -4,12 +4,13 @@ import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
-import androidx.core.content.ContextCompat
-import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import android.os.Bundle
+import androidx.activity.ComponentActivity
 import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import com.kernel.ai.core.ui.theme.KernelAITheme
 import com.kernel.ai.navigation.KernelNavHost
@@ -23,6 +24,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject lateinit var authRepository: HuggingFaceAuthRepository
 
+    /** Bridges ADB `--es chat_input` extras (onCreate + onNewIntent) into the nav graph. */
+    private val adbChatInput = mutableStateOf<String?>(null)
+
     private val requestNotificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
 
@@ -35,6 +39,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        adbChatInput.value = intent.getStringExtra("chat_input")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
@@ -48,7 +53,7 @@ class MainActivity : ComponentActivity() {
         }
         setContent {
             KernelAITheme {
-                KernelNavHost()
+                KernelNavHost(initialChatQuery = adbChatInput.value)
             }
         }
     }
@@ -58,10 +63,13 @@ class MainActivity : ComponentActivity() {
      * With [android:launchMode="singleTop"] and [FLAG_ACTIVITY_SINGLE_TOP], the existing
      * instance receives the callback here rather than being re-created — surviving Samsung's
      * aggressive memory management on Android 16 (S23 Ultra, issue #195).
+     *
+     * Also handles ADB test `--es chat_input` extras for regression testing.
      */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        intent.getStringExtra("chat_input")?.let { adbChatInput.value = it }
         if (AuthorizationResponse.fromIntent(intent) != null ||
             AuthorizationException.fromIntent(intent) != null) {
             authRepository.deliverAuthResponse(intent)

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -70,7 +71,7 @@ private const val ARG_INITIAL_QUERY = "initialQuery"
 private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
 
 @Composable
-fun KernelNavHost() {
+fun KernelNavHost(initialChatQuery: String? = null) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -78,6 +79,16 @@ fun KernelNavHost() {
 
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val coroutineScope = rememberCoroutineScope()
+
+    // ADB test harness: navigate to chat from any screen when chat_input extra is delivered
+    LaunchedEffect(initialChatQuery) {
+        if (!initialChatQuery.isNullOrBlank()) {
+            val encoded = Uri.encode(initialChatQuery)
+            navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded") {
+                popUpTo(ROUTE_LIST)
+            }
+        }
+    }
 
     ModalNavigationDrawer(
         drawerState = drawerState,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -623,6 +623,7 @@ class ChatViewModel @Inject constructor(
                     }
                 }
                 if (skill != null) {
+                    Log.d("KernelAI", "NativeIntentHandler.handle: intent=${matchedIntent.intentName} params=$callParams")
                     val skillResult = skill.execute(SkillCall(skill.name, callParams))
                     when (skillResult) {
                         is com.kernel.ai.core.skills.SkillResult.DirectReply -> {

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -26,10 +27,10 @@ from dataclasses import dataclass
 
 ADB = os.path.expanduser("~/Android/Sdk/platform-tools/adb")
 PACKAGE = "com.kernel.ai.debug"
-ACTIVITY = f"{PACKAGE}/.MainActivity"
-LOGCAT_TAG = "NativeIntentHandler"
+ACTIVITY = f"{PACKAGE}/com.kernel.ai.MainActivity"
+LOGCAT_TAG = "KernelAI"
 INTENT_PATTERN = re.compile(r"NativeIntentHandler\.handle:\s*intent=(\S+)")
-WAIT_SECONDS = 5
+WAIT_SECONDS = 20
 
 
 @dataclass
@@ -71,13 +72,15 @@ TEST_CASES: list[TestCase] = [
 
 
 def run_adb(*args: str) -> str:
-    """Run an ADB command and return stdout."""
+    """Run an ADB command and return stdout. Prints stderr on non-zero exit."""
     result = subprocess.run(
         [ADB, *args],
         capture_output=True,
         text=True,
         timeout=30,
     )
+    if result.returncode != 0 and result.stderr:
+        print(f"\n  [adb warn] {result.stderr.strip()}", file=sys.stderr)
     return result.stdout
 
 
@@ -90,11 +93,9 @@ def read_logcat() -> str:
 
 
 def send_text(text: str) -> None:
-    """Launch the app and broadcast a chat message via ADB."""
-    # Wake the screen and unlock
+    """Deliver chat_input extra via onNewIntent — navigates to chat from any screen."""
     run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
     time.sleep(0.3)
-    # Launch the app
     run_adb(
         "shell",
         "am",
@@ -103,14 +104,14 @@ def send_text(text: str) -> None:
         ACTIVITY,
         "--es",
         "chat_input",
-        text,
+        shlex.quote(text),
     )
 
 
 def extract_intent(logcat_output: str) -> str | None:
-    """Extract the last intent= value from logcat output."""
+    """Extract the first intent= value from logcat output (logcat is cleared before each test)."""
     matches = INTENT_PATTERN.findall(logcat_output)
-    return matches[-1] if matches else None
+    return matches[0] if matches else None
 
 
 def run_tests(dry_run: bool = False) -> int:
@@ -137,6 +138,25 @@ def run_tests(dry_run: bool = False) -> int:
     print("=" * 70)
     print("  ADB SKILL REGRESSION TEST")
     print("=" * 70)
+    print()
+
+    # Warm up: send a dummy query to trigger model load, wait for NativeIntentHandler to fire
+    print("  [init] Warming up model (this takes ~30s on first run) ...", end=" ", flush=True)
+    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    run_adb("shell", "am", "start", "-n", ACTIVITY)
+    time.sleep(3)
+    clear_logcat()
+    run_adb("shell", "am", "start", "-n", ACTIVITY, "--es", "chat_input", shlex.quote("what time is it"))
+    # Poll logcat until NativeIntentHandler fires (model loaded + QIR dispatched) or 60s timeout
+    deadline = time.time() + 60
+    warmed = False
+    while time.time() < deadline:
+        time.sleep(2)
+        log = read_logcat()
+        if "NativeIntentHandler.handle" in log:
+            warmed = True
+            break
+    print("ready" if warmed else "timeout (proceeding anyway)")
     print()
 
     for i, tc in enumerate(TEST_CASES, 1):


### PR DESCRIPTION
## Summary

End-to-end ADB regression harness for skill intent routing, verified 20/20 on device (SM-S918B, Android 16).

## Changes

### App: `chat_input` ADB intent wiring
- **`MainActivity.kt`** — reads `chat_input` string extra in both `onCreate` and `onNewIntent`, exposes via `mutableStateOf`
- **`KernelNavHost.kt`** — top-level `LaunchedEffect(initialChatQuery)` navigates to a new chat from any screen with `popUpTo(ROUTE_LIST)`

### App: Unified skill dispatch logging
- **`ChatViewModel.kt`** — adds `NativeIntentHandler.handle: intent=...` log before `skill.execute()` so direct skills (get_weather, save_memory) are detectable by the harness alongside run_intent skills

### Harness: `scripts/adb_skill_test.py`
- Fixed `ACTIVITY` constant (`.MainActivity` shorthand resolved to wrong package)
- `shlex.quote()` for multi-word ADB shell args
- `extract_intent` uses first match (prevents E4B follow-up tool calls overriding primary intent)
- Surfaces ADB stderr on non-zero exit
- Model warmup + 20s per-test timeout

## Test Results
```
PASSED: 20/20  FAILED: 0/20
```
All skill categories: alarms ✓ weather ✓ lists ✓ time ✓ battery ✓ memory ✓ toggles ✓ flashlight ✓