### PR TITLE
fix(#471): switch getBattery and getTime to SkillResult.DirectReply

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -392,35 +392,38 @@ class NativeIntentHandler @Inject constructor(
         val pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
         val charging = bm.isCharging
         val chargingSuffix = if (charging) " and charging" else ""
-        return SkillResult.Success("Battery is at $pct%$chargingSuffix")
+        // DirectReply: numeric sensor data — LLM rephrasing risks corrupting the percentage value.
+        return SkillResult.DirectReply("Battery is at $pct%$chargingSuffix")
     }
 
     // ── Time / Date ───────────────────────────────────────────────────────────
 
     private fun getTime(params: Map<String, String> = emptyMap()): SkillResult {
         val now = LocalDateTime.now()
+        // DirectReply: factual time/date data — LLM wrapping risks corrupting values
+        // (e.g. "3:47 PM" → "nearly four o'clock") and adds no value for a simple query.
         return when (params["query_type"]) {
-            "time" -> SkillResult.Success(
+            "time" -> SkillResult.DirectReply(
                 "It's ${now.format(DateTimeFormatter.ofPattern("h:mm a"))}",
             )
-            "date" -> SkillResult.Success(
+            "date" -> SkillResult.DirectReply(
                 "Today is ${now.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy"))}",
             )
-            "day_of_week" -> SkillResult.Success(
+            "day_of_week" -> SkillResult.DirectReply(
                 "It's ${now.format(DateTimeFormatter.ofPattern("EEEE"))}",
             )
-            "year" -> SkillResult.Success("It's ${now.year}")
-            "month" -> SkillResult.Success(
+            "year" -> SkillResult.DirectReply("It's ${now.year}")
+            "month" -> SkillResult.DirectReply(
                 "It's ${now.format(DateTimeFormatter.ofPattern("MMMM"))}",
             )
             "week" -> {
                 val week = now.get(WeekFields.ISO.weekOfWeekBasedYear())
-                SkillResult.Success("It's week $week of ${now.year}")
+                SkillResult.DirectReply("It's week $week of ${now.year}")
             }
             else -> {
                 val time = now.format(DateTimeFormatter.ofPattern("h:mm a"))
                 val date = now.format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
-                SkillResult.Success("It's $time on $date")
+                SkillResult.DirectReply("It's $time on $date")
             }
         }
     }


### PR DESCRIPTION
Closes #471

## Changes

**`NativeIntentHandler`**
- `getBattery()`: `Success` → `DirectReply` — battery % is numeric sensor data; LLM risks rounding/paraphrasing it
- `getTime()` all variants (time/date/day/year/month/week): `Success` → `DirectReply` — time values should never be paraphrased

## Full audit table (all intents deliberately classified)

| Skill/Intent | Result | Rationale |
|---|---|---|
| `get_battery` | ✅ DirectReply | Numeric sensor data |
| `get_time` (all) | ✅ DirectReply | Factual temporal data |
| `get_list_items` | ✅ DirectReply | Already correct |
| `add_to_list` / `create_list` | ✅ DirectReply | Already correct — complete structured response |
| `GetSystemInfoSkill` | ✅ DirectReply | Already correct |
| `SearchMemorySkill` | ✅ DirectReply | Already correct |
| `GetWeatherSkill` / `GetWeatherUnifiedSkill` | ✅ DirectReply | Already correct |
| Flashlight / DND / volume / toggles | ✅ Success | Action intents — LLM narration adds value |
| Alarm / timer / calendar | ✅ Success | Action intents |
| SMS / email / media / navigation | ✅ Success | Action intents |