### PR TITLE
feat(#642): show seeding banner in chat while NZ corpus seeds

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v28"  // bumped: kiwi memories migrated to kiwi_memories table
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v29"  // bumped: kiwi memories migrated to kiwi_memories table
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val SESSION_VOCAB_COUNT = 2
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -156,32 +157,36 @@ fun ChatScreen(
             onRetry = viewModel::retryDownload,
             onNavigateToSettings = onNavigateToSettings,
         )
-        is ChatUiState.Ready -> ChatContent(
-            state = state,
-            onInputChanged = viewModel::onInputChanged,
-            onSend = viewModel::sendMessage,
-            onCancel = viewModel::cancelGeneration,
-            onBack = onBack,
-            onNewConversation = {
-                viewModel.startNewConversation()
-                onNewConversation()
-            },
-            onRenameConversation = viewModel::renameConversation,
-            snackbarHostState = snackbarHostState,
-            onCopyMessage = { content ->
-                clipboardManager.setText(AnnotatedString(stripMarkdownForClipboard(content)))
-                scope.launch { snackbarHostState.showSnackbar("Message copied") }
-            },
-            onCopyAll = {
-                scope.launch {
-                    val text = withContext(Dispatchers.Default) {
-                        stripMarkdownForClipboard(viewModel.getConversationAsText())
+        is ChatUiState.Ready -> {
+            val isSeeding by viewModel.isSeeding.collectAsState()
+            ChatContent(
+                state = state,
+                isSeeding = isSeeding,
+                onInputChanged = viewModel::onInputChanged,
+                onSend = viewModel::sendMessage,
+                onCancel = viewModel::cancelGeneration,
+                onBack = onBack,
+                onNewConversation = {
+                    viewModel.startNewConversation()
+                    onNewConversation()
+                },
+                onRenameConversation = viewModel::renameConversation,
+                snackbarHostState = snackbarHostState,
+                onCopyMessage = { content ->
+                    clipboardManager.setText(AnnotatedString(stripMarkdownForClipboard(content)))
+                    scope.launch { snackbarHostState.showSnackbar("Message copied") }
+                },
+                onCopyAll = {
+                    scope.launch {
+                        val text = withContext(Dispatchers.Default) {
+                            stripMarkdownForClipboard(viewModel.getConversationAsText())
+                        }
+                        clipboardManager.setText(AnnotatedString(text))
+                        snackbarHostState.showSnackbar("Conversation copied")
                     }
-                    clipboardManager.setText(AnnotatedString(text))
-                    snackbarHostState.showSnackbar("Conversation copied")
-                }
-            },
-        )
+                },
+            )
+        }
     }
 }
 
