### PR TITLE
feat(settings): unify Timers & Alarms into single screen with FAB, edit, and toggle (#574, #580)

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -119,19 +119,7 @@ fun KernelNavHost(initialChatQuery: String? = null) {
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
                 )
                 NavigationDrawerItem(
-                    label = { Text("Scheduled Alarms") },
-                    icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                    selected = currentBaseRoute == ROUTE_SCHEDULED_ALARMS,
-                    onClick = {
-                        coroutineScope.launch { drawerState.close() }
-                        navController.navigate(ROUTE_SCHEDULED_ALARMS) {
-                            launchSingleTop = true
-                        }
-                    },
-                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-                )
-                NavigationDrawerItem(
-                    label = { Text("Active Timers & Alarms") },
+                    label = { Text("Timers & Alarms") },
                     icon = { Icon(Icons.Default.Timer, contentDescription = null) },
                     selected = currentBaseRoute == ROUTE_SIDE_PANEL,
                     onClick = {
@@ -344,7 +332,8 @@ fun KernelNavHost(initialChatQuery: String? = null) {
                 }
 
                 composable(ROUTE_SCHEDULED_ALARMS) {
-                    ScheduledAlarmsScreen(
+                    // Redirected to the unified Timers & Alarms screen (#574)
+                    SidePanelScreen(
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -1,10 +1,16 @@
 package com.kernel.ai.feature.settings
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +21,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -23,31 +30,48 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import kotlinx.coroutines.delay
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -65,6 +89,10 @@ fun SidePanelScreen(
     val showBulkDeleteConfirmation by viewModel.showBulkDeleteConfirmation.collectAsStateWithLifecycle()
     var pendingDismiss by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
     var pendingCancel by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var editingAlarm by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var showCreateAlarmDialog by remember { mutableStateOf(false) }
+    var showCreateTimerDialog by remember { mutableStateOf(false) }
+    var fabExpanded by remember { mutableStateOf(false) }
 
     // Tick every second so countdown labels stay live
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
@@ -114,13 +142,53 @@ fun SidePanelScreen(
                 )
             } else {
                 TopAppBar(
-                    title = { Text("Active Timers & Alarms") },
+                    title = { Text("Timers & Alarms") },
                     navigationIcon = {
                         IconButton(onClick = onBack) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                         }
                     },
                 )
+            }
+        },
+        floatingActionButton = {
+            if (!isInSelectionMode) {
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    AnimatedVisibility(
+                        visible = fabExpanded,
+                        enter = fadeIn() + expandVertically(expandFrom = Alignment.Bottom),
+                        exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Bottom),
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            ExtendedFloatingActionButton(
+                                text = { Text("New Alarm") },
+                                icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                                onClick = { fabExpanded = false; showCreateAlarmDialog = true },
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                            ExtendedFloatingActionButton(
+                                text = { Text("New Timer") },
+                                icon = { Icon(Icons.Default.Timer, contentDescription = null) },
+                                onClick = { fabExpanded = false; showCreateTimerDialog = true },
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                    FloatingActionButton(onClick = { fabExpanded = !fabExpanded }) {
+                        Icon(
+                            if (fabExpanded) Icons.Default.Close else Icons.Default.Add,
+                            contentDescription = if (fabExpanded) "Close" else "New alarm or timer",
+                        )
+                    }
+                }
             }
         },
     ) { innerPadding ->
@@ -223,13 +291,14 @@ fun SidePanelScreen(
                                     if (isInSelectionMode) {
                                         viewModel.toggleSelection(alarm.id)
                                     } else {
-                                        pendingDismiss = alarm
+                                        editingAlarm = alarm
                                     }
                                 },
                                 onLongPress = {
                                     if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
                                 },
                                 onDismiss = { pendingDismiss = alarm },
+                                onToggle = { viewModel.toggleEnabled(alarm) },
                             )
                             HorizontalDivider()
                         }
@@ -295,6 +364,38 @@ fun SidePanelScreen(
             dismissButton = {
                 TextButton(onClick = viewModel::dismissBulkDeleteConfirmation) { Text("Cancel") }
             },
+        )
+    }
+
+    if (showCreateAlarmDialog) {
+        AlarmCreateEditDialog(
+            existingAlarm = null,
+            onConfirm = { triggerAtMillis, label ->
+                viewModel.scheduleAlarm(triggerAtMillis, label)
+                showCreateAlarmDialog = false
+            },
+            onDismiss = { showCreateAlarmDialog = false },
+        )
+    }
+
+    editingAlarm?.let { alarm ->
+        AlarmCreateEditDialog(
+            existingAlarm = alarm,
+            onConfirm = { triggerAtMillis, label ->
+                viewModel.editAlarm(alarm, triggerAtMillis, label)
+                editingAlarm = null
+            },
+            onDismiss = { editingAlarm = null },
+        )
+    }
+
+    if (showCreateTimerDialog) {
+        TimerCreateDialog(
+            onConfirm = { durationMs, label ->
+                viewModel.scheduleTimer(durationMs, label)
+                showCreateTimerDialog = false
+            },
+            onDismiss = { showCreateTimerDialog = false },
         )
     }
 }
@@ -382,18 +483,26 @@ private fun AlarmPanelRow(
     onTap: () -> Unit,
     onLongPress: () -> Unit,
     onDismiss: () -> Unit,
+    onToggle: () -> Unit,
 ) {
     val formatted = remember(alarm.triggerAtMillis) {
         DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
             .withZone(ZoneId.systemDefault())
             .format(Instant.ofEpochMilli(alarm.triggerAtMillis))
     }
+    val dimAlpha = if (alarm.enabled) 1f else 0.4f
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
             .combinedClickable(onClick = onTap, onLongClick = onLongPress),
-        headlineContent = { Text(alarm.label ?: "Alarm") },
-        supportingContent = { Text(formatted) },
+        headlineContent = {
+            Text(
+                text = alarm.label ?: "Alarm",
+                textDecoration = if (alarm.enabled) null else TextDecoration.LineThrough,
+                modifier = Modifier.alpha(dimAlpha),
+            )
+        },
+        supportingContent = { Text(formatted, modifier = Modifier.alpha(dimAlpha)) },
         leadingContent = {
             if (inSelectionMode) {
                 Checkbox(checked = isSelected, onCheckedChange = { onTap() })
@@ -401,16 +510,184 @@ private fun AlarmPanelRow(
                 Icon(
                     Icons.Default.Alarm,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = if (alarm.enabled) MaterialTheme.colorScheme.primary
+                           else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         },
         trailingContent = {
             if (!inSelectionMode) {
-                IconButton(onClick = onDismiss) {
-                    Icon(Icons.Default.Delete, contentDescription = "Dismiss alarm")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Switch(checked = alarm.enabled, onCheckedChange = { onToggle() })
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Delete, contentDescription = "Dismiss alarm")
+                    }
                 }
             }
         },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlarmCreateEditDialog(
+    existingAlarm: ScheduledAlarmEntity?,
+    onConfirm: (triggerAtMillis: Long, label: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isEdit = existingAlarm != null
+    val defaultTrigger = remember {
+        if (existingAlarm != null) {
+            Instant.ofEpochMilli(existingAlarm.triggerAtMillis)
+        } else {
+            LocalDate.now().plusDays(1).atTime(8, 0)
+                .atZone(ZoneId.systemDefault()).toInstant()
+        }
+    }
+    val defaultZdt = defaultTrigger.atZone(ZoneId.systemDefault())
+    var label by remember { mutableStateOf(existingAlarm?.label ?: "") }
+    var step by remember { mutableStateOf("date") }
+    val dateState = rememberDatePickerState(
+        initialSelectedDateMillis = defaultZdt.toLocalDate()
+            .atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+    )
+    val timeState = rememberTimePickerState(
+        initialHour = defaultZdt.hour,
+        initialMinute = defaultZdt.minute,
+        is24Hour = false,
+    )
+    when (step) {
+        "date" -> {
+            DatePickerDialog(
+                onDismissRequest = onDismiss,
+                confirmButton = {
+                    TextButton(
+                        onClick = { step = "time" },
+                        enabled = dateState.selectedDateMillis != null,
+                    ) { Text("Next") }
+                },
+                dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+            ) { DatePicker(state = dateState) }
+        }
+        "time" -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text(if (isEdit) "Edit alarm time" else "Set time") },
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        TimePicker(state = timeState)
+                    }
+                },
+                confirmButton = { TextButton(onClick = { step = "label" }) { Text("Next") } },
+                dismissButton = { TextButton(onClick = { step = "date" }) { Text("Back") } },
+            )
+        }
+        "label" -> {
+            val selectedDateUtcMillis = dateState.selectedDateMillis ?: return
+            val triggerAtMillis = remember(selectedDateUtcMillis, timeState.hour, timeState.minute) {
+                val localDate = Instant.ofEpochMilli(selectedDateUtcMillis)
+                    .atZone(ZoneId.of("UTC")).toLocalDate()
+                localDate.atTime(LocalTime.of(timeState.hour, timeState.minute))
+                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            }
+            val formatted = remember(triggerAtMillis) {
+                DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
+                    .withZone(ZoneId.systemDefault())
+                    .format(Instant.ofEpochMilli(triggerAtMillis))
+            }
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                title = { Text(if (isEdit) "Edit alarm" else "New alarm") },
+                text = {
+                    Column {
+                        Text(
+                            text = formatted,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        OutlinedTextField(
+                            value = label,
+                            onValueChange = { label = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            placeholder = { Text("Label (optional)") },
+                            singleLine = true,
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { onConfirm(triggerAtMillis, label.takeIf { it.isNotBlank() }) }) {
+                        Text(if (isEdit) "Save" else "Set alarm")
+                    }
+                },
+                dismissButton = { TextButton(onClick = { step = "time" }) { Text("Back") } },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimerCreateDialog(
+    onConfirm: (durationMs: Long, label: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var minutes by remember { mutableIntStateOf(5) }
+    var seconds by remember { mutableIntStateOf(0) }
+    var label by remember { mutableStateOf("") }
+    var minutesText by remember { mutableStateOf("5") }
+    var secondsText by remember { mutableStateOf("0") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Timer, contentDescription = null) },
+        title = { Text("New Timer") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = minutesText,
+                        onValueChange = { v ->
+                            minutesText = v
+                            minutes = v.toIntOrNull()?.coerceIn(0, 999) ?: 0
+                        },
+                        modifier = Modifier.weight(1f),
+                        label = { Text("Minutes") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                        ),
+                    )
+                    OutlinedTextField(
+                        value = secondsText,
+                        onValueChange = { v ->
+                            secondsText = v
+                            seconds = v.toIntOrNull()?.coerceIn(0, 59) ?: 0
+                        },
+                        modifier = Modifier.weight(1f),
+                        label = { Text("Seconds") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                        ),
+                    )
+                }
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Label (optional)") },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            val durationMs = (minutes * 60L + seconds) * 1_000L
+            TextButton(
+                onClick = { onConfirm(durationMs, label.takeIf { it.isNotBlank() }) },
+                enabled = durationMs > 0,
+            ) { Text("Start Timer") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -4,6 +4,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.provider.AlarmClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
 
 enum class AlarmTimerFilter { ALL, ALARMS, TIMERS }
@@ -122,6 +124,95 @@ class SidePanelViewModel @Inject constructor(
         viewModelScope.launch {
             dao.delete(timer.id)
         }
+    }
+
+    /** Schedule a new alarm and persist it. */
+    fun scheduleAlarm(triggerAtMillis: Long, label: String?) {
+        viewModelScope.launch {
+            val alarmId = UUID.randomUUID().toString()
+            val entity = ScheduledAlarmEntity(
+                id = alarmId,
+                triggerAtMillis = triggerAtMillis,
+                label = label?.takeIf { it.isNotBlank() },
+                createdAt = System.currentTimeMillis(),
+                enabled = true,
+            )
+            dao.insert(entity)
+            scheduleAlarmBroadcast(entity)
+        }
+    }
+
+    /** Edit an existing alarm's time and label, rescheduling the broadcast. */
+    fun editAlarm(alarm: ScheduledAlarmEntity, newTriggerAtMillis: Long, newLabel: String?) {
+        viewModelScope.launch {
+            cancelAlarmBroadcast(alarm)
+            val updated = alarm.copy(
+                triggerAtMillis = newTriggerAtMillis,
+                label = newLabel?.takeIf { it.isNotBlank() },
+            )
+            dao.insert(updated)
+            if (updated.enabled) scheduleAlarmBroadcast(updated)
+        }
+    }
+
+    /** Toggle an alarm enabled/disabled, cancelling or rescheduling its broadcast accordingly. */
+    fun toggleEnabled(alarm: ScheduledAlarmEntity) {
+        viewModelScope.launch {
+            val newEnabled = !alarm.enabled
+            dao.setEnabled(alarm.id, newEnabled)
+            if (newEnabled) {
+                scheduleAlarmBroadcast(alarm.copy(enabled = true))
+            } else {
+                cancelAlarmBroadcast(alarm)
+            }
+        }
+    }
+
+    /**
+     * Create a new timer — persists to DB and launches the system clock timer via AlarmClock.
+     * The DB entry provides countdown display; the system handles the actual alert.
+     */
+    fun scheduleTimer(durationMs: Long, label: String?) {
+        viewModelScope.launch {
+            val timerId = UUID.randomUUID().toString()
+            val now = System.currentTimeMillis()
+            val entity = ScheduledAlarmEntity(
+                id = timerId,
+                triggerAtMillis = now + durationMs,
+                label = label?.takeIf { it.isNotBlank() },
+                createdAt = now,
+                entryType = "TIMER",
+                durationMs = durationMs,
+                startedAtMs = now,
+            )
+            dao.insert(entity)
+            val intent = Intent(AlarmClock.ACTION_SET_TIMER).apply {
+                putExtra(AlarmClock.EXTRA_LENGTH, (durationMs / 1_000).toInt())
+                putExtra(AlarmClock.EXTRA_SKIP_UI, false)
+                label?.takeIf { it.isNotBlank() }?.let { putExtra(AlarmClock.EXTRA_MESSAGE, it) }
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
+    }
+
+    private fun scheduleAlarmBroadcast(alarm: ScheduledAlarmEntity) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        val broadcastIntent = Intent().apply {
+            component = android.content.ComponentName(
+                context.packageName,
+                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
+            )
+            putExtra("alarm_label", alarm.label ?: "Alarm")
+            putExtra("alarm_id", alarm.id)
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            alarm.id.hashCode(),
+            broadcastIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, alarm.triggerAtMillis, pendingIntent)
     }
 
     private fun cancelAlarmBroadcast(alarm: ScheduledAlarmEntity) {


### PR DESCRIPTION
## Summary

Merges the separate "Scheduled Alarms" and "Active Timers & Alarms" screens into a single unified **"Timers & Alarms"** screen. Fixes #580 (deleted alarms still firing notifications) as a side effect — the unified screen is now the only delete path, and all deletions correctly cancel the underlying `AlarmManager` pending intent.

## Changes

### `SidePanelScreen.kt`
- Renamed screen title from "Active Timers & Alarms" → "Timers & Alarms"
- **Expandable FAB**: single FAB expands to reveal "New Alarm" and "New Timer" mini-FABs with animated show/hide
- **New alarm flow**: 3-step dialog (date picker → time picker → label) identical to the old `ScheduledAlarmsScreen`
- **New timer flow**: minutes/seconds + optional label dialog; persists to DB and fires `AlarmClock.ACTION_SET_TIMER`
- **`AlarmPanelRow`**: added enable/disable `Switch` to trailing content; single tap now opens edit dialog instead of dismiss confirm; delete icon still triggers dismiss confirm
- Styling: disabled alarms dim and strike-through their label (consistent with old `ScheduledAlarmsScreen`)

### `SidePanelViewModel.kt`
- Added `scheduleAlarm(triggerAtMillis, label)` — inserts entity + schedules `AlarmBroadcastReceiver`
- Added `editAlarm(alarm, newTriggerAtMillis, newLabel)` — cancels old broadcast, upserts, reschedules
- Added `toggleEnabled(alarm)` — toggles DB flag + cancels or reschedules broadcast
- Added `scheduleTimer(durationMs, label)` — inserts TIMER entity + fires `AlarmClock.ACTION_SET_TIMER`
- Added `scheduleAlarmBroadcast()` (mirrors `ScheduledAlarmsViewModel`)
- Added `AlarmClock` and `UUID` imports

### `KernelNavHost.kt`
- Removed "Scheduled Alarms" `NavigationDrawerItem` from the nav drawer
- Renamed "Active Timers & Alarms" drawer item to "Timers & Alarms"
- `ROUTE_SCHEDULED_ALARMS` composable now renders `SidePanelScreen` (redirect for backward compatibility)

## Testing

- [x] `assembleDebug` — BUILD SUCCESSFUL, 0 errors
- [ ] Manual: open "Timers & Alarms" from nav drawer → confirm single entry
- [ ] Manual: FAB → New Alarm → date/time/label → verify alarm appears in list + fires correctly
- [ ] Manual: FAB → New Timer → 1m 30s → verify timer appears in list + clock app opens
- [ ] Manual: toggle alarm enable/disable → verify switch state + alarm cancelled/rescheduled
- [ ] Manual: delete alarm → confirm it does NOT fire (#580)
- [ ] ADB harness: `python3 scripts/adb_skill_test.py --phases alarm_timer` — no regression

## Related Issues

Closes #574
Fixes #580
