### PR TITLE
fix: batch onboarding permission prompts

### DIFF
--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -24,6 +24,10 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    companion object {
+        private const val PREFS_RUNTIME_PERMISSIONS = "runtime_permissions"
+        private const val KEY_ONBOARDING_PERMISSIONS_REQUESTED = "onboarding_permissions_requested"
+    }
 
     @Inject lateinit var authRepository: HuggingFaceAuthRepository
 
@@ -39,14 +43,8 @@ class MainActivity : ComponentActivity() {
     /** Bridges ADB `--es slot_reply_input` extras into ActionsViewModel.onSlotReply(). */
     private val adbSlotReplyInput = mutableStateOf<String?>(null)
 
-    private val requestNotificationPermission =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
-
-    private val requestLocationPermission =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
-
-    private val requestContactsPermission =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+    private val requestOnboardingPermissions =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { /* no-op */ }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,17 +53,7 @@ class MainActivity : ComponentActivity() {
         adbQuickActionInput.value = intent.getStringExtra("quick_action_input")
         adbSlotReplyInput.value = intent.getStringExtra("slot_reply_input")
         handleAdbProfileText(intent)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
-        }
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-            requestLocationPermission.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
-        }
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS)
-                != PackageManager.PERMISSION_GRANTED) {
-            requestContactsPermission.launch(Manifest.permission.READ_CONTACTS)
-        }
+        requestStartupPermissionsIfNeeded()
         setContent {
             KernelAITheme {
                 KernelNavHost(
@@ -109,5 +97,36 @@ class MainActivity : ComponentActivity() {
             val normalized = text.replace("\\n", "\n")
             lifecycleScope.launch { userProfileRepository.save(normalized) }
         }
+    }
+
+    private fun requestStartupPermissionsIfNeeded() {
+        val prefs = getSharedPreferences(PREFS_RUNTIME_PERMISSIONS, MODE_PRIVATE)
+        val forcePromptForTests = intent?.getBooleanExtra("force_permission_prompt", false) == true
+        if (!forcePromptForTests && prefs.getBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, false)) return
+
+        val missingPermissions = buildList {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            if (ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                add(Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+            if (ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+                add(Manifest.permission.READ_CONTACTS)
+            }
+        }
+
+        if (missingPermissions.isEmpty()) {
+            prefs.edit().putBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, true).apply()
+            return
+        }
+
+        // Mark before launch so a config change / activity restart doesn't re-trigger a staggered
+        // sequence of permission prompts across multiple app opens.
+        if (!forcePromptForTests) {
+            prefs.edit().putBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, true).apply()
+        }
+        requestOnboardingPermissions.launch(missingPermissions.toTypedArray())
     }
 }

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/PermissionFlowTest.kt
@@ -66,6 +66,7 @@ class PermissionFlowTest {
             addCategory(Intent.CATEGORY_LAUNCHER)
             component = ComponentName(PACKAGE, "com.kernel.ai.MainActivity")
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra("force_permission_prompt", true)
         }
         context.startActivity(intent)
         device.wait(Until.hasObject(By.pkg(PACKAGE)), LAUNCH_TIMEOUT_MS)


### PR DESCRIPTION
## Summary
Batch runtime permission prompts so the app no longer staggers Notifications, Location, and Contacts requests across multiple launches.

## Changes
- replace three separate startup permission requests in `MainActivity` with a single `RequestMultiplePermissions` flow
- persist a one-time onboarding guard so the permission batch is only shown once during normal app use
- add a test-only `force_permission_prompt` extra so permission instrumentation tests can still trigger the onboarding flow deterministically
- update the permission flow UI test launcher to use the new batch prompt path

## Testing
- `./gradlew :app:assembleDebug --no-daemon`
- `./gradlew :feature:settings:compileDebugAndroidTestKotlin --no-daemon`

## Related issues
Closes #651
