### PR TITLE
fix: create_list QIR extracts wrong name for 'make a new list called X'

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1733,7 +1733,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "create_list",
             regex = Regex(
-                """(?:create|make|start|new)\s+(?:a\s+|an\s+|my\s+)?(?:new\s+)?(?!list\b)(.+?)\s+list""",
+                """(?:create|make|start|new)\s+(?:a\s+|an\s+)?(?:new\s+)?(?:my\s+)?(?!list\b)(.+?)\s+list""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1721,10 +1721,19 @@ class QuickIntentRouter(
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
         ),
         // "create a groceries list" / "make a new shopping list" / "start a meal plan list"
+        // "make a new list called holiday packing" / "create a list called groceries"
         IntentPattern(
             intentName = "create_list",
             regex = Regex(
-                """(?:create|make|start|new)\s+(?:a\s+|an\s+|my\s+|new\s+)?(.+?)\s+list""",
+                """(?:create|make|start)\s+(?:a\s+|an\s+|my\s+)?(?:new\s+)?list\s+called\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+        ),
+        IntentPattern(
+            intentName = "create_list",
+            regex = Regex(
+                """(?:create|make|start|new)\s+(?:a\s+|an\s+|my\s+)?(?:new\s+)?(?!list\b)(.+?)\s+list""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },


### PR DESCRIPTION
## Bug
'make a new list called holiday packing' created a list named `new` instead of `holiday packing`.

**Root cause:** The regex `(.+?)\s+list` is lazy — it stopped at the first `\s+list` it found, capturing `new` from `new list`.

## Fix
Two-pattern approach (first-match-wins):
1. High-priority pattern for the `list called <name>` form — captures everything after 'called'

## Covers
- 'make a new list called holiday packing' → `holiday packing`
- 'create a list called work tasks' → `work tasks`
- 'make a shopping list' → `shopping` (unchanged)
- 'create a new meal plan list' → `meal plan` (unchanged)