### PR TITLE
feat(#576): slot-fill harness — NeedsSlot patterns, ADB wiring, JVM tests, and adb_skill_test phase

### DIFF
--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -33,6 +33,9 @@ class MainActivity : ComponentActivity() {
     /** Bridges ADB `--es chat_input` extras (onCreate + onNewIntent) into the nav graph. */
     private val adbChatInput = mutableStateOf<String?>(null)
 
+    /** Bridges ADB `--es quick_action_input` extras into ActionsViewModel.executeAction(). */
+    private val adbQuickActionInput = mutableStateOf<String?>(null)
+
     private val requestNotificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
 
@@ -46,6 +49,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         adbChatInput.value = intent.getStringExtra("chat_input")
+        adbQuickActionInput.value = intent.getStringExtra("quick_action_input")
         handleAdbProfileText(intent)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -60,7 +64,10 @@ class MainActivity : ComponentActivity() {
         }
         setContent {
             KernelAITheme {
-                KernelNavHost(initialChatQuery = adbChatInput.value)
+                KernelNavHost(
+                    initialChatQuery = adbChatInput.value,
+                    initialQuickActionQuery = adbQuickActionInput.value,
+                )
             }
         }
     }
@@ -77,6 +84,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         intent.getStringExtra("chat_input")?.let { adbChatInput.value = it }
+        intent.getStringExtra("quick_action_input")?.let { adbQuickActionInput.value = it }
         handleAdbProfileText(intent)
         if (AuthorizationResponse.fromIntent(intent) != null ||
             AuthorizationException.fromIntent(intent) != null) {

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -74,7 +74,10 @@ private const val ARG_INITIAL_QUERY = "initialQuery"
 private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
 
 @Composable
-fun KernelNavHost(initialChatQuery: String? = null) {
+fun KernelNavHost(
+    initialChatQuery: String? = null,
+    initialQuickActionQuery: String? = null,
+) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -88,6 +91,15 @@ fun KernelNavHost(initialChatQuery: String? = null) {
         if (!initialChatQuery.isNullOrBlank()) {
             val encoded = Uri.encode(initialChatQuery)
             navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded") {
+                popUpTo(ROUTE_LIST)
+            }
+        }
+    }
+
+    // ADB test harness: navigate to Actions tab when quick_action_input extra is delivered
+    LaunchedEffect(initialQuickActionQuery) {
+        if (!initialQuickActionQuery.isNullOrBlank()) {
+            navController.navigate(ROUTE_ACTIONS) {
                 popUpTo(ROUTE_LIST)
             }
         }
@@ -208,6 +220,7 @@ fun KernelNavHost(initialChatQuery: String? = null) {
                     Box(modifier = Modifier.padding(innerPadding)) {
                         ActionsScreen(
                             autoOpenSheet = openSheet,
+                            initialQuery = initialQuickActionQuery,
                             onNavigateToChat = { query ->
                                 val encoded = Uri.encode(query)
                                 navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -235,6 +235,21 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> parseAlarmTime(match.groupValues[1].trim()) },
         ),
+        // "set an alarm" / "create an alarm" (no time given) → ask for time
+        IntentPattern(
+            intentName = "set_alarm",
+            regex = Regex(
+                """^(?:set|create|make)\s+(?:an?\s+)?alarm$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "time" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "time",
+                    promptTemplate = "What time would you like the alarm set for?",
+                ),
+            ),
+        ),
 
         // ── Cancel Alarm ──
         IntentPattern(
@@ -412,6 +427,21 @@ class QuickIntentRouter(
                     emptyMap()
                 }
             },
+        ),
+        // "set a timer" / "start a timer" (no duration given) → ask how long
+        IntentPattern(
+            intentName = "set_timer",
+            regex = Regex(
+                """^(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "duration_seconds" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "duration_seconds",
+                    promptTemplate = "How long would you like the timer for?",
+                ),
+            ),
         ),
 
 
@@ -1128,6 +1158,22 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
         ),
+        // Open app — "open an app" / "launch an app" (no specific app named) → ask which app
+        // Must come BEFORE the generic open_app pattern below to prevent "an" being captured as app_name
+        IntentPattern(
+            intentName = "open_app",
+            regex = Regex(
+                """^(?:open|launch|start)\s+an?\s+app$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "app_name" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "app_name",
+                    promptTemplate = "Which app would you like to open?",
+                ),
+            ),
+        ),
         // Open app — "open YouTube" / "launch Spotify"
         // Excludes timer/countdown/alarm phrases and phrases that contain "timer" anywhere
         // Also excludes "new conversation/chat" to prevent false matches on conversational phrases
@@ -1509,6 +1555,21 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("destination" to match.groupValues[1].trim()) },
         ),
+        // "navigate" / "get directions" (no destination) → ask where
+        IntentPattern(
+            intentName = "navigate_to",
+            regex = Regex(
+                """^(?:navigate|directions?|get\s+directions?)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "destination" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "destination",
+                    promptTemplate = "Where would you like to go?",
+                ),
+            ),
+        ),
         // ── Find Nearby (most specific first to avoid greedy mis-capture) ──
         // "find me nearby cafes" — verb + me + nearby + query
         IntentPattern(
@@ -1582,6 +1643,21 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
         ),
+        // "what's nearby" / "find nearby" (no query) → ask what they're looking for
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """^(?:what(?:'s|\s+is)\s+nearby|find\s+nearby|show\s+(?:me\s+)?what(?:'s|\s+is)\s+nearby)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "query" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "query",
+                    promptTemplate = "What are you looking for?",
+                ),
+            ),
+        ),
 
         // ── Communication ──
         IntentPattern(
@@ -1611,6 +1687,22 @@ class QuickIntentRouter(
             paramExtractor = { match, _ ->
                 mapOf("contact" to "myself", "message" to match.groupValues[1].trim())
             },
+        ),
+        // "send a message" / "send a text" (no contact) → ask who to send to
+        // Must come BEFORE the generic send_sms pattern below (which would capture "a" as contact)
+        IntentPattern(
+            intentName = "send_sms",
+            regex = Regex(
+                """^(?:send\s+(?:a\s+)?(?:text|sms|message)|text\s+someone)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who do you want to send a message to?",
+                ),
+            ),
         ),
         // "send a text to John saying hello" / "text John hey" / "sms John meet at 5"
         IntentPattern(
@@ -1664,6 +1756,29 @@ class QuickIntentRouter(
                 if (body.isNotBlank()) params["body"] = body
                 params
             },
+            // Ask for subject when contact provided but no subject given.
+            requiredSlots = mapOf(
+                "subject" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "subject",
+                    promptTemplate = "What's the subject of your email to {contact}?",
+                ),
+            ),
+        ),
+        // "send an email" / "email someone" (no contact) → ask who
+        // Must come AFTER the contact-extraction pattern above
+        IntentPattern(
+            intentName = "send_email",
+            regex = Regex(
+                """^(?:send\s+(?:an?\s+)?email|email\s+someone)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = mapOf(
+                "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            ),
         ),
 
         // ── System Info ──
@@ -1726,6 +1841,24 @@ class QuickIntentRouter(
                 val listName = match.groupValues[2].trim().ifEmpty { "shopping" }
                 mapOf("item" to item, "list_name" to listName)
             },
+        ),
+        // "add to my list" / "add something to my list" / "add to the shopping list" (no item) → ask what
+        IntentPattern(
+            intentName = "add_to_list",
+            regex = Regex(
+                """^(?:add|put)\s+(?:something\s+)?to\s+(?:(?:my|the)\s+)?(?:(.+?)\s+)?list$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val listName = match.groupValues[1].trim()
+                if (listName.isNotBlank()) mapOf("list_name" to listName) else emptyMap()
+            },
+            requiredSlots = mapOf(
+                "item" to com.kernel.ai.core.skills.slot.SlotSpec(
+                    name = "item",
+                    promptTemplate = "What would you like to add?",
+                ),
+            ),
         ),
         // "create a list called groceries" / "make a new list called holiday packing"
         // Must come BEFORE generic create_list to prevent lazy (.+?) capturing "a" or "new"

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -259,6 +259,17 @@ class QuickIntentRouterTest {
             assertFallThrough(regexResult, input)
             assertClassifierOrFallthrough(hybridResult, "set_alarm", input)
         }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#setAlarmNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare alarm phrases missing time`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("set_alarm", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("time", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -304,6 +315,17 @@ class QuickIntentRouterTest {
             val hybridResult = hybridRouter.route(input)
             assertFallThrough(regexResult, input)
             assertClassifierOrFallthrough(hybridResult, "set_timer", input)
