### PR TITLE
fix(#572,#573): correct EmbeddingGemma size estimate + HuggingFace sign-in CTA on onboarding

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -259,6 +259,9 @@ fun KernelNavHost(
                                 popUpTo(ROUTE_LIST) { inclusive = true }
                             }
                         },
+                        onNavigateToSettings = {
+                            navController.navigate(ROUTE_SETTINGS)
+                        },
                     )
                 }
 
@@ -275,6 +278,9 @@ fun KernelNavHost(
                         },
                         onNavigateToList = {
                             navController.popBackStack()
+                        },
+                        onNavigateToSettings = {
+                            navController.navigate(ROUTE_SETTINGS)
                         },
                     )
                 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt
@@ -79,7 +79,7 @@ enum class KernelModel(
         displayName = "EmbeddingGemma 300M",
         fileName = "embeddinggemma-300M_seq512_mixed-precision.tflite",
         downloadUrl = "https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq512_mixed-precision.tflite",
-        approxSizeBytes = 350_000_000L,
+        approxSizeBytes = 171_000_000L,
         // Required — powers the RAG memory pipeline on all non-flagship devices.
         isRequired = true,
         preferredForTier = null,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -124,6 +124,7 @@ fun ChatScreen(
     onBack: () -> Unit = {},
     onNewConversation: () -> Unit = {},
     onNavigateToList: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     viewModel: ChatViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -153,6 +154,7 @@ fun ChatScreen(
             isDownloading = state.isDownloading,
             modelProgress = state.modelProgress,
             onRetry = viewModel::retryDownload,
+            onNavigateToSettings = onNavigateToSettings,
         )
         is ChatUiState.Ready -> ChatContent(
             state = state,
@@ -686,6 +688,7 @@ private fun OnboardingContent(
     isDownloading: Boolean,
     modelProgress: List<ModelDownloadProgress>,
     onRetry: (KernelModel) -> Unit,
+    onNavigateToSettings: () -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
@@ -718,7 +721,7 @@ private fun OnboardingContent(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
                     modelProgress.forEach { item ->
-                        ModelProgressRow(item, onRetry = onRetry)
+                        ModelProgressRow(item, onRetry = onRetry, onNavigateToSettings = onNavigateToSettings)
                     }
                 }
             } else if (isDownloading) {
@@ -729,7 +732,11 @@ private fun OnboardingContent(
 }
 
 @Composable
-private fun ModelProgressRow(item: ModelDownloadProgress, onRetry: (KernelModel) -> Unit) {
+private fun ModelProgressRow(
+    item: ModelDownloadProgress,
+    onRetry: (KernelModel) -> Unit,
+    onNavigateToSettings: () -> Unit,
+) {
     val state = item.state
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
@@ -807,12 +814,32 @@ private fun ModelProgressRow(item: ModelDownloadProgress, onRetry: (KernelModel)
                 }
             }
             is DownloadState.NotDownloaded -> {
-                Text(
-                    text = "Queued",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 2.dp),
-                )
+                if (item.model.isGated) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = "Sign in to HuggingFace to download",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = onNavigateToSettings,
+                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                        ) {
+                            Text("Sign in", style = MaterialTheme.typography.labelMedium)
+                        }
+                    }
+                } else {
+                    Text(
+                        text = "Queued",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Two onboarding UX fixes caught during a fresh-install test.

## Changes

### `KernelModel.kt` — fix #572
`EMBEDDING_GEMMA_300M.approxSizeBytes` corrected from `350_000_000L` (~350 MB) to `171_000_000L` (~171 MB). The old value was ~2× the actual file size on device, causing inaccurate progress bars and potentially false low-storage warnings during onboarding.

### `ChatScreen.kt` + `KernelNavHost.kt` — fix #573
`ModelProgressRow` now detects when a model is **gated** (`isGated = true`) and in a `NotDownloaded`/queued state. Instead of the silent "Queued" label, it shows:
- `"Sign in to HuggingFace to download"` text
- `"Sign in"` button → navigates directly to Settings (where HuggingFace auth lives)

Non-gated queued models still show the plain "Queued" label.

`onNavigateToSettings` callback threaded: `ModelProgressRow` → `OnboardingContent` → `ChatScreen`. Both `ChatScreen` composable call sites in `KernelNavHost` wired with `{ navController.navigate(ROUTE_SETTINGS) }`.

## Testing

- [x] `./gradlew assembleDebug` — `BUILD SUCCESSFUL`
- [ ] Fresh-install device test: gated models show Sign in CTA, button opens Settings

## Related issues

Closes #572
Closes #573
