### PR TITLE
fix: unique index on lists.name prevents duplicate-key LazyColumn crash

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -45,7 +45,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 19,
+    version = 20,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -218,6 +218,15 @@ abstract class KernelDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN entry_type TEXT NOT NULL DEFAULT 'ALARM'")
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN duration_ms INTEGER DEFAULT NULL")
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN started_at_ms INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Deduplicates list names and adds unique index to prevent future duplicates crashing LazyColumn. */
+        val MIGRATION_19_20 = object : Migration(19, 20) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Keep only the earliest row for each duplicate list name
+                db.execSQL("DELETE FROM lists WHERE id NOT IN (SELECT MIN(id) FROM lists GROUP BY name)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_lists_name ON lists(name)")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -66,6 +66,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_16_17,
                     KernelDatabase.MIGRATION_17_18,
                     KernelDatabase.MIGRATION_18_19,
+                    KernelDatabase.MIGRATION_19_20,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
@@ -1,9 +1,13 @@
 package com.kernel.ai.core.memory.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "lists")
+@Entity(
+    tableName = "lists",
+    indices = [Index(value = ["name"], unique = true)],
+)
 data class ListNameEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String,


### PR DESCRIPTION
## Problem
The `lists` table had no `UNIQUE` constraint on the `name` column. `OnConflictStrategy.IGNORE` operates on the primary key (`id`, autoincrement), so duplicate list names (e.g. two rows both named `shopping`) were silently inserted. `ListsScreen` uses `items(filtered, key = { it })` in its `LazyColumn`, so duplicates caused:

```
java.lang.IllegalArgumentException: Key "shopping" was already used.
```

## Fix
**Migration 19→20** (DB version bump to 20):
1. Deduplicates existing rows — keeps `MIN(id)` per name, deletes the rest
2. Creates `UNIQUE INDEX index_lists_name ON lists(name)`

**`ListNameEntity`** now declares `@Index(value = ["name"], unique = true)` so Room enforces the constraint at compile time and future `OnConflictStrategy.IGNORE` inserts correctly skip duplicates on name.

## Testing
- Lists screen no longer crashes on devices where duplicate list names accumulated
- Duplicate list names can no longer be inserted