### PR TITLE
feat(#493): multi-turn slot filling via SlotFillerManager

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -43,6 +43,15 @@ class QuickIntentRouter(
             val bestGuess: MatchedIntent? = null,
             val bestConfidence: Float = 0f,
         ) : RouteResult()
+
+        /**
+         * Regex matched but a required parameter is absent — pause execution and ask the user
+         * to supply the missing slot before the intent can be dispatched.
+         */
+        data class NeedsSlot(
+            val intent: MatchedIntent,
+            val missingSlot: com.kernel.ai.core.skills.slot.SlotSpec,
+        ) : RouteResult()
     }
 
     data class MatchedIntent(
@@ -64,6 +73,12 @@ class QuickIntentRouter(
         val intentName: String,
         val regex: Regex,
         val paramExtractor: (MatchResult, String) -> Map<String, String>,
+        /**
+         * Required slots that must be present in the extracted params before the intent can be
+         * executed. If a key is absent or blank, [route] returns [RouteResult.NeedsSlot] so
+         * the caller can ask the user to supply the missing value before proceeding.
+         */
+        val requiredSlots: Map<String, com.kernel.ai.core.skills.slot.SlotSpec> = emptyMap(),
     )
 
     private val patterns: List<IntentPattern> = listOf(
@@ -882,6 +897,13 @@ class QuickIntentRouter(
                 if (msg.isNotBlank()) params["message"] = msg
                 params
             },
+            // Ask for the message body when the user only specified a recipient.
+            requiredSlots = mapOf(
+                "message" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            ),
         ),
         // "send an email to John about meeting" / "email John with body Please review"
         IntentPattern(
@@ -1084,13 +1106,20 @@ class QuickIntentRouter(
             val match = pattern.regex.find(trimmed)
             if (match != null) {
                 val params = pattern.paramExtractor(match, trimmed)
-                return RouteResult.RegexMatch(
-                    MatchedIntent(
-                        intentName = pattern.intentName,
-                        params = params,
-                        source = "regex",
-                    ),
+                // Check required slots — if a mandatory param is missing, pause and ask.
+                val missingSlot = pattern.requiredSlots.entries
+                    .firstOrNull { (key, _) -> params[key].isNullOrBlank() }
+                    ?.value
+                val intent = MatchedIntent(
+                    intentName = pattern.intentName,
+                    params = params,
+                    source = "regex",
                 )
+                return if (missingSlot != null) {
+                    RouteResult.NeedsSlot(intent, missingSlot)
+                } else {
+                    RouteResult.RegexMatch(intent)
+                }
             }
         }
 
@@ -1269,6 +1298,8 @@ class QuickIntentRouter(
         fun matchQuickIntent(input: String): QuickIntent? {
             return when (val result = QuickIntentRouter().route(input)) {
                 is RouteResult.RegexMatch -> QuickIntent(result.intent.intentName, result.intent.params)
+                // NeedsSlot is still a successful regex match — intent is known, slot fill pending.
+                is RouteResult.NeedsSlot -> QuickIntent(result.intent.intentName, result.intent.params)
                 else -> null
             }
         }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/PendingSlotRequest.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/PendingSlotRequest.kt
@@ -1,0 +1,13 @@
+package com.kernel.ai.core.skills.slot
+
+/**
+ * Represents an in-flight slot-filling request — a matched intent whose execution
+ * is paused pending a user reply that will fill [missingSlot].
+ */
+data class PendingSlotRequest(
+    val intentName: String,
+    val existingParams: Map<String, String>,
+    val missingSlot: SlotSpec,
+) {
+    val promptMessage: String get() = missingSlot.buildPrompt(existingParams)
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
@@ -1,0 +1,13 @@
+package com.kernel.ai.core.skills.slot
+
+/** Result returned by [SlotFillerManager.onUserReply]. */
+sealed class SlotFillResult {
+    /** All required slots have been filled — ready to execute the intent. */
+    data class Completed(
+        val intentName: String,
+        val params: Map<String, String>,
+    ) : SlotFillResult()
+
+    /** User sent a blank reply or explicitly cancelled. */
+    data object Cancelled : SlotFillResult()
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
@@ -1,0 +1,59 @@
+package com.kernel.ai.core.skills.slot
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * State machine that manages multi-turn slot-filling for quick intents.
+ *
+ * **Flow:**
+ * 1. [QuickIntentRouter.route] returns [QuickIntentRouter.RouteResult.NeedsSlot] when a
+ *    regex-matched intent is missing a required parameter.
+ * 2. [ChatViewModel] calls [startSlotFill], stores the [PendingSlotRequest], and shows
+ *    [PendingSlotRequest.promptMessage] as an assistant bubble.
+ * 3. On the user's next message, [ChatViewModel] detects [hasPending] and calls
+ *    [onUserReply] *instead* of routing to QIR or the LLM.
+ * 4. [onUserReply] returns [SlotFillResult.Completed] with the merged params, or
+ *    [SlotFillResult.Cancelled] if the user sent a blank reply.
+ * 5. [ChatViewModel] executes the completed intent exactly as it would a direct QIR match.
+ *
+ * This class is a `@Singleton` so it survives configuration changes alongside ChatViewModel.
+ * State is intentionally *not* persisted across process death — an interrupted slot fill
+ * is a recoverable UX edge case (user simply re-asks).
+ */
+@Singleton
+class SlotFillerManager @Inject constructor() {
+
+    private var _pendingRequest: PendingSlotRequest? = null
+
+    val hasPending: Boolean get() = _pendingRequest != null
+
+    val pendingRequest: PendingSlotRequest? get() = _pendingRequest
+
+    fun startSlotFill(request: PendingSlotRequest) {
+        _pendingRequest = request
+    }
+
+    /**
+     * Called with the user's reply when a slot fill is in progress.
+     *
+     * @return [SlotFillResult.Completed] with all params merged, or
+     *         [SlotFillResult.Cancelled] if [message] is blank.
+     */
+    fun onUserReply(message: String): SlotFillResult {
+        val pending = _pendingRequest ?: return SlotFillResult.Cancelled
+        _pendingRequest = null
+        return if (message.isBlank()) {
+            SlotFillResult.Cancelled
+        } else {
+            SlotFillResult.Completed(
+                intentName = pending.intentName,
+                params = pending.existingParams + mapOf(pending.missingSlot.name to message.trim()),
+            )
+        }
+    }
+
+    fun cancel() {
+        _pendingRequest = null
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
@@ -1,0 +1,16 @@
+package com.kernel.ai.core.skills.slot
+
+/**
+ * Describes a required parameter that is missing from a matched intent, together with
+ * a template for the clarifying question to ask the user.
+ *
+ * [promptTemplate] may reference existing params using {key} placeholders:
+ *   e.g. "What would you like to say to {contact}?"
+ */
+data class SlotSpec(
+    val name: String,
+    val promptTemplate: String,
+) {
+    fun buildPrompt(existingParams: Map<String, String>): String =
+        existingParams.entries.fold(promptTemplate) { acc, (k, v) -> acc.replace("{$k}", v) }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -802,6 +802,18 @@ class QuickIntentRouterTest {
             val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
             assertEquals(expectedContact, intent.params["contact"], "contact for '$input'")
         }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\" → contact={1}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendSmsNeedsSlotPhrases")
+        fun `should return NeedsSlot for contact-only phrases`(input: String, expectedContact: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_sms", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedContact, needsSlot.intent.params["contact"], "contact for '$input'")
+            assertEquals("message", needsSlot.missingSlot.name, "missing slot name for '$input'")
+        }
     }
 
     @Nested
@@ -1094,6 +1106,7 @@ class QuickIntentRouterTest {
         addCases(makeCallRegexPhrases(), "make_call", "Make Call (regex)")
         addCases(makeCallClassifierPhrases(), "make_call", "Make Call (classifier)")
         addCases(sendSmsRegexPhrases(), "send_sms", "Send SMS (regex)")
+        addCases(sendSmsNeedsSlotPhrases(), "send_sms", "Send SMS (needs slot)")
         addCases(sendEmailRegexPhrases(), "send_email", "Send Email (regex)")
         addCases(addToListRegexPhrases(), "add_to_list", "Add to List (regex)")
         addCases(addToListClassifierPhrases(), "add_to_list", "Add to List (classifier)")
@@ -1132,14 +1145,17 @@ class QuickIntentRouterTest {
             val regexResult = regexOnlyRouter.route(tc.input)
             val hybridResult = hybridRouter.route(tc.input)
 
-            val regexMatched = regexResult is QuickIntentRouter.RouteResult.RegexMatch
+            val regexMatched = regexResult is QuickIntentRouter.RouteResult.RegexMatch ||
+                regexResult is QuickIntentRouter.RouteResult.NeedsSlot
             val hybridMatched = hybridResult is QuickIntentRouter.RouteResult.RegexMatch ||
-                hybridResult is QuickIntentRouter.RouteResult.ClassifierMatch
+                hybridResult is QuickIntentRouter.RouteResult.ClassifierMatch ||
+                hybridResult is QuickIntentRouter.RouteResult.NeedsSlot
 
             val routedIntent = when (hybridResult) {
                 is QuickIntentRouter.RouteResult.RegexMatch -> hybridResult.intent.intentName
                 is QuickIntentRouter.RouteResult.ClassifierMatch -> hybridResult.intent.intentName
                 is QuickIntentRouter.RouteResult.FallThrough -> null
+                is QuickIntentRouter.RouteResult.NeedsSlot -> hybridResult.intent.intentName
             }
 
             val tier = when {
@@ -1791,15 +1807,21 @@ class QuickIntentRouterTest {
 
         @JvmStatic
         fun sendSmsRegexPhrases(): Stream<Arguments> = Stream.of(
+            // Phrases that include a message body → full RegexMatch
             Arguments.of("text John saying hello", "John"),
             Arguments.of("send a text to Mum saying I'll be late", "Mum"),
             Arguments.of("sms Sarah saying meet at 5", "Sarah"),
-            Arguments.of("send message to Dad", "Dad"),
-            Arguments.of("send sms to the office", "the office"),
             Arguments.of("text Sarah that I'll be late", "Sarah"),
             Arguments.of("text Nick saying on my way", "Nick"),
-            Arguments.of("send a text to Emily", "Emily"),
             Arguments.of("sms Mike saying call me", "Mike"),
+        )
+
+        @JvmStatic
+        fun sendSmsNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            // Phrases with only a contact — message body missing → NeedsSlot
+            Arguments.of("send message to Dad", "Dad"),
+            Arguments.of("send sms to the office", "the office"),
+            Arguments.of("send a text to Emily", "Emily"),
             Arguments.of("text my boss", "my boss"),
         )
 
@@ -2095,6 +2117,10 @@ class QuickIntentRouterTest {
             is QuickIntentRouter.RouteResult.RegexMatch -> {
                 // Also acceptable if regex catches it
                 assertEquals(expectedIntent, result.intent.intentName, "Regex wrong intent for '$input'")
+            }
+            is QuickIntentRouter.RouteResult.NeedsSlot -> {
+                // Regex matched but needs a slot — still counts as routing to the correct intent
+                assertEquals(expectedIntent, result.intent.intentName, "NeedsSlot wrong intent for '$input'")
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -101,6 +101,14 @@ class ActionsViewModel @Inject constructor(
                         _uiState.value = UiState.Idle
                         return@launch
                     }
+                    is QuickIntentRouter.RouteResult.NeedsSlot -> {
+                        // Multi-turn slot-filling isn't supported in the Actions tab —
+                        // navigate to Chat where the full conversation flow can handle it.
+                        Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$query\" → navigating to chat")
+                        _events.emit(UiEvent.NavigateToChat(query))
+                        _uiState.value = UiState.Idle
+                        return@launch
+                    }
                 }
 
                 val entity = run {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -30,6 +30,9 @@ import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.slot.PendingSlotRequest
+import com.kernel.ai.core.skills.slot.SlotFillResult
+import com.kernel.ai.core.skills.slot.SlotFillerManager
 import com.google.ai.edge.litertlm.ToolProvider
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
@@ -72,6 +75,7 @@ class ChatViewModel @Inject constructor(
     private val skillRegistry: SkillRegistry,
     private val skillExecutor: SkillExecutor,
     private val quickIntentRouter: QuickIntentRouter,
+    private val slotFillerManager: SlotFillerManager,
     private val kernelAIToolSet: KernelAIToolSet,
     private val toolProvider: ToolProvider,
     private val embeddingEngine: EmbeddingEngine,
@@ -589,11 +593,60 @@ class ChatViewModel @Inject constructor(
             // On a match: execute the skill immediately, then inject [System: ...] context so
             // E4B generates a natural conversational wrapper around the action result.
             // On failure or UnknownSkill: fall through to E4B unchanged.
+
+            // Slot-fill shortcut: if the previous QIR match was paused awaiting a required
+            // param, route the user's reply here before touching QIR or the LLM.
+            if (slotFillerManager.hasPending) {
+                when (val fillResult = slotFillerManager.onUserReply(text)) {
+                    is SlotFillResult.Completed -> {
+                        val skill = skillRegistry.get("run_intent")
+                        if (skill != null) {
+                            val callParams = mapOf("intent_name" to fillResult.intentName) + fillResult.params
+                            val skillResult = skill.execute(SkillCall(skill.name, callParams))
+                            when (skillResult) {
+                                is SkillResult.DirectReply -> {
+                                    appendAssistantMessageWithToolCall(
+                                        convId = convId,
+                                        content = skillResult.content,
+                                        skillName = fillResult.intentName,
+                                        requestJson = callParams.toString(),
+                                        isSuccess = true,
+                                    )
+                                }
+                                is SkillResult.Success -> appendAssistantMessage(convId, skillResult.content)
+                                is SkillResult.Failure -> appendAssistantMessage(convId, skillResult.error)
+                                else -> appendAssistantMessage(convId, "Something went wrong.")
+                            }
+                        }
+                        return@launch
+                    }
+                    is SlotFillResult.Cancelled -> {
+                        appendAssistantMessage(convId, "Okay, cancelled.")
+                        return@launch
+                    }
+                }
+            }
+
             val routeResult = quickIntentRouter.route(text)
             val matchedIntent = when (routeResult) {
                 is QuickIntentRouter.RouteResult.RegexMatch -> routeResult.intent
                 is QuickIntentRouter.RouteResult.ClassifierMatch -> routeResult.intent
                 is QuickIntentRouter.RouteResult.FallThrough -> null
+                is QuickIntentRouter.RouteResult.NeedsSlot -> {
+                    // Intent matched but a required param is missing — ask the user for it.
+                    slotFillerManager.startSlotFill(
+                        PendingSlotRequest(
+                            intentName = routeResult.intent.intentName,
+                            existingParams = routeResult.intent.params,
+                            missingSlot = routeResult.missingSlot,
+                        ),
+                    )
+                    appendAssistantMessage(
+                        convId,
+                        slotFillerManager.pendingRequest?.promptMessage ?: "What would you like to say?",
+                    )
+                    return@launch
+                }
             }
             if (matchedIntent != null) {
                 // Calendar intent matched by classifier but params not extractable via regex —


### PR DESCRIPTION
Closes #493

## Architecture — SlotFillerManager (Option C)

Dedicated state machine between QuickIntentRouter and ChatViewModel.

```
core/skills/slot/
  SlotSpec.kt           — slot name + prompt template with {param} interpolation
  PendingSlotRequest.kt — in-flight intent + missing slot spec
  SlotFillResult.kt     — Completed(intentName, params) | Cancelled
  SlotFillerManager.kt  — @Singleton state machine
```

## Flow

1. QIR regex matches but required param absent → `RouteResult.NeedsSlot(intent, slotSpec)`
2. `ChatViewModel` → `slotFillerManager.startSlotFill()` → shows prompt as assistant bubble
3. Next user message → `slotFillerManager.onUserReply()` → `SlotFillResult.Completed`
4. ChatViewModel executes the completed intent via `run_intent` → LLM **never involved**

## Spike scenario

```
User: 'send a message to John'
  → contact=John, message absent → NeedsSlot
  → 'What would you like to say to John?'
User: 'hey are you free tonight?'
  → Completed(send_sms, {contact: John, message: hey are you free tonight?})
  → SMS composer opened, pre-filled
```

## Why the design is right for scale

- QIR stays stateless (patterns + extractors only, no conversation state)
- SlotFillerManager is independently testable
- Adding new multi-turn intents = add `requiredSlots` to IntentPattern + SlotSpec
- Works for email (`subject` + `body`), calendar (`title`), etc. — same infrastructure
- ActionsViewModel: NeedsSlot → NavigateToChat (no multi-turn in Actions tab)

## Tests

- `sendSmsNeedsSlotPhrases` — contact-only SMS phrases assert `NeedsSlot` result
- `sendSmsRegexPhrases` — body-present phrases still assert `RegexMatch`
- Aggregate coverage report counts `NeedsSlot` as a regex tier hit