### PR TITLE
Polish list previews and fallback links

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1334,7 +1334,7 @@ class NativeIntentHandler @Inject constructor(
         emptyMessage: String? = null,
     ): ToolPresentation.ListPreview = ToolPresentation.ListPreview(
         title = listName,
-        items = items.map { it.item },
+        items = items.sortedByDescending { it.addedAt }.map { it.item },
         totalCount = items.size,
         emptyMessage = emptyMessage,
     )

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ToolCallInfo
@@ -74,6 +75,43 @@ class ChatScreenToolChipTest {
         composeTestRule.onNodeWithTag("tool_chip").assertIsDisplayed()
         composeTestRule.onNodeWithText("Wellington").assertIsDisplayed()
         composeTestRule.onNodeWithText("🌡 High 13°C • Low 12°C").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolChipShowsSurfacedLink_whenExpandedToolResultContainsUrl() {
+        val message = ChatMessage(
+            id = "link",
+            role = ChatMessage.Role.ASSISTANT,
+            content = "Here's a summary.",
+            toolCall = ToolCallInfo(
+                skillName = "search_wikipedia",
+                requestJson = """{"query":"mother's day","url":"https://en.wikipedia.org/wiki/Mother%27s_Day"}""",
+                resultText = "Summary only. Source: https://en.wikipedia.org/wiki/Mother%27s_Day",
+                isSuccess = true,
+            ),
+        )
+        setContent(message)
+
+        composeTestRule.onNodeWithTag("tool_chip").performClick()
+        composeTestRule.onNodeWithText("https://en.wikipedia.org/wiki/Mother%27s_Day").assertIsDisplayed()
+    }
+
+    @Test
+    fun fallbackBubbleSurfacesToolLink_whenVisibleMessageOmitsUrl() {
+        val message = ChatMessage(
+            id = "bubble-link",
+            role = ChatMessage.Role.ASSISTANT,
+            content = "Here's a summary.",
+            toolCall = ToolCallInfo(
+                skillName = "search_wikipedia",
+                requestJson = """{"query":"mother's day"}""",
+                resultText = "Summary only. Source: https://en.wikipedia.org/wiki/Mother%27s_Day",
+                isSuccess = true,
+            ),
+        )
+        setContent(message)
+
+        composeTestRule.onNodeWithText("https://en.wikipedia.org/wiki/Mother%27s_Day").assertIsDisplayed()
     }
 
     @Test

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/MessageBubbleTestWrapper.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/MessageBubbleTestWrapper.kt
@@ -49,6 +49,15 @@ fun MessageBubbleTestWrapper(
     showThinkingProcess: Boolean = true,
 ) {
     val isUser = message.role == ChatMessage.Role.USER
+    val surfacedFallbackLinks = if (!isUser && message.toolCall?.presentation == null && message.toolCall != null) {
+        collectAdditionalUrls(
+            visibleText = message.content,
+            message.toolCall.resultText,
+            message.toolCall.requestJson,
+        )
+    } else {
+        emptyList()
+    }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -108,10 +117,13 @@ fun MessageBubbleTestWrapper(
             color = MaterialTheme.colorScheme.surfaceVariant,
             shape = RoundedCornerShape(12.dp),
         ) {
-            Text(
-                text = message.content,
-                modifier = Modifier.padding(12.dp),
-            )
+            Column(modifier = Modifier.padding(12.dp)) {
+                Text(text = message.content)
+                if (surfacedFallbackLinks.isNotEmpty()) {
+                    Spacer(Modifier.height(6.dp))
+                    ToolLinkList(urls = surfacedFallbackLinks)
+                }
+            }
         }
     }
 }