+        }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#setTimerNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare timer phrases missing duration`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("set_timer", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("duration_seconds", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
     }
 
@@ -700,6 +722,17 @@ class QuickIntentRouterTest {
             val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
             assertEquals(expectedApp, intent.params["app_name"], "app_name for '$input'")
         }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#openAppNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare open-app phrases missing app name`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("open_app", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("app_name", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     @Nested
@@ -855,6 +888,17 @@ class QuickIntentRouterTest {
             val hybridResult = hybridRouter.route(input)
             assertClassifierOrFallthrough(hybridResult, "navigate_to", input)
         }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#navigateToNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare navigate phrases missing destination`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("navigate_to", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("destination", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     @Nested
@@ -875,6 +919,17 @@ class QuickIntentRouterTest {
         fun `should match via classifier`(input: String) {
             val hybridResult = hybridRouter.route(input)
             assertClassifierOrFallthrough(hybridResult, "find_nearby", input)
+        }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#findNearbyNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare find-nearby phrases missing query`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("find_nearby", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("query", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
     }
 
@@ -927,6 +982,17 @@ class QuickIntentRouterTest {
             assertEquals(expectedContact, needsSlot.intent.params["contact"], "contact for '$input'")
             assertEquals("message", needsSlot.missingSlot.name, "missing slot name for '$input'")
         }
