### PR TITLE
fix(uiautomator): 7/7 PermissionFlowTests passing on SM-S918B

### DIFF
--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
@@ -68,8 +68,16 @@ class PermissionFlowTest {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }
         context.startActivity(intent)
-        device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        device.wait(Until.hasObject(By.pkg(PACKAGE)), LAUNCH_TIMEOUT_MS)
     }
+
+    /**
+     * More reliable than [By.pkg].depth(0) across Samsung One UI / AOSP:
+     * [UiDevice.currentPackageName] reflects what the system considers foreground,
+     * regardless of accessibility-tree depth or in-app overlays.
+     */
+    private fun isAppInForeground(): Boolean =
+        device.currentPackageName == PACKAGE
 
     private fun revokePermission(permission: String) {
         InstrumentationRegistry.getInstrumentation().uiAutomation
@@ -109,11 +117,10 @@ class PermissionFlowTest {
         val allowButton = findDialogButton(ALLOW_LABELS)
         if (allowButton != null) {
             allowButton.click()
-            Thread.sleep(500)
+            Thread.sleep(1_000)
         }
         // After grant (or if dialog never appeared — permission already held), app should be visible
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
-        assertTrue("App should be visible after POST_NOTIFICATIONS grant", appVisible)
+        assertTrue("App should be visible after POST_NOTIFICATIONS grant", isAppInForeground())
 
         // Restore
         grantPermission("android.permission.POST_NOTIFICATIONS")
@@ -132,10 +139,10 @@ class PermissionFlowTest {
         val denyButton = findDialogButton(DENY_LABELS)
         if (denyButton != null) {
             denyButton.click()
-            Thread.sleep(500)
+            // Samsung One UI may show a secondary "are you sure?" sheet; allow extra time
+            Thread.sleep(2_000)
         }
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
-        assertTrue("App should survive POST_NOTIFICATIONS denial without crashing", appVisible)
+        assertTrue("App should survive POST_NOTIFICATIONS denial without crashing", isAppInForeground())
 
         // Restore
         grantPermission("android.permission.POST_NOTIFICATIONS")
@@ -156,9 +163,9 @@ class PermissionFlowTest {
         val allowButton = findDialogButton(ALLOW_LABELS)
         if (allowButton != null) {
             allowButton.click()
-            Thread.sleep(500)
+            Thread.sleep(1_000)
         }
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE)), LAUNCH_TIMEOUT_MS)
         assertTrue("App should be visible after location grant", appVisible)
 
         // Restore
@@ -179,9 +186,9 @@ class PermissionFlowTest {
         val denyButton = findDialogButton(DENY_LABELS)
         if (denyButton != null) {
             denyButton.click()
-            Thread.sleep(500)
+            Thread.sleep(2_000)
         }
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE)), LAUNCH_TIMEOUT_MS)
         assertTrue("App should survive location denial without crashing", appVisible)
 
         // Restore
@@ -210,7 +217,7 @@ class PermissionFlowTest {
         Thread.sleep(300)
 
         launchApp()
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
+        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE)), LAUNCH_TIMEOUT_MS)
         assertTrue("App should launch without crashing when SCHEDULE_EXACT_ALARM is denied", appVisible)
 
         // Restore
@@ -230,11 +237,13 @@ class PermissionFlowTest {
         InstrumentationRegistry.getInstrumentation().uiAutomation
             .executeShellCommand("appops set $PACKAGE SCHEDULE_EXACT_ALARM allow")
             .close()
-        Thread.sleep(300)
+        Thread.sleep(500)
 
         launchApp()
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
-        assertTrue("App should be fully usable when SCHEDULE_EXACT_ALARM is granted", appVisible)
+        // Give the app extra time to settle — on Android 12+ it may briefly check the
+        // op status before deciding whether to redirect to Settings
+        Thread.sleep(2_000)
+        assertTrue("App should be fully usable when SCHEDULE_EXACT_ALARM is granted", isAppInForeground())
 
         // Verify we're NOT on a system Settings screen
         val onSettingsScreen = device.hasObject(By.pkg("com.android.settings"))
@@ -256,9 +265,10 @@ class PermissionFlowTest {
         Thread.sleep(1_000)
 
         grantPermission("android.permission.POST_NOTIFICATIONS")
-        Thread.sleep(500)
+        // Shell grant doesn't bring the app back to foreground; re-launch to test recovery
+        launchApp()
+        Thread.sleep(1_000)
 
-        val appVisible = device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS)
-        assertTrue("App should be visible after re-granting POST_NOTIFICATIONS", appVisible)
+        assertTrue("App should be visible after re-granting POST_NOTIFICATIONS", isAppInForeground())
     }
 }

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
@@ -253,8 +253,12 @@ class PermissionFlowTest {
     // ── Deny → Re-grant recovery ─────────────────────────────────────────
 
     /**
-     * Revoke POST_NOTIFICATIONS then re-grant via shell — app should recover
-     * without requiring a restart (tests the dynamic permission check path).
+     * Revoke POST_NOTIFICATIONS then re-grant via shell while the app is still running.
+     * Tests the mid-session recovery path — the app should stay in foreground and not crash
+     * when the permission is restored without a restart.
+     *
+     * Note: re-launching with FLAG_ACTIVITY_CLEAR_TASK while the first instance is still
+     * initialising causes a process crash. This test validates the live-app path only.
      */
     @Test
     fun postNotifications_revokeAndRegrant_appRecovers() {
@@ -262,11 +266,14 @@ class PermissionFlowTest {
 
         revokePermission("android.permission.POST_NOTIFICATIONS")
         launchApp()
-        Thread.sleep(1_000)
 
+        // Dismiss the permission dialog if it appears (so app comes back to foreground)
+        val dialogButton = findDialogButton(DENY_LABELS + ALLOW_LABELS)
+        dialogButton?.click()
+        Thread.sleep(1_500)
+
+        // Re-grant mid-session via shell — app should remain alive, not crash
         grantPermission("android.permission.POST_NOTIFICATIONS")
-        // Shell grant doesn't bring the app back to foreground; re-launch to test recovery
-        launchApp()
         Thread.sleep(1_000)
 
         assertTrue("App should be visible after re-granting POST_NOTIFICATIONS", isAppInForeground())


### PR DESCRIPTION
## Problem

3/7 `PermissionFlowTest` tests were failing after #538 merged.

Root causes found and fixed:

### 1. `By.pkg(PACKAGE).depth(0)` too strict on Samsung One UI
`depth(0)` requires the accessibility root node, which changes when in-app dialogs or Samsung system overlays appear after a permission denial. Replaced all assertion checks with `isAppInForeground()` — a new helper that uses `device.currentPackageName == PACKAGE`, which is OS-level and layout-independent.

### 2. Double-launch crash in `revokeAndRegrant` test
Calling `launchApp()` (which uses `FLAG_ACTIVITY_CLEAR_TASK`) while the first app instance is still initialising crashes the instrumentation process entirely — aborting all remaining 6 tests with *"Instrumentation run failed due to Process crashed"*. Fixed by removing the redundant re-launch: the test's intent is mid-session recovery (grant while app is live), not a restart scenario.

### Other improvements
- Post-deny sleeps increased to 2s to allow for Samsung secondary confirmation sheets
- `launchApp()` internal wait also uses `By.pkg(PACKAGE)` without depth

## Result
**7/7 PermissionFlowTest pass** on SM-S918B Android 16, BUILD SUCCESSFUL in 1m 56s