### PR TITLE
feat(#439): syntax highlighting for markdown code blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/523-half-jandal-prompt-discipline]
   push:
     branches: [main]
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
@@ -1,6 +1,5 @@
 package com.kernel.ai.feature.chat
 
-import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -62,11 +61,22 @@ fun tokenizeLine(language: String, line: String): List<Token> {
 fun tokenizeCode(language: String, code: String): TokenizedCode {
     val allTokens = mutableListOf<Token>()
     val lines = code.lines()
+    var lineStartOffset = 0
     for ((i, line) in lines.withIndex()) {
         val tokens = tokenizeLine(language, line)
-        allTokens.addAll(tokens)
+        val adjustedTokens = tokens.map { token ->
+            token.copy(
+                start = token.start + lineStartOffset,
+                end = token.end + lineStartOffset,
+            )
+        }
+        allTokens.addAll(adjustedTokens)
         if (i < lines.size - 1) {
-            allTokens.add(Token(TokenType.Newline, "\n", allTokens.lastOrNull()?.end ?: 0, allTokens.lastOrNull()?.end ?: 0))
+            val newlineStart = lineStartOffset + line.length
+            allTokens.add(Token(TokenType.Newline, "\n", newlineStart, newlineStart + 1))
+            lineStartOffset = newlineStart + 1
+        } else {
+            lineStartOffset = lineStartOffset + line.length
         }
     }
     return TokenizedCode(language.lowercase(), allTokens)
@@ -103,9 +113,6 @@ fun registerTokenizer(language: String, tokenizer: LanguageTokenizer) {
         "typescript" -> {
             tokenizers["ts"] = tokenizer
         }
-        "json" -> {
-            tokenizers["jsonc"] = tokenizer
-        }
     }
 }
 
@@ -113,6 +120,7 @@ fun registerTokenizer(language: String, tokenizer: LanguageTokenizer) {
  * Looks up a tokenizer for the given language, falling back to a generic tokenizer.
  */
 private fun getTokenizer(language: String): LanguageTokenizer {
+    ensureTokenizersInitialized()
     val key = language.lowercase().trim()
     return tokenizers[key] ?: GenericTokenizer()
 }
@@ -234,10 +242,9 @@ class KotlinTokenizer : LanguageTokenizer {
     override fun tokenize(line: String): List<Token> {
         val tokens = mutableListOf<Token>()
         var pos = 0
-        val trimmed = line.substringBefore("//").trimStart()
 
         // Check for annotation
-        val annMatch = KOTLIN_ANNOTATIONS.matchEntire(line)
+        val annMatch = KOTLIN_ANNOTATIONS.find(line)
         if (annMatch != null && annMatch.range.start == 0) {
             val annText = annMatch.value
             tokens.add(Token(TokenType.Annotation, annText, 0, annText.length))
@@ -295,8 +302,9 @@ class KotlinTokenizer : LanguageTokenizer {
                     val word = line.substring(start, pos)
                     when {
                         word in KOTLIN_KEYWORDS -> tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        word in KOTLIN_TYPES -> tokens.add(Token(TokenType.Type, word, start, pos))
                         word[0].isUpperCase() -> tokens.add(Token(TokenType.Type, word, start, pos))
-                        else -> tokens.add(Token(TokenType.Variable, word, start, pos))
+                        else -> tokens.add(Token(TokenType.Other, word, start, pos))
                     }
                 }
                 in "({[<>])}" -> {
@@ -386,22 +394,14 @@ class JavaTokenizer : LanguageTokenizer {
                     pos++
                     while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '$')) pos++
                     val word = line.substring(start, pos)
-                    when {
-                        word in JAVA_KEYWORDS -> {
-                            if (word == "new" || word == "return" || word == "if" || word == "else" ||
-                                word == "for" || word == "while" || word == "switch" || word == "case" ||
-                                word == "try" || word == "catch" || word == "throw") {
-                                tokens.add(Token(TokenType.Keyword, word, start, pos))
-                            } else if (word in setOf("public", "private", "protected", "static", "final", "abstract")) {
-                                tokens.add(Token(TokenType.Keyword, word, start, pos))
-                            } else if (word[0].isUpperCase()) {
-                                tokens.add(Token(TokenType.Type, word, start, pos))
-                            } else {
-                                tokens.add(Token(TokenType.Variable, word, start, pos))
-                            }
-                        }
-                        word[0].isUpperCase() -> tokens.add(Token(TokenType.Type, word, start, pos))
-                        else -> tokens.add(Token(TokenType.Variable, word, start, pos))
+                    if (word in JAVA_TYPES) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else if (word in JAVA_KEYWORDS) {
+                        tokens.add(Token(TokenType.Keyword, word, start, pos))
+                    } else if (word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
                     }
                 }
                 in "({[<>])}" -> {
@@ -550,7 +550,7 @@ class JSTokenizer : LanguageTokenizer {
                     val word = line.substring(start, pos)
                     if (word in JS_KEYWORDS) {
                         if (word in setOf(
-                            "function", "async", "const", "let", "var", "class", "extends",
+                            "function", "async", "await", "const", "let", "var", "class", "extends",
                             "if", "else", "for", "while", "return", "throw", "try", "catch",
                             "import", "export", "from", "new", "delete", "typeof",
                             "interface", "type", "enum", "namespace", "module",
@@ -617,7 +617,6 @@ private val PYTHON_KEYWORDS = setOf(
     "and", "or", "is", "lambda", "yield", "import", "from", "as", "with", "try",
     "except", "finally", "raise", "pass", "break", "continue", "global", "nonlocal",
     "assert", "del", "True", "False", "None", "async", "await",
-    "print", "range", "len", "type", "isinstance", "issubclass", "hasattr", "getattr", "setattr", "delattr",
     "super", "self", "cls",
 )
 
@@ -626,6 +625,7 @@ private val PYTHON_TYPES = setOf(
     "Optional", "Any", "Union", "Type", "Object", "None", "NoneType",
     "Iterable", "Iterator", "Generator", "Callable", "Sequence", "Mapping",
     "AbstractClass", "ABC",
+    "int", "float", "str", "bool", "list", "dict", "set", "tuple", "bytes",
 )
 
 class PythonTokenizer : LanguageTokenizer {
@@ -688,6 +688,8 @@ class PythonTokenizer : LanguageTokenizer {
                         } else {
                             tokens.add(Token(TokenType.Variable, word, start, pos))
                         }
+                    } else if (word in PYTHON_TYPES) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
                     } else if (word[0].isUpperCase()) {
                         tokens.add(Token(TokenType.Type, word, start, pos))
                     } else {
@@ -990,6 +992,8 @@ class GoTokenizer : LanguageTokenizer {
                         } else {
                             tokens.add(Token(TokenType.Variable, word, start, pos))
                         }
+                    } else if (word in GO_TYPES) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
                     } else if (word[0].isUpperCase()) {
                         tokens.add(Token(TokenType.Type, word, start, pos))
                     } else {
@@ -1043,13 +1047,11 @@ class GoTokenizer : LanguageTokenizer {
 
 private val RUST_KEYWORDS = setOf(
     "fn", "let", "mut", "const", "static", "ref", "move", "if", "else", "loop", "for",
-    "while", "break", "continue", "return", "match", "Some", "None", "Ok", "Err",
+    "while", "break", "continue", "return", "match",
     "true", "false", "async", "await", "dyn", "impl", "trait", "use", "mod", "pub",
     "crate", "self", "super", "where", "type", "enum", "struct", "union", "unsafe",
-    "extern", "in", "as", "self", "Self", "abstract", "become", "box", "do", "final",
-    "override", "priv", "try", "vec", "Vec", "Option", "Result", "String", "str",
-    "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128",
-    "usize", "f32", "f64", "bool", "char",
+    "extern", "in", "as", "Self", "abstract", "become", "box", "do", "final",
+    "override", "priv", "try",
 )
 
 private val RUST_TYPES = setOf(
@@ -1101,20 +1103,10 @@ class RustTokenizer : LanguageTokenizer {
                     pos++
                     while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
                     val word = line.substring(start, pos)
-                    if (word in RUST_KEYWORDS) {
-                        if (word in setOf("fn", "let", "mut", "const", "static", "if", "else", "loop",
-                                "for", "while", "break", "continue", "return", "match", "async", "await",
-                                "impl", "trait", "use", "mod", "pub", "crate", "self", "super", "where",
-                                "type", "enum", "struct", "union", "unsafe", "extern", "dyn", "ref", "move",
-                                "Ok", "Err", "Some", "None", "true", "false", "in", "as", "Vec", "Option",
-                                "Result", "String", "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16",
-                                "u32", "u64", "u128", "usize", "f32", "f64", "bool", "char")) {
-                            tokens.add(Token(TokenType.Keyword, word, start, pos))
-                        } else if (word[0].isUpperCase()) {
-                            tokens.add(Token(TokenType.Type, word, start, pos))
-                        } else {
-                            tokens.add(Token(TokenType.Variable, word, start, pos))
-                        }
+                    if (word in RUST_TYPES) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else if (word in RUST_KEYWORDS) {
+                        tokens.add(Token(TokenType.Keyword, word, start, pos))
                     } else if (word[0].isUpperCase()) {
                         tokens.add(Token(TokenType.Type, word, start, pos))
                     } else {
@@ -1160,7 +1152,14 @@ class RustTokenizer : LanguageTokenizer {
                 '#' -> {
                     val start = pos
                     // Attribute or macro
-                    if (pos + 1 < line.length && line[pos + 1] == '!') {
+                    if (pos + 1 < line.length && line[pos + 1] == '[') {
+                        pos++
+                        while (pos < line.length && line[pos] != ']') {
+                            pos++
+                        }
+                        if (pos < line.length) pos++
+                        tokens.add(Token(TokenType.Keyword, line.substring(start, pos), start, pos))
+                    } else if (pos + 1 < line.length && line[pos + 1] == '!') {
                         pos++
                         while (pos < line.length && line[pos].isLetter()) pos++
                         tokens.add(Token(TokenType.Keyword, line.substring(start, pos), start, pos))

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
@@ -1,0 +1,1214 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Token types produced by language tokenizers.
+ */
+sealed interface TokenType {
+    data object Keyword : TokenType
+    data object Type : TokenType
+    data object StringLit : TokenType
+    data object NumberLit : TokenType
+    data object Comment : TokenType
+    data object Punctuation : TokenType
+    data object Operator : TokenType
+    data object Annotation : TokenType
+    data object Function : TokenType
+    data object Variable : TokenType
+    data object Whitespace : TokenType
+    data object Newline : TokenType
+    data object Other : TokenType
+}
+
+/**
+ * A single lexical token with its position, content, and type.
+ */
+data class Token(
+    val type: TokenType,
+    val content: String,
+    val start: Int,
+    val end: Int,
+)
+
+/**
+ * Result of tokenizing code in a specific language.
+ */
+data class TokenizedCode(
+    val language: String,
+    val tokens: List<Token>,
+)
+
+/**
+ * Tokenizes a single line of code.
+ * Returns a list of tokens representing the lexical structure of the line.
+ */
+fun tokenizeLine(language: String, line: String): List<Token> {
+    val tokenizer = getTokenizer(language)
+    return try {
+        tokenizer.tokenize(line)
+    } catch (e: Exception) {
+        // Fallback: return the entire line as "Other"
+        listOf(Token(TokenType.Other, line, 0, line.length))
+    }
+}
+
+/**
+ * Tokenizes all lines of code and returns the full tokenized result.
+ */
+fun tokenizeCode(language: String, code: String): TokenizedCode {
+    val allTokens = mutableListOf<Token>()
+    val lines = code.lines()
+    for ((i, line) in lines.withIndex()) {
+        val tokens = tokenizeLine(language, line)
+        allTokens.addAll(tokens)
+        if (i < lines.size - 1) {
+            allTokens.add(Token(TokenType.Newline, "\n", allTokens.lastOrNull()?.end ?: 0, allTokens.lastOrNull()?.end ?: 0))
+        }
+    }
+    return TokenizedCode(language.lowercase(), allTokens)
+}
+
+/**
+ * Async version that runs on Dispatchers.Default.
+ */
+suspend fun tokenizeCodeAsync(
+    language: String,
+    code: String,
+    context: CoroutineContext = Dispatchers.Default,
+): TokenizedCode = withContext(context) {
+    tokenizeCode(language, code)
+}
+
+// ── Tokenizer registry ─────────────────────────────────────────────────────────
+
+private val tokenizers = mutableMapOf<String, LanguageTokenizer>()
+
+/**
+ * Registers a language tokenizer. Called by language-specific modules.
+ */
+fun registerTokenizer(language: String, tokenizer: LanguageTokenizer) {
+    tokenizers[language.lowercase()] = tokenizer
+    // Also register common aliases
+    when (language.lowercase()) {
+        "kotlin" -> {
+            tokenizers["kt"] = tokenizer
+        }
+        "javascript" -> {
+            tokenizers["js"] = tokenizer
+        }
+        "typescript" -> {
+            tokenizers["ts"] = tokenizer
+        }
+        "json" -> {
+            tokenizers["jsonc"] = tokenizer
+        }
+    }
+}
+
+/**
+ * Looks up a tokenizer for the given language, falling back to a generic tokenizer.
+ */
+private fun getTokenizer(language: String): LanguageTokenizer {
+    val key = language.lowercase().trim()
+    return tokenizers[key] ?: GenericTokenizer()
+}
+
+// ── Language tokenizer interface ───────────────────────────────────────────────
+
+/**
+ * Interface for language-specific tokenizers.
+ */
+interface LanguageTokenizer {
+    fun tokenize(line: String): List<Token>
+}
+
+// ── Generic fallback tokenizer ─────────────────────────────────────────────────
+
+/**
+ * A basic tokenizer that recognizes strings and comments for any C-style language.
+ * Used as a fallback when no language-specific tokenizer is registered.
+ */
+open class GenericTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '"', '\'' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != quote) {
+                        if (line[pos] == '\\') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        // Line comment
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else if (pos + 1 < line.length && line[pos + 1] == '*') {
+                        // Block comment start — treat rest as comment
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                        pos++
+                    }
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
+                    val word = line.substring(start, pos)
+                    tokens.add(Token(TokenType.Other, word, start, pos))
+                }
+                in "(){}[]<>" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=<>!&|^~:" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=<>!&|^~.") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty()) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Other, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return tokens
+    }
+}
+
+// ── Kotlin tokenizer ───────────────────────────────────────────────────────────
+
+private val KOTLIN_KEYWORDS = setOf(
+    "package", "import", "class", "interface", "fun", "val", "var", "type", "typealias",
+    "if", "else", "when", "for", "while", "do", "return", "break", "continue",
+    "throw", "try", "catch", "finally", "in", "is", "as", "this", "super",
+    "object", "data", "sealed", "enum", "companion", "init", "constructor",
+    "public", "private", "protected", "internal", "const", "suspend", "inline",
+    "noinline", "crossinline", "tailrec", "operator", "infix", "reified",
+    "by", "lazy", "lateinit", "where", "field", "it", "set", "get",
+    "true", "false", "null", "is", "notnull", "to", "run", "apply", "with",
+    "let", "also", "apply", "use", "measure", "repeat",
+)
+
+private val KOTLIN_TYPES = setOf(
+    "String", "Int", "Long", "Float", "Double", "Boolean", "Char", "Byte",
+    "Short", "Unit", "Any", "Nothing", "List", "Map", "Set", "Pair", "Triple",
+    "Array", "MutableList", "MutableMap", "MutableSet", "Sequence", "IntRange",
+    "CharSequence", "Object", "Class", "Type", "KClass",
+    "CoroutineScope", "Job", "Deferred", "Flow", "MutableState",
+    "Modifier", "Composable", "State",
+)
+
+private val KOTLIN_ANNOTATIONS = Regex("^@[a-zA-Z][a-zA-Z0-9_]*")
+
+class KotlinTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+        val trimmed = line.substringBefore("//").trimStart()
+
+        // Check for annotation
+        val annMatch = KOTLIN_ANNOTATIONS.matchEntire(line)
+        if (annMatch != null && annMatch.range.start == 0) {
+            val annText = annMatch.value
+            tokens.add(Token(TokenType.Annotation, annText, 0, annText.length))
+            pos = annText.length
+            // Add whitespace after annotation
+            while (pos < line.length && line[pos] == ' ') {
+                tokens.add(Token(TokenType.Whitespace, " ", pos, pos + 1))
+                pos++
+            }
+        }
+
+        // Process the rest of the line
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"', '\'' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != quote) {
+                        if (line[pos] == '\\' && quote == '"') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                '`' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != '`') {
+                        if (line[pos] == '\\' && pos + 1 < line.length) pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.' || line[pos] == 'L' || line[pos] == 'f' || line[pos] == 'F')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_', '$' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '$')) pos++
+                    val word = line.substring(start, pos)
+                    when {
+                        word in KOTLIN_KEYWORDS -> tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        word[0].isUpperCase() -> tokens.add(Token(TokenType.Type, word, start, pos))
+                        else -> tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=<>!&|^~:" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=<>!&|^~.:") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Java tokenizer ─────────────────────────────────────────────────────────────
+
+private val JAVA_KEYWORDS = setOf(
+    "package", "import", "class", "interface", "enum", "extends", "implements",
+    "public", "private", "protected", "static", "final", "abstract", "sealed",
+    "void", "return", "if", "else", "switch", "case", "default", "for", "while",
+    "do", "break", "continue", "try", "catch", "finally", "throw", "throws",
+    "new", "this", "super", "instanceof", "synchronized", "volatile", "transient",
+    "native", "strictfp", "assert", "const", "goto",
+    "true", "false", "null",
+)
+
+private val JAVA_TYPES = setOf(
+    "String", "Integer", "Long", "Float", "Double", "Boolean", "Character", "Byte",
+    "Short", "Object", "Class", "Void", "System", "Math", "Arrays", "List",
+    "Map", "Set", "ArrayList", "HashMap", "HashSet", "Vector", "Collection",
+    "Optional", "Stream", "OptionalInt", "OptionalLong", "OptionalDouble",
+)
+
+class JavaTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else if (pos + 1 < line.length && line[pos + 1] == '*') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"', '\'' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != quote) {
+                        if (line[pos] == '\\') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '$')) pos++
+                    val word = line.substring(start, pos)
+                    when {
+                        word in JAVA_KEYWORDS -> {
+                            if (word == "new" || word == "return" || word == "if" || word == "else" ||
+                                word == "for" || word == "while" || word == "switch" || word == "case" ||
+                                word == "try" || word == "catch" || word == "throw") {
+                                tokens.add(Token(TokenType.Keyword, word, start, pos))
+                            } else if (word in setOf("public", "private", "protected", "static", "final", "abstract")) {
+                                tokens.add(Token(TokenType.Keyword, word, start, pos))
+                            } else if (word[0].isUpperCase()) {
+                                tokens.add(Token(TokenType.Type, word, start, pos))
+                            } else {
+                                tokens.add(Token(TokenType.Variable, word, start, pos))
+                            }
+                        }
+                        word[0].isUpperCase() -> tokens.add(Token(TokenType.Type, word, start, pos))
+                        else -> tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=<>!&|^~:" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=<>!&|^~.") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                '@' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '.')) pos++
+                    if (pos > start + 1) {
+                        tokens.add(Token(TokenType.Annotation, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Other, "@", start, pos))
+                    }
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── JavaScript / TypeScript tokenizer ──────────────────────────────────────────
+
+private val JS_KEYWORDS = setOf(
+    "const", "let", "var", "function", "async", "await", "yield",
+    "if", "else", "switch", "case", "default", "for", "while", "do", "break",
+    "continue", "return", "throw", "try", "catch", "finally", "new", "delete",
+    "typeof", "instanceof", "in", "of", "import", "export", "from", "as",
+    "class", "extends", "super", "this", "static", "get", "set",
+    "true", "false", "null", "undefined", "NaN", "Infinity",
+    "void", "delete", "typeof",
+    "interface", "type", "namespace", "module", "enum", "implements",
+    "private", "protected", "public", "readonly", "abstract", "declare",
+    "is", "keyof", "never", "unknown", "any", "string", "number", "boolean",
+    "true", "false",
+)
+
+private val JS_TYPES = setOf(
+    "String", "Number", "Boolean", "Object", "Array", "Map", "Set", "WeakMap",
+    "WeakSet", "Promise", "RegExp", "Date", "Error", "TypeError", "SyntaxError",
+    "JSON", "Math", "console", "window", "document", "globalThis",
+    "ArrayBuffer", "TypedArray", "DataView", "Int8Array", "Int16Array", "Int32Array",
+    "Uint8Array", "Uint16Array", "Uint32Array", "Uint8ClampedArray", "Float32Array",
+    "Float64Array", "BigInt64Array", "BigUint64Array",
+    "Proxy", "Reflect", "Iterator", "Iterable", "Generator",
+)
+
+class JSTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length) {
+                        val next = line[pos + 1]
+                        if (next == '/') {
+                            tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                            pos = line.length
+                        } else if (next == '*') {
+                            tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                            pos = line.length
+                        } else if (pos > 0) {
+                            // Could be regex — check context
+                            val prevToken = tokens.lastOrNull()
+                            if (prevToken != null && prevToken.type in listOf(TokenType.Operator, TokenType.Keyword, TokenType.Punctuation, TokenType.Variable, TokenType.Other)) {
+                                // Likely division
+                                tokens.add(Token(TokenType.Operator, "/", pos, pos + 1))
+                                pos++
+                            } else {
+                                // Likely regex
+                                val start = pos
+                                pos++
+                                while (pos < line.length && line[pos] != '/' && line[pos] != '\\') {
+                                    if (line[pos] == '[') {
+                                        pos++
+                                        while (pos < line.length && line[pos] != ']') {
+                                            if (line[pos] == '\\') pos++
+                                            pos++
+                                        }
+                                    }
+                                    pos++
+                                }
+                                if (pos < line.length) pos++
+                                while (pos < line.length && line[pos] in "gimsuy") pos++
+                                tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                            }
+                        } else {
+                            tokens.add(Token(TokenType.Operator, "/", pos, pos + 1))
+                            pos++
+                        }
+                    } else {
+                        tokens.add(Token(TokenType.Other, "/", pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"', '\'' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != quote) {
+                        if (line[pos] == '\\') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                '`' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != '`') {
+                        if (line[pos] == '\\' && pos + 1 < line.length) pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_', '$' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '$')) pos++
+                    val word = line.substring(start, pos)
+                    if (word in JS_KEYWORDS) {
+                        if (word in setOf(
+                            "function", "async", "const", "let", "var", "class", "extends",
+                            "if", "else", "for", "while", "return", "throw", "try", "catch",
+                            "import", "export", "from", "new", "delete", "typeof",
+                            "interface", "type", "enum", "namespace", "module",
+                        )) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("true", "false", "null", "undefined", "NaN", "Infinity", "void")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("this", "super")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("as", "from", "in", "of", "get", "set", "static")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("is", "keyof", "never", "unknown", "any")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else {
+                            tokens.add(Token(TokenType.Variable, word, start, pos))
+                        }
+                    } else if (word[0].isUpperCase() && word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=<>!&|^~:" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=<>!&|^~.") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                '@' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '.')) pos++
+                    if (pos > start + 1) {
+                        tokens.add(Token(TokenType.Annotation, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Other, "@", start, pos))
+                    }
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Python tokenizer ───────────────────────────────────────────────────────────
+
+private val PYTHON_KEYWORDS = setOf(
+    "def", "class", "return", "if", "elif", "else", "while", "for", "in", "not",
+    "and", "or", "is", "lambda", "yield", "import", "from", "as", "with", "try",
+    "except", "finally", "raise", "pass", "break", "continue", "global", "nonlocal",
+    "assert", "del", "True", "False", "None", "async", "await",
+    "print", "range", "len", "type", "isinstance", "issubclass", "hasattr", "getattr", "setattr", "delattr",
+    "super", "self", "cls",
+)
+
+private val PYTHON_TYPES = setOf(
+    "String", "Integer", "Float", "Boolean", "List", "Dict", "Set", "Tuple",
+    "Optional", "Any", "Union", "Type", "Object", "None", "NoneType",
+    "Iterable", "Iterator", "Generator", "Callable", "Sequence", "Mapping",
+    "AbstractClass", "ABC",
+)
+
+class PythonTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '#' -> {
+                    tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                    pos = line.length
+                }
+                '"', '\'' -> {
+                    val quote = c
+                    // Check for triple-quoted string
+                    if (pos + 2 < line.length && line[pos + 1] == quote && line[pos + 2] == quote) {
+                        val start = pos
+                        pos += 3
+                        while (pos < line.length) {
+                            if (pos + 2 < line.length && line[pos] == quote && line[pos + 1] == quote && line[pos + 2] == quote) {
+                                pos += 3
+                                break
+                            }
+                            pos++
+                        }
+                        tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                    } else {
+                        val start = pos
+                        pos++
+                        while (pos < line.length && line[pos] != quote) {
+                            if (line[pos] == '\\') pos++
+                            pos++
+                        }
+                        if (pos < line.length) pos++
+                        tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                    }
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
+                    val word = line.substring(start, pos)
+                    if (word in PYTHON_KEYWORDS) {
+                        if (word in setOf("def", "class", "if", "elif", "else", "for", "while",
+                                "return", "import", "from", "as", "with", "try", "except", "finally",
+                                "raise", "pass", "break", "continue", "global", "nonlocal", "assert",
+                                "del", "lambda", "yield", "async", "await", "and", "or", "not", "in", "is")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("True", "False", "None")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word in setOf("self", "cls")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else {
+                            tokens.add(Token(TokenType.Variable, word, start, pos))
+                        }
+                    } else if (word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                '(' -> {
+                    tokens.add(Token(TokenType.Punctuation, "(", pos, pos + 1))
+                    pos++
+                }
+                ')' -> {
+                    tokens.add(Token(TokenType.Punctuation, ")", pos, pos + 1))
+                    pos++
+                }
+                '[' -> {
+                    tokens.add(Token(TokenType.Punctuation, "[", pos, pos + 1))
+                    pos++
+                }
+                ']' -> {
+                    tokens.add(Token(TokenType.Punctuation, "]", pos, pos + 1))
+                    pos++
+                }
+                '{' -> {
+                    tokens.add(Token(TokenType.Punctuation, "{", pos, pos + 1))
+                    pos++
+                }
+                '}' -> {
+                    tokens.add(Token(TokenType.Punctuation, "}", pos, pos + 1))
+                    pos++
+                }
+                '=' -> {
+                    tokens.add(Token(TokenType.Operator, "=", pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%@^~" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%@^~") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                '>' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "=>!") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                '<' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "<=!>") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                '\t' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == '\t') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                ',' -> {
+                    tokens.add(Token(TokenType.Punctuation, ",", pos, pos + 1))
+                    pos++
+                }
+                ';' -> {
+                    tokens.add(Token(TokenType.Punctuation, ";", pos, pos + 1))
+                    pos++
+                }
+                '.' -> {
+                    tokens.add(Token(TokenType.Punctuation, ".", pos, pos + 1))
+                    pos++
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Swift tokenizer ────────────────────────────────────────────────────────────
+
+private val SWIFT_KEYWORDS = setOf(
+    "let", "var", "func", "if", "else", "switch", "case", "for", "while", "guard",
+    "return", "break", "continue", "throw", "try", "catch", "do", "defer",
+    "import", "struct", "class", "enum", "protocol", "extension", "init", "deinit",
+    "typealias", "subscript", "return", "self", "Self", "super", "nil",
+    "public", "private", "internal", "fileprivate", "open",
+    "static", "final", "override", "mutating", "nonmutating", "required",
+    "convenience", "lazy", "weak", "unowned", "inout", "async", "await", "throws", "rethrows",
+    "where", "in", "as", "is", "typealias", "some", "any",
+    "true", "false",
+)
+
+private val SWIFT_TYPES = setOf(
+    "String", "Int", "Int8", "Int16", "Int32", "Int64", "UInt", "UInt8", "UInt16",
+    "UInt32", "UInt64", "Float", "Double", "Bool", "Character", "Substring",
+    "Array", "Dictionary", "Set", "Optional", "Never", "Void",
+    "Any", "AnyObject", "AnyClass", "Type", "KeyPath", "Range", "ClosedRange",
+    "Collection", "Sequence", "Iterator", "MutableCollection", "BidirectionalCollection",
+    "RandomAccessCollection", "Comparable", "Equatable", "Hashable", "Codable",
+    "Encodable", "Decodable", "Error", "ThrowableError",
+    "View", "Body", "State", "Binding", "ObservedObject", "EnvironmentObject",
+    "Published", "Environment", "ScenePhase",
+)
+
+class SwiftTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else if (pos + 1 < line.length && line[pos + 1] == '*') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"', '\'' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != quote) {
+                        if (line[pos] == '\\') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
+                    val word = line.substring(start, pos)
+                    if (word in SWIFT_KEYWORDS) {
+                        if (word in setOf("let", "var", "func", "if", "else", "switch", "case", "for",
+                                "while", "guard", "return", "break", "continue", "throw", "try", "catch",
+                                "do", "defer", "import", "struct", "class", "enum", "protocol",
+                                "extension", "init", "deinit", "typealias", "subscript", "self", "Self",
+                                "nil", "true", "false", "async", "await", "throws", "rethrows",
+                                "where", "in", "as", "is", "some", "any", "override", "mutating",
+                                "nonmutating", "required", "convenience", "lazy", "weak", "unowned",
+                                "inout", "static", "final", "public", "private", "internal", "fileprivate")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else {
+                            tokens.add(Token(TokenType.Variable, word, start, pos))
+                        }
+                    } else if (word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=<>!&|^~" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=<>!&|^~") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ':' -> {
+                    tokens.add(Token(TokenType.Punctuation, ":", pos, pos + 1))
+                    pos++
+                }
+                ',' -> {
+                    tokens.add(Token(TokenType.Punctuation, ",", pos, pos + 1))
+                    pos++
+                }
+                '.' -> {
+                    tokens.add(Token(TokenType.Punctuation, ".", pos, pos + 1))
+                    pos++
+                }
+                '@' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '.')) pos++
+                    if (pos > start + 1) {
+                        tokens.add(Token(TokenType.Annotation, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Other, "@", start, pos))
+                    }
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Go tokenizer ───────────────────────────────────────────────────────────────
+
+private val GO_KEYWORDS = setOf(
+    "var", "const", "type", "func", "go", "defer", "return", "if", "else", "switch",
+    "case", "default", "for", "range", "break", "continue", "fallthrough", "goto",
+    "nil", "true", "false", "iota",
+    "package", "import", "chan", "select", "interface", "struct", "map", "slice",
+    "go", "select", "make", "new", "append", "copy", "delete", "len", "cap",
+    "close", "complex", "real", "imag", "panic", "recover", "print", "println",
+)
+
+private val GO_TYPES = setOf(
+    "string", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16",
+    "uint32", "uint64", "float32", "float64", "bool", "byte", "rune", "error",
+    "complex64", "complex128", "unsafe", "uintptr",
+    "String", "Int", "Int8", "Int16", "Int32", "Int64", "Uint", "Uint8", "Uint16",
+    "Uint32", "Uint64", "Float32", "Float64", "Bool",
+)
+
+class GoTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else if (pos + 1 < line.length && line[pos + 1] == '*') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Operator, "/", pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"', '\'', '`' -> {
+                    val quote = c
+                    val start = pos
+                    pos++
+                    if (quote == '`') {
+                        // Raw string literal
+                        while (pos < line.length && line[pos] != '`') pos++
+                        if (pos < line.length) pos++
+                    } else {
+                        while (pos < line.length && line[pos] != quote) {
+                            if (line[pos] == '\\') pos++
+                            pos++
+                        }
+                        if (pos < line.length) pos++
+                    }
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '.' || line[pos] == 'e' || line[pos] == 'E' || line[pos] == 'x' || line[pos] == 'p' || line[pos] == 'P')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
+                    val word = line.substring(start, pos)
+                    if (word in GO_KEYWORDS) {
+                        if (word in setOf("package", "import", "func", "var", "const", "type",
+                                "return", "if", "else", "for", "range", "switch", "case", "default",
+                                "break", "continue", "fallthrough", "goto", "defer", "go", "select",
+                                "chan", "interface", "struct", "make", "new", "nil", "true", "false",
+                                "iota", "map", "append", "copy", "delete", "len", "cap", "close",
+                                "panic", "recover")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word[0].isUpperCase()) {
+                            tokens.add(Token(TokenType.Type, word, start, pos))
+                        } else {
+                            tokens.add(Token(TokenType.Variable, word, start, pos))
+                        }
+                    } else if (word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=!<>&|^~" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=!<>&|^~.") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ':' -> {
+                    tokens.add(Token(TokenType.Punctuation, ":", pos, pos + 1))
+                    pos++
+                }
+                ',' -> {
+                    tokens.add(Token(TokenType.Punctuation, ",", pos, pos + 1))
+                    pos++
+                }
+                '.' -> {
+                    tokens.add(Token(TokenType.Punctuation, ".", pos, pos + 1))
+                    pos++
+                }
+                ';' -> {
+                    tokens.add(Token(TokenType.Punctuation, ";", pos, pos + 1))
+                    pos++
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Rust tokenizer ─────────────────────────────────────────────────────────────
+
+private val RUST_KEYWORDS = setOf(
+    "fn", "let", "mut", "const", "static", "ref", "move", "if", "else", "loop", "for",
+    "while", "break", "continue", "return", "match", "Some", "None", "Ok", "Err",
+    "true", "false", "async", "await", "dyn", "impl", "trait", "use", "mod", "pub",
+    "crate", "self", "super", "where", "type", "enum", "struct", "union", "unsafe",
+    "extern", "in", "as", "self", "Self", "abstract", "become", "box", "do", "final",
+    "override", "priv", "try", "vec", "Vec", "Option", "Result", "String", "str",
+    "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128",
+    "usize", "f32", "f64", "bool", "char",
+)
+
+private val RUST_TYPES = setOf(
+    "String", "str", "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32",
+    "u64", "u128", "usize", "f32", "f64", "bool", "char", "Vec", "Option", "Result",
+    "HashMap", "HashSet", "BTreeMap", "BTreeSet", "LinkedList", "VecDeque",
+    "Arc", "Mutex", "RwLock", "RefCell", "Cell", "Weak", "Pin", "Box", "RC",
+    "Iterator", "IntoIterator", "IntoIterator", "From", "Into", "Display", "Debug",
+    "Clone", "Copy", "PartialEq", "Eq", "PartialOrd", "Ord", "Hash", "Send", "Sync",
+)
+
+class RustTokenizer : LanguageTokenizer {
+    override fun tokenize(line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var pos = 0
+
+        while (pos < line.length) {
+            when (val c = line[pos]) {
+                '/' -> {
+                    if (pos + 1 < line.length && line[pos + 1] == '/') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else if (pos + 1 < line.length && line[pos + 1] == '*') {
+                        tokens.add(Token(TokenType.Comment, line.substring(pos), pos, line.length))
+                        pos = line.length
+                    } else {
+                        tokens.add(Token(TokenType.Operator, "/", pos, pos + 1))
+                        pos++
+                    }
+                }
+                '"' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] != '"') {
+                        if (line[pos] == '\\') pos++
+                        pos++
+                    }
+                    if (pos < line.length) pos++
+                    tokens.add(Token(TokenType.StringLit, line.substring(start, pos), start, pos))
+                }
+                in '0'..'9' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isDigit() || line[pos] == '_' || line[pos] == '.')) pos++
+                    tokens.add(Token(TokenType.NumberLit, line.substring(start, pos), start, pos))
+                }
+                in 'a'..'z', in 'A'..'Z', '_' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_')) pos++
+                    val word = line.substring(start, pos)
+                    if (word in RUST_KEYWORDS) {
+                        if (word in setOf("fn", "let", "mut", "const", "static", "if", "else", "loop",
+                                "for", "while", "break", "continue", "return", "match", "async", "await",
+                                "impl", "trait", "use", "mod", "pub", "crate", "self", "super", "where",
+                                "type", "enum", "struct", "union", "unsafe", "extern", "dyn", "ref", "move",
+                                "Ok", "Err", "Some", "None", "true", "false", "in", "as", "Vec", "Option",
+                                "Result", "String", "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16",
+                                "u32", "u64", "u128", "usize", "f32", "f64", "bool", "char")) {
+                            tokens.add(Token(TokenType.Keyword, word, start, pos))
+                        } else if (word[0].isUpperCase()) {
+                            tokens.add(Token(TokenType.Type, word, start, pos))
+                        } else {
+                            tokens.add(Token(TokenType.Variable, word, start, pos))
+                        }
+                    } else if (word[0].isUpperCase()) {
+                        tokens.add(Token(TokenType.Type, word, start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Variable, word, start, pos))
+                    }
+                }
+                in "({[<>])}" -> {
+                    tokens.add(Token(TokenType.Punctuation, c.toString(), pos, pos + 1))
+                    pos++
+                }
+                in "+-*/%=!<>&|^~" -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && line[pos] in "+-*/%=!<>&|^~.") pos++
+                    tokens.add(Token(TokenType.Operator, line.substring(start, pos), start, pos))
+                }
+                ':' -> {
+                    tokens.add(Token(TokenType.Punctuation, ":", pos, pos + 1))
+                    pos++
+                }
+                ',' -> {
+                    tokens.add(Token(TokenType.Punctuation, ",", pos, pos + 1))
+                    pos++
+                }
+                '.' -> {
+                    tokens.add(Token(TokenType.Punctuation, ".", pos, pos + 1))
+                    pos++
+                }
+                ';' -> {
+                    tokens.add(Token(TokenType.Punctuation, ";", pos, pos + 1))
+                    pos++
+                }
+                '@' -> {
+                    val start = pos
+                    pos++
+                    while (pos < line.length && (line[pos].isLetterOrDigit() || line[pos] == '_' || line[pos] == '.')) pos++
+                    if (pos > start + 1) {
+                        tokens.add(Token(TokenType.Annotation, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Other, "@", start, pos))
+                    }
+                }
+                '#' -> {
+                    val start = pos
+                    // Attribute or macro
+                    if (pos + 1 < line.length && line[pos + 1] == '!') {
+                        pos++
+                        while (pos < line.length && line[pos].isLetter()) pos++
+                        tokens.add(Token(TokenType.Keyword, line.substring(start, pos), start, pos))
+                    } else {
+                        tokens.add(Token(TokenType.Punctuation, "#", pos, pos + 1))
+                        pos++
+                    }
+                }
+                '$' -> {
+                    tokens.add(Token(TokenType.Punctuation, "$", pos, pos + 1))
+                    pos++
+                }
+                ' ' -> {
+                    val start = pos
+                    while (pos < line.length && line[pos] == ' ') pos++
+                    if (tokens.isNotEmpty() && tokens.last().type != TokenType.Whitespace) {
+                        tokens.add(Token(TokenType.Whitespace, line.substring(start, pos), start, pos))
+                    }
+                }
+                else -> {
+                    tokens.add(Token(TokenType.Other, c.toString(), pos, pos + 1))
+                    pos++
+                }
+            }
+        }
+        return if (tokens.isEmpty()) listOf(Token(TokenType.Whitespace, "", 0, 0)) else tokens
+    }
+}
+
+// ── Register all tokenizers ────────────────────────────────────────────────────
+
+// Eager initialization - tokenizers are available immediately
+object Tokenizers {
+    init {
+        registerTokenizer("kotlin", KotlinTokenizer())
+        registerTokenizer("java", JavaTokenizer())
+        registerTokenizer("javascript", JSTokenizer())
+        registerTokenizer("typescript", JSTokenizer())
+        registerTokenizer("python", PythonTokenizer())
+        registerTokenizer("swift", SwiftTokenizer())
+        registerTokenizer("go", GoTokenizer())
+        registerTokenizer("rust", RustTokenizer())
+    }
+}
+
+// Ensure initialization happens before first use
+@Suppress("unused")
+fun ensureTokenizersInitialized() {
+    Tokenizers
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/CodeTokenizer.kt
@@ -215,8 +215,8 @@ private val KOTLIN_KEYWORDS = setOf(
     "public", "private", "protected", "internal", "const", "suspend", "inline",
     "noinline", "crossinline", "tailrec", "operator", "infix", "reified",
     "by", "lazy", "lateinit", "where", "field", "it", "set", "get",
-    "true", "false", "null", "is", "notnull", "to", "run", "apply", "with",
-    "let", "also", "apply", "use", "measure", "repeat",
+    "true", "false", "null", "notnull", "to", "run", "apply", "with",
+    "let", "also", "use", "measure", "repeat",
 )
 
 private val KOTLIN_TYPES = setOf(
@@ -450,11 +450,10 @@ private val JS_KEYWORDS = setOf(
     "typeof", "instanceof", "in", "of", "import", "export", "from", "as",
     "class", "extends", "super", "this", "static", "get", "set",
     "true", "false", "null", "undefined", "NaN", "Infinity",
-    "void", "delete", "typeof",
+    "void",
     "interface", "type", "namespace", "module", "enum", "implements",
     "private", "protected", "public", "readonly", "abstract", "declare",
-    "is", "keyof", "never", "unknown", "any", "string", "number", "boolean",
-    "true", "false",
+    "is", "keyof", "never", "unknown", "any",
 )
 
 private val JS_TYPES = setOf(
@@ -568,7 +567,7 @@ class JSTokenizer : LanguageTokenizer {
                         } else {
                             tokens.add(Token(TokenType.Variable, word, start, pos))
                         }
-                    } else if (word[0].isUpperCase() && word[0].isUpperCase()) {
+                    } else if (word in JS_TYPES || word[0].isUpperCase()) {
                         tokens.add(Token(TokenType.Type, word, start, pos))
                     } else {
                         tokens.add(Token(TokenType.Variable, word, start, pos))
@@ -919,7 +918,7 @@ private val GO_KEYWORDS = setOf(
     "case", "default", "for", "range", "break", "continue", "fallthrough", "goto",
     "nil", "true", "false", "iota",
     "package", "import", "chan", "select", "interface", "struct", "map", "slice",
-    "go", "select", "make", "new", "append", "copy", "delete", "len", "cap",
+    "make", "new", "append", "copy", "delete", "len", "cap",
     "close", "complex", "real", "imag", "panic", "recover", "print", "println",
 )
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -20,10 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.gestures.detectTapGestures
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
@@ -35,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -1011,14 +1008,6 @@ private fun LinkableText(
 }
 
 /**
- * Returns Material 3 semantic colors for syntax highlighting token types.
- */
-@Composable
-private fun CodeTokenColors(): CodeTokenColors {
-    return CodeTokenColors(MaterialTheme.colorScheme)
-}
-
-/**
  * Returns Material 3 semantic colors for syntax highlighting token types from a given ColorScheme.
  */
 private fun CodeTokenColors(colorScheme: androidx.compose.material3.ColorScheme): CodeTokenColors {
@@ -1026,8 +1015,6 @@ private fun CodeTokenColors(colorScheme: androidx.compose.material3.ColorScheme)
     val primary = colorScheme.primary
     val secondary = colorScheme.secondary
     val tertiary = colorScheme.tertiary
-    val surfaceVariant = colorScheme.surfaceVariant
-    val error = colorScheme.error
 
     return CodeTokenColors(
         keyword = primary,
@@ -1084,15 +1071,15 @@ private fun FencedCodeBlock(
         }
     }
 
-    // Tokenize code and build highlighted text
+    // Tokenize code and build highlighted text (async to avoid UI jank)
     val colorScheme = MaterialTheme.colorScheme
-    val highlightedCode = remember(code, language, colorScheme) {
+    val highlightedCode by produceState(AnnotatedString(""), code, language, colorScheme) {
         val trimmedCode = code.trimEnd('\n')
-        if (language.isBlank()) {
+        value = if (language.isBlank()) {
             AnnotatedString(trimmedCode)
         } else {
             try {
-                val tokenized = tokenizeCode(language, trimmedCode)
+                val tokenized = tokenizeCodeAsync(language, trimmedCode)
                 val colors = CodeTokenColors(colorScheme)
                 buildAnnotatedString {
                     for (token in tokenized.tokens) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/MarkdownRenderer.kt
@@ -20,6 +20,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.gestures.detectTapGestures
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
@@ -49,6 +53,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
@@ -1006,15 +1011,69 @@ private fun LinkableText(
 }
 
 /**
+ * Returns Material 3 semantic colors for syntax highlighting token types.
+ */
+@Composable
+private fun CodeTokenColors(): CodeTokenColors {
+    return CodeTokenColors(MaterialTheme.colorScheme)
+}
+
+/**
+ * Returns Material 3 semantic colors for syntax highlighting token types from a given ColorScheme.
+ */
+private fun CodeTokenColors(colorScheme: androidx.compose.material3.ColorScheme): CodeTokenColors {
+    val onSurfaceVariant = colorScheme.onSurfaceVariant
+    val primary = colorScheme.primary
+    val secondary = colorScheme.secondary
+    val tertiary = colorScheme.tertiary
+    val surfaceVariant = colorScheme.surfaceVariant
+    val error = colorScheme.error
+
+    return CodeTokenColors(
+        keyword = primary,
+        type = tertiary,
+        string = secondary,
+        number = tertiary,
+        comment = onSurfaceVariant.copy(alpha = 0.6f),
+        punctuation = onSurfaceVariant,
+        operator = onSurfaceVariant,
+        annotation = secondary,
+        function = primary,
+        variable = onSurfaceVariant,
+    )
+}
+
+/**
+ * Color scheme for syntax highlighting token types.
+ */
+private data class CodeTokenColors(
+    val keyword: Color,
+    val type: Color,
+    val string: Color,
+    val number: Color,
+    val comment: Color,
+    val punctuation: Color,
+    val operator: Color,
+    val annotation: Color,
+    val function: Color,
+    val variable: Color,
+)
+
+/**
  * Renders a fenced code block with:
  *  - `surfaceVariant` background and `RoundedCornerShape(8.dp)`
  *  - `FontFamily.Monospace`, `softWrap = false`, horizontal scroll
  *  - A copy-to-clipboard button anchored top-right; icon changes to ✓ for 2 seconds after copy
  *  - An optional language label above the block (e.g. "yaml", "bash") when present
  *  - Vertical padding (8.dp) to visually separate the block from surrounding text
+ *  - Syntax highlighting for supported languages using Material 3 semantic colors
  */
 @Composable
-private fun FencedCodeBlock(language: String = "", code: String, modifier: Modifier = Modifier) {
+private fun FencedCodeBlock(
+    language: String = "",
+    code: String,
+    modifier: Modifier = Modifier,
+) {
     val clipboardManager = LocalClipboardManager.current
     var copied by remember { mutableStateOf(false) }
 
@@ -1022,6 +1081,45 @@ private fun FencedCodeBlock(language: String = "", code: String, modifier: Modif
         if (copied) {
             delay(2_000)
             copied = false
+        }
+    }
+
+    // Tokenize code and build highlighted text
+    val colorScheme = MaterialTheme.colorScheme
+    val highlightedCode = remember(code, language, colorScheme) {
+        val trimmedCode = code.trimEnd('\n')
+        if (language.isBlank()) {
+            AnnotatedString(trimmedCode)
+        } else {
+            try {
+                val tokenized = tokenizeCode(language, trimmedCode)
+                val colors = CodeTokenColors(colorScheme)
+                buildAnnotatedString {
+                    for (token in tokenized.tokens) {
+                        val spanStyle = when (token.type) {
+                            TokenType.Keyword -> SpanStyle(color = colors.keyword)
+                            TokenType.Type -> SpanStyle(color = colors.type)
+                            TokenType.StringLit -> SpanStyle(color = colors.string)
+                            TokenType.NumberLit -> SpanStyle(color = colors.number)
+                            TokenType.Comment -> SpanStyle(color = colors.comment, fontStyle = FontStyle.Italic)
+                            TokenType.Punctuation -> SpanStyle(color = colors.punctuation)
+                            TokenType.Operator -> SpanStyle(color = colors.operator)
+                            TokenType.Annotation -> SpanStyle(color = colors.annotation)
+                            TokenType.Function -> SpanStyle(color = colors.function, fontWeight = FontWeight.Bold)
+                            TokenType.Variable -> SpanStyle(color = colors.variable)
+                            TokenType.Whitespace -> SpanStyle()
+                            TokenType.Newline -> SpanStyle()
+                            TokenType.Other -> SpanStyle()
+                        }
+                        withStyle(spanStyle) {
+                            append(token.content)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "MarkdownRenderer: syntax highlighting failed for language '$language': ${e.message}")
+                AnnotatedString(trimmedCode)
+            }
         }
     }
 
@@ -1047,9 +1145,9 @@ private fun FencedCodeBlock(language: String = "", code: String, modifier: Modif
                     // Right padding leaves room so long lines don't slide under the copy button
                     .padding(start = 12.dp, end = 48.dp, top = 12.dp, bottom = 12.dp),
             ) {
-                Text(
-                    text     = code.trimEnd('\n'),
-                    style    = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                BasicText(
+                    text = highlightedCode,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                     softWrap = false,
                 )
             }
@@ -1354,6 +1452,326 @@ private fun MarkdownTableAlignmentPreview() {
                 | SwiftUI         | Swift      | 12k   |
                 | Flutter         | Dart       | 160k  |
             """.trimIndent(),
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Kotlin syntax highlighting")
+@Composable
+private fun FencedCodeBlockKotlinPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```kotlin
+import androidx.compose.runtime.*
+
+@Composable
+fun Greeting(name: String, modifier: Modifier = Modifier) {
+    val animatedName = remember { mutableStateOf(name) }
+    
+    // Display a greeting
+    Text(
+        text = "Hello, ${"$"}{animatedName}!",
+        modifier = modifier
+            .padding(16.dp)
+            .background(Color.Blue),
+    )
+}
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Python syntax highlighting")
+@Composable
+private fun FencedCodeBlockPythonPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```python
+def fibonacci(n: int) -> int:
+    \'\'\'Compute the nth Fibonacci number.\'\'\'
+    if n <= 1:
+        return n
+    
+    a, b = 0, 1
+    for _ in range(2, n + 1):
+        a, b = b, a + b
+    return b
+
+# Example usage
+result = fibonacci(10)
+print(f"Fibonacci(10) = {result}")  # Output: 55
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — JavaScript syntax highlighting")
+@Composable
+private fun FencedCodeBlockJavaScriptPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```javascript
+async function fetchUsers(apiUrl) {
+    try {
+        const response = await fetch(apiUrl, {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${"$"}{response.status}`);
+        }
+        
+        const users = await response.json();
+        return users.filter(user => user.active === true);
+    } catch (error) {
+        console.error('Failed to fetch users:', error.message);
+        return [];
+    }
+}
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Rust syntax highlighting")
+@Composable
+private fun FencedCodeBlockRustPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```rust
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+struct Player {
+    name: String,
+    score: u32,
+}
+
+impl Player {
+    fn new(name: &str, score: u32) -> Self {
+        Player {
+            name: name.to_string(),
+            score,
+        }
+    }
+    
+    fn increment_score(&mut self, points: u32) {
+        self.score += points;
+    }
+}
+
+fn main() {
+    let mut players: HashMap<String, Player> = HashMap::new();
+    let mut player = Player::new("Alice", 0);
+    player.increment_score(100);
+    println!("{:?}", player);
+}
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Go syntax highlighting")
+@Composable
+private fun FencedCodeBlockGoPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```go
+package main
+
+import (
+    "fmt"
+    "sync"
+)
+
+type Worker struct {
+    ID       int
+    tasks    chan int
+    results  chan int
+    wg       *sync.WaitGroup
+}
+
+func (w *Worker) Start() {
+    go func() {
+        defer w.wg.Done()
+        for task := range w.tasks {
+            result := task * 2
+            w.results <- result
+        }
+    }()
+}
+
+func main() {
+    numWorkers := 3
+    numTasks := 10
+    
+    tasks := make(chan int, numTasks)
+    results := make(chan int, numTasks)
+    
+    var wg sync.WaitGroup
+    for i := 0; i < numWorkers; i++ {
+        worker := &Worker{
+            ID:      i,
+            tasks:   tasks,
+            results: results,
+            wg:      &wg,
+        }
+        wg.Add(1)
+        worker.Start()
+    }
+    
+    for i := 1; i <= numTasks; i++ {
+        tasks <- i
+    }
+    close(tasks)
+    wg.Wait()
+    close(results)
+    
+    for result := range results {
+        fmt.Println(result)
+    }
+}
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Swift syntax highlighting")
+@Composable
+private fun FencedCodeBlockSwiftPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```swift
+import Foundation
+
+struct UserProfile {
+    let username: String
+    let email: String
+    var isActive: Bool
+    
+    func validate() -> Bool {
+        return !username.isEmpty && email.contains("@")
+    }
+}
+
+class UserManager {
+    private var users: [String: UserProfile] = [:]
+    
+    func addUser(_ profile: UserProfile) throws {
+        guard profile.validate() else {
+            throw UserManagerError.invalidProfile
+        }
+        users[profile.username] = profile
+    }
+    
+    func findUser(named name: String) -> UserProfile? {
+        return users[name]
+    }
+}
+
+enum UserManagerError: Error {
+    case invalidProfile
+    case userNotFound
+}
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — TypeScript syntax highlighting")
+@Composable
+private fun FencedCodeBlockTypeScriptPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```typescript
+interface ApiResponse<T> {
+    data: T;
+    status: number;
+    message: string;
+}
+
+class HttpClient {
+    private baseUrl: string;
+    private headers: Record<string, string>;
+    
+    constructor(baseUrl: string, token?: string) {
+        this.baseUrl = baseUrl;
+        this.headers = {
+            'Content-Type': 'application/json',
+        };
+        if (token) {
+            this.headers['Authorization'] = `Bearer ${"$"}{token}`;
+        }
+    }
+    
+    async get<T>(endpoint: string): Promise<ApiResponse<T>> {
+        const response = await fetch(`${"$"}{this.baseUrl}${"$"}{endpoint}`, {
+            method: 'GET',
+            headers: this.headers,
+        });
+        return response.json() as ApiResponse<T>;
+    }
+}
+
+export default HttpClient;
+```""",
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Code block — Java syntax highlighting")
+@Composable
+private fun FencedCodeBlockJavaPreview() {
+    KernelAITheme {
+        MarkdownContent(
+            modifier = Modifier.padding(16.dp),
+            text = """```java
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A simple repository pattern implementation for user management.
+ */
+public class UserRepository {
+    private final List<User> users;
+    private final DataSource dataSource;
+    
+    public UserRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+        this.users = new ArrayList<>();
+    }
+    
+    public User findById(Long id) {
+        return users.stream()
+            .filter(user -> user.getId().equals(id))
+            .findFirst()
+            .orElse(null);
+    }
+    
+    public List<User> findByActive(boolean active) {
+        return users.stream()
+            .filter(User::isActive)
+            .collect(Collectors.toList());
+    }
+    
+    @Transactional
+    public User save(User user) {
+        if (user.getId() == null) {
+            users.add(user);
+        }
+        return user;
+    }
+}
+```""",
         )
     }
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/CodeTokenizerTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/CodeTokenizerTest.kt
@@ -1,0 +1,779 @@
+package com.kernel.ai.feature.chat
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+/**
+ * Unit tests for the code tokenizer infrastructure and language tokenizers in [CodeTokenizer].
+ *
+ * Covers:
+ *  - Core tokenizer infrastructure (TokenType, Token, tokenizeCode, tokenizeLine)
+ *  - Generic fallback tokenizer
+ *  - Kotlin tokenizer (keywords, types, strings, comments, annotations)
+ *  - Java tokenizer (keywords, types, strings, comments)
+ *  - JavaScript / TypeScript tokenizer (keywords, types, strings, regex, comments)
+ *  - Python tokenizer (keywords, types, strings, comments, triple-quoted strings)
+ *  - Swift tokenizer (keywords, types, strings, comments, attributes)
+ *  - Go tokenizer (keywords, types, strings, comments, raw strings)
+ *  - Rust tokenizer (keywords, types, strings, comments, attributes)
+ *  - Language alias registration (kt, js, ts, jsonc)
+ *  - Empty and edge cases
+ */
+class CodeTokenizerTest {
+
+    @Nested
+    @DisplayName("Core tokenizer infrastructure")
+    inner class CoreTokenizer {
+
+        @Test
+        fun `tokenizeLine returns tokens for each language`() {
+            val languages = listOf("kotlin", "java", "javascript", "typescript", "python", "swift", "go", "rust")
+            val line = "val x = 42"
+            for (lang in languages) {
+                val tokens = tokenizeLine(lang, line)
+                assertTrue(tokens.isNotEmpty(), "Language '$lang' should produce tokens")
+            }
+        }
+
+        @Test
+        fun `tokenizeCode returns TokenizedCode with language and tokens`() {
+            val code = "val x = 42"
+            val result = tokenizeCode("kotlin", code)
+            assertEquals("kotlin", result.language)
+            assertTrue(result.tokens.isNotEmpty(), "Should produce tokens")
+        }
+
+        @Test
+        fun `tokenizeCode preserves code content in tokens`() {
+            val code = "val x = 42"
+            val result = tokenizeCode("kotlin", code)
+            val reconstructed = result.tokens.joinToString("") { it.content }
+            assertEquals(code, reconstructed)
+        }
+
+        @Test
+        fun `tokenizeCode handles multi-line code`() {
+            val code = "val x = 1\nval y = 2"
+            val result = tokenizeCode("kotlin", code)
+            assertTrue(result.tokens.isNotEmpty())
+            val hasNewline = result.tokens.any { it.type == TokenType.Newline }
+            assertTrue(hasNewline, "Multi-line code should contain newline tokens")
+        }
+
+        @Test
+        fun `tokenizeCode with blank language returns tokens`() {
+            val code = "some code here"
+            val result = tokenizeCode("", code)
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeCode with unrecognized language uses generic tokenizer`() {
+            val code = "x = 42"
+            val result = tokenizeCode("fortran", code)
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeLine with empty line returns whitespace token`() {
+            val tokens = tokenizeLine("kotlin", "")
+            assertTrue(tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeLine with whitespace returns whitespace token`() {
+            val tokens = tokenizeLine("kotlin", "   ")
+            assertTrue(tokens.isNotEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("Generic fallback tokenizer")
+    inner class GenericTokenizerTest {
+
+        @Test
+        fun `generic tokenizer recognizes strings`() {
+            val line = "val x = \"hello\""
+            val tokens = GenericTokenizer().tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `generic tokenizer recognizes numbers`() {
+            val line = "val x = 42"
+            val tokens = GenericTokenizer().tokenize(line)
+            val numberTokens = tokens.filter { it.type == TokenType.NumberLit }
+            assertTrue(numberTokens.isNotEmpty(), "Should recognize number literals")
+        }
+
+        @Test
+        fun `generic tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = GenericTokenizer().tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `generic tokenizer recognizes punctuation`() {
+            val line = "func(a, b)"
+            val tokens = GenericTokenizer().tokenize(line)
+            val punctTokens = tokens.filter { it.type == TokenType.Punctuation }
+            assertTrue(punctTokens.isNotEmpty(), "Should recognize punctuation")
+        }
+
+        @Test
+        fun `generic tokenizer recognizes operators`() {
+            val line = "a + b * c"
+            val tokens = GenericTokenizer().tokenize(line)
+            val opTokens = tokens.filter { it.type == TokenType.Operator }
+            assertTrue(opTokens.isNotEmpty(), "Should recognize operators")
+        }
+    }
+
+    @Nested
+    @DisplayName("Kotlin tokenizer")
+    inner class KotlinTokenizerTest {
+
+        private val tokenizer = KotlinTokenizer()
+
+        @Test
+        fun `kotlin tokenizer recognizes keywords`() {
+            val line = "val x = 42"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "val" }, "Should recognize 'val' as keyword")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes type names`() {
+            val line = "val x: String = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "String" }, "Should recognize 'String' as type")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes string literals`() {
+            val line = "val x = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes raw string literals`() {
+            val line = "val x = \"\"\"hello\"\"\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize raw string literals")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes backtick strings`() {
+            val line = "val x = `hello`"
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize backtick strings")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes annotations`() {
+            val line = "@Composable fun greet() {}"
+            val tokens = tokenizer.tokenize(line)
+            val annotationTokens = tokens.filter { it.type == TokenType.Annotation }
+            assertTrue(annotationTokens.isNotEmpty(), "Should recognize annotations")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes numbers`() {
+            val line = "val x = 42"
+            val tokens = tokenizer.tokenize(line)
+            val numberTokens = tokens.filter { it.type == TokenType.NumberLit }
+            assertTrue(numberTokens.isNotEmpty(), "Should recognize number literals")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes operators`() {
+            val line = "val x = a + b"
+            val tokens = tokenizer.tokenize(line)
+            val opTokens = tokens.filter { it.type == TokenType.Operator }
+            assertTrue(opTokens.isNotEmpty(), "Should recognize operators")
+        }
+
+        @Test
+        fun `kotlin tokenizer recognizes function names`() {
+            val line = "fun greet(name: String): String { return name }"
+            val tokens = tokenizer.tokenize(line)
+            val otherTokens = tokens.filter { it.type == TokenType.Other }
+            assertTrue(otherTokens.any { it.content == "greet" }, "Should recognize 'greet' as identifier")
+        }
+
+        @Test
+        fun `kotlin tokenizer handles when expression`() {
+            val line = "when (x) { 1 -> \"one\" }"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "when" }, "Should recognize 'when' as keyword")
+        }
+
+        @Test
+        fun `kotlin tokenizer handles lambda`() {
+            val line = "list.map { it + 1 }"
+            val tokens = tokenizer.tokenize(line)
+            assertTrue(tokens.isNotEmpty(), "Should tokenize lambda expression")
+        }
+    }
+
+    @Nested
+    @DisplayName("Java tokenizer")
+    inner class JavaTokenizerTest {
+
+        private val tokenizer = JavaTokenizer()
+
+        @Test
+        fun `java tokenizer recognizes keywords`() {
+            val line = "public class Example {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "public" }, "Should recognize 'public' as keyword")
+            assertTrue(keywordTokens.any { it.content == "class" }, "Should recognize 'class' as keyword")
+        }
+
+        @Test
+        fun `java tokenizer recognizes types`() {
+            val line = "String name = \"hello\";"
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "String" }, "Should recognize 'String' as type")
+        }
+
+        @Test
+        fun `java tokenizer recognizes string literals`() {
+            val line = "String name = \"hello\";"
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `java tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `java tokenizer recognizes block comments`() {
+            val line = "/* block comment */"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize block comments")
+        }
+
+        @Test
+        fun `java tokenizer recognizes annotations`() {
+            val line = "@Override public void run() {}"
+            val tokens = tokenizer.tokenize(line)
+            val annotationTokens = tokens.filter { it.type == TokenType.Annotation }
+            assertTrue(annotationTokens.isNotEmpty(), "Should recognize annotations")
+        }
+
+        @Test
+        fun `java tokenizer recognizes new keyword`() {
+            val line = "new ArrayList<>()"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "new" }, "Should recognize 'new' as keyword")
+        }
+
+        @Test
+        fun `java tokenizer recognizes try-catch`() {
+            val line = "try { } catch (Exception e) {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "try" }, "Should recognize 'try' as keyword")
+            assertTrue(keywordTokens.any { it.content == "catch" }, "Should recognize 'catch' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("JavaScript tokenizer")
+    inner class JSTokenizerTest {
+
+        private val tokenizer = JSTokenizer()
+
+        @Test
+        fun `js tokenizer recognizes keywords`() {
+            val line = "const x = 42"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "const" }, "Should recognize 'const' as keyword")
+        }
+
+        @Test
+        fun `js tokenizer recognizes async and await`() {
+            val line = "async function fetchData() { return await fetch(url) }"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "async" }, "Should recognize 'async' as keyword")
+            assertTrue(keywordTokens.any { it.content == "await" }, "Should recognize 'await' as keyword")
+        }
+
+        @Test
+        fun `js tokenizer recognizes string literals`() {
+            val line = "const msg = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+       @Test
+        fun `js tokenizer recognizes template literals`() {
+            val line = "`hello ${"$"}{name}`"
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize template literals")
+        }
+
+        @Test
+        fun `js tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `js tokenizer recognizes arrow functions`() {
+            val line = "const fn = (a, b) => a + b"
+            val tokens = tokenizer.tokenize(line)
+            assertTrue(tokens.isNotEmpty(), "Should tokenize arrow functions")
+        }
+
+        @Test
+        fun `js tokenizer recognizes import and export`() {
+            val line = "import { foo } from 'bar'"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "import" }, "Should recognize 'import' as keyword")
+            assertTrue(keywordTokens.any { it.content == "from" }, "Should recognize 'from' as keyword")
+        }
+
+        @Test
+        fun `js tokenizer recognizes class syntax`() {
+            val line = "class Foo extends Bar {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "class" }, "Should recognize 'class' as keyword")
+            assertTrue(keywordTokens.any { it.content == "extends" }, "Should recognize 'extends' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("Python tokenizer")
+    inner class PythonTokenizerTest {
+
+        private val tokenizer = PythonTokenizer()
+
+        @Test
+        fun `python tokenizer recognizes keywords`() {
+            val line = "def hello(name: str) -> str:"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "def" }, "Should recognize 'def' as keyword")
+        }
+
+        @Test
+        fun `python tokenizer recognizes string literals`() {
+            val line = "msg = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `python tokenizer recognizes triple-quoted strings`() {
+            val line = "\"\"\"\"\"\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize triple-quoted strings")
+        }
+
+        @Test
+        fun `python tokenizer recognizes comments`() {
+            val line = "# This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `python tokenizer recognizes if and else`() {
+            val line = "if x > 0:"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "if" }, "Should recognize 'if' as keyword")
+        }
+
+        @Test
+        fun `python tokenizer recognizes for loop`() {
+            val line = "for item in items:"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "for" }, "Should recognize 'for' as keyword")
+            assertTrue(keywordTokens.any { it.content == "in" }, "Should recognize 'in' as keyword")
+        }
+
+        @Test
+        fun `python tokenizer recognizes type hints`() {
+            val line = "def foo(x: int) -> List[str]:"
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "int" }, "Should recognize 'int' as type")
+            assertTrue(typeTokens.any { it.content == "List" }, "Should recognize 'List' as type")
+        }
+
+        @Test
+        fun `python tokenizer recognizes self`() {
+            val line = "def foo(self):"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "self" }, "Should recognize 'self' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("Swift tokenizer")
+    inner class SwiftTokenizerTest {
+
+        private val tokenizer = SwiftTokenizer()
+
+        @Test
+        fun `swift tokenizer recognizes keywords`() {
+            val line = "let x = 42"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "let" }, "Should recognize 'let' as keyword")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes var keyword`() {
+            val line = "var name: String = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "var" }, "Should recognize 'var' as keyword")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes struct keyword`() {
+            val line = "struct MyStruct {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "struct" }, "Should recognize 'struct' as keyword")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes string literals`() {
+            val line = "let msg = \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes attributes`() {
+            val line = "@State var count = 0"
+            val tokens = tokenizer.tokenize(line)
+            val annotationTokens = tokens.filter { it.type == TokenType.Annotation }
+            assertTrue(annotationTokens.isNotEmpty(), "Should recognize attributes")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes types`() {
+            val line = "let x: Int = 42"
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "Int" }, "Should recognize 'Int' as type")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes guard`() {
+            val line = "guard let x = optional else { return }"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "guard" }, "Should recognize 'guard' as keyword")
+        }
+
+        @Test
+        fun `swift tokenizer recognizes async and throws`() {
+            val line = "func fetchData() async throws -> Data"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "async" }, "Should recognize 'async' as keyword")
+            assertTrue(keywordTokens.any { it.content == "throws" }, "Should recognize 'throws' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("Go tokenizer")
+    inner class GoTokenizerTest {
+
+        private val tokenizer = GoTokenizer()
+
+        @Test
+        fun `go tokenizer recognizes keywords`() {
+            val line = "package main"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "package" }, "Should recognize 'package' as keyword")
+        }
+
+        @Test
+        fun `go tokenizer recognizes func keyword`() {
+            val line = "func main() {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "func" }, "Should recognize 'func' as keyword")
+        }
+
+        @Test
+        fun `go tokenizer recognizes string literals`() {
+            val line = "msg := \"hello\""
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `go tokenizer recognizes raw string literals`() {
+            val line = "msg := `hello`"
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize raw string literals")
+        }
+
+        @Test
+        fun `go tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `go tokenizer recognizes types`() {
+            val line = "var x int"
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "int" }, "Should recognize 'int' as type")
+        }
+
+        @Test
+        fun `go tokenizer recognizes struct keyword`() {
+            val line = "type MyStruct struct {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "type" }, "Should recognize 'type' as keyword")
+            assertTrue(keywordTokens.any { it.content == "struct" }, "Should recognize 'struct' as keyword")
+        }
+
+        @Test
+        fun `go tokenizer recognizes interface keyword`() {
+            val line = "type Reader interface {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "interface" }, "Should recognize 'interface' as keyword")
+        }
+
+        @Test
+        fun `go tokenizer recognizes go keyword`() {
+            val line = "go func() {}()"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "go" }, "Should recognize 'go' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("Rust tokenizer")
+    inner class RustTokenizerTest {
+
+        private val tokenizer = RustTokenizer()
+
+        @Test
+        fun `rust tokenizer recognizes keywords`() {
+            val line = "fn main() {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "fn" }, "Should recognize 'fn' as keyword")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes let keyword`() {
+            val line = "let x = 42;"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "let" }, "Should recognize 'let' as keyword")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes string literals`() {
+            val line = "let msg = \"hello\";"
+            val tokens = tokenizer.tokenize(line)
+            val stringTokens = tokens.filter { it.type == TokenType.StringLit }
+            assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes comments`() {
+            val line = "// This is a comment"
+            val tokens = tokenizer.tokenize(line)
+            val commentTokens = tokens.filter { it.type == TokenType.Comment }
+            assertTrue(commentTokens.isNotEmpty(), "Should recognize comments")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes attributes`() {
+            val line = "#[derive(Debug)]"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content.contains("#") }, "Should recognize attributes")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes types`() {
+            val line = "let x: i32 = 42;"
+            val tokens = tokenizer.tokenize(line)
+            val typeTokens = tokens.filter { it.type == TokenType.Type }
+            assertTrue(typeTokens.any { it.content == "i32" }, "Should recognize 'i32' as type")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes impl block`() {
+            val line = "impl MyStruct {}"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "impl" }, "Should recognize 'impl' as keyword")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes match expression`() {
+            val line = "match x { Some(v) => v, None => 0 }"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "match" }, "Should recognize 'match' as keyword")
+        }
+
+        @Test
+        fun `rust tokenizer recognizes unsafe keyword`() {
+            val line = "unsafe { }"
+            val tokens = tokenizer.tokenize(line)
+            val keywordTokens = tokens.filter { it.type == TokenType.Keyword }
+            assertTrue(keywordTokens.any { it.content == "unsafe" }, "Should recognize 'unsafe' as keyword")
+        }
+    }
+
+    @Nested
+    @DisplayName("Language alias registration")
+    inner class LanguageAliasTest {
+
+        @Test
+        fun `tokenizeLine works with kt alias for kotlin`() {
+            val tokens = tokenizeLine("kt", "val x = 42")
+            assertTrue(tokens.isNotEmpty(), "Should work with 'kt' alias")
+        }
+
+        @Test
+        fun `tokenizeLine works with js alias for javascript`() {
+            val tokens = tokenizeLine("js", "const x = 42")
+            assertTrue(tokens.isNotEmpty(), "Should work with 'js' alias")
+        }
+
+        @Test
+        fun `tokenizeLine works with ts alias for typescript`() {
+            val tokens = tokenizeLine("ts", "const x: number = 42")
+            assertTrue(tokens.isNotEmpty(), "Should work with 'ts' alias")
+        }
+
+        @Test
+        fun `tokenizeLine works with jsonc alias for json`() {
+            val tokens = tokenizeLine("jsonc", "{\"key\": \"value\"}")
+            assertTrue(tokens.isNotEmpty(), "Should work with 'jsonc' alias")
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    inner class EdgeCases {
+
+        @Test
+        fun `tokenizeCode with empty code returns tokens`() {
+            val result = tokenizeCode("kotlin", "")
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeCode with only whitespace returns tokens`() {
+            val result = tokenizeCode("kotlin", "   ")
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeCode with very long line returns tokens`() {
+            val longLine = "val x = \"${"a".repeat(1000)}\""
+            val result = tokenizeCode("kotlin", longLine)
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeCode with special characters returns tokens`() {
+            val code = "val x = '@#$%^&*()'"
+            val result = tokenizeCode("kotlin", code)
+            assertTrue(result.tokens.isNotEmpty())
+        }
+
+        @Test
+        fun `tokenizeLine does not throw on any input`() {
+            val inputs = listOf(
+                "",
+                " ",
+                "   ",
+                "\t",
+                "\n",
+                "```",
+                "'''",
+                "\"\"\"",
+                "''''",
+                "@@@",
+                "<<<>>>!!!",
+            )
+            for (input in inputs) {
+                assertDoesNotThrow {
+                    tokenizeLine("kotlin", input)
+                }
+            }
+        }
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/CodeTokenizerTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/CodeTokenizerTest.kt
@@ -39,6 +39,33 @@ class CodeTokenizerTest {
         }
 
         @Test
+        fun `tokenizeLine uses language-specific tokenizers not generic`() {
+            val ktTokens = tokenizeLine("kotlin", "val x = 42")
+            assertTrue(ktTokens.any { it.type == TokenType.Keyword && it.content == "val" }, "Kotlin should recognize 'val' as keyword")
+
+            val pyTokens = tokenizeLine("python", "def foo():")
+            assertTrue(pyTokens.any { it.type == TokenType.Keyword && it.content == "def" }, "Python should recognize 'def' as keyword")
+
+            val goTokens = tokenizeLine("go", "func main() {}")
+            assertTrue(goTokens.any { it.type == TokenType.Keyword && it.content == "func" }, "Go should recognize 'func' as keyword")
+
+            val rsTokens = tokenizeLine("rust", "fn main() {}")
+            assertTrue(rsTokens.any { it.type == TokenType.Keyword && it.content == "fn" }, "Rust should recognize 'fn' as keyword")
+        }
+
+        @Test
+        fun `tokenizeLine recognizes language aliases`() {
+            val ktTokens = tokenizeLine("kt", "val x = 42")
+            assertTrue(ktTokens.any { it.type == TokenType.Keyword && it.content == "val" }, "Alias 'kt' should work like 'kotlin'")
+
+            val jsTokens = tokenizeLine("js", "const x = 1")
+            assertTrue(jsTokens.any { it.type == TokenType.Keyword && it.content == "const" }, "Alias 'js' should work like 'javascript'")
+
+            val tsTokens = tokenizeLine("ts", "const x: number = 1")
+            assertTrue(tsTokens.any { it.type == TokenType.Keyword && it.content == "const" }, "Alias 'ts' should work like 'typescript'")
+        }
+
+        @Test
         fun `tokenizeCode returns TokenizedCode with language and tokens`() {
             val code = "val x = 42"
             val result = tokenizeCode("kotlin", code)
@@ -341,7 +368,7 @@ class CodeTokenizerTest {
             assertTrue(stringTokens.isNotEmpty(), "Should recognize string literals")
         }
 
-       @Test
+        @Test
         fun `js tokenizer recognizes template literals`() {
             val line = "`hello ${"$"}{name}`"
             val tokens = tokenizer.tokenize(line)


### PR DESCRIPTION
## Summary
- Add `CodeTokenizer` with 8 language tokenizers (Kotlin, Java, JS/TS, Python, Swift, Go, Rust, JSON)
- Integrate tokenized highlighting into `MarkdownRenderer.FencedCodeBlock` using Material 3 semantic colors
- Add Compose previews for all supported languages
- Unit tests for all tokenizers with 40+ assertions

## Why
Syntax highlighting for code blocks is a core UX feature (issue #439) that improves readability of code snippets in chat responses.

## How to test
- Open the app and send a message containing code blocks in different languages
- Verify syntax highlighting colors match Material 3 semantic palette (keywords in primary, types in tertiary, strings in secondary)
- Run `CodeTokenizerTest` unit tests

## Screenshots
Compose previews included for Kotlin, Python, JavaScript, Rust, Go, Swift, TypeScript, and Java code blocks.