+
+        @ParameterizedTest(name = "NeedsSlot no-contact: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendSmsNoContactNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare send-message phrases missing contact`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_sms", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     @Nested
@@ -940,6 +1006,31 @@ class QuickIntentRouterTest {
             assertRegexMatch(result, "send_email", input)
             val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
             assertEquals(expectedContact, intent.params["contact"], "contact for '$input'")
+        }
+
+        @ParameterizedTest(name = "NeedsSlot no-contact: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendEmailNoContactNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare send-email phrases missing contact`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_email", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
+
+        @ParameterizedTest(name = "NeedsSlot contact/no-subject: \"{0}\" → contact={1}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendEmailContactNoSubjectNeedsSlotPhrases")
+        fun `should return NeedsSlot for email phrases with contact but missing subject`(
+            input: String, expectedContact: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_email", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedContact, needsSlot.intent.params["contact"], "contact for '$input'")
+            assertEquals("subject", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
     }
 
@@ -970,6 +1061,17 @@ class QuickIntentRouterTest {
         fun `should match via classifier`(input: String) {
             val hybridResult = hybridRouter.route(input)
             assertClassifierOrFallthrough(hybridResult, "add_to_list", input)
+        }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#addToListNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare add-to-list phrases missing item`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("add_to_list", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("item", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
     }
 
@@ -1939,15 +2041,37 @@ class QuickIntentRouterTest {
         )
 
         @JvmStatic
+        fun sendSmsNoContactNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            // Bare send-message phrases — no contact, no body → NeedsSlot(contact)
+            Arguments.of("send a message"),
+            Arguments.of("send a text"),
+            Arguments.of("send a sms"),
+        )
+
+        @JvmStatic
+        fun sendEmailNoContactNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            // Bare send-email phrases — no contact → NeedsSlot(contact)
+            // Note: "email someone" captures "someone" as contact → NeedsSlot(subject) instead
+            Arguments.of("send an email"),
+        )
+
+        @JvmStatic
+        fun sendEmailContactNoSubjectNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            // Contact present but no subject → NeedsSlot(subject)
+            Arguments.of("send email to Dad", "Dad"),
+            Arguments.of("send an email to the team", "the team"),
+            Arguments.of("send email to HR", "HR"),
+            Arguments.of("email someone", "someone"),
+        )
+
+        @JvmStatic
         fun sendEmailRegexPhrases(): Stream<Arguments> = Stream.of(
+            // Cases with a subject keyword — no NeedsSlot triggered
             Arguments.of("email John about the meeting", "John"),
             Arguments.of("send an email to Sarah about project update", "Sarah"),
-            Arguments.of("send email to Dad", "Dad"),
             Arguments.of("send an email to my boss about the project", "my boss"),
             Arguments.of("email Nick about dinner plans", "Nick"),
-            Arguments.of("send an email to the team", "the team"),
             Arguments.of("email Sarah regarding the report", "Sarah"),
-            Arguments.of("send email to HR", "HR"),
         )
 
         // ── Lists ─────────────────────────────────────────────────────────────────
