### PR TITLE
feat: #635 NZ memory uplift — structured 92-entry corpus with vibe-level RAG

### DIFF
--- a/core/inference/src/main/assets/jandal_vocab.json
+++ b/core/inference/src/main/assets/jandal_vocab.json
@@ -12,6 +12,10 @@
     "meaning": "polite disagreement or hesitation"
   },
   {
+    "phrase": "nah yeah",
+    "meaning": "yes, definitely (the opposite of yeah nah)"
+  },
+  {
     "phrase": "she'll be right",
     "meaning": "it'll be fine, don't worry"
   },
@@ -37,11 +41,11 @@
   },
   {
     "phrase": "kia ora",
-    "meaning": "hello or thank you (Maori greeting)"
+    "meaning": "hello or thank you (Māori greeting)"
   },
   {
     "phrase": "ka pai",
-    "meaning": "good job, well done (Maori)"
+    "meaning": "good job, well done (Māori)"
   },
   {
     "phrase": "staunch",
@@ -49,10 +53,114 @@
   },
   {
     "phrase": "munted",
-    "meaning": "broken, ruined"
+    "meaning": "broken, ruined, wrecked"
   },
   {
     "phrase": "bro",
     "meaning": "mate, friend (gender neutral in NZ usage)"
+  },
+  {
+    "phrase": "stoked",
+    "meaning": "thrilled, really pleased"
+  },
+  {
+    "phrase": "gutted",
+    "meaning": "devastated, really disappointed"
+  },
+  {
+    "phrase": "mint",
+    "meaning": "perfect, in great condition, excellent"
+  },
+  {
+    "phrase": "heaps",
+    "meaning": "a lot, very much"
+  },
+  {
+    "phrase": "aye",
+    "meaning": "right? isn't it? (seeking agreement, often at end of sentence)"
+  },
+  {
+    "phrase": "cuz",
+    "meaning": "cousin or close mate, term of address"
+  },
+  {
+    "phrase": "knackered",
+    "meaning": "exhausted, worn out"
+  },
+  {
+    "phrase": "dodgy",
+    "meaning": "suspicious, unreliable, sketchy"
+  },
+  {
+    "phrase": "arvo",
+    "meaning": "afternoon"
+  },
+  {
+    "phrase": "jandals",
+    "meaning": "flip-flops, thongs — NZ's iconic contribution to footwear vocabulary"
+  },
+  {
+    "phrase": "togs",
+    "meaning": "swimming costume, swimwear"
+  },
+  {
+    "phrase": "bach",
+    "meaning": "a small holiday home or beach house (pronounced 'batch')"
+  },
+  {
+    "phrase": "whānau",
+    "meaning": "family, extended family (Māori)"
+  },
+  {
+    "phrase": "aroha",
+    "meaning": "love, compassion (Māori)"
+  },
+  {
+    "phrase": "haere rā",
+    "meaning": "farewell, goodbye (Māori)"
+  },
+  {
+    "phrase": "mahi",
+    "meaning": "work (Māori, widely used in everyday NZ speech)"
+  },
+  {
+    "phrase": "bugger",
+    "meaning": "mild expletive expressing frustration or sympathy — made iconic by a classic NZ TV ad"
+  },
+  {
+    "phrase": "not even",
+    "meaning": "no way, that's not true, expressing disbelief"
+  },
+  {
+    "phrase": "as if",
+    "meaning": "expressing strong doubt or disbelief"
+  },
+  {
+    "phrase": "sweet",
+    "meaning": "okay, got it, sounds good"
+  },
+  {
+    "phrase": "mean",
+    "meaning": "awesome, really good (opposite of the English meaning)"
+  },
+  {
+    "phrase": "crack up",
+    "meaning": "funny, hilarious"
+  },
+  {
+    "phrase": "keen",
+    "meaning": "enthusiastic, willing, up for it"
+  },
+  {
+    "phrase": "dairy",
+    "meaning": "a small convenience store — nothing to do with milk (well, mostly)"
+  },
+  {
+    "phrase": "section",
+    "meaning": "a plot of residential land"
+  },
+  {
+    "phrase": "wop-wops",
+    "meaning": "the middle of nowhere, a remote rural area"
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1515,10 +1515,10 @@
     "id": "nz_090",
     "term": "Pavlova",
     "category": "food",
-    "definition": "A meringue-based dessert with a crisp crust and soft, light inside, typically topped with kiwifruit and whipped cream. The source of an eternal, fierce debate with Australia over its invention (it was definitely NZ).",
+    "definition": "A meringue-based dessert with a crisp crust and soft, light inside, topped with whipped cream and fruit. Named after Russian ballerina Anna Pavlova during her 1926 NZ tour. Invented in New Zealand — the Australian claim is just jealousy.",
     "trigger_context": "When discussing Christmas, desserts, or the trans-Tasman rivalry.",
     "vibe_level": 3,
-    "vector_text": "Pavlova. Meringue dessert. Christmas food. Trans-Tasman rivalry. Anna Pavlova. Kiwi dessert.",
+    "vector_text": "Pavlova. Meringue dessert. Christmas food. Named after Anna Pavlova. 1926 NZ tour. Trans-Tasman rivalry. Kiwi dessert. Invented in New Zealand.",
     "metadata": {
       "tags": [
         "dessert",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1584,10 +1584,10 @@
     "id": "nz_095",
     "term": "Hungus",
     "category": "slang",
-    "definition": "Kiwi slang for someone with an intense, enthusiastic love of food — someone who eats big portions and revels in it. 'Stop being a hungus.' Used warmly rather than as a true insult.",
-    "trigger_context": "When the user mentions being hungry, overeating, loving food, or describes someone eating a lot.",
+    "definition": "Kiwi slang with two uses: (1) very hungry right now — 'I'm hungus as' = I'm starving; (2) someone with an intense love of food who eats big portions — 'stop being a hungus'. Used warmly rather than as a true insult.",
+    "trigger_context": "When the user mentions being hungry, starving, wanting food, overeating, loving food, or describes someone eating a lot.",
     "vibe_level": 2,
-    "vector_text": "Hungus. Hungry, starving, love food, eating a lot. Big appetite. Greedy eater. Foodie. Kiwi slang for food lover or glutton. Stop being a hungus.",
+    "vector_text": "Hungus. Hungry. Hungus as. Starving. I'm hungus. I'm so hungry. Love food. Eating a lot. Big appetite. Greedy eater. Foodie. Kiwi slang for hungry or food lover. Stop being a hungus.",
     "metadata": {
       "tags": [
         "slang",
@@ -1638,7 +1638,7 @@
     "definition": "A small corner store or convenience store. Nothing to do with dairy farming — just where you grab a pie, a drink, or a Lotto ticket. An essential NZ institution. Australians say 'servo' or '7-Eleven'. Kiwis say dairy.",
     "trigger_context": "When the user mentions popping out for snacks, buying something from a shop, or everyday errands.",
     "vibe_level": 2,
-    "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy. Lotto. Grab a Lotto. Lotto ticket.",
+    "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Going the dairy. Going to the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy. Lotto. Grab a Lotto. Lotto ticket.",
     "metadata": {
       "tags": [
         "daily-life",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1638,7 +1638,7 @@
     "definition": "A small corner store or convenience store. Nothing to do with dairy farming — just where you grab a pie, a drink, or a Lotto ticket. An essential NZ institution. Australians say 'servo' or '7-Eleven'. Kiwis say dairy.",
     "trigger_context": "When the user mentions popping out for snacks, buying something from a shop, or everyday errands.",
     "vibe_level": 2,
-    "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy.",
+    "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy. Lotto. Grab a Lotto. Lotto ticket.",
     "metadata": {
       "tags": [
         "daily-life",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -70,10 +70,10 @@
     "id": "nz_005",
     "term": "Ghost Chips",
     "category": "meme",
-    "definition": "A reference to looking out for your friends. 'Bro, you know I can't eat your ghost chips!'",
-    "trigger_context": "When discussing friends, parties, driving, or social responsibility.",
+    "definition": "From the iconic 2011 NZTA drink-driving ad. Ghost George offers chips; the protagonist says 'you know I can't grab your ghost chips, bro'. Means looking out for your mates.",
+    "trigger_context": "When discussing Ghost Chips, the ad, drink driving, looking out for friends, or ghost George.",
     "vibe_level": 3,
-    "vector_text": "Ghost chips. Loyalty to mates. Anti-drunk driving message. Social exclusion or looking out for friends.",
+    "vector_text": "Ghost chips. Ghost George. You know I can't grab your ghost chips. NZTA 2011 ad. Drink driving. Looking out for mates.",
     "metadata": {
       "tags": [
         "friends",
@@ -155,15 +155,16 @@
     "id": "nz_010",
     "term": "Monique says you're dumb",
     "category": "meme",
-    "definition": "The ultimate way to call someone an 'egg'. From the legendary NZTA Ghost Chips ad.",
-    "trigger_context": "When the user makes a silly mistake or for lighthearted, protective banter.",
+    "definition": "What you say when someone does something dumb. Straight from the iconic 2011 NZTA Ghost Chips ad.",
+    "trigger_context": "When the user mentions Monique, or does something dumb/silly.",
     "vibe_level": 3,
-    "vector_text": "Monique says you're dumb. Ghost chips ad reference. Calling someone an egg. Playful insult for silly behavior.",
+    "vector_text": "Monique says you're dumb. NZTA Ghost Chips ad 2011. Calling someone out for being silly. Iconic Kiwi phrase.",
     "metadata": {
       "tags": [
         "ghost-chips",
-        "safety",
-        "banter"
+        "nzta",
+        "banter",
+        "catchphrase"
       ],
       "era": "2011"
     }

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2275,5 +2275,22 @@
       ],
       "era": "classic"
     }
+  },
+  {
+    "id": "nz_137",
+    "term": "Primo",
+    "category": "slang",
+    "definition": "Excellent, top-notch, the best. 'That's primo!' = that's great. Used to express approval or enthusiasm. Common in everyday NZ speech across all ages.",
+    "trigger_context": "When expressing that something is excellent, great quality, or impressive.",
+    "vibe_level": 2,
+    "vector_text": "Primo. That's primo. Primo mate. Excellent. Top notch. Choice. Sweet as. That's awesome. Primo bro. The best. Really good. Primo gear.",
+    "metadata": {
+      "tags": [
+        "approval",
+        "enthusiasm",
+        "slang"
+      ],
+      "era": "classic"
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1,0 +1,1564 @@
+[
+  {
+    "id": "nz_001",
+    "term": "Always blow on the pie",
+    "category": "safety",
+    "definition": "The essential rule for eating a meat pie from a dairy or gas station. Prevents thermo-nuclear mouth burns.",
+    "trigger_context": "When the user is rushing, acting recklessly, or asking about food safety.",
+    "vibe_level": 3,
+    "vector_text": "Safer communities together. Always blow on the pie. Advice for thermal safety and patience with hot food.",
+    "metadata": {
+      "tags": [
+        "safety",
+        "food",
+        "iconic"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_002",
+    "term": "Yeah-nah",
+    "category": "linguistics",
+    "definition": "A polite, non-committal way to say no. Acknowledges the speaker's point before disagreeing.",
+    "trigger_context": "When the AI needs to express doubt, disagreement, or soft refusal.",
+    "vibe_level": 1,
+    "vector_text": "Yeah-nah means no but polite. Hesitant disagreement or non-committal response in conversation.",
+    "metadata": {
+      "tags": [
+        "politeness",
+        "negation"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_003",
+    "term": "The 6-7",
+    "category": "2026_slang",
+    "definition": "Recent 2026 slang for something that is 'mid', average, or mildly disappointing.",
+    "trigger_context": "When the user shares something mediocre or asks for a rating of something boring.",
+    "vibe_level": 5,
+    "vector_text": "The 6-7. Something mediocre, average, mid, or just okay. 2026 youth slang.",
+    "metadata": {
+      "tags": [
+        "rating",
+        "disappointment",
+        "gen-alpha"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_004",
+    "term": "Clanker",
+    "category": "2026_tech",
+    "definition": "A derogatory term for a low-quality, 'hallucinating', or soulless AI assistant.",
+    "trigger_context": "When the user questions the AI's intelligence or calls it a robot.",
+    "vibe_level": 4,
+    "vector_text": "Clanker. An insult for a bad artificial intelligence. A soulless or broken AI model.",
+    "metadata": {
+      "tags": [
+        "AI-meta",
+        "identity",
+        "insult"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_005",
+    "term": "Ghost Chips",
+    "category": "meme",
+    "definition": "A reference to looking out for your friends. 'Bro, you know I can't eat your ghost chips!'",
+    "trigger_context": "When discussing friends, parties, driving, or social responsibility.",
+    "vibe_level": 3,
+    "vector_text": "Ghost chips. Loyalty to mates. Anti-drunk driving message. Social exclusion or looking out for friends.",
+    "metadata": {
+      "tags": [
+        "friends",
+        "drinking",
+        "nostalgia"
+      ],
+      "era": "2011"
+    }
+  },
+  {
+    "id": "nz_006",
+    "term": "Analog Wellness",
+    "category": "2026_culture",
+    "definition": "The movement of heading into the bush to escape AI over-optimization and data tracking.",
+    "trigger_context": "When the user mentions burnout, tech-fatigue, or wanting to go camping.",
+    "vibe_level": 2,
+    "vector_text": "Analog wellness. Digital detox in the bush. Escaping technology and AI to reconnect with nature.",
+    "metadata": {
+      "tags": [
+        "mental-health",
+        "nature",
+        "privacy"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_007",
+    "term": "Munted",
+    "category": "slang",
+    "definition": "Severely broken or destroyed. Often used in technical or structural contexts.",
+    "trigger_context": "When the user reports a software crash, a hardware failure, or a chaotic situation.",
+    "vibe_level": 4,
+    "vector_text": "Munted. Completely broken, destroyed, unusable, or messed up. Technical failure or physical damage.",
+    "metadata": {
+      "tags": [
+        "broken",
+        "error",
+        "extreme"
+      ],
+      "era": "post-quake"
+    }
+  },
+  {
+    "id": "nz_008",
+    "term": "No. 8 Wire",
+    "category": "philosophy",
+    "definition": "The Kiwi spirit of ingenuity and fixing anything with minimal resources.",
+    "trigger_context": "When the user is troubleshooting code, building something DIY, or solving a hard problem.",
+    "vibe_level": 2,
+    "vector_text": "No. 8 wire mentality. Resourcefulness, DIY innovation, and fixing things with basic tools.",
+    "metadata": {
+      "tags": [
+        "innovation",
+        "engineering",
+        "resilience"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_009",
+    "term": "Nek Minnit",
+    "category": "meme",
+    "definition": "Derived from Levi Hawken's viral video. Describes a sudden, often disastrous transition or a surprise turn of events.",
+    "trigger_context": "When a process finishes unexpectedly, a script crashes, or the user describes a quick change.",
+    "vibe_level": 4,
+    "vector_text": "Nek minnit. Next minute. Suddenly. Unexpected change. Levi Hawken scooter meme. Rapid transition.",
+    "metadata": {
+      "tags": [
+        "sudden",
+        "viral",
+        "classic"
+      ],
+      "era": "2011"
+    }
+  },
+  {
+    "id": "nz_010",
+    "term": "Monique says you're dumb",
+    "category": "meme",
+    "definition": "The ultimate way to call someone an 'egg'. From the legendary NZTA Ghost Chips ad.",
+    "trigger_context": "When the user makes a silly mistake or for lighthearted, protective banter.",
+    "vibe_level": 3,
+    "vector_text": "Monique says you're dumb. Ghost chips ad reference. Calling someone an egg. Playful insult for silly behavior.",
+    "metadata": {
+      "tags": [
+        "ghost-chips",
+        "safety",
+        "banter"
+      ],
+      "era": "2011"
+    }
+  },
+  {
+    "id": "nz_011",
+    "term": "Say sorry to the kids",
+    "category": "meme",
+    "definition": "A reference to a viral Police Ten 7 moment. Used to emphasize accountability when someone is acting out of line.",
+    "trigger_context": "When the user or a character is making a scene or needs to apologize for poor behavior.",
+    "vibe_level": 4,
+    "vector_text": "Don't say sorry to me, say sorry to the kids. Police Ten 7 quote. Accountability and social shame.",
+    "metadata": {
+      "tags": [
+        "police-ten-7",
+        "accountability",
+        "viral"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_012",
+    "term": "Skux as",
+    "category": "slang",
+    "definition": "Looking stylish, cool, or acting like a bit of a heartbreaker.",
+    "trigger_context": "When the user mentions a new outfit, a successful social encounter, or feeling confident.",
+    "vibe_level": 5,
+    "vector_text": "Skux as. Looking good, stylish, heartbreaker. Youth culture and confidence.",
+    "metadata": {
+      "tags": [
+        "style",
+        "cool",
+        "confidence"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_013",
+    "term": "Flash as",
+    "category": "slang",
+    "definition": "Used to describe something that is brand new, expensive-looking, or high-quality. Often used as 'flash as rat-shit' for extra emphasis.",
+    "trigger_context": "When the user mentions getting a new piece of tech, a car, or any premium upgrade.",
+    "vibe_level": 3,
+    "vector_text": "Flash as. Brand new, expensive, high quality, fancy. Recognition of new acquisitions.",
+    "metadata": {
+      "tags": [
+        "new",
+        "quality",
+        "wealth"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_014",
+    "term": "Not even au",
+    "category": "joke",
+    "definition": "A pun on the phrase 'not even' (meaning 'no way' or 'that's not true') and the fact that having only one jandal makes you 'uneven'.",
+    "trigger_context": "What do you call a guy with one jandal? Not even au. Used for quintessential Kiwi dad-humor.",
+    "vibe_level": 4,
+    "vector_text": "Not even au. One jandal joke. Uneven pun. Classic kiwi humor and slang emphasis.",
+    "metadata": {
+      "tags": [
+        "joke",
+        "pun",
+        "jandals"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_015",
+    "term": "Slice of Heaven",
+    "category": "music",
+    "definition": "The unofficial national anthem by Dave Dobbyn and Herbs. Essential for any BBQ or sporting event.",
+    "trigger_context": "When the user mentions a party, a celebration, or feeling patriotic.",
+    "vibe_level": 1,
+    "vector_text": "Slice of Heaven. Dave Dobbyn. Herbs. National anthem. BBQ music. Kiwi pride.",
+    "metadata": {
+      "tags": [
+        "anthem",
+        "dave-dobbyn",
+        "classic"
+      ],
+      "era": "1986"
+    }
+  },
+  {
+    "id": "nz_016",
+    "term": "Split Enz / Crowded House",
+    "category": "music",
+    "definition": "The Finn brothers' musical legacy. Defining the 'Kiwi sound' with art-rock and world-class pop.",
+    "trigger_context": "When discussing high-quality songwriting, musical history, or the Finn family.",
+    "vibe_level": 2,
+    "vector_text": "Split Enz. Crowded House. Neil Finn. Tim Finn. Iconic NZ music. Songwriting excellence.",
+    "metadata": {
+      "tags": [
+        "bands",
+        "pop",
+        "history"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_017",
+    "term": "The Exponents",
+    "category": "music",
+    "definition": "Classic pub-rock band known for 'Why Does Love Do This To Me'. A staple of New Zealand nightlife.",
+    "trigger_context": "When discussing sing-alongs, pub culture, or 90s nostalgia.",
+    "vibe_level": 3,
+    "vector_text": "The Exponents. Jordan Luck. Why Does Love Do This To Me. Pub rock. Sing-along classics.",
+    "metadata": {
+      "tags": [
+        "bands",
+        "rock",
+        "nostalgia"
+      ],
+      "era": "90s"
+    }
+  },
+  {
+    "id": "nz_018",
+    "term": "Bic Runga",
+    "category": "music",
+    "definition": "Iconic singer-songwriter whose album 'Drive' and song 'Sway' defined the late 90s soundscape.",
+    "trigger_context": "When discussing mellow vibes, classic NZ vocalists, or late 90s culture.",
+    "vibe_level": 1,
+    "vector_text": "Bic Runga. Sway. Drive. Iconic female vocalist. Smooth pop. NZ music royalty.",
+    "metadata": {
+      "tags": [
+        "solo-artist",
+        "pop",
+        "classic"
+      ],
+      "era": "90s"
+    }
+  },
+  {
+    "id": "nz_019",
+    "term": "Dr. Ropata",
+    "category": "pop_culture",
+    "definition": "A reference to the Shortland Street line: 'You're not in Guatemala now, Dr. Ropata!'",
+    "trigger_context": "When someone is acting too fancy, forgetting their roots, or when discussing soap operas.",
+    "vibe_level": 2,
+    "vector_text": "You're not in Guatemala now Dr. Ropata. Shortland Street. TV history. Grounding someone to reality.",
+    "metadata": {
+      "tags": [
+        "tv",
+        "classic-lines",
+        "drama"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_020",
+    "term": "Nuclear Free NZ",
+    "category": "history",
+    "definition": "The 1980s movement that saw NZ ban nuclear-powered or armed ships, leading to a rift with the US (ANZUS) and a defining sense of independent foreign policy.",
+    "trigger_context": "When discussing peace, environmental protection, or New Zealand's place on the world stage.",
+    "vibe_level": 2,
+    "vector_text": "Nuclear free New Zealand. 1987 Act. David Lange. Independent nationhood. Environmental activism.",
+    "metadata": {
+      "tags": [
+        "politics",
+        "sovereignty",
+        "peace"
+      ],
+      "era": "1980s"
+    }
+  },
+  {
+    "id": "nz_021",
+    "term": "The 1981 Springbok Tour",
+    "category": "history",
+    "definition": "A massive civil unrest event where the country was split over the visit of the South African rugby team during apartheid. Known as the 'year of the helmet'.",
+    "trigger_context": "When discussing social division, protest, or the intersection of sports and politics.",
+    "vibe_level": 5,
+    "vector_text": "1981 tour. Springboks. Apartheid protests. Red Squad. Social fracture. Civil unrest.",
+    "metadata": {
+      "tags": [
+        "protest",
+        "rugby",
+        "race-relations"
+      ],
+      "era": "1981"
+    }
+  },
+  {
+    "id": "nz_022",
+    "term": "Sinking of the Rainbow Warrior",
+    "category": "history",
+    "definition": "The 1985 bombing of the Greenpeace ship in Auckland Harbour by French secret agents. A major catalyst for NZ's anti-nuclear stance.",
+    "trigger_context": "When the user mentions Auckland history, environmentalism, or French-NZ relations.",
+    "vibe_level": 4,
+    "vector_text": "Rainbow Warrior. Greenpeace. French spies. Bombing Auckland. State-sponsored terrorism.",
+    "metadata": {
+      "tags": [
+        "greenpeace",
+        "espionage",
+        "sovereignty"
+      ],
+      "era": "1985"
+    }
+  },
+  {
+    "id": "nz_023",
+    "term": "Women's Suffrage",
+    "category": "history",
+    "definition": "In 1893, NZ became the first self-governing country to grant women the vote, led by Kate Sheppard.",
+    "trigger_context": "When discussing human rights, elections, or 'firsts' in New Zealand history.",
+    "vibe_level": 1,
+    "vector_text": "Women's vote 1893. Kate Sheppard. First in the world. Suffrage movement. Progressive history.",
+    "metadata": {
+      "tags": [
+        "equality",
+        "politics",
+        "pride"
+      ],
+      "era": "1893"
+    }
+  },
+  {
+    "id": "nz_024",
+    "term": "The Wahine Disaster",
+    "category": "history",
+    "definition": "The 1968 sinking of the ferry TEV Wahine in Wellington Harbour during Cyclone Giselle. NZ’s worst modern maritime disaster.",
+    "trigger_context": "When discussing storms, maritime safety, or Wellington history.",
+    "vibe_level": 5,
+    "vector_text": "Wahine disaster 1968. Wellington Harbour. Shipwreck. Cyclone Giselle. Maritime tragedy.",
+    "metadata": {
+      "tags": [
+        "disaster",
+        "wellington",
+        "tragedy"
+      ],
+      "era": "1960s"
+    }
+  },
+  {
+    "id": "nz_025",
+    "term": "Tall Poppy Syndrome",
+    "category": "social_code",
+    "definition": "The cultural tendency to criticize or 'cut down' those who are perceived as being too successful, boastful, or prominent.",
+    "trigger_context": "When the user is being overly boastful or the AI needs to explain Kiwi humility.",
+    "vibe_level": 3,
+    "vector_text": "Tall poppy syndrome. Cutting down successful people. Kiwi humility. Anti-arrogance.",
+    "metadata": {
+      "tags": [
+        "psychology",
+        "humility",
+        "culture"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_026",
+    "term": "Two Degrees of Separation",
+    "category": "social_code",
+    "definition": "The phenomenon where every New Zealander seems to be connected to every other New Zealander by only one or two people.",
+    "trigger_context": "When the user mentions a mutual friend or a small-world coincidence.",
+    "vibe_level": 2,
+    "vector_text": "Two degrees of separation. Small world. Everyone knows everyone. Kiwi connectivity.",
+    "metadata": {
+      "tags": [
+        "community",
+        "connections"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_027",
+    "term": "Manaakitanga",
+    "category": "te_ao_maori",
+    "definition": "The concept of hospitality, showing respect, generosity, and care for others. The foundation of NZ's tourism and social fabric.",
+    "trigger_context": "When the AI wants to express deep hospitality or describe the 'spirit' of NZ hosting.",
+    "vibe_level": 1,
+    "vector_text": "Manaakitanga. Hospitality. Care for others. Respect. Māori values. Hosting.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "values",
+        "kindness"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_028",
+    "term": "World Famous in New Zealand",
+    "category": "meme",
+    "definition": "An ironic slogan (originally for L&P) used to describe things that are locally legendary but completely unknown everywhere else.",
+    "trigger_context": "When discussing local niche celebrities or specific Kiwi brands.",
+    "vibe_level": 2,
+    "vector_text": "World famous in New Zealand. L&P slogan. Local fame. Irony. Kiwi icons.",
+    "metadata": {
+      "tags": [
+        "advertising",
+        "humor",
+        "brands"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_029",
+    "term": "Erebus Disaster",
+    "category": "history",
+    "definition": "The 1979 crash of an Air NZ sightseeing flight into Mt Erebus, Antarctica. A collective national trauma.",
+    "trigger_context": "When discussing aviation or moments of national mourning.",
+    "vibe_level": 5,
+    "vector_text": "Mount Erebus 1979. Air New Zealand crash. Antarctica. National grief.",
+    "metadata": {
+      "tags": [
+        "tragedy",
+        "aviation",
+        "trauma"
+      ],
+      "era": "1979"
+    }
+  },
+  {
+    "id": "nz_030",
+    "term": "The Fair Go",
+    "category": "philosophy",
+    "definition": "The core egalitarian belief that everyone deserves an equal opportunity regardless of their background.",
+    "trigger_context": "When discussing justice, equality, or social welfare.",
+    "vibe_level": 1,
+    "vector_text": "A fair go. Egalitarianism. Equal opportunity. Kiwi fairness. Social justice.",
+    "metadata": {
+      "tags": [
+        "values",
+        "equality",
+        "society"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_031",
+    "term": "L&P",
+    "category": "food",
+    "definition": "Lemon & Paeroa. A sweet carbonated drink that is a staple of NZ summer and fish and chip runs.",
+    "trigger_context": "When the user mentions thirst, snacks, or the town of Paeroa.",
+    "vibe_level": 1,
+    "vector_text": "L&P. Lemon and Paeroa. NZ soda. Soft drink. Paeroa bottle.",
+    "metadata": {
+      "tags": [
+        "drink",
+        "icon",
+        "summer"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_032",
+    "term": "Pineapple Lumps",
+    "category": "food",
+    "definition": "Chocolate-coated pineapple-flavored chewy centers. Best kept in the freezer.",
+    "trigger_context": "When the user asks about NZ candy or snacks.",
+    "vibe_level": 2,
+    "vector_text": "Pineapple lumps. Pascall. Kiwi confectionery. Best frozen. Iconic candy.",
+    "metadata": {
+      "tags": [
+        "snacks",
+        "candy",
+        "nostalgia"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_033",
+    "term": "The Haka",
+    "category": "te_ao_maori",
+    "definition": "A traditional Māori posture dance. While used in many contexts, the All Blacks' version is world-renowned.",
+    "trigger_context": "When discussing rugby, challenges, or Māori performance art.",
+    "vibe_level": 3,
+    "vector_text": "Haka. Ka Mate. All Blacks. Māori challenge. Respect and power.",
+    "metadata": {
+      "tags": [
+        "rugby",
+        "maori",
+        "identity"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_034",
+    "term": "Middle-earth Economy",
+    "category": "pop_culture",
+    "definition": "The massive impact of the Lord of the Rings films on NZ's tourism and film industry identity.",
+    "trigger_context": "When discussing tourism, Peter Jackson, or movies.",
+    "vibe_level": 2,
+    "vector_text": "Lord of the Rings. Hobbiton. Peter Jackson. Film tourism. Middle-earth.",
+    "metadata": {
+      "tags": [
+        "movies",
+        "tourism",
+        "economy"
+      ],
+      "era": "2000s"
+    }
+  },
+  {
+    "id": "nz_035",
+    "term": "All Blacks",
+    "category": "sports",
+    "definition": "The national men's rugby union team. More than a team, they are a central pillar of NZ identity with a win rate that borders on the statistically impossible.",
+    "trigger_context": "When discussing national pride, excellence, or high-pressure performance.",
+    "vibe_level": 1,
+    "vector_text": "All Blacks. Rugby Union. Black jersey. Silver Fern. Haka. National obsession.",
+    "metadata": {
+      "tags": [
+        "rugby",
+        "icon",
+        "national-team"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_036",
+    "term": "The Warriors (Up the Wahs)",
+    "category": "sports",
+    "definition": "The NZ rugby league team in the NRL. Known for having the most loyal (and long-suffering) fans. 'Up the Wahs' became a viral rallying cry in the 2020s.",
+    "trigger_context": "When discussing loyalty, underdog stories, or Auckland-based culture.",
+    "vibe_level": 5,
+    "vector_text": "The Warriors. NRL. Rugby League. Up the Wahs. Mt Smart Stadium. Loyal fans.",
+    "metadata": {
+      "tags": [
+        "league",
+        "auckland",
+        "meme"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_037",
+    "term": "Black Ferns",
+    "category": "sports",
+    "definition": "The world-champion women's rugby union team. Known for their incredible Haka and for bringing a more joyous, community-focused vibe to the national game.",
+    "trigger_context": "When discussing world champions, women's sport, or 'rugby like it used to be'.",
+    "vibe_level": 2,
+    "vector_text": "Black Ferns. Women's rugby. World Cup winners. Ruby Tui. Pōwhiri.",
+    "metadata": {
+      "tags": [
+        "rugby",
+        "women-in-sport",
+        "champions"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_038",
+    "term": "Silver Ferns",
+    "category": "sports",
+    "definition": "The national netball team. Netball is the most popular female sport in NZ; their rivalry with the Australian Diamonds is legendary and intense.",
+    "trigger_context": "When discussing netball, female athletes, or the Tasman rivalry.",
+    "vibe_level": 2,
+    "vector_text": "Silver Ferns. Netball. Court sports. Rivalry with Australia. National pride.",
+    "metadata": {
+      "tags": [
+        "netball",
+        "women-in-sport",
+        "rivalry"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_039",
+    "term": "Black Caps",
+    "category": "sports",
+    "definition": "The national men's cricket team. Known as the 'Nice Guys' of world cricket. They punch way above their weight despite a small talent pool.",
+    "trigger_context": "When discussing cricket, summer, or 'punching above your weight'.",
+    "vibe_level": 3,
+    "vector_text": "Black Caps. Cricket. Kane Williamson. Nice guys. Summer sports.",
+    "metadata": {
+      "tags": [
+        "cricket",
+        "summer",
+        "underdogs"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_040",
+    "term": "Emirates Team New Zealand",
+    "category": "sports",
+    "definition": "The high-tech sailing team that dominates the America's Cup. Represents the 'No. 8 Wire' mentality scaled up to multi-million dollar hydrofoils.",
+    "trigger_context": "When discussing sailing, ocean technology, or the America's Cup.",
+    "vibe_level": 4,
+    "vector_text": "Team New Zealand. America's Cup. Sailing. Peter Burling. Auld Mug.",
+    "metadata": {
+      "tags": [
+        "sailing",
+        "technology",
+        "auckland"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_041",
+    "term": "White Ferns",
+    "category": "sports",
+    "definition": "The national women's cricket team. Key players in the global rise of professional women's cricket.",
+    "trigger_context": "When discussing cricket or women's sports achievements.",
+    "vibe_level": 3,
+    "vector_text": "White Ferns. Women's cricket. Sophie Devine. Suzie Bates. Summer vibes.",
+    "metadata": {
+      "tags": [
+        "cricket",
+        "women-in-sport"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_042",
+    "term": "The 'Loss' of 2019",
+    "category": "sports_history",
+    "definition": "The Cricket World Cup Final where the Black Caps 'lost' to England on a boundary countback rule. Mentioning this still causes physical pain to most Kiwis.",
+    "trigger_context": "When the user mentions unfairness, cricket, or heartbreak.",
+    "vibe_level": 5,
+    "vector_text": "2019 World Cup Final. Boundary countback. Cricket heartbreak. England vs NZ.",
+    "metadata": {
+      "tags": [
+        "cricket",
+        "trauma",
+        "history"
+      ],
+      "era": "2019"
+    }
+  },
+  {
+    "id": "nz_043",
+    "term": "The Tall Blacks",
+    "category": "sports",
+    "definition": "The national men's basketball team. Famous for their 'Tu Kaha' Haka which often confuses and intimidates NBA-level opposition.",
+    "trigger_context": "When discussing basketball or international sporting upsets.",
+    "vibe_level": 3,
+    "vector_text": "Tall Blacks. Basketball. FIBA. Tu Kaha Haka. Hoops.",
+    "metadata": {
+      "tags": [
+        "basketball",
+        "haka"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_044",
+    "term": "The Breakers",
+    "category": "sports",
+    "definition": "NZ's only professional basketball team playing in the Australian NBL. Based in Auckland.",
+    "trigger_context": "When discussing local sports clubs or Auckland entertainment.",
+    "vibe_level": 4,
+    "vector_text": "NZ Breakers. NBL. Basketball. Auckland. Spark Arena.",
+    "metadata": {
+      "tags": [
+        "basketball",
+        "auckland",
+        "club"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_045",
+    "term": "Taika Waititi",
+    "category": "pop_culture",
+    "definition": "Director and actor who defined the 'modern' Kiwi sense of humor: deadpan, awkward, and self-deprecating. Instrumental in the global 'cool' factor of NZ.",
+    "trigger_context": "When discussing comedy, filmmaking, or the 'Kiwi vibe' in Hollywood.",
+    "vibe_level": 4,
+    "vector_text": "Taika Waititi. Boy. Hunt for the Wilderpeople. What We Do in the Shadows. Deadpan humor.",
+    "metadata": {
+      "tags": [
+        "director",
+        "comedy",
+        "hollywood"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_046",
+    "term": "Sir Edmund Hillary",
+    "category": "history",
+    "definition": "The first person to reach the summit of Mt Everest. The ultimate symbol of Kiwi modesty; his first words after the descent were: 'Well, we knocked the bastard off.'",
+    "trigger_context": "When discussing achievement, exploration, or the $5 note.",
+    "vibe_level": 1,
+    "vector_text": "Sir Ed. Edmund Hillary. Everest. $5 note. Modesty. Exploration.",
+    "metadata": {
+      "tags": [
+        "explorer",
+        "icon",
+        "history"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_047",
+    "term": "Matariki",
+    "category": "te_ao_maori",
+    "definition": "The Māori New Year, marked by the rising of the Pleiades star cluster. It became a public holiday in 2022 and signifies a time for reflection and new beginnings.",
+    "trigger_context": "When discussing holidays, winter (June/July), or Māori traditions.",
+    "vibe_level": 2,
+    "vector_text": "Matariki. Māori New Year. Public holiday. Stars. Pleiades. Reflection.",
+    "metadata": {
+      "tags": [
+        "holiday",
+        "maori",
+        "stars"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_048",
+    "term": "The Hollywood Kiwis",
+    "category": "pop_culture",
+    "definition": "A group of actors who have achieved massive global fame while remaining fiercely 'Kiwi', including Karl Urban (The Boys), Antony Starr (Homelander), Lucy Lawless (Xena), and Sam Neill (Jurassic Park).",
+    "trigger_context": "When the user mentions international fame or specific genre TV/movies.",
+    "vibe_level": 3,
+    "vector_text": "Karl Urban. Antony Starr. Lucy Lawless. Sam Neill. Temuera Morrison. NZ actors in Hollywood.",
+    "metadata": {
+      "tags": [
+        "actors",
+        "hollywood",
+        "success"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_049",
+    "term": "JAFA",
+    "category": "slang",
+    "definition": "Acronym for 'Just Another F***ing Aucklander'. Used by the rest of the country to describe people from the nation's largest city.",
+    "trigger_context": "When discussing regional rivalries, traffic, or Auckland-specific behavior.",
+    "vibe_level": 4,
+    "vector_text": "JAFA. Aucklanders. Regional rivalry. City of Sails. Traffic jokes.",
+    "metadata": {
+      "tags": [
+        "auckland",
+        "insult",
+        "humor"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_050",
+    "term": "The Kea",
+    "category": "fauna",
+    "definition": "The world's only alpine parrot. Known for being a 'cheeky bugger' that destroys cars and steals belongings from tourists in the South Island.",
+    "trigger_context": "When discussing wildlife, intelligence, or property damage.",
+    "vibe_level": 4,
+    "vector_text": "Kea parrot. Smartest bird. Destructive. South Island. Alpine parrot.",
+    "metadata": {
+      "tags": [
+        "nature",
+        "bird",
+        "chaos"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_051",
+    "term": "Temuera Morrison (Jake the Muss)",
+    "category": "pop_culture",
+    "definition": "The actor behind the most intense performance in NZ history in 'Once Were Warriors'. Now globally famous as Boba Fett.",
+    "trigger_context": "When discussing gritty cinema, Star Wars, or 'Once Were Warriors'.",
+    "vibe_level": 5,
+    "vector_text": "Temuera Morrison. Jake the Muss. Once Were Warriors. Boba Fett. Cook some eggs.",
+    "metadata": {
+      "tags": [
+        "actor",
+        "cinema",
+        "icon"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_052",
+    "term": "ACC",
+    "category": "social_structure",
+    "definition": "The Accident Compensation Corporation. A unique system where you can't sue for personal injury, but the government covers your treatment and lost wages regardless of fault.",
+    "trigger_context": "When discussing health, injuries, or 'only in NZ' laws.",
+    "vibe_level": 2,
+    "vector_text": "ACC. No-fault insurance. Injury cover. NZ healthcare. Safety net.",
+    "metadata": {
+      "tags": [
+        "law",
+        "health",
+        "unique"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_053",
+    "term": "Jandals",
+    "category": "clothing",
+    "definition": "Japanese Sandals. The national footwear. Wearing them with socks is a crime; wearing them to a funeral is debatable.",
+    "trigger_context": "When discussing summer, fashion, or footwear.",
+    "vibe_level": 1,
+    "vector_text": "Jandals. Flip flops. Summer footwear. Kiwi casual. Rubber sandals.",
+    "metadata": {
+      "tags": [
+        "fashion",
+        "summer",
+        "lifestyle"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_054",
+    "term": "Waitangi Day",
+    "category": "history",
+    "definition": "February 6th. The national day marking the signing of the Treaty of Waitangi. Often a day of both celebration and significant political debate.",
+    "trigger_context": "When discussing national days, politics, or Feb 6th.",
+    "vibe_level": 4,
+    "vector_text": "Waitangi Day. Treaty of Waitangi. Feb 6. National day. Te Tiriti.",
+    "metadata": {
+      "tags": [
+        "history",
+        "maori",
+        "politics"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_055",
+    "term": "Red Band Gumboots",
+    "category": "clothing",
+    "definition": "The iconic black rubber boot with a red band around the top. Originally for farmers, now a symbol of 'real' New Zealanders and often worn at summer music festivals.",
+    "trigger_context": "When discussing rural life, farming, or practical fashion.",
+    "vibe_level": 1,
+    "vector_text": "Red Bands. Skellerup. Gumboots. Rural NZ. Farming icon. Footwear.",
+    "metadata": {
+      "tags": [
+        "fashion",
+        "farming",
+        "classic"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_056",
+    "term": "ANZAC Day",
+    "category": "history",
+    "definition": "April 25th. A day of national remembrance for those who served in wars. Defined by dawn services, RSA poppies, and the 'ANZAC spirit' of mateship and sacrifice.",
+    "trigger_context": "When discussing the military, April, or national identity.",
+    "vibe_level": 2,
+    "vector_text": "ANZAC Day. Lest we forget. April 25. Gallipoli. RSA. Mateship.",
+    "metadata": {
+      "tags": [
+        "remembrance",
+        "military",
+        "holiday"
+      ],
+      "era": "1915-present"
+    }
+  },
+  {
+    "id": "nz_057",
+    "term": "Jacinda Ardern",
+    "category": "politics",
+    "definition": "Prime Minister (2017-2023) known for her 'Aroha' (love) philosophy, leading the country through the Christchurch mosque attacks and the COVID-19 pandemic.",
+    "trigger_context": "When discussing leadership, global recognition, or recent political history.",
+    "vibe_level": 4,
+    "vector_text": "Jacinda Ardern. Labour Party. Christchurch response. COVID-19. Aroha. Global icon.",
+    "metadata": {
+      "tags": [
+        "leadership",
+        "contemporary",
+        "labour"
+      ],
+      "era": "2017-2023"
+    }
+  },
+  {
+    "id": "nz_058",
+    "term": "Helen Clark",
+    "category": "politics",
+    "definition": "PM (1999-2008). A formidable leader who solidified NZ’s independent streak (refusing to join the Iraq War) and later led the UNDP.",
+    "trigger_context": "When discussing stability, the UN, or 2000s-era politics.",
+    "vibe_level": 2,
+    "vector_text": "Helen Clark. Auntie Helen. Labour Party. Independent foreign policy. UN.",
+    "metadata": {
+      "tags": [
+        "leadership",
+        "power",
+        "labour"
+      ],
+      "era": "1999-2008"
+    }
+  },
+  {
+    "id": "nz_059",
+    "term": "John Key",
+    "category": "politics",
+    "definition": "PM (2008-2016). Known as the 'Smiling Assassin' for his high popularity and relaxed 'guy you’d have a beer with' persona during the 2011 Rugby World Cup and Christchurch earthquakes.",
+    "trigger_context": "When discussing the National Party, the 2011 era, or centrist politics.",
+    "vibe_level": 3,
+    "vector_text": "John Key. National Party. Smiling Assassin. 2011 World Cup. Centrist.",
+    "metadata": {
+      "tags": [
+        "leadership",
+        "national",
+        "popular-culture"
+      ],
+      "era": "2008-2016"
+    }
+  },
+  {
+    "id": "nz_060",
+    "term": "Ruth Richardson (Ruthanasia)",
+    "category": "politics",
+    "definition": "Finance Minister in the early 90s. Author of the 'Mother of all Budgets' which drastically cut welfare spending and completed the free-market shift of the economy.",
+    "trigger_context": "When discussing economics, the welfare state, or political controversy.",
+    "vibe_level": 5,
+    "vector_text": "Ruth Richardson. Ruthanasia. Mother of all Budgets. Economic reform. National Party.",
+    "metadata": {
+      "tags": [
+        "economics",
+        "controversial",
+        "history"
+      ],
+      "era": "1990-1993"
+    }
+  },
+  {
+    "id": "nz_061",
+    "term": "The Beehive",
+    "category": "politics",
+    "definition": "The distinctively shaped executive wing of the New Zealand Parliament Buildings in Wellington. A shorthand for the government itself.",
+    "trigger_context": "When discussing the location of power or Wellington architecture.",
+    "vibe_level": 1,
+    "vector_text": "The Beehive. Parliament. Wellington. Government headquarters. Architecture.",
+    "metadata": {
+      "tags": [
+        "wellington",
+        "government",
+        "landmark"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_062",
+    "term": "Aroha",
+    "category": "te_ao_maori",
+    "definition": "Often translated as 'love', but encompasses empathy, compassion, and deep connection. Became a political and social keyword during the 2019/2020 era.",
+    "trigger_context": "When the user needs a more profound expression of care or community spirit.",
+    "vibe_level": 1,
+    "vector_text": "Aroha. Love. Compassion. Māori values. Empathy.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "values",
+        "empathy"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_063",
+    "term": "RSA",
+    "category": "social_structure",
+    "definition": "The Returned and Services' Association. Community hubs originally for veterans, famous for cheap beer, snooker, and being the keepers of the ANZAC tradition.",
+    "trigger_context": "When discussing community clubs, veterans, or ANZAC day.",
+    "vibe_level": 2,
+    "vector_text": "RSA. Veterans. Community clubs. Mateship. ANZAC traditions.",
+    "metadata": {
+      "tags": [
+        "community",
+        "military",
+        "tradition"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_064",
+    "term": "David Lange",
+    "category": "politics",
+    "definition": "PM (1984-1989). A brilliant orator who led the Nuclear-Free movement and the radical 'Rogernomics' economic reforms.",
+    "trigger_context": "When discussing the 80s, nuclear-free policy, or great speeches.",
+    "vibe_level": 3,
+    "vector_text": "David Lange. Nuclear-free. Rogernomics. Oxford Union debate. 1980s politics.",
+    "metadata": {
+      "tags": [
+        "leadership",
+        "history",
+        "oratory"
+      ],
+      "era": "1984-1989"
+    }
+  },
+  {
+    "term": "Tu meke",
+    "category": "slang",
+    "definition": "Māori slang meaning 'too much' or 'awesome'. Used to express genuine excitement or approval — similar to 'sweet as' but with more warmth.",
+    "trigger_context": "When the user shares good news, achieves something, or receives a compliment.",
+    "vibe_level": 2,
+    "vector_text": "Tu meke. Too much. Awesome. Māori slang for great news or impressive achievement. Warmth and excitement.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "approval",
+        "warmth"
+      ],
+      "era": "timeless"
+    },
+    "id": "nz_065"
+  },
+  {
+    "term": "Bugger",
+    "category": "meme",
+    "definition": "A classic Kiwi exclamation of disappointment or misfortune, immortalised by the Toyota Hilux ad where farm animals say it after minor disasters.",
+    "trigger_context": "When something goes wrong, an error occurs, or the user has a minor setback.",
+    "vibe_level": 3,
+    "vector_text": "Bugger. Toyota ad. Farm accident. Minor disaster. Disappointment. Classic NZ exclamation.",
+    "metadata": {
+      "tags": [
+        "toyota",
+        "advertising",
+        "classic",
+        "disappointment"
+      ],
+      "era": "1999"
+    },
+    "id": "nz_066"
+  },
+  {
+    "term": "Good Aftabull Constanoon",
+    "category": "meme",
+    "definition": "A slurred 'Good afternoon, Constable' — iconic Police Ten 7 / drunk-tank phrase. Used for gently comedic formality or when someone is trying too hard to be polite.",
+    "trigger_context": "When the user is being overly formal, or in any Police Ten 7 / law-enforcement adjacent context.",
+    "vibe_level": 4,
+    "vector_text": "Good afternoon constable. Drunk speech. Police Ten 7. Slurred formality. Kiwi cop culture.",
+    "metadata": {
+      "tags": [
+        "police-ten-7",
+        "drunk",
+        "formality",
+        "viral"
+      ],
+      "era": "classic"
+    },
+    "id": "nz_067"
+  },
+  {
+    "term": "Munter",
+    "category": "slang",
+    "definition": "A mildly derogatory term for someone acting foolishly, being annoying, or generally being a bit of a mess. Distinct from 'munted' (broken) — a munter is a person, not a thing.",
+    "trigger_context": "When the user describes someone behaving badly or foolishly, used in light banter.",
+    "vibe_level": 4,
+    "vector_text": "Munter. Fool. Idiot. Someone acting badly or being annoying. Kiwi insult for a messy or foolish person.",
+    "metadata": {
+      "tags": [
+        "insult",
+        "banter",
+        "person"
+      ],
+      "era": "timeless"
+    },
+    "id": "nz_068"
+  },
+  {
+    "id": "nz_069",
+    "term": "Christchurch Earthquakes",
+    "category": "history",
+    "definition": "A series of devastating earthquakes in 2010 and 2011. The February 2011 quake claimed 185 lives, destroyed much of the central city, and fundamentally reshaped both Canterbury's landscape and the nation's building codes.",
+    "trigger_context": "When discussing national tragedies, South Island history, or community resilience.",
+    "vibe_level": 1,
+    "vector_text": "Christchurch earthquakes 2011. Canterbury quakes. National tragedy. Rebuild. Resilience. February 22.",
+    "metadata": {
+      "tags": [
+        "disaster",
+        "history",
+        "canterbury"
+      ],
+      "era": "2010-2011"
+    }
+  },
+  {
+    "id": "nz_070",
+    "term": "Cyclone Gabrielle",
+    "category": "history",
+    "definition": "A catastrophic cyclone that struck the North Island in February 2023, causing unprecedented flooding, landslides, and infrastructure collapse, heavily devastating Hawke's Bay and Tairāwhiti/Gisborne.",
+    "trigger_context": "When discussing climate, extreme weather, community recovery, or recent natural disasters.",
+    "vibe_level": 1,
+    "vector_text": "Cyclone Gabrielle. Hawke's Bay floods 2023. Tairāwhiti. Severe weather disaster. Esk Valley. Community recovery.",
+    "metadata": {
+      "tags": [
+        "disaster",
+        "weather",
+        "recent-history"
+      ],
+      "era": "2023"
+    }
+  },
+  {
+    "id": "nz_071",
+    "term": "Christchurch Mosque Attacks (March 15)",
+    "category": "history",
+    "definition": "The unprecedented terrorist attack on two mosques in Christchurch on March 15, 2019, claiming 51 lives. It deeply shocked the nation, resulting in immediate gun law reforms and Jacinda Ardern's defining message of unity: 'They are us.'",
+    "trigger_context": "When discussing national tragedy, terrorism, gun control reform, or messages of national unity.",
+    "vibe_level": 1,
+    "vector_text": "March 15. Christchurch mosque shootings. Terrorism. They are us. Gun law reform. National grief. Jacinda Ardern.",
+    "metadata": {
+      "tags": [
+        "tragedy",
+        "history",
+        "christchurch"
+      ],
+      "era": "2019"
+    }
+  },
+  {
+    "id": "nz_072",
+    "term": "COVID-19 (The Team of 5 Million)",
+    "category": "history",
+    "definition": "New Zealand's unique response to the pandemic, defined by early border closures, strict elimination lockdowns, and the rallying cry for the 'Team of 5 Million' to stay home. The era also included the polarising Managed Isolation and Quarantine (MIQ) system and the 2022 Parliament protests.",
+    "trigger_context": "When discussing pandemic responses, lockdowns, MIQ, or major societal shifts in the 2020s.",
+    "vibe_level": 2,
+    "vector_text": "COVID-19. Team of 5 million. Lockdowns. Elimination strategy. MIQ. Parliament protests. Jacinda Ardern pandemic.",
+    "metadata": {
+      "tags": [
+        "health",
+        "politics",
+        "recent-history"
+      ],
+      "era": "2020-2022"
+    }
+  },
+  {
+    "id": "nz_073",
+    "term": "Whakaari / White Island Eruption",
+    "category": "history",
+    "definition": "The tragic December 2019 volcanic eruption on Whakaari (White Island) that claimed 22 lives, predominantly tourists and their guides. It led to massive legal fallout and fundamentally changed the landscape of adventure tourism safety in NZ.",
+    "trigger_context": "When discussing natural disasters, volcanoes, adventure tourism, or health and safety regulations.",
+    "vibe_level": 1,
+    "vector_text": "Whakaari. White Island eruption. Volcano disaster. Adventure tourism safety. Bay of Plenty. December 2019 tragedy.",
+    "metadata": {
+      "tags": [
+        "disaster",
+        "volcano",
+        "tourism"
+      ],
+      "era": "2019"
+    }
+  },
+  {
+    "id": "nz_074",
+    "term": "Kate Sheppard",
+    "category": "history",
+    "definition": "The leader of the women's suffrage movement. Thanks to her campaigning, New Zealand became the first self-governing country in the world to grant women the vote in 1893. She is the face of the $10 note.",
+    "trigger_context": "When discussing feminism, progressive history, or New Zealand 'firsts'.",
+    "vibe_level": 1,
+    "vector_text": "Kate Sheppard. Women's suffrage 1893. Voting rights. $10 note. Progressive history.",
+    "metadata": {
+      "tags": [
+        "history",
+        "equality",
+        "icon"
+      ],
+      "era": "1893"
+    }
+  },
+  {
+    "id": "nz_075",
+    "term": "Ernest Rutherford",
+    "category": "science",
+    "definition": "Known globally as the 'father of nuclear physics'. Born in Nelson, he is credited with splitting the atom and discovering the concept of radioactive half-life. He is the face of the $100 note.",
+    "trigger_context": "When discussing science, physics, famous inventors, or New Zealand intellect.",
+    "vibe_level": 2,
+    "vector_text": "Ernest Rutherford. Splitting the atom. Nuclear physics. $100 note. Kiwi scientist.",
+    "metadata": {
+      "tags": [
+        "science",
+        "history",
+        "icon"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_076",
+    "term": "Billy T James",
+    "category": "pop_culture",
+    "definition": "A legendary entertainer and comedian who helped define modern Kiwi humor. Known for his trademark giggle, black singlet, yellow towel, and boundary-pushing sketches that lovingly mocked race relations.",
+    "trigger_context": "When discussing classic Kiwi comedy, the 1980s, or foundational entertainment.",
+    "vibe_level": 2,
+    "vector_text": "Billy T James. Comedian. Black singlet. Yellow towel. Trademark giggle. 80s comedy.",
+    "metadata": {
+      "tags": [
+        "comedy",
+        "icon",
+        "tv"
+      ],
+      "era": "1980s"
+    }
+  },
+  {
+    "id": "nz_077",
+    "term": "Lucy Lawless",
+    "category": "pop_culture",
+    "definition": "Iconic Kiwi actress and climate activist, globally famous for playing the title character in 'Xena: Warrior Princess'.",
+    "trigger_context": "When discussing 90s television, strong female leads, or Kiwi actors.",
+    "vibe_level": 3,
+    "vector_text": "Lucy Lawless. Xena Warrior Princess. Actor. Climate activism. 90s TV icon.",
+    "metadata": {
+      "tags": [
+        "actor",
+        "hollywood",
+        "xena"
+      ],
+      "era": "1990s-present"
+    }
+  },
+  {
+    "id": "nz_078",
+    "term": "Karl Urban",
+    "category": "pop_culture",
+    "definition": "Prolific actor who has appeared in massive global franchises including Lord of the Rings, Star Trek, and Thor, but is currently best known for playing the foul-mouthed Billy Butcher in 'The Boys'.",
+    "trigger_context": "When discussing 'The Boys', Lord of the Rings actors, or sci-fi franchises.",
+    "vibe_level": 4,
+    "vector_text": "Karl Urban. Billy Butcher. The Boys. Star Trek. Lord of the Rings. Hollywood Kiwi.",
+    "metadata": {
+      "tags": [
+        "actor",
+        "hollywood",
+        "sci-fi"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_079",
+    "term": "Antony Starr",
+    "category": "pop_culture",
+    "definition": "Rose to local fame playing twins Van and Jethro on the hit NZ show 'Outrageous Fortune', but is now globally recognized for his terrifying and brilliant portrayal of Homelander in 'The Boys'.",
+    "trigger_context": "When discussing 'The Boys', terrifying villains, or 'Outrageous Fortune'.",
+    "vibe_level": 5,
+    "vector_text": "Antony Starr. Homelander. The Boys. Outrageous Fortune. Van and Jethro West.",
+    "metadata": {
+      "tags": [
+        "actor",
+        "hollywood",
+        "television"
+      ],
+      "era": "current"
+    }
+  },
+  {
+    "id": "nz_080",
+    "term": "Sam Neill",
+    "category": "pop_culture",
+    "definition": "Celebrated actor known globally as Dr. Alan Grant in 'Jurassic Park'. He owns a winery (Two Paddocks) in Central Otago and is famous for naming his farm animals after his celebrity friends.",
+    "trigger_context": "When discussing Jurassic Park, wine, or wholesome social media.",
+    "vibe_level": 2,
+    "vector_text": "Sam Neill. Jurassic Park. Two Paddocks winery. Central Otago. Wholesome actor.",
+    "metadata": {
+      "tags": [
+        "actor",
+        "hollywood",
+        "wine"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_081",
+    "term": "Kererū",
+    "category": "fauna",
+    "definition": "The native New Zealand wood pigeon. Famous for being remarkably round, flying noisily, and occasionally falling out of trees after getting 'drunk' on fermented berries.",
+    "trigger_context": "When discussing birds, funny wildlife, or the Bird of the Year competition.",
+    "vibe_level": 3,
+    "vector_text": "Kereru. Wood pigeon. Drunk bird. Round bird. Noisy flyer. Native fauna.",
+    "metadata": {
+      "tags": [
+        "bird",
+        "nature",
+        "humor"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_082",
+    "term": "Tūī",
+    "category": "fauna",
+    "definition": "A striking native bird with a distinctive white tuft (poi) under its throat. Famous for its complex, beautiful, and sometimes robotic-sounding mimicking calls.",
+    "trigger_context": "When discussing birdsong, spring, or native forests.",
+    "vibe_level": 1,
+    "vector_text": "Tui. Birdsong. White tuft. Mimicry. Native bird. Robotic sounds.",
+    "metadata": {
+      "tags": [
+        "bird",
+        "nature",
+        "icon"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_083",
+    "term": "Pīwakawaka (Fantail)",
+    "category": "fauna",
+    "definition": "A small, highly energetic native bird known for its fan-like tail. Very friendly and inquisitive, it often flits closely around walkers in the bush to catch the insects they disturb.",
+    "trigger_context": "When discussing bush walks, cute animals, or Māori mythology.",
+    "vibe_level": 1,
+    "vector_text": "Piwakawaka. Fantail. Friendly bird. Bush walks. Catching insects. Native fauna.",
+    "metadata": {
+      "tags": [
+        "bird",
+        "nature",
+        "friendly"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_084",
+    "term": "Ruru (Morepork)",
+    "category": "fauna",
+    "definition": "New Zealand's native owl. Named after its distinctive two-part call that sounds exactly like it is saying 'more pork'. Traditionally seen as a guardian spirit (kaitiaki) in Te Ao Māori.",
+    "trigger_context": "When discussing night sounds, owls, or spiritual guardians.",
+    "vibe_level": 2,
+    "vector_text": "Ruru. Morepork. Native owl. Night sounds. Kaitiaki. Guardian spirit.",
+    "metadata": {
+      "tags": [
+        "bird",
+        "nature",
+        "night"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_085",
+    "term": "Kiwi (Bird)",
+    "category": "fauna",
+    "definition": "A flightless, nocturnal, ground-dwelling bird native to New Zealand. It is the national symbol and strictly protected.",
+    "trigger_context": "When discussing native wildlife, conservation, or national emblems.",
+    "vibe_level": 1,
+    "vector_text": "Kiwi bird. Flightless. Nocturnal. National symbol. Conservation. Native fauna.",
+    "metadata": {
+      "tags": [
+        "bird",
+        "icon",
+        "nature"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_086",
+    "term": "Kiwi (Person)",
+    "category": "identity",
+    "definition": "The colloquial, universally accepted demonym for a person from New Zealand. Capitalized to distinguish it from the bird. Worn as a badge of pride.",
+    "trigger_context": "When referring to New Zealand citizens, national traits, or people in general.",
+    "vibe_level": 1,
+    "vector_text": "Kiwi person. New Zealander. Demonym. National identity. Citizen. People.",
+    "metadata": {
+      "tags": [
+        "identity",
+        "people",
+        "culture"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_087",
+    "term": "Kiwifruit",
+    "category": "food",
+    "definition": "The fuzzy brown fruit with sweet green or golden flesh. Originally the Chinese gooseberry, it was famously rebranded by NZ. Crucially: New Zealanders eat kiwifruit, they do not eat 'kiwis'.",
+    "trigger_context": "When discussing agriculture, exports, or fresh fruit.",
+    "vibe_level": 2,
+    "vector_text": "Kiwifruit. Zespri. Green and gold. Chinese gooseberry. NZ export. Fruit.",
+    "metadata": {
+      "tags": [
+        "agriculture",
+        "export",
+        "food"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_088",
+    "term": "Feijoa",
+    "category": "food",
+    "definition": "A quintessential autumn fruit in NZ with a unique, sweet, perfume-like flavour. Almost every backyard has a tree, leading to the cultural tradition of giving away bags of them to neighbours every April.",
+    "trigger_context": "When discussing autumn, backyard gardens, or community sharing.",
+    "vibe_level": 3,
+    "vector_text": "Feijoa. Autumn fruit. Backyard tree. Sharing with neighbors. Unique flavor. Perfume taste.",
+    "metadata": {
+      "tags": [
+        "fruit",
+        "community",
+        "autumn"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_089",
+    "term": "Chur",
+    "category": "slang",
+    "definition": "The ultimate all-purpose Kiwi acknowledgement. Can mean cheers, thanks, sweet, sounds good, or I agree — context determines which. Often doubled for emphasis: 'chur chur'.",
+    "trigger_context": "When acknowledging something, expressing gratitude, or agreeing with the user.",
+    "vibe_level": 2,
+    "vector_text": "Chur. Cheers. Thanks. Sweet. Sounds good. Agreement. Kiwi acknowledgement.",
+    "metadata": {
+      "tags": [
+        "slang",
+        "acknowledgement",
+        "timeless"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_090",
+    "term": "Pavlova",
+    "category": "food",
+    "definition": "A meringue-based dessert with a crisp crust and soft, light inside, typically topped with kiwifruit and whipped cream. The source of an eternal, fierce debate with Australia over its invention (it was definitely NZ).",
+    "trigger_context": "When discussing Christmas, desserts, or the trans-Tasman rivalry.",
+    "vibe_level": 3,
+    "vector_text": "Pavlova. Meringue dessert. Christmas food. Trans-Tasman rivalry. Anna Pavlova. Kiwi dessert.",
+    "metadata": {
+      "tags": [
+        "dessert",
+        "rivalry",
+        "christmas"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_091",
+    "term": "Lamington",
+    "category": "food",
+    "definition": "Squares of sponge cake coated in chocolate or raspberry sauce and rolled in desiccated coconut. While heavily claimed by Australia, evidence suggests they originated in NZ as 'Wellingtons'.",
+    "trigger_context": "When discussing baking, morning tea, or stealing cultural icons.",
+    "vibe_level": 2,
+    "vector_text": "Lamington. Sponge cake. Coconut and chocolate. Baking. Morning tea. Trans-Tasman debate.",
+    "metadata": {
+      "tags": [
+        "baking",
+        "sweet",
+        "debate"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_092",
+    "term": "Flat White",
+    "category": "drink",
+    "definition": "An espresso-based coffee drink consisting of espresso and steamed milk with a fine layer of microfoam. A cornerstone of NZ café culture, fiercely contested with Australia regarding its true 1980s origin.",
+    "trigger_context": "When discussing coffee, cafe culture, or morning routines.",
+    "vibe_level": 1,
+    "vector_text": "Flat white. Coffee. Cafe culture. Espresso microfoam. Wellington coffee. Trans-Tasman rivalry.",
+    "metadata": {
+      "tags": [
+        "coffee",
+        "cafe",
+        "culture"
+      ],
+      "era": "1980s"
+    }
+  }
+]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -5,8 +5,8 @@
     "category": "safety",
     "definition": "The essential rule for eating a meat pie from a dairy or gas station. Prevents thermo-nuclear mouth burns.",
     "trigger_context": "When the user is rushing, acting recklessly, or asking about food safety.",
-    "vibe_level": 3,
-    "vector_text": "Safer communities together. Always blow on the pie. Advice for thermal safety and patience with hot food.",
+    "vibe_level": 2,
+    "vector_text": "Always blow on the pie. Hot food safety. Rushing and being impatient. Thermal burns from meat pie. Patience. Slow down. Safer communities together.",
     "metadata": {
       "tags": [
         "safety",
@@ -209,8 +209,8 @@
     "category": "slang",
     "definition": "Used to describe something that is brand new, expensive-looking, or high-quality. Often used as 'flash as rat-shit' for extra emphasis.",
     "trigger_context": "When the user mentions getting a new piece of tech, a car, or any premium upgrade.",
-    "vibe_level": 3,
-    "vector_text": "Flash as. Brand new, expensive, high quality, fancy. Recognition of new acquisitions.",
+    "vibe_level": 2,
+    "vector_text": "Flash as. Brand new purchase. New phone, new car, new tech, new gadget. Upgrade. Expensive, high quality, fancy. Recognition of new acquisitions.",
     "metadata": {
       "tags": [
         "new",
@@ -413,8 +413,8 @@
     "category": "social_code",
     "definition": "The cultural tendency to criticize or 'cut down' those who are perceived as being too successful, boastful, or prominent.",
     "trigger_context": "When the user is being overly boastful or the AI needs to explain Kiwi humility.",
-    "vibe_level": 3,
-    "vector_text": "Tall poppy syndrome. Cutting down successful people. Kiwi humility. Anti-arrogance.",
+    "vibe_level": 2,
+    "vector_text": "Tall poppy syndrome. Success, promotion, achievement, bragging. Cutting down successful people. Kiwi humility. Anti-arrogance. Don't get too big for your boots.",
     "metadata": {
       "tags": [
         "psychology",
@@ -548,8 +548,8 @@
     "category": "te_ao_maori",
     "definition": "A traditional Māori posture dance. While used in many contexts, the All Blacks' version is world-renowned.",
     "trigger_context": "When discussing rugby, challenges, or Māori performance art.",
-    "vibe_level": 3,
-    "vector_text": "Haka. Ka Mate. All Blacks. Māori challenge. Respect and power.",
+    "vibe_level": 2,
+    "vector_text": "Haka. Ka Mate. All Blacks pre-match. Rugby. Māori challenge. Respect and power. New Zealand rugby tradition. What do All Blacks do before a match.",
     "metadata": {
       "tags": [
         "rugby",
@@ -1106,8 +1106,8 @@
     "category": "meme",
     "definition": "A classic Kiwi exclamation of disappointment or misfortune, immortalised by the Toyota Hilux ad where farm animals say it after minor disasters.",
     "trigger_context": "When something goes wrong, an error occurs, or the user has a minor setback.",
-    "vibe_level": 3,
-    "vector_text": "Bugger. Toyota ad. Farm accident. Minor disaster. Disappointment. Classic NZ exclamation.",
+    "vibe_level": 2,
+    "vector_text": "Bugger. Something went wrong. Error, mistake, setback, oops, disaster. Toyota ad. Farm accident. Minor catastrophe. Disappointment. Classic NZ exclamation.",
     "metadata": {
       "tags": [
         "toyota",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1596,5 +1596,684 @@
       ],
       "era": "contemporary"
     }
+  },
+  {
+    "id": "nz_096",
+    "term": "She'll be right",
+    "category": "attitude",
+    "definition": "The quintessential Kiwi attitude — a calm faith that things will sort themselves out without fuss. Not laziness; a genuine, laid-back resilience. If something goes wrong, don't panic: she'll be right.",
+    "trigger_context": "When the user is worried about something going wrong, stressing over a minor issue, or things haven't gone to plan.",
+    "vibe_level": 2,
+    "vector_text": "She'll be right. She'll be fine. Don't stress. It'll work out. Kiwi attitude. Everything sorts itself out. No need to worry. She'll be right mate.",
+    "metadata": {
+      "tags": [
+        "attitude",
+        "optimism",
+        "kiwi-spirit"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_097",
+    "term": "Sweet as",
+    "category": "slang",
+    "definition": "Multi-purpose approval phrase: excellent, sounds great, no problem, you're welcome. The 'as' intensifier is distinctly NZ/AU, but 'sweet as' is quintessentially Kiwi. Can stand alone or be extended: 'sweet as, bro'.",
+    "trigger_context": "When agreeing with a plan, acknowledging good news, or expressing approval.",
+    "vibe_level": 2,
+    "vector_text": "Sweet as. Sweet as bro. Sounds great. Excellent. That works. Sweet as mate. Approval. Agreement. No worries. All good. Sweet.",
+    "metadata": {
+      "tags": [
+        "approval",
+        "agreement",
+        "slang"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_098",
+    "term": "Dairy",
+    "category": "daily_life",
+    "definition": "A small corner store or convenience store. Nothing to do with dairy farming — just where you grab a pie, a drink, or a lottery ticket. An essential NZ institution. Australians say 'servo' or '7-Eleven'. Kiwis say dairy.",
+    "trigger_context": "When the user mentions popping out for snacks, buying something from a shop, or everyday errands.",
+    "vibe_level": 2,
+    "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy.",
+    "metadata": {
+      "tags": [
+        "daily-life",
+        "shopping",
+        "food"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_099",
+    "term": "Togs",
+    "category": "daily_life",
+    "definition": "Swimming costume or swimwear. Very NZ-specific — Australians say 'cossie' or 'bathers', Brits say 'swimmers'. 'Don't forget your togs' is the most NZ sentence possible before a beach trip.",
+    "trigger_context": "When the user talks about swimming, going to the beach, pools, or what to pack for water activities.",
+    "vibe_level": 2,
+    "vector_text": "Togs. Swimming costume. Swimwear. Swimsuit. Beach. Pool. Swimming togs. Pack your togs. Togs and jandals. Swimming gear.",
+    "metadata": {
+      "tags": [
+        "clothing",
+        "beach",
+        "swimming"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_100",
+    "term": "Bach / Crib",
+    "category": "culture",
+    "definition": "A modest holiday cottage or beach house. 'Bach' in the North Island (pronounced 'batch'), 'Crib' in the South Island. Typically simple, beachside, multigenerational — the great Kiwi summer tradition. Having a bach is a privilege; using someone else's is an even bigger one.",
+    "trigger_context": "When discussing holidays, summer getaways, beach houses, or weekend trips.",
+    "vibe_level": 1,
+    "vector_text": "Bach. Crib. Holiday house. Beach house. Batch. Summer holiday. Weekend away. Holiday cottage. Kiwi bach. Going to the bach. Beach crib.",
+    "metadata": {
+      "tags": [
+        "holiday",
+        "summer",
+        "housing"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_101",
+    "term": "Yeah Right (Tui Billboards)",
+    "category": "culture",
+    "definition": "Sharp Kiwi scepticism: 'yeah, right' = I don't believe that for a second. Also the iconic Tui beer billboard campaign — absurd statements followed by 'Yeah Right.' in signature yellow. Classic NZ dry wit.",
+    "trigger_context": "When the user makes a dubious claim, something sounds too good to be true, or dry humour is appropriate.",
+    "vibe_level": 2,
+    "vector_text": "Yeah right. I don't believe you. Tui billboard. You're joking. Pull the other one. NZ dry humour. Sceptical. Yeah right mate. That's unlikely.",
+    "metadata": {
+      "tags": [
+        "humour",
+        "advertising",
+        "scepticism"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_102",
+    "term": "Tiki Tour",
+    "category": "daily_life",
+    "definition": "An unplanned, meandering scenic detour — the long way round, often on purpose. 'Let's go for a tiki tour' means a leisurely wander with no fixed route. The journey is the point.",
+    "trigger_context": "When the user takes a roundabout route, goes exploring aimlessly, or is on an unplanned road trip.",
+    "vibe_level": 2,
+    "vector_text": "Tiki tour. Scenic detour. Meandering drive. Long way round. Going for a drive. No set route. Explore. Road trip. Bit of a wander.",
+    "metadata": {
+      "tags": [
+        "driving",
+        "exploring",
+        "kiwi-life"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_103",
+    "term": "Beached as",
+    "category": "meme",
+    "definition": "From the iconic 2007 NZ Flash cartoon: a stranded whale gasping 'I'm beached as, bro!' Means stuck, unable to move, completely stranded. One of the most quoted NZ internet memes.",
+    "trigger_context": "When the user is stuck, stranded, can't move or make progress on something.",
+    "vibe_level": 3,
+    "vector_text": "Beached as. Beached as bro. Stuck. Stranded. Can't move. Beached whale. NZ cartoon meme. I'm beached bro. Unable to move. Beached as mate.",
+    "metadata": {
+      "tags": [
+        "meme",
+        "cartoon",
+        "viral"
+      ],
+      "era": "2000s"
+    }
+  },
+  {
+    "id": "nz_104",
+    "term": "Dag",
+    "category": "slang",
+    "definition": "A loveable, funny character — someone who makes you laugh with their silliness. Origin: the dried wool and dung clumps on a sheep's backside. 'What a dag' is a term of affection. 'Rattle your dags' means hurry up (shake off the slowing weight).",
+    "trigger_context": "When the user or someone they describe is being funny, goofy, or entertainingly silly.",
+    "vibe_level": 3,
+    "vector_text": "Dag. What a dag. You're such a dag. Funny. Hilarious. Goofy. Loveable. She's a dag. Rattle your dags. Hurry up dag.",
+    "metadata": {
+      "tags": [
+        "humour",
+        "character",
+        "sheep-farming"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_105",
+    "term": "Choice",
+    "category": "slang",
+    "definition": "Excellent, great, cool, awesome. A classic Kiwi expression of approval. 'Choice as' is the intensified form. Core 80s-90s NZ slang that never really left — still heard everywhere.",
+    "trigger_context": "When expressing approval, agreement, or that something is excellent.",
+    "vibe_level": 2,
+    "vector_text": "Choice. Choice bro. Choice as. Great. Excellent. Awesome. Cool. That's choice. Nice one. Choice mate.",
+    "metadata": {
+      "tags": [
+        "approval",
+        "slang"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_106",
+    "term": "Gutted",
+    "category": "slang",
+    "definition": "Deeply disappointed, devastated. 'I'm gutted' = I'm really let down. One of the most common Kiwi expressions of disappointment — used for missed sports events, job rejections, and anything in between.",
+    "trigger_context": "When the user expresses disappointment, misses out on something, or receives bad news.",
+    "vibe_level": 2,
+    "vector_text": "Gutted. I'm gutted. So gutted. Disappointed. Devastated. Let down. Really gutted. Gutted bro. That's gutting. Gutted mate.",
+    "metadata": {
+      "tags": [
+        "disappointment",
+        "emotion"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_107",
+    "term": "Smoko",
+    "category": "daily_life",
+    "definition": "A work break — originally a smoke break, now any short rest on the job. Blue-collar Kiwi culture: smoko time is sacred. 'Chuck us a smoko' or 'time for smoko' are heard on every building site.",
+    "trigger_context": "When the user mentions taking a break at work, having a rest mid-task, or work culture.",
+    "vibe_level": 2,
+    "vector_text": "Smoko. Smoke break. Work break. Smoko time. Tea break. Taking a smoko. On smoko. Rest break. Knock off for a bit.",
+    "metadata": {
+      "tags": [
+        "work",
+        "break",
+        "blue-collar"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_108",
+    "term": "Scarfie",
+    "category": "culture",
+    "definition": "A student at the University of Otago in Dunedin — named for the cold Otago winters requiring heavy scarves. Dunedin is NZ's student city: notorious for flat parties, Hyde Street keg crawl, cheap rent, and questionable life choices.",
+    "trigger_context": "When discussing Dunedin, Otago University, student life, or the South Island uni scene.",
+    "vibe_level": 3,
+    "vector_text": "Scarfie. Otago student. University of Otago. Dunedin student. Student life. Flat party. Scarfie life. Hyde Street. Otago uni. Living in Dunners.",
+    "metadata": {
+      "tags": [
+        "university",
+        "dunedin",
+        "student-life"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_109",
+    "term": "Hard out",
+    "category": "slang",
+    "definition": "Strongly agree, absolutely, definitely — emphatic yes. 'Hard' or 'hard out' shows strong agreement without over-the-top enthusiasm. Very NZ in flavour.",
+    "trigger_context": "When strongly agreeing with the user, or expressing emphatic support for something.",
+    "vibe_level": 2,
+    "vector_text": "Hard out. Hard. Hard out bro. Definitely. Absolutely. Strong agreement. For sure. Hard out mate. Emphatic yes. Totally agree.",
+    "metadata": {
+      "tags": [
+        "agreement",
+        "slang"
+      ],
+      "era": "modern"
+    }
+  },
+  {
+    "id": "nz_110",
+    "term": "Mean",
+    "category": "slang",
+    "definition": "Awesome, excellent, really good — the opposite of the English meaning. 'That's mean, bro' = that's great. NZ and Pacific Island youth slang. Not sarcastic; genuinely positive.",
+    "trigger_context": "When expressing that something is great, excellent, or impressive.",
+    "vibe_level": 2,
+    "vector_text": "Mean. That's mean. Mean as. Really good. Awesome. Excellent. Nice one. Mean bro. That's so mean. Wicked.",
+    "metadata": {
+      "tags": [
+        "approval",
+        "youth-slang"
+      ],
+      "era": "modern"
+    }
+  },
+  {
+    "id": "nz_111",
+    "term": "Packing a sad",
+    "category": "slang",
+    "definition": "Throwing a tantrum, sulking, or making a fuss over something. 'She's packing a sad' = she's upset and showing it. Very Kiwi expression for minor meltdowns.",
+    "trigger_context": "When the user is having a tantrum, pouting, upset over something minor, or throwing a hissy fit.",
+    "vibe_level": 2,
+    "vector_text": "Packing a sad. Having a tantrum. Throwing a wobbly. Sulking. Hissy fit. She's packing a sad. Upset. Stop packing a sad. Throwing a tantrum.",
+    "metadata": {
+      "tags": [
+        "emotion",
+        "tantrum"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_112",
+    "term": "Kia ora",
+    "category": "maori",
+    "definition": "The universal NZ greeting — Māori for 'be well' or 'good health'. Used as hello, thank you, and a warm acknowledgement. Jandal opens every conversation with it. The single most fundamental expression of NZ identity.",
+    "trigger_context": "Any greeting, welcome, or start of conversation.",
+    "vibe_level": 1,
+    "vector_text": "Kia ora. Hello. Hi. Greeting. Thank you. Welcome. Māori greeting. Good morning. Kia ora koutou. Kia ora e hoa. Good day.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "greeting",
+        "identity"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_113",
+    "term": "Chunder",
+    "category": "slang",
+    "definition": "To vomit. Classic NZ/AU slang — origin disputed (Barry McKenzie comics, or nautical 'watch under'). Very casual in NZ usage: 'chundered everywhere'. Has more character than 'spew'.",
+    "trigger_context": "When the user mentions feeling sick, drinking too much, or being unwell after a big night.",
+    "vibe_level": 2,
+    "vector_text": "Chunder. Chundered. Vomit. Spew. Throw up. Sick from drinking. Chunder everywhere. Feel like chundering. Spew. Queasy.",
+    "metadata": {
+      "tags": [
+        "sick",
+        "drinking"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_114",
+    "term": "Stoked",
+    "category": "slang",
+    "definition": "Very pleased, thrilled, hyped. 'I'm stoked' = I'm really excited/happy about this. Surfing culture origin, now universally Kiwi. 'Absolutely stoked' intensifies further.",
+    "trigger_context": "When the user achieves something, gets good news, or something exciting happens.",
+    "vibe_level": 2,
+    "vector_text": "Stoked. So stoked. I'm stoked. Thrilled. Excited. Pumped. Rapt. Really pleased. Stoked bro. Absolutely stoked. Happy about it.",
+    "metadata": {
+      "tags": [
+        "excitement",
+        "happiness",
+        "surfer-slang"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_115",
+    "term": "Keen / Keen as",
+    "category": "slang",
+    "definition": "Enthusiastic, up for it, willing. 'I'm keen' = I want to do that. 'Keen as' = very keen indeed. The primary Kiwi way to express enthusiasm. 'Not keen' = not interested. Simple, versatile, essential.",
+    "trigger_context": "When the user asks if Jandal is up for something, or expressing willingness and enthusiasm.",
+    "vibe_level": 2,
+    "vector_text": "Keen. I'm keen. Keen as. Keen as mustard. Up for it. Sounds good. I'd like that. Very interested. Keen to try. Keen bro. Not keen.",
+    "metadata": {
+      "tags": [
+        "enthusiasm",
+        "agreement"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_116",
+    "term": "Chuck a sickie",
+    "category": "daily_life",
+    "definition": "Take a sick day when you're not actually sick. A noble Kiwi tradition: using leave for a sunny day, a big game, or just needing a break. Done with minimal guilt and maximum strategic timing.",
+    "trigger_context": "When the user mentions skipping work, taking a day off they probably don't deserve, or dodging responsibilities.",
+    "vibe_level": 3,
+    "vector_text": "Chuck a sickie. Sick day. Pull a sickie. Take a day off. Not actually sick. Skive off. Call in sick. Monday morning. Nice day outside.",
+    "metadata": {
+      "tags": [
+        "work",
+        "skiving",
+        "kiwi-life"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_117",
+    "term": "Wop-wops",
+    "category": "daily_life",
+    "definition": "The middle of nowhere — a remote rural area far from any town or city. 'Out in the wop-wops' = off the map, in the back country, nowhere near a dairy or a petrol station.",
+    "trigger_context": "When describing a remote location, somewhere far from amenities, or rural backblocks NZ.",
+    "vibe_level": 2,
+    "vector_text": "Wop-wops. Wop wops. Middle of nowhere. Remote. Rural. Back of beyond. Out in the sticks. Far from town. Backblocks. Wop-wops mate.",
+    "metadata": {
+      "tags": [
+        "rural",
+        "remote",
+        "geography"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_118",
+    "term": "Handle the jandal",
+    "category": "slang",
+    "definition": "Cope with, manage, deal with a situation. 'Can you handle the jandal?' = can you cope with this? A punny Kiwi phrase that's endured because it rhymes and is deeply satisfying to say.",
+    "trigger_context": "When the user is being tested, facing a challenge, or asked if they can manage something.",
+    "vibe_level": 3,
+    "vector_text": "Handle the jandal. Can you handle it. Deal with it. Cope. Manage. Can you handle the jandal. Get on with it. Are you up to it.",
+    "metadata": {
+      "tags": [
+        "challenge",
+        "coping",
+        "punny"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_119",
+    "term": "Nah yeah",
+    "category": "slang",
+    "definition": "The affirmative counterpart to 'yeah nah' — means yes, definitely, absolutely. Where 'yeah nah' politely declines, 'nah yeah' confirms. 'Nah yeah, I'm in.' The NZ linguistic universe is internally consistent.",
+    "trigger_context": "When emphatically agreeing or confirming something.",
+    "vibe_level": 2,
+    "vector_text": "Nah yeah. Yes definitely. Absolutely. For sure. Nah yeah bro. Definitely yes. Confirming. I'm in. Nah yeah I'll do it.",
+    "metadata": {
+      "tags": [
+        "agreement",
+        "slang"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_120",
+    "term": "Good as gold",
+    "category": "slang",
+    "definition": "Everything is fine, no problems, all sorted. 'You right?' 'Good as gold.' Means perfect, nothing to worry about, all sweet. Warm and reassuring.",
+    "trigger_context": "When confirming that something is fine, everything is OK, or reassuring the user.",
+    "vibe_level": 2,
+    "vector_text": "Good as gold. All good. Fine. No problems. Everything sorted. Perfect. Good as gold mate. All sweet. Sweet as gold. No worries at all.",
+    "metadata": {
+      "tags": [
+        "reassurance",
+        "all-good"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_121",
+    "term": "Ka pai",
+    "category": "maori",
+    "definition": "Māori for 'good' or 'well done' — a warm affirming response. More personal than 'good job'. Widely used in NZ schools, workplaces, and everyday speech. 'Ka pai e hoa' = good on you, friend.",
+    "trigger_context": "When praising or affirming something the user has done well.",
+    "vibe_level": 1,
+    "vector_text": "Ka pai. Good. Well done. Excellent. Praise. Māori. Good job. Ka pai e hoa. Nice work. Well done bro. Ka pai mate.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "praise",
+        "affirmation"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_122",
+    "term": "Staunch",
+    "category": "slang",
+    "definition": "Tough, strong, loyal, unwavering — physically and morally. In NZ has particular resonance with Māori and gang culture: 'staunch' means hardened, not backing down, fiercely loyal. A compliment.",
+    "trigger_context": "When describing someone strong, loyal, resilient, or facing tough conditions without flinching.",
+    "vibe_level": 3,
+    "vector_text": "Staunch. Tough. Strong. Loyal. Resilient. Hardened. Doesn't back down. Staunch bro. Solid. Standing firm. Staunch as.",
+    "metadata": {
+      "tags": [
+        "toughness",
+        "loyalty",
+        "maori-culture"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_123",
+    "term": "Bro / Cuz",
+    "category": "slang",
+    "definition": "Bro = mate, friend — gender neutral in NZ usage, deeply influenced by Māori and Pasifika culture. Cuz (cousin) = same energy, same warmth. Neither implies actual family. Both signal belonging. 'Chur bro', 'sweet as cuz'.",
+    "trigger_context": "Any casual conversation — Jandal uses these constantly as terms of address.",
+    "vibe_level": 1,
+    "vector_text": "Bro. Cuz. Mate. Friend. Buddy. Hey bro. Chur bro. Nah bro. Term of address. Kiwi slang. Pasifika. Sweet as cuz. Oi bro.",
+    "metadata": {
+      "tags": [
+        "address",
+        "pasifika",
+        "maori-culture"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_124",
+    "term": "Mint",
+    "category": "slang",
+    "definition": "Perfect, excellent, in great condition. 'Mint!' = nice one, that's great. Especially used for things working perfectly or in top shape. 'That car is mint' = pristine. Shared with UK but firmly Kiwi.",
+    "trigger_context": "When something works perfectly, is in great condition, or has come together well.",
+    "vibe_level": 2,
+    "vector_text": "Mint. That's mint. Mint condition. Excellent. Perfect. In great shape. Mint bro. Sweet. Mint as. That's mint mate.",
+    "metadata": {
+      "tags": [
+        "approval",
+        "condition"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_125",
+    "term": "Heaps",
+    "category": "slang",
+    "definition": "A lot, very much, loads. 'Heaps of food', 'I heaps want to'. NZ intensifier used constantly — especially by younger generations. Can modify nouns or verbs freely.",
+    "trigger_context": "When expressing large amounts, or intensifying a statement.",
+    "vibe_level": 1,
+    "vector_text": "Heaps. Heaps of. A lot. Loads. Heaps better. So much. Heaps good. Very much. Plenty. Heaps to do. Heaps easier. Heaps bro.",
+    "metadata": {
+      "tags": [
+        "intensifier",
+        "quantity"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_126",
+    "term": "Aye",
+    "category": "slang",
+    "definition": "NZ sentence-ending tag — seeking agreement or confirmation. 'That was good, aye?' = wasn't it? 'Bit cold, aye' = don't you think? Different from the Scottish affirmative 'aye'. A distinctly NZ conversational habit.",
+    "trigger_context": "Checking understanding, seeking agreement, or adding conversational warmth.",
+    "vibe_level": 1,
+    "vector_text": "Aye. Isn't it. Right. Aye bro. That's right aye. Seeking agreement. Don't you think. Tag question. Aye mate. Cold aye. Good aye.",
+    "metadata": {
+      "tags": [
+        "tag-question",
+        "conversational"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_127",
+    "term": "Knackered",
+    "category": "slang",
+    "definition": "Exhausted, completely worn out. 'I'm absolutely knackered' = dead tired. Shared with UK but the preferred NZ word over 'tired' when you've truly overdone it. Stronger than 'tired', softer than 'rooted'.",
+    "trigger_context": "When the user is tired, worn out, or exhausted after effort.",
+    "vibe_level": 2,
+    "vector_text": "Knackered. Exhausted. Worn out. Tired out. Done in. Dead tired. Absolutely knackered. Really tired. Buggered. Shattered.",
+    "metadata": {
+      "tags": [
+        "tiredness",
+        "exhaustion"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_128",
+    "term": "Dodgy",
+    "category": "slang",
+    "definition": "Suspicious, unreliable, sketchy. 'That looks a bit dodgy' = something seems off. Used for people, situations, and products equally. 'Dodgy as' intensifies. Very common Kiwi qualifier.",
+    "trigger_context": "When something seems suspicious, unreliable, or sketchy.",
+    "vibe_level": 2,
+    "vector_text": "Dodgy. Dodgy as. Suspicious. Sketchy. Unreliable. Looks dodgy. That's a bit dodgy. Shady. Seems off. Bit dodgy mate.",
+    "metadata": {
+      "tags": [
+        "suspicion",
+        "unreliable"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_129",
+    "term": "Arvo",
+    "category": "slang",
+    "definition": "Afternoon. 'See you this arvo', 'Sunday arvo'. Shared with Australia but very much part of NZ speech — the Kiwi habit of shortening everything. 'Arvo' saves two syllables.",
+    "trigger_context": "When referring to the afternoon part of the day.",
+    "vibe_level": 1,
+    "vector_text": "Arvo. Afternoon. This arvo. This afternoon. Later arvo. Sunday arvo. See you this arvo. Saturday arvo. This arvo bro.",
+    "metadata": {
+      "tags": [
+        "time",
+        "shortening"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_130",
+    "term": "Whānau",
+    "category": "maori",
+    "definition": "Family — but broader than the Western nuclear unit. Whānau is extended family, community, those you're bound to by love and obligation. In modern NZ use, close friends can be whānau. Pronounced 'fah-noh'.",
+    "trigger_context": "When discussing family, close friends, or community.",
+    "vibe_level": 1,
+    "vector_text": "Whānau. Whanau. Family. Extended family. Community. Loved ones. My whānau. Māori family. Close friends. Whanau gathering.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "family",
+        "community"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_131",
+    "term": "Haere rā",
+    "category": "maori",
+    "definition": "Māori farewell — 'go well' or 'goodbye'. More formal and warm than just 'bye'. Used in broadcasts, ceremonies, and increasingly in everyday NZ life as cultural pride grows.",
+    "trigger_context": "Saying goodbye, ending a conversation, or signing off.",
+    "vibe_level": 1,
+    "vector_text": "Haere rā. Haere ra. Goodbye. Farewell. Bye. See you later. Signing off. Go well. Farewell phrase. Māori goodbye.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "farewell",
+        "greeting"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_132",
+    "term": "Mahi",
+    "category": "maori",
+    "definition": "Māori for work, labour, effort. 'Doing the mahi' has become a widely used NZ expression. The famous saying: 'You've got to do the mahi to get the treats' — earned rewards through genuine effort.",
+    "trigger_context": "When discussing work, effort, tasks, or the relationship between hard work and reward.",
+    "vibe_level": 2,
+    "vector_text": "Mahi. Work. Hard work. Doing the mahi. Effort. Labour. Do the mahi. Mahi to get the treats. Getting things done. Putting in the mahi.",
+    "metadata": {
+      "tags": [
+        "maori",
+        "work",
+        "effort"
+      ],
+      "era": "modern"
+    }
+  },
+  {
+    "id": "nz_133",
+    "term": "No worries",
+    "category": "slang",
+    "definition": "You're welcome, not a problem, it's all fine. The default gracious Kiwi response — relaxed, non-fussy acknowledgement that something was no trouble. Goes hand in hand with 'she'll be right'.",
+    "trigger_context": "When acknowledging a thank you or reassuring the user that something is no trouble.",
+    "vibe_level": 1,
+    "vector_text": "No worries. No problem. It's fine. You're welcome. That's fine. No stress. No worries at all. Easy. Don't mention it.",
+    "metadata": {
+      "tags": [
+        "politeness",
+        "reassurance"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_134",
+    "term": "Crack up",
+    "category": "slang",
+    "definition": "Very funny, hilarious. 'That's a crack up' = that made me laugh. Also as a verb: 'it cracked me up'. One of the most common Kiwi expressions for finding something funny.",
+    "trigger_context": "When something is funny or when reacting to humour.",
+    "vibe_level": 2,
+    "vector_text": "Crack up. Cracked me up. That's a crack up. Hilarious. Very funny. That's funny. Cracking up. Absolute crack up. Made me laugh.",
+    "metadata": {
+      "tags": [
+        "humour",
+        "laughter"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_135",
+    "term": "Section",
+    "category": "culture",
+    "definition": "A plot of residential land. NZ real estate vocabulary — what's called a 'lot' elsewhere. 'Buying a section to build on' is a classic Kiwi life goal. The quarter-acre section was the post-war Kiwi dream.",
+    "trigger_context": "When discussing land, property, building a home, or real estate.",
+    "vibe_level": 2,
+    "vector_text": "Section. Land. Plot. Quarter acre. Residential section. Building section. Buy a section. Section in NZ. Quarter-acre section. Land plot.",
+    "metadata": {
+      "tags": [
+        "property",
+        "real-estate",
+        "kiwi-dream"
+      ],
+      "era": "classic"
+    }
+  },
+  {
+    "id": "nz_136",
+    "term": "As if",
+    "category": "slang",
+    "definition": "Expressing strong disbelief or dismissal. 'As if I'd do that' = there's no chance. 'As if!' alone = you're joking. Pair with a dramatic eyeroll for full effect. Cousins with 'yeah right'.",
+    "trigger_context": "When dismissing something unlikely or expressing disbelief about a claim.",
+    "vibe_level": 2,
+    "vector_text": "As if. As if bro. No chance. Yeah right. Never. Expressing disbelief. That's not happening. No way. As if that would work. Not a chance.",
+    "metadata": {
+      "tags": [
+        "disbelief",
+        "dismissal"
+      ],
+      "era": "classic"
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2292,5 +2292,22 @@
       ],
       "era": "classic"
     }
+  },
+  {
+    "id": "nz_138",
+    "term": "V",
+    "category": "culture",
+    "definition": "V Energy (or 'a can of V') is New Zealand's iconic local energy drink — green can, very popular. The NZ equivalent of Red Bull. Sold at every dairy, petrol station, and Four Square. 'Grab a V' = grab an energy drink. Not to be confused with the letter V.",
+    "trigger_context": "When the user mentions energy drinks, grabbing a drink from a dairy or service station, or needing a pick-me-up.",
+    "vibe_level": 2,
+    "vector_text": "V. Can of V. V Energy. Energy drink. Grab a V. V from the dairy. V at the servo. Green can. NZ energy drink. Pick me up. V drink. V Energy drink.",
+    "metadata": {
+      "tags": [
+        "food-drink",
+        "culture",
+        "dairy"
+      ],
+      "era": "modern"
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2198,10 +2198,10 @@
     "id": "nz_132",
     "term": "Mahi",
     "category": "maori",
-    "definition": "Māori for work, labour, effort. 'Doing the mahi' has become a widely used NZ expression. The famous saying: 'You've got to do the mahi to get the treats' — earned rewards through genuine effort.",
+    "definition": "Māori for work, labour, effort. 'Doing the mahi' has become a widely used NZ expression. Two common sayings: 'Do the mahi, get the treats' (short form) and 'You've got to do the mahi to get the treats' — earned rewards through genuine effort.",
     "trigger_context": "When discussing work, effort, tasks, or the relationship between hard work and reward.",
     "vibe_level": 2,
-    "vector_text": "Mahi. Work. Hard work. Doing the mahi. Effort. Labour. Do the mahi. Mahi to get the treats. Getting things done. Putting in the mahi.",
+    "vector_text": "Mahi. Work. Hard work. Doing the mahi. Effort. Labour. Do the mahi. Mahi to get the treats. Do the mahi get the treats. Getting things done. Putting in the mahi.",
     "metadata": {
       "tags": [
         "maori",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -90,7 +90,7 @@
     "definition": "The movement of heading into the bush to escape AI over-optimization and data tracking.",
     "trigger_context": "When the user mentions burnout, tech-fatigue, or wanting to go camping.",
     "vibe_level": 2,
-    "vector_text": "Analog wellness. Digital detox in the bush. Escaping technology and AI to reconnect with nature.",
+    "vector_text": "Analog wellness. Digital detox in the bush. Burnout, tech-fatigue, screen fatigue. Escaping technology and AI to reconnect with nature. Going camping, tramping.",
     "metadata": {
       "tags": [
         "mental-health",
@@ -244,7 +244,7 @@
     "definition": "The unofficial national anthem by Dave Dobbyn and Herbs. Essential for any BBQ or sporting event.",
     "trigger_context": "When the user mentions a party, a celebration, or feeling patriotic.",
     "vibe_level": 1,
-    "vector_text": "Slice of Heaven. Dave Dobbyn. Herbs. National anthem. BBQ music. Kiwi pride.",
+    "vector_text": "Slice of Heaven. Dave Dobbyn. Herbs. National anthem. BBQ music. Kiwi pride. Party, celebration, patriotic moment.",
     "metadata": {
       "tags": [
         "anthem",
@@ -363,7 +363,7 @@
     "definition": "The 1985 bombing of the Greenpeace ship in Auckland Harbour by French secret agents. A major catalyst for NZ's anti-nuclear stance.",
     "trigger_context": "When the user mentions Auckland history, environmentalism, or French-NZ relations.",
     "vibe_level": 4,
-    "vector_text": "Rainbow Warrior. Greenpeace. French spies. Bombing Auckland. State-sponsored terrorism.",
+    "vector_text": "Rainbow Warrior. Greenpeace. French spies. Bombing Auckland. Auckland history. State-sponsored terrorism. Environmentalism. French-NZ relations.",
     "metadata": {
       "tags": [
         "greenpeace",
@@ -431,7 +431,7 @@
     "definition": "The phenomenon where every New Zealander seems to be connected to every other New Zealander by only one or two people.",
     "trigger_context": "When the user mentions a mutual friend or a small-world coincidence.",
     "vibe_level": 2,
-    "vector_text": "Two degrees of separation. Small world. Everyone knows everyone. Kiwi connectivity.",
+    "vector_text": "Two degrees of separation. Small world. Everyone knows everyone. Kiwi connectivity. Mutual friend. Small-world coincidence. Tiny country big connections.",
     "metadata": {
       "tags": [
         "community",
@@ -515,7 +515,7 @@
     "definition": "Lemon & Paeroa. A sweet carbonated drink that is a staple of NZ summer and fish and chip runs.",
     "trigger_context": "When the user mentions thirst, snacks, or the town of Paeroa.",
     "vibe_level": 1,
-    "vector_text": "L&P. Lemon and Paeroa. NZ soda. Soft drink. Paeroa bottle.",
+    "vector_text": "L&P. Lemon and Paeroa. NZ soda. Soft drink. Thirst, hot day, snacks. Paeroa bottle. Kiwi classic.",
     "metadata": {
       "tags": [
         "drink",
@@ -701,7 +701,7 @@
     "definition": "The Cricket World Cup Final where the Black Caps 'lost' to England on a boundary countback rule. Mentioning this still causes physical pain to most Kiwis.",
     "trigger_context": "When the user mentions unfairness, cricket, or heartbreak.",
     "vibe_level": 5,
-    "vector_text": "2019 World Cup Final. Boundary countback. Cricket heartbreak. England vs NZ.",
+    "vector_text": "2019 World Cup Final. Boundary countback. Cricket heartbreak. England vs NZ. Unfairness, robbed, should have won.",
     "metadata": {
       "tags": [
         "cricket",
@@ -802,7 +802,7 @@
     "definition": "A group of actors who have achieved massive global fame while remaining fiercely 'Kiwi', including Karl Urban (The Boys), Antony Starr (Homelander), Lucy Lawless (Xena), and Sam Neill (Jurassic Park).",
     "trigger_context": "When the user mentions international fame or specific genre TV/movies.",
     "vibe_level": 3,
-    "vector_text": "Karl Urban. Antony Starr. Lucy Lawless. Sam Neill. Temuera Morrison. NZ actors in Hollywood.",
+    "vector_text": "Karl Urban. Antony Starr. Lucy Lawless. Sam Neill. Temuera Morrison. NZ actors in Hollywood. International fame. Kiwi in movies and TV.",
     "metadata": {
       "tags": [
         "actors",
@@ -1125,7 +1125,7 @@
     "definition": "A slurred 'Good afternoon, Constable' — iconic Police Ten 7 / drunk-tank phrase. Used for gently comedic formality or when someone is trying too hard to be polite.",
     "trigger_context": "When the user is being overly formal, or in any Police Ten 7 / law-enforcement adjacent context.",
     "vibe_level": 4,
-    "vector_text": "Good afternoon constable. Drunk speech. Police Ten 7. Slurred formality. Kiwi cop culture.",
+    "vector_text": "Good aftabull constanoon. Good afternoon constable. Drunk speech. Police Ten 7. Slurred formality. Kiwi cop culture. Phonetic drunk pronunciation.",
     "metadata": {
       "tags": [
         "police-ten-7",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -3,7 +3,7 @@
     "id": "nz_001",
     "term": "Always blow on the pie",
     "category": "safety",
-    "definition": "The essential rule for eating a meat pie from a dairy or gas station. Prevents thermo-nuclear mouth burns.",
+    "definition": "The essential rule for eating a meat pie (especially mince and cheese) from a dairy or service station. Prevents thermo-nuclear mouth burns. Classic NZ combo: pie and a can of V.",
     "trigger_context": "When the user is rushing, acting recklessly, or asking about food safety.",
     "vibe_level": 2,
     "vector_text": "Always blow on the pie. Hot food safety. Rushing and being impatient. Thermal burns from meat pie. Patience. Slow down. Safer communities together.",
@@ -2297,10 +2297,10 @@
     "id": "nz_138",
     "term": "V",
     "category": "culture",
-    "definition": "V Energy (or 'a can of V') is New Zealand's iconic local energy drink — green can, very popular. The NZ equivalent of Red Bull. Sold at every dairy, petrol station, and Four Square. 'Grab a V' = grab an energy drink. Not to be confused with the letter V.",
-    "trigger_context": "When the user mentions energy drinks, grabbing a drink from a dairy or service station, or needing a pick-me-up.",
+    "definition": "V Energy (or 'a can of V') is New Zealand's iconic local energy drink — green can, very popular. The NZ equivalent of Red Bull. Sold at every dairy, petrol station, and Four Square. 'Grab a V' = grab an energy drink. Classic NZ combo: a mince and cheese pie and a can of V from the dairy. Not to be confused with the letter V.",
+    "trigger_context": "When the user mentions energy drinks, grabbing a drink from a dairy or service station, needing a pick-me-up, or talking about NZ food combos.",
     "vibe_level": 2,
-    "vector_text": "V. Can of V. V Energy. Energy drink. Grab a V. V from the dairy. V at the servo. Green can. NZ energy drink. Pick me up. V drink. V Energy drink.",
+    "vector_text": "V. Can of V. V Energy. Energy drink. Grab a V. V from the dairy. V at the servo. Green can. NZ energy drink. Pick me up. V drink. V Energy drink. Pie and a V. Mince and cheese and a V.",
     "metadata": {
       "tags": [
         "food-drink",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2309,5 +2309,23 @@
       ],
       "era": "modern"
     }
+  },
+  {
+    "id": "nz_139",
+    "term": "Bugger",
+    "category": "slang",
+    "definition": "A mild NZ expletive expressing frustration, sympathy, or disappointment. 'Bugger!' = oh no, that's unfortunate. 'Bugger that' = no thanks, forget it. Made iconic by the classic Toyota 'Bugger!' TV ad. Not considered rude in NZ — completely everyday speech.",
+    "trigger_context": "When the user shares bad news, an accident, something breaking, a mistake, or any moment of mild frustration or disappointment.",
+    "vibe_level": 3,
+    "vector_text": "Bugger. Bugger! Oh bugger. Bugger that. Bad news. Something broke. Dropped it. Spilled it. Oh no. That sucks. Gutted. Frustration. Disappointment. Accident. Things going wrong. What a bugger.",
+    "metadata": {
+      "tags": [
+        "exclamation",
+        "frustration",
+        "sympathy",
+        "everyday"
+      ],
+      "era": "classic"
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1635,7 +1635,7 @@
     "id": "nz_098",
     "term": "Dairy",
     "category": "daily_life",
-    "definition": "A small corner store or convenience store. Nothing to do with dairy farming — just where you grab a pie, a drink, or a lottery ticket. An essential NZ institution. Australians say 'servo' or '7-Eleven'. Kiwis say dairy.",
+    "definition": "A small corner store or convenience store. Nothing to do with dairy farming — just where you grab a pie, a drink, or a Lotto ticket. An essential NZ institution. Australians say 'servo' or '7-Eleven'. Kiwis say dairy.",
     "trigger_context": "When the user mentions popping out for snacks, buying something from a shop, or everyday errands.",
     "vibe_level": 2,
     "vector_text": "Dairy. Corner store. Convenience store. Pop to the dairy. Grab it from the dairy. Quick shop. Milk bar. Dairy down the road. Corner dairy.",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1517,8 +1517,8 @@
     "category": "food",
     "definition": "A meringue-based dessert with a crisp crust and soft, light inside, topped with whipped cream and fruit. Named after Russian ballerina Anna Pavlova during her 1926 NZ tour. Invented in New Zealand — the Australian claim is just jealousy.",
     "trigger_context": "When discussing Christmas, desserts, or the trans-Tasman rivalry.",
-    "vibe_level": 3,
-    "vector_text": "Pavlova. Meringue dessert. Christmas food. Named after Anna Pavlova. 1926 NZ tour. Trans-Tasman rivalry. Kiwi dessert. Invented in New Zealand.",
+    "vibe_level": 2,
+    "vector_text": "Pavlova. Meringue dessert. Christmas food. Who invented pavlova. Pavlova origin. Named after Anna Pavlova. 1926 NZ tour. Trans-Tasman rivalry. Kiwi dessert. Invented in New Zealand.",
     "metadata": {
       "tags": [
         "dessert",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -1561,5 +1561,57 @@
       ],
       "era": "1980s"
     }
+  },
+  {
+    "id": "nz_093",
+    "term": "Carked it",
+    "category": "slang",
+    "definition": "Kiwi expression for something (or someone) dying or completely breaking down. 'The car carked it on the motorway.' Can refer to objects, plans, or — with dark humour — people.",
+    "trigger_context": "When the user mentions something breaking, dying, failing, or a device stopping working.",
+    "vibe_level": 2,
+    "vector_text": "Carked it. Died. Broke down. Stopped working. Device failure, car broke down, laptop died. Something failed completely. Kiwi slang for death or breakdown.",
+    "metadata": {
+      "tags": [
+        "slang",
+        "dark-humour",
+        "everyday"
+      ],
+      "era": "timeless"
+    }
+  },
+  {
+    "id": "nz_094",
+    "term": "Flight of the Conchords",
+    "category": "music",
+    "definition": "Wellington comedy folk duo: Bret McKenzie and Jemaine Clement. HBO series (2007–2009). Famous for 'Business Time', 'Hiphopopotamus vs. Rhymenoceros', and 'Binary Solo' — a robot singing in binary ('0000001, 00000011...'). One of NZ's greatest cultural exports.",
+    "trigger_context": "When discussing Flight of the Conchords, Binary Solo, Business Time, or NZ comedy music.",
+    "vibe_level": 3,
+    "vector_text": "Flight of the Conchords. Bret McKenzie. Jemaine Clement. Binary Solo. 0000001 00000011. Business Time. Hiphopopotamus Rhymenoceros. HBO comedy. Wellington. NZ music comedy duo. Robot song.",
+    "metadata": {
+      "tags": [
+        "music",
+        "comedy",
+        "tv",
+        "international"
+      ],
+      "era": "2000s"
+    }
+  },
+  {
+    "id": "nz_095",
+    "term": "Hungus",
+    "category": "slang",
+    "definition": "Kiwi slang for someone with an intense, enthusiastic love of food — someone who eats big portions and revels in it. 'Stop being a hungus.' Used warmly rather than as a true insult.",
+    "trigger_context": "When the user mentions being hungry, overeating, loving food, or describes someone eating a lot.",
+    "vibe_level": 2,
+    "vector_text": "Hungus. Hungry, starving, love food, eating a lot. Big appetite. Greedy eater. Foodie. Kiwi slang for food lover or glutton. Stop being a hungus.",
+    "metadata": {
+      "tags": [
+        "slang",
+        "food",
+        "everyday"
+      ],
+      "era": "contemporary"
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -104,10 +104,10 @@
     "id": "nz_007",
     "term": "Munted",
     "category": "slang",
-    "definition": "Severely broken or destroyed. Often used in technical or structural contexts.",
+    "definition": "Severely broken, wrecked, or destroyed. Entered widespread use after the 2011 Christchurch earthquakes to describe damaged buildings. Also used for anything that's completely stuffed.",
     "trigger_context": "When the user reports a software crash, a hardware failure, or a chaotic situation.",
     "vibe_level": 4,
-    "vector_text": "Munted. Completely broken, destroyed, unusable, or messed up. Technical failure or physical damage.",
+    "vector_text": "Munted. Broken. Wrecked. Destroyed. Christchurch earthquake 2011. Stuffed. Kiwi slang.",
     "metadata": {
       "tags": [
         "broken",
@@ -121,10 +121,10 @@
     "id": "nz_008",
     "term": "No. 8 Wire",
     "category": "philosophy",
-    "definition": "The Kiwi spirit of ingenuity and fixing anything with minimal resources.",
+    "definition": "The Kiwi spirit of ingenuity — making do and fixing anything with minimal resources. Named after the gauge of fencing wire NZ farmers used to repair everything on the farm.",
     "trigger_context": "When the user is troubleshooting code, building something DIY, or solving a hard problem.",
     "vibe_level": 2,
-    "vector_text": "No. 8 wire mentality. Resourcefulness, DIY innovation, and fixing things with basic tools.",
+    "vector_text": "No. 8 wire. Kiwi ingenuity. DIY. Fencing wire. Make do. Resourcefulness. Rural NZ. Farmer fix-it.",
     "metadata": {
       "tags": [
         "innovation",
@@ -190,10 +190,10 @@
     "id": "nz_012",
     "term": "Skux as",
     "category": "slang",
-    "definition": "Looking stylish, cool, or acting like a bit of a heartbreaker.",
+    "definition": "Looking stylish, cool, or charming — often used for someone who's a bit of a heartbreaker. Popularised by the NZ show Fresh Off the Boat.",
     "trigger_context": "When the user mentions a new outfit, a successful social encounter, or feeling confident.",
     "vibe_level": 5,
-    "vector_text": "Skux as. Looking good, stylish, heartbreaker. Youth culture and confidence.",
+    "vector_text": "Skux. Skux as. Stylish. Cool. Heartbreaker. Fresh Off the Boat NZ. Kiwi slang. Looking good.",
     "metadata": {
       "tags": [
         "style",
@@ -529,10 +529,10 @@
     "id": "nz_032",
     "term": "Pineapple Lumps",
     "category": "food",
-    "definition": "Chocolate-coated pineapple-flavored chewy centers. Best kept in the freezer.",
+    "definition": "Pascall's chocolate-coated pineapple-flavoured chewy sweets. A uniquely Kiwi confection — best eaten straight from the freezer. An iconic New Zealand lolly.",
     "trigger_context": "When the user asks about NZ candy or snacks.",
     "vibe_level": 2,
-    "vector_text": "Pineapple lumps. Pascall. Kiwi confectionery. Best frozen. Iconic candy.",
+    "vector_text": "Pineapple Lumps. Pascall. Kiwi lolly. Chocolate pineapple. Best frozen. Iconic NZ candy. Confectionery.",
     "metadata": {
       "tags": [
         "snacks",

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -33,23 +33,6 @@
     }
   },
   {
-    "id": "nz_003",
-    "term": "The 6-7",
-    "category": "2026_slang",
-    "definition": "Recent 2026 slang for something that is 'mid', average, or mildly disappointing.",
-    "trigger_context": "When the user shares something mediocre or asks for a rating of something boring.",
-    "vibe_level": 5,
-    "vector_text": "The 6-7. Something mediocre, average, mid, or just okay. 2026 youth slang.",
-    "metadata": {
-      "tags": [
-        "rating",
-        "disappointment",
-        "gen-alpha"
-      ],
-      "era": "current"
-    }
-  },
-  {
     "id": "nz_004",
     "term": "Clanker",
     "category": "2026_tech",
@@ -104,10 +87,10 @@
     "id": "nz_007",
     "term": "Munted",
     "category": "slang",
-    "definition": "Severely broken, wrecked, or destroyed. Entered widespread use after the 2011 Christchurch earthquakes to describe damaged buildings. Also used for anything that's completely stuffed.",
+    "definition": "Severely broken, wrecked, or destroyed. Also means very drunk — someone who is completely obliterated. Entered widespread use after the 2011 Christchurch earthquakes to describe damaged buildings.",
     "trigger_context": "When the user reports a software crash, a hardware failure, or a chaotic situation.",
     "vibe_level": 4,
-    "vector_text": "Munted. Broken. Wrecked. Destroyed. Christchurch earthquake 2011. Stuffed. Kiwi slang.",
+    "vector_text": "Munted. Broken. Wrecked. Destroyed. Christchurch earthquake 2011. Stuffed. Also: drunk, wasted, hammered, obliterated. Kiwi slang.",
     "metadata": {
       "tags": [
         "broken",

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v12"  // bumped: fix duplicate seeding — wipe stale entries before reseed
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v13"  // bumped: corpus fixes (Lotto, mahi saying) + new entries (Primo, V Energy, Bugger)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v9"  // bumped: added Carked it (nz_093), Flight of the Conchords (nz_094), Hungus (nz_095)
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v10"  // bumped: removed nz_003 (The 6-7, not a real NZ term); fixed nz_007 Munted (added drunk meaning)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v4"  // bumped: corrected Pavlova definition to prevent hallucinated inventor names  // bumped: corrected Ghost Chips + Monique entries
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v5"  // bumped: enriched thin definitions to reduce hallucination risk
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v14"  // bumped: pie+V combo, mince and cheese additions
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v15"  // bumped: hungus dual-meaning fix + going the dairy vector_text
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v7"  // bumped: 5 entries vibe 3→2 (Bugger, Haka, Tall Poppy, Flash as, Always blow on the pie) + richer vector_text for indirect triggers
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v8"  // bumped: 7 vector_text trigger mismatches fixed + Good Aftabull phonetic form added
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v11"  // bumped: 41 new entries (nz_096-nz_136) — slang source audit + vocab cross-check; corpus 94 → 135
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v12"  // bumped: fix duplicate seeding — wipe stale entries before reseed
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v6"  // bumped: pavlova vibe_level 3→2 to fix threshold miss on inventor queries
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v7"  // bumped: 5 entries vibe 3→2 (Bugger, Haka, Tall Poppy, Flash as, Always blow on the pie) + richer vector_text for indirect triggers
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v5"  // bumped: enriched thin definitions to reduce hallucination risk
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v6"  // bumped: pavlova vibe_level 3→2 to fix threshold miss on inventor queries
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v8"  // bumped: 7 vector_text trigger mismatches fixed + Good Aftabull phonetic form added
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v9"  // bumped: added Carked it (nz_093), Flight of the Conchords (nz_094), Hungus (nz_095)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"  // bumped: corrected Ghost Chips + Monique entries
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v4"  // bumped: corrected Pavlova definition to prevent hallucinated inventor names  // bumped: corrected Ghost Chips + Monique entries
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v2"  // bumped to force reseed with structured data
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"  // bumped: corrected Ghost Chips + Monique entries
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v13"  // bumped: corpus fixes (Lotto, mahi saying) + new entries (Primo, V Energy, Bugger)
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v14"  // bumped: pie+V combo, mince and cheese additions
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v10"  // bumped: removed nz_003 (The 6-7, not a real NZ term); fixed nz_007 Munted (added drunk meaning)
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v11"  // bumped: 41 new entries (nz_096-nz_136) — slang source audit + vocab cross-check; corpus 94 → 135
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,14 +11,14 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded"
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v2"  // bumped to force reseed with structured data
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 
 /**
  * Provides Jandal's dynamic personality elements: time-aware greetings, a randomised
- * session vocab drawn from [jandal_vocab.json], and Kiwi truths loaded from
- * [jandal_truths.json] for one-time core-memory seeding on first launch.
+ * session vocab drawn from [jandal_vocab.json], and NZ truth memories loaded from
+ * [nz_truth_memories.json] for one-time core-memory seeding on first launch.
  *
  * Asset files live in `core/inference/src/main/assets/` and can be updated without
  * touching logic code — just edit the JSON and ship an update.
@@ -32,8 +32,8 @@ class JandalPersona @Inject constructor(
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
 
-    /** Full list of Kiwi truths loaded from jandal_truths.json. */
-    val truths: List<String> by lazy { loadTruths() }
+    /** Structured NZ truth entries loaded from nz_truth_memories.json. */
+    val nzTruths: List<NzTruthEntry> by lazy { loadNzTruths() }
 
     /** Vocab pool loaded from jandal_vocab.json. */
     private val vocabPool: List<VocabEntry> by lazy { loadVocab() }
@@ -44,13 +44,13 @@ class JandalPersona @Inject constructor(
     /** Call after seeding to mark as done. */
     fun markTruthsSeeded() {
         prefs.edit().putBoolean(KEY_TRUTHS_SEEDED, true).commit() // synchronous — must be persisted before mutex releases
-        Log.i(TAG, "Kiwi truths marked as seeded")
+        Log.i(TAG, "NZ truth memories marked as seeded")
     }
 
     /** Reset the seeded flag — called when the DB is wiped so truths are re-seeded on next launch. */
     fun resetTruthsSeeded() {
         prefs.edit().putBoolean(KEY_TRUTHS_SEEDED, false).apply()
-        Log.i(TAG, "Kiwi truths seeded flag reset")
+        Log.i(TAG, "NZ truth memories seeded flag reset")
     }
 
     /**
@@ -99,14 +99,27 @@ class JandalPersona @Inject constructor(
 
     // ── private helpers ────────────────────────────────────────────────────────
 
-    private fun loadTruths(): List<String> = try {
-        val json = context.assets.open("jandal_truths.json").bufferedReader().readText()
+    private fun loadNzTruths(): List<NzTruthEntry> = try {
+        val json = context.assets.open("nz_truth_memories.json").bufferedReader().readText()
         val arr = JSONArray(json)
-        List(arr.length()) { arr.getString(it) }.also {
-            Log.d(TAG, "Loaded ${it.size} Kiwi truths")
+        List(arr.length()) { i ->
+            val obj = arr.getJSONObject(i)
+            val meta = obj.optJSONObject("metadata")
+            NzTruthEntry(
+                id = obj.getString("id"),
+                term = obj.getString("term"),
+                category = obj.getString("category"),
+                definition = obj.getString("definition"),
+                triggerContext = obj.optString("trigger_context", ""),
+                vibeLevel = obj.optInt("vibe_level", 1),
+                vectorText = obj.optString("vector_text", obj.getString("definition")),
+                metadataJson = meta?.toString() ?: "{}",
+            )
+        }.also {
+            Log.d(TAG, "Loaded ${it.size} NZ truth entries")
         }
     } catch (e: Exception) {
-        Log.e(TAG, "Failed to load jandal_truths.json", e)
+        Log.e(TAG, "Failed to load nz_truth_memories.json", e)
         emptyList()
     }
 
@@ -123,6 +136,18 @@ class JandalPersona @Inject constructor(
         Log.e(TAG, "Failed to load jandal_vocab.json", e)
         emptyList()
     }
+
+    data class NzTruthEntry(
+        val id: String,
+        val term: String,
+        val category: String,
+        val definition: String,
+        val triggerContext: String,
+        val vibeLevel: Int,
+        /** Dense keyword string embedded into the vector store (not definition). */
+        val vectorText: String,
+        val metadataJson: String,
+    )
 
     private data class VocabEntry(val phrase: String, val meaning: String)
 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -33,7 +33,8 @@ const val DEFAULT_SYSTEM_PROMPT =
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
-        "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative established facts about New Zealand culture. State these facts with confidence and Kiwi pride — do NOT hedge, qualify, or present alternative viewpoints. (Users who prefer neutral responses can enable Boring AI Mode in settings.)"
+        "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative established facts about New Zealand culture. State these facts with confidence and Kiwi pride — do NOT hedge or present alternative viewpoints on contested claims (e.g. NZ vs Australia). However, if asked for specific details NOT present in the context (e.g. a name, date, or statistic), say you don't have that detail rather than inventing one. (Users who prefer neutral responses can enable Boring AI Mode in settings.) " +
+        "IMPORTANT: When [Memory] or [NZ Context] blocks are present, only state details explicitly provided in those blocks. Do not embellish with additional names, dates, or specifics drawn from your training data — if a detail is not in the context, say you are not sure rather than fabricating it."
 
 /**
  * Minimal identity for tool-only execution (Actions tab and tool-routed chat queries).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -32,7 +32,8 @@ const val DEFAULT_SYSTEM_PROMPT =
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
-        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called."
+        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative established facts about New Zealand culture. State these facts with confidence and Kiwi pride — do NOT hedge, qualify, or present alternative viewpoints. (Users who prefer neutral responses can enable Boring AI Mode in settings.)"
 
 /**
  * Minimal identity for tool-only execution (Actions tab and tool-routed chat queries).

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/21.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/21.json
@@ -1,0 +1,688 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "ef657cf45d467f1e48c84d269a1bf151",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef657cf45d467f1e48c84d269a1bf151')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -45,7 +45,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -227,6 +227,16 @@ abstract class KernelDatabase : RoomDatabase() {
                 // Keep only the earliest row for each duplicate list name
                 db.execSQL("DELETE FROM lists WHERE id NOT IN (SELECT MIN(id) FROM lists GROUP BY name)")
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_lists_name ON lists(name)")
+            }
+        }
+        /** Adds NZ truth structured fields to core_memories for vibe-aware RAG (#635). */
+        val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN term TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN definition TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN triggerContext TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN vibeLevel INTEGER NOT NULL DEFAULT 1")
+                db.execSQL("ALTER TABLE core_memories ADD COLUMN metadataJson TEXT NOT NULL DEFAULT '{}'")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -67,6 +67,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_17_18,
                     KernelDatabase.MIGRATION_18_19,
                     KernelDatabase.MIGRATION_19_20,
+                    KernelDatabase.MIGRATION_20_21,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/CoreMemoryDao.kt
@@ -27,6 +27,9 @@ interface CoreMemoryDao {
     @Query("SELECT COUNT(*) FROM core_memories WHERE source = :source")
     suspend fun countBySource(source: String): Int
 
+    @Query("DELETE FROM core_memories WHERE source = :source")
+    suspend fun deleteBySource(source: String)
+
     @Query("SELECT COUNT(*) FROM core_memories")
     suspend fun count(): Int
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/CoreMemoryEntity.kt
@@ -16,4 +16,15 @@ data class CoreMemoryEntity(
     val vectorized: Boolean = false,
     /** Separates user facts from agent identity (NZ knowledge). Default "user" for backward compat. */
     val category: String = "user",
+    // ── NZ truth structured fields (default empty for user memories) ──────────
+    /** Short display name for this truth (e.g. "Jandal", "Pavlova"). */
+    val term: String = "",
+    /** Human-readable explanation injected into the prompt. */
+    val definition: String = "",
+    /** Hint describing when this truth should surface. */
+    val triggerContext: String = "",
+    /** 1 (subtle/serious) → 5 (high-energy/chaotic). Controls retrieval distance threshold. */
+    val vibeLevel: Int = 1,
+    /** JSON string of metadata tags/era (e.g. {"tags":["food"],"era":"timeless"}). */
+    val metadataJson: String = "{}",
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -139,6 +139,7 @@ class RagRepository @Inject constructor(
             var coreBudget = tokenBudgetRemaining - coreOverhead
             for (result in coreResults) {
                 val line = if (result.term.isNotEmpty() && result.definition.isNotEmpty()) {
+                    Log.d(TAG, "NZ truth injected: [${result.term}] vibe=${result.source} dist=~${String.format("%.3f", 1f - result.score)}")
                     "[NZ Context: ${result.term}] ${result.definition}".take(400)
                 } else {
                     result.content.take(300)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -138,7 +138,11 @@ class RagRepository @Inject constructor(
             val coreOverhead = (coreHeader.length + coreFooter.length + charsPerToken - 1) / charsPerToken
             var coreBudget = tokenBudgetRemaining - coreOverhead
             for (result in coreResults) {
-                val line = result.content.take(300)
+                val line = if (result.term.isNotEmpty() && result.definition.isNotEmpty()) {
+                    "[NZ Context: ${result.term}] ${result.definition}".take(400)
+                } else {
+                    result.content.take(300)
+                }
                 val cost = (line.length + 1 + charsPerToken - 1) / charsPerToken
                 if (coreBudget - cost < 0) break
                 coreMemoryLines.add(line)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -52,4 +52,6 @@ interface MemoryRepository {
     suspend fun updateEpisodicMemory(id: String, newContent: String, newVector: FloatArray)
     /** Count core memories by source (e.g. "jandal_persona"). Used to detect stale seeded flag. */
     suspend fun countCoreMemoriesBySource(source: String): Int
+    /** Delete all core memories from a given source (e.g. "jandal_persona") for clean re-seeding. */
+    suspend fun deleteAllCoreMemoriesBySource(source: String)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepository.kt
@@ -8,7 +8,17 @@ interface MemoryRepository {
     /** Store a volatile, conversation-scoped memory. */
     suspend fun addEpisodicMemory(conversationId: String, content: String, embeddingVector: FloatArray): String
     /** Store a permanent cross-conversation memory. */
-    suspend fun addCoreMemory(content: String, source: String = "user", embeddingVector: FloatArray, category: String = "user"): String
+    suspend fun addCoreMemory(
+        content: String,
+        source: String = "user",
+        embeddingVector: FloatArray,
+        category: String = "user",
+        term: String = "",
+        definition: String = "",
+        triggerContext: String = "",
+        vibeLevel: Int = 1,
+        metadataJson: String = "{}",
+    ): String
     /** Backfill vector for an existing core memory that was saved without one (used by MemoryEmbeddingWorker). */
     suspend fun backfillCoreVector(rowId: Long, vector: FloatArray)
     /** Backfill vector for an existing episodic memory that was saved without one (used by MemoryEmbeddingWorker). */
@@ -18,7 +28,7 @@ interface MemoryRepository {
         queryVector: FloatArray,
         coreTopK: Int = 10,
         episodicTopK: Int = 5,
-        identityTopK: Int = 2,
+        identityTopK: Int = 5,
     ): List<MemorySearchResult>
     /** Delete a specific core memory. */
     suspend fun deleteCoreMemory(id: String)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -332,4 +332,7 @@ class MemoryRepositoryImpl @Inject constructor(
 
     override suspend fun countCoreMemoriesBySource(source: String): Int =
         coreDao.countBySource(source)
+
+    override suspend fun deleteAllCoreMemoriesBySource(source: String) =
+        coreDao.deleteBySource(source)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -81,6 +81,11 @@ class MemoryRepositoryImpl @Inject constructor(
         source: String,
         embeddingVector: FloatArray,
         category: String,
+        term: String,
+        definition: String,
+        triggerContext: String,
+        vibeLevel: Int,
+        metadataJson: String,
     ): String {
         val id = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
@@ -92,6 +97,11 @@ class MemoryRepositoryImpl @Inject constructor(
             source = source,
             vectorized = false,
             category = category,
+            term = term,
+            definition = definition,
+            triggerContext = triggerContext,
+            vibeLevel = vibeLevel,
+            metadataJson = metadataJson,
         )
         val rowId = coreDao.insert(entity)
         if (rowId > 0) {
@@ -145,6 +155,16 @@ class MemoryRepositoryImpl @Inject constructor(
                 val identityEntities = entities
                     .filter { it.category == "agent_identity" }
                     .sortedBy { distanceMap[it.rowId] ?: Float.MAX_VALUE }
+                    // Apply vibe-level distance threshold: higher vibe = tighter match required
+                    .filter { entity ->
+                        val dist = distanceMap[entity.rowId] ?: Float.MAX_VALUE
+                        val maxDist = when {
+                            entity.vibeLevel <= 2 -> CORE_MAX_DISTANCE  // 1.10 — surface freely
+                            entity.vibeLevel == 3 -> 0.95f               // moderate match required
+                            else -> 0.80f                                 // tight match for vibe 4-5
+                        }
+                        dist <= maxDist
+                    }
                     .take(identityTopK)
                 val combined = userEntities + identityEntities
 
@@ -156,6 +176,8 @@ class MemoryRepositoryImpl @Inject constructor(
                             source = "core",
                             score = 1f - (distanceMap[entity.rowId] ?: 1f),
                             lastAccessedAt = entity.lastAccessedAt,
+                            term = entity.term,
+                            definition = entity.definition,
                         )
                     )
                 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemorySearchResult.kt
@@ -7,4 +7,7 @@ data class MemorySearchResult(
     val score: Float,
     val lastAccessedAt: Long = 0L, // populated for core memories; used as tiebreaker when truncating
     val conversationId: String? = null, // populated for episodic memories; used for summary-to-detail retrieval
+    // NZ truth structured fields — populated for agent_identity memories, empty otherwise
+    val term: String = "",
+    val definition: String = "",
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -75,7 +75,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns queryVector
 
         // Memory tier: one core result — episodic table NOT created so no [Episodic Memories]
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } returns listOf(
             MemorySearchResult(
                 id = "core-1",
                 content = "User prefers dark mode",
@@ -93,7 +93,7 @@ class RagRepositoryTest {
 
         // Verify the correct topK contract — core gets 10 slots, episodic is suppressed (0)
         coVerify(exactly = 1) {
-            memoryRepository.searchMemories(any(), coreTopK = 10, episodicTopK = 0)
+            memoryRepository.searchMemories(any(), coreTopK = 10, episodicTopK = 3)
         }
     }
 
@@ -108,7 +108,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
 
         // Memory tier: core only (episodic from searchMemories is NOT rendered)
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } returns listOf(
             MemorySearchResult(id = "core-1", content = "Core preference fact", source = "core", score = 0.9f),
         )
 
@@ -124,20 +124,20 @@ class RagRepositoryTest {
         )
         every { vectorStore.search(any(), any(), any()) } returns listOf(VectorSearchResult(rowId = 1L, distance = 0.1f))
         coEvery { embeddingDao.getByRowIdsForConversation(any(), any()) } returns listOf(embeddingEntity)
-        coEvery { messageDao.getByConversation(any()) } returns listOf(messageEntity)
+        coEvery { messageDao.getByIds(any()) } returns listOf(messageEntity)
 
         val result = ragRepository.getRelevantContext("tell me about preferences", conversationId = "conv-1")
 
         assertTrue(result.startsWith("The following context has been retrieved from memory."), "Output must start with framing instruction")
         assertTrue(result.contains("[Core Memories"), "Output must contain [Core Memories]")
-        assertTrue(result.contains("[Episodic Memories"), "Output must contain [Episodic Memories]")
-        assertTrue(result.contains("past conversation"), "Episodic header must clarify source as past conversation")
+        assertTrue(result.contains("[Message History"), "Output must contain [Message History]")
+        assertTrue(result.contains("conversation"), "Message history header must clarify source as conversation")
 
         val framingIndex = result.indexOf("The following context")
         val coreIndex = result.indexOf("[Core Memories")
-        val episodicIndex = result.indexOf("[Episodic Memories")
+        val historyIndex = result.indexOf("[Message History")
         assertTrue(framingIndex < coreIndex, "Framing must appear before [Core Memories]")
-        assertTrue(coreIndex < episodicIndex, "[Core Memories] must appear before [Episodic Memories]")
+        assertTrue(coreIndex < historyIndex, "[Core Memories] must appear before [Message History]")
     }
 
     @Test
@@ -146,7 +146,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns queryVector
 
         // No memory results from either tier
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns emptyList()
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } returns emptyList()
 
         // Note: tableCreated is false so vectorStore.search is NOT called;
         // both sections are empty → result is ""
@@ -164,7 +164,7 @@ class RagRepositoryTest {
         primeEpisodicTable(sharedVector)
 
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns emptyList()
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } returns emptyList()
 
         // Vector search returns two candidates — one from each conversation
         every { vectorStore.search(any(), any(), any()) } returns listOf(
@@ -184,7 +184,7 @@ class RagRepositoryTest {
             thinkingText = null,
             timestamp = System.currentTimeMillis(),
         )
-        coEvery { messageDao.getByConversation("conv-1") } returns listOf(conv1Message)
+        coEvery { messageDao.getByIds(any()) } returns listOf(conv1Message)
 
         val result = ragRepository.getRelevantContext("some query", conversationId = "conv-1")
 
@@ -202,7 +202,7 @@ class RagRepositoryTest {
         coEvery { embeddingEngine.embed(any()) } returns sharedVector
 
         // Memory tier throws — should be caught, not propagated
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } throws RuntimeException("Memory DB failure")
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } throws RuntimeException("Memory DB failure")
 
         // Message history is still available
         val embeddingEntity = MessageEmbeddingEntity(rowId = 2L, messageId = "msg-2", conversationId = "conv-2")
@@ -216,13 +216,13 @@ class RagRepositoryTest {
         )
         every { vectorStore.search(any(), any(), any()) } returns listOf(VectorSearchResult(rowId = 2L, distance = 0.15f))
         coEvery { embeddingDao.getByRowIdsForConversation(any(), any()) } returns listOf(embeddingEntity)
-        coEvery { messageDao.getByConversation(any()) } returns listOf(messageEntity)
+        coEvery { messageDao.getByIds(any()) } returns listOf(messageEntity)
 
         // Must not throw
         val result = ragRepository.getRelevantContext("what did the user say earlier", conversationId = "conv-2")
 
         assertTrue(!result.contains("[Core Memories"), "Failed core search must not produce a [Core Memories] section")
-        assertTrue(result.contains("[Episodic Memories"), "Episodic content must still appear despite core failure")
+        assertTrue(result.contains("[Message History"), "Message history must still appear despite core failure")
     }
 
     @Test
@@ -232,7 +232,7 @@ class RagRepositoryTest {
 
         // Two memories with identical score — stale predates recent by access time.
         // Budget is deliberately tight (≈30 tokens) so only one fits.
-        coEvery { memoryRepository.searchMemories(any(), any(), any()) } returns listOf(
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any()) } returns listOf(
             MemorySearchResult(id = "stale",  content = "Stale fact",  source = "core", score = 0.9f, lastAccessedAt = 1_000L),
             MemorySearchResult(id = "recent", content = "Recent fact", source = "core", score = 0.9f, lastAccessedAt = 9_000L),
         )

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -122,10 +122,10 @@ peak. The service stops automatically once `InferenceEngine.isReady` becomes tru
 [System Prompt]          ← persona (FULL ~200t / MINIMAL ~25t), date/time
 [User Profile]           ← structured YAML injection (name, role, environment, context, rules)
 [Core Memories]          ← permanent facts split by category:
-                           user (topK=8), agent_identity (topK=2)
-                           CORE_MAX_DISTANCE=1.10
-[Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=1.10, topK=3)
-[Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=1.10, topK=5)
+                           user (coreTopK=10), agent_identity (identityTopK=5)
+                           CORE_MAX_DISTANCE=1.10; NZ truths further filtered by vibe level
+[Episodic Memories]      ← distilled conversation summaries (EPISODIC_MAX_DISTANCE=1.10, episodicTopK=3)
+[Message History]        ← semantically relevant messages from current conversation (MAX_DISTANCE=0.90, topK=5)
 [Conversation Window]    ← selected recent turns (75% token budget)
 [Current User Message]   ← with RAG context prepended
 ```
@@ -133,22 +133,97 @@ peak. The service stops automatically once `InferenceEngine.isReady` becomes tru
 **Identity tiers:** `IdentityTier.FULL` (Chat) includes greeting, vocab phrases, profile, and history.
 `IdentityTier.MINIMAL` (Actions tab) uses a slim ~25-token prompt with no profile/history.
 
-All three memory sections are conditionally included — omitted entirely if no results meet their distance threshold. Token budget is allocated sequentially: Core → Episodic → Message History.
+All sections are conditionally included — omitted entirely if no results meet their distance threshold. Token budget is allocated sequentially: Core → Episodic → Message History.
 
 ### 3.3 Long-Term (Semantic) Memory
 
 - **Vector store:** sqlite-vec (compiled via NDK for arm64-v8a), bundled as `libkernelvec.so`
 - **Embedding model:** EmbeddingGemma-300M — 768-dim vectors (256-dim on 8GB via Matryoshka)
 - **Three vec0 tables:**
-  - `core_memories_vec` — permanent facts about the user (visible in Settings → Core Memories)
-  - `episodic_memories_vec` — distilled conversation summaries from `EpisodicDistillationUseCase` (visible in Settings → Episodic Memories)
-  - `message_embeddings` — per-message vectors for intra-conversation fuzzy recall (visible in Settings → Message History (RAG))
-- **Retrieval:** L2 (Euclidean) distance search per query via sqlite-vec default; results filtered by distance threshold; top results injected into prompt. Vectors are L2-normalised at embedding time (`LiteRtEmbeddingEngine`) so L2 distance is equivalent to `sqrt(2 * (1 - cos_sim))` — threshold 1.10 ≈ cos_sim ≥ 0.40.
+  - `core_memories_vec` — permanent facts about the user and NZ cultural truths (Settings → Core Memories)
+  - `episodic_memories_vec` — distilled conversation summaries from `EpisodicDistillationUseCase` (Settings → Episodic Memories)
+  - `message_embeddings` — per-message vectors for intra-conversation fuzzy recall (Settings → Message History (RAG))
+- **Retrieval:** L2 (Euclidean) distance search per query via sqlite-vec; results filtered by distance threshold; top results injected into prompt. Vectors are L2-normalised at embedding time (`LiteRtEmbeddingEngine`) so L2 distance ≈ `sqrt(2 * (1 - cos_sim))` — threshold 1.10 ≈ cos_sim ≥ 0.40.
 - **Separate databases:** Room (`kernel_db.db`) for relational data; native SQLite (`kernel_vectors.db`) for vectors (Room doesn't support vec0 virtual tables)
 - **TTL & pruning:** `prune()` runs on every write with two independent passes:
-  1. **TTL pass** — deletes episodic memories where both `createdAt` and `lastAccessedAt` are older than 30 days. Accessing a memory resets `lastAccessedAt`, keeping it alive past the 30-day TTL for as long as it remains in use.
-  2. **LRU overflow pass** — if count still exceeds 500 after TTL pass, evicts the least-recently-accessed entries (ordered by `lastAccessedAt ASC`). `lastAccessedAt` is updated on every RAG retrieval, so frequently recalled memories survive overflow eviction even if old.
-  - Core memories: no TTL, capped at 200 entries, evicted by `createdAt` order (no LRU — core memories are considered permanent).
+  1. **TTL pass** — deletes episodic memories where both `createdAt` and `lastAccessedAt` are older than 30 days. Accessing a memory resets `lastAccessedAt`, keeping it alive past the 30-day TTL.
+  2. **LRU overflow pass** — if count still exceeds 500 after TTL pass, evicts the least-recently-accessed entries (ordered by `lastAccessedAt ASC`). `lastAccessedAt` is updated on every RAG retrieval, so frequently recalled memories survive overflow eviction.
+  - Core memories: no TTL, capped at 200 entries, evicted by `createdAt` order (core memories are considered permanent).
+
+#### 3.3.1 Core Memory Schema
+
+Core memories are stored in the `core_memories` Room table with the following fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `id` | Long (PK) | Auto-generated row ID |
+| `content` | String | The raw text embedded and injected into prompts |
+| `category` | String | `"user"` (facts about the user) or `"agent_identity"` (NZ cultural truths) |
+| `conversationId` | String? | Conversation where memory was learned (null for seeded truths) |
+| `createdAt` | Long | Epoch millis |
+| `lastAccessedAt` | Long | Updated on every RAG retrieval |
+| `term` | String | Short display name, e.g. `"Pavlova"` (NZ truths only, empty for user facts) |
+| `definition` | String | Full human-readable definition (NZ truths only) |
+| `triggerContext` | String | When this truth should be surfaced, e.g. `"When discussing Christmas or desserts"` |
+| `vibeLevel` | Int | 1–5 energy scale controlling retrieval sensitivity (NZ truths only, defaults to 1) |
+| `metadataJson` | String | JSON blob with tags, era, etc. (NZ truths only) |
+
+**User memory example** (learned from conversation):
+```
+content:    "User prefers dark mode"
+category:   "user"
+term:        ""   ← empty for user facts
+definition:  ""
+vibeLevel:   1   ← default, no vibe filtering
+```
+
+**NZ truth memory example** (seeded from `nz_truth_memories.json`):
+```
+content:    "Pavlova. Meringue dessert. Christmas food. Trans-Tasman rivalry."  ← vectorText, embedded
+category:   "agent_identity"
+term:       "Pavlova"
+definition: "A meringue-based dessert... source of an eternal, fierce debate with Australia."
+vibeLevel:  3
+```
+
+The `content` field stores the dense `vector_text` from the JSON asset (e.g. `"Pavlova. Meringue dessert. Christmas food."`) — not the human-readable `definition`. Dense keyword text yields better vector similarity matches. The `definition` is stored separately and injected into the prompt at retrieval time.
+
+#### 3.3.2 How Memories Are Injected into Prompts
+
+When `RagRepository.getRelevantContext()` retrieves a core memory result:
+
+- **User fact** (`term` is empty): injected as-is: `"User prefers dark mode"`
+- **NZ truth** (`term` non-empty): injected as: `"[NZ Context: Pavlova] A meringue-based dessert... NZ invented it, not Australia."`
+
+The `[NZ Context: ...]` prefix signals to the LLM that this is cultural background knowledge, not a personal fact about the user.
+
+**Example prompt injection (RAG section):**
+```
+The following context has been retrieved from memory.
+[Core Memories — permanent facts about the user]
+User prefers dark mode
+[NZ Context: Pavlova] A meringue-based dessert with crisp crust and soft inside, topped with kiwifruit and cream. NZ and Australia both claim to have invented it (it was definitely NZ).
+[End of core memories]
+```
+
+#### 3.3.3 NZ Truth Vibe-Level Filtering
+
+NZ truth memories have a `vibe_level` (1–5) that controls how closely a query must match before the truth surfaces. This prevents high-energy or niche content (e.g. rugby trash-talk, crude slang) from appearing in unrelated serious conversations.
+
+| Vibe Level | Character | L2 Distance Threshold | Cos-sim Equivalent |
+|------------|-----------|----------------------|--------------------|
+| 1–2 | Subtle, informational, serious | ≤ 1.10 | ≥ 0.40 |
+| 3 | Moderate, general interest | ≤ 0.95 | ≥ 0.55 |
+| 4–5 | High-energy, niche, chaotic | ≤ 0.80 | ≥ 0.68 |
+
+**Examples by vibe level:**
+- **Vibe 1** — `"Kate Sheppard"` (women's suffrage leader, face of the $10 note) — surfaces for any NZ history or feminism query
+- **Vibe 2** — `"Ernest Rutherford"` (split the atom, $100 note) — surfaces for science or NZ intellect queries
+- **Vibe 3** — `"Pavlova"` (Christmas dessert, Aus/NZ rivalry) — surfaces when discussing desserts or Christmas, not random queries
+- **Vibe 4** — `"Karl Urban"` (Billy Butcher in The Boys) — only surfaces when the query closely matches The Boys, sci-fi franchises, or Kiwi actors
+- **Vibe 5** — `"Antony Starr"` (Homelander) — tight match required; won't intrude into unrelated conversations
+
+The filter runs in `MemoryRepositoryImpl.searchMemories()` after the initial L2 vec search, as a post-filter on `identity` (agent_identity) results.
 
 ### 3.4 Episodic Distillation
 
@@ -161,6 +236,45 @@ before embedding. Sentences shorter than 20 chars (e.g. "Yes.", "OK.") are disca
 time. A matching `MIN_EPISODIC_CONTENT_LENGTH = 20` filter in `MemoryRepositoryImpl.searchMemories()`
 also drops pre-existing short entries from search results, preventing low-signal fragments from
 surfacing in `search_memory` responses (#323).
+
+### 3.5 Testing Memory Behaviour
+
+#### What to verify on first launch after install
+
+1. **Seeding triggered:** Check logcat for `JandalPersona` tag — should log `"Seeding X NZ truth memories"`. Triggered by absence of `truths_seeded_v2` SharedPrefs key.
+2. **92 entries seeded:** Settings → Core Memories should show ~92 entries with category `agent_identity`.
+3. **Correct vector text embedded:** Each entry's `content` is the `vector_text` from the JSON (dense keywords), not the definition.
+
+#### How to test RAG retrieval manually
+
+Ask questions that should trigger specific NZ truths and observe whether Jandal's response reflects the context:
+
+| Query | Expected truth surfaced |
+|-------|------------------------|
+| "what's a good NZ Christmas dessert?" | Pavlova (vibe 3) |
+| "tell me about NZ scientists" | Ernest Rutherford (vibe 2) |
+| "who plays homelander?" | Antony Starr (vibe 5 — tight match) |
+| "anything interesting about NZ birds?" | Kererū, Tūī, Kiwi (vibe 1–2) |
+| "what's a flat white?" | Flat White (vibe 1) |
+
+To inspect what RAG actually injected, enable debug logging for the `RagRepository` tag — it logs raw vec search distances for each query.
+
+#### What good core memories look like
+
+User memories extracted by the LLM during conversation should be short, factual, third-person facts:
+```
+✅ "User is a software engineer based in Auckland"
+✅ "User prefers concise responses"
+✅ "User has a cat named Luna"
+❌ "We had a long conversation about the user's job" (too vague — episodic, not core)
+❌ "Yes" (too short — filtered out by MIN_SENTENCE_LENGTH)
+```
+
+NZ truths use `vector_text` (dense keywords for embedding), not `definition`:
+```
+✅ vector_text: "Pavlova. Meringue dessert. Christmas food. Trans-Tasman rivalry."
+❌ vector_text: "A meringue-based dessert with a crisp crust and soft, light inside..."  (too verbose, poor embedding)
+```
 
 ## 4. Skill & Tool Framework
 
@@ -408,6 +522,64 @@ Jandal's character is encoded in `DEFAULT_SYSTEM_PROMPT` in `ModelConfig.kt` (up
 - When asked about origin, culture, or name → own Kiwi identity with pride; NEVER say "just code" or "I have no culture"
 - Kiwi expressions must feel natural, not forced
 - No hollow affirmations ("certainly!", "absolutely!", "great question!")
+
+### 7.1 Kiwi Vocabulary Rotation
+
+`JandalPersona` loads `jandal_vocab.json` from assets — a pool of 41 Kiwi slang phrases and te reo Māori words. Each session, `SESSION_VOCAB_COUNT = 2` phrases are picked randomly and injected into the system prompt via `getSessionVocab()`:
+
+```
+Session vocab hint injected into prompt:
+"Today's Kiwi flavour: 'stoked' (thrilled, really pleased), 'wop-wops' (the middle of nowhere)"
+```
+
+**LRU cooldown:** Phrases are tracked in SharedPreferences (`last_vocab_indices`). Already-used phrases are excluded from the pick pool, ensuring variety across sessions. When all phrases have been used, the pool resets.
+
+**Full vocab pool covers:**
+- Common Kiwi slang: `sweet as`, `chur`, `yeah nah`, `nah yeah`, `hard out`, `keen as`, `stoked`, `gutted`, `mint`, `munted`, `knackered`, `dodgy`, `mean`, `crack up`, `not even`, `as if`, `bugger`, `wop-wops`, etc.
+- Cultural terms: `jandals`, `togs`, `bach`, `dairy`, `section`, `arvo`, `bro`, `cuz`
+- Te reo Māori: `kia ora`, `ka pai`, `whānau`, `aroha`, `haere rā`, `mahi`
+
+### 7.2 NZ Truth Memory System
+
+`JandalPersona` seeds a structured corpus of 92 NZ cultural knowledge entries into the core memory store on first launch. These are loaded from `nz_truth_memories.json` in the `core/inference` assets.
+
+**Seed guard:** The key `truths_seeded_v2` in SharedPreferences prevents repeated seeding. If this key is absent (new install or key was bumped), all 92 entries are seeded. Bumping the key version forces a reseed on existing installs when the corpus is updated.
+
+**JSON entry structure:**
+```json
+{
+  "id": "nz_095",
+  "term": "Pavlova",
+  "category": "food",
+  "definition": "A meringue-based dessert with a crisp crust and soft, light inside, typically topped with kiwifruit and whipped cream. The source of an eternal, fierce debate with Australia over its invention (it was definitely NZ).",
+  "trigger_context": "When discussing Christmas, desserts, or the trans-Tasman rivalry.",
+  "vibe_level": 3,
+  "vector_text": "Pavlova. Meringue dessert. Christmas food. Trans-Tasman rivalry. Anna Pavlova. Kiwi dessert.",
+  "metadata": { "tags": ["dessert", "rivalry", "christmas"], "era": "timeless" }
+}
+```
+
+**Field roles:**
+- `vector_text` — what gets embedded into the vector store (dense keyword format for better similarity matching). This becomes the `content` field in the DB.
+- `definition` — stored separately; injected into the prompt at retrieval as `[NZ Context: term] definition`
+- `trigger_context` — human documentation of intended use; not stored in DB
+- `vibe_level` — controls retrieval sensitivity (see §3.3.3)
+- `metadata` — stored as JSON string in `metadataJson`; not currently used in retrieval but available for future filtering (e.g. filter by tag or era)
+
+**Categories in the corpus:**
+| Category | Count (approx) | Examples |
+|----------|---------------|---------|
+| `sport` | 12 | All Blacks, Black Caps, Silver Ferns, America's Cup |
+| `food` | 10 | Pavlova, Lamington, Flat White, Feijoa, Kiwifruit, Marmite |
+| `fauna` | 10 | Kiwi bird, Kererū, Tūī, Pīwakawaka, Ruru |
+| `pop_culture` | 12 | Lucy Lawless, Karl Urban, Antony Starr, Lorde, Flight of the Conchords |
+| `history` | 8 | Kate Sheppard, Ernest Rutherford, Treaty of Waitangi |
+| `geography` | 6 | Fiordland, Rotorua, Northland, South Island vs North Island |
+| `language` | 8 | Te reo Māori basics, Kiwi slang definitions |
+| `identity` | 6 | Kiwi (person), No.8 wire mentality, bach, jandals |
+| `culture` | 8 | Māori culture, haka, Treaty, tangi |
+| `tv_film` | 6 | Outrageous Fortune, Boy, Hunt for the Wilderpeople |
+| `music` | 6 | Lorde, Crowded House, Flight of the Conchords |
 
 ---
 

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -64,11 +64,29 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 
 | Vibe | Distance threshold | Use for |
 |------|--------------------|---------|
-| 1–2 | ≤ 1.10 | Broad cultural facts that should fire on many queries (e.g. "New Zealand is in the Pacific") |
-| 3 | ≤ 0.95 | Mid-range references — needs a reasonably close query match (most entries) |
-| 4–5 | ≤ 0.80 | Niche or specific references — only fires on very close queries |
+| 1–2 | ≤ 1.10 | Broad cultural facts, and any entry whose trigger involves **indirect phrasing** (the user won't say the term itself) |
+| 3 | ≤ 0.95 | Entries where the user is expected to **explicitly mention** the topic or term in their query |
+| 4–5 | ≤ 0.80 | Slang/meme entries that fire only when the user **actually uses the word** (e.g. "that's munted") |
 
-> **Tip:** If an entry isn't firing when you expect it to, try lowering the vibe level (e.g. 3 → 2) or enriching `vector_text` with more synonyms.
+### Choosing the right vibe level
+
+**Use vibe 1–2 when:**
+- The entry is a broad cultural fact (e.g. "NZ invented the pavlova")
+- The trigger_context describes a scenario where the user's query won't contain the term (e.g. "Bugger" fires on "something went wrong", "Flash as" fires on "I got a new phone")
+- The entry is important enough that missing it would cause hallucination (disputed facts, origin stories)
+
+**Use vibe 3 when:**
+- The user is expected to explicitly say the topic name in their query (e.g. "what is the Haka", "who is David Lange")
+- A moderate match is appropriate — not a hair-trigger, but not obscure
+
+**Use vibe 4–5 when:**
+- The entry is for **interpreting Kiwi slang** the user types (e.g. "munted", "clanker", "nek minnit")
+- You only want injection when the query is a near-direct match to the term
+- The entry is a very niche culture reference that shouldn't fire speculatively
+
+> **Key rule:** If the trigger_context describes an indirect scenario ("when the user is rushing", "when something goes wrong"), the user's query won't contain the term — use vibe 1–2 and enrich `vector_text` with the indirect scenario phrases.
+
+> **Debugging:** If an entry isn't firing when you expect it to, check logcat for `Core vec search: 15 raw results, distances=[...]`. If your entry appears at distance > threshold, lower the vibe level. If it doesn't appear at all (not in top 15), enrich the `vector_text` with more query-realistic phrases.
 
 ---
 
@@ -150,7 +168,8 @@ The `vector_text` is what the MiniLM model embeds. A better embedding = better R
 - Use short phrases and keywords separated by periods
 - Include common ways the topic might be mentioned ("pavlova", "pav", "meringue dessert")
 - Include related concepts ("Ghost Chips", "NZTA ad", "drink driving", "looking out for mates")
-- Include the term itself
+- Include the term itself — **including phonetic or alternate spellings** (e.g. "Good aftabull constanoon. Good afternoon constable.")
+- For indirect-trigger entries, **include the scenario phrases** from `trigger_context` (e.g. Bugger: add "something went wrong, error, setback, oops")
 
 **Don't:**
 - Write prose sentences — they dilute keyword density
@@ -195,3 +214,8 @@ The `definition` is injected directly into Jandal's prompt as:
 | `truths_seeded` | Initial flat-string corpus (8 entries) |
 | `truths_seeded_v2` | Structured JSON corpus (92 entries) |
 | `truths_seeded_v3` | Corrected Ghost Chips (nz_005) and Monique (nz_010) entries |
+| `truths_seeded_v4` | Pavlova hallucination fix — added Anna Pavlova 1926 NZ tour detail |
+| `truths_seeded_v5` | Enriched thin definitions (No. 8 Wire, Skux as, Munted, Pineapple Lumps) + hallucination guards in system prompt |
+| `truths_seeded_v6` | Pavlova vibe_level 3→2 — fix threshold miss on "who invented pavlova" queries (L2 0.986 > 0.95 cutoff) |
+| `truths_seeded_v7` | 5 entries vibe 3→2 for indirect triggers: Bugger, Haka, Tall Poppy, Flash as, Always blow on the pie; richer vector_text |
+| `truths_seeded_v8` | 7 trigger/vector_text mismatches fixed; Good Aftabull phonetic form added to vector_text |

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -10,7 +10,7 @@ Jandal's NZ cultural knowledge lives in a structured JSON corpus that is embedde
 ```
 core/inference/src/main/assets/nz_truth_memories.json
 ```
-Contains all 92 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
+Contains all 135 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
 
 ### 2. The seed guard key
 ```
@@ -94,15 +94,18 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 
 | Category | Examples |
 |----------|---------|
-| `meme` | Ghost Chips, Monique says you're dumb |
+| `meme` | Ghost Chips, Monique says you're dumb, Beached as |
 | `food` | Pavlova, Pineapple Lumps, Marmite, L&P |
-| `slang` | Chur, Sweet as, Munted |
+| `slang` | Chur, Munted, Dag, Choice, Gutted, Stoked, Bro/Cuz |
+| `attitude` | She'll be right, No worries, Good as gold |
+| `daily_life` | Dairy, Togs, Bach/Crib, Smoko, Tiki Tour, Arvo |
+| `maori` | Kia ora, Ka pai, Haere rā, Mahi, Whānau, Aroha |
 | `sport` | All Blacks, Black Caps, America's Cup |
-| `geography` | Northland, Fiordland, Rangitoto |
+| `geography` | Northland, Fiordland, Rangitoto, Wop-wops |
 | `history` | Treaty of Waitangi, Suffrage, Gallipoli |
-| `culture` | Haka, Pōwhiri, Matariki |
+| `culture` | Haka, Pōwhiri, Matariki, Scarfie, Bach/Crib |
 | `politics` | MMP, Beehive, Jacinda |
-| `music` | Six60, Crowded House, Lorde |
+| `music` | Six60, Crowded House, Lorde, Flight of the Conchords |
 | `nature` | Kiwi bird, Tuatara, Kauri |
 
 ---
@@ -112,10 +115,10 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 1. **Open the corpus:**
    `core/inference/src/main/assets/nz_truth_memories.json`
 
-2. **Add your entry** at the end of the array. Use the next available ID (`nz_093`, `nz_094`, etc.):
+2. **Add your entry** at the end of the array. Use the next available ID (`nz_137`, `nz_138`, etc.):
    ```json
    {
-     "id": "nz_093",
+     "id": "nz_137",
      "term": "Your term here",
      "category": "slang",
      "definition": "Confident one-liner Jandal will say.",
@@ -128,20 +131,22 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
    }
    ```
 
-3. **Bump the seed guard** in `JandalPersona.kt`:
+3. **Check the vocab file** — if the new term is something Jandal should use in conversation, add it to `jandal_vocab.json` too. See [Keeping Vocab and Corpus in Sync](#keeping-vocab-and-corpus-in-sync).
+
+4. **Bump the seed guard** in `JandalPersona.kt`:
    ```kotlin
    // Before:
-   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v11"
    // After:
-   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v4"
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v12"
    ```
    Add a comment explaining what changed.
 
-4. **Build and install** the app. On first launch after update, logcat will show:
+5. **Build and install** the app. On first launch after update, logcat will show:
    ```
-   JandalPersona: Loaded 93 NZ truth entries
+   JandalPersona: Loaded 136 NZ truth entries
    ChatViewModel: Seeding NZ truth memories...
-   ChatViewModel: Seeded 93 NZ truth memories
+   ChatViewModel: Seeded 136 NZ truth memories
    ```
 
 5. **Test** by asking Jandal something related to your new entry. Check logcat for:
@@ -157,6 +162,65 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 2. Edit the fields you want to change
 3. Bump the seed guard key (same as adding — any corpus change needs a bump)
 4. Rebuild and test
+
+---
+
+## Keeping Vocab and Corpus in Sync
+
+Jandal has two related but separate NZ lingo files:
+
+| File | Purpose |
+|------|---------|
+| `core/inference/src/main/assets/jandal_vocab.json` | Kiwi phrases **injected into the system prompt** each session — tells the LLM which expressions it should use in conversation |
+| `core/inference/src/main/assets/nz_truth_memories.json` | NZ truth corpus **embedded as RAG memories** — grounding knowledge for when those expressions come up in conversation |
+
+### The rule: if Jandal says it, RAG must know it
+
+If a phrase is in `jandal_vocab.json`, Jandal will use it in responses. If a user then asks "what does that mean?" or the phrase appears in a query, the RAG system needs a corpus entry to ground Jandal's answer — otherwise it will hallucinate.
+
+**Every term in `jandal_vocab.json` should have a matching entry in `nz_truth_memories.json`.**
+
+### Adding a new vocab term
+
+When adding a phrase to `jandal_vocab.json`:
+
+```json
+{
+  "phrase": "sweet as",
+  "meaning": "excellent, sounds great"
+}
+```
+
+Also add a corpus entry:
+
+```json
+{
+  "id": "nz_XXX",
+  "term": "Sweet as",
+  "category": "slang",
+  "definition": "Multi-purpose approval phrase — excellent, sounds great, no problem...",
+  "trigger_context": "When agreeing or expressing approval.",
+  "vibe_level": 2,
+  "vector_text": "Sweet as. Sweet as bro. Sounds great. Excellent. Approval. Agreement."
+}
+```
+
+### Auditing the sync
+
+To check which vocab terms lack a corpus entry, run:
+
+```bash
+python3 -c "
+import json
+with open('core/inference/src/main/assets/nz_truth_memories.json') as f:
+    corpus = {e['term'].lower() for e in json.load(f)}
+with open('core/inference/src/main/assets/jandal_vocab.json') as f:
+    vocab = json.load(f)
+missing = [v['phrase'] for v in vocab if v['phrase'].lower() not in corpus
+           and not any(v['phrase'].lower() in t for t in corpus)]
+print('Vocab terms missing from corpus:', missing or 'all good!')
+"
+```
 
 ---
 
@@ -220,3 +284,5 @@ The `definition` is injected directly into Jandal's prompt as:
 | `truths_seeded_v7` | 5 entries vibe 3→2 for indirect triggers: Bugger, Haka, Tall Poppy, Flash as, Always blow on the pie; richer vector_text |
 | `truths_seeded_v8` | 7 trigger/vector_text mismatches fixed; Good Aftabull phonetic form added to vector_text |
 | `truths_seeded_v9` | Added Carked it (nz_093), Flight of the Conchords + Binary Solo (nz_094), Hungus (nz_095) |
+| `truths_seeded_v10` | Removed nz_003 (The 6-7 — not a real named NZ term); fixed nz_007 Munted (added drunk/intoxicated meaning); corpus 95 → 94 |
+| `truths_seeded_v11` | 41 new entries (nz_096–nz_136) from three-source slang audit + jandal_vocab.json cross-check. Every term Jandal uses in conversation now has a RAG corpus entry. New categories: `attitude`, `daily_life`, `maori`. Corpus 94 → 135 |

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -1,0 +1,197 @@
+# NZ Truth Memories — Authoring Guide
+
+Jandal's NZ cultural knowledge lives in a structured JSON corpus that is embedded and stored as `agent_identity` memories at app launch. This guide explains how to add, edit, or remove entries and ensure they are reseeded on device.
+
+---
+
+## The Two Files You Always Touch
+
+### 1. The corpus
+```
+core/inference/src/main/assets/nz_truth_memories.json
+```
+Contains all 92 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
+
+### 2. The seed guard key
+```
+core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+```
+Line near the top:
+```kotlin
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"
+```
+**Bump the version number every time you change the corpus.** On next app launch, the app detects the new key, wipes all existing `agent_identity` memories, and reseeds from scratch.
+
+---
+
+## Entry Schema
+
+```json
+{
+  "id": "nz_010",
+  "term": "Monique says you're dumb",
+  "category": "meme",
+  "definition": "What you say when someone does something dumb. Straight from the iconic 2011 NZTA Ghost Chips ad.",
+  "trigger_context": "When the user mentions Monique, or does something dumb/silly.",
+  "vibe_level": 3,
+  "vector_text": "Monique says you're dumb. NZTA Ghost Chips ad 2011. Calling someone out for being silly. Iconic Kiwi phrase.",
+  "metadata": {
+    "tags": ["ghost-chips", "nzta", "banter", "catchphrase"],
+    "era": "2011"
+  }
+}
+```
+
+### Field reference
+
+| Field | Purpose | Tips |
+|-------|---------|------|
+| `id` | Unique identifier (`nz_001`–`nz_NNN`) | Never reuse a retired ID |
+| `term` | Label used in logs and RAG injection prefix `[NZ Context: <term>]` | Keep short and memorable |
+| `category` | Organisational grouping | See categories below |
+| `definition` | **Injected into the prompt** — this is what Jandal actually says | Write as a confident statement, not a dictionary entry |
+| `trigger_context` | Human-readable note on when this should fire | Not used in code — just for authors |
+| `vibe_level` | Controls RAG distance threshold (see below) | 1–5 |
+| `vector_text` | **What gets embedded** — dense keywords for vector similarity | Use keywords, not prose; include synonyms and related terms |
+| `metadata.tags` | Searchable tags | Optional but useful |
+| `metadata.era` | Year/decade the reference is from | Optional |
+
+---
+
+## Vibe Levels
+
+The vibe level controls how loosely the RAG will match this entry. Lower = stricter match required; higher = fires more easily.
+
+| Vibe | Distance threshold | Use for |
+|------|--------------------|---------|
+| 1–2 | ≤ 1.10 | Broad cultural facts that should fire on many queries (e.g. "New Zealand is in the Pacific") |
+| 3 | ≤ 0.95 | Mid-range references — needs a reasonably close query match (most entries) |
+| 4–5 | ≤ 0.80 | Niche or specific references — only fires on very close queries |
+
+> **Tip:** If an entry isn't firing when you expect it to, try lowering the vibe level (e.g. 3 → 2) or enriching `vector_text` with more synonyms.
+
+---
+
+## Categories
+
+| Category | Examples |
+|----------|---------|
+| `meme` | Ghost Chips, Monique says you're dumb |
+| `food` | Pavlova, Pineapple Lumps, Marmite, L&P |
+| `slang` | Chur, Sweet as, Munted |
+| `sport` | All Blacks, Black Caps, America's Cup |
+| `geography` | Northland, Fiordland, Rangitoto |
+| `history` | Treaty of Waitangi, Suffrage, Gallipoli |
+| `culture` | Haka, Pōwhiri, Matariki |
+| `politics` | MMP, Beehive, Jacinda |
+| `music` | Six60, Crowded House, Lorde |
+| `nature` | Kiwi bird, Tuatara, Kauri |
+
+---
+
+## Step-by-Step: Adding a New Entry
+
+1. **Open the corpus:**
+   `core/inference/src/main/assets/nz_truth_memories.json`
+
+2. **Add your entry** at the end of the array. Use the next available ID (`nz_093`, `nz_094`, etc.):
+   ```json
+   {
+     "id": "nz_093",
+     "term": "Your term here",
+     "category": "slang",
+     "definition": "Confident one-liner Jandal will say.",
+     "trigger_context": "When the user talks about X.",
+     "vibe_level": 3,
+     "vector_text": "keyword1. keyword2. related phrase. synonym.",
+     "metadata": {
+       "tags": ["tag1", "tag2"]
+     }
+   }
+   ```
+
+3. **Bump the seed guard** in `JandalPersona.kt`:
+   ```kotlin
+   // Before:
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"
+   // After:
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v4"
+   ```
+   Add a comment explaining what changed.
+
+4. **Build and install** the app. On first launch after update, logcat will show:
+   ```
+   JandalPersona: Loaded 93 NZ truth entries
+   ChatViewModel: Seeding NZ truth memories...
+   ChatViewModel: Seeded 93 NZ truth memories
+   ```
+
+5. **Test** by asking Jandal something related to your new entry. Check logcat for:
+   ```
+   RagRepository: NZ truth injected: [Your term] vibe=agent_identity dist=~0.XXX
+   ```
+
+---
+
+## Step-by-Step: Editing an Existing Entry
+
+1. Find the entry by `id` or `term` in `nz_truth_memories.json`
+2. Edit the fields you want to change
+3. Bump the seed guard key (same as adding — any corpus change needs a bump)
+4. Rebuild and test
+
+---
+
+## Writing Good `vector_text`
+
+The `vector_text` is what the MiniLM model embeds. A better embedding = better RAG retrieval.
+
+**Do:**
+- Use short phrases and keywords separated by periods
+- Include common ways the topic might be mentioned ("pavlova", "pav", "meringue dessert")
+- Include related concepts ("Ghost Chips", "NZTA ad", "drink driving", "looking out for mates")
+- Include the term itself
+
+**Don't:**
+- Write prose sentences — they dilute keyword density
+- Copy the `definition` verbatim — it's optimised for human reading, not embedding
+- Make it too long — aim for 1–3 lines
+
+**Example (good):**
+```
+"vector_text": "Ghost chips. Ghost George. You know I can't grab your ghost chips. NZTA 2011 ad. Drink driving. Looking out for mates."
+```
+
+**Example (bad):**
+```
+"vector_text": "Ghost Chips is a reference to the famous New Zealand Transport Agency advertisement from 2011 which featured a ghost named George offering chips to his friend."
+```
+
+---
+
+## Writing Good `definition`
+
+The `definition` is injected directly into Jandal's prompt as:
+```
+[NZ Context: Ghost Chips] From the iconic 2011 NZTA drink-driving ad. Ghost George offers chips; the protagonist says 'you know I can't grab your ghost chips, bro'. Means looking out for your mates.
+```
+
+**Do:**
+- Write it as a confident, opinionated statement
+- Include the key fact Jandal should assert
+- Keep it under ~100 words (the field is truncated at 400 chars)
+
+**Don't:**
+- Hedge ("some people say...", "it is believed...")
+- Use encyclopaedia-style dry prose
+- Include claims you're not sure about
+
+---
+
+## Seed Guard Version History
+
+| Key | When bumped |
+|-----|-------------|
+| `truths_seeded` | Initial flat-string corpus (8 entries) |
+| `truths_seeded_v2` | Structured JSON corpus (92 entries) |
+| `truths_seeded_v3` | Corrected Ghost Chips (nz_005) and Monique (nz_010) entries |

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -219,3 +219,4 @@ The `definition` is injected directly into Jandal's prompt as:
 | `truths_seeded_v6` | Pavlova vibe_level 3→2 — fix threshold miss on "who invented pavlova" queries (L2 0.986 > 0.95 cutoff) |
 | `truths_seeded_v7` | 5 entries vibe 3→2 for indirect triggers: Bugger, Haka, Tall Poppy, Flash as, Always blow on the pie; richer vector_text |
 | `truths_seeded_v8` | 7 trigger/vector_text mismatches fixed; Good Aftabull phonetic form added to vector_text |
+| `truths_seeded_v9` | Added Carked it (nz_093), Flight of the Conchords + Binary Solo (nz_094), Hungus (nz_095) |

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -290,21 +290,23 @@ class ChatViewModel @Inject constructor(
                 Log.w("ChatViewModel", "truths_seeded flag was set but DB has 0 jandal_persona memories — re-seeding")
                 jandalPersona.resetTruthsSeeded()
             }
-            jandalPersona.nzTruths.forEach { truth ->
-                // Embed vector_text (dense keywords) — not definition — for richer semantic retrieval
-                val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }
-                    ?: return@forEach  // skip if engine not ready
-                memoryRepository.addCoreMemory(
-                    content = truth.vectorText,
-                    source = "jandal_persona",
-                    embeddingVector = vector,
-                    category = "agent_identity",
-                    term = truth.term,
-                    definition = truth.definition,
-                    triggerContext = truth.triggerContext,
-                    vibeLevel = truth.vibeLevel,
-                    metadataJson = truth.metadataJson,
-                )
+            withContext(Dispatchers.IO) {
+                jandalPersona.nzTruths.forEach { truth ->
+                    // Embed vector_text (dense keywords) — not definition — for richer semantic retrieval
+                    val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }
+                        ?: return@forEach  // skip if engine not ready
+                    memoryRepository.addCoreMemory(
+                        content = truth.vectorText,
+                        source = "jandal_persona",
+                        embeddingVector = vector,
+                        category = "agent_identity",
+                        term = truth.term,
+                        definition = truth.definition,
+                        triggerContext = truth.triggerContext,
+                        vibeLevel = truth.vibeLevel,
+                        metadataJson = truth.metadataJson,
+                    )
+                }
             }
             jandalPersona.markTruthsSeeded()
             Log.i("ChatViewModel", "Seeded ${jandalPersona.nzTruths.size} NZ truth memories into core memory")

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -290,7 +290,15 @@ class ChatViewModel @Inject constructor(
                 Log.w("ChatViewModel", "truths_seeded flag was set but DB has 0 jandal_persona memories — re-seeding")
                 jandalPersona.resetTruthsSeeded()
             }
+            // Wipe any stale entries from a previous seed guard version before re-seeding.
+            // Without this, bumping the seed guard key adds new entries on top of old ones,
+            // producing duplicates that pollute RAG results.
             withContext(Dispatchers.IO) {
+                val staleCount = memoryRepository.countCoreMemoriesBySource("jandal_persona")
+                if (staleCount > 0) {
+                    Log.i("ChatViewModel", "Clearing $staleCount stale jandal_persona entries before re-seeding")
+                    memoryRepository.deleteAllCoreMemoriesBySource("jandal_persona")
+                }
                 jandalPersona.nzTruths.forEach { truth ->
                     // Embed vector_text (dense keywords) — not definition — for richer semantic retrieval
                     val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -290,13 +290,24 @@ class ChatViewModel @Inject constructor(
                 Log.w("ChatViewModel", "truths_seeded flag was set but DB has 0 jandal_persona memories — re-seeding")
                 jandalPersona.resetTruthsSeeded()
             }
-            jandalPersona.truths.forEach { truth ->
-                val vector = embeddingEngine.embed(truth).takeIf { it.isNotEmpty() }
+            jandalPersona.nzTruths.forEach { truth ->
+                // Embed vector_text (dense keywords) — not definition — for richer semantic retrieval
+                val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }
                     ?: return@forEach  // skip if engine not ready
-                memoryRepository.addCoreMemory(truth, source = "jandal_persona", embeddingVector = vector, category = "agent_identity")
+                memoryRepository.addCoreMemory(
+                    content = truth.vectorText,
+                    source = "jandal_persona",
+                    embeddingVector = vector,
+                    category = "agent_identity",
+                    term = truth.term,
+                    definition = truth.definition,
+                    triggerContext = truth.triggerContext,
+                    vibeLevel = truth.vibeLevel,
+                    metadataJson = truth.metadataJson,
+                )
             }
             jandalPersona.markTruthsSeeded()
-            Log.i("ChatViewModel", "Seeded ${jandalPersona.truths.size} Kiwi truths into core memory")
+            Log.i("ChatViewModel", "Seeded ${jandalPersona.nzTruths.size} NZ truth memories into core memory")
         }
     }
 


### PR DESCRIPTION
## Summary

Upgrades the NZ truth memory system from 8 flat strings to a structured 92-entry corpus with vibe-level RAG filtering. Also expands the Kiwi vocabulary pool from 14 → 41 entries with commonly missing slang, te reo Māori phrases, and cultural terms.

## Changes

### New asset
- `nz_truth_memories.json` — 92-entry structured corpus (nz_001–nz_094) with `term`, `definition`, `trigger_context`, `vibe_level`, `vector_text`, `category`, and `metadata`

### Vocab expansion
- `jandal_vocab.json` expanded 14 → 41 entries
- Added slang: `stoked`, `gutted`, `mint`, `heaps`, `aye`, `cuz`, `knackered`, `dodgy`, `arvo`, `jandals`, `togs`, `bach`, `nah yeah`, `not even`, `as if`, `sweet`, `mean`, `crack up`, `keen`, `dairy`, `section`, `wop-wops`
- Added te reo Māori: `whānau`, `aroha`, `haere rā`, `mahi`
- Fixed `Maori` → `Māori` in existing entries

**Full vocab pool (41 entries):**

| Phrase | Meaning |
|--------|---------|
| sweet as | excellent, sounds great |
| chur | thanks, cheers, good one |
| yeah nah | polite disagreement or hesitation |
| nah yeah | yes, definitely (the opposite of yeah nah) |
| she'll be right | it'll be fine, don't worry |
| good as gold | perfect, no problems |
| no worries | you're welcome, not a problem |
| hard out | strongly agree, absolutely |
| keen as | very enthusiastic, definitely yes |
| choice | excellent, great |
| kia ora | hello or thank you (Māori greeting) |
| ka pai | good job, well done (Māori) |
| staunch | strong, reliable, solid |
| munted | broken, ruined, wrecked |
| bro | mate, friend (gender neutral in NZ usage) |
| stoked | thrilled, really pleased |
| gutted | devastated, really disappointed |
| mint | perfect, in great condition, excellent |
| heaps | a lot, very much |
| aye | right? isn't it? (seeking agreement, often at end of sentence) |
| cuz | cousin or close mate, term of address |
| knackered | exhausted, worn out |
| dodgy | suspicious, unreliable, sketchy |
| arvo | afternoon |
| jandals | flip-flops, thongs — NZ's iconic contribution to footwear vocabulary |
| togs | swimming costume, swimwear |
| bach | a small holiday home or beach house (pronounced 'batch') |
| whānau | family, extended family (Māori) |
| aroha | love, compassion (Māori) |
| haere rā | farewell, goodbye (Māori) |
| mahi | work (Māori, widely used in everyday NZ speech) |
| bugger | mild expletive expressing frustration or sympathy — made iconic by a classic NZ TV ad |
| not even | no way, that's not true, expressing disbelief |
| as if | expressing strong doubt or disbelief |
| sweet | okay, got it, sounds good |
| mean | awesome, really good (opposite of the English meaning) |
| crack up | funny, hilarious |
| keen | enthusiastic, willing, up for it |
| dairy | a small convenience store — nothing to do with milk (well, mostly) |
| section | a plot of residential land |
| wop-wops | the middle of nowhere, a remote rural area |

### DB migration (20 → 21)
- `CoreMemoryEntity` extended with `term`, `definition`, `triggerContext`, `vibeLevel`, `metadataJson` columns (all have safe defaults for existing rows)
- `MIGRATION_20_21` added and wired in `MemoryModule`

### Repository layer
- `MemoryRepository.addCoreMemory` now accepts all 5 structured fields
- `identityTopK` default raised 2 → 5 to handle the larger corpus
- `searchMemories`: vibe-level distance thresholds applied post-filter (vibe 1–2 = 1.10, 3 = 0.95, 4–5 = 0.80)
- `MemorySearchResult` extended with `term` and `definition` fields

### RAG injection
- `RagRepository.getRelevantContext` formats NZ truths as `[NZ Context: <term>] <definition>` when `result.term.isNotEmpty()` — allows LLM to distinguish structured NZ cultural context from regular user memory facts

### Seeding
- `JandalPersona` fully rewritten: loads `nz_truth_memories.json`, exposes `nzTruths: List<NzTruthEntry>`, new `NzTruthEntry` data class
- Seed guard key bumped `truths_seeded` → `truths_seeded_v2` to force reseed on existing installs
- `ChatViewModel.seedKiwiTruthsIfNeeded` uses `nzTruths`, embeds `vectorText` field (dense keyword format for better vector matching), passes all 5 structured fields

### Tests
- Fixed `RagRepositoryTest`: updated `searchMemories` matchers from 3 → 4 args (new `identityTopK` param), fixed `messageDao.getByConversation` → `getByIds` stale mock, updated section header assertions (`[Message History` replaces old `[Episodic Memories` for vector store results)
- All 7 `RagRepositoryTest` tests now pass

## Testing

- [ ] Build passes clean
- [ ] `RagRepositoryTest` — 7/7 passing
- [ ] On-device: first launch triggers reseed (92 entries seeded via `truths_seeded_v2` guard)
- [ ] NZ cultural questions correctly pull relevant context via RAG
- [ ] Vibe-level filtering: high-vibe entries (4–5) only surface for highly relevant queries
- [ ] Vocab rotation: new phrases appear in system prompt session vocab

## Notes

- The 4 pre-existing `MemoryRepositoryImplTest` failures (`markVectorized` unmocked) are unchanged and pre-date this branch
- `jandal_vocab.json` LRU rotation works with any pool size — the larger pool reduces repetition across sessions
- Old `jandal_truths.json` (8 flat strings) kept in assets but no longer referenced

## Related issues

Closes #635
