### PR TITLE
Add rich tool result presentations

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/23.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/23.json
@@ -1,0 +1,800 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "5b1fac6a8df1e8982ef9b3012ec360f8",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5b1fac6a8df1e8982ef9b3012ec360f8')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -48,7 +48,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 22,
+    version = 23,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -268,6 +268,13 @@ abstract class KernelDatabase : RoomDatabase() {
                     """.trimIndent()
                 )
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_kiwi_memories_id ON kiwi_memories (id)")
+            }
+        }
+
+        /** Adds presentationJson to quick_actions for rich tool result UI (#222). */
+        val MIGRATION_22_23 = object : Migration(22, 23) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE quick_actions ADD COLUMN presentationJson TEXT DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -70,6 +70,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_19_20,
                     KernelDatabase.MIGRATION_20_21,
                     KernelDatabase.MIGRATION_21_22,
+                    KernelDatabase.MIGRATION_22_23,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/QuickActionEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/QuickActionEntity.kt
@@ -20,5 +20,7 @@ data class QuickActionEntity(
     val resultText: String,
     /** Whether the action completed successfully. */
     val isSuccess: Boolean,
+    /** Optional serialized ToolPresentation payload for rich result UI. */
+    val presentationJson: String? = null,
     val timestamp: Long = System.currentTimeMillis(),
 )

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -46,16 +46,19 @@ class KernelAIToolSet @Inject constructor(
     @Volatile private var toolCalledInThisTurn = false
     @Volatile private var lastToolName: String? = null
     @Volatile private var lastToolResult: String? = null
+    @Volatile private var lastToolPresentation: ToolPresentation? = null
 
     fun resetTurnState() {
         toolCalledInThisTurn = false
         lastToolName = null
         lastToolResult = null
+        lastToolPresentation = null
     }
 
     fun wasToolCalled(): Boolean = toolCalledInThisTurn
     fun lastToolName(): String? = lastToolName
     fun lastToolResult(): String? = lastToolResult
+    fun lastToolPresentation(): ToolPresentation? = lastToolPresentation
 
     // -------------------------------------------------------------------------
     // Gateway tools — each delegates to the matching Skill.execute()
@@ -181,6 +184,11 @@ class KernelAIToolSet @Inject constructor(
             val result = runBlocking {
                 skill.execute(SkillCall(skillName = skillName, arguments = args))
             }
+            lastToolPresentation = when (result) {
+                is SkillResult.Success -> result.presentation
+                is SkillResult.DirectReply -> result.presentation
+                else -> null
+            }
             when (result) {
                 is SkillResult.Success -> mapOf("result" to result.content)
                 is SkillResult.DirectReply -> mapOf("result" to result.content)
@@ -189,6 +197,7 @@ class KernelAIToolSet @Inject constructor(
                 is SkillResult.UnknownSkill -> mapOf("error" to "Unknown skill: ${result.skillName}")
             }
         } catch (e: Exception) {
+            lastToolPresentation = null
             Log.e(TAG, "ToolSet: $skillName execution failed", e)
             mapOf("error" to (e.message ?: "Unknown error executing $skillName"))
         }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1949,11 +1949,20 @@ class QuickIntentRouter(
                 )
             },
         ),
-        // "what's on my shopping list" / "show me my grocery list" / "read out my to-do list"
+        // "what's on my shopping list" / "what's in my shopping list" / "show me my grocery list"
         IntentPattern(
             intentName = "get_list_items",
             regex = Regex(
-                """(?:what(?:'s|\s+is)\s+on|show(?:\s+me)?|read(?:\s+out)?|get|list)\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                """(?:what(?:'s|\s+is)\s+(?:on|in)|show(?:\s+me)?|read(?:\s+out)?|get|list)\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+        ),
+        // "display list called shopping" / "show list called groceries"
+        IntentPattern(
+            intentName = "get_list_items",
+            regex = Regex(
+                """(?:display|show|read|get)\s+(?:the\s+)?list\s+called\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
@@ -22,11 +22,17 @@ package com.kernel.ai.core.skills
 sealed class SkillResult {
     /** Skill ran successfully. [content] is injected back into the conversation as system context
      *  so the LLM can produce a natural conversational wrapper around it. */
-    data class Success(val content: String) : SkillResult()
+    data class Success(
+        val content: String,
+        val presentation: ToolPresentation? = null,
+    ) : SkillResult()
     /** Skill ran successfully and [content] should be shown to the user verbatim — the LLM is
      *  bypassed entirely. Use for skills that return structured data (e.g. weather readings,
      *  sensor values) where LLM rephrasing risks corrupting numbers or units. */
-    data class DirectReply(val content: String) : SkillResult()
+    data class DirectReply(
+        val content: String,
+        val presentation: ToolPresentation? = null,
+    ) : SkillResult()
     /** Skill not found in registry. */
     data class UnknownSkill(val skillName: String) : SkillResult()
     /** Skill found but execution failed. */

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
@@ -10,10 +10,13 @@ sealed interface ToolPresentation {
         val feelsLikeText: String?,
         val description: String,
         val emoji: String,
+        val highLowText: String? = null,
         val humidityText: String?,
         val windText: String?,
         val precipText: String?,
+        val uvText: String? = null,
         val airQualityText: String?,
+        val sunText: String? = null,
     ) : ToolPresentation
 
     data class Status(
@@ -54,10 +57,13 @@ object ToolPresentationJson {
             put("feelsLikeText", presentation.feelsLikeText)
             put("description", presentation.description)
             put("emoji", presentation.emoji)
+            put("highLowText", presentation.highLowText)
             put("humidityText", presentation.humidityText)
             put("windText", presentation.windText)
             put("precipText", presentation.precipText)
+            put("uvText", presentation.uvText)
             put("airQualityText", presentation.airQualityText)
+            put("sunText", presentation.sunText)
         }
 
         is ToolPresentation.Status -> JSONObject().apply {
@@ -90,10 +96,13 @@ object ToolPresentationJson {
             feelsLikeText = obj.optString("feelsLikeText").takeIf { it.isNotBlank() },
             description = obj.optString("description"),
             emoji = obj.optString("emoji"),
+            highLowText = obj.optString("highLowText").takeIf { it.isNotBlank() },
             humidityText = obj.optString("humidityText").takeIf { it.isNotBlank() },
             windText = obj.optString("windText").takeIf { it.isNotBlank() },
             precipText = obj.optString("precipText").takeIf { it.isNotBlank() },
+            uvText = obj.optString("uvText").takeIf { it.isNotBlank() },
             airQualityText = obj.optString("airQualityText").takeIf { it.isNotBlank() },
+            sunText = obj.optString("sunText").takeIf { it.isNotBlank() },
         )
 
         "status" -> ToolPresentation.Status(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
@@ -1,0 +1,122 @@
+package com.kernel.ai.core.skills
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+sealed interface ToolPresentation {
+    data class Weather(
+        val locationName: String,
+        val temperatureText: String,
+        val feelsLikeText: String?,
+        val description: String,
+        val emoji: String,
+        val humidityText: String?,
+        val windText: String?,
+        val precipText: String?,
+        val airQualityText: String?,
+    ) : ToolPresentation
+
+    data class Status(
+        val icon: String,
+        val title: String,
+        val subtitle: String? = null,
+    ) : ToolPresentation
+
+    data class ListPreview(
+        val title: String,
+        val items: List<String>,
+        val totalCount: Int,
+        val emptyMessage: String? = null,
+    ) : ToolPresentation
+
+    data class ComputedResult(
+        val primaryText: String,
+        val contextText: String,
+        val breakdownText: String? = null,
+    ) : ToolPresentation
+}
+
+object ToolPresentationJson {
+    private const val KEY_TYPE = "type"
+
+    fun toJsonString(presentation: ToolPresentation): String = toJsonObject(presentation).toString()
+
+    fun fromJsonString(json: String?): ToolPresentation? {
+        if (json.isNullOrBlank()) return null
+        return runCatching { fromJsonObject(JSONObject(json)) }.getOrNull()
+    }
+
+    fun toJsonObject(presentation: ToolPresentation): JSONObject = when (presentation) {
+        is ToolPresentation.Weather -> JSONObject().apply {
+            put(KEY_TYPE, "weather")
+            put("locationName", presentation.locationName)
+            put("temperatureText", presentation.temperatureText)
+            put("feelsLikeText", presentation.feelsLikeText)
+            put("description", presentation.description)
+            put("emoji", presentation.emoji)
+            put("humidityText", presentation.humidityText)
+            put("windText", presentation.windText)
+            put("precipText", presentation.precipText)
+            put("airQualityText", presentation.airQualityText)
+        }
+
+        is ToolPresentation.Status -> JSONObject().apply {
+            put(KEY_TYPE, "status")
+            put("icon", presentation.icon)
+            put("title", presentation.title)
+            put("subtitle", presentation.subtitle)
+        }
+
+        is ToolPresentation.ListPreview -> JSONObject().apply {
+            put(KEY_TYPE, "list_preview")
+            put("title", presentation.title)
+            put("items", JSONArray(presentation.items))
+            put("totalCount", presentation.totalCount)
+            put("emptyMessage", presentation.emptyMessage)
+        }
+
+        is ToolPresentation.ComputedResult -> JSONObject().apply {
+            put(KEY_TYPE, "computed_result")
+            put("primaryText", presentation.primaryText)
+            put("contextText", presentation.contextText)
+            put("breakdownText", presentation.breakdownText)
+        }
+    }
+
+    fun fromJsonObject(obj: JSONObject): ToolPresentation? = when (obj.optString(KEY_TYPE)) {
+        "weather" -> ToolPresentation.Weather(
+            locationName = obj.optString("locationName"),
+            temperatureText = obj.optString("temperatureText"),
+            feelsLikeText = obj.optString("feelsLikeText").takeIf { it.isNotBlank() },
+            description = obj.optString("description"),
+            emoji = obj.optString("emoji"),
+            humidityText = obj.optString("humidityText").takeIf { it.isNotBlank() },
+            windText = obj.optString("windText").takeIf { it.isNotBlank() },
+            precipText = obj.optString("precipText").takeIf { it.isNotBlank() },
+            airQualityText = obj.optString("airQualityText").takeIf { it.isNotBlank() },
+        )
+
+        "status" -> ToolPresentation.Status(
+            icon = obj.optString("icon"),
+            title = obj.optString("title"),
+            subtitle = obj.optString("subtitle").takeIf { it.isNotBlank() },
+        )
+
+        "list_preview" -> ToolPresentation.ListPreview(
+            title = obj.optString("title"),
+            items = obj.optJSONArray("items")?.let { arr ->
+                MutableList(arr.length()) { index -> arr.optString(index) }
+            } ?: emptyList(),
+            totalCount = obj.optInt("totalCount"),
+            emptyMessage = obj.optString("emptyMessage").takeIf { it.isNotBlank() },
+        )
+
+        "computed_result" -> ToolPresentation.ComputedResult(
+            primaryText = obj.optString("primaryText"),
+            contextText = obj.optString("contextText"),
+            breakdownText = obj.optString("breakdownText").takeIf { it.isNotBlank() },
+        )
+
+        else -> null
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillParameter
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.skills.ToolPresentation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -258,7 +259,34 @@ class GetWeatherSkill @Inject constructor(
         }.trimEnd()
 
         Log.d(TAG, "GetWeatherSkill: fetched ${len}-day forecast for $locationLabel")
-        return SkillResult.DirectReply(text)
+        val firstCode = codes.optInt(0, -1)
+        val firstHigh = maxTemps.optDouble(0, Double.NaN)
+        val firstLow = minTemps.optDouble(0, Double.NaN)
+        val firstRain = precip.optDouble(0, Double.NaN)
+        val firstUv = uvMaxArr?.let {
+            if (it.length() > 0 && !it.isNull(0)) it.getDouble(0) else null
+        }
+        val temperatureText = buildString {
+            if (!firstHigh.isNaN()) append("%.0f°C".format(firstHigh))
+            if (!firstLow.isNaN()) {
+                if (isNotEmpty()) append(" / ")
+                append("%.0f°C".format(firstLow))
+            }
+        }.ifBlank { "Forecast unavailable" }
+        return SkillResult.DirectReply(
+            text,
+            presentation = ToolPresentation.Weather(
+                locationName = locationLabel,
+                temperatureText = temperatureText,
+                feelsLikeText = null,
+                description = wmoDescription(firstCode),
+                emoji = wmoEmoji(firstCode),
+                humidityText = null,
+                windText = null,
+                precipText = if (!firstRain.isNaN()) "%.0fmm rain".format(firstRain) else null,
+                airQualityText = firstUv?.let { "UV %.0f (%s)".format(it, uvIndexLabel(it)) },
+            ),
+        )
     }
 
     private fun formatForecastDate(dateStr: String): String {
@@ -426,7 +454,27 @@ class GetWeatherSkill @Inject constructor(
 
         Log.d(TAG, "GetWeatherSkill: fetched weather for $locationLabel")
         // DirectReply: structured data — numeric temperature/humidity/wind values
-        return SkillResult.DirectReply(text)
+        val precipText = buildString {
+            if (precipChance >= 0) append("Rain chance $precipChance%")
+            if (!precipitation.isNaN()) {
+                if (isNotEmpty()) append(" • ")
+                append("%.1fmm".format(precipitation))
+            }
+        }.takeIf { it.isNotBlank() }
+        return SkillResult.DirectReply(
+            text,
+            presentation = ToolPresentation.Weather(
+                locationName = locationLabel,
+                temperatureText = if (!temp.isNaN()) "%.0f°C".format(temp) else "?",
+                feelsLikeText = if (!feelsLike.isNaN()) "Feels like %.0f°C".format(feelsLike) else null,
+                description = description,
+                emoji = emoji,
+                humidityText = if (humidity >= 0) "Humidity $humidity%" else null,
+                windText = if (!windSpeed.isNaN()) "Wind %.1f m/s".format(windSpeed) else null,
+                precipText = precipText,
+                airQualityText = airQuality?.usAqi?.let { "AQI $it" },
+            ),
+        )
     }
 
     private fun uvIndexLabel(uv: Double): String = when {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -266,6 +266,12 @@ class GetWeatherSkill @Inject constructor(
         val firstUv = uvMaxArr?.let {
             if (it.length() > 0 && !it.isNull(0)) it.getDouble(0) else null
         }
+        val firstSunrise = sunriseArr?.let {
+            if (it.length() > 0 && !it.isNull(0)) it.getString(0).substringAfterLast("T") else null
+        }
+        val firstSunset = sunsetArr?.let {
+            if (it.length() > 0 && !it.isNull(0)) it.getString(0).substringAfterLast("T") else null
+        }
         val temperatureText = buildString {
             if (!firstHigh.isNaN()) append("%.0f°C".format(firstHigh))
             if (!firstLow.isNaN()) {
@@ -273,6 +279,19 @@ class GetWeatherSkill @Inject constructor(
                 append("%.0f°C".format(firstLow))
             }
         }.ifBlank { "Forecast unavailable" }
+        val highLowText = buildString {
+            if (!firstHigh.isNaN()) append("High %.0f°C".format(firstHigh))
+            if (!firstLow.isNaN()) {
+                if (isNotEmpty()) append(" • ")
+                append("Low %.0f°C".format(firstLow))
+            }
+        }.takeIf { it.isNotBlank() }
+        val sunText = when {
+            firstSunrise != null && firstSunset != null -> "Sunrise $firstSunrise • Sunset $firstSunset"
+            firstSunrise != null -> "Sunrise $firstSunrise"
+            firstSunset != null -> "Sunset $firstSunset"
+            else -> null
+        }
         return SkillResult.DirectReply(
             text,
             presentation = ToolPresentation.Weather(
@@ -281,10 +300,13 @@ class GetWeatherSkill @Inject constructor(
                 feelsLikeText = null,
                 description = wmoDescription(firstCode),
                 emoji = wmoEmoji(firstCode),
+                highLowText = highLowText,
                 humidityText = null,
                 windText = null,
                 precipText = if (!firstRain.isNaN()) "%.0fmm rain".format(firstRain) else null,
-                airQualityText = firstUv?.let { "UV %.0f (%s)".format(it, uvIndexLabel(it)) },
+                uvText = firstUv?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
+                airQualityText = null,
+                sunText = sunText,
             ),
         )
     }
@@ -461,6 +483,26 @@ class GetWeatherSkill @Inject constructor(
                 append("%.1fmm".format(precipitation))
             }
         }.takeIf { it.isNotBlank() }
+        val highLowText = buildString {
+            tempMax?.let { append("High %.0f°C".format(it)) }
+            tempMin?.let {
+                if (isNotEmpty()) append(" • ")
+                append("Low %.0f°C".format(it))
+            }
+        }.takeIf { it.isNotBlank() }
+        val uvText = buildString {
+            uvIndex?.let { append("UV %.0f (%s)".format(it, uvIndexLabel(it))) }
+            uvIndexMax?.let {
+                if (isNotEmpty()) append(" • ")
+                append("Max %.0f".format(it))
+            }
+        }.takeIf { it.isNotBlank() }
+        val sunText = when {
+            sunriseTime != null && sunsetTime != null -> "Sunrise $sunriseTime • Sunset $sunsetTime"
+            sunriseTime != null -> "Sunrise $sunriseTime"
+            sunsetTime != null -> "Sunset $sunsetTime"
+            else -> null
+        }
         return SkillResult.DirectReply(
             text,
             presentation = ToolPresentation.Weather(
@@ -469,10 +511,13 @@ class GetWeatherSkill @Inject constructor(
                 feelsLikeText = if (!feelsLike.isNaN()) "Feels like %.0f°C".format(feelsLike) else null,
                 description = description,
                 emoji = emoji,
+                highLowText = highLowText,
                 humidityText = if (humidity >= 0) "Humidity $humidity%" else null,
                 windText = if (!windSpeed.isNaN()) "Wind %.1f m/s".format(windSpeed) else null,
                 precipText = precipText,
-                airQualityText = airQuality?.usAqi?.let { "AQI $it" },
+                uvText = uvText,
+                airQualityText = airQuality?.usAqi?.let { "AQI $it (${aqiLabel(it)})" },
+                sunText = sunText,
             ),
         )
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -194,6 +194,7 @@ class NativeIntentHandler @Inject constructor(
      */
     private fun normalizeIntentName(raw: String): String {
         val trimmed = raw.trim().lowercase()
+        INTENT_ALIASES[trimmed]?.let { return it }
         if (trimmed in KNOWN_INTENTS) return trimmed
         // Strip all word separators and compare canonically
         val stripped = trimmed.replace(Regex("[_\\s]+"), "")
@@ -201,6 +202,10 @@ class NativeIntentHandler @Inject constructor(
     }
 
     companion object {
+        private val INTENT_ALIASES = mapOf(
+            "get_list" to "get_list_items",
+        )
+
         private val KNOWN_INTENTS = setOf(
             "toggle_flashlight_on", "toggle_flashlight_off",
             "send_email", "send_sms", "make_call",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -30,6 +30,7 @@ import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.ToolPresentation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.DayOfWeek
 import java.time.Instant
@@ -1125,11 +1126,15 @@ class NativeIntentHandler @Inject constructor(
         val item = params["item"] ?: return SkillResult.Failure("add_to_list", "No item specified")
         val raw = (params["list_name"] ?: "shopping list").lowercase().trim()
         val listName = normalizeListName(raw)
-        runBlocking {
+        val items = runBlocking {
             listNameDao.insert(ListNameEntity(name = listName))
             listItemDao.insert(ListItemEntity(listName = listName, item = item))
+            listItemDao.getByList(listName)
         }
-        return SkillResult.DirectReply("Added \"$item\" to your $listName.")
+        return SkillResult.DirectReply(
+            "Added \"$item\" to your $listName.",
+            presentation = buildListPreview(listName, items),
+        )
     }
 
     private fun bulkAddToList(params: Map<String, String>): SkillResult {
@@ -1144,13 +1149,15 @@ class NativeIntentHandler @Inject constructor(
             itemsParam.split(",").map { it.trim() }.filter { it.isNotBlank() }
         }
         if (items.isEmpty()) return SkillResult.Failure("bulk_add_to_list", "No valid items to add")
-        runBlocking {
+        val currentItems = runBlocking {
             listNameDao.insert(ListNameEntity(name = listName))
             items.forEach { listItemDao.insert(ListItemEntity(listName = listName, item = it)) }
+            listItemDao.getByList(listName)
         }
         return SkillResult.DirectReply(
             "Added ${items.size} item${if (items.size == 1) "" else "s"} to your $listName:\n" +
-                items.joinToString(", ")
+                items.joinToString(", "),
+            presentation = buildListPreview(listName, currentItems),
         )
     }
 
@@ -1158,7 +1165,10 @@ class NativeIntentHandler @Inject constructor(
         val raw = params["list_name"] ?: return SkillResult.Failure("create_list", "No list name specified")
         val name = raw.lowercase().trim()
         runBlocking { listNameDao.insert(ListNameEntity(name = name)) }
-        return SkillResult.DirectReply("Created list \"$name\".")
+        return SkillResult.DirectReply(
+            "Created list \"$name\".",
+            presentation = buildListPreview(name, emptyList(), "No items yet."),
+        )
     }
 
     private fun getListItems(params: Map<String, String>): SkillResult {
@@ -1166,10 +1176,16 @@ class NativeIntentHandler @Inject constructor(
         val listName = normalizeListName(raw)
         val items = runBlocking { listItemDao.getByList(listName) }
         return if (items.isEmpty()) {
-            SkillResult.DirectReply("Your $listName is empty.")
+            SkillResult.DirectReply(
+                "Your $listName is empty.",
+                presentation = buildListPreview(listName, emptyList(), "No items yet."),
+            )
         } else {
             val bullets = items.joinToString("\n") { "• ${it.item}" }
-            SkillResult.DirectReply("$listName (${items.size} item${if (items.size == 1) "" else "s"}):\n$bullets")
+            SkillResult.DirectReply(
+                "$listName (${items.size} item${if (items.size == 1) "" else "s"}):\n$bullets",
+                presentation = buildListPreview(listName, items),
+            )
         }
     }
 
@@ -1181,8 +1197,14 @@ class NativeIntentHandler @Inject constructor(
         val match = all.firstOrNull { it.item.equals(item, ignoreCase = true) }
             ?: all.firstOrNull { it.item.contains(item, ignoreCase = true) }
             ?: return SkillResult.DirectReply("\"$item\" not found in $listName.")
-        runBlocking { listItemDao.deleteItem(match.id) }
-        return SkillResult.DirectReply("Removed \"${match.item}\" from $listName.")
+        val remaining = runBlocking {
+            listItemDao.deleteItem(match.id)
+            listItemDao.getByList(listName)
+        }
+        return SkillResult.DirectReply(
+            "Removed \"${match.item}\" from $listName.",
+            presentation = buildListPreview(listName, remaining, "No items left."),
+        )
     }
 
     // ── Smart Home (stub — pending #311 / #312) ───────────────────────────────
@@ -1273,8 +1295,44 @@ class NativeIntentHandler @Inject constructor(
                 append(" — $targetFormatted.")
             }
         }
-        return SkillResult.DirectReply(reply)
+        val primaryText = when {
+            days == 0L -> "Today"
+            days > 0 -> "$absDays day${if (absDays != 1L) "s" else ""}"
+            else -> "$absDays day${if (absDays != 1L) "s" else ""} ago"
+        }
+        val contextText = when {
+            days == 0L -> targetFormatted
+            days > 0 -> "Until $targetFormatted"
+            else -> "Since $targetFormatted"
+        }
+        val breakdownText = if (weeks > 0) {
+            buildString {
+                append("$weeks week${if (weeks != 1L) "s" else ""}")
+                if (remainderDays > 0) {
+                    append(", $remainderDays day${if (remainderDays != 1L) "s" else ""}")
+                }
+            }
+        } else null
+        return SkillResult.DirectReply(
+            reply,
+            presentation = ToolPresentation.ComputedResult(
+                primaryText = primaryText,
+                contextText = contextText,
+                breakdownText = breakdownText,
+            ),
+        )
     }
+
+    private fun buildListPreview(
+        listName: String,
+        items: List<ListItemEntity>,
+        emptyMessage: String? = null,
+    ): ToolPresentation.ListPreview = ToolPresentation.ListPreview(
+        title = listName,
+        items = items.map { it.item },
+        totalCount = items.size,
+        emptyMessage = emptyMessage,
+    )
 
     /**
      * Parses a date string in various natural formats, including named NZ/common holidays.

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
@@ -1,0 +1,34 @@
+package com.kernel.ai.core.skills
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class QuickIntentRouterListRoutingTest {
+
+    private lateinit var router: QuickIntentRouter
+
+    @BeforeEach
+    fun setUp() {
+        router = QuickIntentRouter()
+    }
+
+    @Test
+    fun `routes whats in my shopping list via regex`() {
+        val result = router.route("what's in my shopping list")
+
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("get_list_items", match.intent.intentName)
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+
+    @Test
+    fun `routes display list called shopping via regex`() {
+        val result = router.route("display list called shopping")
+
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("get_list_items", match.intent.intentName)
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2166,6 +2166,8 @@ class QuickIntentRouterTest {
         fun getListItemsRegexPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("show my todo list", "todo"),
             Arguments.of("what's on my shopping list", "shopping"),
+            Arguments.of("what's in my shopping list", "shopping"),
+            Arguments.of("display list called shopping", "shopping"),
             Arguments.of("show me my grocery list", "grocery"),
             Arguments.of("read my shopping list", "shopping"),
             Arguments.of("get my to-do list", "to-do"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
@@ -1,0 +1,71 @@
+package com.kernel.ai.core.skills
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ToolPresentationJsonTest {
+
+    @Test
+    fun `weather presentation round-trips through json`() {
+        val original = ToolPresentation.Weather(
+            locationName = "Wellington",
+            temperatureText = "13°C / 12°C",
+            feelsLikeText = "Feels like 11°C",
+            description = "Rain",
+            emoji = "🌧️",
+            humidityText = "Humidity 82%",
+            windText = "Wind 4 m/s",
+            precipText = "5mm rain",
+            airQualityText = "AQI 12",
+        )
+
+        val parsed = ToolPresentationJson.fromJsonString(ToolPresentationJson.toJsonString(original))
+
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `list preview presentation round-trips through json`() {
+        val original = ToolPresentation.ListPreview(
+            title = "Shopping",
+            items = listOf("milk", "eggs", "bread"),
+            totalCount = 3,
+            emptyMessage = null,
+        )
+
+        val parsed = ToolPresentationJson.fromJsonString(ToolPresentationJson.toJsonString(original))
+
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `computed result presentation round-trips through json`() {
+        val original = ToolPresentation.ComputedResult(
+            primaryText = "125 days",
+            contextText = "Until 22 Aug 2026",
+            breakdownText = "17 weeks, 6 days",
+        )
+
+        val parsed = ToolPresentationJson.fromJsonString(ToolPresentationJson.toJsonString(original))
+
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `invalid json returns null`() {
+        assertNull(ToolPresentationJson.fromJsonString("{not-valid-json"))
+    }
+
+    @Test
+    fun `status presentation parses to correct subtype`() {
+        val parsed = ToolPresentationJson.fromJsonString(
+            ToolPresentationJson.toJsonString(
+                ToolPresentation.Status(icon = "💾", title = "Remembered", subtitle = null),
+            ),
+        )
+
+        assertInstanceOf(ToolPresentation.Status::class.java, parsed)
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
@@ -15,10 +15,13 @@ class ToolPresentationJsonTest {
             feelsLikeText = "Feels like 11°C",
             description = "Rain",
             emoji = "🌧️",
+            highLowText = "High 13°C • Low 12°C",
             humidityText = "Humidity 82%",
             windText = "Wind 4 m/s",
             precipText = "5mm rain",
+            uvText = "UV 5 (Moderate) • Max 7",
             airQualityText = "AQI 12",
+            sunText = "Sunrise 07:10 • Sunset 17:31",
         )
 
         val parsed = ToolPresentationJson.fromJsonString(ToolPresentationJson.toJsonString(original))

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1,0 +1,37 @@
+package com.kernel.ai.core.skills.natives
+
+import android.content.Context
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.dao.ListItemDao
+import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NativeIntentHandlerTest {
+
+    private val handler = NativeIntentHandler(
+        context = mockk<Context>(relaxed = true),
+        scheduledAlarmDao = mockk<ScheduledAlarmDao>(relaxed = true),
+        listItemDao = mockk<ListItemDao>(relaxed = true),
+        listNameDao = mockk<ListNameDao>(relaxed = true),
+        contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true),
+        memoryRepository = mockk<MemoryRepository>(relaxed = true),
+        embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
+    )
+
+    @Test
+    fun `get_list alias normalizes to get_list_items`() {
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "normalizeIntentName",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val normalized = method.invoke(handler, "get_list") as String
+
+        assertEquals("get_list_items", normalized)
+    }
+}

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.chat
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ToolCallInfo
@@ -71,6 +72,8 @@ class ChatScreenToolChipTest {
         setContent(message)
 
         composeTestRule.onNodeWithTag("tool_chip").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Wellington").assertIsDisplayed()
+        composeTestRule.onNodeWithText("🌡 High 13°C • Low 12°C").assertIsDisplayed()
     }
 
     @Test

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.chat
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ToolCallInfo
 import org.junit.Rule
@@ -33,6 +34,35 @@ class ChatScreenToolChipTest {
                 requestJson = """{"seconds":60}""",
                 resultText = "Timer set for 60 seconds",
                 isSuccess = true,
+            ),
+        )
+        setContent(message)
+
+        composeTestRule.onNodeWithTag("tool_chip").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolChipVisible_whenRichPresentationPresent() {
+        val message = ChatMessage(
+            id = "rich",
+            role = ChatMessage.Role.ASSISTANT,
+            content = "Weather response",
+            toolCall = ToolCallInfo(
+                skillName = "get_weather",
+                requestJson = """{"location":"Wellington"}""",
+                resultText = "Wellington forecast: 13°C / 12°C",
+                isSuccess = true,
+                presentation = ToolPresentation.Weather(
+                    locationName = "Wellington",
+                    temperatureText = "13°C / 12°C",
+                    feelsLikeText = null,
+                    description = "Rain",
+                    emoji = "🌧️",
+                    humidityText = "82%",
+                    windText = "4 m/s",
+                    precipText = "5mm rain",
+                    airQualityText = null,
+                ),
             ),
         )
         setContent(message)

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -58,10 +58,13 @@ class ChatScreenToolChipTest {
                     feelsLikeText = null,
                     description = "Rain",
                     emoji = "🌧️",
+                    highLowText = "High 13°C • Low 12°C",
                     humidityText = "82%",
                     windText = "4 m/s",
                     precipText = "5mm rain",
+                    uvText = "UV max 6 (High)",
                     airQualityText = null,
+                    sunText = "Sunrise 07:10 • Sunset 17:31",
                 ),
             ),
         )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.ImeAction
 import com.kernel.ai.core.memory.entity.QuickActionEntity
+import com.kernel.ai.core.skills.ToolPresentationJson
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -461,6 +462,9 @@ private fun ActionHistoryCard(
 ) {
     var expanded by remember { mutableStateOf(false) }
     var isOverflowing by remember { mutableStateOf(false) }
+    val presentation = remember(action.presentationJson) {
+        ToolPresentationJson.fromJsonString(action.presentationJson)
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -517,25 +521,31 @@ private fun ActionHistoryCard(
                 }
             }
 
-            // Result text
             Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = action.resultText,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = if (expanded) Int.MAX_VALUE else 3,
-                overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
-                onTextLayout = { result -> if (result.hasVisualOverflow) isOverflowing = true },
-            )
-            if (isOverflowing || expanded) {
-                TextButton(
-                    onClick = { expanded = !expanded },
-                    modifier = Modifier.align(Alignment.End),
-                ) {
-                    Text(
-                        text = if (expanded) "Show less" else "Show more",
-                        style = MaterialTheme.typography.labelSmall,
-                    )
+            if (presentation != null && action.isSuccess) {
+                ToolPresentationContent(
+                    presentation = presentation,
+                    compact = true,
+                )
+            } else {
+                Text(
+                    text = action.resultText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = if (expanded) Int.MAX_VALUE else 3,
+                    overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                    onTextLayout = { result -> if (result.hasVisualOverflow) isOverflowing = true },
+                )
+                if (isOverflowing || expanded) {
+                    TextButton(
+                        onClick = { expanded = !expanded },
+                        modifier = Modifier.align(Alignment.End),
+                    ) {
+                        Text(
+                            text = if (expanded) "Show less" else "Show more",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
                 }
             }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.skills.QuickIntentRouter
 import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -263,12 +264,14 @@ class ActionsViewModel @Inject constructor(
             skillName = skillName,
             resultText = result.content,
             isSuccess = true,
+            presentationJson = result.presentation?.let(ToolPresentationJson::toJsonString),
         )
         is SkillResult.Success -> QuickActionEntity(
             userQuery = query,
             skillName = skillName,
             resultText = result.content,
             isSuccess = true,
+            presentationJson = result.presentation?.let(ToolPresentationJson::toJsonString),
         )
         is SkillResult.Failure -> QuickActionEntity(
             userQuery = query,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -400,6 +400,8 @@ private fun MessageBubble(
     } else {
         MaterialTheme.colorScheme.surfaceVariant
     }
+    val richPresentation = message.toolCall?.presentation
+    val suppressAssistantBubble = !isUser && richPresentation != null && message.toolCall?.isSuccess == true
     var showMenu by remember { mutableStateOf(false) }
 
     // Both user and assistant messages use combinedClickable for long-press → context menu.
@@ -456,6 +458,15 @@ private fun MessageBubble(
             }
         }
 
+        if (!isUser && richPresentation != null) {
+            ToolPresentationContent(
+                presentation = richPresentation,
+                modifier = Modifier
+                    .padding(bottom = 4.dp)
+                    .widthIn(max = 320.dp),
+            )
+        }
+
         // Tool call chip (shown above message bubble for assistant messages)
         if (!isUser && message.toolCall != null) {
             ToolCallChip(
@@ -466,77 +477,79 @@ private fun MessageBubble(
             )
         }
 
-        Box(modifier = bubbleModifier) {
-            Surface(
-                color = bubbleColor,
-                shape = RoundedCornerShape(
-                    topStart = if (isUser) 18.dp else 4.dp,
-                    topEnd = if (isUser) 4.dp else 18.dp,
-                    bottomStart = 18.dp,
-                    bottomEnd = 18.dp,
-                ),
-                modifier = Modifier
-                    .widthIn(max = 300.dp),
-            ) {
-                if (isUser) {
-                    // User messages: plain text, no link/code parsing needed.
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = message.content,
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                    }
-                } else {
-                    // Assistant messages: render full Markdown with inline + block support.
-                    Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
-                        val contentColor = LocalContentColor.current
-                        MarkdownContent(
-                            text  = message.content,
-                            style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
-                            onLongPress = { showMenu = true },
-                        )
-                        if (message.isStreaming) {
-                            val generatingMessage = remember { LoadingMessages.randomGenerating() }
-                            Row(
-                                modifier = Modifier.padding(top = 6.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(12.dp),
-                                    strokeWidth = 2.dp,
-                                )
-                                Text(
-                                    text = generatingMessage,
-                                    style = MaterialTheme.typography.labelSmall.copy(
-                                        fontStyle = FontStyle.Italic,
-                                    ),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+        if (!suppressAssistantBubble) {
+            Box(modifier = bubbleModifier) {
+                Surface(
+                    color = bubbleColor,
+                    shape = RoundedCornerShape(
+                        topStart = if (isUser) 18.dp else 4.dp,
+                        topEnd = if (isUser) 4.dp else 18.dp,
+                        bottomStart = 18.dp,
+                        bottomEnd = 18.dp,
+                    ),
+                    modifier = Modifier
+                        .widthIn(max = 300.dp),
+                ) {
+                    if (isUser) {
+                        // User messages: plain text, no link/code parsing needed.
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = message.content,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.weight(1f, fill = false),
+                            )
+                        }
+                    } else {
+                        // Assistant messages: render full Markdown with inline + block support.
+                        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                            val contentColor = LocalContentColor.current
+                            MarkdownContent(
+                                text = message.content,
+                                style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
+                                onLongPress = { showMenu = true },
+                            )
+                            if (message.isStreaming) {
+                                val generatingMessage = remember { LoadingMessages.randomGenerating() }
+                                Row(
+                                    modifier = Modifier.padding(top = 6.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(12.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                    Text(
+                                        text = generatingMessage,
+                                        style = MaterialTheme.typography.labelSmall.copy(
+                                            fontStyle = FontStyle.Italic,
+                                        ),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            DropdownMenu(
-                expanded = showMenu,
-                onDismissRequest = { showMenu = false },
-            ) {
-                DropdownMenuItem(
-                    text = { Text("Copy message") },
-                    onClick = {
-                        showMenu = false
-                        onCopy(message.content)
-                    },
-                    leadingIcon = {
-                        Icon(Icons.Default.ContentCopy, contentDescription = null)
-                    },
-                )
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Copy message") },
+                        onClick = {
+                            showMenu = false
+                            onCopy(message.content)
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null)
+                        },
+                    )
+                }
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -42,6 +42,8 @@ import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import com.kernel.ai.feature.chat.model.ToolCallInfo
+import com.kernel.ai.feature.chat.model.toJsonString
+import com.kernel.ai.feature.chat.model.toolCallInfoFromJson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -391,20 +393,7 @@ class ChatViewModel @Inject constructor(
                     role = if (entity.role == "user") ChatMessage.Role.USER else ChatMessage.Role.ASSISTANT,
                     content = entity.content,
                     thinkingText = entity.thinkingText,
-                    toolCall = entity.toolCallJson?.let { json ->
-                        try {
-                            val obj = org.json.JSONObject(json)
-                            ToolCallInfo(
-                                skillName = obj.getString("skillName"),
-                                requestJson = obj.getString("requestJson"),
-                                resultText = obj.getString("resultText"),
-                                isSuccess = obj.getBoolean("isSuccess"),
-                            )
-                        } catch (e: Exception) {
-                            Log.w("KernelAI", "Failed to deserialize toolCallJson: ${e.message}")
-                            null
-                        }
-                    },
+                    toolCall = entity.toolCallJson?.let(::toolCallInfoFromJson),
                 )
             }
             // History is in Room but not in LiteRT's KV cache — replay on next send.
@@ -582,15 +571,9 @@ class ChatViewModel @Inject constructor(
             toolCall = toolCall,
         )
         _messages.update { it + msg }
-        val toolCallJsonStr = org.json.JSONObject().apply {
-            put("skillName", toolCall.skillName)
-            put("requestJson", toolCall.requestJson)
-            put("resultText", toolCall.resultText)
-            put("isSuccess", toolCall.isSuccess)
-        }.toString()
         val savedId = conversationRepository.addMessage(
             convId, "assistant", content,
-            toolCallJson = toolCallJsonStr,
+            toolCallJson = toolCall.toJsonString(),
         )
         if (shouldIndexToolCallResult(skillName)) ragRepository.indexMessage(savedId, convId, content)
     }
@@ -1013,6 +996,7 @@ class ChatViewModel @Inject constructor(
                                     requestJson = "",
                                     resultText = result,
                                     isSuccess = !result.startsWith("error"),
+                                    presentation = kernelAIToolSet.lastToolPresentation(),
                                 )
                             } else null
 
@@ -1025,7 +1009,12 @@ class ChatViewModel @Inject constructor(
 
                             if (nativeToolCall != null || toolCallResult != null) {
                                 val toolCall = nativeToolCall ?: toolCallResult!!.first
-                                val resultContent = if (nativeToolCall != null) fullContent else toolCallResult!!.second
+                                val resultContent = when {
+                                    nativeToolCall != null && toolCall.presentation != null && toolCall.isSuccess ->
+                                        toolCall.resultText
+                                    nativeToolCall != null -> fullContent
+                                    else -> toolCallResult!!.second
+                                }
 
                                 // Update streaming message with result text
                                 _messages.update { msgs ->
@@ -1039,16 +1028,10 @@ class ChatViewModel @Inject constructor(
                                 }
 
                                 // Persist with toolCallJson
-                                val toolCallJsonStr = org.json.JSONObject().apply {
-                                    put("skillName", toolCall.skillName)
-                                    put("requestJson", toolCall.requestJson)
-                                    put("resultText", toolCall.resultText)
-                                    put("isSuccess", toolCall.isSuccess)
-                                }.toString()
                                 val savedId = conversationRepository.addMessage(
                                     convId, "assistant", resultContent,
                                     thinkingText = thinking,
-                                    toolCallJson = toolCallJsonStr,
+                                    toolCallJson = toolCall.toJsonString(),
                                 )
                                 // Only index knowledge results (e.g. Wikipedia) — not device
                                 // actions, weather, or system info which are ephemeral (#614).
@@ -1339,6 +1322,7 @@ class ChatViewModel @Inject constructor(
                     requestJson = extracted,
                     resultText = result.content,
                     isSuccess = true,
+                    presentation = result.presentation,
                 )
                 Pair(toolCall, result.content)
             }
@@ -1351,6 +1335,7 @@ class ChatViewModel @Inject constructor(
                     requestJson = extracted,
                     resultText = result.content,
                     isSuccess = true,
+                    presentation = result.presentation,
                 )
                 Pair(toolCall, result.content)
             }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -34,6 +34,7 @@ import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.SlotFillResult
 import com.kernel.ai.core.skills.slot.SlotFillerManager
@@ -556,6 +557,7 @@ class ChatViewModel @Inject constructor(
         skillName: String,
         requestJson: String,
         isSuccess: Boolean,
+        presentation: ToolPresentation? = null,
     ) {
         val msgId = UUID.randomUUID().toString()
         val toolCall = ToolCallInfo(
@@ -563,6 +565,7 @@ class ChatViewModel @Inject constructor(
             requestJson = requestJson,
             resultText = content,
             isSuccess = isSuccess,
+            presentation = presentation,
         )
         val msg = ChatMessage(
             id = msgId,
@@ -673,6 +676,7 @@ class ChatViewModel @Inject constructor(
                                         skillName = fillResult.intentName,
                                         requestJson = callParams.toString(),
                                         isSuccess = true,
+                                        presentation = skillResult.presentation,
                                     )
                                 }
                                 is SkillResult.Success -> appendAssistantMessage(convId, skillResult.content, shouldIndex = false)
@@ -708,6 +712,7 @@ class ChatViewModel @Inject constructor(
                                 skillName = pendingConfirmation.intentName,
                                 requestJson = callParams.toString(),
                                 isSuccess = true,
+                                presentation = skillResult.presentation,
                             )
                             return@launch
                         }
@@ -806,6 +811,7 @@ class ChatViewModel @Inject constructor(
                                 skillName = matchedIntent.intentName,
                                 requestJson = callParams.toString(),
                                 isSuccess = true,
+                                presentation = skillResult.presentation,
                             )
                             return@launch
                         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -75,16 +75,33 @@ private fun WeatherPresentationCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
+            presentation.highLowText?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
             val secondary = listOfNotNull(
                 presentation.humidityText,
                 presentation.windText,
                 presentation.precipText,
+                presentation.uvText,
                 presentation.airQualityText,
             )
             if (secondary.isNotEmpty()) {
                 Spacer(Modifier.height(8.dp))
                 Text(
                     text = secondary.joinToString(" • "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            presentation.sunText?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = it,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -78,22 +78,47 @@ private fun WeatherPresentationCard(
             presentation.highLowText?.let {
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = it,
+                    text = withLeadingIcon(it, "🌡"),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
             }
-            val secondary = listOfNotNull(
-                presentation.humidityText,
-                presentation.windText,
-                presentation.precipText,
-                presentation.uvText,
-                presentation.airQualityText,
-            )
-            if (secondary.isNotEmpty()) {
+            weatherDetailText(presentation.humidityText, "💧")?.let { detail ->
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = secondary.joinToString(" • "),
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            weatherDetailText(presentation.windText, "💨")?.let { detail ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            weatherDetailText(presentation.precipText, "☔")?.let { detail ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            weatherDetailText(presentation.uvText, "☀️")?.let { detail ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            weatherDetailText(presentation.airQualityText, "🌬")?.let { detail ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = detail,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
@@ -101,7 +126,7 @@ private fun WeatherPresentationCard(
             presentation.sunText?.let {
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = it,
+                    text = withLeadingIcon(it, "🌅"),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
@@ -109,6 +134,21 @@ private fun WeatherPresentationCard(
         }
     }
 }
+
+private fun weatherDetailText(value: String?, icon: String): String? =
+    value?.takeIf { it.isNotBlank() }?.let { withLeadingIcon(it, icon) }
+
+private fun withLeadingIcon(text: String, icon: String): String =
+    if (text.firstOrNull()?.isHighSurrogate() == true || text.firstOrNull()?.isLowSurrogate() == true) {
+        text
+    } else if (text.startsWith(icon) || text.startsWith("🌡") || text.startsWith("💧") ||
+        text.startsWith("💨") || text.startsWith("☔") || text.startsWith("☀") ||
+        text.startsWith("🌬") || text.startsWith("🌅") || text.startsWith("🌇")
+    ) {
+        text
+    } else {
+        "$icon $text"
+    }
 
 @Composable
 private fun StatusPresentationCard(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -1,0 +1,207 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.kernel.ai.core.skills.ToolPresentation
+
+@Composable
+fun ToolPresentationContent(
+    presentation: ToolPresentation,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    when (presentation) {
+        is ToolPresentation.Weather -> WeatherPresentationCard(presentation, modifier, compact)
+        is ToolPresentation.Status -> StatusPresentationCard(presentation, modifier)
+        is ToolPresentation.ListPreview -> ListPreviewPresentationCard(presentation, modifier, compact)
+        is ToolPresentation.ComputedResult -> ComputedResultPresentationCard(presentation, modifier)
+    }
+}
+
+@Composable
+private fun WeatherPresentationCard(
+    presentation: ToolPresentation.Weather,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(if (compact) 12.dp else 16.dp)) {
+            Text(
+                text = presentation.locationName,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.height(6.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = presentation.emoji,
+                    style = if (compact) MaterialTheme.typography.headlineSmall else MaterialTheme.typography.headlineMedium,
+                )
+                Column {
+                    Text(
+                        text = presentation.temperatureText,
+                        style = if (compact) MaterialTheme.typography.headlineSmall else MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                    presentation.feelsLikeText?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = presentation.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            val secondary = listOfNotNull(
+                presentation.humidityText,
+                presentation.windText,
+                presentation.precipText,
+                presentation.airQualityText,
+            )
+            if (secondary.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = secondary.joinToString(" • "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusPresentationCard(
+    presentation: ToolPresentation.Status,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(text = presentation.icon, style = MaterialTheme.typography.titleMedium)
+            Column {
+                Text(
+                    text = presentation.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                presentation.subtitle?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListPreviewPresentationCard(
+    presentation: ToolPresentation.ListPreview,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(if (compact) 12.dp else 16.dp)) {
+            Text(
+                text = presentation.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            Spacer(Modifier.height(6.dp))
+            if (presentation.items.isEmpty()) {
+                Text(
+                    text = presentation.emptyMessage ?: "No items yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            } else {
+                val visibleItems = presentation.items.take(if (compact) 3 else 5)
+                visibleItems.forEach { item ->
+                    Text(
+                        text = "• $item",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+                if (presentation.totalCount > visibleItems.size) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "+ ${presentation.totalCount - visibleItems.size} more",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComputedResultPresentationCard(
+    presentation: ToolPresentation.ComputedResult,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = presentation.primaryText,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = presentation.contextText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            presentation.breakdownText?.let {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfo.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfo.kt
@@ -1,8 +1,11 @@
 package com.kernel.ai.feature.chat.model
 
+import com.kernel.ai.core.skills.ToolPresentation
+
 data class ToolCallInfo(
     val skillName: String,
     val requestJson: String,   // the raw JSON Gemma-4 output
     val resultText: String,    // the skill result (success message or error)
     val isSuccess: Boolean,
+    val presentation: ToolPresentation? = null,
 )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfoJson.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ToolCallInfoJson.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.feature.chat.model
+
+import com.kernel.ai.core.skills.ToolPresentationJson
+import org.json.JSONObject
+
+fun ToolCallInfo.toJsonString(): String = JSONObject().apply {
+    put("skillName", skillName)
+    put("requestJson", requestJson)
+    put("resultText", resultText)
+    put("isSuccess", isSuccess)
+    presentation?.let { put("presentation", ToolPresentationJson.toJsonObject(it)) }
+}.toString()
+
+fun toolCallInfoFromJson(json: String?): ToolCallInfo? {
+    if (json.isNullOrBlank()) return null
+    return runCatching {
+        val obj = JSONObject(json)
+        ToolCallInfo(
+            skillName = obj.getString("skillName"),
+            requestJson = obj.getString("requestJson"),
+            resultText = obj.getString("resultText"),
+            isSuccess = obj.getBoolean("isSuccess"),
+            presentation = obj.optJSONObject("presentation")?.let(ToolPresentationJson::fromJsonObject),
+        )
+    }.getOrNull()
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/model/ToolCallInfoJsonTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/model/ToolCallInfoJsonTest.kt
@@ -21,10 +21,13 @@ class ToolCallInfoJsonTest {
                 feelsLikeText = null,
                 description = "Rain",
                 emoji = "🌧️",
+                highLowText = "High 13°C • Low 12°C",
                 humidityText = "82%",
                 windText = "4 m/s",
                 precipText = "5mm rain",
+                uvText = "UV max 6 (High)",
                 airQualityText = null,
+                sunText = "Sunrise 07:10 • Sunset 17:31",
             ),
         )
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/model/ToolCallInfoJsonTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/model/ToolCallInfoJsonTest.kt
@@ -1,0 +1,41 @@
+package com.kernel.ai.feature.chat.model
+
+import com.kernel.ai.core.skills.ToolPresentation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ToolCallInfoJsonTest {
+
+    @Test
+    fun `tool call info round-trips with presentation`() {
+        val original = ToolCallInfo(
+            skillName = "get_weather",
+            requestJson = """{"location":"Wellington"}""",
+            resultText = "Wellington forecast: 13°C / 12°C",
+            isSuccess = true,
+            presentation = ToolPresentation.Weather(
+                locationName = "Wellington",
+                temperatureText = "13°C / 12°C",
+                feelsLikeText = null,
+                description = "Rain",
+                emoji = "🌧️",
+                humidityText = "82%",
+                windText = "4 m/s",
+                precipText = "5mm rain",
+                airQualityText = null,
+            ),
+        )
+
+        val parsed = toolCallInfoFromJson(original.toJsonString())
+
+        assertNotNull(parsed)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `invalid tool call json returns null`() {
+        assertNull(toolCallInfoFromJson("nope"))
+    }
+}


### PR DESCRIPTION
## Summary
Add the first rich tool result UI slice for #222 so structured tool outputs can render as shared cards in chat and Quick Actions instead of relying on model paraphrase.

## Changes
- add shared `ToolPresentation` models and JSON persistence helpers
- persist rich tool result payloads through chat history, Quick Actions history, and native SDK tool-call handling
- render shared rich-result cards in chat and Quick Actions
- wire weather, list, and date-diff results to emit structured presentations
- prefer tool-authored result text for native tool calls with a presentation so visible answers stay aligned with tool truth
- add Room migration/schema update and focused tests for presentation JSON/tool-call JSON handling

## Testing
- [x] `./gradlew :core:skills:testDebugUnitTest --tests com.kernel.ai.core.skills.ToolPresentationJsonTest :feature:chat:testDebugUnitTest --tests com.kernel.ai.feature.chat.model.ToolCallInfoJsonTest :feature:chat:compileDebugKotlin :feature:chat:compileDebugAndroidTestKotlin :core:memory:compileDebugUnitTestKotlin`
- [ ] On-device validation for weather, Quick Actions history, list preview, and date diff

## Related issues
- Part of #222
- Verification target for #654
