### PR TITLE
docs: triage unlabelled issues — add phase labels, milestones, and roadmap entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,353 @@
-# Contributing to Kernel AI Assistant
+# Contributing to Jandal AI
 
-## PR & Review Workflow
+Welcome! This document describes how development on this project works — branching, CI, documentation, labelling, and everything in between.
 
-All changes go through a PR — direct pushes to `main` are blocked by branch protection.
+---
 
-### Standard Flow
+## Table of Contents
 
-1. **Implement** on a feature branch (`feat/`, `fix/`, `docs/` prefix)
-2. **Open PR** targeting `main` — title should reference the issue number (e.g. `fix: enable episodic RAG (#233)`)
-3. **CI must pass** — "Build & Test" check is required before merge
-4. **Unit tests** — significant new logic (parsers, use cases, repositories, ViewModels) should include unit tests. Use JUnit 5 + MockK. See `core/skills/src/test/` and `core/memory/src/test/` for examples. Copilot code-reviewer will flag missing coverage on critical paths.
-4. **Code review** — run the Copilot code-reviewer agent on the PR
-5. **Address findings:**
-   - **Major issues** (bugs, logic errors, data loss risk, crashes) → fix on the branch, then run a scoped re-review on the fix commits only
-   - **Minor issues** (cosmetic, trivial, low-risk) → fix and go straight to merge, no re-review needed
-6. **Merge** — always squash merge: `gh pr merge --squash --admin --delete-branch`
+1. [Project Structure](#project-structure)
+2. [Development Setup](#development-setup)
+3. [Branch Strategy](#branch-strategy)
+4. [Commit Messages](#commit-messages)
+5. [Pull Request Workflow](#pull-request-workflow)
+6. [CI / Build Checks](#ci--build-checks)
+7. [Testing](#testing)
+8. [Issue Lifecycle](#issue-lifecycle)
+9. [Labels](#labels)
+10. [Milestones](#milestones)
+11. [Documentation](#documentation)
+12. [Code Style](#code-style)
 
-### Branch Naming
+---
 
-| Prefix | Use |
-|--------|-----|
-| `feat/` | New features |
-| `fix/` | Bug fixes |
-| `docs/` | Documentation only |
-| `refactor/` | Refactors with no behaviour change |
-| `chore/` | Build, deps, tooling |
+## Project Structure
 
-### Commit Messages
+Multi-module Gradle project. Each feature or concern lives in its own module:
+
+```
+app/                        → Application module, NavHost, Hilt entry point
+core/
+  inference/                → LiteRT-LM engine, model loading, JandalPersona, QIR
+  memory/                   → Room DB, RAG pipeline, vector search (sqlite-vec NDK)
+  skills/                   → Skill registry, SkillExecutor, tool call parsing
+  data/                     → DataStore preferences, repositories
+  ui/                       → Shared Compose components
+feature/
+  chat/                     → ConversationListScreen, ChatScreen, ChatViewModel
+  settings/                 → SettingsScreen, ModelManagementScreen, MemoryScreen
+  actions/                  → Quick Actions tab, ActionsViewModel, slot-fill state machine
+  lists/                    → Lists CRUD UI and ViewModel
+  alarms/                   → Alarms screen, AlarmViewModel
+  contacts/                 → People & Contacts screen
+docs/
+  ROADMAP.md                → Living roadmap — keep in sync with issues
+  SPECIFICATION.md          → Authoritative technical reference
+scripts/                    → ADB test harness, device automation tools
+```
+
+---
+
+## Development Setup
+
+### Requirements
+
+- Android Studio Meerkat or newer
+- Android SDK 35 (Android 15) — min SDK
+- JDK 17+
+- A physical device with Snapdragon 8 Gen 2+ or equivalent for on-device testing (emulator cannot run LiteRT GPU inference)
+
+### First run
+
+```bash
+git clone https://github.com/NickMonrad/kernel-ai-assistant.git
+cd kernel-ai-assistant
+./gradlew assembleDebug
+```
+
+First build compiles the NDK SQLite + sqlite-vec shared library (`libkernelvec.so`) which takes a few minutes. Subsequent builds are incremental.
+
+### Tested Devices
+
+| Device | Chip | RAM | Backend |
+|--------|------|-----|---------|
+| Samsung Galaxy S23 Ultra | Snapdragon 8 Gen 2 (SM8550) | 12 GB | NPU (Hexagon) |
+| Google Pixel 10 | Tensor G5 | 12 GB | GPU |
+
+---
+
+## Branch Strategy
+
+**`main` is protected.** Direct pushes are blocked. All changes go through a PR with a passing CI check.
+
+### Naming convention
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat/NNN-short-description` | New feature tied to an issue |
+| `fix/NNN-short-description` | Bug fix tied to an issue |
+| `docs/short-description` | Documentation only — no code change |
+| `refactor/short-description` | Refactor with no behaviour change |
+| `chore/short-description` | Build, deps, tooling |
+
+Examples:
+```
+feat/602-nav-restructure
+fix/618-seed-memories-stale-flag
+docs/triage-phase-labels
+```
+
+### Rules
+
+- Branch off `main` — never off another feature branch
+- One issue per branch where practical; complex epics may span one branch but should still be scoped
+- Delete the branch after merge (`--delete-branch` flag on `gh pr merge`)
+
+---
+
+## Commit Messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):
-```
-fix: short description (#issue-number)
-feat: short description (#issue-number)
-docs: short description
-```
 
-Always include the co-authored-by trailer for Copilot-assisted commits:
 ```
+type(scope): short description (#issue-number)
+
+Optional longer body if the change is non-obvious.
+
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ```
 
-### Issues & Roadmap
+**Types:** `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `perf`
 
-- All significant work should have a GitHub issue
-- Issues on the roadmap get the `roadmap` label and are assigned to the active milestone
-- Sub-issues are linked via GitHub's sub-issue relationship (not just cross-references)
-- `docs/ROADMAP.md` and `docs/SPECIFICATION.md` are kept in sync with issue state — update them in the same PR as the code change where possible
+**Scope:** optional; use the module name (e.g. `memory`, `qir`, `settings`, `chat`)
 
-### Milestones
+Examples:
+```
+feat(memory): add countBySource to CoreMemoryDao (#618)
+fix(qir): re-seed kiwi truths when DB wiped — stale SharedPrefs flag (#618)
+docs: update ROADMAP with 3G slot-fill sub-issues
+```
 
-| Milestone | Focus |
-|-----------|-------|
-| Phase 3: Resident Agent + Native Skills | Active — Gemma-4 E4B, skill framework, memory tools, Jandal personality |
-| Phase 4: Dreaming Engine | Planned — overnight distillation, semantic cache, self-healing identity |
+Always include the `Co-authored-by` trailer for Copilot-assisted commits.
 
-### Memory & Specification Docs
+---
 
-- `docs/SPECIFICATION.md` — authoritative technical reference; update whenever architecture or behaviour changes
-- `docs/ROADMAP.md` — living roadmap; mark issues done when closed, add new issues when raised
+## Pull Request Workflow
+
+### Steps
+
+1. **Create branch** — from `main`, using the naming convention above
+2. **Implement** — write code, tests, and update docs in the same PR where possible
+3. **Build locally** before opening PR:
+   ```bash
+   ./gradlew :app:assembleDebug
+   ```
+4. **Open PR** via `gh pr create --body-file` (use a file to avoid shell escaping issues with multi-line bodies)
+5. **CI must pass** — "Build & Test" check is required; PRs without a green check cannot merge
+6. **Code review** — run the Copilot code-reviewer agent on non-trivial PRs
+7. **Address findings:**
+   - **Major** (bugs, data loss risk, crashes, logic errors) → fix on the branch, request scoped re-review
+   - **Minor** (cosmetic, trivial, style) → fix and go straight to merge
+8. **Merge** — always squash merge:
+   ```bash
+   gh pr merge NNN --squash --admin --delete-branch
+   ```
+
+### PR Title Format
+
+```
+type(scope): short description (#issue-number)
+```
+
+Matches commit convention. The issue number in the title links the PR to the issue in GitHub's UI.
+
+### PR Body Template
+
+```markdown
+## Summary
+What this PR does and why.
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+- [ ] Builds clean (`./gradlew :app:assembleDebug`)
+- [ ] Manual testing on device
+- [ ] Unit tests pass
+
+## Related issues
+Closes #NNN
+```
+
+---
+
+## CI / Build Checks
+
+The **"Build & Test"** GitHub Actions workflow runs on every PR and push to `main`:
+
+| Job | What it does |
+|-----|-------------|
+| `build` | `./gradlew assembleDebug` — full app build including NDK |
+| `unit-test` | `./gradlew testDebugUnitTest` — all JVM unit tests |
+
+**Required to merge:** the `Build & Test` check must be green. PRs with a failing build or failing unit tests cannot be merged.
+
+### Running CI locally
+
+```bash
+# Full build
+./gradlew assembleDebug
+
+# Unit tests only (faster)
+./gradlew testDebugUnitTest
+
+# Specific module
+./gradlew :core:memory:testDebugUnitTest
+```
+
+### NDK note
+
+The NDK (`libkernelvec.so`) is compiled as part of `:core:memory`. If you change `CMakeLists.txt` or the NDK sources, allow extra build time.
+
+---
+
+## Testing
+
+### Unit tests
+
+- Location: `<module>/src/test/java/`
+- Framework: JUnit 5 + MockK
+- Reference examples: `core/skills/src/test/`, `core/memory/src/test/`
+
+**What to test:** parsers, use cases, repositories, ViewModels, state machines, intent routing logic. Anything with branching logic that doesn't require Android framework.
+
+**What not to test:** UI composition (Compose preview tests are not required), simple data classes, generated Room DAOs.
+
+### On-device testing
+
+Use the ADB test harness in `scripts/` for intent routing regression:
+
+```bash
+# Run full NL test suite via ADB
+python3 scripts/adb_skill_test.py --device <serial>
+```
+
+See `docs/adb-testing.md` for full harness documentation.
+
+### Writing tests for new features
+
+- New intent patterns in `QuickIntentRouter` → add to the regex test suite
+- New slot-fill paths → add `ActionsViewModelTest` cases
+- New skill implementations → add `SkillExecutorTest` cases
+- New memory operations → add DAO and repository tests
+
+---
+
+## Issue Lifecycle
+
+1. **File** — open an issue with a clear title. Link to parent epic if applicable
+2. **Triage** — add labels (phase, type, priority, size), set milestone
+3. **Assign** — add `go:yes` when ready to implement; `go:needs-research` for spikes
+4. **Branch** — create a `feat/NNN-` or `fix/NNN-` branch
+5. **PR** — open PR, reference issue with `Closes #NNN`
+6. **Merge** — PR merge auto-closes the issue
+7. **Roadmap** — mark the issue done in `docs/ROADMAP.md` (same PR or follow-up `docs/` PR)
+
+Sub-issues are tracked using GitHub's native sub-issue relationship. Parent epics use the `type:epic` label.
+
+---
+
+## Labels
+
+### Phase
+
+| Label | Meaning |
+|-------|---------|
+| `Phase 3` | Phase 3: Resident Agent + Native Skills |
+
+### Priority
+
+| Label | Meaning |
+|-------|---------|
+| `priority:p0` | Blocking release — fix immediately |
+| `priority:p1` | This sprint |
+| `priority:p2` | Next sprint |
+| `priority:high` | Important, tackle soon (non-sprint) |
+| `priority:medium` | Useful, schedule when reasonable |
+| `priority:low` | Nice to have, no urgency |
+
+### Size / Complexity
+
+| Label | Effort |
+|-------|--------|
+| `size:XS` | < 2 hours — trivial change |
+| `size:S` | ~half day — well-defined |
+| `size:M` | 1–2 days — moderate complexity |
+| `size:L` | 3–5 days — significant work |
+| `size:XL` | Week+ — major/architectural |
+
+### Type
+
+| Label | Meaning |
+|-------|---------|
+| `type:feature` | New capability |
+| `type:bug` | Something broken |
+| `type:chore` | Maintenance, refactoring |
+| `type:docs` | Documentation |
+| `type:epic` | Parent issue decomposed into sub-issues |
+| `type:spike` | Research — produces a plan, not code |
+
+### Status / Routing
+
+| Label | Meaning |
+|-------|---------|
+| `go:yes` | Ready to implement |
+| `go:needs-research` | Needs investigation before implementing |
+| `go:no` | Not pursuing |
+| `roadmap` | Incorporated into `docs/ROADMAP.md` |
+| `release:v0.x.x` | Targeted for a specific release |
+| `release:backlog` | Not yet scheduled |
+
+---
+
+## Milestones
+
+| Milestone | Status | Focus |
+|-----------|--------|-------|
+| Phase 3: Resident Agent + Native Skills | 🔄 Active | Skills, multi-turn dialog, memory, QIR improvements |
+| Phase 4: Dreaming Engine | ⬜ Planned | Overnight distillation, semantic cache, self-healing identity |
+| Phase 5: Wasm Runtime + Skill Store | ⬜ Planned | Community-extensible Wasm plugins |
+| Phase 6: Device Optimisation | ⬜ Planned | 8GB RAM support, dynamic model loading |
+| Tech Debt & Research | 🔄 Active | Spikes, cleanup, investigations |
+
+Assign new issues to the relevant milestone when labelling. Issues with no target yet get `release:backlog`.
+
+---
+
+## Documentation
+
+Three key docs — keep them in sync:
+
+| File | Purpose | When to update |
+|------|---------|----------------|
+| `README.md` | Public-facing overview, feature list, roadmap summary | When shipping a significant new feature; move it from "Coming Soon" to "Delivered" |
+| `docs/ROADMAP.md` | Technical living roadmap with sub-issue tables and design decisions | When an issue is filed (add to Ideas table), implemented (mark ✅), or phased (add to sub-section) |
+| `docs/SPECIFICATION.md` | Authoritative architecture and behaviour reference | When architecture or system behaviour changes — update in the same PR as the code |
+
+### README Delivered/Coming Soon
+
+- **Delivered** — shipped features with a merged PR. Add when you merge.
+- **Coming Soon** — issues with `go:yes` or `priority:p1/p2`. Include the issue number and phase tag.
+
+---
+
+## Code Style
+
+- **Kotlin** — follow standard Kotlin idioms; no explicit style linter enforced but match surrounding code
+- **Compose** — Material 3 components throughout; no custom theming layers
+- **No commented-out code** — delete dead code rather than commenting it out
+- **No TODOs in merged code** — convert to a GitHub issue instead
+- **Imports** — no wildcard imports; organise with IDE auto-format before commit
+- **Module boundaries** — `feature/` modules must not depend on each other; go through `core/` interfaces
+

--- a/README.md
+++ b/README.md
@@ -59,15 +59,19 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 
 ### Coming Soon
 - 🗣️ **Voice + text input** — tap-to-talk with auto-stop *(Phase 3)*
+- 💬 **Multi-turn dialog** — slot filling, confirmation, and context-switching across intents *(Phase 3G, #522)*
+- 🌦️ **Smarter intent routing** — colloquial phrases ("is it gonna rain?") routed natively *(Phase 3C, #608)*
+- 📅 **Native date arithmetic** — `date_diff` tool for reliable date calculations *(Phase 3C, #619)*
 - 🗒️ **Lists — stretch goals** — cards, swipe-to-complete, rich content, attachments, sorting *(Phase 3, #472)*
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen *(Phase 3, #479)*
+- 📱 **Homescreen widget** — quick actions and voice from the launcher *(Phase 3F, #617)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
 - ⚡ **Semantic cache** — instant responses for repeated knowledge queries *(Phase 4)*
 - 🪪 **Self-healing identity** — structured user profile, LLM-managed via Dreaming cycle *(Phase 4)*
 - 🧩 **Wasm skill store** — community-extensible plugins with sandboxed execution *(Phase 5)*
 - 🏠 **Home Assistant / Google Home** — smart home control *(Phase 5)*
 - 📱 **8GB device optimisation** — dynamic weight loading/unloading, E2B fallback *(Phase 6)*
-- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 3)*
+- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 3F)*
 
 ## Roadmap
 
@@ -75,7 +79,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 |-------|-------------|--------|
 | 1 | Core LiteRT-LM integration + GPU/NPU acceleration + Chat UI | ✅ |
 | 2 | sqlite-vec + EmbeddingGemma for local RAG + memory, UI polish, model selection | ✅ |
-| 3 | Native Skills (alarms, lists, weather, media, navigation) + episodic distillation + nav drawer + Brand refresh | 🔄 |
+| 3 | Native Skills (alarms, lists, weather, media, navigation) + multi-turn dialog + episodic distillation + nav drawer + Brand refresh | 🔄 |
 | 4 | Dreaming Engine (WorkManager overnight cycle) + Semantic Cache + Self-Healing Identity System | ⬜ |
 | 5 | Chicory Wasm runtime + GitHub Skill Store | ⬜ |
 | 6 | 8GB device optimization (dynamic weight loading) | ⬜ |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -183,6 +183,8 @@ The architectural foundation that determines tool call accuracy and response qua
 | Sub-Issue | Title | Status | Priority |
 |-----------|-------|--------|----------|
 | [#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222) | Rich tool result UI — weather cards, confirmation chips, list cards | ⬜ Pending | 🔴 High |
+| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM is unreliable) | ⬜ Pending | 🔴 High |
+| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | ⬜ Pending | 🔴 High |
 | [#261](https://github.com/NickMonrad/kernel-ai-assistant/issues/261) | Skill discoverability UI — settings screen with enable/disable | ⬜ Pending | 🟡 Medium |
 | [#256](https://github.com/NickMonrad/kernel-ai-assistant/issues/256) | SMS/email — pre-populate recipient from contacts | ⬜ Pending | 🟡 Medium |
 | [#258](https://github.com/NickMonrad/kernel-ai-assistant/issues/258) | Maps & location — navigate, open, nearby search | ⬜ Pending | 🟡 Medium |
@@ -260,6 +262,12 @@ Slot filling, disambiguation, confirmation, and context-switching — transforms
 | [#493](https://github.com/NickMonrad/kernel-ai-assistant/issues/493) | Multi-turn spike — slot fill loop for `send_sms` | ✅ Done (spike) | 🔴 High |
 | [#518](https://github.com/NickMonrad/kernel-ai-assistant/issues/518) | Research: dialog state machine patterns (Gemini brainstorm) | ✅ Done (research) | — |
 | [#522](https://github.com/NickMonrad/kernel-ai-assistant/issues/522) | Phase 2: full dialog management — 7 conversational paths, session stack, slot schemas for 9 intents | ⬜ Pending | 🔴 High |
+| [#621](https://github.com/NickMonrad/kernel-ai-assistant/issues/621) | Dispatch pending intent on user confirmation (multi-turn QIR) | ⬜ Pending | 🔴 High |
+| [#620](https://github.com/NickMonrad/kernel-ai-assistant/issues/620) | Bypass `needsConfirmation` for no-param MiniLM matches | ⬜ Pending | 🔴 High |
+| [#591](https://github.com/NickMonrad/kernel-ai-assistant/issues/591) | NeedsSlot for remaining bare-query intents (`make_call`, `create_calendar_event`, etc.) | ⬜ Pending | 🟡 Medium |
+| [#601](https://github.com/NickMonrad/kernel-ai-assistant/issues/601) | Multi-slot: re-check for missing slots after each slot reply | ⬜ Pending | 🟡 Medium |
+| [#600](https://github.com/NickMonrad/kernel-ai-assistant/issues/600) | Slot fill spec: document expected multi-step interactions per intent | ⬜ Pending | 🟡 Medium |
+| [#599](https://github.com/NickMonrad/kernel-ai-assistant/issues/599) | Unit tests for ActionsViewModel slot-fill state machine | ⬜ Pending | 🟡 Medium |
 
 **Key design decisions (from #518 research):**
 - State machine: `IDLE → QIR_MATCH → SLOT_FILLING ↔ AWAITING_SLOT → CONFIRMING → EXECUTING`
@@ -471,6 +479,17 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#525](https://github.com/NickMonrad/kernel-ai-assistant/issues/525) | Timer management — list, pause, cancel individual timers | Phase 3H | ✅ Done — PR #520 |
 | [#526](https://github.com/NickMonrad/kernel-ai-assistant/issues/526) | Side panel: active alarms and timers in nav drawer | Phase 3H | ✅ Done — PR #530 |
 | [#529](https://github.com/NickMonrad/kernel-ai-assistant/issues/529) | Improve LLM tool selection for bulk list operations | Phase 3H | 🔄 Open — on-device verification needed |
+| [#591](https://github.com/NickMonrad/kernel-ai-assistant/issues/591) | NeedsSlot for remaining bare-query intents (`make_call`, `create_calendar_event`, etc.) | Phase 3G | ⬜ Pending |
+| [#593](https://github.com/NickMonrad/kernel-ai-assistant/issues/593) | Minor UX: icon on model download screen | Phase 3B | ⬜ Pending |
+| [#599](https://github.com/NickMonrad/kernel-ai-assistant/issues/599) | Unit tests for ActionsViewModel slot-fill state machine | Phase 3G | ⬜ Pending |
+| [#600](https://github.com/NickMonrad/kernel-ai-assistant/issues/600) | Slot fill spec: document expected multi-step interactions per intent | Phase 3G | ⬜ Pending |
+| [#601](https://github.com/NickMonrad/kernel-ai-assistant/issues/601) | Multi-slot: re-check for missing slots after each slot reply | Phase 3G | ⬜ Pending |
+| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | Phase 3C | ⬜ Pending |
+| [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | Phase 3F | ⬜ Pending |
+| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM arithmetic unreliable) | Phase 3C | ⬜ Pending |
+| [#620](https://github.com/NickMonrad/kernel-ai-assistant/issues/620) | Bypass `needsConfirmation` for no-param MiniLM matches | Phase 3G | ⬜ Pending |
+| [#621](https://github.com/NickMonrad/kernel-ai-assistant/issues/621) | Multi-turn QIR: dispatch pending intent on user confirmation | Phase 3G | ⬜ Pending |
+| [#624](https://github.com/NickMonrad/kernel-ai-assistant/issues/624) | Add more NZ truth memories (Kiwi memes + cultural touchpoints) | Phase 3B | ⬜ Pending |
 
 ---
 


### PR DESCRIPTION
## Summary
Triage pass on all open issues without phase assignments. Labels, milestones, and ROADMAP.md all updated in one go.

## Issues triaged

| # | Phase | Priority | Size | Notes |
|---|-------|----------|------|-------|
| #621 | 3G | p1 | S | Multi-turn QIR dispatch on confirmation |
| #620 | 3G | p1 | XS | Bypass needsConfirmation for no-param matches |
| #619 | 3C | p1 | S | date_diff native impl — LLM arithmetic unreliable |
| #608 | 3C | p1 | S | Colloquial weather phrases fall through to LLM |
| #601 | 3G | p2 | M | Multi-slot re-check after each slot reply |
| #600 | 3G | p2 | S | Slot fill spec documentation |
| #599 | 3G | p2 | M | Unit tests for ActionsViewModel slot-fill |
| #591 | 3G | p2 | M | NeedsSlot for remaining bare-query intents |
| #500 | 3D | p2 | M | Core memory UX |
| #617 | 3F | medium | L | Homescreen widget — release:backlog |
| #593 | 3B | low | XS | Model download screen icon |
| #624 | 3B | low | XS | More NZ truth memories |

## Changes
- Added `Phase 3`, priority, size, `go:yes`/`go:no` labels to all 12 issues via `gh issue edit`
- Set milestone `Phase 3: Resident Agent + Native Skills` on all except #593 and #624
- Updated `docs/ROADMAP.md`:
  - Expanded 3G sub-issue table with #591, #599, #600, #601, #620, #621
  - Added #619 and #608 to 3C sub-issue table
  - Added all 13 issues to the Ideas & Enhancements tracking table
