### PR TITLE
Refresh product documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A high-performance, **local-first** intelligent agent for Android. All inference
 
 The app operates on a **Brain–Memory–Action** triad using a three-tier Resident Agent Architecture:
 
-* **The Brain:** **Gemma-4 E-4B/E-2B** runs resident on GPU via LiteRT — always loaded, always ready. A lightweight **`QuickIntentRouter`** (pure Kotlin regex, zero memory) handles instant device actions (<5ms). Complex queries go straight to Gemma-4 for full reasoning with native tool calling.
+* **The Brain:** **Gemma-4 E-4B/E-2B** runs resident on GPU via LiteRT. A lightweight **`QuickIntentRouter`** (regex + MiniLM fallback) handles instant device actions and slot-filling fast paths. Complex queries go straight to Gemma-4 for full reasoning with native tool calling.
 * **The Memory:** A local **RAG (Retrieval-Augmented Generation)** system using **sqlite-vec** and **EmbeddingGemma-300M**. The assistant remembers personal facts, preferences, and conversation history across sessions with zero data leaving the device. Episodic distillation consolidates each conversation into long-term memories.
-* **The Action:** A modular skill framework. **Tier 2** native Kotlin actions execute instantly (torch, timer, DND, bluetooth). **Tier 3** complex skills (weather, calendar, email) are handled by the resident Gemma-4 model via LiteRT-LM's native `@Tool` annotations with SDK constrained decoding. Community-extensible **WebAssembly** skills run sandboxed via **Chicory** for safe extensibility.
+* **The Action:** A modular skill framework. **Tier 2** native Kotlin actions execute instantly (torch, timer, DND, bluetooth, lists, date arithmetic). **Tier 3** complex skills (weather, calendar, memory recall, Wikipedia) are handled by the resident Gemma-4 model via LiteRT-LM's native `@Tool` annotations with SDK constrained decoding and rich inline result cards. Community-extensible **WebAssembly** skills run sandboxed via **Chicory** for safe extensibility.
 
 ## Tech Stack
 
@@ -45,7 +45,11 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - ⚡ **Quick Actions tab** — instant device commands (torch, timer, DND, bluetooth) via zero-overhead Kotlin pattern matcher
 - 💭 **Episodic memory distillation** — Gemma-4 summarises each conversation into long-term memories
 - 🔧 **Native skills** — alarms, timers, SMS, email, torch, calendar events, weather (GPS + city), navigation, media playback, Wikipedia
+- 📆 **Native date arithmetic** — deterministic `get_date_diff` handling for "days until/since" queries
 - 🔍 **search_memory** — semantic search across core + episodic memories on demand
+- 🌦️ **Weather follow-up resolution** — colloquial weather phrasing plus indirect references like "there" and "the capital of New Zealand"
+- 🧩 **Quick intent slot filling** — supported fast-path intents can pause for missing required parameters instead of failing silently
+- 🪪 **Rich tool presentations** — weather cards, list cards, confirmation chips, expandable previews, and surfaced fallback links
 - 🔎 **Tool call debugging** — expand any tool call chip to see request/result, tap to copy
 - 🧭 **Nav drawer** — Lists and Alarms accessible from Chat, Actions, and all main screens via hamburger menu
 - 📋 **Lists** — create and manage named lists via chat ("add milk to shopping list") or the Lists UI; full CRUD with active/completed sections
@@ -58,11 +62,9 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 📝 **Bulk list add** — add multiple items to a list in one request ("save all ingredients to shopping list")
 
 ### Coming Soon
