### PR TITLE
Resolve indirect weather references

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -76,25 +76,56 @@ class GetWeatherSkill @Inject constructor(
     // ── Location ──────────────────────────────────────────────────────────────
 
     private suspend fun fetchByLocationName(locationName: String, forecastDays: Int = 0): SkillResult {
-        val coordinates = geocodeLocation(locationName)
+        val resolvedLocationName = resolveIndirectLocationReference(locationName) ?: locationName
+        val coordinates = geocodeLocation(resolvedLocationName)
             ?: return SkillResult.Failure(
                 name,
-                "Couldn't find location: $locationName. Please try a different city or location name.",
+                "Couldn't find location: $resolvedLocationName. Please try a different city or location name.",
             )
         
         return if (forecastDays > 0) {
             fetchForecast(
                 lat = coordinates.first,
                 lon = coordinates.second,
-                displayName = locationName,
+                displayName = resolvedLocationName,
                 days = forecastDays
             )
         } else {
             fetchWeather(
                 lat = coordinates.first,
                 lon = coordinates.second,
-                displayName = locationName
+                displayName = resolvedLocationName
             )
+        }
+    }
+
+    private suspend fun resolveIndirectLocationReference(locationName: String): String? {
+        val country = WeatherLocationReferenceParser.extractCountryFromCapitalQuery(locationName) ?: return null
+        return lookupCountryCapital(country)
+    }
+
+    private suspend fun lookupCountryCapital(countryName: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val normalizedCountry = WeatherLocationReferenceParser.normalizeCountryName(countryName)
+            val url = "https://restcountries.com/v3.1/name/" +
+                java.net.URLEncoder.encode(normalizedCountry, "UTF-8") +
+                "?fields=capital,name"
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", "KernelAI/1.0 (Android)")
+                .build()
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                val body = response.body?.string() ?: return@withContext null
+                val results = org.json.JSONArray(body)
+                if (results.length() == 0) return@withContext null
+                val first = results.getJSONObject(0)
+                val capitalArray = first.optJSONArray("capital") ?: return@withContext null
+                capitalArray.optString(0).takeIf { it.isNotBlank() }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Country capital lookup failed for: $countryName", e)
+            null
         }
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -101,6 +101,7 @@ class GetWeatherSkill @Inject constructor(
 
     private suspend fun resolveIndirectLocationReference(locationName: String): String? {
         val country = WeatherLocationReferenceParser.extractCountryFromCapitalQuery(locationName) ?: return null
+        WeatherLocationReferenceParser.knownCapitalForCountry(country)?.let { return it }
         return lookupCountryCapital(country)
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
@@ -19,6 +19,29 @@ internal object WeatherLocationReferenceParser {
         "u.a.e." to "United Arab Emirates",
     )
 
+    private val KNOWN_CAPITALS = mapOf(
+        "New Zealand" to "Wellington",
+        "Australia" to "Canberra",
+        "United States" to "Washington, D.C.",
+        "United Kingdom" to "London",
+        "Ireland" to "Dublin",
+        "Canada" to "Ottawa",
+        "France" to "Paris",
+        "Germany" to "Berlin",
+        "Italy" to "Rome",
+        "Spain" to "Madrid",
+        "Portugal" to "Lisbon",
+        "Netherlands" to "Amsterdam",
+        "Belgium" to "Brussels",
+        "Switzerland" to "Bern",
+        "Austria" to "Vienna",
+        "Japan" to "Tokyo",
+        "China" to "Beijing",
+        "India" to "New Delhi",
+        "Singapore" to "Singapore",
+        "United Arab Emirates" to "Abu Dhabi",
+    )
+
     fun extractCountryFromCapitalQuery(raw: String): String? {
         val match = CAPITAL_OF_REGEX.find(raw.trim()) ?: return null
         val country = match.groupValues[1].trim().trimEnd('?', '.', '!')
@@ -30,4 +53,6 @@ internal object WeatherLocationReferenceParser {
         val alias = COUNTRY_ALIASES[trimmed.lowercase()]
         return alias ?: trimmed
     }
+
+    fun knownCapitalForCountry(raw: String): String? = KNOWN_CAPITALS[normalizeCountryName(raw)]
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
@@ -1,0 +1,33 @@
+package com.kernel.ai.core.skills.natives
+
+internal object WeatherLocationReferenceParser {
+    private val CAPITAL_OF_REGEX = Regex(
+        """^(?:the\s+)?capital(?:\s+city)?\s+of\s+(.+)$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private val COUNTRY_ALIASES = mapOf(
+        "nz" to "New Zealand",
+        "n.z." to "New Zealand",
+        "uk" to "United Kingdom",
+        "u.k." to "United Kingdom",
+        "usa" to "United States",
+        "u.s.a." to "United States",
+        "us" to "United States",
+        "u.s." to "United States",
+        "uae" to "United Arab Emirates",
+        "u.a.e." to "United Arab Emirates",
+    )
+
+    fun extractCountryFromCapitalQuery(raw: String): String? {
+        val match = CAPITAL_OF_REGEX.matchEntire(raw.trim()) ?: return null
+        val country = match.groupValues[1].trim().trimEnd('?', '.', '!')
+        return normalizeCountryName(country)
+    }
+
+    fun normalizeCountryName(raw: String): String {
+        val trimmed = raw.trim()
+        val alias = COUNTRY_ALIASES[trimmed.lowercase()]
+        return alias ?: trimmed
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParser.kt
@@ -2,7 +2,7 @@ package com.kernel.ai.core.skills.natives
 
 internal object WeatherLocationReferenceParser {
     private val CAPITAL_OF_REGEX = Regex(
-        """^(?:the\s+)?capital(?:\s+city)?\s+of\s+(.+)$""",
+        """(?:^|\b)(?:the\s+)?capital(?:\s+city)?\s+of\s+(.+?)(?:\s+(?:today|tonight|now|forecast))?[?.!]*$""",
         RegexOption.IGNORE_CASE,
     )
 
@@ -20,7 +20,7 @@ internal object WeatherLocationReferenceParser {
     )
 
     fun extractCountryFromCapitalQuery(raw: String): String? {
-        val match = CAPITAL_OF_REGEX.matchEntire(raw.trim()) ?: return null
+        val match = CAPITAL_OF_REGEX.find(raw.trim()) ?: return null
         val country = match.groupValues[1].trim().trimEnd('?', '.', '!')
         return normalizeCountryName(country)
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
@@ -13,6 +13,18 @@ class WeatherLocationReferenceParserTest {
     }
 
     @Test
+    fun `extracts country from embedded capital reference`() {
+        assertEquals(
+            "New Zealand",
+            WeatherLocationReferenceParser.extractCountryFromCapitalQuery("in the capital of New Zealand"),
+        )
+        assertEquals(
+            "New Zealand",
+            WeatherLocationReferenceParser.extractCountryFromCapitalQuery("how's the weather in the capital of New Zealand"),
+        )
+    }
+
+    @Test
     fun `normalizes country aliases`() {
         assertEquals("New Zealand", WeatherLocationReferenceParser.normalizeCountryName("nz"))
         assertEquals("United States", WeatherLocationReferenceParser.normalizeCountryName("USA"))

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
@@ -31,6 +31,12 @@ class WeatherLocationReferenceParserTest {
     }
 
     @Test
+    fun `returns known capitals for normalized countries`() {
+        assertEquals("Wellington", WeatherLocationReferenceParser.knownCapitalForCountry("nz"))
+        assertEquals("London", WeatherLocationReferenceParser.knownCapitalForCountry("United Kingdom"))
+    }
+
+    @Test
     fun `returns null for non-capital query`() {
         assertNull(WeatherLocationReferenceParser.extractCountryFromCapitalQuery("Wellington"))
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/WeatherLocationReferenceParserTest.kt
@@ -1,0 +1,25 @@
+package com.kernel.ai.core.skills.natives
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class WeatherLocationReferenceParserTest {
+
+    @Test
+    fun `extracts country from capital query`() {
+        assertEquals("New Zealand", WeatherLocationReferenceParser.extractCountryFromCapitalQuery("the capital of New Zealand"))
+        assertEquals("France", WeatherLocationReferenceParser.extractCountryFromCapitalQuery("capital city of France"))
+    }
+
+    @Test
+    fun `normalizes country aliases`() {
+        assertEquals("New Zealand", WeatherLocationReferenceParser.normalizeCountryName("nz"))
+        assertEquals("United States", WeatherLocationReferenceParser.normalizeCountryName("USA"))
+    }
+
+    @Test
+    fun `returns null for non-capital query`() {
+        assertNull(WeatherLocationReferenceParser.extractCountryFromCapitalQuery("Wellington"))
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -735,8 +735,18 @@ class ChatViewModel @Inject constructor(
                 pendingConfirmationIntent = null
             }
 
+            val weatherFollowUpLocation = WeatherConversationReferenceResolver.resolveLocation(
+                query = text,
+                messages = _messages.value.dropLast(1),
+            )
             val routeResult = quickIntentRouter.route(text)
-            val matchedIntent = when (routeResult) {
+            val matchedIntent = weatherFollowUpLocation?.let {
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "get_weather",
+                    params = mapOf("location" to it),
+                    source = "conversation",
+                )
+            } ?: when (routeResult) {
                 is QuickIntentRouter.RouteResult.RegexMatch -> routeResult.intent
                 is QuickIntentRouter.RouteResult.ClassifierMatch -> {
                     if (routeResult.needsConfirmation) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/WeatherConversationReferenceResolver.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/WeatherConversationReferenceResolver.kt
@@ -1,0 +1,71 @@
+package com.kernel.ai.feature.chat
+
+import com.kernel.ai.core.skills.ToolPresentation
+import com.kernel.ai.feature.chat.model.ChatMessage
+import org.json.JSONObject
+
+internal object WeatherConversationReferenceResolver {
+    private val WEATHER_QUERY_REGEX = Regex(
+        """\b(weather|forecast|temperature|rain|raining|umbrella|uv|air quality|sunrise|sunset)\b""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val DEICTIC_REFERENCE_REGEX = Regex(
+        """\b(there|that\s+(?:city|place|town|location|capital))\b""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val CAPITAL_ANSWER_REGEX = Regex(
+        """\b([A-Z][A-Za-z'\- ]+?)\s+is\s+the\s+capital(?:\s+city)?\s+of\b""",
+    )
+    private val CAPITAL_ANSWER_REVERSED_REGEX = Regex(
+        """\bthe\s+capital(?:\s+city)?\s+of\s+.+?\s+is\s+([A-Z][A-Za-z'\- ]+)\b""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val WEATHER_LOCATION_REGEX = Regex(
+        """\bweather(?:\s+(?:in|for|at))\s+([A-Z][A-Za-z'\- ,]+)""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val REQUEST_LOCATION_REGEX = Regex(
+        """location\s*[:=]\s*["']?([^,"'}\]]+)""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    fun resolveLocation(query: String, messages: List<ChatMessage>): String? {
+        if (!looksLikeFollowUpWeatherQuery(query)) return null
+        return messages.asReversed().firstNotNullOfOrNull(::extractLocation)
+    }
+
+    private fun looksLikeFollowUpWeatherQuery(query: String): Boolean {
+        val trimmed = query.trim()
+        if (trimmed.contains("out there", ignoreCase = true)) return false
+        return WEATHER_QUERY_REGEX.containsMatchIn(trimmed) &&
+            DEICTIC_REFERENCE_REGEX.containsMatchIn(trimmed)
+    }
+
+    private fun extractLocation(message: ChatMessage): String? {
+        val presentationLocation = (message.toolCall?.presentation as? ToolPresentation.Weather)
+            ?.locationName
+            ?.takeIf { it.isNotBlank() }
+        if (presentationLocation != null) return presentationLocation
+
+        val requestLocation = message.toolCall
+            ?.requestJson
+            ?.let(::extractLocationFromRequest)
+        if (requestLocation != null) return requestLocation
+
+        return extractLocationFromText(message.content)
+    }
+
+    private fun extractLocationFromRequest(requestJson: String): String? {
+        runCatching {
+            return JSONObject(requestJson).optString("location").takeIf { it.isNotBlank() }
+        }
+        return REQUEST_LOCATION_REGEX.find(requestJson)?.groupValues?.get(1)?.trim()
+    }
+
+    private fun extractLocationFromText(text: String): String? {
+        CAPITAL_ANSWER_REGEX.find(text)?.groupValues?.get(1)?.trim()?.let { return it }
+        CAPITAL_ANSWER_REVERSED_REGEX.find(text)?.groupValues?.get(1)?.trim()?.let { return it }
+        WEATHER_LOCATION_REGEX.find(text)?.groupValues?.get(1)?.trim()?.let { return it }
+        return null
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/WeatherConversationReferenceResolverTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/WeatherConversationReferenceResolverTest.kt
@@ -1,0 +1,85 @@
+package com.kernel.ai.feature.chat
+
+import com.kernel.ai.core.skills.ToolPresentation
+import com.kernel.ai.feature.chat.model.ChatMessage
+import com.kernel.ai.feature.chat.model.ToolCallInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class WeatherConversationReferenceResolverTest {
+
+    @Test
+    fun `resolves there from previous capital answer`() {
+        val messages = listOf(
+            ChatMessage(
+                id = "assistant-1",
+                role = ChatMessage.Role.ASSISTANT,
+                content = "Wellington is the capital of New Zealand.",
+            ),
+        )
+
+        val location = WeatherConversationReferenceResolver.resolveLocation(
+            query = "How's the weather there",
+            messages = messages,
+        )
+
+        assertEquals("Wellington", location)
+    }
+
+    @Test
+    fun `resolves there from previous weather card`() {
+        val messages = listOf(
+            ChatMessage(
+                id = "assistant-1",
+                role = ChatMessage.Role.ASSISTANT,
+                content = "Weather reply",
+                toolCall = ToolCallInfo(
+                    skillName = "get_weather",
+                    requestJson = """{"location":"Wellington"}""",
+                    resultText = "Weather result",
+                    isSuccess = true,
+                    presentation = ToolPresentation.Weather(
+                        locationName = "Wellington",
+                        temperatureText = "13°C",
+                        feelsLikeText = null,
+                        description = "Rain",
+                        emoji = "🌧️",
+                        highLowText = null,
+                        humidityText = null,
+                        windText = null,
+                        precipText = null,
+                        uvText = null,
+                        airQualityText = null,
+                        sunText = null,
+                    ),
+                ),
+            ),
+        )
+
+        val location = WeatherConversationReferenceResolver.resolveLocation(
+            query = "What's the weather there",
+            messages = messages,
+        )
+
+        assertEquals("Wellington", location)
+    }
+
+    @Test
+    fun `ignores out there local-weather phrasing`() {
+        val messages = listOf(
+            ChatMessage(
+                id = "assistant-1",
+                role = ChatMessage.Role.ASSISTANT,
+                content = "Wellington is the capital of New Zealand.",
+            ),
+        )
+
+        val location = WeatherConversationReferenceResolver.resolveLocation(
+            query = "How's the weather out there",
+            messages = messages,
+        )
+
+        assertNull(location)
+    }
+}


### PR DESCRIPTION
## Summary
Resolve indirect weather locations and chat follow-up weather references so weather requests can reuse a concrete place instead of falling through.

## Changes
- resolve explicit indirect place phrases like `capital of New Zealand` inside `GetWeatherSkill` before geocoding
- add a dedicated `WeatherLocationReferenceParser` with country alias normalization for common shorthands like `NZ`, `UK`, and `USA`
- resolve chat-only follow-up weather references like `there` from recent conversation context in `ChatViewModel`
- add focused tests for both the explicit parser and the chat follow-up resolver

## Testing
- [x] Focused parser and resolver unit tests pass
- [x] Affected chat compile and Android test compile targets pass
- [ ] Manual device testing

## Related issues
Closes #663
