### PR TITLE
fix(chat): FLAGSHIP engine stuck loading — initEngineWhenReady waits for E2B forever

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -392,10 +392,7 @@ class ChatViewModel @Inject constructor(
      */
     private suspend fun initEngineWhenReady() {
         downloadManager.downloadStates
-            .filter { states ->
-                KernelModel.entries.filter { it.isRequired }
-                    .all { states[it] is DownloadState.Downloaded }
-            }
+            .filter { states -> downloadManager.areRequiredModelsDownloaded() }
             .first()
 
         gemma4InitMutex.withLock {


### PR DESCRIPTION
## Summary

On FLAGSHIP devices (S23 Ultra, ≥10 GB RAM), `GEMMA_4_E2B` is never downloaded — only `GEMMA_4_E4B` is used. `initEngineWhenReady()` was waiting for **all required models** to reach `DownloadState.Downloaded` before starting engine initialisation, but E2B is never queued on FLAGSHIP so this filter blocked forever. The engine never became ready and the app was permanently stuck on the loading screen.

## Root Cause

```kotlin
// BEFORE — blocks forever on FLAGSHIP (E2B never downloaded)
downloadManager.downloadStates
    .filter { states ->
        KernelModel.entries.filter { it.isRequired }
            .all { states[it] is DownloadState.Downloaded }
    }
    .first()
```

`areRequiredModelsDownloaded()` already contains the correct FLAGSHIP logic (`E4B || E2B`), but `initEngineWhenReady()` wasn't using it.

## Fix

```kotlin
// AFTER — delegates to the correct FLAGSHIP-aware check
downloadManager.downloadStates
    .filter { states -> downloadManager.areRequiredModelsDownloaded() }
    .first()
```

## Changes

- `ChatViewModel.kt` — `initEngineWhenReady()` now uses `downloadManager.areRequiredModelsDownloaded()` instead of a naive all-required-models check

## Testing

- [x] Verified on S23 Ultra (FLAGSHIP): engine now initialises in ~26s after fresh install with only E4B on disk
- [x] `Engine ready — backend: GPU, maxTokens: 8000` confirmed in logcat
- [x] Build successful

## Notes

This bug only manifested after a fresh install (uninstall + reinstall) that wiped the stored HuggingFace token, causing E2B to never be queued. On non-FLAGSHIP devices E2B is always downloaded so the bug was invisible there.
