### PR TITLE
feat(#443): add MiniLM to model management as built-in model

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -34,6 +34,11 @@ enum class KernelModel(
      * Model Management UI so users can accept the licence before downloading.
      */
     val licenceUrl: String? = null,
+    /**
+     * If `true`, this model is bundled as an app asset and is always available without
+     * downloading. Model Management shows it as "Built-in" — no download or delete controls.
+     */
+    val isBundled: Boolean = false,
 ) {
     GEMMA_4_E2B(
         displayName = "Gemma 4 E-2B",
@@ -111,6 +116,22 @@ enum class KernelModel(
         preferredForTier = null,
         isGated = true,
         licenceUrl = "https://huggingface.co/litert-community/embeddinggemma-300m",
+    ),
+
+    /**
+     * all-MiniLM-L6-v2 (int8 TFLite) — fast semantic intent classifier bundled as an app asset.
+     * Powers the Tier 2 classifier in QuickIntentRouter. Not downloadable — always available.
+     * Shown in Model Management as "Built-in" for user awareness.
+     */
+    MINI_LM(
+        displayName = "MiniLM-L6 Intent Classifier",
+        fileName = "minilm-l6-v2-int8.tflite",
+        downloadUrl = "",
+        approxSizeBytes = 23_000_000L, // ~23 MB bundled asset
+        isRequired = false,
+        preferredForTier = null,
+        isGated = false,
+        isBundled = true,
     );
 
     /**
@@ -134,8 +155,9 @@ fun KernelModel.localFile(context: Context): File {
     return File(modelsDir, fileName)
 }
 
-/** True if the model file exists and is non-empty. */
+/** True if the model file exists and is non-empty. Bundled models are always considered downloaded. */
 fun KernelModel.isDownloaded(context: Context): Boolean {
+    if (isBundled) return true
     val file = localFile(context)
     return file.exists() && file.length() > 0
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -60,10 +60,10 @@ class ModelDownloadManager @Inject constructor(
     private val _downloadStates: MutableStateFlow<Map<KernelModel, DownloadState>> =
         MutableStateFlow(
             KernelModel.entries.associateWith { model ->
-                if (model.isDownloaded(context)) {
-                    DownloadState.Downloaded(model.localFile(context).absolutePath)
-                } else {
-                    DownloadState.NotDownloaded
+                when {
+                    model.isBundled -> DownloadState.Downloaded("bundled")
+                    model.isDownloaded(context) -> DownloadState.Downloaded(model.localFile(context).absolutePath)
+                    else -> DownloadState.NotDownloaded
                 }
             }
         )
@@ -129,6 +129,7 @@ class ModelDownloadManager @Inject constructor(
      *   Samsung's battery manager prevented from dispatching, and to restart FAILED jobs.
      */
     fun startDownload(model: KernelModel, force: Boolean = false) {
+        if (model.isBundled) return  // bundled assets are always available; nothing to download
         if (!force && model.isDownloaded(context)) {
             updateState(model, DownloadState.Downloaded(model.localFile(context).absolutePath))
             return

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
@@ -435,16 +435,26 @@ private fun ModelRow(
                         }
                     }
                     is DownloadState.Downloaded -> {
-                        Icon(
-                            Icons.Default.CheckCircle,
-                            contentDescription = "Downloaded",
-                            tint = Color(0xFF4CAF50),
-                            modifier = Modifier.size(20.dp),
-                        )
-                        if (!model.isRequired) {
-                            Spacer(modifier = Modifier.width(4.dp))
-                            TextButton(onClick = onDelete) {
-                                Text("Delete", color = MaterialTheme.colorScheme.error)
+                        if (model.isBundled) {
+                            SuggestionChip(
+                                onClick = {},
+                                label = { Text("Built-in", style = MaterialTheme.typography.labelSmall) },
+                                colors = SuggestionChipDefaults.suggestionChipColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                ),
+                            )
+                        } else {
+                            Icon(
+                                Icons.Default.CheckCircle,
+                                contentDescription = "Downloaded",
+                                tint = Color(0xFF4CAF50),
+                                modifier = Modifier.size(20.dp),
+                            )
+                            if (!model.isRequired) {
+                                Spacer(modifier = Modifier.width(4.dp))
+                                TextButton(onClick = onDelete) {
+                                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                                }
                             }
                         }
                     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
@@ -77,7 +77,7 @@ class ModelManagementViewModel @Inject constructor(
     }
 
     fun deleteModel(model: KernelModel) {
-        if (model.isRequired) return
+        if (model.isRequired || model.isBundled) return
         viewModelScope.launch(Dispatchers.IO) {
             model.localFile(context).delete()
             // Also delete any stale .tmp resume file


### PR DESCRIPTION
Closes #443

## Summary
MiniLM-L6-v2 int8 classifier was absent from Model Management despite being bundled in the APK and powering the Tier 2 intent classifier in QuickIntentRouter.

## Changes
- Add `isBundled: Boolean = false` to `KernelModel` enum constructor
- Add `MINI_LM` entry (`isBundled = true`, ~23 MB asset)
- `isDownloaded()`: returns `true` immediately for bundled models
- `ModelDownloadManager`: reports bundled models as `Downloaded("bundled")`; guards `startDownload()` against bundled models
- `ModelManagementViewModel.deleteModel()`: guards against `isBundled`
- `ModelManagementScreen`: shows 'Built-in' chip for bundled models (no download/delete controls)

## UI result
MiniLM appears in the Models list as:
`MiniLM-L6 Intent Classifier  [Optional]  23 MB  [Built-in]`

No download or delete buttons — it's always available as an app asset.