### PR TITLE
fix(quick-intent): add 'show nearby' verb to find_nearby regex pattern (#685)

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1658,7 +1658,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
-                """(?:find|search\s+for|look\s+for|locate)\s+nearby\s+(.+)""",
+                """(?:find|search\s+for|look\s+for|locate|show)\s+nearby\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2097,6 +2097,8 @@ class QuickIntentRouterTest {
             Arguments.of("find coffee shops close by", "coffee shops"),
             Arguments.of("search for supermarkets nearby", "supermarkets"),
             Arguments.of("find ATMs near me", "ATMs"),
+            Arguments.of("show nearby supermarkets", "supermarkets"),
+            Arguments.of("show nearby cafes", "cafes"),
         )
 
         @JvmStatic


### PR DESCRIPTION
## Summary
Fixes #685 — `"show nearby supermarkets"` was falling through to the LLM instead of matching the `find_nearby` intent.

The `find_nearby` regex patterns were missing `show` as a verb in the `"find nearby X"` pattern, so phrases like `"show nearby supermarkets"` didn't match any regex and fell through to E4B.

## Changes
- `core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt`: Added `show` to the verb group in the `"find nearby X"` regex pattern (line 1661).
- `core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt`: Added two test cases for `"show nearby supermarkets"` and `"show nearby cafes"`.

## Testing
- [x] Builds clean (`./gradlew :core:skills:testDebugUnitTest` — QuickIntentRouter tests pass)
- [ ] Manual testing on device
- [x] Unit tests pass

## Related issues
Closes #685