@@ -119,6 +131,13 @@ fun MessageBubbleTestWrapper(
 @Composable
 private fun ToolCallChipTestWrapper(toolCall: ToolCallInfo, modifier: Modifier = Modifier) {
     var expanded by remember { mutableStateOf(false) }
+    val toolLinks = remember(toolCall.requestJson, toolCall.resultText) {
+        collectAdditionalUrls(
+            visibleText = "",
+            toolCall.resultText,
+            toolCall.requestJson,
+        )
+    }
     val clipboardManager = LocalClipboardManager.current
     Surface(
         modifier = modifier.fillMaxWidth().testTag("tool_chip"),
@@ -159,6 +178,10 @@ private fun ToolCallChipTestWrapper(toolCall: ToolCallInfo, modifier: Modifier =
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (toolLinks.isNotEmpty()) {
+                    Spacer(Modifier.height(6.dp))
+                    ToolLinkList(urls = toolLinks)
+                }
                 Spacer(Modifier.height(4.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -528,6 +528,7 @@ private fun ActionHistoryCard(
                     compact = true,
                 )
             } else {
+                val resultLinks = remember(action.resultText) { extractUrls(action.resultText) }
                 Text(
                     text = action.resultText,
                     style = MaterialTheme.typography.bodySmall,
@@ -536,6 +537,10 @@ private fun ActionHistoryCard(
                     overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
                     onTextLayout = { result -> if (result.hasVisualOverflow) isOverflowing = true },
                 )
+                if (resultLinks.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    ToolLinkList(urls = resultLinks)
+                }
                 if (isOverflowing || expanded) {
                     TextButton(
                         onClick = { expanded = !expanded },

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -401,6 +401,15 @@ private fun MessageBubble(
         MaterialTheme.colorScheme.surfaceVariant
     }
     val richPresentation = message.toolCall?.presentation
+    val surfacedFallbackLinks = if (!isUser && richPresentation == null && message.toolCall != null) {
+        collectAdditionalUrls(
+            visibleText = message.content,
+            message.toolCall.resultText,
+            message.toolCall.requestJson,
+        )
+    } else {
+        emptyList()
+    }
     val suppressAssistantBubble = !isUser && richPresentation != null && message.toolCall?.isSuccess == true
     var showMenu by remember { mutableStateOf(false) }
 
@@ -511,6 +520,10 @@ private fun MessageBubble(
                                 style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
                                 onLongPress = { showMenu = true },
                             )
+                            if (surfacedFallbackLinks.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(6.dp))
+                                ToolLinkList(urls = surfacedFallbackLinks)
+                            }
                             if (message.isStreaming) {
                                 val generatingMessage = remember { LoadingMessages.randomGenerating() }
                                 Row(
@@ -870,6 +883,13 @@ private fun formatEta(remainingMs: Long): String {
 @Composable
 private fun ToolCallChip(toolCall: ToolCallInfo, modifier: Modifier = Modifier) {
     var expanded by remember { mutableStateOf(false) }
+    val toolLinks = remember(toolCall.requestJson, toolCall.resultText) {
+        collectAdditionalUrls(
+            visibleText = "",
+            toolCall.resultText,
+            toolCall.requestJson,
+        )
+    }
     val clipboardManager = LocalClipboardManager.current
     Surface(
         modifier = modifier.fillMaxWidth().testTag("tool_chip"),
@@ -910,6 +930,10 @@ private fun ToolCallChip(toolCall: ToolCallInfo, modifier: Modifier = Modifier) 
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (toolLinks.isNotEmpty()) {
+                    Spacer(Modifier.height(6.dp))
+                    ToolLinkList(urls = toolLinks)
+                }
                 Spacer(Modifier.height(4.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolLinkSupport.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolLinkSupport.kt
@@ -1,0 +1,47 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private val RAW_URL_REGEX = Regex("""https?://[^\s<>"()]+[^\s<>"().,!?;:]""")
+
+internal fun extractUrls(text: String?): List<String> =
+    text
+        ?.let { source -> RAW_URL_REGEX.findAll(source).map { it.value }.toList() }
+        ?.distinct()
+        ?: emptyList()
+
+internal fun collectAdditionalUrls(visibleText: String, vararg candidateTexts: String?): List<String> {
+    val visibleUrls = extractUrls(visibleText).toSet()
+    return candidateTexts
+        .flatMap { extractUrls(it) }
+        .distinct()
+        .filterNot { it in visibleUrls }
+}
+
+@Composable
+internal fun ToolLinkList(
+    urls: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    if (urls.isEmpty()) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        urls.forEach { url ->
+            MarkdownContent(
+                text = url,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.primary,
+                ),
+            )
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -12,7 +12,12 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kernel.ai.core.skills.ToolPresentation
@@ -189,6 +194,15 @@ private fun ListPreviewPresentationCard(
     modifier: Modifier = Modifier,
     compact: Boolean = false,
 ) {
+    var expanded by rememberSaveable(presentation.title, presentation.totalCount, compact) { mutableStateOf(false) }
+    val collapsedCount = if (compact) 3 else 5
+    val hasHiddenItems = presentation.totalCount > collapsedCount
+    val visibleItems = if (hasHiddenItems && !expanded) {
+        presentation.items.take(collapsedCount)
+    } else {
+        presentation.items
+    }
+
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
@@ -208,7 +222,6 @@ private fun ListPreviewPresentationCard(
                     color = MaterialTheme.colorScheme.onTertiaryContainer,
                 )
             } else {
-                val visibleItems = presentation.items.take(if (compact) 3 else 5)
                 visibleItems.forEach { item ->
                     Text(
                         text = "• $item",
@@ -216,13 +229,22 @@ private fun ListPreviewPresentationCard(
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                     )
                 }
-                if (presentation.totalCount > visibleItems.size) {
+                if (hasHiddenItems) {
                     Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = "+ ${presentation.totalCount - visibleItems.size} more",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer,
-                    )
+                    TextButton(
+                        onClick = { expanded = !expanded },
+                        modifier = Modifier.padding(start = 4.dp),
+                    ) {
+                        Text(
+                            text = if (expanded) {
+                                "Show less"
+                            } else {
+                                "+ ${presentation.totalCount - collapsedCount} more"
+                            },
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onTertiaryContainer,
+                        )
+                    }
                 }
             }
         }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ToolLinkSupportTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ToolLinkSupportTest.kt
@@ -1,0 +1,43 @@
+package com.kernel.ai.feature.chat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ToolLinkSupportTest {
+
+    @Test
+    fun `extractUrls returns distinct raw urls`() {
+        assertEquals(
+            listOf("https://example.com/foo", "https://wikipedia.org/wiki/Mother's_Day"),
+            extractUrls(
+                """
+                See https://example.com/foo and https://wikipedia.org/wiki/Mother's_Day
+                plus https://example.com/foo again.
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `collectAdditionalUrls excludes urls already visible in assistant text`() {
+        assertEquals(
+            listOf("https://wikipedia.org/wiki/Mother's_Day"),
+            collectAdditionalUrls(
+                visibleText = "I found a summary for you.",
+                """Result: Summary only. Source: https://wikipedia.org/wiki/Mother's_Day""",
+                """{"url":"https://wikipedia.org/wiki/Mother's_Day"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `collectAdditionalUrls removes urls already present in visible text`() {
+        assertEquals(
+            emptyList<String>(),
+            collectAdditionalUrls(
+                visibleText = "Open https://example.com/article for the full article.",
+                """Result: https://example.com/article""",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Polish the post-rich-result follow-ups for list previews and fallback links.

## Changes
- reverse list preview payload ordering so compact cards show the newest list additions first
- make list preview cards expand and collapse from the `+N more` affordance
- surface actionable URLs in fallback chat bubbles, tool chips, and quick action history when rich cards are unavailable
- add focused tests for fallback link extraction and UI coverage for surfaced tool links

## Testing
- [x] Focused unit tests pass
- [x] Affected core and feature compile targets pass
- [ ] Manual device testing

## Related issues
Closes #664
Closes #665
