### PR TITLE
fix(#611): clarify loadSkill gateway name vs JS sub-skill name

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -95,9 +95,9 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
-    @Tool(description = "Run a built-in JavaScript skill. Use 'query-wikipedia' for Wikipedia or encyclopedia lookups. DO NOT use for weather — use the getWeather tool instead.")
+    @Tool(description = "Run a built-in JavaScript skill. Use 'query-wikipedia' for Wikipedia or encyclopedia lookups. DO NOT use for weather — use the getWeather tool instead. NOTE: to use this tool, first call loadSkill('run_js') — do NOT call loadSkill('query-wikipedia').")
     fun runJs(
-        @ToolParam(description = "The JS skill to run: 'get-weather-city' or 'query-wikipedia'") skillName: String,
+        @ToolParam(description = "The JS skill to run: 'get-weather-city' or 'query-wikipedia'. IMPORTANT: load this tool with loadSkill('run_js'), not loadSkill('query-wikipedia').") skillName: String,
         @ToolParam(description = "The search query or input (city name for weather, topic for Wikipedia)") query: String,
         @ToolParam(description = "For get-weather-city only: number of forecast days 1-7. Omit for current weather, use 3 when user asks for forecast without specifying days") forecastDays: String,
     ): Map<String, String> {


### PR DESCRIPTION
## Summary

The model was calling `loadSkill('query-wikipedia')` when trying to look up Wikipedia articles, causing an "Unknown skill" error and a confusing failure loop.

## Root cause

`loadSkill` only accepts gateway names (`run_intent`, `run_js`, etc.) — not JS sub-skill names like `query-wikipedia`. The model confused the two because:
1. The `runJs()` @Tool description mentioned `query-wikipedia` by name
2. The system prompt says "call loadSkill first before using any other tool"
3. The model conflated the JS sub-skill name with the gateway skill name → called `loadSkill('query-wikipedia')` → got "Unknown skill" → tried `run_js(skill_name='query-wikipedia')` as a confused fallback → same error, infinite loop

The `query-wikipedia` skill asset (`core/skills/src/main/assets/skills/query-wikipedia/index.html`) exists and works fine — the model just never reached it.

## Changes

`core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt`
- Added explicit NOTE to `runJs()` `@Tool` description: "to use this tool, first call `loadSkill('run_js')` — do NOT call `loadSkill('query-wikipedia')`"
- Added same clarification to the `skillName` `@ToolParam` description

## Testing

- [ ] Ask "Can you look up the second Schleswig war on Wikipedia"
- [ ] Verify model calls `loadSkill('run_js')` → then `runJs(skillName='query-wikipedia', query='Second Schleswig War')`
- [ ] Verify a Wikipedia summary is returned in chat

## Related issues

Closes #611
