### PR TITLE
docs: Sprint 4 completion — roadmap and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 🧭 **Nav drawer** — Lists and Alarms accessible from Chat, Actions, and all main screens via hamburger menu
 - 📋 **Lists** — create and manage named lists via chat ("add milk to shopping list") or the Lists UI; full CRUD with active/completed sections
 - 🗓️ **Scheduled Alarms** — date-specific alarms scheduled via Jandal appear in the Alarms screen for review and cancellation
+- 📟 **Side panel** — slide-out drawer accessible from Chat and Settings shows active alarms and timers with live countdown; cancel any from the panel
+- 🎵 **Media controls** — pause, stop, skip, and previous track via Jandal ("skip song", "pause music")
+- 🎙️ **Podcast playback** — open a podcast app and start/resume playback ("play my podcasts", "resume podcast")
+- ⏱️ **Timer management** — list active timers and cancel individual ones ("cancel my 10 minute timer")
+- 🗑️ **Alarm multiselect delete** — select multiple alarms in the Alarms screen and delete them at once
+- 📝 **Bulk list add** — add multiple items to a list in one request ("save all ingredients to shopping list")
 
 ### Coming Soon
 - 🗣️ **Voice + text input** — tap-to-talk with auto-stop *(Phase 3)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kernel AI Assistant — Roadmap
 
-> **Last updated:** 2026-04-16 (post-sprint: #343 thinking toggle shipped PR #413; #353 MiniLM classifier complete; #373 FallThrough wired; #402 #403 #405 bugs fixed; DND shipped; #407 WebSearchSkill added as future work)
+> **Last updated:** 2026-04-17 (Sprint 4 complete: PRs #520 #528 #530 merged — media controls, podcasts, timer management, side panel, alarm multiselect, bulk list add, profile crash fix, mailto URI fix, opencode agents)
 >
 > This is the living roadmap for Kernel AI. It tracks what's been built, what's next,
 > and what's planned. If you have ideas, [open an issue](https://github.com/NickMonrad/kernel-ai-assistant/issues/new)
@@ -464,9 +464,13 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#407](https://github.com/NickMonrad/kernel-ai-assistant/issues/407) | WebSearchSkill — Brave/Tavily API for LLM tool calling | Phase 3C | ⬜ Pending |
 | [#493](https://github.com/NickMonrad/kernel-ai-assistant/issues/493) | Multi-turn spike — slot fill loop, disambig chips | Phase 3G | ✅ Done (spike) |
 | [#518](https://github.com/NickMonrad/kernel-ai-assistant/issues/518) | Research: multi-turn dialog state machine patterns | Phase 3G | ✅ Done (research) |
-| [#519](https://github.com/NickMonrad/kernel-ai-assistant/issues/519) | User profile parser bugs + Phase 2b LLM extraction | Phase 3D | ⬜ PR #520 open |
-| [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Media control intents: pause, stop, skip, previous | Phase 3H | ⬜ Pending |
+| [#519](https://github.com/NickMonrad/kernel-ai-assistant/issues/519) | User profile parser bugs + Phase 2b LLM extraction | Phase 3D | ✅ Done — PR #520 |
+| [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Media control intents: pause, stop, skip, previous | Phase 3H | ✅ Done — PR #520 |
 | [#522](https://github.com/NickMonrad/kernel-ai-assistant/issues/522) | Multi-turn dialog management — Phase 2 full implementation | Phase 3G | ⬜ Pending |
+| [#524](https://github.com/NickMonrad/kernel-ai-assistant/issues/524) | Add podcast patterns to QIR | Phase 3H | ✅ Done — PR #520 |
+| [#525](https://github.com/NickMonrad/kernel-ai-assistant/issues/525) | Timer management — list, pause, cancel individual timers | Phase 3H | ✅ Done — PR #520 |
+| [#526](https://github.com/NickMonrad/kernel-ai-assistant/issues/526) | Side panel: active alarms and timers in nav drawer | Phase 3H | ✅ Done — PR #530 |
+| [#529](https://github.com/NickMonrad/kernel-ai-assistant/issues/529) | Improve LLM tool selection for bulk list operations | Phase 3H | 🔄 Open — on-device verification needed |
 
 ---
 


### PR DESCRIPTION
Updates README and ROADMAP for Sprint 4 ship:

- Mark issues #519 #521 #524 #525 #526 as done
- Add #524 #525 #526 #529 rows to roadmap issue tracker
- Update "Last updated" header to 2026-04-17
- Add side panel, media controls, podcasts, timer management, alarm multiselect, bulk list add to README delivered features

PRs shipped this sprint: #520 (profile parser, QIR, media, podcasts, timers), #528 (opencode agents), #530 (side panel, alarm multiselect, profile crash, bulk add, DAO fix)