### PR TITLE
test(#504): UIAutomator permission flow tests

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/20.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/20.json
@@ -1,0 +1,658 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "3f685b3c361d51438c29122464b77004",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3f685b3c361d51438c29122464b77004')"
+    ]
+  }
+}

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     debugImplementation(libs.compose.ui.test.manifest)
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
+    androidTestImplementation(libs.uiautomator)
 
     implementation(libs.datastore.preferences)
 

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
@@ -1,0 +1,258 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI Automator tests for OS-level permission flows — #504.
+ *
+ * These tests cross the app/OS boundary and cannot be covered by Espresso alone.
+ * Each test grants or denies a system permission dialog and verifies the app
+ * responds correctly.
+ *
+ * Device: Samsung SM-S918B (Android 16 / API 36)
+ * Package: com.kernel.ai.debug
+ *
+ * Run with:
+ *   ./gradlew :feature:settings:connectedDebugAndroidTest \
+ *       -Pandroid.testInstrumentationRunnerArguments.class=\
+ *       com.kernel.ai.feature.settings.PermissionFlowTest
+ */
+@RunWith(AndroidJUnit4::class)
+class PermissionFlowTest {
+
+    private lateinit var device: UiDevice
+    private lateinit var context: Context
+
+    companion object {
+        private const val PACKAGE = "com.kernel.ai.debug"
+        private const val LAUNCH_TIMEOUT_MS = 8_000L
+        private const val DIALOG_TIMEOUT_MS = 5_000L
+
+        // Samsung One UI / AOSP button labels for system dialogs
+        private val ALLOW_LABELS = listOf("Allow", "While using the app", "Only this time")
+        private val DENY_LABELS = listOf("Don't allow", "Deny", "No thanks")
+        private val ALLOW_EXACT_ALARM_LABELS = listOf("Allow", "Permitted")
+    }
+
+    @Before
+    fun setUp() {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        context = ApplicationProvider.getApplicationContext()
+        device.wakeUp()
+        device.pressHome()
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private fun launchApp() {
+        val intent = context.packageManager.getLaunchIntentForPackage(PACKAGE)
+            ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+        context.startActivity(intent)
+        device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+    }
+
+    private fun revokePermission(permission: String) {
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("pm revoke $PACKAGE $permission")
+            .close()
+    }
+
+    private fun grantPermission(permission: String) {
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("pm grant $PACKAGE $permission")
+            .close()
+    }
+
+    private fun findDialogButton(labels: List<String>): UiObject2? {
+        for (label in labels) {
+            val obj = device.wait(Until.findObject(By.text(label)), DIALOG_TIMEOUT_MS)
+            if (obj != null) return obj
+        }
+        return null
+    }
+
+    // ── POST_NOTIFICATIONS ───────────────────────────────────────────────
+
+    /**
+     * Grant POST_NOTIFICATIONS via the system dialog.
+     * Verifies the app is in the foreground after grant (dialog dismissed, not crashed).
+     *
+     * Android 13+ (API 33+) requires runtime permission for notifications.
+     */
+    @Test
+    fun postNotifications_grant_appContinues() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        revokePermission("android.permission.POST_NOTIFICATIONS")
+        launchApp()
+
+        val allowButton = findDialogButton(ALLOW_LABELS)
+        if (allowButton != null) {
+            allowButton.click()
+            Thread.sleep(500)
+        }
+        // After grant (or if dialog never appeared — permission already held), app should be visible
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should be visible after POST_NOTIFICATIONS grant", appVisible)
+
+        // Restore
+        grantPermission("android.permission.POST_NOTIFICATIONS")
+    }
+
+    /**
+     * Deny POST_NOTIFICATIONS — app should degrade gracefully (no crash).
+     */
+    @Test
+    fun postNotifications_deny_appContinues() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        revokePermission("android.permission.POST_NOTIFICATIONS")
+        launchApp()
+
+        val denyButton = findDialogButton(DENY_LABELS)
+        if (denyButton != null) {
+            denyButton.click()
+            Thread.sleep(500)
+        }
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should survive POST_NOTIFICATIONS denial without crashing", appVisible)
+
+        // Restore
+        grantPermission("android.permission.POST_NOTIFICATIONS")
+    }
+
+    // ── ACCESS_FINE_LOCATION ─────────────────────────────────────────────
+
+    /**
+     * Grant ACCESS_FINE_LOCATION — weather skill should use GPS path.
+     * Verifies the app reaches foreground after dialog (not stuck on permission screen).
+     */
+    @Test
+    fun locationPermission_grant_appContinues() {
+        revokePermission("android.permission.ACCESS_FINE_LOCATION")
+        revokePermission("android.permission.ACCESS_COARSE_LOCATION")
+        launchApp()
+
+        val allowButton = findDialogButton(ALLOW_LABELS)
+        if (allowButton != null) {
+            allowButton.click()
+            Thread.sleep(500)
+        }
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should be visible after location grant", appVisible)
+
+        // Restore
+        grantPermission("android.permission.ACCESS_FINE_LOCATION")
+        grantPermission("android.permission.ACCESS_COARSE_LOCATION")
+    }
+
+    /**
+     * Deny ACCESS_FINE_LOCATION — app should fall back to profile/city-based weather.
+     * Verifies no crash and app is still usable.
+     */
+    @Test
+    fun locationPermission_deny_appFallsBackGracefully() {
+        revokePermission("android.permission.ACCESS_FINE_LOCATION")
+        revokePermission("android.permission.ACCESS_COARSE_LOCATION")
+        launchApp()
+
+        val denyButton = findDialogButton(DENY_LABELS)
+        if (denyButton != null) {
+            denyButton.click()
+            Thread.sleep(500)
+        }
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should survive location denial without crashing", appVisible)
+
+        // Restore
+        grantPermission("android.permission.ACCESS_FINE_LOCATION")
+        grantPermission("android.permission.ACCESS_COARSE_LOCATION")
+    }
+
+    // ── SCHEDULE_EXACT_ALARM ─────────────────────────────────────────────
+
+    /**
+     * SCHEDULE_EXACT_ALARM on Android 12+ (API 31+) is a special permission that
+     * redirects to a Settings screen rather than a dialog. This test verifies:
+     * 1. When the permission is revoked, the app is still launchable (no crash on start)
+     * 2. When restored, the alarm scheduling code path is available
+     *
+     * Full grant-via-Settings flow requires accessibility service or manual tap;
+     * we test the revoke→app-survives path and grant via shell.
+     */
+    @Test
+    fun scheduleExactAlarm_revoked_appStillLaunches() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("appops set $PACKAGE SCHEDULE_EXACT_ALARM deny")
+            .close()
+        Thread.sleep(300)
+
+        launchApp()
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should launch without crashing when SCHEDULE_EXACT_ALARM is denied", appVisible)
+
+        // Restore
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("appops set $PACKAGE SCHEDULE_EXACT_ALARM allow")
+            .close()
+    }
+
+    /**
+     * SCHEDULE_EXACT_ALARM granted via shell — verify app uses exact alarm path.
+     * Checks the app reaches foreground without a permissions redirect screen.
+     */
+    @Test
+    fun scheduleExactAlarm_granted_noRedirectScreen() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("appops set $PACKAGE SCHEDULE_EXACT_ALARM allow")
+            .close()
+        Thread.sleep(300)
+
+        launchApp()
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should be fully usable when SCHEDULE_EXACT_ALARM is granted", appVisible)
+
+        // Verify we're NOT on a system Settings screen
+        val onSettingsScreen = device.hasObject(By.pkg("com.android.settings"))
+        assertTrue("Should not have been redirected to Settings", !onSettingsScreen)
+    }
+
+    // ── Deny → Re-grant recovery ─────────────────────────────────────────
+
+    /**
+     * Revoke POST_NOTIFICATIONS then re-grant via shell — app should recover
+     * without requiring a restart (tests the dynamic permission check path).
+     */
+    @Test
+    fun postNotifications_revokeAndRegrant_appRecovers() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        revokePermission("android.permission.POST_NOTIFICATIONS")
+        launchApp()
+        Thread.sleep(1_000)
+
+        grantPermission("android.permission.POST_NOTIFICATIONS")
+        Thread.sleep(500)
+
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        assertTrue("App should be visible after re-granting POST_NOTIFICATIONS", appVisible)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ hiltNavigationCompose = "1.2.0"
 junit = "5.11.4"
 mockk = "1.13.16"
 coroutinesTest = "1.10.1"
