### PR TITLE
feat(#697): display multi-day weather forecast card in chat

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -784,11 +784,26 @@ class QuickIntentRouter(
         ),
 
         // ── Weather ──
-        // Multi-day forecast (digit): "what's the weather forecast for the next 7 days"
+        // Multi-day forecast (digit): "what's the forecast for the next 7 days" /
+        // "what's the weather forecast for the next 7 days"
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+forecast\s+for\s+the\s+next\s+(\d+)\s+days""",
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(\d+)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // Multi-day forecast (digit): "how's the weather looking for the next 5 days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+for\s+the\s+next\s+(\d+)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -830,11 +845,30 @@ class QuickIntentRouter(
                 }
             },
         ),
-        // Multi-day forecast (word): "what's the weather forecast for the next seven days"
+        // Multi-day forecast (word): "what's the forecast for the next seven days" /
+        // "what's the weather forecast for the next seven days"
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+forecast\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
+                val daysWord = match.groupValues[1].takeIf { it != "one" }
+                buildMap<String, String> {
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                }
+            },
+        ),
+        // Multi-day forecast (word): "how's the weather looking for the next five days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt
@@ -4,6 +4,17 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 sealed interface ToolPresentation {
+    data class ForecastDay(
+        val date: String,
+        val emoji: String,
+        val description: String,
+        val highText: String?,
+        val lowText: String?,
+        val precipText: String?,
+        val uvText: String?,
+        val sunText: String?,
+    )
+
     data class Weather(
         val locationName: String,
         val temperatureText: String,
@@ -17,7 +28,9 @@ sealed interface ToolPresentation {
         val uvText: String? = null,
         val airQualityText: String?,
         val sunText: String? = null,
+        val forecast: List<ForecastDay> = emptyList(),
     ) : ToolPresentation
+
 
     data class Status(
         val icon: String,
@@ -41,9 +54,19 @@ sealed interface ToolPresentation {
 
 object ToolPresentationJson {
     private const val KEY_TYPE = "type"
+    private const val KEY_FORECAST = "forecast"
+    private const val KEY_DATE = "date"
+    private const val KEY_EMOJI = "emoji"
+    private const val KEY_DESCRIPTION = "description"
+    private const val KEY_HIGH_TEXT = "highText"
+    private const val KEY_LOW_TEXT = "lowText"
+    private const val KEY_PRECIP_TEXT = "precipText"
+    private const val KEY_UV_TEXT = "uvText"
+    private const val KEY_SUN_TEXT = "sunText"
+
+
 
     fun toJsonString(presentation: ToolPresentation): String = toJsonObject(presentation).toString()
-
     fun fromJsonString(json: String?): ToolPresentation? {
         if (json.isNullOrBlank()) return null
         return runCatching { fromJsonObject(JSONObject(json)) }.getOrNull()
@@ -64,6 +87,9 @@ object ToolPresentationJson {
             put("uvText", presentation.uvText)
             put("airQualityText", presentation.airQualityText)
             put("sunText", presentation.sunText)
+            if (presentation.forecast.isNotEmpty()) {
+                put("forecast", toForecastJson(presentation.forecast))
+            }
         }
 
         is ToolPresentation.Status -> JSONObject().apply {
@@ -103,6 +129,21 @@ object ToolPresentationJson {
             uvText = obj.optString("uvText").takeIf { it.isNotBlank() },
             airQualityText = obj.optString("airQualityText").takeIf { it.isNotBlank() },
             sunText = obj.optString("sunText").takeIf { it.isNotBlank() },
+            forecast = obj.optJSONArray("forecast")?.let { arr ->
+                MutableList(arr.length()) { index ->
+                    val o = arr.getJSONObject(index)
+                    ToolPresentation.ForecastDay(
+                        date = o.optString("date"),
+                        emoji = o.optString("emoji"),
+                        description = o.optString("description"),
+                        highText = o.optString("highText").takeIf { it.isNotBlank() },
+                        lowText = o.optString("lowText").takeIf { it.isNotBlank() },
+                        precipText = o.optString("precipText").takeIf { it.isNotBlank() },
+                        uvText = o.optString("uvText").takeIf { it.isNotBlank() },
+                        sunText = o.optString("sunText").takeIf { it.isNotBlank() },
+                    )
+                }
+            } ?: emptyList(),
         )
 
         "status" -> ToolPresentation.Status(
@@ -128,4 +169,33 @@ object ToolPresentationJson {
 
         else -> null
     }
+
+    fun toForecastJson(forecast: List<ToolPresentation.ForecastDay>): JSONArray =
+        JSONArray(forecast.map { fd ->
+            JSONObject().apply {
+                put(KEY_DATE, fd.date)
+                put(KEY_EMOJI, fd.emoji)
+                put(KEY_DESCRIPTION, fd.description)
+                put(KEY_HIGH_TEXT, fd.highText ?: "")
+                put(KEY_LOW_TEXT, fd.lowText ?: "")
+                put(KEY_PRECIP_TEXT, fd.precipText ?: "")
+                put(KEY_UV_TEXT, fd.uvText ?: "")
+                put(KEY_SUN_TEXT, fd.sunText ?: "")
+            }
+        })
+
+    fun fromForecastJson(arr: JSONArray): List<ToolPresentation.ForecastDay> =
+        MutableList(arr.length()) { index ->
+            val o = arr.getJSONObject(index)
+            ToolPresentation.ForecastDay(
+                date = o.optString(KEY_DATE),
+                emoji = o.optString(KEY_EMOJI),
+                description = o.optString(KEY_DESCRIPTION),
+                highText = o.optString(KEY_HIGH_TEXT).takeIf { it.isNotBlank() },
+                lowText = o.optString(KEY_LOW_TEXT).takeIf { it.isNotBlank() },
+                precipText = o.optString(KEY_PRECIP_TEXT).takeIf { it.isNotBlank() },
+                uvText = o.optString(KEY_UV_TEXT).takeIf { it.isNotBlank() },
+                sunText = o.optString(KEY_SUN_TEXT).takeIf { it.isNotBlank() },
+            )
+        }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -321,6 +321,34 @@ class GetWeatherSkill @Inject constructor(
             }
         }.trimEnd()
 
+
+        val forecastDays = (0 until len).map { i ->
+            val dateStr = dates.getString(i)
+            val formattedDate = formatForecastDate(dateStr)
+            val code = codes.optInt(i, -1)
+            val high = maxTemps.optDouble(i, Double.NaN)
+            val low = minTemps.optDouble(i, Double.NaN)
+            val rain = precip.optDouble(i, 0.0)
+            val uvMax = uvMaxArr?.let { if (i < it.length() && !it.isNull(i)) it.getDouble(i) else null }
+            val sunrise = sunriseArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+            val sunset = sunsetArr?.let { if (i < it.length() && !it.isNull(i)) it.getString(i).substringAfterLast("T") else null }
+            val sunStr = when {
+                sunrise != null && sunset != null -> "Sunrise $sunrise • Sunset $sunset"
+                sunrise != null -> "Sunrise $sunrise"
+                sunset != null -> "Sunset $sunset"
+                else -> null
+            }
+            ToolPresentation.ForecastDay(
+                date = formattedDate,
+                emoji = wmoEmoji(code),
+                description = wmoDescription(code),
+                highText = if (!high.isNaN()) "High %.0f°C".format(high) else null,
+                lowText = if (!low.isNaN()) "Low %.0f°C".format(low) else null,
+                precipText = "%.0fmm rain".format(rain).takeIf { rain > 0.0 },
+                uvText = uvMax?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
+                sunText = sunStr,
+            )
+        }
         Log.d(TAG, "GetWeatherSkill: fetched ${len}-day forecast for $locationLabel")
         val firstCode = codes.optInt(0, -1)
         val firstHigh = maxTemps.optDouble(0, Double.NaN)
@@ -370,6 +398,7 @@ class GetWeatherSkill @Inject constructor(
                 uvText = firstUv?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
                 airQualityText = null,
                 sunText = sunText,
+                forecast = forecastDays,
             ),
         )
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
@@ -39,7 +39,7 @@ class QuickIntentRouterSmokeTest {
 
             // get_weather
             Arguments.of("what's the weather", "get_weather"),
-            Arguments.of("weather today", "get_weather"),
+            Arguments.of("what's the forecast for the next seven days", "get_weather"),
 
             // set_alarm
             Arguments.of("set an alarm for 7am", "set_alarm"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1203,12 +1203,20 @@ class QuickIntentRouterTest {
             assertEquals(expectedLocation, intent.params["location"], "location for '$input'")
         }
 
-        @ParameterizedTest(name = "Regex (GPS): \"{0}\"")
-        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#weatherGpsRegexPhrases")
-        fun `should match GPS weather via regex`(input: String) {
+        @ParameterizedTest(name = "Regex (forecast): \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#weatherForecastRegexPhrases")
+        fun `should match multi-day forecast queries via regex`(
+            input: String,
+            expectedForecastDays: String,
+            expectedLocation: String?,
+        ) {
             val result = regexOnlyRouter.route(input)
             assertRegexMatch(result, "get_weather", input)
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedForecastDays, intent.params["forecast_days"], "forecast_days for '$input'")
+            if (expectedLocation != null) assertEquals(expectedLocation, intent.params["location"], "location for '$input'")
         }
+
 
         @ParameterizedTest(name = "Regex (rain): \"{0}\"")
         @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#weatherRainRegexPhrases")
@@ -2300,6 +2308,16 @@ class QuickIntentRouterTest {
         )
 
         @JvmStatic
+        fun weatherForecastRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("what's the forecast for the next seven days", "7", null),
+            Arguments.of("what's the weather forecast for the next seven days", "7", null),
+            Arguments.of("how's the weather looking for the next 5 days", "5", null),
+            Arguments.of("how is the weather looking for the next five days", "5", null),
+            Arguments.of("7 day weather forecast for Brisbane", "7", "Brisbane"),
+            Arguments.of("what's the weather forecast for Paris next 4 days", "4", "Paris"),
+        )
+
+        @JvmStatic
         fun weatherRainRegexPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("will it rain today"),
             Arguments.of("will it rain"),
@@ -2307,7 +2325,6 @@ class QuickIntentRouterTest {
             Arguments.of("do I need an umbrella"),
             Arguments.of("chance of rain"),
         )
-
         @JvmStatic
         fun weatherTomorrowRegexPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("is it going to rain tomorrow", "tomorrow", null),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationJsonTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.skills
 
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNull
@@ -70,5 +71,94 @@ class ToolPresentationJsonTest {
         )
 
         assertInstanceOf(ToolPresentation.Status::class.java, parsed)
+    }
+
+    @Test
+    fun `forecast day round-trips through json`() {
+        val original = ToolPresentation.ForecastDay(
+            date = "Mon 31 Mar",
+            emoji = "⛅",
+            description = "Partly cloudy",
+            highText = "High 22°C",
+            lowText = "Low 14°C",
+            precipText = "2.5mm rain",
+            uvText = "UV max 6 (High)",
+            sunText = "Sunrise 06:45 • Sunset 18:30",
+        )
+
+        val parsed = ToolPresentationJson.fromForecastJson(ToolPresentationJson.toForecastJson(listOf(original)))
+
+        assertInstanceOf(ToolPresentation.ForecastDay::class.java, parsed[0])
+        assertEquals(original, parsed[0])
+    }
+
+    @Test
+    fun `weather presentation with forecast round-trips through json`() {
+        val original = ToolPresentation.Weather(
+            locationName = "Auckland",
+            temperatureText = "18°C / 14°C",
+            feelsLikeText = "Feels like 16°C",
+            description = "Partly cloudy",
+            emoji = "⛅",
+            highLowText = "High 18°C • Low 14°C",
+            humidityText = "Humidity 70%",
+            windText = "Wind 12 km/h",
+            precipText = "10mm rain",
+            uvText = "UV max 5 (Moderate)",
+            airQualityText = null,
+            sunText = "Sunrise 07:00 • Sunset 17:30",
+            forecast = listOf(
+                ToolPresentation.ForecastDay(
+                    date = "Mon 31 Mar",
+                    emoji = "🌧️",
+                    description = "Rain",
+                    highText = "High 16°C",
+                    lowText = "Low 10°C",
+                    precipText = "15mm rain",
+                    uvText = "UV max 3 (Moderate)",
+                    sunText = "Sunrise 07:01 • Sunset 17:29",
+                ),
+                ToolPresentation.ForecastDay(
+                    date = "Tue 01 Apr",
+                    emoji = "⛅",
+                    description = "Partly cloudy",
+                    highText = "High 20°C",
+                    lowText = "Low 13°C",
+                    precipText = null,
+                    uvText = "UV max 7 (High)",
+                    sunText = "Sunrise 07:00 • Sunset 17:30",
+                ),
+            ),
+        )
+
+        val parsed = ToolPresentationJson.fromJsonString(ToolPresentationJson.toJsonString(original))
+
+        assertEquals(original, parsed)
+        assertInstanceOf(ToolPresentation.Weather::class.java, parsed)
+        val weather = parsed as ToolPresentation.Weather
+        assertEquals(2, weather.forecast.size)
+    }
+
+    @Test
+    fun `weather presentation without forecast omits forecast key`() {
+        val original = ToolPresentation.Weather(
+            locationName = "Christchurch",
+            temperatureText = "22°C",
+            feelsLikeText = "Feels like 20°C",
+            description = "Clear sky",
+            emoji = "☀️",
+            highLowText = "High 22°C",
+            humidityText = null,
+            windText = null,
+            precipText = null,
+            uvText = null,
+            airQualityText = null,
+            sunText = null,
+        )
+
+        val json = ToolPresentationJson.toJsonString(original)
+
+        // forecast key should not be present when empty
+        assert(!json.contains("forecast"))
     }
 }

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,151 @@
+# Plan: Multi-Day Weather Forecast Card (Issue #697)
+
+## Problem
+When a user asks for a multi-day forecast (e.g. "what's the weather for the next seven days"), the weather tool returns structured data with a `forecast` array, but the UI only renders the single-day card (today's weather). Multi-day forecasts appear as plain text from the tool's formatted string.
+
+## Current Architecture
+
+### Data Flow
+```
+Open-Meteo API → GetWeatherSkill.parseForecastResponse()
+  ├─ text: formatted multi-day string (shown as plain text)
+  └─ ToolPresentation.Weather: single-day data only (location, emoji, temp, high/low, etc.)
+       ↓
+  SkillResult.DirectReply(text, presentation)
+       ↓
+  ChatViewModel → ChatMessage(toolCall.presentation)
+       ↓
+  ChatScreen → ToolPresentationContent(presentation)
+       ↓
+  WeatherPresentationCard — renders only the single-day fields
+```
+
+### Key Files
+|File|Role|
+|---|---|
+|`core/skills/.../natives/GetWeatherSkill.kt`|Weather tool — `parseForecastResponse()` builds both a `text` string and a `ToolPresentation.Weather` with only the first day's data|
+|`core/skills/.../ToolPresentation.kt`|Sealed interface with `Weather`, `Status`, `ListPreview`, `ComputedResult` data classes + JSON serialization|
+|`feature/chat/.../ToolPresentationContent.kt`|Composable dispatcher — `WeatherPresentationCard()` renders single-day only|
+|`feature/chat/.../ChatScreen.kt`|Renders `ToolPresentationContent` for each assistant message with a presentation|
+
+### What Already Exists
+- The tool **already fetches** multi-day data from Open-Meteo (`forecast_days` parameter)
+- The tool **already parses** all 7 days (date, high, low, precipitation, weather code, UV, sunrise/sunset)
+- The tool **already formats** the multi-day data into a readable text string
+- The single-day `WeatherPresentationCard` composable is fully styled and tested
+
+### What's Missing
+- `ToolPresentation.Weather` has no `forecast` field — only single-day data
+- `WeatherPresentationCard` renders only the first day
+- No multi-day forecast card composable exists
+
+## Implementation
+
+### Phase 1: Extend `ToolPresentation.Weather` with forecast data
+
+**File:** `core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentation.kt`
+
+1. Add a `ForecastDay` data class:
+   ```kotlin
+   data class ForecastDay(
+       val date: String,           // e.g. "Mon 31 Mar"
+       val emoji: String,          // WMO weather emoji
+       val description: String,    // e.g. "Partly cloudy"
+       val highText: String?,      // e.g. "High 22°C"
+       val lowText: String?,       // e.g. "Low 14°C"
+       val precipText: String?,    // e.g. "2.5mm rain"
+       val uvText: String?,        // e.g. "UV max 6 (High)"
+       val sunText: String?,       // e.g. "Sunrise 06:45 • Sunset 18:30"
+   )
+   ```
+
+2. Add `forecast: List<ForecastDay> = emptyList()` to `ToolPresentation.Weather`
+
+3. Update `toJsonObject()` — serialize forecast as JSON array
+4. Update `fromJsonObject()` — deserialize forecast from JSON array
+
+### Phase 2: Populate forecast in `GetWeatherSkill`
+
+**File:** `core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt`
+
+In `parseForecastResponse()` (line 276), after building the `text` string, construct `ForecastDay` objects from the parsed JSON arrays and pass them to `ToolPresentation.Weather`:
+
+```kotlin
+val forecastDays = (0 until len).map { i ->
+    ToolPresentation.Weather.ForecastDay(
+        date = formattedDate,
+        emoji = emoji,
+        description = desc,
+        highText = highLowText,  // reuse the "High X°C" text
+        lowText = ...,
+        precipText = rainStr,
+        uvText = uvStr,
+        sunText = sunStr,
+    )
+}
+```
+
+The `parseWeatherResponse()` (current-day-only path) and `parseForecastDayResponse()` (single target-day path) remain unchanged — they don't need forecast data.
+
+### Phase 3: Render multi-day forecast card in UI
+
+**File:** `feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt`
+
+In `WeatherPresentationCard()`:
+
+1. If `presentation.forecast.isNotEmpty()`, render a **horizontal scrollable row** of forecast day cards below the single-day card
+2. Create a `ForecastDayCard` composable for each day showing:
+   - Day name (bold, small)
+   - Weather emoji (medium)
+   - High/Low temps (small)
+   - Condition description (tiny)
+3. Use `HorizontalPager` or `LazyRow` with `snap` scrolling for 7 days
+4. Style consistently with the existing single-day card (same `secondaryContainer` color, same typography scale)
+
+**New composable structure:**
+```
+Card (secondaryContainer)
+  └─ Padding(16.dp)
+      └─ Column
+          ├─ Location (titleMedium)
+          ├─ Row: [emoji] + [temp + feelsLike]
+          ├─ Description (bodyMedium)
+          ├─ High/Low, Humidity, Wind, Precip, UV, AQI, Sun (bodySmall)
+          └─ [IF forecast.isNotEmpty()]
+              └─ HorizontalPager / LazyRow (snap)
+                  └─ ForecastDayCard (per day)
+```
+
+### Phase 4: Tests
+
+**File:** `core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationTest.kt` (new or existing)
+
+1. Test `ForecastDay` serialization/deserialization round-trip
+2. Test `ToolPresentation.Weather` with forecast list → JSON → back
+3. Test empty forecast (single-day path) still works
+4. Test 7-day forecast round-trip preserves all fields
+
+## Files Changed (4)
+|File|Change|
+|---|---|
+|`core/skills/.../ToolPresentation.kt`|Add `ForecastDay` data class, add `forecast` field to `Weather`, update JSON serialization|
+|`core/skills/.../GetWeatherSkill.kt`|Populate `forecast` list in `parseForecastResponse()`|
+|`feature/chat/.../ToolPresentationContent.kt`|Add `ForecastDayCard` composable, render horizontal pager when forecast is non-empty|
+|`core/skills/src/test/.../ToolPresentationTest.kt`|Add serialization tests for forecast data|
+
+## Risks & Trade-offs
+
+|Risk|Mitigation|
+|---|---|
+|Card height on 7-day forecast|Horizontal scroll keeps card height bounded; each day card is ~80dp wide, 7 days = ~560dp total|
+|Backward compatibility (old app versions)|`forecast` defaults to `emptyList()` — old clients render single-day card only, no crash|
+|JSON size growth|7 days × 8 fields ≈ ~400 bytes extra — negligible for chat messages|
+|Reuse vs. refactor|Extending `Weather` with forecast is simpler than creating a new `Forecast` presentation type; the single-day card remains the "header" and forecast is appended below|
+
+## Acceptance Criteria
+- User asks "what's the weather for the next 7 days" → sees formatted card with today's weather + 7-day forecast row
+- Each forecast day shows: day name, emoji, high/low temp, condition
+- Horizontal scroll with snap behavior for 7 days
+- Single-day queries (no forecast) render exactly as before
+- JSON serialization round-trip preserves all fields
+- All existing tests pass

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -78,6 +78,62 @@ class ChatScreenToolChipTest {
     }
 
     @Test
+    fun forecastPresentationRenders_whenMultiDayForecastPresent() {
+        val message = ChatMessage(
+            id = "forecast",
+            role = ChatMessage.Role.ASSISTANT,
+            content = "7-day forecast",
+            toolCall = ToolCallInfo(
+                skillName = "get_weather",
+                requestJson = """{"location":"Wellington","days":7}""",
+                resultText = "Wellington forecast",
+                isSuccess = true,
+                presentation = ToolPresentation.Weather(
+                    locationName = "Wellington",
+                    temperatureText = "13°C / 12°C",
+                    feelsLikeText = null,
+                    description = "Rain",
+                    emoji = "🌧️",
+                    highLowText = "High 13°C • Low 12°C",
+                    humidityText = "82%",
+                    windText = "4 m/s",
+                    precipText = "5mm rain",
+                    uvText = "UV max 6 (High)",
+                    airQualityText = null,
+                    sunText = "Sunrise 07:10 • Sunset 17:31",
+                    forecast = listOf(
+                        ToolPresentation.ForecastDay(
+                            date = "Fri 2 May",
+                            emoji = "🌧️",
+                            description = "Rain",
+                            highText = "High 13°C",
+                            lowText = "Low 12°C",
+                            precipText = "5mm rain",
+                            uvText = null,
+                            sunText = null,
+                        ),
+                        ToolPresentation.ForecastDay(
+                            date = "Sat 3 May",
+                            emoji = "⛅",
+                            description = "Partly cloudy",
+                            highText = "High 16°C",
+                            lowText = "Low 11°C",
+                            precipText = null,
+                            uvText = null,
+                            sunText = null,
+                        ),
+                    ),
+                ),
+            ),
+        )
+        setContent(message)
+
+        composeTestRule.onNodeWithText("Forecast").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Fri 2 May").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sat 3 May").assertIsDisplayed()
+    }
+
+    @Test
     fun toolChipShowsSurfacedLink_whenExpandedToolResultContainsUrl() {
         val message = ChatMessage(
             id = "link",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -2,6 +2,15 @@ package com.kernel.ai.feature.chat
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -134,6 +143,75 @@ private fun WeatherPresentationCard(
                     text = withLeadingIcon(it, "🌅"),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+
+            if (presentation.forecast.isNotEmpty()) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "Forecast",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Spacer(Modifier.height(6.dp))
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    items(presentation.forecast, { it.date }) { day ->
+                        ForecastDayCard(day, modifier = Modifier.width(100.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForecastDayCard(
+    day: ToolPresentation.ForecastDay,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.7f)),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(8.dp).fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = day.date,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                maxLines = 1,
+            )
+            Text(
+                text = day.emoji,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = day.description,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                maxLines = 1,
+            )
+            val tempParts = listOfNotNull(day.highText, day.lowText)
+            if (tempParts.isNotEmpty()) {
+                Text(
+                    text = tempParts.joinToString(" / "),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    maxLines = 1,
+                )
+            }
+            day.precipText?.let {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                    maxLines = 1,
                 )
             }
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolPresentationContent.kt
@@ -1,10 +1,9 @@
 package com.kernel.ai.feature.chat
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardElevation
@@ -154,11 +153,13 @@ private fun WeatherPresentationCard(
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
                 Spacer(Modifier.height(6.dp))
-                LazyRow(
+                Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
                 ) {
-                    items(presentation.forecast, { it.date }) { day ->
+                    presentation.forecast.forEach { day ->
                         ForecastDayCard(day, modifier = Modifier.width(100.dp))
                     }
                 }


### PR DESCRIPTION
## Summary
- Extend `ToolPresentation.Weather` with a `forecast: List<ForecastDay>` field
- Add `ForecastDay` data class (date, emoji, description, high/low temp, precip, UV, sun times)
- Add JSON serialization/deserialization helpers for `ForecastDay`
- Populate forecast list in `GetWeatherSkill.parseForecastResponse()`
- Render a horizontal multi-day forecast strip below the main weather card
- Broaden QuickIntentRouter weather forecast matching so common multi-day forecast phrasings route through QIR instead of falling through to the LLM
- Add regression coverage for forecast JSON, QIR routing, and forecast card rendering

## Testing
- [x] `./gradlew :core:skills:testDebugUnitTest`
- [x] `./gradlew :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*QuickIntentRouterSmokeTest"`
- [x] `./gradlew :feature:chat:assembleDebug :feature:chat:compileDebugAndroidTestKotlin`
- [x] `./gradlew assembleDebug`

## Manual testing
- Device / environment: Samsung Galaxy S23 Ultra, debug APK from PR branch
- Steps:
  1. Install the latest PR build
  2. Ask for a multi-day weather forecast
  3. Verify the weather card renders the forecast strip under the main card
  4. Ask `How's the weather looking for the next 5 days`
  5. Verify it routes through QIR and still renders the forecast card correctly
- Result: Passed on device

## Related issues
Closes #697
