### PR TITLE
fix(qir): move cancel_timer patterns before set_timer — fixes 'cancel the 10 min timer' routing

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -230,82 +230,9 @@ class QuickIntentRouter(
             paramExtractor = { _, _ -> emptyMap() },
         ),
 
-        // ── Timer ──
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)(?:\s+(?:and\s+)?(\d+)\s*(minutes?|mins?|seconds?|secs?|m|s))?""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, input -> parseTimerDuration(match, input) },
-        ),
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, input -> parseTimerDuration(match, input) },
-        ),
-        // "5 minute timer" / "5 minute egg timer" / "3 minute pasta timer"
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)\s+.*?timer""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, input -> parseTimerDuration(match, input) },
-        ),
-        // "remind me in <N> <unit>" → set_timer
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """remind\s+me\s+in\s+(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, input -> parseTimerDuration(match, input) },
-        ),
-        // "time me for <N> <unit>" → set_timer
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """time\s+me\s+(?:for\s+)?(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, input -> parseTimerDuration(match, input) },
-        ),
-        // "start a one hour timer" / "set a half hour timer" — written-out durations before open_app
-        IntentPattern(
-            intentName = "set_timer",
-            regex = Regex(
-                """(?:set|start|create)\s+(?:a\s+)?(?:one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty|an?\s+|half\s+an?\s+)\s*(?:and\s+a\s+half\s+)?(?:hours?|hrs?|minutes?|mins?|seconds?|secs?)\s+(?:\w+\s+)*timer""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { _, input ->
-                val wordMap = mapOf(
-                    "one" to 1, "two" to 2, "three" to 3, "four" to 4, "five" to 5,
-                    "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9, "ten" to 10,
-                    "fifteen" to 15, "twenty" to 20, "thirty" to 30, "an" to 1, "a" to 1,
-                )
-                val lower = input.lowercase()
-                val numMatch = Regex("""(one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty|an?)\s+(?:and\s+a\s+half\s+)?(hours?|hrs?|minutes?|mins?|seconds?|secs?)""").find(lower)
-                if (numMatch != null) {
-                    val qty = wordMap[numMatch.groupValues[1]] ?: 1
-                    val unit = numMatch.groupValues[2]
-                    val half = lower.contains("and a half") || lower.contains("and-a-half")
-                    val seconds = when {
-                        unit.startsWith("h") -> qty * 3600 + (if (half) 1800 else 0)
-                        unit.startsWith("m") -> qty * 60 + (if (half) 30 else 0)
-                        else -> qty + (if (half) 0 else 0)
-                    }
-                    mapOf("duration_seconds" to seconds.toString())
-                } else {
-                    emptyMap()
-                }
-            },
-        ),
-
         // ── Cancel Timer ──
+        // These must appear before set_timer — "cancel the 10 minute timer" substring-matches set_timer
+        // patterns unless cancel intents take priority in the list.
         // Explicit "turn off" pattern first — long alternation groups can misbehave on Android's regex engine
         IntentPattern(
             intentName = "cancel_timer",
@@ -395,6 +322,83 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
+
+        // ── Timer (set) ──
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)(?:\s+(?:and\s+)?(\d+)\s*(minutes?|mins?|seconds?|secs?|m|s))?""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
+        ),
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
+        ),
+        // "5 minute timer" / "5 minute egg timer" / "3 minute pasta timer"
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)\s+.*?timer""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
+        ),
+        // "remind me in <N> <unit>" → set_timer
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """remind\s+me\s+in\s+(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
+        ),
+        // "time me for <N> <unit>" → set_timer
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """time\s+me\s+(?:for\s+)?(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, input -> parseTimerDuration(match, input) },
+        ),
+        // "start a one hour timer" / "set a half hour timer" — written-out durations before open_app
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """(?:set|start|create)\s+(?:a\s+)?(?:one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty|an?\s+|half\s+an?\s+)\s*(?:and\s+a\s+half\s+)?(?:hours?|hrs?|minutes?|mins?|seconds?|secs?)\s+(?:\w+\s+)*timer""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, input ->
+                val wordMap = mapOf(
+                    "one" to 1, "two" to 2, "three" to 3, "four" to 4, "five" to 5,
+                    "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9, "ten" to 10,
+                    "fifteen" to 15, "twenty" to 20, "thirty" to 30, "an" to 1, "a" to 1,
+                )
+                val lower = input.lowercase()
+                val numMatch = Regex("""(one|two|three|four|five|six|seven|eight|nine|ten|fifteen|twenty|thirty|an?)\s+(?:and\s+a\s+half\s+)?(hours?|hrs?|minutes?|mins?|seconds?|secs?)""").find(lower)
+                if (numMatch != null) {
+                    val qty = wordMap[numMatch.groupValues[1]] ?: 1
+                    val unit = numMatch.groupValues[2]
+                    val half = lower.contains("and a half") || lower.contains("and-a-half")
+                    val seconds = when {
+                        unit.startsWith("h") -> qty * 3600 + (if (half) 1800 else 0)
+                        unit.startsWith("m") -> qty * 60 + (if (half) 30 else 0)
+                        else -> qty + (if (half) 0 else 0)
+                    }
+                    mapOf("duration_seconds" to seconds.toString())
+                } else {
+                    emptyMap()
+                }
+            },
+        ),
+
+
 
         // ── Calendar ──
         // "add/create/schedule/set up a [dentist/gym/meeting/event] [for/on] [date] [at time]"

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -308,6 +308,55 @@ class QuickIntentRouterTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // CANCEL TIMER TESTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Cancel Timer")
+    inner class CancelTimer {
+
+        @Test
+        fun `cancel the 10 minute timer should route to cancel_timer_named not set_timer`() {
+            // Regression: "10 minute timer" substring matched set_timer before cancel_timer_named
+            // Fix: cancel patterns moved before set_timer in the pattern list
+            val result = regexOnlyRouter.route("cancel the 10 minute timer")
+            assertRegexMatch(result, "cancel_timer_named", "cancel the 10 minute timer")
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("10 minute", intent.params["name"], "name param should be '10 minute'")
+        }
+
+        @Test
+        fun `stop the pasta timer should route to cancel_timer_named`() {
+            val result = regexOnlyRouter.route("stop the pasta timer")
+            assertRegexMatch(result, "cancel_timer_named", "stop the pasta timer")
+        }
+
+        @Test
+        fun `cancel my egg timer should route to cancel_timer_named`() {
+            val result = regexOnlyRouter.route("cancel my egg timer")
+            assertRegexMatch(result, "cancel_timer_named", "cancel my egg timer")
+        }
+
+        @Test
+        fun `cancel the timer should route to cancel_timer not cancel_timer_named`() {
+            val result = regexOnlyRouter.route("cancel the timer")
+            assertRegexMatch(result, "cancel_timer", "cancel the timer")
+        }
+
+        @Test
+        fun `5 minute timer should still route to set_timer`() {
+            val result = regexOnlyRouter.route("5 minute timer")
+            assertRegexMatch(result, "set_timer", "5 minute timer")
+        }
+
+        @Test
+        fun `10 minute tea timer should still route to set_timer`() {
+            val result = regexOnlyRouter.route("10 minute tea timer")
+            assertRegexMatch(result, "set_timer", "10 minute tea timer")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // DND TESTS
     // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem\n\n'cancel the 10 minute timer' was incorrectly routing to `set_timer` instead of `cancel_timer_named`.\n\nThe pattern `(\d+)\s*(unit)\s+.*?timer` (for '5 minute timer' style queries) matches `10 minute timer` as a **substring** of 'cancel the 10 minute timer'. Since `set_timer` appeared before `cancel_timer_named` in the pattern list, it fired first.\n\n## Fix\n\nMoved the entire **Cancel Timer / List Timers / Timer Remaining** block to appear **before** the set_timer block. Cancel patterns require an explicit cancel/stop/dismiss/delete verb, so no set_timer test cases are affected.\n\n## Tests\n\n6 new regression tests added to `CancelTimer` nested class:\n- `cancel the 10 minute timer` → `cancel_timer_named` (regression guard)\n- `stop the pasta timer` → `cancel_timer_named`\n- `cancel my egg timer` → `cancel_timer_named`\n- `cancel the timer` → `cancel_timer` (generic)\n- `5 minute timer` → `set_timer` (no regression)\n- `10 minute tea timer` → `set_timer` (no regression)\n\n580 total tests, 9 failing (all pre-existing, unrelated to this change).\n\nCloses #561