### PR TITLE
feat(589): NativeSlotFiller — slot-fill via ModalBottomSheet in Actions tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +72,53 @@ jobs:
           name: apk-${{ github.sha }}
           path: app/build/outputs/apk/debug/
           retention-days: 14
+
+      - name: Publish PR preview APK
+        if: success() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          APK=app/build/outputs/apk/debug/app-debug.apk
+          SHORT_SHA=${GITHUB_SHA::7}
+          TAG="pr-${PR_NUMBER}"
+
+          # Upsert the pr-N pre-release (delete first so we can re-attach the APK)
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git tag -f "$TAG"
+          git push -f origin "$TAG"
+          gh release create "$TAG" "$APK" \
+            --title "PR #${PR_NUMBER} debug build — ${SHORT_SHA}" \
+            --notes "Debug APK for PR #${PR_NUMBER}. Commit: ${GITHUB_SHA}. Build #${BUILD_NUMBER}." \
+            --prerelease
+
+          APK_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/app-debug.apk"
+
+          # Build comment JSON (pass body via argv to avoid quoting/encoding issues)
+          COMMENT_BODY="<!-- pr-apk-comment -->
+## 📦 Debug APK ready
+
+**[⬇️ Download app-debug.apk](${APK_URL})**
+
+Commit: \`${SHORT_SHA}\` · Build #${BUILD_NUMBER}
+
+_Updated on each push to this branch. Removed when the PR is merged or closed._"
+
+          python3 -c "import json,sys; print(json.dumps({'body': sys.argv[1]}))" \
+            "$COMMENT_BODY" > /tmp/pr-comment.json
+
+          # Post or update sticky comment (identified by marker in first line)
+          EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- pr-apk-comment -->"))][0].id // empty')
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+              -X PATCH --input /tmp/pr-comment.json
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -X POST --input /tmp/pr-comment.json
+          fi
 
       - name: Publish debug release
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,11 @@ jobs:
 
           APK_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/app-debug.apk"
 
-          # Build comment JSON (pass body via argv to avoid quoting/encoding issues)
-          COMMENT_BODY="<!-- pr-apk-comment -->
-## 📦 Debug APK ready
-
-**[⬇️ Download app-debug.apk](${APK_URL})**
-
-Commit: \`${SHORT_SHA}\` · Build #${BUILD_NUMBER}
-
-_Updated on each push to this branch. Removed when the PR is merged or closed._"
-
-          python3 -c "import json,sys; print(json.dumps({'body': sys.argv[1]}))" \
-            "$COMMENT_BODY" > /tmp/pr-comment.json
+          # Build comment JSON via printf+python — avoids YAML block-scalar indentation issues
+          printf '<!-- pr-apk-comment -->\n## Debug APK ready\n\n**[Download app-debug.apk](%s)**\n\nCommit: `%s` - Build #%s\n\n_Updated on each push. Removed when PR is merged or closed._\n' \
+            "$APK_URL" "$SHORT_SHA" "$BUILD_NUMBER" \
+            | python3 -c "import json,sys; print(json.dumps({'body':sys.stdin.read()}))" \
+            > /tmp/pr-comment.json
 
           # Post or update sticky comment (identified by marker in first line)
           EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,27 @@
+name: PR cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  delete-preview-release:
+    name: Delete PR preview release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete pr-N release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TAG="pr-${PR_NUMBER}"
+          gh release delete "$TAG" --repo $GITHUB_REPOSITORY --yes 2>/dev/null || true
+          git push origin --delete "$TAG" 2>/dev/null || true

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -56,6 +56,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
 import com.kernel.ai.core.memory.entity.QuickActionEntity
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -75,6 +78,7 @@ fun ActionsScreen(
     val actions by viewModel.actions.collectAsStateWithLifecycle()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
+    val pendingSlot by viewModel.pendingSlot.collectAsStateWithLifecycle()
 
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
     var showClearConfirmation by rememberSaveable { mutableStateOf(false) }
@@ -260,6 +264,17 @@ fun ActionsScreen(
         )
     }
 
+    // Slot-fill sheet — shown when QIR needs a missing parameter.
+    // Swipe-down or cancel = silent dismiss, no log entry.
+    pendingSlot?.let { slot ->
+        SlotFillBottomSheet(
+            promptMessage = slot.request.promptMessage,
+            uiState = uiState,
+            onDismiss = { viewModel.cancelSlotFill() },
+            onSubmit = { reply -> viewModel.onSlotReply(reply) },
+        )
+    }
+
     // Clear history confirmation
     if (showClearConfirmation) {
         AlertDialog(
@@ -278,6 +293,67 @@ fun ActionsScreen(
                 TextButton(onClick = { showClearConfirmation = false }) { Text("Cancel") }
             },
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SlotFillBottomSheet(
+    promptMessage: String,
+    uiState: ActionsViewModel.UiState,
+    onDismiss: () -> Unit,
+    onSubmit: (String) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    var inputText by rememberSaveable { mutableStateOf("") }
+
+    fun submit() {
+        val text = inputText.trim()
+        if (text.isNotBlank()) {
+            inputText = ""
+            scope.launch { sheetState.hide() }.invokeOnCompletion { onSubmit(text) }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+        ) {
+            Text(
+                text = promptMessage,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { inputText = it },
+                placeholder = { Text("Your answer…") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { submit() }),
+                trailingIcon = {
+                    if (uiState == ActionsViewModel.UiState.Executing) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    } else {
+                        IconButton(
+                            onClick = { submit() },
+                            enabled = inputText.isNotBlank(),
+                        ) {
+                            Icon(Icons.Default.Send, contentDescription = "Submit")
+                        }
+                    }
+                },
+            )
+        }
     }
 }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -307,17 +307,21 @@ private fun SlotFillBottomSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     var inputText by rememberSaveable { mutableStateOf("") }
+    // Guards against submit() and onDismissRequest firing simultaneously (e.g. tap Send + swipe).
+    var isSubmitting by rememberSaveable { mutableStateOf(false) }
 
     fun submit() {
         val text = inputText.trim()
-        if (text.isNotBlank()) {
-            inputText = ""
-            scope.launch { sheetState.hide() }.invokeOnCompletion { onSubmit(text) }
+        if (text.isNotBlank() && !isSubmitting) {
+            isSubmitting = true
+            scope.launch { sheetState.hide() }.invokeOnCompletion { cause ->
+                if (cause == null) onSubmit(text)
+            }
         }
     }
 
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
         sheetState = sheetState,
     ) {
         Column(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -70,6 +70,7 @@ class ActionsViewModel @Inject constructor(
     data class PendingSlotState(
         val request: PendingSlotRequest,
         val originalQuery: String,
+        // TODO(#350/#588): use inputMode to adapt SlotFillBottomSheet for voice (mic button, no keyboard)
         val inputMode: InputMode,
     )
 
@@ -101,6 +102,12 @@ class ActionsViewModel @Inject constructor(
      */
     fun executeAction(query: String, inputMode: InputMode = InputMode.Text) {
         if (query.isBlank()) return
+        if (_pendingSlot.value != null) {
+            // A slot-fill is already in progress — ignore until the user replies or cancels.
+            // Voice (#350) may want to cancel-and-proceed here instead.
+            Log.w(TAG, "ActionsViewModel: executeAction called while slot-fill pending — ignoring \"$query\"")
+            return
+        }
         _error.value = null
 
         viewModelScope.launch {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.entity.QuickActionEntity
 import com.kernel.ai.core.skills.QuickIntentRouter
-import com.kernel.ai.core.skills.Skill
 import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,12 +23,20 @@ import javax.inject.Inject
 
 private const val TAG = "KernelAI"
 
+/** Input modality for an action. Carried through slot-fill state for voice-readiness (#350/#588). */
+enum class InputMode { Text, Voice }
+
 /**
  * Manages the Actions tab: fast intent routing via [QuickIntentRouter] (Tier 2),
- * skill execution, and action-history persistence.
+ * skill execution, action-history persistence, and local slot-fill state.
  *
  * Routing is synchronous (<30 ms) — no model loading required at app start.
  * Skill execution runs on the viewModelScope coroutine.
+ *
+ * Slot-fill state is managed locally here (not via SlotFillerManager, which is
+ * ChatViewModel's concern). When QIR returns NeedsSlot, [_pendingSlot] is primed
+ * and [ActionsScreen] shows a ModalBottomSheet. On reply, the merged params are
+ * executed directly. See #589.
  */
 @HiltViewModel
 class ActionsViewModel @Inject constructor(
@@ -55,11 +63,25 @@ class ActionsViewModel @Inject constructor(
         data class NavigateToChat(val query: String) : UiEvent
     }
 
+    /**
+     * Local slot-fill state. Holds the pending [PendingSlotRequest] plus the original
+     * user query (for history logging) and the [InputMode] (for voice-readiness).
+     */
+    data class PendingSlotState(
+        val request: PendingSlotRequest,
+        val originalQuery: String,
+        val inputMode: InputMode,
+    )
+
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     private val _events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
     val events = _events.asSharedFlow()
+
+    /** Non-null while waiting for the user to supply a missing slot value. */
+    private val _pendingSlot = MutableStateFlow<PendingSlotState?>(null)
+    val pendingSlot: StateFlow<PendingSlotState?> = _pendingSlot.asStateFlow()
 
     /** Last error message to show in the UI. Cleared on next action. */
     private val _error = MutableStateFlow<String?>(null)
@@ -72,9 +94,12 @@ class ActionsViewModel @Inject constructor(
      *
      * Routing is synchronous (<30 ms) — no model loading required. If the router matches
      * a known intent, the corresponding skill executes and the result is persisted to history.
-     * Unrecognised queries are recorded as not-handled so the user gets immediate feedback.
+     * If a required slot is missing, [pendingSlot] is primed and execution pauses until
+     * [onSlotReply] is called. Unrecognised queries fall through to Chat.
+     *
+     * @param inputMode Carried into [PendingSlotState] for voice-readiness; no-op until #350.
      */
-    fun executeAction(query: String) {
+    fun executeAction(query: String, inputMode: InputMode = InputMode.Text) {
         if (query.isBlank()) return
         _error.value = null
 
@@ -83,11 +108,8 @@ class ActionsViewModel @Inject constructor(
                 _uiState.value = UiState.Executing
 
                 val routeResult = quickIntentRouter.route(query)
-                val intent = when (routeResult) {
-                    is QuickIntentRouter.RouteResult.RegexMatch -> routeResult.intent
-                    is QuickIntentRouter.RouteResult.ClassifierMatch -> routeResult.intent
+                when (routeResult) {
                     is QuickIntentRouter.RouteResult.FallThrough -> {
-                        // No quick action match — hand off to the LLM via the chat screen.
                         Log.d(TAG, "ActionsViewModel: FallThrough for \"$query\" → navigating to chat")
                         quickActionDao.insert(
                             QuickActionEntity(
@@ -98,49 +120,26 @@ class ActionsViewModel @Inject constructor(
                             )
                         )
                         _events.emit(UiEvent.NavigateToChat(query))
-                        _uiState.value = UiState.Idle
-                        return@launch
                     }
                     is QuickIntentRouter.RouteResult.NeedsSlot -> {
-                        // Multi-turn slot-filling isn't handled in the Actions tab.
-                        // Navigate to Chat with the original query — ChatViewModel will re-route
-                        // it through QIR, detect NeedsSlot, start the slot-fill, and show the
-                        // prompt. Do NOT prime SlotFillerManager here: if we did, Chat's
-                        // initialQuery auto-submit would be consumed as the slot *value* instead
-                        // of being routed as a new intent.
-                        Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$query\" → navigating to chat")
-                        _events.emit(UiEvent.NavigateToChat(query))
-                        _uiState.value = UiState.Idle
-                        return@launch
-                    }
-                }
-
-                val entity = run {
-                    // Router intent names (e.g. "toggle_flashlight_on") are sub-intent values
-                    // passed as the intent_name param to run_intent — they are not skill names.
-                    // Resolve: direct skill name match first, then fall back to run_intent.
-                    val directSkill = skillRegistry.get(intent.intentName)
-                    val (skill, callParams) = when {
-                        directSkill != null -> directSkill to intent.params
-                        else -> {
-                            val runIntent = skillRegistry.get("run_intent")
-                            runIntent to (mapOf("intent_name" to intent.intentName) + intent.params)
-                        }
-                    }
-                    if (skill != null) {
-                        val skillResult = skill.execute(SkillCall(skill.name, callParams))
-                        buildEntityFromSkillResult(query, intent.intentName, skillResult)
-                    } else {
-                        Log.w(TAG, "ActionsViewModel: intent '${intent.intentName}' has no registered skill")
-                        QuickActionEntity(
-                            userQuery = query,
-                            skillName = intent.intentName,
-                            resultText = "Action recognised but not yet implemented.",
-                            isSuccess = false,
+                        // Pause execution — show slot prompt in a ModalBottomSheet.
+                        // Do NOT use SlotFillerManager; state lives locally here.
+                        Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$query\" → showing slot sheet")
+                        _pendingSlot.value = PendingSlotState(
+                            request = PendingSlotRequest(
+                                intentName = routeResult.intent.intentName,
+                                existingParams = routeResult.intent.params,
+                                missingSlot = routeResult.missingSlot,
+                            ),
+                            originalQuery = query,
+                            inputMode = inputMode,
                         )
                     }
+                    is QuickIntentRouter.RouteResult.RegexMatch ->
+                        quickActionDao.insert(executeIntent(query, routeResult.intent.intentName, routeResult.intent.params))
+                    is QuickIntentRouter.RouteResult.ClassifierMatch ->
+                        quickActionDao.insert(executeIntent(query, routeResult.intent.intentName, routeResult.intent.params))
                 }
-                quickActionDao.insert(entity)
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: executeAction failed — ${e.message}", e)
                 _error.value = e.message ?: "Unknown error"
@@ -155,6 +154,48 @@ class ActionsViewModel @Inject constructor(
                 _uiState.value = UiState.Idle
             }
         }
+    }
+
+    /**
+     * Called when the user submits a reply to a slot-fill prompt.
+     *
+     * Merges the reply into the existing params and executes the intent directly.
+     * For multi-slot intents (future), re-route through QIR after merging.
+     */
+    fun onSlotReply(text: String) {
+        val pending = _pendingSlot.value ?: return
+        if (text.isBlank()) {
+            cancelSlotFill()
+            return
+        }
+        _pendingSlot.value = null
+        val mergedParams = pending.request.existingParams +
+                mapOf(pending.request.missingSlot.name to text.trim())
+
+        viewModelScope.launch {
+            _uiState.value = UiState.Executing
+            try {
+                val entity = executeIntent(pending.originalQuery, pending.request.intentName, mergedParams)
+                quickActionDao.insert(entity)
+            } catch (e: Exception) {
+                Log.e(TAG, "ActionsViewModel: onSlotReply failed — ${e.message}", e)
+                _error.value = e.message ?: "Unknown error"
+                quickActionDao.insert(
+                    QuickActionEntity(
+                        userQuery = pending.originalQuery,
+                        resultText = "Error: ${e.message ?: "Unknown"}",
+                        isSuccess = false,
+                    )
+                )
+            } finally {
+                _uiState.value = UiState.Idle
+            }
+        }
+    }
+
+    /** Silently dismiss the slot-fill sheet with no log entry. */
+    fun cancelSlotFill() {
+        _pendingSlot.value = null
     }
 
     fun deleteAction(id: String) {
@@ -176,7 +217,36 @@ class ActionsViewModel @Inject constructor(
 
     // ── Private helpers ─────────────────────────────────────────────────────
 
-    private suspend fun buildEntityFromSkillResult(
+    /**
+     * Resolves [intentName] to a skill and executes it with [params].
+     * Router intent names (e.g. "toggle_flashlight_on") are sub-intent values passed as the
+     * intent_name param to run_intent — they are not skill names themselves.
+     */
+    private suspend fun executeIntent(
+        query: String,
+        intentName: String,
+        params: Map<String, String>,
+    ): QuickActionEntity {
+        val directSkill = skillRegistry.get(intentName)
+        val (skill, callParams) = when {
+            directSkill != null -> directSkill to params
+            else -> skillRegistry.get("run_intent") to (mapOf("intent_name" to intentName) + params)
+        }
+        return if (skill != null) {
+            val skillResult = skill.execute(SkillCall(skill.name, callParams))
+            buildEntityFromSkillResult(query, intentName, skillResult)
+        } else {
+            Log.w(TAG, "ActionsViewModel: intent '$intentName' has no registered skill")
+            QuickActionEntity(
+                userQuery = query,
+                skillName = intentName,
+                resultText = "Action recognised but not yet implemented.",
+                isSuccess = false,
+            )
+        }
+    }
+
+    private fun buildEntityFromSkillResult(
         query: String,
         skillName: String,
         result: SkillResult,


### PR DESCRIPTION
## Summary

Implements NativeSlotFiller (#589): when QIR returns `NeedsSlot` from the Actions tab, instead of navigating to Chat, a `ModalBottomSheet` overlay appears in-place with the slot prompt. The user answers, the merged params are executed directly, and the result is logged to action history — all without leaving the Actions tab.

## Changes

### `ActionsViewModel.kt`
- Add `InputMode` enum (`Text` / `Voice`) — no-op until #350/#588, but carried through state now
- Add `PendingSlotState` data class wrapping `PendingSlotRequest` + `originalQuery` + `inputMode`
- Add `_pendingSlot: MutableStateFlow<PendingSlotState?>` + public `pendingSlot` StateFlow
- `executeAction(query, inputMode)`: on `NeedsSlot` prime `_pendingSlot` instead of emitting `NavigateToChat`
- Add `onSlotReply(text)`: merges slot value into existing params, executes intent directly
- Add `cancelSlotFill()`: clears `_pendingSlot`, silent dismiss, no log entry
- Refactor intent execution into private `executeIntent()` helper (shared by `executeAction` and `onSlotReply`)
- Slot state managed locally — **not** via `SlotFillerManager` (which remains ChatViewModel's concern)

### `ActionsScreen.kt`
- Observe `pendingSlot` from ViewModel
- Show `SlotFillBottomSheet` when `pendingSlot` is non-null; swipe-down calls `cancelSlotFill()`
- Add `SlotFillBottomSheet` composable: displays `promptMessage`, `OutlinedTextField` with `ImeAction.Done` wired to submit, spinner while executing

## Testing
- [ ] "send a message to Laurelle" → slot sheet appears with "Who would you like to send a message to?" prompt
- [ ] Submit reply → message intent executes, result appears in history, sheet dismisses
- [ ] Swipe down sheet → silent dismiss, no log entry
- [ ] ADB harness `slot_fill` phase still passes (uses `send_text()` for now — see #597 for post-#589 harness update)

## Design notes
- `SlotFillerManager` untouched — Chat slot-fill unaffected
- `KernelNavHost` untouched — no new navigation routes
- Voice readiness: `executeAction(query, InputMode.Voice)` is the hook point for #588

## Related issues
Closes #589
Tracked by #597 (harness update — `slot_reply_input` ADB extra, blocked on this PR)
Informs #588 (VoiceSession architecture — see design comment on that issue)
