### PR TITLE
fix(actions): slot-fill regression — navigate with original query + don't require LLM ready

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -10,8 +10,6 @@ import com.kernel.ai.core.skills.Skill
 import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
-import com.kernel.ai.core.skills.slot.PendingSlotRequest
-import com.kernel.ai.core.skills.slot.SlotFillerManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,7 +35,6 @@ class ActionsViewModel @Inject constructor(
     private val quickIntentRouter: QuickIntentRouter,
     private val skillRegistry: SkillRegistry,
     private val quickActionDao: QuickActionDao,
-    private val slotFillerManager: SlotFillerManager,
 ) : ViewModel() {
 
     // ── Action history ──────────────────────────────────────────────────────
@@ -105,17 +102,14 @@ class ActionsViewModel @Inject constructor(
                         return@launch
                     }
                     is QuickIntentRouter.RouteResult.NeedsSlot -> {
-                        // Multi-turn slot-filling — prime the SlotFillerManager then navigate to
-                        // Chat so the slot prompt is shown instead of re-routing the original query.
-                        Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$query\" → priming slot fill, navigating to chat")
-                        slotFillerManager.startSlotFill(
-                            PendingSlotRequest(
-                                intentName = routeResult.intent.intentName,
-                                existingParams = routeResult.intent.params,
-                                missingSlot = routeResult.missingSlot,
-                            ),
-                        )
-                        _events.emit(UiEvent.NavigateToChat(""))
+                        // Multi-turn slot-filling isn't handled in the Actions tab.
+                        // Navigate to Chat with the original query — ChatViewModel will re-route
+                        // it through QIR, detect NeedsSlot, start the slot-fill, and show the
+                        // prompt. Do NOT prime SlotFillerManager here: if we did, Chat's
+                        // initialQuery auto-submit would be consumed as the slot *value* instead
+                        // of being routed as a new intent.
+                        Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$query\" → navigating to chat")
+                        _events.emit(UiEvent.NavigateToChat(query))
                         _uiState.value = UiState.Idle
                         return@launch
                     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -131,12 +131,14 @@ fun ChatScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
-    // Auto-send the initial query from Actions tab FallThrough (runs once).
-    // Wait for ViewModel to be fully ready and not generating before sending.
+    // Auto-send the initial query from Actions tab (runs once per navigation).
+    // We only wait for conversation initialisation, NOT for the LLM to be ready.
+    // NeedsSlot queries never invoke the model, and sendMessage() triggers model
+    // loading internally for FallThrough/LLM queries — so this is safe either way.
     LaunchedEffect(initialQuery) {
         if (!initialQuery.isNullOrBlank()) {
             val ready = withTimeoutOrNull(30_000L) {
-                viewModel.uiState.first { it is ChatUiState.Ready && !it.isGenerating && !it.isLoadingModel }
+                viewModel.isConversationReady.first { it }
             }
             if (ready != null) {
                 viewModel.onInputChanged(initialQuery)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -136,6 +137,13 @@ class ChatViewModel @Inject constructor(
 
     /** True once [initializeConversation] has completed and [conversationId] is set. */
     private val _conversationInitialized = MutableStateFlow(false)
+
+    /**
+     * Exposed for [ChatScreen]'s initialQuery auto-submit: fires as soon as the conversation
+     * record exists, without waiting for the LLM to load. Slot-fill queries (NeedsSlot) never
+     * need the model; [sendMessage] handles model loading internally for LLM-routed queries.
+     */
+    val isConversationReady: StateFlow<Boolean> = _conversationInitialized.asStateFlow()
     private val _showThinkingProcess = MutableStateFlow(true)
 
     /** Ensures at most one concurrent Gemma-4 initialisation attempt. */


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in #579 that caused "send a message to Laurelle" (and similar slot-fill intents) from the Quick Actions tab to either fall back to LLM or silently drop the query.

## Root cause (#579 regression)

`ActionsViewModel.NeedsSlot` was changed to:
1. Prime `SlotFillerManager` with `startSlotFill()` **before** navigating to Chat
2. Navigate with an empty string `""` as `initialQuery`

This caused two problems:
- `ChatScreen.LaunchedEffect` checks `!initialQuery.isNullOrBlank()` → `false` for `""` → auto-submit **never fires**, chat opens blank
- The primed `hasPending=true` singleton meant any subsequent user input was consumed as a slot value (treating the original query string as the message body)

## Fix 1 — ActionsViewModel (main regression fix)

- Remove `startSlotFill()` call from `NeedsSlot` handler
- Navigate with the **original query** (e.g. `"send a message to Laurelle"`) instead of `""`
- Remove now-unused `SlotFillerManager` constructor dependency
- Added warning comment: do NOT prime `SlotFillerManager` before navigating

**Correct NeedsSlot flow after this fix:**
1. ActionsViewModel: `NavigateToChat("send a message to Laurelle")`
2. ChatScreen: auto-submits the query
3. ChatViewModel: `hasPending=false` → QIR → NeedsSlot → `startSlotFill({contact=Laurelle})` → shows "What would you like to say to Laurelle?"
4. User replies → `onUserReply(message)` → Completed → executes `send_sms`

## Fix 2 — ChatScreen LaunchedEffect (model-loading edge case)

Previously the LaunchedEffect waited for full `ChatUiState.Ready` (requires `engine.isReady` — LLM loaded). If the model was still loading at navigation time, the 30 s timeout would expire and silently drop the query.

NeedsSlot intents never invoke the LLM. `sendMessage()` already handles model loading internally for FallThrough/LLM routes (calls `initGemma4()` inside). So waiting for `engine.isReady` is unnecessary.

- Expose `_conversationInitialized` as `isConversationReady: StateFlow<Boolean>` from `ChatViewModel`
- Update `ChatScreen.LaunchedEffect` to `await isConversationReady.first { it }` — fires as soon as the conversation DB record exists, regardless of model state

## Changes

- `ActionsViewModel.kt`: remove `startSlotFill()`, navigate with original query, remove `SlotFillerManager` dep
- `ChatViewModel.kt`: expose `isConversationReady: StateFlow<Boolean>`, add `asStateFlow` import
- `ChatScreen.kt`: LaunchedEffect now awaits `isConversationReady` instead of full `ChatUiState.Ready`

## Testing

- [x] `./gradlew :feature:chat:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :core:skills:test` — no new failures (pre-existing: `kill the light` classifier, LaTeX nested fractions)
- [x] On-device: "send a message to Laurelle" from Quick Actions → slot-fill prompt appears, message content passes correctly to Chat

## Related issues

Closes #576 (partial — slot-fill regression fix; full harness work remains)
