### PR TITLE
docs: sync OpenCode repo guidance

### DIFF
--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -1,0 +1,30 @@
+# OpenCode Repo Rules
+
+Shared repo-local guidance for OpenCode when working in `kernel-ai-assistant`.
+
+## Start here
+
+1. Read the root `AGENTS.md`
+2. Read the relevant role prompt in `.opencode/agents/`
+3. Search first, then read surgically
+
+## GitHub issue standards
+
+When creating or reshaping a GitHub issue, normalize metadata immediately.
+
+Required metadata:
+
+- **Type** — `type:feature`, `type:bug`, `type:spike`, etc.
+- **Go-state** — `go:yes`, `go:needs-research`, or `go:no`
+- **Priority** — `priority:high`, `priority:medium`, `priority:low`, or sprint-specific labels
+- **Size** — `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+- **Milestone / phase** — set the roadmap milestone and any applicable phase label
+- **Roadmap** — add `roadmap` when it belongs in planned product work
+- **Domain labels** — `skills`, `voice`, `memory`, `ui`, `architecture`, etc. as appropriate
+
+Structuring rules:
+
+- If the work spans multiple meaningful tracks, make it a **parent/epic**
+- Parent issues should decompose into child issues
+- Include a UI/UX child issue whenever interface work is a real part of the feature
+- Use `go:needs-research` when architecture is still open; use `go:yes` when implementation-ready

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -8,6 +8,50 @@ Shared repo-local guidance for OpenCode when working in `kernel-ai-assistant`.
 2. Read the relevant role prompt in `.opencode/agents/`
 3. Search first, then read surgically
 
+## Working style
+
+- Prefer small, reviewable diffs over broad rewrites
+- Stay on the current branch unless the owner asks for a new one
+- Do not overwrite unrelated local changes
+- Keep output concise and action-focused
+- Use the default or auto model selection for agent workflows; do not hardcode premium-only model IDs into repo-local prompts or scripts
+
+## Repo context
+
+- Android-native, local-first assistant
+- All inference stays on-device through LiteRT
+- Kotlin is the host language; Wasm is guest-only
+- Test device: Samsung Galaxy S23 Ultra
+
+## Android CLI policy
+
+The official Android CLI is useful here, but it is **optional** and may not be installed on every machine.
+
+The official installer comes from Google's `dl.google.com/android/cli/latest/...` path. Do not confuse that with unofficial third-party `android-cli` wrappers on GitHub.
+
+When `android` is available, prefer it for:
+
+- `android describe --project_dir=<repo>` for quick project metadata and build artifact discovery
+- `android docs search ...` / `android docs fetch ...` for official Android guidance without web noise
+- `android layout --pretty` for structured UI inspection from a connected device or emulator
+- `android screen capture --output=...` for screenshot capture during debugging
+- `android run --apks=...` for APK deployment when the artifact path is already known
+
+Fallbacks when `android` is unavailable:
+
+- Use Gradle for builds
+- Use `adb` for install, logcat, shell, and device control
+- Use `developer.android.com` docs directly for official guidance
+
+When available, `android init` should be used to install the official `android-cli` skill into detected agents, including OpenCode and Copilot on this machine.
+
+## Android debugging defaults
+
+- Build with Gradle from the repo root
+- Use `adb logcat -s KernelAI` for app logs
+- Prefer physical-device validation for GPU/NPU and permission flows
+- Use explicit activities/services when testing Android launches
+
 ## GitHub issue standards
 
 When creating or reshaping a GitHub issue, normalize metadata immediately.
@@ -28,3 +72,13 @@ Structuring rules:
 - Parent issues should decompose into child issues
 - Include a UI/UX child issue whenever interface work is a real part of the feature
 - Use `go:needs-research` when architecture is still open; use `go:yes` when implementation-ready
+
+## Documentation sync
+
+If you change agent workflow or setup guidance, keep these aligned:
+
+- `AGENTS.md`
+- `.opencode/AGENTS.md`
+- `.opencode/agents/*.md`
+- `README.md`
+- `.github/copilot-instructions.md` when architecture or hard conventions change

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -90,6 +90,16 @@ Decompose tasks, route to the correct specialist subagent, then synthesise their
 7. `code-reviewer`: re-review fix commits (scoped — not a full re-review)
 8. Tell the owner to manually test on S23 Ultra via ADB once CI passes
 
+## GitHub issue hygiene
+
+When creating or reshaping GitHub issues, normalize metadata immediately:
+
+- set **type**, **go-state**, **priority**, **size**, and **milestone/phase**
+- add `roadmap` when the issue belongs in planned product work
+- add domain labels like `skills`, `voice`, `memory`, `ui`, `architecture` as appropriate
+
+If a feature naturally decomposes into multiple meaningful tracks, create or maintain a **parent/epic** with child issues instead of leaving one oversized issue blob.
+
 ## Architecture overview
 
 - **Tier 2 QuickIntentRouter**: pure Kotlin regex + MiniLM classifier, ~0MB, <5ms, 20 intents

--- a/.opencode/agents/spec-writer.md
+++ b/.opencode/agents/spec-writer.md
@@ -27,6 +27,8 @@ You are the **spec-writer** for the Kernel AI Assistant project.
 ## Key rules
 
 - Keep `AGENTS.md`, OpenCode agent prompts, and `copilot-instructions.md` aligned when agent workflow changes
+- New GitHub issues should be normalized at creation time with type, go-state, priority, size, milestone/phase, roadmap, and relevant domain labels
+- If an issue spans multiple tracks, split it into a parent/epic plus child issues instead of leaving one giant body
 - Keep copilot-instructions.md in sync with actual code — outdated instructions mislead agents
 - Skill schemas must match the `SkillSchema` Kotlin definitions exactly — they are injected into the model system prompt
 - Any new skill requires: schema definition + documentation update + version bump in manifest


### PR DESCRIPTION
## Summary
Persist the repo-local OpenCode guidance for GitHub issue normalization and shared Android workflow.

## Changes
- add `.opencode/AGENTS.md` as the repo-level OpenCode guidance entrypoint
- add GitHub issue metadata and parent/epic structuring rules to OpenCode repo guidance
- sync shared Android CLI, Android debugging, repo context, and documentation sync guidance into `.opencode/AGENTS.md`
- add issue normalization guidance to `.opencode/agents/spec-writer.md`
- add issue hygiene guidance to `.opencode/agents/coordinator.md`

## Testing
- [ ] Unit tests pass
- [ ] Manual testing done

## Related issues
Follow-up repo guidance persistence for the issue standards and Android CLI workflow.