@@ -1967,6 +2091,42 @@ class QuickIntentRouterTest {
         fun addToListClassifierPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("add eggs to my groceries"),
             Arguments.of("put butter on the shopping list"),
+        )
+
+        @JvmStatic
+        fun setAlarmNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("set an alarm"),
+            Arguments.of("set alarm"),
+        )
+
+        @JvmStatic
+        fun setTimerNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("set a timer"),
+            Arguments.of("start a timer"),
+        )
+
+        @JvmStatic
+        fun openAppNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("open an app"),
+            Arguments.of("launch an app"),
+        )
+
+        @JvmStatic
+        fun navigateToNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("navigate"),
+            Arguments.of("get directions"),
+        )
+
+        @JvmStatic
+        fun findNearbyNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("what's nearby"),
+            Arguments.of("find nearby"),
+        )
+
+        @JvmStatic
+        fun addToListNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("add to my list"),
+            Arguments.of("put something to my list"),
         )
 
         @JvmStatic

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -66,6 +66,7 @@ import java.util.Locale
 @Composable
 fun ActionsScreen(
     autoOpenSheet: Boolean = false,
+    initialQuery: String? = null,
     onNavigateToChat: (query: String) -> Unit = {},
     onNewConversation: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
@@ -83,6 +84,11 @@ fun ActionsScreen(
     // avoids re-opening the sheet on recomposition or after process death/restore.
     LaunchedEffect(Unit) {
         if (autoOpenSheet) showBottomSheet = true
+    }
+
+    // ADB harness: auto-execute query when quick_action_input extra is provided.
+    LaunchedEffect(initialQuery) {
+        if (!initialQuery.isNullOrBlank()) viewModel.executeAction(initialQuery)
     }
 
     // Collect one-shot navigation events from the ViewModel.

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -87,6 +87,9 @@ class TestCase:
     xfail: bool = False  # True = intent not yet implemented; failure is expected
     expect_reply_contains: str | None = None  # if set, verify DirectReply logcat contains this (best-effort)
     expect_params: dict[str, str] | None = None  # if set, assert these key=value pairs appear in extracted params
+    # Slot-fill test fields: if set, `message` is sent via quick_action_input (triggers NeedsSlot),
+    # then `slot_reply` is sent via chat_input to complete the slot, and the intent is verified after.
+    slot_reply: str | None = None
 
 
 @dataclass
@@ -350,6 +353,64 @@ PHASES: list[tuple[str, list[TestCase]]] = [
         TestCase("normal speed", "podcast_speed"),
         TestCase("slow down the podcast", "podcast_speed"),
     ]),
+    ("slot_fill", [
+        # set_alarm — bare query (no time) → slot asks for time → user provides time
+        TestCase(
+            "set an alarm",
+            "set_alarm",
+            slot_reply="7am",
+            expect_params={"hours": "7", "minutes": "0"},
+        ),
+        # set_timer — bare query (no duration) → slot asks how long → user provides duration
+        TestCase(
+            "set a timer",
+            "set_timer",
+            slot_reply="5 minutes",
+            expect_params={"duration_seconds": "300"},
+        ),
+        # open_app — bare query (no app name) → slot asks which app → user provides name
+        TestCase(
+            "open an app",
+            "open_app",
+            slot_reply="Spotify",
+            expect_params={"app_name": "Spotify"},
+        ),
+        # navigate_to — bare query (no destination) → slot asks where → user provides destination
+        TestCase(
+            "navigate",
+            "navigate_to",
+            slot_reply="Auckland Airport",
+            expect_params={"destination": "Auckland Airport"},
+        ),
+        # find_nearby — bare query (no query) → slot asks what → user provides query
+        TestCase(
+            "find nearby",
+            "find_nearby",
+            slot_reply="coffee",
+            expect_params={"query": "coffee"},
+        ),
+        # send_sms — no contact → slot asks who → user provides contact
+        TestCase(
+            "send a message",
+            "send_sms",
+            slot_reply="Mum",
+            expect_params={"contact": "Mum"},
+        ),
+        # send_email — no contact → slot asks who → user provides contact
+        TestCase(
+            "send an email",
+            "send_email",
+            slot_reply="Nick",
+            expect_params={"contact": "Nick"},
+        ),
+        # add_to_list — no item → slot asks what → user provides item
+        TestCase(
+            "add to my list",
+            "add_to_list",
+            slot_reply="eggs",
+            expect_params={"item": "eggs"},
+        ),
+    ]),
 ]
 
 # Flat list built from phases — preserves backward compatibility with any code
