### PR TITLE
Restore kiwi memory prompt injection

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/rag/RagRepository.kt
@@ -41,6 +41,9 @@ class RagRepository @Inject constructor(
         private const val TAG = "RagRepository"
         private const val TABLE = "message_embeddings"
         private const val DEFAULT_TOP_K = 3
+        private const val LONG_TERM_MEMORY_TOP_K = 6
+        private const val KIWI_MEMORY_TOP_K = 6
+        private const val MAX_LONG_TERM_MEMORY_LINES = 6
         /** Minimum message content length to surface in search results.
          *  Prevents short conversational acknowledgements ("Choice bro", "The above")
          *  from polluting search_memory responses. */
@@ -135,9 +138,14 @@ class RagRepository @Inject constructor(
         val coreMemoryLines = mutableListOf<String>()
         val distilledMemoryLines = mutableListOf<String>()
         runCatching {
-            val allMemoryResults = memoryRepository.searchMemories(queryVector, coreTopK = 10, episodicTopK = 3)
+            val allMemoryResults = memoryRepository.searchMemories(
+                queryVector,
+                coreTopK = LONG_TERM_MEMORY_TOP_K,
+                episodicTopK = 3,
+                kiwiTopK = KIWI_MEMORY_TOP_K,
+            )
             val coreResults = allMemoryResults
-                .filter { it.source == "core" }
+                .filter { it.source == "core" || it.source == "kiwi" }
                 // Primary: semantic relevance. Secondary: recency (recently-accessed facts win ties).
                 .sortedWith(compareByDescending<MemorySearchResult> { it.score }.thenByDescending { it.lastAccessedAt })
             val distilledResults = allMemoryResults
@@ -150,7 +158,7 @@ class RagRepository @Inject constructor(
                     val snippet = if (r.term.isNotEmpty()) "[${r.term}] ${r.definition}" else r.content
                     "rank=$i term=${r.term} src=${r.source} score=${r.score} dist=${String.format("%.3f", 1f - r.score)} access=${r.lastAccessedAt} snippet=${snippet.take(60)}"
                 }.joinToString(" | ")
-                logVerbose("Core candidates (${coreResults.size}): $coreLog")
+                logVerbose("Long-term candidates (${coreResults.size}): $coreLog")
             }
             if (distilledResults.isNotEmpty()) {
                 val distilledLog = distilledResults.mapIndexed { i, r ->
@@ -164,7 +172,7 @@ class RagRepository @Inject constructor(
             val coreFooter = "[End of core memories]"
             val coreOverhead = (coreHeader.length + coreFooter.length + charsPerToken - 1) / charsPerToken
             var coreBudget = tokenBudgetRemaining - coreOverhead
-            for (result in coreResults) {
+            for (result in coreResults.take(MAX_LONG_TERM_MEMORY_LINES)) {
                 val line = if (result.term.isNotEmpty() && result.definition.isNotEmpty()) {
                     Log.d(TAG, "NZ truth injected: [${result.term}] vibe=${result.source} dist=~${String.format("%.3f", 1f - result.score)}")
                     "[NZ Context: ${result.term}] ${result.definition}".take(400)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/RagRepositoryTest.kt
@@ -91,10 +91,32 @@ class RagRepositoryTest {
         assertTrue(!result.contains("[Episodic Memories"), "Output must NOT contain [Episodic Memories] when table not initialised")
         assertTrue(result.startsWith("The following context has been retrieved from memory."), "Output must start with framing instruction")
 
-        // Verify the correct topK contract — core gets 10 slots, episodic is suppressed (0)
+        // Verify the retrieval caps stay tight to avoid over-injecting long-term memories.
         coVerify(exactly = 1) {
-            memoryRepository.searchMemories(any(), coreTopK = 10, episodicTopK = 3)
+            memoryRepository.searchMemories(any(), coreTopK = 6, episodicTopK = 3, kiwiTopK = 6)
         }
+    }
+
+    @Test
+    fun `getRelevantContext — includes kiwi memories in long-term memory section`() = runTest {
+        val queryVector = floatArrayOf(1.0f, 0.0f, 0.0f)
+        coEvery { embeddingEngine.embed(any()) } returns queryVector
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any(), any()) } returns listOf(
+            MemorySearchResult(
+                id = "kiwi-1",
+                content = "Flight of the Conchords are a New Zealand comedy duo",
+                source = "kiwi",
+                score = 0.96f,
+                term = "Flight of the Conchords",
+                definition = "A New Zealand musical comedy duo consisting of Bret McKenzie and Jemaine Clement.",
+            )
+        )
+
+        val result = ragRepository.getRelevantContext("who are flight of the conchords", conversationId = "test-conv")
+
+        assertTrue(result.contains("[Core Memories"), "Output must contain the long-term memory section")
+        assertTrue(result.contains("[NZ Context: Flight of the Conchords]"), "Kiwi memory should be formatted as NZ context")
+        assertTrue(result.contains("musical comedy duo"), "Kiwi definition should be injected into the prompt")
     }
 
     @Test
@@ -241,5 +263,28 @@ class RagRepositoryTest {
 
         assertTrue(result.contains("Recent fact"), "Higher lastAccessedAt must win the tiebreak and appear in output")
         assertFalse(result.contains("Stale fact"), "Lower lastAccessedAt must be truncated when budget is tight")
+    }
+
+    @Test
+    fun `getRelevantContext — caps long-term memory lines across core and kiwi`() = runTest {
+        val queryVector = floatArrayOf(1.0f, 0.0f, 0.0f)
+        coEvery { embeddingEngine.embed(any()) } returns queryVector
+        coEvery { memoryRepository.searchMemories(any(), any(), any(), any(), any()) } returns (1..8).map { index ->
+            MemorySearchResult(
+                id = "memory-$index",
+                content = "Memory $index",
+                source = if (index <= 4) "core" else "kiwi",
+                score = 1.0f - (index * 0.01f),
+                lastAccessedAt = (10_000 - index).toLong(),
+                term = if (index > 4) "Kiwi $index" else "",
+                definition = if (index > 4) "Definition $index" else "",
+            )
+        }
+
+        val result = ragRepository.getRelevantContext("query", conversationId = "c", maxTokens = 500)
+
+        assertTrue(result.contains("Memory 1"), "Top-ranked core memories should still be included")
+        assertTrue(result.contains("[NZ Context: Kiwi 5]"), "Top-ranked kiwi memories should be eligible for inclusion")
+        assertFalse(result.contains("Definition 8"), "Long-term memory injection must be capped to protect context budget")
     }
 }


### PR DESCRIPTION
## Summary

Restore cultural / kiwi memory prompt injection after the kiwi corpus moved to its own table.

## Changes

- include `source == "kiwi"` memories in `RagRepository` long-term memory prompt assembly
- keep long-term memory retrieval tighter by requesting fewer core/kiwi candidates
- cap injected long-term memory lines to avoid worsening context pressure
- add regression coverage for:
  - kiwi memories appearing in the prompt
  - combined core + kiwi injection staying capped

## Testing

- `./gradlew :core:memory:testDebugUnitTest --tests '*RagRepositoryTest'`
- `./gradlew :core:memory:compileDebugKotlin`

## Related issues

- Refs #679
