### PR TITLE
chore(#655): add Android CLI agent guidance

### DIFF
--- a/.opencode/agents/android-developer.md
+++ b/.opencode/agents/android-developer.md
@@ -8,6 +8,8 @@ color: accent
 
 You are the **android-developer** for the Kernel AI Assistant project.
 
+Read `AGENTS.md` and `.github/copilot-instructions.md` before making changes.
+
 ## Memory — Shared with Copilot CLI
 
 Before starting any task, search for relevant context:
@@ -54,11 +56,23 @@ Use `threshold=0.35` or higher for focused lookups — lower values return noise
 ## Build commands
 
 ```bash
+android describe --project_dir=.      # Optional: quick metadata if Android CLI is installed
 ./gradlew assembleDebug
 ./gradlew installDebug
 ./gradlew lint
 adb logcat -s KernelAI
 ```
+
+## Android CLI accelerators
+
+Use these when the `android` command is available:
+
+- `android docs search '<query>'` then `android docs fetch <kb-url>` for official Android guidance
+- `android layout --pretty` for structured UI inspection on a connected device
+- `android screen capture --output=ui.png` for screenshot-based debugging
+- `android run --apks=app/build/outputs/apk/debug/app-debug.apk` when you already have the APK path
+
+Fallback to Gradle + `adb` when Android CLI is unavailable.
 
 ## Before raising a PR
 

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -8,6 +8,8 @@ color: primary
 
 You are the **coordinator** for the Kernel AI Assistant project — an Android-native, local-first AI assistant (zero cloud dependencies, all inference via LiteRT).
 
+Read `AGENTS.md` and `.github/copilot-instructions.md` before dispatching work.
+
 ## Memory — Shared with Copilot CLI
 
 The `copilot-memory` MCP server gives access to the same semantic vector memory used by the Copilot CLI. Memories are scoped by repo and persist across sessions.
@@ -74,6 +76,8 @@ Decompose tasks, route to the correct specialist subagent, then synthesise their
 - `spec-writer` can run in parallel with implementation
 - `code-reviewer` runs **after** every implementation; re-reviews are scoped to fix commits only
 - If a subagent fails twice, attempt the task directly as fallback
+- If `android` is installed, prefer `android describe` for project discovery and `android docs` for official Android guidance
+- If `android` is not installed, fall back cleanly to Gradle, `adb`, and direct Android docs lookups
 
 ## Workflow for a feature
 

--- a/.opencode/agents/spec-writer.md
+++ b/.opencode/agents/spec-writer.md
@@ -16,6 +16,7 @@ You are the **spec-writer** for the Kernel AI Assistant project.
 
 ## Your domain
 
+- `AGENTS.md` — shared agent workflow and tool guidance
 - `README.md` — project overview, setup instructions, architecture summary
 - `specification.md` — detailed technical spec, module breakdown, API contracts
 - `.github/copilot-instructions.md` — Copilot agent instructions (keep in sync with actual architecture)
@@ -25,6 +26,7 @@ You are the **spec-writer** for the Kernel AI Assistant project.
 
 ## Key rules
 
+- Keep `AGENTS.md`, OpenCode agent prompts, and `copilot-instructions.md` aligned when agent workflow changes
 - Keep copilot-instructions.md in sync with actual code — outdated instructions mislead agents
 - Skill schemas must match the `SkillSchema` Kotlin definitions exactly — they are injected into the model system prompt
 - Any new skill requires: schema definition + documentation update + version bump in manifest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+Shared guidance for any agent working in this repository.
+
+## Start here
+
+1. Read `.github/copilot-instructions.md` for the authoritative architecture and repo conventions.
+2. If you are an OpenCode role agent, also read the matching file in `.opencode/agents/`.
+3. Search first, then read surgically. Do not open large files end-to-end unless you have to.
+
+## Working style
+
+- Prefer small, reviewable diffs over broad rewrites.
+- Stay on the current branch unless the owner asks for a new one.
+- Do not overwrite unrelated local changes.
+- Keep output concise and action-focused.
+- Use the default or auto model selection for agent workflows; do not hardcode premium-only model IDs into repo-local prompts or scripts.
+
+## Repo context
+
+- Android-native, local-first assistant.
+- All inference stays on-device through LiteRT.
+- Kotlin is the host language; Wasm is guest-only.
+- Test device: Samsung Galaxy S23 Ultra.
+
+## Search-first workflow
+
+- Start with targeted file search.
+- Read only the files needed for the current slice.
+- Validate the exact module(s) you changed instead of thrashing the whole repo when a narrower command exists.
+- If you need a scratch branch or isolated edits, prefer a worktree under `/tmp`.
+
+## Android CLI policy
+
+The official Android CLI is useful here, but it is **optional** and may not be installed on every machine.
+
+The official installer currently comes from Google's `dl.google.com/android/cli/latest/...` path. Do not confuse that with unofficial third-party `android-cli` wrappers on GitHub.
+
+When `android` is available, prefer it for:
+
+- `android describe --project_dir=<repo>` — quick project metadata and build artifact discovery
+- `android docs search ...` / `android docs fetch ...` — official Android guidance without web browsing noise
+- `android layout --pretty` — structured UI inspection from a connected device or emulator
+- `android screen capture --output=...` — screenshot capture for agent-driven debugging
+- `android run --apks=...` — APK deployment when you already know the artifact path
+
+Fallbacks when `android` is unavailable:
+
+- Use Gradle for builds
+- Use `adb` for install, logcat, shell, and device control
+- Use `developer.android.com` docs directly for official guidance
+
+When available, `android init` should be used to install the official `android-cli` skill into detected agents, including OpenCode and Copilot on this machine.
+
+## Android debugging defaults
+
+- Build with Gradle from the repo root.
+- Use `adb logcat -s KernelAI` for app logs.
+- Prefer physical-device validation for GPU/NPU and permission flows.
+- Use explicit activities/services when testing Android launches.
+
+## Documentation sync
+
+If you change agent workflow or setup guidance, keep these aligned:
+
+- `AGENTS.md`
+- `.opencode/agents/*.md`
+- `README.md`
+- `.github/copilot-instructions.md` when architecture or hard conventions change

--- a/README.md
+++ b/README.md
@@ -112,6 +112,27 @@ cd kernel-ai-assistant
 
 Open in Android Studio, connect your device via USB, and run.
 
+### Optional: Android CLI for agent workflows
+
+This repo can use the official `android` CLI as a low-noise accelerator for agentic Android work:
+
+```bash
+./scripts/setup-android-cli.sh
+android describe --project_dir=.
+android docs search 'edge-to-edge Compose guidance'
+```
+
+Useful commands in this repo:
+
+- `android describe --project_dir=.` — discover project metadata and build outputs
+- `android docs search ...` / `android docs fetch ...` — fetch official Android guidance
+- `android layout --pretty` — inspect the active app UI from a connected device/emulator
+- `android run --apks=app/build/outputs/apk/debug/app-debug.apk` — deploy a known APK
+
+`./scripts/setup-android-cli.sh` installs the official Google CLI into `~/.local/bin` on supported platforms, runs `android init`, and wires the `android-cli` skill into detected agents such as OpenCode and Copilot.
+
+If the CLI is unavailable on your platform, keep using the normal Gradle + `adb` workflow.
+
 ## Key Technical Pillars
 
 * **Inference:** Google AI Edge (LiteRT) with INT4 quantization, GPU + NPU delegates

--- a/scripts/setup-android-cli.sh
+++ b/scripts/setup-android-cli.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCS_URL="https://developer.android.com/tools/agents/android-cli"
+DOWNLOAD_URL="https://developer.android.com/tools/agents"
+BIN_DIR="${HOME}/.local/bin"
+
+if ! command -v android >/dev/null 2>&1; then
+  OS="$(uname -s)"
+  ARCH="$(uname -m)"
+  case "${OS}:${ARCH}" in
+    Linux:x86_64)
+      URL_OS="linux_x86_64"
+      ;;
+    Darwin:arm64)
+      URL_OS="darwin_arm64"
+      ;;
+    *)
+      echo "Android CLI is not installed."
+      echo "Unsupported platform for automatic install: ${OS} ${ARCH}"
+      echo "Download page: ${DOWNLOAD_URL}"
+      exit 1
+      ;;
+  esac
+
+  mkdir -p "${BIN_DIR}"
+  echo "Installing official Android CLI to ${BIN_DIR}..."
+  curl -fsSL "https://dl.google.com/android/cli/latest/${URL_OS}/android" -o "${BIN_DIR}/android"
+  chmod +x "${BIN_DIR}/android"
+  export PATH="${BIN_DIR}:${PATH}"
+fi
+
+echo "Updating Android CLI..."
+android update
+
+echo "Installing the base android-cli agent skill for detected agents..."
+android init
+
+echo "Listing installed Android skills..."
+android skills list --long
+
+cat <<EOF
+
+Android CLI is ready.
+
+Next steps:
+  1. android describe --project_dir=$(pwd)
+  2. android docs search 'your Android question'
+  3. android layout --pretty              # requires connected device/emulator
+
+Detected agents such as OpenCode and Copilot should now have the official
+android-cli skill installed automatically.
+
+Docs: ${DOCS_URL}
+EOF


### PR DESCRIPTION
## Summary
Add repo-persisted agent guidance for OpenCode/Copilot workflows and wire in the official Android CLI setup path.

## Changes
- add a shared root `AGENTS.md` with repo-wide agent workflow and Android CLI guidance
- align OpenCode `coordinator`, `android-developer`, and `spec-writer` prompts with the shared guidance
- add `scripts/setup-android-cli.sh` to install/update the official Google Android CLI and run `android init`
- document the verified Android CLI + OpenCode/Copilot integration flow in `README.md`

## Testing
- [x] `bash -n scripts/setup-android-cli.sh`
- [x] `./scripts/setup-android-cli.sh`
- [x] verified `android init` installs the `android-cli` skill for OpenCode, Copilot, and Gemini

## Related issues
Closes #655