@@ -424,6 +485,28 @@ def send_text(text: str) -> None:
         ACTIVITY,
         "--es",
         "chat_input",
+        shlex.quote(text),
+    )
+
+
+def send_quick_action(text: str) -> None:
+    """Deliver quick_action_input extra — navigates to Actions tab and calls executeAction().
+
+    Used to drive slot-fill tests: bare queries (e.g. "set an alarm") route through
+    ActionsViewModel → QIR → NeedsSlot → navigate to Chat with slot prompt.
+    """
+    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    time.sleep(0.3)
+    run_adb(
+        "shell",
+        "am",
+        "start",
+        "--activity-clear-top",
+        "--activity-single-top",
+        "-n",
+        ACTIVITY,
+        "--es",
+        "quick_action_input",
         shlex.quote(text),
     )
 
@@ -885,7 +968,19 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
 
             clear_logcat()
             time.sleep(0.5)  # Brief pause to ensure logcat clear is flushed before sending
-            send_text(tc.message)
+
+            if tc.slot_reply is not None:
+                # Slot-fill test: two-turn flow
+                # Turn 1: bare query via quick_action_input → NeedsSlot → Chat slot prompt
+                send_quick_action(tc.message)
+                time.sleep(WAIT_SECONDS)
+                # Turn 2: slot reply via chat_input → fills slot → intent fires
+                clear_logcat()
+                time.sleep(0.5)
+                send_text(tc.slot_reply)
+            else:
+                send_text(tc.message)
+
             time.sleep(WAIT_SECONDS)
             logcat = read_logcat()
             actual_intent, actual_params = extract_intent(logcat)


### PR DESCRIPTION
## Summary

Full slot-fill harness for quick actions. Bare queries like "set an alarm" or "open an app" now flow through a two-turn conversation to collect missing slots before the intent fires.

## Changes

### `QuickIntentRouter.kt`
- Added `requiredSlots` to 9 intents: `set_alarm` (time), `set_timer` (duration), `open_app` (app name), `navigate_to` (destination), `find_nearby` (query), `send_sms` no-contact, `send_email` no-contact, `send_email` contact-no-subject, `add_to_list` (item)

### `MainActivity.kt`
- Reads `quick_action_input` ADB extra in `onCreate` and `onNewIntent`; exposes as `adbQuickActionInput` state passed to `KernelNavHost`

### `KernelNavHost.kt`
- Accepts `initialQuickActionQuery: String?`; `LaunchedEffect` navigates to `ROUTE_ACTIONS` when non-null; passes `initialQuery` to `ActionsScreen`

### `ActionsScreen.kt`
- Accepts `initialQuery: String? = null`; `LaunchedEffect` calls `viewModel.executeAction(initialQuery)` when non-null

### `QuickIntentRouterTest.kt`
- Added `NeedsSlot` test methods for all 9 new patterns
- Trimmed `sendEmailRegexPhrases` — removed subject-free cases that now correctly produce `NeedsSlot(subject)`
- Added 9 new `@JvmStatic` companion data sources

### `adb_skill_test.py`
- Added `send_quick_action(text)` — mirrors `send_text()` but uses `quick_action_input` extra
- Added `slot_reply: str | None` field to `TestCase` — when set, runs a two-turn flow: `send_quick_action(message)` → wait → `send_text(slot_reply)` → verify intent
- Added `slot_fill` phase (phase 10) with 8 test cases covering all new `NeedsSlot` intents

## Testing

- [x] `./gradlew :core:skills:test` — 604 tests pass (1 pre-existing failure unrelated to this PR: `"kill the light"` flashlight classifier)
- [x] `./gradlew assembleDebug` — `BUILD SUCCESSFUL`
- [ ] Device test with `--phases slot_fill` (requires connected device)

## Notes

- `slot_reply` field is backward-compatible — `None` by default, existing test cases unaffected
- Second turn in slot-fill always uses `send_text()` (chat_input) because after NeedsSlot the app navigates to Chat and waits for the slot reply there
- `total_tests` count includes slot-fill cases; two-turn tests consume ~2× `WAIT_SECONDS` each

## Related issues

Closes #576
