### PR TITLE
fix(#618): re-seed Kiwi truths when DB has been wiped (stale SharedPrefs flag)

### DIFF
--- a/app/src/main/assets/intent_phrases.json
+++ b/app/src/main/assets/intent_phrases.json
@@ -18,7 +18,9 @@
         "light it up",
         "light on",
         "lights on",
-        "light please"
+        "light please",
+        "illumination on",
+        "turn on the illumination"
       ]
     },
     "toggle_flashlight_off": {
@@ -37,7 +39,9 @@
         "switch the light off",
         "light off",
         "lights off",
-        "light out"
+        "light out",
+        "illumination off",
+        "turn off the illumination"
       ]
     },
     "set_alarm": {

--- a/app/src/main/assets/intent_phrases.json
+++ b/app/src/main/assets/intent_phrases.json
@@ -15,7 +15,10 @@
         "chuck on the torch",
         "it's dark in here",
         "I need some light",
-        "light it up"
+        "light it up",
+        "light on",
+        "lights on",
+        "light please"
       ]
     },
     "toggle_flashlight_off": {
@@ -31,7 +34,10 @@
         "turn that torch off",
         "disable the flashlight",
         "I don't need the light anymore",
-        "switch the light off"
+        "switch the light off",
+        "light off",
+        "lights off",
+        "light out"
       ]
     },
     "set_alarm": {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -47,6 +47,12 @@ class JandalPersona @Inject constructor(
         Log.i(TAG, "Kiwi truths marked as seeded")
     }
 
+    /** Reset the seeded flag — called when the DB is wiped so truths are re-seeded on next launch. */
+    fun resetTruthsSeeded() {
+        prefs.edit().putBoolean(KEY_TRUTHS_SEEDED, false).apply()
+        Log.i(TAG, "Kiwi truths seeded flag reset")
+    }
+
     /**
      * Returns an explicit time-aware greeting instruction tailored to whether this is the
      * first reply in the conversation or a follow-up.

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -24,6 +24,9 @@ interface CoreMemoryDao {
     @Query("DELETE FROM core_memories WHERE id = :id")
     suspend fun delete(id: String)
 
+    @Query("SELECT COUNT(*) FROM core_memories WHERE source = :source")
+    suspend fun countBySource(source: String): Int
+
     @Query("SELECT COUNT(*) FROM core_memories")
     suspend fun count(): Int
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -40,4 +40,6 @@ interface MemoryRepository {
     suspend fun updateCoreMemory(id: String, newContent: String, newVector: FloatArray? = null)
     /** Update the content of an existing episodic memory and re-embed it. */
     suspend fun updateEpisodicMemory(id: String, newContent: String, newVector: FloatArray)
+    /** Count core memories by source (e.g. "jandal_persona"). Used to detect stale seeded flag. */
+    suspend fun countCoreMemoriesBySource(source: String): Int
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -307,4 +307,7 @@ class MemoryRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override suspend fun countCoreMemoriesBySource(source: String): Int =
+        coreDao.countBySource(source)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -6,6 +6,7 @@ import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.memory.dao.ConversationDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +32,35 @@ class EpisodicDistillationUseCase @Inject constructor(
         /** Minimum character length for a distilled sentence to be worth embedding and storing. */
         private const val MIN_SENTENCE_LENGTH = 20
         private val LEADING_JUNK = Regex("""^[\s\d]+[.)]\s*|^[-•*]\s*""")
+
+        /**
+         * Skills whose results are ephemeral device/system state — distilled sentences about
+         * these pollute future RAG with stale facts like "The torch is on" (#614).
+         */
+        private val EPHEMERAL_SKILLS = setOf(
+            "run_intent", "toggle_flashlight_on", "toggle_flashlight_off",
+            "get_weather", "get_system_info", "get_time", "get_date",
+            "set_alarm", "set_timer", "set_volume", "set_brightness",
+            "toggle_dnd", "toggle_wifi", "toggle_bluetooth",
+        )
+
+        /**
+         * Sentence-level post-filter: returns true if the sentence describes transient device
+         * state that would be stale and misleading when retrieved in future conversations.
+         */
+        private fun isEphemeralSentence(sentence: String): Boolean {
+            val lower = sentence.lowercase()
+            return EPHEMERAL_PATTERNS.any { lower.contains(it) }
+        }
+
+        private val EPHEMERAL_PATTERNS = listOf(
+            "torch", "flashlight", "turned on the light", "turned off the light",
+            "lights on", "lights off", "light on", "light off", "illuminat",
+            "smart home", "smart_home", "couldn't turn", "could not turn",
+            "unable to turn", "set an alarm", "set a timer", "alarm set",
+            "timer set", "volume set", "brightness set", "wi-fi", "wifi",
+            "bluetooth", "do not disturb", "dnd",
+        )
     }
 
     /**
@@ -52,19 +82,35 @@ class EpisodicDistillationUseCase @Inject constructor(
                 return
             }
 
-            val transcript = messages.joinToString("\n") { msg ->
+            // Strip device-action assistant turns from the transcript — they carry ephemeral
+            // device state ("Torch enabled", "smart_home_off failed") that would be misleading
+            // if surfaced as a memory in a future conversation (#614).
+            val filteredMessages = messages.filter { msg ->
+                if (msg.role != "assistant" || msg.toolCallJson == null) return@filter true
+                val skillName = runCatching {
+                    JSONObject(msg.toolCallJson).getString("skillName")
+                }.getOrNull() ?: return@filter true
+                skillName !in EPHEMERAL_SKILLS
+            }
+
+            if (filteredMessages.size < MIN_TURNS) {
+                Log.d(TAG, "Episodic distillation skipped for $conversationId: only ${filteredMessages.size} non-ephemeral messages after filtering (min $MIN_TURNS)")
+                return
+            }
+
+            val transcript = filteredMessages.joinToString("\n") { msg ->
                 val label = if (msg.role == "user") "User" else "Assistant"
                 "$label: ${msg.content}"
             }
 
             val sentenceRange = when {
-                messages.size >= 17 -> "6–10 sentences"
-                messages.size >= 9  -> "5–8 sentences"
-                else                -> "3–5 sentences"
+                filteredMessages.size >= 17 -> "6–10 sentences"
+                filteredMessages.size >= 9  -> "5–8 sentences"
+                else                        -> "3–5 sentences"
             }
 
             val prompt = """
-Summarise the key facts, preferences, and events from this conversation in $sentenceRange. Each sentence should be a standalone fact. Output only the sentences, one per line, with no numbering or bullet points.
+Summarise the key facts, preferences, and events from this conversation in $sentenceRange. Each sentence should be a standalone fact about the user's interests, preferences, or knowledge. Do not include device control commands, smart home actions, alarms, timers, or other transient device state. Output only the sentences, one per line, with no numbering or bullet points.
 
 [CONVERSATION]
 $transcript
@@ -80,6 +126,8 @@ $transcript
             val sentences = response.lines()
                 .map { LEADING_JUNK.replace(it.trim(), "") }
                 .filter { it.length >= MIN_SENTENCE_LENGTH }
+                .filterNot { isEphemeralSentence(it) }
+
             if (sentences.isEmpty()) {
                 Log.w(TAG, "Episodic distillation: no sentences parsed for $conversationId")
                 return

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import org.tensorflow.lite.Interpreter
 import java.nio.channels.FileChannel
@@ -49,30 +51,51 @@ class MiniLMIntentClassifier @Inject constructor(
     @Volatile private var vocab: Map<String, Int>? = null
     @Volatile private var interpreter: Interpreter? = null
     @Volatile private var intentCentroids: Map<String, FloatArray>? = null
+    @Volatile private var initFailed: Boolean = false
     private val interpreterLock = Any()
-
-    init {
-        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            try {
-                val v = loadVocab()
-                val interp = loadInterpreter() ?: return@launch
-                val phrasesJson = context.assets.open(PHRASES_ASSET).bufferedReader().readText()
-                val centroids = computeCentroids(phrasesJson, v, interp)
-                vocab = v
-                interpreter = interp
-                intentCentroids = centroids
-                Log.i(TAG, "Ready: ${centroids.size} intent centroids loaded")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to initialise — classify() will return null", e)
+    private val initJob = CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+        try {
+            val v = loadVocab()
+            val interp = loadInterpreter() ?: run {
+                initFailed = true
+                return@launch
             }
+            val phrasesJson = context.assets.open(PHRASES_ASSET).bufferedReader().readText()
+            val centroids = computeCentroids(phrasesJson, v, interp)
+            vocab = v
+            interpreter = interp
+            intentCentroids = centroids
+            Log.i(TAG, "Ready: ${centroids.size} intent centroids loaded")
+        } catch (e: Exception) {
+            initFailed = true
+            Log.e(TAG, "Failed to initialise — classify() will return null", e)
         }
     }
 
     override fun classify(input: String): QuickIntentRouter.IntentClassifier.Classification? {
-        val v = vocab ?: return null
-        val interp = interpreter ?: return null
-        val centroids = intentCentroids ?: return null
         if (input.isBlank()) return null
+
+        // If init hasn't finished yet, wait up to 500ms before giving up — prevents the race
+        // condition where the first user message arrives before centroid pre-computation is done.
+        if (intentCentroids == null && !initFailed) {
+            Log.i(TAG, "classify('$input') — init still in progress, waiting up to 500ms")
+            runBlocking { withTimeoutOrNull(500) { initJob.join() } }
+        }
+
+        val v = vocab ?: run {
+            Log.i(TAG, "classify('$input') — not ready (vocab null, initFailed=$initFailed), skipping")
+            return null
+        }
+        val interp = interpreter ?: run {
+            Log.i(TAG, "classify('$input') — not ready (interpreter null), skipping")
+            return null
+        }
+        val centroids = intentCentroids ?: run {
+            Log.i(TAG, "classify('$input') — not ready (centroids null), skipping")
+            return null
+        }
+
+        Log.i(TAG, "classify('$input') — running against ${centroids.size} centroids")
 
         val queryEmbedding = synchronized(interpreterLock) {
             embed(input.lowercase().trim(), v, interp)
@@ -90,10 +113,16 @@ class MiniLMIntentClassifier @Inject constructor(
             }
         }
 
-        if (bestIntent == null || bestScore < CONFIDENCE_THRESHOLD) return null
-        if (bestScore - secondScore < AMBIGUITY_MARGIN) return null
+        if (bestIntent == null || bestScore < CONFIDENCE_THRESHOLD) {
+            Log.i(TAG, "classify('$input') — below threshold: best=$bestIntent score=${"%.3f".format(bestScore)} threshold=$CONFIDENCE_THRESHOLD")
+            return null
+        }
+        if (bestScore - secondScore < AMBIGUITY_MARGIN) {
+            Log.i(TAG, "classify('$input') — ambiguous: best=$bestIntent score=${"%.3f".format(bestScore)} second=${"%.3f".format(secondScore)}")
+            return null
+        }
 
-        Log.d(TAG, "classify('$input') -> $bestIntent (score=$bestScore)")
+        Log.i(TAG, "classify('$input') -> $bestIntent (score=${"%.3f".format(bestScore)}, margin=${"%.3f".format(bestScore - secondScore)})")
         return QuickIntentRouter.IntentClassifier.Classification(bestIntent, bestScore)
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
@@ -96,7 +96,10 @@ class MiniLMIntentClassifier @Inject constructor(
         }
 
         Log.i(TAG, "classify('$input') — running against ${centroids.size} centroids")
-
+        if (centroids.isEmpty()) {
+            Log.w(TAG, "classify('$input') — centroid map is empty (all phrase embeds failed at init), skipping")
+            return null
+        }
         val queryEmbedding = synchronized(interpreterLock) {
             embed(input.lowercase().trim(), v, interp)
         } ?: return null
@@ -226,7 +229,9 @@ class MiniLMIntentClassifier @Inject constructor(
 
             val inputIdsBatch = Array(1) { inputIds }
             val maskBatch = Array(1) { mask }
-            val tokenTypeIds = Array(1) { IntArray(MAX_SEQ_LEN) }  // all zeros
+            // Model has 2 inputs only: input_ids + attention_mask.
+            // token_type_ids is NOT a separate input on this model variant — passing it caused
+            // "Invalid input Tensor index: 2" and silently broke every embed call.
 
             // Check output tensor shape to handle both model variants:
             // [1, MAX_SEQ_LEN, EMBEDDING_DIM] — all token embeddings, we mean-pool
@@ -237,7 +242,7 @@ class MiniLMIntentClassifier @Inject constructor(
                 // Model already outputs a single pooled embedding
                 val output = Array(1) { FloatArray(EMBEDDING_DIM) }
                 interp.runForMultipleInputsOutputs(
-                    arrayOf(inputIdsBatch, maskBatch, tokenTypeIds),
+                    arrayOf(inputIdsBatch, maskBatch),
                     mapOf(0 to output)
                 )
                 output[0].l2Normalize()
@@ -245,7 +250,7 @@ class MiniLMIntentClassifier @Inject constructor(
                 // Output: [1, MAX_SEQ_LEN, EMBEDDING_DIM] — all token embeddings
                 val tokenEmbeddings = Array(1) { Array(MAX_SEQ_LEN) { FloatArray(EMBEDDING_DIM) } }
                 interp.runForMultipleInputsOutputs(
-                    arrayOf(inputIdsBatch, maskBatch, tokenTypeIds),
+                    arrayOf(inputIdsBatch, maskBatch),
                     mapOf(0 to tokenEmbeddings)
                 )
                 // Mean pooling over non-padding tokens, then L2-normalise

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/MiniLMIntentClassifier.kt
@@ -50,7 +50,10 @@ class MiniLMIntentClassifier @Inject constructor(
     // All mutable state is set exactly once from the init coroutine and then read-only.
     @Volatile private var vocab: Map<String, Int>? = null
     @Volatile private var interpreter: Interpreter? = null
-    @Volatile private var intentCentroids: Map<String, FloatArray>? = null
+    /** Per-intent list of individual phrase embeddings. Scoring uses max similarity (nearest
+     *  neighbour) across all stored vectors rather than a single averaged centroid, which avoids
+     *  the drift that occurs when diverse training phrases are averaged together. */
+    @Volatile private var intentPhraseVectors: Map<String, List<FloatArray>>? = null
     @Volatile private var initFailed: Boolean = false
     private val interpreterLock = Any()
     private val initJob = CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
@@ -61,11 +64,12 @@ class MiniLMIntentClassifier @Inject constructor(
                 return@launch
             }
             val phrasesJson = context.assets.open(PHRASES_ASSET).bufferedReader().readText()
-            val centroids = computeCentroids(phrasesJson, v, interp)
+            val phraseVectors = buildPhraseVectors(phrasesJson, v, interp)
             vocab = v
             interpreter = interp
-            intentCentroids = centroids
-            Log.i(TAG, "Ready: ${centroids.size} intent centroids loaded")
+            intentPhraseVectors = phraseVectors
+            val totalVectors = phraseVectors.values.sumOf { it.size }
+            Log.i(TAG, "Ready: ${phraseVectors.size} intents, $totalVectors phrase vectors loaded (nearest-neighbour)")
         } catch (e: Exception) {
             initFailed = true
             Log.e(TAG, "Failed to initialise — classify() will return null", e)
@@ -76,8 +80,8 @@ class MiniLMIntentClassifier @Inject constructor(
         if (input.isBlank()) return null
 
         // If init hasn't finished yet, wait up to 500ms before giving up — prevents the race
-        // condition where the first user message arrives before centroid pre-computation is done.
-        if (intentCentroids == null && !initFailed) {
+        // condition where the first user message arrives before phrase vector pre-computation is done.
+        if (intentPhraseVectors == null && !initFailed) {
             Log.i(TAG, "classify('$input') — init still in progress, waiting up to 500ms")
             runBlocking { withTimeoutOrNull(500) { initJob.join() } }
         }
@@ -90,14 +94,14 @@ class MiniLMIntentClassifier @Inject constructor(
             Log.i(TAG, "classify('$input') — not ready (interpreter null), skipping")
             return null
         }
-        val centroids = intentCentroids ?: run {
-            Log.i(TAG, "classify('$input') — not ready (centroids null), skipping")
+        val phraseVectors = intentPhraseVectors ?: run {
+            Log.i(TAG, "classify('$input') — not ready (phraseVectors null), skipping")
             return null
         }
 
-        Log.i(TAG, "classify('$input') — running against ${centroids.size} centroids")
-        if (centroids.isEmpty()) {
-            Log.w(TAG, "classify('$input') — centroid map is empty (all phrase embeds failed at init), skipping")
+        Log.i(TAG, "classify('$input') — running against ${phraseVectors.size} intents")
+        if (phraseVectors.isEmpty()) {
+            Log.w(TAG, "classify('$input') — phrase vector map is empty (all embeds failed at init), skipping")
             return null
         }
         val queryEmbedding = synchronized(interpreterLock) {
@@ -108,8 +112,11 @@ class MiniLMIntentClassifier @Inject constructor(
         var bestScore = -1f
         var secondScore = -1f
 
-        for ((name, centroid) in centroids) {
-            val score = dot(queryEmbedding, centroid)
+        // Nearest-neighbour: score each intent as the max similarity across all its phrase vectors.
+        // This avoids centroid drift where averaging 12+ diverse phrases pulls the centroid away
+        // from individual extremes (e.g. "it's dark in here" scoring 0.49 against its own centroid).
+        for ((name, vectors) in phraseVectors) {
+            val score = vectors.maxOf { dot(queryEmbedding, it) }
             when {
                 score > bestScore -> { secondScore = bestScore; bestScore = score; bestIntent = name }
                 score > secondScore -> secondScore = score
@@ -286,16 +293,16 @@ class MiniLMIntentClassifier @Inject constructor(
         return sum
     }
 
-    // ── Centroid pre-computation ─────────────────────────────────────────────
+    // ── Phrase vector pre-computation ────────────────────────────────────────
 
-    private fun computeCentroids(
+    private fun buildPhraseVectors(
         phrasesJson: String,
         vocab: Map<String, Int>,
         interp: Interpreter,
-    ): Map<String, FloatArray> {
+    ): Map<String, List<FloatArray>> {
         val root = JSONObject(phrasesJson)
         val intents = root.getJSONObject("intents")
-        val centroids = HashMap<String, FloatArray>()
+        val result = HashMap<String, List<FloatArray>>()
 
         for (intentName in intents.keys()) {
             val phrases = intents.getJSONObject(intentName).getJSONArray("phrases")
@@ -307,13 +314,9 @@ class MiniLMIntentClassifier @Inject constructor(
                 }?.let { vectors += it }
             }
             if (vectors.isEmpty()) continue
-
-            // Average the phrase embeddings into a single centroid, then re-normalise
-            val centroid = FloatArray(EMBEDDING_DIM)
-            for (v in vectors) for (j in v.indices) centroid[j] += v[j]
-            for (j in centroid.indices) centroid[j] /= vectors.size
-            centroids[intentName] = centroid.l2Normalize()
+            result[intentName] = vectors
+            Log.d(TAG, "  $intentName: ${vectors.size} phrase vectors")
         }
-        return centroids
+        return result
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -117,11 +117,11 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight on" / "torch on" / "torch on torch" — object + on (no verb, trailing words ok)
+        // Pattern: "flashlight on" / "torch on" / "light on" — object + on (no verb, trailing words ok)
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light)\s+on\b""",
+                """^(?:torch|flashlight|flash\s*light|light)\s+on\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -153,11 +153,11 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight off" / "torch off" / "torch off torch" — object + off (no verb, trailing words ok)
+        // Pattern: "flashlight off" / "torch off" / "light off" — object + off (no verb, trailing words ok)
         IntentPattern(
             intentName = "toggle_flashlight_off",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light)\s+off\b""",
+                """^(?:torch|flashlight|flash\s*light|light)\s+off\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -117,11 +117,11 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight on" / "torch on" — object + on (no verb)
+        // Pattern: "flashlight on" / "torch on" / "torch on torch" — object + on (no verb, trailing words ok)
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light)\s+on$""",
+                """^(?:torch|flashlight|flash\s*light)\s+on\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -153,11 +153,11 @@ class QuickIntentRouter(
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight off" / "torch off" — object + off (no verb)
+        // Pattern: "flashlight off" / "torch off" / "torch off torch" — object + off (no verb, trailing words ok)
         IntentPattern(
             intentName = "toggle_flashlight_off",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light)\s+off$""",
+                """^(?:torch|flashlight|flash\s*light)\s+off\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -103,7 +103,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """(?:turn|switch|put)\s+on\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light)""",
+                """(?:turn|switch|put)\s+on\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light|illumination)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -112,25 +112,25 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """(?:turn|switch|put)\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light)\s+on""",
+                """(?:turn|switch|put)\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light|illumination)\s+on""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight on" / "torch on" / "light on" — object + on (no verb, trailing words ok)
+        // Pattern: "flashlight on" / "torch on" / "light on" / "illumination on" — object + on
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light|light)\s+on\b""",
+                """^(?:torch|flashlight|flash\s*light|light|illumination)\s+on\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: bare "torch" / "flashlight" — single-word terse command
+        // Pattern: bare "torch" / "flashlight" / "illuminate" — terse ON command
         IntentPattern(
             intentName = "toggle_flashlight_on",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light)$""",
+                """^(?:torch|flashlight|flash\s*light|illuminate)\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -139,7 +139,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "toggle_flashlight_off",
             regex = Regex(
-                """(?:turn|switch|put)\s+off\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light)""",
+                """(?:turn|switch|put)\s+off\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light|illumination)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -148,16 +148,16 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "toggle_flashlight_off",
             regex = Regex(
-                """(?:turn|switch|put)\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light)\s+off""",
+                """(?:turn|switch|put)\s+(?:the\s+)?(?:torch|flashlight|flash\s*light|light|illumination)\s+off""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
         ),
-        // Pattern: "flashlight off" / "torch off" / "light off" — object + off (no verb, trailing words ok)
+        // Pattern: "flashlight off" / "torch off" / "light off" / "illumination off" — object + off
         IntentPattern(
             intentName = "toggle_flashlight_off",
             regex = Regex(
-                """^(?:torch|flashlight|flash\s*light|light)\s+off\b""",
+                """^(?:torch|flashlight|flash\s*light|light|illumination)\s+off\b""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -110,9 +110,13 @@ class NativeIntentHandler @Inject constructor(
 ) {
 
     fun handle(intentName: String, params: Map<String, String>): SkillResult {
-        Log.d(TAG, "NativeIntentHandler.handle: intent=$intentName params=$params")
+        val normalizedName = normalizeIntentName(intentName)
+        if (normalizedName != intentName) {
+            Log.w(TAG, "NativeIntentHandler: normalized intent '$intentName' -> '$normalizedName'")
+        }
+        Log.d(TAG, "NativeIntentHandler.handle: intent=$normalizedName params=$params")
         return try {
-            when (intentName) {
+            when (normalizedName) {
                 "toggle_flashlight_on" -> setTorch(true)
                 "toggle_flashlight_off" -> setTorch(false)
                 "send_email" -> sendEmail(params)
@@ -167,12 +171,54 @@ class NativeIntentHandler @Inject constructor(
                 else -> SkillResult.Failure("run_intent", "Unknown intent: $intentName")
             }
         } catch (e: Exception) {
-            Log.e(TAG, "NativeIntentHandler.handle($intentName) failed", e)
+            Log.e(TAG, "NativeIntentHandler.handle($normalizedName) failed", e)
             SkillResult.Failure("run_intent", e.message ?: "Unknown error")
         }
     }
 
-    // ── Torch ─────────────────────────────────────────────────────────────────
+    /**
+     * Normalizes LLM-generated intent names to their canonical form.
+     *
+     * Small models occasionally omit underscores (e.g. "toggle_flashlightoff" instead of
+     * "toggle_flashlight_off") or add spaces. This function:
+     *   1. Trims and lowercases the input
+     *   2. Returns immediately on exact match
+     *   3. Strips all underscores/spaces and compares against the same normalization of every
+     *      known intent name — handles any underscore insertion or omission
+     */
+    private fun normalizeIntentName(raw: String): String {
+        val trimmed = raw.trim().lowercase()
+        if (trimmed in KNOWN_INTENTS) return trimmed
+        // Strip all word separators and compare canonically
+        val stripped = trimmed.replace(Regex("[_\\s]+"), "")
+        return KNOWN_INTENTS.firstOrNull { it.replace("_", "") == stripped } ?: trimmed
+    }
+
+    companion object {
+        private val KNOWN_INTENTS = setOf(
+            "toggle_flashlight_on", "toggle_flashlight_off",
+            "send_email", "send_sms", "make_call",
+            "set_alarm", "cancel_alarm",
+            "set_timer", "cancel_timer", "cancel_timer_named", "list_timers", "get_timer_remaining",
+            "create_calendar_event",
+            "get_battery", "get_time", "get_date",
+            "toggle_dnd_on", "toggle_dnd_off",
+            "set_volume", "set_brightness",
+            "toggle_wifi", "toggle_bluetooth", "toggle_airplane_mode", "toggle_hotspot",
+            "play_media", "play_media_album", "play_media_playlist",
+            "play_youtube", "play_spotify", "play_plexamp", "play_youtube_music",
+            "play_netflix", "play_plex", "play_podcast",
+            "pause_media", "stop_media", "next_track", "previous_track",
+            "podcast_skip_forward", "podcast_skip_back", "podcast_speed",
+            "open_app", "navigate_to", "find_nearby",
+            "add_to_list", "bulk_add_to_list", "create_list", "get_list_items", "remove_from_list",
+            "smart_home_on", "smart_home_off",
+            "get_weather", "get_system_info",
+            "save_memory",
+        )
+    }
+
+
 
     private fun setTorch(enabled: Boolean): SkillResult {
         val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -90,11 +90,11 @@ internal fun looksLikeToolConfirmation(response: String): Boolean {
         // Catch "I've turned X on/off" where object sits between "turned" and "on/off"
         "i've turned", "i have turned",
         // Kiwi/casual action verbs — "I've flicked the flashlight on", "flicked it on"
-        "flicked", "switched on", "switched off",
+        "i've flicked", "i have flicked", "flicked it on", "flicked it off",
+        "switched on", "switched off",
         // Torch/light state claims — "the light's on", "flashlight is on", etc.
         "the light's on", "the light's off", "lights are on", "lights are off",
         "torch is on", "torch is off", "flashlight is on", "flashlight is off",
-        "is now on", "is now off",
         "i've lit", "i have lit",
         "done!", "all done", "got it, i've", "sure thing",
     )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -87,6 +87,8 @@ internal fun looksLikeToolConfirmation(response: String): Boolean {
         "created your", "i've created", "list created", "created a new",
         "set an alarm", "alarm set", "timer set", "i've set",
         "turned on", "turned off", "toggled",
+        // Catch "I've turned X on/off" where object sits between "turned" and "on/off"
+        "i've turned", "i have turned",
         "done!", "all done", "got it, i've", "sure thing",
     )
     return actionPhrases.any { lower.contains(it) }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -89,6 +89,13 @@ internal fun looksLikeToolConfirmation(response: String): Boolean {
         "turned on", "turned off", "toggled",
         // Catch "I've turned X on/off" where object sits between "turned" and "on/off"
         "i've turned", "i have turned",
+        // Kiwi/casual action verbs — "I've flicked the flashlight on", "flicked it on"
+        "flicked", "switched on", "switched off",
+        // Torch/light state claims — "the light's on", "flashlight is on", etc.
+        "the light's on", "the light's off", "lights are on", "lights are off",
+        "torch is on", "torch is off", "flashlight is on", "flashlight is off",
+        "is now on", "is now off",
+        "i've lit", "i have lit",
         "done!", "all done", "got it, i've", "sure thing",
     )
     return actionPhrases.any { lower.contains(it) }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -635,9 +635,13 @@ class ChatViewModel @Inject constructor(
             // Set by the Tier 2 intercept when a skill executes successfully; injected into
             // the E4B prompt so it can generate a natural conversational wrapper.
             var systemContext: String? = null
-            // Set true when QIR routes to a device action — suppresses RAG indexing for
-            // both the user message and the LLM wrapper response (#614).
+            // Set true when QIR routes to a device action, OR when the LLM calls a non-indexable
+            // tool (run_intent, get_weather, etc.) — suppresses RAG indexing for both the user
+            // message and the LLM response to prevent stale device state in future RAG (#614).
             var isDeviceActionExchange = false
+            // Hoisted so the Complete handler can index the user message after knowing whether
+            // any device-action tools were called during LLM inference.
+            var savedUserMsgId = ""
 
             try {
             val userMsgId = UUID.randomUUID().toString()
@@ -647,8 +651,9 @@ class ChatViewModel @Inject constructor(
                 content = text,
             )
             _messages.update { it + userMessage }
-            val savedUserMsgId = conversationRepository.addMessage(convId, "user", text)
-            // User message indexing is deferred — skipped for device-action exchanges (see below).
+            savedUserMsgId = conversationRepository.addMessage(convId, "user", text)
+            // User message indexing is deferred to the LLM Complete handler — skipped if any
+            // non-indexable tool (run_intent, weather, etc.) is called during inference.
 
             // After the very first user message, immediately set a placeholder title from the
             // first ~40 characters of the message so the conversation list never shows a blank
@@ -794,13 +799,6 @@ class ChatViewModel @Inject constructor(
                 }
             }
             // _isLoadingModel is always cleared by the outer finally block below.
-
-            // Only index the user message when the exchange goes to the LLM (knowledge queries,
-            // conversational turns). Device-action exchanges (QIR match → run_intent) are skipped
-            // to prevent stale device state from polluting future RAG retrievals.
-            if (!isDeviceActionExchange) {
-                ragRepository.indexMessage(savedUserMsgId, convId, text)
-            }
 
             // 2. Gemma-4 streaming inference path.
             // Capture isFirstReply before adding the streaming placeholder — once the placeholder
@@ -1001,6 +999,10 @@ class ChatViewModel @Inject constructor(
                                 // actions, weather, or system info which are ephemeral (#614).
                                 if (shouldIndexToolCallResult(toolCall.skillName)) {
                                     ragRepository.indexMessage(savedId, convId, resultContent)
+                                } else {
+                                    // LLM called a device/ephemeral tool — suppress indexing of
+                                    // the user message and final response too.
+                                    isDeviceActionExchange = true
                                 }
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
                                     contextWindowManager.estimateTokens(resultContent) +
@@ -1052,7 +1054,12 @@ class ChatViewModel @Inject constructor(
                                 // Don't index hallucination error messages — they're noise (#614).
                                 // Don't index LLM wrappers around device actions — stale device state
                                 // ("The light's on!") poisons future RAG retrievals (#614).
+                                // Also index the user message here (deferred from sendMessage entry)
+                                // so we can skip it too if a device tool was called during inference.
                                 if (!isHallucination && !isDeviceActionExchange) {
+                                    if (savedUserMsgId.isNotBlank()) {
+                                        ragRepository.indexMessage(savedUserMsgId, convId, text)
+                                    }
                                     ragRepository.indexMessage(savedAssistantMsgId, convId, displayContent)
                                 }
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -281,7 +281,15 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun seedKiwiTruthsIfNeeded() {
         truthsSeedingMutex.withLock {
-            if (jandalPersona.isTruthsSeeded) return
+            if (jandalPersona.isTruthsSeeded) {
+                // Guard against stale flag: DB may have been wiped (e.g. migration) while
+                // the SharedPreferences flag remained true. Re-seed if no jandal_persona
+                // memories are actually present.
+                val seededCount = memoryRepository.countCoreMemoriesBySource("jandal_persona")
+                if (seededCount > 0) return
+                Log.w("ChatViewModel", "truths_seeded flag was set but DB has 0 jandal_persona memories — re-seeding")
+                jandalPersona.resetTruthsSeeded()
+            }
             jandalPersona.truths.forEach { truth ->
                 val vector = embeddingEngine.embed(truth).takeIf { it.isNotEmpty() }
                     ?: return@forEach  // skip if engine not ready

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -982,7 +982,11 @@ class ChatViewModel @Inject constructor(
                                     thinkingText = thinking,
                                     toolCallJson = toolCallJsonStr,
                                 )
-                                ragRepository.indexMessage(savedId, convId, resultContent)
+                                // Only index knowledge results (e.g. Wikipedia) — not device
+                                // actions, weather, or system info which are ephemeral (#614).
+                                if (shouldIndexToolCallResult(toolCall.skillName)) {
+                                    ragRepository.indexMessage(savedId, convId, resultContent)
+                                }
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
                                     contextWindowManager.estimateTokens(resultContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
@@ -1030,7 +1034,10 @@ class ChatViewModel @Inject constructor(
                                     msgs.map { if (it.id == assistantMsgId) it.copy(content = displayContent, isStreaming = false) else it }
                                 }
                                 val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", displayContent, thinking)
-                                ragRepository.indexMessage(savedAssistantMsgId, convId, displayContent)
+                                // Don't index hallucination error messages — they're noise (#614).
+                                if (!isHallucination) {
+                                    ragRepository.indexMessage(savedAssistantMsgId, convId, displayContent)
+                                }
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +
                                     contextWindowManager.estimateTokens(displayContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
@@ -1356,6 +1363,24 @@ private const val HALLUCINATION_RETRY_CORRECTION =
     "[System: Your previous response was blocked. It appeared to describe performing an action " +
     "without actually calling the required tool function. You MUST call the appropriate tool — " +
     "do not narrate results. If the tool is unavailable, say so honestly.]"
+
+/**
+ * Returns true if a tool call result should be indexed in episodic RAG memory.
+ *
+ * Device actions, weather, and system info are ephemeral — indexing them causes the
+ * model to surface stale device state as facts in future turns (#614). Knowledge
+ * results (e.g. Wikipedia via run_js) are worth recalling.
+ */
+private fun shouldIndexToolCallResult(skillName: String): Boolean = when (skillName) {
+    "run_intent",       // device actions — transient state, not facts
+    "get_weather",      // ephemeral — must always call live
+    "get_system_info",  // ephemeral — time/date always stale
+    "load_skill",       // meta-tool — no content value
+    "save_memory",      // memory system handles indexing separately
+    "search_memory",    // read-only, no new content
+    -> false
+    else -> true        // run_js (wikipedia etc.) — knowledge worth recalling
+}
 
 private fun formatBytes(bytes: Long): String = when {
     bytes >= 1_073_741_824L -> "%.1f GB".format(bytes / 1_073_741_824.0)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -540,8 +540,11 @@ class ChatViewModel @Inject constructor(
     /**
      * Immediately appends a completed assistant message to the UI and persists it to Room.
      * Used by the QuickIntentRouter skill-dispatch path where there is no streaming.
+     *
+     * [shouldIndex] — set false for device action responses, slot-fill prompts, and error
+     * messages that should not surface in future RAG retrievals.
      */
-    private suspend fun appendAssistantMessage(convId: String, content: String) {
+    private suspend fun appendAssistantMessage(convId: String, content: String, shouldIndex: Boolean = true) {
         val msgId = UUID.randomUUID().toString()
         val msg = ChatMessage(
             id = msgId,
@@ -550,7 +553,7 @@ class ChatViewModel @Inject constructor(
         )
         _messages.update { it + msg }
         val savedId = conversationRepository.addMessage(convId, "assistant", content)
-        ragRepository.indexMessage(savedId, convId, content)
+        if (shouldIndex) ragRepository.indexMessage(savedId, convId, content)
     }
 
     /** Like [appendAssistantMessage] but also attaches a [ToolCallInfo] chip so the UI shows
@@ -587,7 +590,7 @@ class ChatViewModel @Inject constructor(
             convId, "assistant", content,
             toolCallJson = toolCallJsonStr,
         )
-        ragRepository.indexMessage(savedId, convId, content)
+        if (shouldIndexToolCallResult(skillName)) ragRepository.indexMessage(savedId, convId, content)
     }
 
     fun retryDownload(model: KernelModel) {
@@ -632,6 +635,9 @@ class ChatViewModel @Inject constructor(
             // Set by the Tier 2 intercept when a skill executes successfully; injected into
             // the E4B prompt so it can generate a natural conversational wrapper.
             var systemContext: String? = null
+            // Set true when QIR routes to a device action — suppresses RAG indexing for
+            // both the user message and the LLM wrapper response (#614).
+            var isDeviceActionExchange = false
 
             try {
             val userMsgId = UUID.randomUUID().toString()
@@ -642,7 +648,7 @@ class ChatViewModel @Inject constructor(
             )
             _messages.update { it + userMessage }
             val savedUserMsgId = conversationRepository.addMessage(convId, "user", text)
-            ragRepository.indexMessage(savedUserMsgId, convId, text)
+            // User message indexing is deferred — skipped for device-action exchanges (see below).
 
             // After the very first user message, immediately set a placeholder title from the
             // first ~40 characters of the message so the conversation list never shows a blank
@@ -679,15 +685,15 @@ class ChatViewModel @Inject constructor(
                                         isSuccess = true,
                                     )
                                 }
-                                is SkillResult.Success -> appendAssistantMessage(convId, skillResult.content)
-                                is SkillResult.Failure -> appendAssistantMessage(convId, skillResult.error)
-                                else -> appendAssistantMessage(convId, "Something went wrong.")
+                                is SkillResult.Success -> appendAssistantMessage(convId, skillResult.content, shouldIndex = false)
+                                is SkillResult.Failure -> appendAssistantMessage(convId, skillResult.error, shouldIndex = false)
+                                else -> appendAssistantMessage(convId, "Something went wrong.", shouldIndex = false)
                             }
                         }
                         return@launch
                     }
                     is SlotFillResult.Cancelled -> {
-                        appendAssistantMessage(convId, "Okay, cancelled.")
+                        appendAssistantMessage(convId, "Okay, cancelled.", shouldIndex = false)
                         return@launch
                     }
                 }
@@ -710,6 +716,7 @@ class ChatViewModel @Inject constructor(
                     appendAssistantMessage(
                         convId,
                         slotFillerManager.pendingRequest?.promptMessage ?: "What would you like to say?",
+                        shouldIndex = false,
                     )
                     return@launch
                 }
@@ -733,6 +740,7 @@ class ChatViewModel @Inject constructor(
                 // Router intent names (e.g. "toggle_flashlight_on") are sub-intent values
                 // handled by the run_intent skill — they aren't top-level skill names.
                 // Resolve: direct skill match first, then fall back to run_intent.
+                isDeviceActionExchange = true
                 val directSkill = skillRegistry.get(matchedIntent.intentName)
                 val (skill, callParams) = when {
                     directSkill != null -> directSkill to matchedIntent.params
@@ -762,7 +770,7 @@ class ChatViewModel @Inject constructor(
                             systemContext = "[System: ${matchedIntent.intentName} — ${skillResult.content}]"
                             // E4B not loaded yet: show action result directly and skip the wrapper.
                             if (!inferenceEngine.isReady.value) {
-                                appendAssistantMessage(convId, skillResult.content)
+                                appendAssistantMessage(convId, skillResult.content, shouldIndex = false)
                                 return@launch
                             }
                         }
@@ -781,11 +789,18 @@ class ChatViewModel @Inject constructor(
                 initGemma4()
                 if (!inferenceEngine.isReady.value) {
                     // Model still not ready (e.g. file absent) — tell the user and bail.
-                    appendAssistantMessage(convId, "Still loading the AI model, please try again in a moment.")
+                    appendAssistantMessage(convId, "Still loading the AI model, please try again in a moment.", shouldIndex = false)
                     return@launch
                 }
             }
             // _isLoadingModel is always cleared by the outer finally block below.
+
+            // Only index the user message when the exchange goes to the LLM (knowledge queries,
+            // conversational turns). Device-action exchanges (QIR match → run_intent) are skipped
+            // to prevent stale device state from polluting future RAG retrievals.
+            if (!isDeviceActionExchange) {
+                ragRepository.indexMessage(savedUserMsgId, convId, text)
+            }
 
             // 2. Gemma-4 streaming inference path.
             // Capture isFirstReply before adding the streaming placeholder — once the placeholder
@@ -1035,7 +1050,9 @@ class ChatViewModel @Inject constructor(
                                 }
                                 val savedAssistantMsgId = conversationRepository.addMessage(convId, "assistant", displayContent, thinking)
                                 // Don't index hallucination error messages — they're noise (#614).
-                                if (!isHallucination) {
+                                // Don't index LLM wrappers around device actions — stale device state
+                                // ("The light's on!") poisons future RAG retrievals (#614).
+                                if (!isHallucination && !isDeviceActionExchange) {
                                     ragRepository.indexMessage(savedAssistantMsgId, convId, displayContent)
                                 }
                                 estimatedTokensUsed += contextWindowManager.estimateTokens(text) +


### PR DESCRIPTION
## Summary

Fixes #618 — seed memories (Kiwi truths) were not populating at startup after a DB wipe or schema migration.

## Root Cause

`JandalPersona.isTruthsSeeded` reads a SharedPreferences flag (`truths_seeded`) that persists across DB recreations. After a migration or full data clear, the `core_memories` table is empty but the flag is still `true` — so `seedKiwiTruthsIfNeeded()` returned immediately every time, leaving Jandal's identity truths permanently absent.

The `no such table: core_memories_vec` warning seen in logs was a symptom of the same problem: vec table creation is triggered by the first insert, which never happened.

## Changes

- **`CoreMemoryDao`** — added `countBySource(source: String): Int` query
- **`MemoryRepository` / `MemoryRepositoryImpl`** — exposed `countCoreMemoriesBySource()` method
- **`JandalPersona`** — added `resetTruthsSeeded()` helper to clear the stale flag
- **`ChatViewModel.seedKiwiTruthsIfNeeded()`** — if `isTruthsSeeded=true`, verify at least one `jandal_persona` row exists in the DB; if not, reset the flag and re-seed with a warning log

## Behaviour After Fix

- First launch (fresh install): seeds normally as before ✅
- Subsequent launches (flag=true, rows present): skips seeding, no extra DB query cost (single `COUNT` query) ✅
- After DB wipe / migration (flag=true, rows=0): detects mismatch, logs warning, resets flag, re-seeds ✅

## Testing

- [ ] Fresh install — 8 Kiwi truths appear in Core Memories screen
- [ ] Force-stop + relaunch — no re-seeding (flag respected when rows present)
- [ ] Clear app data → relaunch — truths re-seeded correctly

## Related Issues

Closes #618
Unblocks #500 (core memory UX)