-- 🗣️ **Voice + text input** — tap-to-talk with auto-stop *(Phase 3)*
-- 💬 **Multi-turn dialog** — slot filling, confirmation, and context-switching across intents *(Phase 3G, #522)*
-- 🌦️ **Smarter intent routing** — colloquial phrases ("is it gonna rain?") routed natively *(Phase 3C, #608)*
-- 📅 **Native date arithmetic** — `date_diff` tool for reliable date calculations *(Phase 3C, #619)*
-- 🗒️ **Lists — stretch goals** — cards, swipe-to-complete, rich content, attachments, sorting *(Phase 3, #472)*
+- 🗣️ **Voice input** — tap-to-talk with auto-stop *(Phase 3F)*
+- 💬 **Expanded multi-turn dialog** — broader confirmation, digression, and slot-filling coverage across more intents *(Phase 3G, #522 and follow-ups)*
+- 🗒️ **Lists — management upgrades** — rename, pin, sort, edit items, favorites, and due dates *(#662)*
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen *(Phase 3, #479)*
 - 📱 **Homescreen widget** — quick actions and voice from the launcher *(Phase 3F, #617)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
@@ -107,8 +109,12 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 ```bash
 git clone https://github.com/NickMonrad/kernel-ai-assistant.git
 cd kernel-ai-assistant
-./scripts/download-models.sh       # Download AI models from HuggingFace (~3GB)
+./gradlew assembleDebug
 ```
+
+Model files are managed manually for local development. Place the required `.litertlm`,
+`.tflite`, and `sentencepiece.model` files under `models/` and push them to the device
+using the instructions in [`models/README.md`](models/README.md).
 
 Open in Android Studio, connect your device via USB, and run.
 
@@ -132,6 +138,21 @@ Useful commands in this repo:
 `./scripts/setup-android-cli.sh` installs the official Google CLI into `~/.local/bin` on supported platforms, runs `android init`, and wires the `android-cli` skill into detected agents such as OpenCode and Copilot.
 
 If the CLI is unavailable on your platform, keep using the normal Gradle + `adb` workflow.
+
+## Testing
+
+- Automated test overview: [`docs/automated-testing.md`](docs/automated-testing.md)
+- Device setup and logcat guide: [`docs/adb-testing.md`](docs/adb-testing.md)
+- Detailed backlog/specification: [`docs/testing/automated-test-specification.md`](docs/testing/automated-test-specification.md)
+
+Common commands:
+
+```bash
+./gradlew testDebugUnitTest
+./gradlew connectedDebugAndroidTest
+python3 scripts/adb_skill_test.py --phases weather,lists
+python3 scripts/adb_skill_test.py --profile
+```
 
 ## Key Technical Pillars
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kernel AI Assistant — Roadmap
 
-> **Last updated:** 2026-04-17 (Sprint 4 complete: PRs #520 #528 #530 merged — media controls, podcasts, timer management, side panel, alarm multiselect, bulk list add, profile crash fix, mailto URI fix, opencode agents)
+> **Last updated:** 2026-04-21 (docs refresh for #513; recent shipped work includes PRs #661, #667, and #668 — rich tool result UI, indirect weather resolution, and list/fallback-link polish)
 >
 > This is the living roadmap for Kernel AI. It tracks what's been built, what's next,
 > and what's planned. If you have ideas, [open an issue](https://github.com/NickMonrad/kernel-ai-assistant/issues/new)
@@ -21,7 +21,7 @@
 | **Chat model** | Gemma-4 E-4B / E-2B |
 | **Embeddings** | EmbeddingGemma-300M (SentencePiece + TFLite) |
 | **Intent router (simple)** | `QuickIntentRouter` (Kotlin regex, zero memory, <5ms) |
-| **Intent router (complex)** | Gemma-4 native JSON tool-call format |
+| **Intent router (complex)** | Gemma-4 native SDK tool calling (`@Tool`) + constrained decoding |
 | **Vector search** | sqlite-vec 0.1.9 via bundled SQLite 3.49.2 |
 | **Wasm runtime** | Chicory (pure JVM) |
 | **Test device** | Samsung Galaxy S23 Ultra (SD 8 Gen 2, 12GB RAM) |
@@ -158,7 +158,7 @@ The architectural foundation that determines tool call accuracy and response qua
 | [#301](https://github.com/NickMonrad/kernel-ai-assistant/issues/301) | Switch vec0 tables to `distance_metric=cosine` | ⬜ Pending | 🟢 Low |
 | [#230](https://github.com/NickMonrad/kernel-ai-assistant/issues/230) | Review `safeTokenCount()` token alignment logic | ⬜ Pending | 🟢 Low |
 
-> **Key insight (from #340 analysis):** Our system prompt previously injected ~500+ tokens of tool rules on every turn. Issues #341 (lazy loading) and #372 (native SDK tool calling) resolved this: the prompt now carries ~100 tokens of skill names, and the SDK handles tool declaration generation + constrained decoding for guaranteed well-formed calls. PR #382 (#367 + #374) further reduced total prompt tokens by ~62% (1,257t → 480t) via slim identity prompt, YAML structured profile, and NZ knowledge split. topK is now user-configurable via #342 (PR #388).
+> **Key insight (from #340 analysis):** Phase 3A delivered the current prompt/tooling shape: concise system rules, `load_skill` for on-demand full instructions, LiteRT-LM native SDK tool calling with constrained decoding, and a legacy text-extraction fallback for the cases where the model emits raw JSON instead of going through the SDK path. PR #382 (#367 + #374) further reduced prompt pressure via a slim identity prompt, YAML structured profile, and NZ knowledge split. topK is now user-configurable via #342 (PR #388).
 
 ---
 
@@ -182,18 +182,14 @@ The architectural foundation that determines tool call accuracy and response qua
 
 | Sub-Issue | Title | Status | Priority |
 |-----------|-------|--------|----------|
-| [#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222) | Rich tool result UI — weather cards, confirmation chips, list cards | ⬜ Pending | 🔴 High |
-| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM is unreliable) | ⬜ Pending | 🔴 High |
-| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | ⬜ Pending | 🔴 High |
+| [#222](https://github.com/NickMonrad/kernel-ai-assistant/issues/222) | Rich tool result UI — weather cards, confirmation chips, list cards | ✅ Done | 🔴 High |
+| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM is unreliable) | ✅ Done | 🔴 High |
+| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | ✅ Done | 🔴 High |
 | [#261](https://github.com/NickMonrad/kernel-ai-assistant/issues/261) | Skill discoverability UI — settings screen with enable/disable | ⬜ Pending | 🟡 Medium |
 | [#256](https://github.com/NickMonrad/kernel-ai-assistant/issues/256) | SMS/email — pre-populate recipient from contacts | ⬜ Pending | 🟡 Medium |
 | [#258](https://github.com/NickMonrad/kernel-ai-assistant/issues/258) | Maps & location — navigate, open, nearby search | ⬜ Pending | 🟡 Medium |
 | [#327](https://github.com/NickMonrad/kernel-ai-assistant/issues/327) | Full date-specific alarms via `AlarmManager.setExact()` | ⬜ Pending | 🟢 Low |
 | [#407](https://github.com/NickMonrad/kernel-ai-assistant/issues/407) | WebSearchSkill — LLM tool calling via Brave/Tavily API | ⬜ Pending | 🟡 Medium |
-
-**Still pending (no issue yet):**
-- `add_to_shopping_list` — Room-backed local list
-- WiFi / Bluetooth / Airplane / Hotspot toggles — settings intent fallbacks
 
 **Already completed skills:**
 - ✅ set_alarm (PR #257/#262, time param fix PR #339)
@@ -207,6 +203,13 @@ The architectural foundation that determines tool call accuracy and response qua
 - ✅ get_system_info (datetime fix PR #339)
 - ✅ create_calendar_event (PR #309, date/time parsing PR #325)
 - ✅ set_do_not_disturb (shipped — `NotificationManager.setInterruptionFilter()`, PR #390)
+- ✅ rich tool result UI baseline (#222, PR #661)
+- ✅ `get_date_diff` native date arithmetic (#619)
+- ✅ colloquial + indirect weather routing (#608, #663, PR #667)
+- ✅ list preview + fallback link polish (#664, #665, PR #668)
+
+**Still pending:**
+- WiFi / Bluetooth / Airplane / Hotspot settings fallbacks
 
 ---
 
@@ -281,7 +284,7 @@ Slot filling, disambiguation, confirmation, and context-switching — transforms
 
 | Sub-Issue | Title | Status | Priority |
 |-----------|-------|--------|----------|
-| [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Add media control intents: pause, stop, skip, previous | ⬜ Pending | 🟡 Medium |
+| [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Add media control intents: pause, stop, skip, previous | ✅ Done | 🟡 Medium |
 
 ---
 
@@ -484,9 +487,9 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#599](https://github.com/NickMonrad/kernel-ai-assistant/issues/599) | Unit tests for ActionsViewModel slot-fill state machine | Phase 3G | ⬜ Pending |
 | [#600](https://github.com/NickMonrad/kernel-ai-assistant/issues/600) | Slot fill spec: document expected multi-step interactions per intent | Phase 3G | ⬜ Pending |
 | [#601](https://github.com/NickMonrad/kernel-ai-assistant/issues/601) | Multi-slot: re-check for missing slots after each slot reply | Phase 3G | ⬜ Pending |
-| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | Phase 3C | ⬜ Pending |
+| [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | Phase 3C | ✅ Done — PR #667 follow-up completed the routing/references path |
 | [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | Phase 3F | ⬜ Pending |
-| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM arithmetic unreliable) | Phase 3C | ⬜ Pending |
+| [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM arithmetic unreliable) | Phase 3C | ✅ Done |
 | [#620](https://github.com/NickMonrad/kernel-ai-assistant/issues/620) | Bypass `needsConfirmation` for no-param MiniLM matches | Phase 3G | ⬜ Pending |
 | [#621](https://github.com/NickMonrad/kernel-ai-assistant/issues/621) | Multi-turn QIR: dispatch pending intent on user confirmation | Phase 3G | ⬜ Pending |
 | [#624](https://github.com/NickMonrad/kernel-ai-assistant/issues/624) | Add more NZ truth memories (Kiwi memes + cultural touchpoints) | Phase 3B | ⬜ Pending |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-04-19 (revised post-PR #646, closes #637)
+> **Last updated:** 2026-04-21 (docs refresh for #513; aligned with PRs #661, #667, and #668)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -254,7 +254,7 @@ surfacing in `search_memory` responses (#323).
 
 #### What to verify on first launch after install
 
-1. **Seeding triggered:** Check logcat for `JandalPersona` tag — should log `"Seeding X NZ truth memories"`. Triggered by absence of `truths_seeded_v27` SharedPrefs key.
+1. **Seeding triggered:** Check logcat for `JandalPersona` tag — should log `"Seeding X NZ truth memories"`. Triggered by absence of the current `truths_seeded_v29` SharedPrefs key.
 2. **138 entries seeded:** Settings → Core Memories should show ~138 entries with category `agent_identity`.
 3. **Correct vector text embedded:** Each entry's `content` is the `vector_text` from the JSON (dense keywords), not the definition.
 
@@ -385,13 +385,14 @@ ExperimentalFlags.enableConversationConstrainedDecoding = false
 > calls `loadSkill()` to retrieve full parameter docs, examples, and enforcement rules
 > on demand. This keeps the baseline prompt compact and improves tool call accuracy.
 
-**KernelAIToolSet gateway (5 tools):**
+**KernelAIToolSet gateway tools:**
 
 | Gateway | Tool method | Dispatcher | Use for |
 |---------|------------|-----------|---------|
 | Meta | `loadSkill(skillName)` | `LoadSkillSkill` | Load full instructions before using any tool |
-| Native | `runIntent(intentName, parameters)` | `NativeIntentHandler.kt` | Android OS intents (alarm, timer, email, SMS, torch, calendar) |
-| WebView JS | `runJs(skillName, query, forecastDays)` | `JsSkillRunner.kt` | JS skills in `assets/skills/` (weather, Wikipedia) |
+| Native | `runIntent(intentName, parameters)` | `NativeIntentHandler.kt` | Android OS intents and deterministic local actions (alarm, timer, DND, media, navigation, date diff, lists, etc.) |
+| WebView JS | `runJs(skillName, query, forecastDays)` | `JsSkillRunner.kt` | JS skills in `assets/skills/` (currently Wikipedia and a legacy city-weather path) |
+| Native | `getWeather(location, forecastDays)` | `GetWeatherUnifiedSkill.kt` | Unified weather entry point (GPS + explicit city + indirect-location resolution) |
 | Memory | `saveMemory(content)` | `SaveMemorySkill` | Store facts to long-term memory |
 | Memory | `searchMemory(query)` | `SearchMemorySkill` | Semantic search across memories |
 
@@ -424,9 +425,19 @@ fallback exists for edge cases where the model emits raw JSON outside the SDK pa
 | `toggle_flashlight_off` | Torch off | `CameraManager.setTorchMode(false)` | ✅ |
 | `send_email` | Email composer | `ACTION_SEND` + `message/rfc822` | ✅ |
 | `send_sms` | SMS composer | `ACTION_SENDTO` + `smsto:` | ✅ |
+| `make_call` | Dialer / call handoff | `ACTION_DIAL` | ✅ |
 | `set_alarm` | Set alarm | `AlarmClock.ACTION_SET_ALARM` | ✅ |
 | `set_timer` | Countdown timer | `AlarmClock.ACTION_SET_TIMER` | ✅ |
 | `create_calendar_event` | Add calendar event | `ACTION_INSERT` + `CONTENT_URI` | ✅ |
+| `toggle_dnd_on/off` | Do Not Disturb | `NotificationManager.setInterruptionFilter()` | ✅ |
+| `toggle_wifi` / `toggle_bluetooth` | Connectivity toggles | Settings / adapter bridge | ✅ |
+| `toggle_airplane_mode` / `toggle_hotspot` | Settings handoff | Settings intent / guarded flow | ✅ |
+| `set_volume` | Media volume | `AudioManager` | ✅ |
+| `play_media` family | Media playback / app-specific launches | Media session + explicit app intents | ✅ |
+| `navigate_to` / `find_nearby` / `open_app` | Navigation / nearby / launcher intents | Explicit Android intents | ✅ |
+| `get_battery` / `get_time` / `get_date` | Deterministic device info | Android APIs / `LocalDateTime` | ✅ |
+| `get_date_diff` | Deterministic date arithmetic | `LocalDate` calculation | ✅ |
+| `add_to_list` / `bulk_add_to_list` / `create_list` / `get_list_items` / `remove_from_list` | Room-backed list management | `NativeIntentHandler` + Room DAOs | ✅ |
 
 > **Package visibility (Android 11+):** `ACTION_SET_ALARM` and `ACTION_SET_TIMER` are declared
 > in a `<queries>` block in `AndroidManifest.xml` so `PackageManager.resolveActivity()` returns
@@ -461,8 +472,8 @@ fallback exists for edge cases where the model emits raw JSON outside the SDK pa
 
 | `skill_name` | Location | Status |
 |-------------|----------|--------|
-| `get-weather-city` | `assets/skills/get-weather-city/index.html` | ✅ (current + forecast) |
-| `query_wikipedia` | `assets/skills/query-wikipedia/index.html` | ✅ |
+| `get-weather-city` | `assets/skills/get-weather-city/index.html` | ✅ (legacy city-weather path; unified `getWeather()` is preferred) |
+| `query-wikipedia` | `assets/skills/query-wikipedia/index.html` | ✅ |
 
 > **`get-weather-city` forecast support (PR #269):** Pass `forecast_days` (integer 1–7) for a
 > day-by-day forecast instead of current conditions. When `forecast_days > 0` or
@@ -479,13 +490,14 @@ async function ai_edge_gallery_get_result(args) { /* ... */ return resultString;
 `JsSkillRunner` injects args as a JSON string, evaluates the function in a hidden WebView,
 and awaits the result with a 15s timeout.
 
-**Non-gateway skills (direct Skill implementations):**
+**Backing `Skill` implementations:**
 
 | Skill name | Description | Status |
 |------------|-------------|--------|
 | `get_system_info` | Device/model/backend/battery stats | ✅ |
 | `save_memory` | Persist a note/fact to `core_memories_vec` | ✅ (explicit trigger only — see memory rule below) |
-| `search_memory` | Semantic search across `message_embeddings` — cross-conversation by default, or scoped to one conversation | ✅ |
+| `search_memory` | Semantic search across core memories, episodic memories, and `message_embeddings` | ✅ |
+| `get_weather_gps` / `get_weather` | Weather retrieval with GPS, explicit locations, and indirect-location resolution | ✅ |
 
 > **save_memory trigger:** Works reliably when the user explicitly says "remember", "save",
 > "don't forget", "can you remember", or "make a note of". Does not activate proactively from
@@ -493,15 +505,13 @@ and awaits the result with a 15s timeout.
 > enforced as a hard `[Tool Use]` rule in `ChatViewModel.buildSystemPrompt()`, not via the
 > skill description.
 
-> **search_memory:** A direct `Skill` implementation (not a gateway skill) registered in
-> `SkillsModule.kt` via Hilt `@Binds @IntoSet`. Accepts a required `query` string,
-> optional `conversationId` (scopes search to one conversation for summary-to-detail
-> drill-down), and optional `topK` (default 5). Wraps `RagRepository.searchMessages()`,
-> which embeds the query and performs L2 distance search on `message_embeddings` at
-> `MAX_DISTANCE=1.10` (≈ cos_sim ≥ 0.40). Results are formatted as a numbered list with date, role, and
-> `conversation:ID` prefix. Uses a batch `MessageDao.getByIds()` call — single DB query
-> regardless of result count (avoids N+1). The system prompt injects its description as a
-> tool example so Gemma-4 knows when to invoke it.
+> **search_memory:** Exposed to the model via `KernelAIToolSet.searchMemory()` and backed by
+> `SearchMemorySkill`. It merges explicit memories (`MemoryRepository.searchMemories()`) with
+> raw message-history retrieval (`RagRepository.searchMessages()`). Message-history lookups use
+> sqlite-vec L2 distance on `message_embeddings` at `MAX_DISTANCE=0.90`, while core/episodic
+> memory retrieval uses the wider calibrated thresholds in `MemoryRepositoryImpl`
+> (`CORE_MAX_DISTANCE=1.25`, `EPISODIC_MAX_DISTANCE=1.10`). Results are returned as a numbered
+> direct reply with dates and conversation prefixes, bypassing LLM rephrasing to preserve detail.
 
 **System prompt `[Tool Use]` rules (enforced in `ChatViewModel.buildSystemPrompt()`):**
 - Memory rule: user says "remember", "save", "don't forget", "can you remember", or "make a note of" → MUST call `save_memory`
@@ -543,7 +553,7 @@ Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime
 - **Chat:** Streaming token display, thinking mode indicator, markdown rendering, multi-conversation
 - **Actions tab:** History list, FAB (⚡) for new commands, bottom sheet input, Room-persisted history
 - **Voice:** Tap-to-toggle with auto-stop on silence (future: "Hey Jandal" wake word)
-- **Skill results:** Inline rich cards in the conversation stream
+- **Skill results:** Inline rich cards in the conversation stream, with expandable list previews and link surfacing for fallback/plain-text results
 - **Persona:** Friendly, concise, dry-humoured Kiwi — see §7 for full identity details
 
 **Tool call debugging chip (`ToolCallChip`):** Tool calls appear as collapsible chips in the
@@ -620,7 +630,7 @@ Session vocab hint injected into prompt:
 
 `JandalPersona` seeds a structured corpus of 138 NZ cultural knowledge entries into the core memory store on first launch. These are loaded from `nz_truth_memories.json` in the `core/inference` assets.
 
-**Seed guard:** The key `truths_seeded_v27` in SharedPreferences (`jandal_persona` prefs file) prevents repeated seeding. If this key is absent (new install or key was bumped), all 138 entries are seeded. **Convention: bump the version suffix every time the corpus is reseeded** (e.g. `truths_seeded_v27` → `truths_seeded_v28`). This forces a full re-seed on all existing installs the next time the app launches, without requiring a DB wipe. The current key is `truths_seeded_v27`.
+**Seed guard:** The key `truths_seeded_v29` in SharedPreferences (`jandal_persona` prefs file) prevents repeated seeding. If this key is absent (new install or key was bumped), all 138 entries are seeded. **Convention: bump the version suffix every time the corpus changes materially** (e.g. `truths_seeded_v28` → `truths_seeded_v29`). This forces a full re-seed on existing installs the next time the app launches, without requiring a DB wipe. The current key is `truths_seeded_v29`.
 
 **JSON entry structure:**
 ```json
@@ -705,21 +715,21 @@ viewModelScope.launch {
 
 ---
 
-## 10. Development Prerequisites
+## 8. Development Prerequisites
 
 | Requirement | Detail |
 |-------------|--------|
 | Machine RAM | 32GB minimum (LiteRT builds + Android Emulator) |
 | Android Studio | Ladybug (2024.2.1) or newer |
 | Android NDK | Required for sqlite-vec JNI bridge |
-| JDK | 21 (Homebrew OpenJDK) |
+| JDK | 17 |
 | Min SDK | API 35 (Android 15) |
 | Target SDK | 36 |
 | Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16) |
 
-**Backend note:** `Build.SOC_MANUFACTURER` on S23 Ultra returns `"QTI"` (not `"Qualcomm"`),
-so `hasQualcommNpu = false` and the backend falls through to GPU (OpenCL / Adreno 740).
-The NPU path requires `"Qualcomm"` string match — this is a known device quirk.
+**Backend note:** Current dev/test guidance assumes the Samsung Galaxy S23 Ultra uses the
+Hexagon NPU path when the required delegate and models are present, with GPU fallback still
+supported for first-run delegate warm-up or unsupported devices.
 
 ---
 
@@ -753,20 +763,26 @@ When adding dependencies or features that span multiple modules (especially feat
 ./gradlew lint                       # Android lint
 ./gradlew installDebug               # Build + install on connected device
 ./gradlew :core:inference:test       # Single-module test
+python3 scripts/adb_skill_test.py    # Device routing/profile regression harness
 ```
 
 **CI:** Runs lint + unit tests + debug build. No real model inference in CI — `InferenceEngine`
 is behind an interface and mocked in all tests. Models (~3GB) are never downloaded in CI.
 
+See [`docs/automated-testing.md`](./automated-testing.md) for the current automation overview,
+[`docs/adb-testing.md`](./adb-testing.md) for device bring-up/logcat workflows, and
+[`docs/testing/automated-test-specification.md`](./testing/automated-test-specification.md)
+for the larger planned coverage matrix.
+
 ---
 
-## 11. Roadmap Summary
+## 10. Roadmap Summary
 
 | Phase | Description | Status |
 |-------|-------------|--------|
 | 1 | Core LiteRT-LM chat + GPU/NPU + GPU alignment fixes + OOM protection | ✅ Complete |
 | 2 | sqlite-vec RAG + EmbeddingGemma + episodic distillation + memory UI | ✅ Complete |
-| 3 | Resident Agent Architecture: two-gateway skills (run_intent + run_js), E4B tool calling, alarm/timer/torch/email/SMS, Wikipedia, weather GPS | 🔄 In Progress |
+| 3 | Resident Agent Architecture: QIR + native SDK tool calling, rich tool results, weather/list/date/media skills, and broader multi-turn support | 🔄 In Progress |
 | 4 | Dreaming Engine (overnight distillation) + Semantic Cache + Self-Healing Identity | ⬜ Planned |
 | 5 | Chicory Wasm Runtime + GitHub Skill Store | ⬜ Planned |
 | 6 | 8GB device optimisation (dynamic weight loading, E2B auto-select) + wake word | ⬜ Planned |

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -1,0 +1,62 @@
+# Automated Testing
+
+This document is the current automation overview for Kernel AI. It complements the deeper
+planning/spec work in [`docs/testing/automated-test-specification.md`](./testing/automated-test-specification.md)
+and the device setup guide in [`docs/adb-testing.md`](./adb-testing.md).
+
+## Current automated coverage
+
+| Layer | Tooling | What it covers | Entry point |
+|-------|---------|----------------|-------------|
+| Unit tests | Gradle + JUnit 5 + MockK | Core Kotlin logic, routing, parsing, repositories, presenters | `./gradlew testDebugUnitTest` |
+| Instrumented UI tests | Gradle + Compose/AndroidX test | Compose UI and connected-device Android tests | `./gradlew connectedDebugAndroidTest` |
+| Device regression harness | `adb` + Python | End-to-end intent routing, profile extraction, and on-device chat/action flows | `python3 scripts/adb_skill_test.py` |
+
+## ADB regression harness
+
+The main device automation entry point is [`scripts/adb_skill_test.py`](../scripts/adb_skill_test.py).
+
+Useful commands:
+
+```bash
+# Preview the run plan without touching a device
+python3 scripts/adb_skill_test.py --dry-run
+
+# Run the full skill-routing suite
+python3 scripts/adb_skill_test.py
+
+# Run only selected phases
+python3 scripts/adb_skill_test.py --phases weather,lists
+
+# Run profile-extraction checks
+python3 scripts/adb_skill_test.py --profile
+
+# Post a summary comment back to the open PR for the current branch
+python3 scripts/adb_skill_test.py --post-pr
+```
+
+Supported harness phases today:
+
+1. `alarm_timer`
+2. `weather`
+3. `media`
+4. `lists`
+5. `smart_home`
+6. `memory`
+7. `navigation`
+8. `system`
+9. `misc`
+10. `slot_fill`
+
+Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
+See [`scripts/test-reports/README.md`](../scripts/test-reports/README.md) for the report format.
+
+## What is still planned
+
+The repository already contains a much larger long-form test specification in
+[`docs/testing/automated-test-specification.md`](./testing/automated-test-specification.md),
+including proposed UI Automator coverage and future suite expansion. Not every item in that
+document is wired into a single runnable repo command yet.
+
+Treat this file as the "what exists today" index, and the detailed testing specification as
+the "where we want to grow next" design document.


### PR DESCRIPTION
## Summary
Refresh the top-level product docs so they match the current shipped behavior and testing workflow.

## Changes
- update `README.md` to reflect shipped rich tool results, weather/date/list progress, current setup, and testing entry points
- refresh `docs/ROADMAP.md` to mark recent shipped issues as done and call out PRs #661, #667, and #668
- align `docs/SPECIFICATION.md` with the current tool surface, memory/testing details, JDK 17, and `truths_seeded_v29`
- add `docs/automated-testing.md` as a current-state testing overview that links to the existing detailed test spec

## Testing
- [x] Documentation consistency review

## Related issues
Closes #513