+uiautomator = "2.3.0"
 
 # LiteRT
 litertlm = "0.10.0"
@@ -114,6 +115,9 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 # Weather skill deps
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+
+# Testing — UIAutomator
+uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Closes #504

## Changes
- Adds `uiautomator = "2.3.0"` to version catalog
- Adds `androidTestImplementation(libs.uiautomator)` to `feature/settings`
- New `PermissionFlowTest.kt` — 7 instrumented tests using `UiDevice` + shell `pm grant`/`revoke` for cross-process permission flows Espresso cannot reach:

| Test | Coverage |
|------|----------|
| `postNotifications_grant_appContinues` | Grant dialog → app visible |
| `postNotifications_deny_appContinues` | Deny dialog → graceful degradation |
| `postNotifications_revokeAndRegrant_appRecovers` | Dynamic re-grant recovery |
| `locationPermission_grant_appContinues` | Location grant → app visible |
| `locationPermission_deny_appFallsBackGracefully` | Location deny → no crash |
| `scheduleExactAlarm_revoked_appStillLaunches` | SCHEDULE_EXACT_ALARM denied → app launches |
| `scheduleExactAlarm_granted_noRedirectScreen` | Granted → not redirected to Settings |

## Notes
- Android version guards on all API 31+ / 33+ tests
- Restores permission state after each test