@@ -189,6 +194,7 @@ fun ChatScreen(
 @Composable
 private fun ChatContent(
     state: ChatUiState.Ready,
+    isSeeding: Boolean,
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
@@ -343,6 +349,32 @@ private fun ChatContent(
                             modifier = Modifier.padding(top = 2.dp),
                         )
                     }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = isSeeding,
+                enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(initialAlpha = 0.7f),
+                exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(targetAlpha = 0.7f),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 1.5.dp,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Updating knowledge base…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -91,6 +91,8 @@ class ChatViewModel @Inject constructor(
     private val verboseLoggingPreferenceUseCase: com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase,
 ) : ViewModel() {
 
+    val isSeeding: StateFlow<Boolean> = nzTruthSeedingService.isSeeding
+
     /** Passed via nav arg; null means "start a new conversation". */
     private val navConversationId: String? = savedStateHandle["conversationId"]
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/NzTruthSeedingService.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/NzTruthSeedingService.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -35,67 +38,75 @@ class NzTruthSeedingService @Inject constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mutex = Mutex()
+    private val _isSeeding = MutableStateFlow(false)
+    val isSeeding: StateFlow<Boolean> = _isSeeding.asStateFlow()
 
     /**
      * Launches seeding in the background if it hasn't completed yet.
      * Safe to call multiple times — only one seeding job runs at a time.
      */
     fun seedIfNeeded() {
+        if (_isSeeding.value) return
         scope.launch { doSeedIfNeeded() }
     }
 
     private suspend fun doSeedIfNeeded() {
-        mutex.withLock {
-            if (jandalPersona.isTruthsSeeded) {
-                // Guard against stale flag: DB may have been wiped (e.g. migration) while
-                // SharedPreferences flag remained true. Re-seed if no jandal_persona kiwi memories present.
-                val seededCount = memoryRepository.getAllKiwiMemories()
+        _isSeeding.value = true
+        try {
+            mutex.withLock {
+                if (jandalPersona.isTruthsSeeded) {
+                    // Guard against stale flag: DB may have been wiped (e.g. migration) while
+                    // SharedPreferences flag remained true. Re-seed if no jandal_persona kiwi memories present.
+                    val seededCount = memoryRepository.getAllKiwiMemories()
+                        .count { it.source == "jandal_persona" }
+                    if (seededCount > 0) return
+                    Log.w(TAG, "truths_seeded flag was set but DB has 0 jandal_persona kiwi memories — re-seeding")
+                    jandalPersona.resetTruthsSeeded()
+                }
+
+                // Wipe any stale entries from a previous seed-guard version before re-seeding.
+                val staleCount = memoryRepository.getAllKiwiMemories()
                     .count { it.source == "jandal_persona" }
-                if (seededCount > 0) return
-                Log.w(TAG, "truths_seeded flag was set but DB has 0 jandal_persona kiwi memories — re-seeding")
-                jandalPersona.resetTruthsSeeded()
-            }
+                if (staleCount > 0) {
+                    Log.i(TAG, "Clearing $staleCount stale jandal_persona entries from kiwi table before re-seeding")
+                    memoryRepository.deleteAllKiwiMemoriesBySource("jandal_persona")
+                }
+                // Clean up any legacy jandal_persona entries from core_memories (pre-#500 versions).
+                val legacyCoreCount = memoryRepository.countCoreMemoriesBySource("jandal_persona")
+                if (legacyCoreCount > 0) {
+                    Log.i(TAG, "Cleaning up $legacyCoreCount legacy jandal_persona entries from core_memories")
+                    memoryRepository.deleteAllCoreMemoriesBySource("jandal_persona")
+                }
+                // Always reset the kiwi vec table to purge ghost entries from any previous seeding cycles.
+                memoryRepository.resetKiwiVecTable()
 
-            // Wipe any stale entries from a previous seed-guard version before re-seeding.
-            val staleCount = memoryRepository.getAllKiwiMemories()
-                .count { it.source == "jandal_persona" }
-            if (staleCount > 0) {
-                Log.i(TAG, "Clearing $staleCount stale jandal_persona entries from kiwi table before re-seeding")
-                memoryRepository.deleteAllKiwiMemoriesBySource("jandal_persona")
-            }
-            // Clean up any legacy jandal_persona entries from core_memories (pre-#500 versions).
-            val legacyCoreCount = memoryRepository.countCoreMemoriesBySource("jandal_persona")
-            if (legacyCoreCount > 0) {
-                Log.i(TAG, "Cleaning up $legacyCoreCount legacy jandal_persona entries from core_memories")
-                memoryRepository.deleteAllCoreMemoriesBySource("jandal_persona")
-            }
-            // Always reset the kiwi vec table to purge ghost entries from any previous seeding cycles.
-            memoryRepository.resetKiwiVecTable()
+                var seeded = 0
+                jandalPersona.nzTruths.forEach { truth ->
+                    val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }
+                        ?: return@forEach // skip if engine not ready
+                    val now = System.currentTimeMillis()
+                    val entity = KiwiMemoryEntity(
+                        id = truth.id,
+                        content = truth.vectorText,
+                        source = JandalPersona.SOURCE,
+                        category = "agent_identity",
+                        term = truth.term,
+                        definition = truth.definition,
+                        triggerContext = truth.triggerContext,
+                        vibeLevel = truth.vibeLevel,
+                        metadataJson = truth.metadataJson,
+                        createdAt = now,
+                        lastAccessedAt = now,
+                    )
+                    memoryRepository.upsertKiwiMemory(entity, vector)
+                    seeded++
+                }
 
-            var seeded = 0
-            jandalPersona.nzTruths.forEach { truth ->
-                val vector = embeddingEngine.embed(truth.vectorText).takeIf { it.isNotEmpty() }
-                    ?: return@forEach // skip if engine not ready
-                val now = System.currentTimeMillis()
-                val entity = KiwiMemoryEntity(
-                    id = truth.id,
-                    content = truth.vectorText,
-                    source = JandalPersona.SOURCE,
-                    category = "agent_identity",
-                    term = truth.term,
-                    definition = truth.definition,
-                    triggerContext = truth.triggerContext,
-                    vibeLevel = truth.vibeLevel,
-                    metadataJson = truth.metadataJson,
-                    createdAt = now,
-                    lastAccessedAt = now,
-                )
-                memoryRepository.upsertKiwiMemory(entity, vector)
-                seeded++
+                jandalPersona.markTruthsSeeded()
+                Log.i(TAG, "Seeded $seeded NZ truth memories into kiwi_memories table")
             }
-
-            jandalPersona.markTruthsSeeded()
-            Log.i(TAG, "Seeded $seeded NZ truth memories into kiwi_memories table")
+        } finally {
+            _isSeeding.value = false
         }
     }
 }


### PR DESCRIPTION
## Summary
Show a non-blocking banner in the chat screen while the NZ corpus seeds, informing users that the knowledge base is being updated.

Closes #642

## Why
When the seed guard version bumps (e.g., on app update), RAG results can be incomplete during the ~2 minute seeding window. Without any visual feedback, users may think the feature is broken or not working.

## How
- Added AnimatedVisibility banner above the message list in ChatScreen.kt
- Banner shows a subtle spinner + "Updating knowledge base…" text
- Uses surfaceVariant background with low alpha for non-intrusive styling
- Slides in/out from top with fade animation for smooth transitions
- Non-blocking: user can still type and send messages while seeding