### PR TITLE
feat(#708): improve deterministic dialog reliability

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -75,6 +75,7 @@ private const val ROUTE_LIST_ITEMS = "lists/{listName}"
 private const val ARG_LIST_NAME = "listName"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
+private const val ARG_MINIMAL_CONTEXT = "minimalContext"
 private const val ARG_START_VOICE = "startVoice"
 private const val STATE_OPEN_SHEET_CONSUMED = "openSheetConsumed"
 private const val STATE_START_VOICE_CONSUMED = "startVoiceConsumed"
@@ -288,7 +289,9 @@ fun KernelNavHost(
                             },
                             onNavigateToChat = { query ->
                                 val encoded = Uri.encode(query)
-                                navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded")
+                                navController.navigate(
+                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true"
+                                )
                             },
                             onNewConversation = {
                                 navController.navigate(ROUTE_CHAT)
@@ -301,12 +304,18 @@ fun KernelNavHost(
                 }
 
                 composable(
-                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}",
-                    arguments = listOf(navArgument(ARG_INITIAL_QUERY) {
-                        type = NavType.StringType
-                        defaultValue = ""
-                        nullable = false
-                    }),
+                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}",
+                    arguments = listOf(
+                        navArgument(ARG_INITIAL_QUERY) {
+                            type = NavType.StringType
+                            defaultValue = ""
+                            nullable = false
+                        },
+                        navArgument(ARG_MINIMAL_CONTEXT) {
+                            type = NavType.BoolType
+                            defaultValue = false
+                        },
+                    ),
                 ) { backStackEntry ->
                     val initialQuery = backStackEntry.arguments?.getString(ARG_INITIAL_QUERY)
                         ?.takeIf { it.isNotBlank() }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2186,7 +2186,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "add_to_list",
             regex = Regex(
-                """add\s+(.+?)\s+to\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                """^add\s+(.+?)\s+to\s+(?:(?:my|the)\s+)?(?!(?:my|the)\b)(.+?)\s+list(?:\s*,?\s*(?:please|pls))?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -2201,7 +2201,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "add_to_list",
             regex = Regex(
-                """put\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?(.+?)\s+list""",
+                """^put\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?(?!(?:my|the)\b)(.+?)\s+list(?:\s*,?\s*(?:please|pls))?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -2229,7 +2229,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "add_to_list",
             regex = Regex(
-                """(?:chuck|stick|bung|pop|toss)\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?(?:(.+?)\s+)?list""",
+                """^(?:chuck|stick|bung|pop|toss)\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?(?!(?:my|the)\b)(.+?)\s+list(?:\s*,?\s*(?:please|pls))?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -76,6 +76,86 @@ class QuickIntentRouter(
         RegexOption.IGNORE_CASE,
     )
 
+    private val slotContracts: Map<String, Map<String, com.kernel.ai.core.skills.slot.SlotSpec>> = mapOf(
+        "make_call" to mapOf(
+            "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "contact",
+                promptTemplate = "Who would you like to call?",
+            ),
+        ),
+        "send_sms" to mapOf(
+            "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "contact",
+                promptTemplate = "Who do you want to send a message to?",
+            ),
+            "message" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "message",
+                promptTemplate = "What would you like to say to {contact}?",
+            ),
+        ),
+        "send_email" to mapOf(
+            "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "contact",
+                promptTemplate = "Who would you like to email?",
+            ),
+            "subject" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "subject",
+                promptTemplate = "What's the subject of your email to {contact}?",
+            ),
+            "body" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "body",
+                promptTemplate = "What would you like the email to say?",
+            ),
+        ),
+        "add_to_list" to mapOf(
+            "item" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "item",
+                promptTemplate = "What would you like to add?",
+            ),
+            "list_name" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "list_name",
+                promptTemplate = "Which list should I add it to?",
+            ),
+        ),
+        "create_list" to mapOf(
+            "list_name" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "list_name",
+                promptTemplate = "What would you like to call the list?",
+            ),
+        ),
+        "save_memory" to mapOf(
+            "content" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "content",
+                promptTemplate = "What would you like me to remember?",
+            ),
+        ),
+    )
+
+    private fun slotContract(intentName: String): Map<String, com.kernel.ai.core.skills.slot.SlotSpec> =
+        slotContracts[intentName] ?: emptyMap()
+
+    private val placeholderContacts = setOf(
+        "someone",
+        "somebody",
+        "anyone",
+        "anybody",
+    )
+
+    private val placeholderItems = setOf(
+        "something",
+        "anything",
+    )
+
+    private fun normalizeOptionalContact(raw: String): String? = raw.trim()
+        .takeIf { it.isNotBlank() }
+        ?.takeUnless { it.lowercase() in placeholderContacts }
+
+    private fun normalizeOptionalItem(raw: String): String? = raw.trim()
+        .takeIf { it.isNotBlank() }
+        ?.takeUnless { it.lowercase() in placeholderItems }
+
+
+
     // ── Regex patterns ────────────────────────────────────────────────────────
 
     private data class IntentPattern(
@@ -1409,11 +1489,11 @@ class QuickIntentRouter(
         ),
         // Open app — "open YouTube" / "launch Spotify"
         // Excludes timer/countdown/alarm phrases and phrases that contain "timer" anywhere
-        // Also excludes "new conversation/chat" to prevent false matches on conversational phrases
+        // Also excludes list and new-conversation/chat phrases to prevent false matches on slot-fill commands
         IntentPattern(
             intentName = "open_app",
             regex = Regex(
-                """^(?:open|launch|start)\s+(?:the\s+)?(?!(?:a\s+)?(?:count(?:down|ing)|timer|alarm|new\s+conversation|new\s+chat|conversation|chat)\b)(?!.*\btimer\b)(.+?)(?:\s+app)?$""",
+                """^(?:open|launch|start)\s+(?:the\s+)?(?!(?:a\s+)?(?:count(?:down|ing)|timer|alarm|(?:my\s+)?list|new\s+conversation|new\s+chat|conversation|chat)\b)(?!.*\btimer\b)(.+?)(?:\s+app)?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("app_name" to match.groupValues[1].trim()) },
@@ -1902,13 +1982,26 @@ class QuickIntentRouter(
         ),
 
         // ── Communication ──
+        // "make a call" / "call someone" / "ring anybody" (no concrete contact) → ask who
+        IntentPattern(
+            intentName = "make_call",
+            regex = Regex(
+                """^(?:make\s+(?:a\s+)?call|(?:call|ring|dial|phone)\s+(?:someone|somebody|anyone|anybody))$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = slotContract("make_call"),
+        ),
         IntentPattern(
             intentName = "make_call",
             regex = Regex(
                 """^(?:call|ring|dial|phone)\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("contact" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ ->
+                normalizeOptionalContact(match.groupValues[1])?.let { mapOf("contact" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("make_call"),
         ),
         // "give Sarah a call" / "give mum a ring"
         IntentPattern(
@@ -1917,7 +2010,10 @@ class QuickIntentRouter(
                 """^give\s+(.+?)\s+a\s+(?:call|ring|buzz)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("contact" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ ->
+                normalizeOptionalContact(match.groupValues[1])?.let { mapOf("contact" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("make_call"),
         ),
         // Self-send: "text myself [message]" / "text me [message]" — contact resolved to own number
         IntentPattern(
@@ -1929,6 +2025,7 @@ class QuickIntentRouter(
             paramExtractor = { match, _ ->
                 mapOf("contact" to "myself", "message" to match.groupValues[1].trim())
             },
+            requiredSlots = slotContract("send_sms"),
         ),
         // "send a message" / "send a text" (no contact) → ask who to send to
         // Must come BEFORE the generic send_sms pattern below (which would capture "a" as contact)
@@ -1939,12 +2036,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
-            requiredSlots = mapOf(
-                "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
-                    name = "contact",
-                    promptTemplate = "Who do you want to send a message to?",
-                ),
-            ),
+            requiredSlots = slotContract("send_sms"),
         ),
         // "send a text to John saying hello" / "text John hey" / "sms John meet at 5"
         IntentPattern(
@@ -1954,18 +2046,13 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                val params = mutableMapOf("contact" to match.groupValues[1].trim())
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalContact(match.groupValues[1])?.let { params["contact"] = it }
                 val msg = match.groupValues[2].trim()
                 if (msg.isNotBlank()) params["message"] = msg
                 params
             },
-            // Ask for the message body when the user only specified a recipient.
-            requiredSlots = mapOf(
-                "message" to com.kernel.ai.core.skills.slot.SlotSpec(
-                    name = "message",
-                    promptTemplate = "What would you like to say to {contact}?",
-                ),
-            ),
+            requiredSlots = slotContract("send_sms"),
         ),
         // "message mum that I'm on my way" / "message John saying..."
         IntentPattern(
@@ -1975,11 +2062,23 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                mapOf(
-                    "contact" to match.groupValues[1].trim(),
-                    "message" to match.groupValues[2].trim(),
-                )
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalContact(match.groupValues[1])?.let { params["contact"] = it }
+                params["message"] = match.groupValues[2].trim()
+                params
             },
+            requiredSlots = slotContract("send_sms"),
+        ),
+        // "send an email" / "email someone" (no concrete contact) → ask who
+        // Must come BEFORE the contact-extraction pattern below
+        IntentPattern(
+            intentName = "send_email",
+            regex = Regex(
+                """^(?:send\s+(?:an?\s+)?email|email(?:\s+someone)?)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = slotContract("send_email"),
         ),
         // "send an email to John about meeting" / "email John with body Please review"
         IntentPattern(
@@ -1991,37 +2090,17 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                val params = mutableMapOf("contact" to match.groupValues[1].trim())
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalContact(match.groupValues[1])?.let { params["contact"] = it }
                 val subject = match.groupValues[2].trim()
                 val body = match.groupValues[3].trim()
                 if (subject.isNotBlank()) params["subject"] = subject
                 if (body.isNotBlank()) params["body"] = body
                 params
             },
-            // Ask for subject when contact provided but no subject given.
-            requiredSlots = mapOf(
-                "subject" to com.kernel.ai.core.skills.slot.SlotSpec(
-                    name = "subject",
-                    promptTemplate = "What's the subject of your email to {contact}?",
-                ),
-            ),
+            requiredSlots = slotContract("send_email"),
         ),
-        // "send an email" / "email someone" (no contact) → ask who
-        // Must come AFTER the contact-extraction pattern above
-        IntentPattern(
-            intentName = "send_email",
-            regex = Regex(
-                """^(?:send\s+(?:an?\s+)?email|email\s+someone)$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { _, _ -> emptyMap() },
-            requiredSlots = mapOf(
-                "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
-                    name = "contact",
-                    promptTemplate = "Who would you like to email?",
-                ),
-            ),
-        ),
+
 
         // ── System Info ──
         // "show my device info" / "what are my device specs" / "show system info"
@@ -2091,6 +2170,19 @@ class QuickIntentRouter(
         ),
 
         // ── Lists ──
+        // "add milk to my list" / "put eggs on the list" (item present, list missing) → ask which list
+        IntentPattern(
+            intentName = "add_to_list",
+            regex = Regex(
+                """^(?:add\s+(.+?)\s+to|put\s+(.+?)\s+on)\s+(?:(?:my|the)\s+)?list$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val item = normalizeOptionalItem(match.groupValues[1].ifBlank { match.groupValues[2] })
+                if (item != null) mapOf("item" to item) else emptyMap()
+            },
+            requiredSlots = slotContract("add_to_list"),
+        ),
         IntentPattern(
             intentName = "add_to_list",
             regex = Regex(
@@ -2098,11 +2190,12 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                mapOf(
-                    "item" to match.groupValues[1].trim(),
-                    "list_name" to match.groupValues[2].trim(),
-                )
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalItem(match.groupValues[1])?.let { params["item"] = it }
+                params["list_name"] = match.groupValues[2].trim()
+                params
             },
+            requiredSlots = slotContract("add_to_list"),
         ),
         // "put milk on my shopping list" / "put eggs on the grocery list"
         IntentPattern(
@@ -2112,13 +2205,27 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                mapOf(
-                    "item" to match.groupValues[1].trim(),
-                    "list_name" to match.groupValues[2].trim(),
-                )
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalItem(match.groupValues[1])?.let { params["item"] = it }
+                params["list_name"] = match.groupValues[2].trim()
+                params
             },
+            requiredSlots = slotContract("add_to_list"),
         ),
-        // "chuck milk on the list" / "stick eggs on my shopping list" — NZ/AU/UK informal verbs
+        // "chuck milk on my list" / "stick eggs on the list" (item present, list missing) → ask which list
+        IntentPattern(
+            intentName = "add_to_list",
+            regex = Regex(
+                """^(?:chuck|stick|bung|pop|toss)\s+(.+?)\s+on\s+(?:(?:my|the)\s+)?list$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val item = normalizeOptionalItem(match.groupValues[1])
+                if (item != null) mapOf("item" to item) else emptyMap()
+            },
+            requiredSlots = slotContract("add_to_list"),
+        ),
+        // "chuck milk on the shopping list" / "stick eggs on my grocery list" — NZ/AU/UK informal verbs
         IntentPattern(
             intentName = "add_to_list",
             regex = Regex(
@@ -2126,10 +2233,13 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                val item = match.groupValues[1].trim()
-                val listName = match.groupValues[2].trim().ifEmpty { "shopping" }
-                mapOf("item" to item, "list_name" to listName)
+                val params = mutableMapOf<String, String>()
+                normalizeOptionalItem(match.groupValues[1])?.let { params["item"] = it }
+                val listName = match.groupValues[2].trim()
+                if (listName.isNotBlank()) params["list_name"] = listName
+                params
             },
+            requiredSlots = slotContract("add_to_list"),
         ),
         // "add to my list" / "add something to my list" / "add to the shopping list" (no item) → ask what
         IntentPattern(
@@ -2142,12 +2252,17 @@ class QuickIntentRouter(
                 val listName = match.groupValues[1].trim()
                 if (listName.isNotBlank()) mapOf("list_name" to listName) else emptyMap()
             },
-            requiredSlots = mapOf(
-                "item" to com.kernel.ai.core.skills.slot.SlotSpec(
-                    name = "item",
-                    promptTemplate = "What would you like to add?",
-                ),
+            requiredSlots = slotContract("add_to_list"),
+        ),
+        // "create a list" / "make a new list" / "start my list" → ask for the list name
+        IntentPattern(
+            intentName = "create_list",
+            regex = Regex(
+                """^(?:create|make|start|new)\s+(?:a\s+|an\s+)?(?:new\s+)?(?:my\s+)?list$""",
+                RegexOption.IGNORE_CASE,
             ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = slotContract("create_list"),
         ),
         // "create a list called groceries" / "make a new list called holiday packing"
         // Must come BEFORE generic create_list to prevent lazy (.+?) capturing "a" or "new"
@@ -2158,6 +2273,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("create_list"),
         ),
         // "create a groceries list" / "make a new shopping list" / "start a meal plan list"
         // "make a new list called holiday packing" / "create a list called groceries"
@@ -2168,6 +2284,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("create_list"),
         ),
         IntentPattern(
             intentName = "create_list",
@@ -2176,6 +2293,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("create_list"),
         ),
         // "remove milk from my shopping list" / "take eggs off the grocery list"
         IntentPattern(
@@ -2211,6 +2329,16 @@ class QuickIntentRouter(
         ),
 
         // ── Save Memory ──
+        // Pattern: "remember something" / "save something to memory" / "make a note" → ask what to remember
+        IntentPattern(
+            intentName = "save_memory",
+            regex = Regex(
+                """^(?:remember\s+something|(?:save|store|keep)\s+something\s+(?:to|in)\s+memory|(?:(?:make|take|save)\s+(?:a\s+)?)note)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+            requiredSlots = slotContract("save_memory"),
+        ),
         // Pattern: "save [to/that/...] memory that X" / "save this to memory: X"
         IntentPattern(
             intentName = "save_memory",
@@ -2219,6 +2347,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "remember that X" / "remember: X"
         IntentPattern(
@@ -2228,6 +2357,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "note that X" / "make a note that X" / "don't forget that X"
         IntentPattern(
@@ -2237,6 +2367,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
+            requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "my X is Y" — captures personal facts like "my dog's name is Biscuit"
         // Anchored to start of message and requires "my" to reduce false positives.
@@ -2249,7 +2380,9 @@ class QuickIntentRouter(
             paramExtractor = { match, raw ->
                 mapOf("content" to raw.trim())
             },
+            requiredSlots = slotContract("save_memory"),
         ),
+
 
         // ── Brightness ──
         // Explicit Android-compat: "increase brightness" — split from complex alternation
@@ -2367,13 +2500,22 @@ class QuickIntentRouter(
      * Returns the first [RouteResult.RegexMatch] or [RouteResult.NeedsSlot] found, or null if
      * no pattern matches.
      */
+    private fun missingRequiredSlot(
+        requiredSlots: Map<String, com.kernel.ai.core.skills.slot.SlotSpec>,
+        params: Map<String, String>,
+    ): com.kernel.ai.core.skills.slot.SlotSpec? =
+        requiredSlots.entries.firstOrNull { (key, _) -> params[key].isNullOrBlank() }?.value
+
+    fun nextMissingSlot(
+        intentName: String,
+        params: Map<String, String>,
+    ): com.kernel.ai.core.skills.slot.SlotSpec? = missingRequiredSlot(slotContract(intentName), params)
+
     private fun tryMatchPatterns(trimmed: String, candidates: List<IntentPattern>): RouteResult? {
         for (pattern in candidates) {
             val match = pattern.regex.find(trimmed) ?: continue
             val params = pattern.paramExtractor(match, trimmed)
-            val missingSlot = pattern.requiredSlots.entries
-                .firstOrNull { (key, _) -> params[key].isNullOrBlank() }
-                ?.value
+            val missingSlot = missingRequiredSlot(pattern.requiredSlots, params)
             val intent = MatchedIntent(
                 intentName = pattern.intentName,
                 params = params,
@@ -2387,6 +2529,7 @@ class QuickIntentRouter(
         }
         return null
     }
+
 
     fun route(input: String): RouteResult {
         val trimmed = INTENT_PREFIX_RE.replace(input.trim(), "")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -85,7 +85,6 @@ class RunIntentSkill @Inject constructor(
         "Flashlight on → runIntent(intentName=\"toggle_flashlight_on\", parameters=\"{}\")",
         "Flashlight off → runIntent(intentName=\"toggle_flashlight_off\", parameters=\"{}\")",
         // Communication
-        "Send email → runIntent(intentName=\"send_email\", parameters='{\"subject\":\"Hi\",\"body\":\"Text\"}')",
         "Send email to John → runIntent(intentName=\"send_email\", parameters='{\"contact\":\"John\",\"subject\":\"Hi\",\"body\":\"Text\"}')",
         "Send SMS → runIntent(intentName=\"send_sms\", parameters='{\"contact\":\"Mom\",\"message\":\"On my way\"}')",
         "Call Dad → runIntent(intentName=\"make_call\", parameters='{\"contact\":\"Dad\"}')",
@@ -130,7 +129,7 @@ class RunIntentSkill @Inject constructor(
         appendLine("  toggle_flashlight_on, toggle_flashlight_off — No params")
         appendLine()
         appendLine("COMMUNICATION:")
-        appendLine("  send_email — params: contact (optional, name to resolve email from contacts), subject, body")
+        appendLine("  send_email — params: contact, subject, body")
         appendLine("  send_sms — params: contact, message")
         appendLine("  make_call — params: contact")
         appendLine()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -67,7 +67,7 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
  * Supported intents:
  *   toggle_flashlight_on    — Camera2 torch on
  *   toggle_flashlight_off   — Camera2 torch off
- *   send_email              — ACTION_SENDTO mailto: URI (params: subject, body)
+ *   send_email              — ACTION_SENDTO mailto: URI (params: contact, subject, body)
  *   send_sms                — ACTION_SENDTO SMS composer (params: message)
  *   set_alarm               — AlarmClock.ACTION_SET_ALARM (params: hours, minutes, label)
  *   set_timer               — Built-in timer via AlarmManager (params: duration_seconds, label)
@@ -95,7 +95,7 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
  *   navigate_to             — Google Maps / geo: URI (params: destination)
  *   find_nearby             — geo: URI nearby search (params: query)
  *   make_call               — ACTION_DIAL with contact resolution (params: contact)
- *   add_to_list             — Insert item into list (params: item, list_name?) — returns DirectReply
+ *   add_to_list             — Insert item into list (params: item, list_name) — returns DirectReply
  *   bulk_add_to_list        — Insert multiple items at once (params: items (CSV or JSON array), list_name?) — returns DirectReply
  *   create_list             — Create a named list (params: list_name)
  *   get_list_items          — Retrieve unchecked items from a list (params: list_name?)
@@ -261,25 +261,31 @@ class NativeIntentHandler @Inject constructor(
     private fun sendEmail(params: Map<String, String>): SkillResult {
         // Use ACTION_SENDTO with mailto: URI so the system routes directly to an
         // email app instead of showing the generic share sheet (ACTION_SEND behaviour).
-        val contact = params["contact"]
-        val resolvedEmail = contact?.let { resolveContactEmail(it) }
-        val mailtoUri = if (resolvedEmail != null) {
-            val subject = Uri.encode(params["subject"] ?: "")
-            val body = Uri.encode(params["body"] ?: "")
-            // Email address must NOT be percent-encoded (RFC 6068) — only query params are encoded
-            Uri.parse("mailto:$resolvedEmail?subject=$subject&body=$body")
-        } else {
-            val subject = Uri.encode(params["subject"] ?: "")
-            val body = Uri.encode(params["body"] ?: "")
-            Uri.parse("mailto:?subject=$subject&body=$body")
-        }
+        val contact = params["contact"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("send_email", "No contact specified")
+        val subject = params["subject"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("send_email", "No subject specified")
+        val body = params["body"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("send_email", "No body specified")
+        val resolvedEmail = resolveContactEmail(contact)
+            ?: contact.takeIf(::looksLikeEmailAddress)
+
+        val encodedSubject = Uri.encode(subject)
+        val encodedBody = Uri.encode(body)
+        // Email address must NOT be percent-encoded (RFC 6068) — only query params are encoded
+        val mailtoUri = resolvedEmail?.let {
+            Uri.parse("mailto:$it?subject=$encodedSubject&body=$encodedBody")
+        } ?: Uri.parse("mailto:?subject=$encodedSubject&body=$encodedBody")
         val intent = Intent(Intent.ACTION_SENDTO, mailtoUri).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         return try {
             context.startActivity(intent)
-            val recipientLabel = resolvedEmail?.let { " to $it" } ?: ""
-            SkillResult.Success("Email composer opened$recipientLabel.")
+            if (resolvedEmail != null) {
+                SkillResult.Success("Email composer opened to $resolvedEmail.")
+            } else {
+                SkillResult.Success("Email composer opened. Couldn't prefill recipient for $contact.")
+            }
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("send_email", "No email app available")
         }
@@ -1462,18 +1468,30 @@ class NativeIntentHandler @Inject constructor(
         }
     }
 
+    private fun looksLikeEmailAddress(raw: String): Boolean {
+        val trimmed = raw.trim()
+        val atIndex = trimmed.indexOf('@')
+        return atIndex > 0 && atIndex < trimmed.lastIndex && trimmed.substring(atIndex + 1).contains('.')
+    }
+
     // ── List Management (#315 / #476 / #477) ─────────────────────────────────
 
-    private fun normalizeListName(raw: String): String = when (raw.lowercase().trim()) {
-        "grocery list", "groceries", "grocery" -> "shopping list"
-        "todo", "to do", "todos", "to-do" -> "to-do list"
-        else -> raw.lowercase().trim()
+    private fun normalizeListName(raw: String): String {
+        val trimmed = raw.lowercase().trim()
+        val alias = trimmed.removePrefix("my ").removePrefix("the ")
+        return when (alias) {
+            "shopping", "shopping list", "grocery list", "groceries", "grocery" -> "shopping list"
+            "todo", "to do", "todos", "to-do", "to-do list" -> "to-do list"
+            else -> trimmed
+        }
     }
 
     private fun addToList(params: Map<String, String>): SkillResult {
-        val item = params["item"] ?: return SkillResult.Failure("add_to_list", "No item specified")
-        val raw = (params["list_name"] ?: "shopping list").lowercase().trim()
-        val listName = normalizeListName(raw)
+        val item = params["item"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("add_to_list", "No item specified")
+        val raw = params["list_name"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("add_to_list", "No list name specified")
+        val listName = normalizeListName(raw.lowercase())
         val items = runBlocking {
             listNameDao.insert(ListNameEntity(name = listName))
             listItemDao.insert(ListItemEntity(listName = listName, item = item))
@@ -1511,7 +1529,7 @@ class NativeIntentHandler @Inject constructor(
 
     private fun createList(params: Map<String, String>): SkillResult {
         val raw = params["list_name"] ?: return SkillResult.Failure("create_list", "No list name specified")
-        val name = raw.lowercase().trim()
+        val name = normalizeListName(raw)
         runBlocking { listNameDao.insert(ListNameEntity(name = name)) }
         return SkillResult.DirectReply(
             "Created list \"$name\".",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1438,26 +1438,44 @@ class NativeIntentHandler @Inject constructor(
     /** Resolves a contact name to an email address. Only pre-populates on unique match. */
     private fun resolveContactEmail(name: String): String? {
         return try {
-            val uri = ContactsContract.CommonDataKinds.Email.CONTENT_URI
-            val projection = arrayOf(
-                ContactsContract.CommonDataKinds.Email.ADDRESS,
-                ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY,
-            )
-            val selection = "${ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY} LIKE ?"
-            val selectionArgs = arrayOf("%$name%")
-            context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
-                val matches = mutableListOf<String>()
-                while (cursor.moveToNext()) {
-                    val address = cursor.getString(
-                        cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS)
+            val aliasMatch = runBlocking { contactAliasRepository.getByAlias(name) }
+            if (aliasMatch != null) {
+                val aliasEmails = queryContactEmails(
+                    selection = "${ContactsContract.CommonDataKinds.Email.CONTACT_ID} = ?",
+                    selectionArgs = arrayOf(aliasMatch.contactId),
+                ).distinct()
+                when (aliasEmails.size) {
+                    1 -> {
+                        Log.d(TAG, "Email resolved via alias '$name' → ${aliasEmails[0]}")
+                        return aliasEmails[0]
+                    }
+                    0 -> Log.d(TAG, "Alias '${aliasMatch.alias}' found but no email found for contactId=${aliasMatch.contactId}")
+                    else -> {
+                        Log.d(TAG, "Alias '${aliasMatch.alias}' resolved to multiple emails — not pre-populating")
+                        return null
+                    }
+                }
+            }
+
+            val nameLookups = buildList {
+                add(name)
+                aliasMatch?.displayName
+                    ?.takeIf { it.isNotBlank() && !it.equals(name, ignoreCase = true) }
+                    ?.let(::add)
+            }
+
+            val matches = nameLookups
+                .flatMap { lookupName ->
+                    queryContactEmails(
+                        selection = "${ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY} LIKE ?",
+                        selectionArgs = arrayOf("%$lookupName%"),
                     )
-                    if (!address.isNullOrBlank()) matches += address
                 }
-                when (matches.size) {
-                    0 -> { Log.d(TAG, "No email found for '$name'"); null }
-                    1 -> { Log.d(TAG, "Email resolved: '$name' → ${matches[0]}"); matches[0] }
-                    else -> { Log.d(TAG, "Multiple emails match '$name' — not pre-populating"); null }
-                }
+                .distinct()
+            when (matches.size) {
+                0 -> { Log.d(TAG, "No email found for '$name'"); null }
+                1 -> { Log.d(TAG, "Email resolved: '$name' → ${matches[0]}"); matches[0] }
+                else -> { Log.d(TAG, "Multiple emails match '$name' — not pre-populating"); null }
             }
         } catch (e: SecurityException) {
             Log.w(TAG, "READ_CONTACTS permission not granted — cannot resolve email for '$name'", e)
@@ -1466,6 +1484,27 @@ class NativeIntentHandler @Inject constructor(
             Log.w(TAG, "Email lookup failed for '$name'", e)
             null
         }
+    }
+
+    private fun queryContactEmails(
+        selection: String,
+        selectionArgs: Array<String>,
+    ): List<String> {
+        val uri = ContactsContract.CommonDataKinds.Email.CONTENT_URI
+        val projection = arrayOf(
+            ContactsContract.CommonDataKinds.Email.ADDRESS,
+            ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY,
+        )
+        return context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
+            buildList {
+                while (cursor.moveToNext()) {
+                    val address = cursor.getString(
+                        cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS),
+                    )
+                    if (!address.isNullOrBlank()) add(address)
+                }
+            }
+        }.orEmpty()
     }
 
     private fun looksLikeEmailAddress(raw: String): Boolean {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
@@ -8,6 +8,11 @@ sealed class SlotFillResult {
         val params: Map<String, String>,
     ) : SlotFillResult()
 
+    /** Another required slot is still missing — keep collecting. */
+    data class NeedsMore(
+        val request: PendingSlotRequest,
+    ) : SlotFillResult()
+
     /** User sent a blank reply or explicitly cancelled. */
     data object Cancelled : SlotFillResult()
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
@@ -1,10 +1,11 @@
 package com.kernel.ai.core.skills.slot
 
+import com.kernel.ai.core.skills.QuickIntentRouter
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * State machine that manages multi-turn slot-filling for quick intents.
+ * State machine that manages multi-turn slot-filling for quick intents in conversation mode.
  *
  * **Flow:**
  * 1. [QuickIntentRouter.route] returns [QuickIntentRouter.RouteResult.NeedsSlot] when a
@@ -13,8 +14,9 @@ import javax.inject.Singleton
  *    [PendingSlotRequest.promptMessage] as an assistant bubble.
  * 3. On the user's next message, [ChatViewModel] detects [hasPending] and calls
  *    [onUserReply] *instead* of routing to QIR or the LLM.
- * 4. [onUserReply] returns [SlotFillResult.Completed] with the merged params, or
- *    [SlotFillResult.Cancelled] if the user sent a blank reply.
+ * 4. [onUserReply] merges the reply, asks [QuickIntentRouter.nextMissingSlot], and either
+ *    returns [SlotFillResult.NeedsMore] with the next prompt or [SlotFillResult.Completed]
+ *    with the fully merged params.
  * 5. [ChatViewModel] executes the completed intent exactly as it would a direct QIR match.
  *
  * This class is a `@Singleton` so it survives configuration changes alongside ChatViewModel.
@@ -22,38 +24,63 @@ import javax.inject.Singleton
  * is a recoverable UX edge case (user simply re-asks).
  */
 @Singleton
-class SlotFillerManager @Inject constructor() {
+class SlotFillerManager @Inject constructor(
+    private val quickIntentRouter: QuickIntentRouter,
+ ) {
 
-    private var _pendingRequest: PendingSlotRequest? = null
+    private val pendingRequests = mutableMapOf<String, PendingSlotRequest>()
 
-    val hasPending: Boolean get() = _pendingRequest != null
+    val hasPending: Boolean get() = pendingRequests.isNotEmpty()
 
-    val pendingRequest: PendingSlotRequest? get() = _pendingRequest
+    fun hasPendingFor(conversationId: String): Boolean = pendingRequests.containsKey(conversationId)
 
-    fun startSlotFill(request: PendingSlotRequest) {
-        _pendingRequest = request
+    val pendingRequest: PendingSlotRequest? get() = pendingRequests.values.firstOrNull()
+
+    fun pendingRequestFor(conversationId: String): PendingSlotRequest? = pendingRequests[conversationId]
+
+    fun startSlotFill(conversationId: String, request: PendingSlotRequest) {
+        pendingRequests[conversationId] = request
     }
+
 
     /**
      * Called with the user's reply when a slot fill is in progress.
      *
-     * @return [SlotFillResult.Completed] with all params merged, or
+     * @return [SlotFillResult.Completed] with all params merged when the slot contract is
+     *         satisfied, [SlotFillResult.NeedsMore] when another required slot remains, or
      *         [SlotFillResult.Cancelled] if [message] is blank.
      */
-    fun onUserReply(message: String): SlotFillResult {
-        val pending = _pendingRequest ?: return SlotFillResult.Cancelled
-        _pendingRequest = null
-        return if (message.isBlank()) {
-            SlotFillResult.Cancelled
+    fun onUserReply(conversationId: String, message: String): SlotFillResult {
+        val pending = pendingRequests[conversationId] ?: return SlotFillResult.Cancelled
+        val normalizedMessage = normalizeSlotReply(message, pending.missingSlot.name)
+        if (normalizedMessage.isBlank()) {
+            pendingRequests.remove(conversationId)
+            return SlotFillResult.Cancelled
+        }
+
+        val mergedParams = pending.existingParams + mapOf(pending.missingSlot.name to normalizedMessage)
+        val nextMissingSlot = quickIntentRouter.nextMissingSlot(
+            intentName = pending.intentName,
+            params = mergedParams,
+        )
+        return if (nextMissingSlot != null) {
+            val nextRequest = PendingSlotRequest(
+                intentName = pending.intentName,
+                existingParams = mergedParams,
+                missingSlot = nextMissingSlot,
+            )
+            pendingRequests[conversationId] = nextRequest
+            SlotFillResult.NeedsMore(nextRequest)
         } else {
+            pendingRequests.remove(conversationId)
             SlotFillResult.Completed(
                 intentName = pending.intentName,
-                params = pending.existingParams + mapOf(pending.missingSlot.name to message.trim()),
+                params = mergedParams,
             )
         }
     }
 
     fun cancel() {
-        _pendingRequest = null
+        pendingRequests.clear()
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
@@ -14,3 +14,29 @@ data class SlotSpec(
     fun buildPrompt(existingParams: Map<String, String>): String =
         existingParams.entries.fold(promptTemplate) { acc, (k, v) -> acc.replace("{$k}", v) }
 }
+
+
+fun normalizeSlotReply(text: String, slotName: String): String {
+    val trimmed = text.trim()
+    if (trimmed.isBlank()) return trimmed
+
+    return when (slotName.lowercase()) {
+        "contact" -> trimmed.replace(Regex("^(?:to|for)\\s+", RegexOption.IGNORE_CASE), "").trim()
+        "list_name" -> normalizeListSlotReply(trimmed)
+        else -> trimmed
+    }
+}
+
+private fun normalizeListSlotReply(trimmed: String): String {
+    val genericAlias = Regex(
+        "^(?:(?:to|on|onto|in|into)\\s+)?(?:(?:my|the)\\s+)?(shopping|grocery|groceries|todo|to do|to-do)(?:\\s+list)?$",
+        RegexOption.IGNORE_CASE,
+    ).matchEntire(trimmed)
+    return genericAlias?.groupValues?.get(1)?.lowercase()?.let(::canonicalGenericListAlias) ?: trimmed
+}
+
+private fun canonicalGenericListAlias(alias: String): String = when (alias) {
+    "shopping", "grocery", "groceries" -> "shopping list"
+    "todo", "to do", "to-do" -> "to-do list"
+    else -> alias
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
@@ -31,4 +31,58 @@ class QuickIntentRouterListRoutingTest {
         assertEquals("get_list_items", match.intent.intentName)
         assertEquals("shopping", match.intent.params["list_name"])
     }
+
+    @Test
+    fun `routes add bread to my list as missing list slot`() {
+        val result = router.route("add bread to my list")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("bread", match.intent.params["item"])
+        assertEquals("list_name", match.missingSlot.name)
+    }
+
+    @Test
+    fun `routes add to explicit shopping list with trailing please`() {
+        val result = router.route("add milk to my shopping list please")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("milk", match.intent.params["item"])
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+
+    @Test
+    fun `routes add to explicit shopping list with trailing punctuation`() {
+        val result = router.route("add milk to my shopping list.")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("milk", match.intent.params["item"])
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+
+    @Test
+    fun `routes add to explicit shopping list with comma please`() {
+        val result = router.route("add milk to my shopping list, please")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("milk", match.intent.params["item"])
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+
+    @Test
+    fun `routes put to explicit shopping list with comma please`() {
+        val result = router.route("put milk on my shopping list, please")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("milk", match.intent.params["item"])
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
+
+    @Test
+    fun `routes informal add to explicit shopping list with comma please`() {
+        val result = router.route("chuck milk on my shopping list, please")
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("milk", match.intent.params["item"])
+        assertEquals("shopping", match.intent.params["list_name"])
+    }
 }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1039,6 +1039,17 @@ class QuickIntentRouterTest {
             val hybridResult = hybridRouter.route(input)
             assertClassifierOrFallthrough(hybridResult, "make_call", input)
         }
+
+        @ParameterizedTest(name = "NeedsSlot no-contact: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#makeCallNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare call phrases missing contact`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("make_call", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     @Nested
@@ -1076,6 +1087,18 @@ class QuickIntentRouterTest {
             assertEquals("send_sms", needsSlot.intent.intentName, "intent for '$input'")
             assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
+
+        @ParameterizedTest(name = "NeedsSlot placeholder-contact: \"{0}\" → message={1}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendSmsPlaceholderContactNeedsSlotPhrases")
+        fun `should return NeedsSlot for sms phrases with placeholder recipient`(input: String, expectedMessage: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_sms", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedMessage, needsSlot.intent.params["message"], "message for '$input'")
+            assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
     }
 
     @Nested
@@ -1102,6 +1125,18 @@ class QuickIntentRouterTest {
             assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
 
+        @ParameterizedTest(name = "NeedsSlot placeholder-contact: \"{0}\" → subject={1}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendEmailPlaceholderContactNeedsSlotPhrases")
+        fun `should return NeedsSlot for email phrases with placeholder recipient`(input: String, expectedSubject: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_email", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedSubject, needsSlot.intent.params["subject"], "subject for '$input'")
+            assertEquals("contact", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
+
         @ParameterizedTest(name = "NeedsSlot contact/no-subject: \"{0}\" → contact={1}")
         @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendEmailContactNoSubjectNeedsSlotPhrases")
         fun `should return NeedsSlot for email phrases with contact but missing subject`(
@@ -1114,6 +1149,21 @@ class QuickIntentRouterTest {
             assertEquals("send_email", needsSlot.intent.intentName, "intent for '$input'")
             assertEquals(expectedContact, needsSlot.intent.params["contact"], "contact for '$input'")
             assertEquals("subject", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
+
+        @ParameterizedTest(name = "NeedsSlot subject/no-body: \"{0}\" → contact={1}, subject={2}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#sendEmailContactSubjectNoBodyNeedsSlotPhrases")
+        fun `should return NeedsSlot for email phrases with contact and subject but missing body`(
+            input: String, expectedContact: String, expectedSubject: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("send_email", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedContact, needsSlot.intent.params["contact"], "contact for '$input'")
+            assertEquals(expectedSubject, needsSlot.intent.params["subject"], "subject for '$input'")
+            assertEquals("body", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
     }
 
@@ -1158,6 +1208,18 @@ class QuickIntentRouterTest {
         }
     }
 
+        @ParameterizedTest(name = "NeedsSlot no-list: \"{0}\" → item={1}")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#addToListMissingListNeedsSlotPhrases")
+        fun `should return NeedsSlot for add-to-list phrases missing list name`(input: String, expectedItem: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("add_to_list", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals(expectedItem, needsSlot.intent.params["item"], "item for '$input'")
+            assertEquals("list_name", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
+
     @Nested
     @DisplayName("Create List")
     inner class CreateList {
@@ -1171,6 +1233,17 @@ class QuickIntentRouterTest {
             assertEquals(expectedList, intent.params["list_name"], "list_name for '$input'")
         }
     }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#createListNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare create-list phrases missing list name`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("create_list", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("list_name", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
 
     @Nested
     @DisplayName("Get List Items")
@@ -1281,6 +1354,17 @@ class QuickIntentRouterTest {
             assertEquals(expectedContent, intent.params["content"], "content for '$input'")
         }
     }
+
+        @ParameterizedTest(name = "NeedsSlot: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#saveMemoryNeedsSlotPhrases")
+        fun `should return NeedsSlot for bare save-memory phrases missing content`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result,
+                "Expected NeedsSlot for '$input'")
+            val needsSlot = result as QuickIntentRouter.RouteResult.NeedsSlot
+            assertEquals("save_memory", needsSlot.intent.intentName, "intent for '$input'")
+            assertEquals("content", needsSlot.missingSlot.name, "missing slot for '$input'")
+        }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // BRIGHTNESS TESTS
@@ -1421,13 +1505,20 @@ class QuickIntentRouterTest {
         addCases(findNearbyRegexPhrases(), "find_nearby", "Find Nearby (regex)")
         addCases(findNearbyClassifierPhrases(), "find_nearby", "Find Nearby (classifier)")
         addCases(makeCallRegexPhrases(), "make_call", "Make Call (regex)")
+        addCases(makeCallNeedsSlotPhrases(), "make_call", "Make Call (needs slot)")
         addCases(makeCallClassifierPhrases(), "make_call", "Make Call (classifier)")
         addCases(sendSmsRegexPhrases(), "send_sms", "Send SMS (regex)")
         addCases(sendSmsNeedsSlotPhrases(), "send_sms", "Send SMS (needs slot)")
         addCases(sendEmailRegexPhrases(), "send_email", "Send Email (regex)")
+        addCases(sendEmailNoContactNeedsSlotPhrases(), "send_email", "Send Email (needs slot: contact)")
+        addCases(sendEmailContactNoSubjectNeedsSlotPhrases(), "send_email", "Send Email (needs slot: subject)")
+        addCases(sendEmailContactSubjectNoBodyNeedsSlotPhrases(), "send_email", "Send Email (needs slot: body)")
         addCases(addToListRegexPhrases(), "add_to_list", "Add to List (regex)")
+        addCases(addToListNeedsSlotPhrases(), "add_to_list", "Add to List (needs slot: item)")
+        addCases(addToListMissingListNeedsSlotPhrases(), "add_to_list", "Add to List (needs slot: list)")
         addCases(addToListClassifierPhrases(), "add_to_list", "Add to List (classifier)")
         addCases(createListRegexPhrases(), "create_list", "Create List (regex)")
+        addCases(createListNeedsSlotPhrases(), "create_list", "Create List (needs slot)")
         addCases(getListItemsRegexPhrases(), "get_list_items", "Get List Items (regex)")
         addCases(weatherCityRegexPhrases(), "get_weather", "Weather City (regex)")
         addCases(weatherGpsRegexPhrases(), "get_weather", "Weather GPS (regex)")
@@ -1437,6 +1528,7 @@ class QuickIntentRouterTest {
         addCases(weatherAqiRegexPhrases(), "get_weather", "Weather AQI (regex)")
         addCases(weatherSunriseRegexPhrases(), "get_weather", "Weather Sunrise/Sunset (regex)")
         addCases(saveMemoryRegexPhrases(), "save_memory", "Save Memory (regex)")
+        addCases(saveMemoryNeedsSlotPhrases(), "save_memory", "Save Memory (needs slot)")
         addCases(brightnessRegexPhrases(), "set_brightness", "Brightness (regex)")
         addCases(smartHomeOnRegexPhrases(), "smart_home_on", "Smart Home ON (regex)")
         addCases(smartHomeOnClassifierPhrases(), "smart_home_on", "Smart Home ON (classifier)")
@@ -2148,6 +2240,17 @@ class QuickIntentRouterTest {
         )
 
         @JvmStatic
+        fun makeCallNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("make a call"),
+            Arguments.of("call someone"),
+            Arguments.of("ring someone"),
+            Arguments.of("dial somebody"),
+            Arguments.of("phone anyone"),
+            Arguments.of("call anybody"),
+            Arguments.of("give somebody a call"),
+        )
+
+        @JvmStatic
         fun sendSmsRegexPhrases(): Stream<Arguments> = Stream.of(
             // Phrases that include a message body → full RegexMatch
             Arguments.of("text John saying hello", "John"),
@@ -2176,10 +2279,22 @@ class QuickIntentRouterTest {
         )
 
         @JvmStatic
+        fun sendSmsPlaceholderContactNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("text someone saying hello", "hello"),
+            Arguments.of("message somebody that I'll be late", "I'll be late"),
+        )
+
+        @JvmStatic
         fun sendEmailNoContactNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
-            // Bare send-email phrases — no contact → NeedsSlot(contact)
-            // Note: "email someone" captures "someone" as contact → NeedsSlot(subject) instead
+            // Bare send-email phrases — no concrete contact → NeedsSlot(contact)
             Arguments.of("send an email"),
+            Arguments.of("email someone"),
+        )
+
+        @JvmStatic
+        fun sendEmailPlaceholderContactNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("email someone about the meeting", "the meeting"),
+            Arguments.of("send an email to anybody regarding dinner plans", "dinner plans"),
         )
 
         @JvmStatic
@@ -2188,17 +2303,24 @@ class QuickIntentRouterTest {
             Arguments.of("send email to Dad", "Dad"),
             Arguments.of("send an email to the team", "the team"),
             Arguments.of("send email to HR", "HR"),
-            Arguments.of("email someone", "someone"),
+        )
+
+        @JvmStatic
+        fun sendEmailContactSubjectNoBodyNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            // Contact + subject present but body missing → NeedsSlot(body)
+            Arguments.of("email John about the meeting", "John", "the meeting"),
+            Arguments.of("send an email to Sarah regarding project update", "Sarah", "project update"),
+            Arguments.of("send an email to my boss about the project", "my boss", "the project"),
         )
 
         @JvmStatic
         fun sendEmailRegexPhrases(): Stream<Arguments> = Stream.of(
-            // Cases with a subject keyword — no NeedsSlot triggered
-            Arguments.of("email John about the meeting", "John"),
-            Arguments.of("send an email to Sarah about project update", "Sarah"),
-            Arguments.of("send an email to my boss about the project", "my boss"),
-            Arguments.of("email Nick about dinner plans", "Nick"),
-            Arguments.of("email Sarah regarding the report", "Sarah"),
+            // Cases with contact, subject, and body → full RegexMatch
+            Arguments.of("email John about the meeting body Please review the agenda", "John"),
+            Arguments.of("send an email to Sarah about project update body Can we talk tomorrow?", "Sarah"),
+            Arguments.of("send an email to my boss about the project body Draft is ready for review", "my boss"),
+            Arguments.of("email Nick about dinner plans body Want to eat at seven?", "Nick"),
+            Arguments.of("email Sarah regarding the report body I attached the latest version", "Sarah"),
         )
 
         // ── Lists ─────────────────────────────────────────────────────────────────
@@ -2253,7 +2375,17 @@ class QuickIntentRouterTest {
         @JvmStatic
         fun addToListNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("add to my list"),
-            Arguments.of("put something to my list"),
+            Arguments.of("add something to my list"),
+            Arguments.of("add something to shopping list"),
+            Arguments.of("put something on the list"),
+        )
+
+        @JvmStatic
+        fun addToListMissingListNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("add milk to my list", "milk"),
+            Arguments.of("add milk to list", "milk"),
+            Arguments.of("put eggs on the list", "eggs"),
+            Arguments.of("chuck bread on my list", "bread"),
         )
 
         @JvmStatic
@@ -2264,6 +2396,14 @@ class QuickIntentRouterTest {
             Arguments.of("make my chores list", "chores"),
             Arguments.of("create a meal plan list", "meal plan"),
             Arguments.of("new packing list", "packing"),
+        )
+
+        @JvmStatic
+        fun createListNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("create a list"),
+            Arguments.of("make a new list"),
+            Arguments.of("start my list"),
+            Arguments.of("new list"),
         )
 
         @JvmStatic
@@ -2392,6 +2532,14 @@ class QuickIntentRouterTest {
             Arguments.of("note that the gate code is 4567", "the gate code is 4567"),
             Arguments.of("don't forget that mum's birthday is March 3", "mum's birthday is March 3"),
             Arguments.of("store that my doctor is Dr Smith", "my doctor is Dr Smith"),
+        )
+
+        @JvmStatic
+        fun saveMemoryNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remember something"),
+            Arguments.of("save something to memory"),
+            Arguments.of("make a note"),
+            Arguments.of("take a note"),
         )
 
         // ── Brightness ───────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -13,8 +13,11 @@ import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.skills.SkillResult
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -33,12 +36,15 @@ class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
+    private val scheduledAlarmDao = mockk<ScheduledAlarmDao>(relaxed = true)
+    private val listItemDao = mockk<ListItemDao>(relaxed = true)
+    private val listNameDao = mockk<ListNameDao>(relaxed = true)
 
     private val handler = NativeIntentHandler(
         context = context,
-        scheduledAlarmDao = mockk<ScheduledAlarmDao>(relaxed = true),
-        listItemDao = mockk<ListItemDao>(relaxed = true),
-        listNameDao = mockk<ListNameDao>(relaxed = true),
+        scheduledAlarmDao = scheduledAlarmDao,
+        listItemDao = listItemDao,
+        listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
         memoryRepository = mockk<MemoryRepository>(relaxed = true),
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
@@ -51,6 +57,7 @@ class NativeIntentHandlerTest {
         every { Log.w(any<String>(), any<String>(), any()) } returns 0
         every { Log.e(any<String>(), any<String>(), any()) } returns 0
         every { context.contentResolver } returns contentResolver
+        every { context.startActivity(any()) } just Runs
     }
 
     @AfterEach
@@ -217,6 +224,135 @@ class NativeIntentHandlerTest {
 
         assertEquals(null, generic)
         assertEquals("Daft Punk", meaningful)
+    }
+
+    @Test
+    fun `send email fails fast when contact is missing`() {
+        val result = handler.handle(
+            "send_email",
+            mapOf(
+                "subject" to "Hello",
+                "body" to "World",
+            ),
+        )
+
+        assertEquals(
+            SkillResult.Failure("send_email", "No contact specified"),
+            result,
+        )
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `send email fails fast when body is missing`() {
+        val result = handler.handle(
+            "send_email",
+            mapOf(
+                "contact" to "Nick",
+                "subject" to "Hello",
+            ),
+        )
+
+        assertEquals(
+            SkillResult.Failure("send_email", "No body specified"),
+            result,
+        )
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+
+    @Test
+    fun `add to list fails fast when list name is missing`() {
+        val result = handler.handle(
+            "add_to_list",
+            mapOf("item" to "milk"),
+        )
+
+        assertEquals(
+            SkillResult.Failure("add_to_list", "No list name specified"),
+            result,
+        )
+        coVerify(exactly = 0) { listNameDao.insert(any()) }
+        coVerify(exactly = 0) { listItemDao.insert(any()) }
+    }
+
+    @Test
+    fun `shopping list aliases resolve to the same stored list`() {
+        coEvery { listItemDao.getByList("shopping list") } returnsMany
+            listOf(
+                emptyList(),
+                listOf(ListItemEntity(listName = "shopping list", item = "milk")),
+            )
+
+        val addResult = handler.handle(
+            "add_to_list",
+            mapOf(
+                "item" to "milk",
+                "list_name" to "shopping list",
+            ),
+        )
+        val readResult = handler.handle(
+            "get_list_items",
+            mapOf("list_name" to "shopping"),
+        )
+
+        assertEquals(
+            SkillResult.DirectReply(
+                "Added \"milk\" to your shopping list.",
+                presentation = addResult.let { (it as SkillResult.DirectReply).presentation },
+            ),
+            addResult,
+        )
+        assertEquals(
+            SkillResult.DirectReply(
+                "shopping list (1 item):\n• milk",
+                presentation = readResult.let { (it as SkillResult.DirectReply).presentation },
+            ),
+            readResult,
+        )
+        coVerify(exactly = 2) { listItemDao.getByList("shopping list") }
+    }
+
+    @Test
+    fun `create list shares canonical shopping alias with add and get`() {
+        coEvery { listItemDao.getByList("shopping list") } returnsMany
+            listOf(
+                emptyList(),
+                listOf(ListItemEntity(listName = "shopping list", item = "milk")),
+            )
+
+        val createResult = handler.handle(
+            "create_list",
+            mapOf("list_name" to "shopping"),
+        )
+        handler.handle(
+            "add_to_list",
+            mapOf(
+                "item" to "milk",
+                "list_name" to "shopping list",
+            ),
+        )
+        val readResult = handler.handle(
+            "get_list_items",
+            mapOf("list_name" to "shopping"),
+        )
+
+        assertEquals(
+            SkillResult.DirectReply(
+                "Created list \"shopping list\".",
+                presentation = createResult.let { (it as SkillResult.DirectReply).presentation },
+            ),
+            createResult,
+        )
+        assertEquals(
+            SkillResult.DirectReply(
+                "shopping list (1 item):\n• milk",
+                presentation = readResult.let { (it as SkillResult.DirectReply).presentation },
+            ),
+            readResult,
+        )
+        coVerify(atLeast = 1) { listNameDao.insert(match { it.name == "shopping list" }) }
+        coVerify(exactly = 2) { listItemDao.getByList("shopping list") }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.media.AudioManager
+import android.net.Uri
 import android.provider.ContactsContract
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
@@ -13,6 +14,7 @@ import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
@@ -53,6 +55,17 @@ class NativeIntentHandlerTest {
     @BeforeEach
     fun setUp() {
         mockkStatic(Log::class)
+        mockkStatic(Uri::class)
+        every { Uri.encode(any()) } answers {
+            java.net.URLEncoder.encode(firstArg<String>(), java.nio.charset.StandardCharsets.UTF_8)
+                .replace("+", "%20")
+        }
+        every { Uri.parse(any()) } answers {
+            val raw = firstArg<String>()
+            mockk<Uri>(relaxed = true).also { uri ->
+                every { uri.toString() } returns raw
+            }
+        }
         every { Log.d(any<String>(), any<String>()) } returns 0
         every { Log.w(any<String>(), any<String>(), any()) } returns 0
         every { Log.e(any<String>(), any<String>(), any()) } returns 0
@@ -62,6 +75,7 @@ class NativeIntentHandlerTest {
 
     @AfterEach
     fun tearDown() {
+        unmockkStatic(Uri::class)
         unmockkStatic(Log::class)
     }
 
@@ -244,20 +258,78 @@ class NativeIntentHandlerTest {
     }
 
     @Test
-    fun `send email fails fast when body is missing`() {
-        val result = handler.handle(
-            "send_email",
-            mapOf(
-                "contact" to "Nick",
-                "subject" to "Hello",
+    fun `resolveContactEmail uses alias contact id when available`() {
+        coEvery { contactAliasRepository.getByAlias("My wife") } returns
+            ContactAliasEntity(
+                alias = "wife",
+                displayName = "Alice Smith",
+                contactId = "42",
+                phoneNumber = "021111222",
+            )
+        every {
+            contentResolver.query(
+                ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                any(),
+                "${ContactsContract.CommonDataKinds.Email.CONTACT_ID} = ?",
+                match<Array<String>> { it.contentEquals(arrayOf("42")) },
+                null,
+            )
+        } returns emailCursor(
+            EmailRow(
+                address = "alice@example.com",
+                displayName = "Alice Smith",
             ),
         )
 
-        assertEquals(
-            SkillResult.Failure("send_email", "No body specified"),
-            result,
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveContactEmail",
+            String::class.java,
+        ).apply { isAccessible = true }
+        val resolved = method.invoke(handler, "My wife") as String?
+
+        assertEquals("alice@example.com", resolved)
+    }
+
+    @Test
+    fun `resolveContactEmail falls back to alias display name when contact id has no email`() {
+        coEvery { contactAliasRepository.getByAlias("My wife") } returns
+            ContactAliasEntity(
+                alias = "wife",
+                displayName = "Alice Smith",
+                contactId = "42",
+                phoneNumber = "021111222",
+            )
+        every {
+            contentResolver.query(
+                ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                any(),
+                "${ContactsContract.CommonDataKinds.Email.CONTACT_ID} = ?",
+                match<Array<String>> { it.contentEquals(arrayOf("42")) },
+                null,
+            )
+        } returns emailCursor()
+        every {
+            contentResolver.query(
+                ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                any(),
+                "${ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY} LIKE ?",
+                match<Array<String>> { it.contentEquals(arrayOf("%Alice Smith%")) },
+                null,
+            )
+        } returns emailCursor(
+            EmailRow(
+                address = "alice@example.com",
+                displayName = "Alice Smith",
+            ),
         )
-        verify(exactly = 0) { context.startActivity(any()) }
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveContactEmail",
+            String::class.java,
+        ).apply { isAccessible = true }
+        val resolved = method.invoke(handler, "My wife") as String?
+
+        assertEquals("alice@example.com", resolved)
     }
 
 
@@ -404,6 +476,11 @@ class NativeIntentHandlerTest {
         val phoneType: Int = ContactsContract.CommonDataKinds.Phone.TYPE_OTHER,
     )
 
+    private data class EmailRow(
+        val address: String,
+        val displayName: String,
+    )
+
     private fun phoneCursor(vararg rows: PhoneRow): Cursor {
         val cursor = mockk<Cursor>()
         val columns = mapOf(
@@ -429,6 +506,28 @@ class NativeIntentHandlerTest {
         every { cursor.getInt(3) } answers { if (rows[index].isPrimary) 1 else 0 }
         every { cursor.getInt(4) } answers { if (rows[index].isSuperPrimary) 1 else 0 }
         every { cursor.getInt(5) } answers { rows[index].phoneType }
+        every { cursor.close() } just Runs
+
+        return cursor
+    }
+
+    private fun emailCursor(vararg rows: EmailRow): Cursor {
+        val cursor = mockk<Cursor>()
+        val columns = mapOf(
+            ContactsContract.CommonDataKinds.Email.ADDRESS to 0,
+            ContactsContract.CommonDataKinds.Email.DISPLAY_NAME_PRIMARY to 1,
+        )
+        var index = -1
+
+        every { cursor.moveToNext() } answers {
+            index += 1
+            index < rows.size
+        }
+        every { cursor.getColumnIndexOrThrow(any()) } answers {
+            columns[firstArg<String>()] ?: error("Unknown column ${firstArg<String>()}")
+        }
+        every { cursor.getString(0) } answers { rows[index].address }
+        every { cursor.getString(1) } answers { rows[index].displayName }
         every { cursor.close() } just Runs
 
         return cursor

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -1,0 +1,282 @@
+package com.kernel.ai.core.skills.slot
+
+import com.kernel.ai.core.skills.QuickIntentRouter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SlotFillerManagerTest {
+    private lateinit var manager: SlotFillerManager
+
+    private val conversationOne = "conv-1"
+    private val conversationTwo = "conv-2"
+
+    @BeforeEach
+    fun setUp() {
+        manager = SlotFillerManager(QuickIntentRouter())
+    }
+
+    @Test
+    fun `send email chains contact subject and body before completion`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "send_email",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            ),
+        )
+
+        val first = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "to Nick"),
+        )
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertEquals("subject", first.request.missingSlot.name)
+        assertEquals(
+            "What's the subject of your email to Nick?",
+            first.request.promptMessage,
+        )
+
+        val second = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "Weekend plans"),
+        )
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertEquals("body", second.request.missingSlot.name)
+        assertEquals(
+            "What would you like the email to say?",
+            second.request.promptMessage,
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "Let's catch up on Saturday"),
+        )
+        assertFalse(manager.hasPending)
+        assertEquals(
+            mapOf(
+                "contact" to "Nick",
+                "subject" to "Weekend plans",
+                "body" to "Let's catch up on Saturday",
+            ),
+            completed.params,
+        )
+    }
+
+    @Test
+    fun `pending slot fill is scoped to its originating conversation`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "send_email",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            ),
+        )
+
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertFalse(manager.hasPendingFor(conversationTwo))
+        assertNull(manager.pendingRequestFor(conversationTwo))
+
+        val wrongConversationResult = manager.onUserReply(conversationTwo, "Nick")
+
+        assertInstanceOf(SlotFillResult.Cancelled::class.java, wrongConversationResult)
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertEquals("contact", manager.pendingRequestFor(conversationOne)?.missingSlot?.name)
+    }
+
+    @Test
+    fun `starting a second conversation slot fill preserves the first one`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "send_email",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            ),
+        )
+        manager.startSlotFill(
+            conversationTwo,
+            PendingSlotRequest(
+                intentName = "add_to_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "item",
+                    promptTemplate = "What would you like to add?",
+                ),
+            ),
+        )
+
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertTrue(manager.hasPendingFor(conversationTwo))
+        assertEquals("contact", manager.pendingRequestFor(conversationOne)?.missingSlot?.name)
+        assertEquals("item", manager.pendingRequestFor(conversationTwo)?.missingSlot?.name)
+    }
+
+    @Test
+    fun `add to list asks for list name after item reply`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_to_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "item",
+                    promptTemplate = "What would you like to add?",
+                ),
+            ),
+        )
+
+        val next = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "milk"),
+        )
+        assertTrue(manager.hasPendingFor(conversationOne))
+        assertEquals("list_name", next.request.missingSlot.name)
+        assertEquals("Which list should I add it to?", next.request.promptMessage)
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "on my shopping list"),
+        )
+        assertFalse(manager.hasPending)
+        assertEquals(
+            mapOf(
+                "item" to "milk",
+                "list_name" to "shopping list",
+            ),
+            completed.params,
+        )
+    }
+
+    @Test
+    fun `create list preserves leading words in legitimate list names`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "create_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "What would you like to call the list?",
+                ),
+            ),
+        )
+
+        val titled = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "The Boys"),
+        )
+        assertEquals("The Boys", titled.params["list_name"])
+
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "create_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "What would you like to call the list?",
+                ),
+            ),
+        )
+
+        val todo = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "to do list"),
+        )
+        assertEquals("to-do list", todo.params["list_name"])
+    }
+
+    @Test
+    fun `generic shopping list replies normalize without mangling named lists`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_to_list",
+                existingParams = mapOf("item" to "milk"),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "Which list should I add it to?",
+                ),
+            ),
+        )
+
+        val possessive = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "my shopping list"),
+        )
+        assertEquals("shopping list", possessive.params["list_name"])
+
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_to_list",
+                existingParams = mapOf("item" to "milk"),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "Which list should I add it to?",
+                ),
+            ),
+        )
+
+        val article = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "the shopping list"),
+        )
+        assertEquals("shopping list", article.params["list_name"])
+
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "create_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "What would you like to call the list?",
+                ),
+            ),
+        )
+
+        val named = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "My Tasks"),
+        )
+        assertEquals("My Tasks", named.params["list_name"])
+    }
+
+    @Test
+    fun `blank reply cancels and clears pending request`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "send_sms",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "contact",
+                    promptTemplate = "Who do you want to send a message to?",
+                ),
+            ),
+        )
+
+        val result = manager.onUserReply(conversationOne, "   ")
+
+        assertInstanceOf(SlotFillResult.Cancelled::class.java, result)
+        assertFalse(manager.hasPending)
+        assertNull(manager.pendingRequest)
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -339,20 +339,44 @@ best-matching intent wins if it clears both a confidence floor and an ambiguity 
 
 If the classifier is absent or returns `null`, the input falls through to Stage 3 (Gemma-4 E4B).
 
-**QIR + Slot-filling state machine:**
+**Actions-tab deterministic slot-fill loop:**
 
-The combined QIR/slot-filling pipeline is a four-state machine managed by `SlotFillerManager`
-(`@Singleton`, survives configuration changes):
+For quick actions, pending slot state lives inside `ActionsViewModel`, not a shared
+`SlotFillerManager` singleton. `executeAction()` reacts to `QuickIntentRouter.RouteResult`
+like this:
 
-| State | Condition | Next states |
-|-------|-----------|-------------|
-| `IDLE` | `SlotFillerManager.hasPending = false`; no intent in flight | → `RESOLVED` (regex/classifier match with all params) · → `COLLECTING` (match but missing slot) · → `FAILED` (FallThrough) |
-| `COLLECTING` | `RouteResult.NeedsSlot` returned; `hasPending = true`; assistant has asked user for missing slot | → `RESOLVED` (user supplies non-blank reply) · → `FAILED` (user sends blank reply) |
-| `RESOLVED` | `SlotFillResult.Completed` or direct `RegexMatch`/`ClassifierMatch` with all params present; intent dispatched | → `IDLE` (after dispatch) |
-| `FAILED` | `RouteResult.FallThrough` (no match) or `SlotFillResult.Cancelled` (blank user reply) | → `IDLE` (falls through to Gemma-4 for FallThrough; slot is abandoned for Cancelled) |
+1. `RegexMatch` / `ClassifierMatch` with complete params → execute immediately.
+2. `NeedsSlot` → call `primePendingSlot(...)` and show the missing-slot prompt.
+3. `FallThrough` → hand off to chat.
 
-> **Note:** State is not persisted across process death. An interrupted slot fill is a
-> recoverable UX edge case — the user simply re-asks.
+When a slot reply arrives, `onSlotReply()` merges the reply into the accumulated params,
+calls `quickIntentRouter.nextMissingSlot(intentName, mergedParams)`, and then either:
+
+- prompts for the next missing required slot if one remains
+- clears pending state and executes only when all required slots are present
+- cancels on a blank reply via `cancelSlotFill()`
+
+Current deterministic slot-fill coverage in this sprint is:
+
+| Intent | Required slots |
+|--------|----------------|
+| `set_alarm` | `time` |
+| `set_timer` | `duration_seconds` |
+| `open_app` | `app_name` |
+| `navigate_to` | `destination` |
+| `find_nearby` | `query` |
+| `send_sms` | `contact`, `message` |
+| `send_email` | `contact`, `subject`, `body` |
+| `add_to_list` | `item`, `list_name` |
+| `make_call` | `contact` |
+| `save_memory` | `content` |
+| `create_list` | `list_name` |
+
+`add_to_list` has no implicit default shopping-list fallback in this slot contract.
+This sprint explicitly excludes weather/forecast, `create_calendar_event`,
+`remove_from_list`, and zero-slot toggles/media controls from multi-turn slot
+continuation. Weather/forecast stays single-turn because the existing weather path already
+has safe defaults, including current-location behavior and optional forecast fields.
 
 | Pattern | Action | OS API |
 |---------|--------|--------|
@@ -434,6 +458,11 @@ so `ChatViewModel` can attach tool call metadata to the UI. A `ToolCallExtractor
 fallback exists for edge cases where the model emits raw JSON outside the SDK path.
 
 **Registered `run_intent` intents:**
+
+> This is the broader native-tool inventory. The current deterministic quick-action
+> slot-fill sprint only locks `set_alarm`, `set_timer`, `open_app`, `navigate_to`,
+> `find_nearby`, `send_sms`, `send_email`, `add_to_list`, `make_call`, `save_memory`,
+> and `create_list`.
 
 | `intent_name` | Action | OS API | Status |
 |---------------|--------|--------|--------|

--- a/docs/research/multi-turn-phase2-spec.md
+++ b/docs/research/multi-turn-phase2-spec.md
@@ -1,892 +1,152 @@
 # Multi-Turn Dialog Management — Phase 2 Technical Specification
-
 > **Issue:** [#522](https://github.com/NickMonrad/kernel-ai-assistant/issues/522)
-> **Supersedes:** Phase 1 spike (#493, PR #517) — single slot-fill loop for `send_sms`
-> **Status:** Draft
-> **Last updated:** 2026-04-17
+> **Status:** Narrowed to the current deterministic quick-action slot-fill sprint
+> **Last updated:** 2026-05-01
 
 ---
 
-## Table of Contents
+## 1. Purpose
 
-1. [Executive Summary](#1-executive-summary)
-2. [Architecture Overview](#2-architecture-overview)
-3. [Dialog Flows](#3-dialog-flows)
-4. [Data Model](#4-data-model)
-5. [ChatViewModel Integration](#5-chatviewmodel-integration)
-6. [UI Changes](#6-ui-changes)
-7. [Scope & Non-Goals](#7-scope--non-goals)
-8. [Test Cases](#8-test-cases)
-9. [Migration from Phase 1](#9-migration-from-phase-1)
-10. [Open Questions](#10-open-questions)
+This document replaces the earlier broad Phase 2 proposal with the smaller slice that is
+actually being implemented in the current sprint.
 
----
+Current implementation anchors:
+- `core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt`
+- `feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt`
 
-## 1. Executive Summary
+For this sprint:
+- `QuickIntentRouter` owns the required-slot contracts and returns
+  `RouteResult.NeedsSlot(intent, missingSlot)` when a required value is absent or blank.
+- `ActionsViewModel` owns pending quick-action slot state locally via `_pendingSlot`; the
+  Actions tab does not use a singleton `SlotFillerManager` or a new `DialogManager`.
+- `ActionsViewModel.onSlotReply()` merges each reply into the pending params, asks
+  `quickIntentRouter.nextMissingSlot(...)` for the next missing required slot, and only
+  executes once the slot contract is complete.
+- Blank slot replies cancel the pending action through `cancelSlotFill()`; they do not
+  execute partial intents.
 
-Phase 1 proved the core slot-filling loop: `QuickIntentRouter` returns `NeedsSlot` →
-`SlotFillerManager` holds the pending intent → user replies → intent executes. This worked
-for the single-slot `send_sms` case but has fundamental limitations:
-
-- **Single slot only** — can't chain two missing slots (e.g. SMS missing both recipient and body)
-- **No disambiguation** — if "Bob" matches two contacts, there's no way to ask which one
-- **No confirmation** — destructive actions (send email, delete alarm) execute immediately
-- **No error recovery** — skill failures are reported but offer no retry/fallback path
-- **No anaphoric context** — "call him" or "do it again" can't resolve against recent intents
-
-Phase 2 replaces `SlotFillerManager` with **`DialogManager`** — a general-purpose
-multi-turn state machine that handles all five dialog flows through a single unified
-processing pipeline. The existing `SlotFillerManager` API surface is preserved as a
-thin shim during migration, then removed.
-
-### Design Principles
-
-1. **Single entry point** — `DialogManager.process(userMessage)` is the only call
-   `ChatViewModel` needs to make. It returns a `DialogDecision` (execute / ask / cancel).
-2. **State, not strategy** — all flows share the same state machine; the *type* of the
-   pending action determines which transitions are valid, not a separate class hierarchy.
-3. **Timeout by turns, not wall-clock** — if the user sends 3 unrelated messages without
-   answering the clarifying question, the pending dialog is silently abandoned.
-4. **Chip-first UX** — whenever the system asks a question, it provides tappable chips so
-   the user rarely needs to free-type an answer.
-5. **QIR bypass preserved** — `QuickIntentRouter` is not modified. `DialogManager` sits
-   *between* QIR and execution, intercepting `RouteResult.NeedsSlot` and the new
-   `NeedsDisambiguation` / `NeedsConfirmation` results.
+This document describes only that deterministic quick-action flow. It does not claim that
+confirmation, disambiguation, anaphora, timeout counters, or error-recovery state machines
+already exist for the Actions tab.
 
 ---
 
-## 2. Architecture Overview
+## 2. Current Flow
 
-### 2.1 Call Graph (Phase 2)
+### 2.1 Entry from QuickIntentRouter
 
+`ActionsViewModel.executeAction()` routes the normalized query through
+`QuickIntentRouter.route()`.
+
+- `RegexMatch` / `ClassifierMatch` with all required params present → execute immediately.
+- `NeedsSlot` → store a `PendingSlotState` locally and show the missing-slot prompt in the
+  Actions sheet.
+- `FallThrough` → hand off to chat.
+
+### 2.2 Slot continuation
+
+`ActionsViewModel.onSlotReply()` now supports true multi-slot continuation for the reviewed
+quick actions:
+
+1. Read the current `PendingSlotState`.
+2. Normalize the reply (voice replies still go through the existing slot-specific normalizer).
+3. Merge the reply into the accumulated params for the current missing slot.
+4. Call `quickIntentRouter.nextMissingSlot(intentName, mergedParams)`.
+5. If another required slot is still missing, prime `_pendingSlot` again with the merged
+   params and the next missing slot prompt.
+6. If no required slot remains, clear `_pendingSlot` and execute the intent.
+
+This is the whole contract for the sprint: after every reply, ask for the next missing
+required slot until the contract is satisfied.
+
+### 2.3 Example: `send_email`
+
+```text
+User:  "Send an email"
+QIR:   NeedsSlot(intent=send_email, missingSlot=contact)
+
+Assistant: "Who would you like to email?"
+User:      "Alice"
+
+Assistant: "What's the subject of your email to Alice?"
+User:      "Meeting tomorrow"
+
+Assistant: "What would you like the email to say?"
+User:      "Please review the agenda before 9."
+
+Result: execute `send_email` with
+        { contact: "Alice", subject: "Meeting tomorrow", body: "Please review the agenda before 9." }
 ```
-User message
-     │
-     ▼
-ChatViewModel.sendMessage(text)
-     │
-     ├─── DialogManager.process(text) ◄── NEW: single entry point
-     │         │
-     │         ├─ Has pending dialog?
-     │         │    YES → route reply to pending flow
-     │         │           → DialogDecision.Execute / .AskFollowUp / .Cancel
-     │         │    NO  → pass through (no dialog active)
-     │         │           → DialogDecision.PassThrough
-     │         │
-     │         └─ (anaphoric check on PassThrough — "call him", "do it again")
-     │              → DialogDecision.Execute (resolved) or PassThrough (no match)
-     │
-     ├─── [if PassThrough] QuickIntentRouter.route(text)
-     │         │
-     │         ├─ RegexMatch / ClassifierMatch
-     │         │    └─ DialogManager.evaluate(intent, skillResult?)
-     │         │         ├─ needs confirmation? → AskConfirmation
-     │         │         ├─ needs disambiguation? → AskDisambiguation
-     │         │         └─ ready → Execute
-     │         │
-     │         ├─ NeedsSlot
-     │         │    └─ DialogManager.startSlotFill(intent, missingSlot)
-     │         │         → AskFollowUp (slot question + chips)
-     │         │
-     │         └─ FallThrough → Gemma-4 E4B inference
-     │              └─ (post-execution) DialogManager.evaluate(intent, skillResult?)
-     │                   ├─ SkillResult.Failure → AskErrorRecovery (retry/fallback chips)
-     │                   └─ success → record in context ring for anaphora
-     │
-     └─── Execute intent / show response
-```
-
-### 2.2 State Machine
-
-```
-                    ┌──────────────────────────────────────────────────┐
-                    │                                                  │
-                    ▼                                                  │
-              ┌──────────┐     NeedsSlot      ┌────────────────┐      │
-              │          │ ──────────────────► │                │      │
-              │   IDLE   │                     │  SLOT_FILLING  │──┐   │
-              │          │ ◄────────────────── │                │  │   │
-              └──────────┘   filled / cancel   └────────────────┘  │   │
-                │  ▲  ▲                          │ still missing   │   │
-                │  │  │                          └─────────────────┘   │
-                │  │  │                                                │
-                │  │  │        multi-match     ┌────────────────────┐  │
-                │  │  │  ────────────────────► │                    │  │
-                │  │  └─────────────────────── │  DISAMBIGUATING    │  │
-                │  │         selected/cancel   │                    │  │
-                │  │                           └────────────────────┘  │
-                │  │                                                   │
-                │  │         destructive       ┌────────────────────┐  │
-                │  │  ────────────────────────►│                    │  │
-                │  └────────────────────────── │    CONFIRMING      │──┘
-                │        confirmed / cancel    │                    │  timeout
-                │                              └────────────────────┘
-                │
-                │         skill failure        ┌────────────────────┐
-                │  ────────────────────────────►│                    │
-                └──────────────────────────────│  ERROR_RECOVERY    │
-                         retry / abandon       │                    │
-                                               └────────────────────┘
-```
-
-**Transitions:**
-
-| From | Event | To | Side effect |
-|------|-------|----|-------------|
-| `IDLE` | QIR → `NeedsSlot` | `SLOT_FILLING` | Show prompt + chips |
-| `IDLE` | skill result has multiple matches | `DISAMBIGUATING` | Show option chips |
-| `IDLE` | intent in confirmation list | `CONFIRMING` | Show confirm/cancel chips |
-| `IDLE` | skill execution failed | `ERROR_RECOVERY` | Show retry/fallback chips |
-| `SLOT_FILLING` | user fills slot, more missing | `SLOT_FILLING` | Ask next slot |
-| `SLOT_FILLING` | user fills last slot | `IDLE` or `CONFIRMING` | Execute or confirm |
-| `SLOT_FILLING` | blank / "cancel" / timeout | `IDLE` | Abandon |
-| `DISAMBIGUATING` | user selects option | `IDLE` or `CONFIRMING` | Execute or confirm |
-| `DISAMBIGUATING` | "cancel" / timeout | `IDLE` | Abandon |
-| `CONFIRMING` | "yes" / confirm chip | `IDLE` | Execute |
-| `CONFIRMING` | "no" / cancel chip / timeout | `IDLE` | Abandon |
-| `ERROR_RECOVERY` | "retry" chip | `IDLE` | Re-execute |
-| `ERROR_RECOVERY` | "cancel" / timeout | `IDLE` | Abandon |
-
-**Timeout rule:** 3 consecutive user messages that don't match the expected reply pattern
-cause automatic transition to `IDLE` with a silent abandon (no "cancelled" message — the
-user has clearly moved on).
-
-### 2.3 New Files
-
-| File | Module | Purpose |
-|------|--------|---------|
-| `DialogManager.kt` | `core:skills` | State machine, replaces `SlotFillerManager` |
-| `DialogState.kt` | `core:skills` | Sealed class for all states |
-| `DialogDecision.kt` | `core:skills` | Sealed class returned by `process()` |
-| `PendingAction.kt` | `core:skills` | Frozen intent + accumulated context |
-| `ConfirmationPolicy.kt` | `core:skills` | Per-intent config: requires confirmation? |
-| `ContextRing.kt` | `core:skills` | Fixed-size ring buffer of recent executed intents (for anaphora) |
-| `DialogManagerTest.kt` | `core:skills` (test) | Unit tests for all state transitions |
-
-### 2.4 Modified Files
-
-| File | Change |
-|------|--------|
-| `ChatViewModel.kt` | Replace `SlotFillerManager` with `DialogManager`; add `evaluate()` calls after QIR match and after E4B skill execution |
-| `QuickIntentRouter.kt` | No changes — `NeedsSlot` already works; disambiguation is detected *after* execution |
-| `SlotFillerManager.kt` | Deprecated; thin delegation shim to `DialogManager` during migration, then removed |
-| `ChatScreen.kt` / composables | New chip types (confirmation, error recovery); input hint changes |
-| `SkillResult.kt` | Add `Ambiguous(matches: List<AmbiguousMatch>)` variant |
 
 ---
 
-## 3. Dialog Flows
-
-### 3.1 Slot Filling (hardened)
-
-**Trigger:** `QuickIntentRouter.route()` returns `RouteResult.NeedsSlot`, *or* the LLM
-calls a `@Tool` method with missing required parameters detected post-parse.
-
-**Phase 1 limitation:** Only one slot could be missing. If `send_sms` was missing both
-`recipient` and `body`, only the first was caught.
-
-**Phase 2 design:** `DialogManager` iterates through *all* missing required slots,
-asking for each in sequence. After the last slot is filled, the intent either executes
-immediately or transitions to `CONFIRMING` if the intent requires confirmation.
-
-#### Example: SMS missing both recipient and body
-
-```
-User:  "Send a text message"
-QIR:   NeedsSlot(intent=send_sms, missingSlot=recipient)
-
-State: IDLE → SLOT_FILLING
-       PendingAction { intent=send_sms, filled={}, remaining=[recipient, body] }
-
-Jandal: "Who would you like to text?"
-        chips: [recent contacts from call log — "Alice", "Bob", "Mum"]
-
-User:  "Bob" (or taps "Bob" chip)
-
-State: SLOT_FILLING → SLOT_FILLING
-       PendingAction { intent=send_sms, filled={recipient: "Bob"}, remaining=[body] }
-
-Jandal: "What would you like to say to Bob?"
-        chips: (none — free-text expected)
-
-User:  "I'm running 10 minutes late"
-
-State: SLOT_FILLING → CONFIRMING (send_sms requires confirmation)
-       PendingAction { filled={recipient: "Bob", body: "I'm running 10 minutes late"} }
-
-Jandal: "Send 'I'm running 10 minutes late' to Bob?"
-        chips: ["Send ✓", "Cancel ✗"]
-```
-
-#### Guardrails
-
-- **Max 3 slot prompts per intent** — if the 4th slot is still missing, abandon with
-  "I couldn't complete that — could you try rephrasing?"
-- **Over-filling:** user reply during slot fill bypasses QIR entirely. The full text
-  is taken as the slot value. "Tell him I'm running late and bring pizza" → body =
-  full string, no re-routing.
-- **Cancel keywords:** "never mind", "cancel", "forget it", "stop" → immediate abandon.
-
-### 3.2 Disambiguation
-
-**Trigger:** A skill's `execute()` returns `SkillResult.Ambiguous` — meaning the
-provided slot value matched multiple records and the skill can't determine which one.
-
-This is a *post-execution* dialog. The skill runs, discovers ambiguity, and returns
-the matches. `DialogManager` freezes the original intent and asks the user to choose.
-
-#### Example: Two contacts named "John"
-
-```
-User:  "Call John"
-QIR:   RegexMatch(intent=make_call, params={recipient: "John"})
-Skill: SkillResult.Ambiguous(matches=[
-         {label: "John Smith (Mobile)", value: "+6421555001"},
-         {label: "John Davies (Work)", value: "+6421555002"},
-       ])
-
-State: IDLE → DISAMBIGUATING
-       PendingAction { intent=make_call, slot=recipient, matches=[...] }
-
-Jandal: "I found two contacts named John. Which one?"
-        chips: ["John Smith (Mobile)", "John Davies (Work)", "Cancel"]
-
-User:  taps "John Smith (Mobile)"
-
-State: DISAMBIGUATING → IDLE
-       Execute make_call with recipient="+6421555001"
-```
-
-#### Design Notes
-
-- Chips are generated from `AmbiguousMatch.label`. Max 5 options shown; if >5 matches,
-  show top 5 + a "Type to narrow down…" hint.
-- Disambiguation results are *not* cached. If the user cancels and re-asks, the skill
-  re-executes and may return different results (contacts could change).
-- If the skill returns exactly 0 matches → that's a `SkillResult.Failure`, not ambiguity.
-
-### 3.3 Confirmation
-
-**Trigger:** The resolved intent is in the **confirmation-required** list *and* all
-slots are filled. Confirmation is the *last* gate before execution.
-
-#### Confirmation Policy
-
-```kotlin
-object ConfirmationPolicy {
-    private val REQUIRES_CONFIRMATION = setOf(
-        "send_sms",
-        "send_email",
-        "make_call",
-        // Future: "delete_alarm", "delete_calendar_event"
-    )
-
-    fun requiresConfirmation(intentName: String): Boolean =
-        intentName in REQUIRES_CONFIRMATION
-}
-```
-
-**Design rationale:** Alarms, timers, and calendar events are *not* destructive — the
-user can see them in the system clock/calendar and dismiss them. SMS, email, and calls
-are irreversible once dispatched.
-
-#### Example: Send email
-
-```
-User:  "Email Alice about the meeting tomorrow"
-E4B:   runIntent(intent_name=send_email, recipient="Alice", subject="Meeting tomorrow")
-
-State: IDLE → CONFIRMING
-       PendingAction { intent=send_email, params={recipient: "Alice", subject: "Meeting tomorrow"} }
-
-Jandal: "Send email to Alice with subject 'Meeting tomorrow'?"
-        chips: ["Send ✓", "Cancel ✗"]
-
-User:  "Yes" (or taps "Send ✓")
-
-State: CONFIRMING → IDLE
-       Execute send_email
-```
-
-#### Confirm/Cancel Detection
-
-Positive: "yes", "yep", "yeah", "sure", "do it", "send it", "confirm", "go ahead",
-"ok", chip tap on confirm chip.
-
-Negative: "no", "nope", "cancel", "don't", "stop", chip tap on cancel chip.
-
-Ambiguous reply (doesn't match positive or negative): re-prompt once —
-"Sorry, should I send it? Yes or no?"
-If still ambiguous after re-prompt → cancel.
-
-### 3.4 Error Recovery
-
-**Trigger:** `Skill.execute()` returns `SkillResult.Failure` *and* the failure is
-potentially recoverable (network timeout, permission denied, app not found).
-
-Not all failures are recoverable. The skill categorizes failures:
-
-```kotlin
-sealed class SkillResult {
-    data class Failure(
-        val error: String,
-        val recoverable: Boolean = false,  // NEW field
-        val retryable: Boolean = false,    // NEW field
-        val fallbackSuggestion: String? = null, // e.g. "Try composing manually"
-    ) : SkillResult()
-}
-```
-
-#### Example: SMS send failure
-
-```
-User:  "Text Bob I'm on my way"
-Exec:  send_sms(recipient="Bob", body="I'm on my way")
-       → SkillResult.Failure(error="No SMS app found", recoverable=true,
-           retryable=true, fallbackSuggestion="Open Messages app manually")
-
-State: IDLE → ERROR_RECOVERY
-       PendingAction { intent=send_sms, params={...}, error="No SMS app found" }
-
-Jandal: "I couldn't send that text — no SMS app was found."
-        chips: ["Try Again", "Open Messages App", "Cancel"]
-
-User:  taps "Try Again"
-
-State: ERROR_RECOVERY → IDLE
-       Re-execute send_sms with same params
-```
-
-#### Non-Recoverable Failures
-
-If `recoverable == false`, `DialogManager` does *not* enter `ERROR_RECOVERY`. The
-failure message is shown directly (current behavior), and the intent is recorded in the
-context ring as a failed attempt (for potential "try that again" anaphora).
-
-### 3.5 Anaphoric Resolution
-
-**Trigger:** User sends a message containing a pronoun or short reference that maps to a
-recently executed intent. `DialogManager` checks this *before* QIR routing, since
-anaphoric references wouldn't match any regex pattern.
-
-#### Context Ring
-
-`ContextRing` is a fixed-size (capacity = 5) ring buffer storing the last N successfully
-executed intents with their full parameters, timestamps, and results.
-
-```kotlin
-data class ContextEntry(
-    val intentName: String,
-    val params: Map<String, String>,
-    val result: SkillResult,       // what happened
-    val timestamp: Long,           // System.currentTimeMillis()
-    val userUtterance: String,     // original user message
-)
-```
-
-#### Resolution Strategy
-
-Anaphoric resolution uses a keyword-to-slot mapping, not LLM inference (keeping it
-zero-latency like QIR). Patterns checked:
-
-| User says | Pattern | Resolves to |
-|-----------|---------|-------------|
-| "call him" / "call her" / "call them" | `call\b.*\b(him\|her\|them)` | Most recent intent with a `recipient` param → `make_call(recipient=<that>)` |
-| "text him" / "message her" | `(text\|message)\b.*\b(him\|her\|them)` | Most recent `recipient` → `send_sms(recipient=<that>)` |
-| "do it again" / "do that again" | `do (it\|that) again` | Re-execute most recent intent with same params |
-| "cancel that" / "undo that" | `cancel\|undo` + `that\|it` | Not executed — returns PassThrough (cancel requires knowing *what* to cancel; out of scope for Phase 2) |
-| "try that again" / "retry" | `(try|retry).*again` | Re-execute most recent *failed* intent |
-
-#### Example: "Call him back"
-
-```
---- Context ring contains: ---
-  [0] send_sms(recipient="Bob", body="I'm late") — 2 min ago
-  [1] make_call(recipient="Alice") — 5 min ago
-
-User:  "Call him back"
-DialogManager.process():
-  1. No pending dialog
-  2. Anaphoric check: matches "call ... him" pattern
-  3. Scan context ring for most recent entry with a `recipient` param
-  4. Found: send_sms to "Bob" (2 min ago)
-  5. Generate: make_call(recipient="Bob")
-
-State: IDLE → (may go to CONFIRMING if make_call requires confirmation)
-
-Jandal: "Calling Bob…"
-```
-
-#### Limitations
-
-- Pronoun gender is not actually resolved — "him", "her", "them" all map to the most
-  recent `recipient`. This is correct >95% of the time in a single-user assistant.
-- Context ring is in-memory only. Process death clears it.
-- If no context entry matches the anaphoric pattern → `DialogDecision.PassThrough`,
-  and the message falls through to QIR/E4B as normal.
+## 3. Sprint Scope
+
+### 3.1 Included intents
+
+The deterministic slot-fill contract is locked for these intents in this sprint:
+
+| Intent | Required slots | Current prompt source |
+|--------|----------------|-----------------------|
+| `set_alarm` | `time` | inline `SlotSpec` in `QuickIntentRouter` |
+| `set_timer` | `duration_seconds` | inline `SlotSpec` in `QuickIntentRouter` |
+| `open_app` | `app_name` | inline `SlotSpec` in `QuickIntentRouter` |
+| `navigate_to` | `destination` | inline `SlotSpec` in `QuickIntentRouter` |
+| `find_nearby` | `query` | inline `SlotSpec` in `QuickIntentRouter` |
+| `send_sms` | `contact`, `message` | `slotContracts["send_sms"]` |
+| `send_email` | `contact`, `subject`, `body` | `slotContracts["send_email"]` |
+| `add_to_list` | `item`, `list_name` | `slotContracts["add_to_list"]` |
+| `make_call` | `contact` | `slotContracts["make_call"]` |
+| `save_memory` | `content` | `slotContracts["save_memory"]` |
+| `create_list` | `list_name` | `slotContracts["create_list"]` |
+
+### 3.2 Locked reviewed requirements
+
+These are the reviewed contracts that this sprint must preserve:
+
+- `send_sms` requires `contact` and `message`.
+- `send_email` requires `contact`, `subject`, and `body`.
+- `add_to_list` requires `item` and `list_name`; there is no implicit default shopping list
+  in the slot-fill contract.
+- `make_call` requires `contact`.
+- `save_memory` requires `content`.
+- `create_list` requires `list_name`.
+
+### 3.3 Explicit exclusions
+
+The following are intentionally outside this sprint's deterministic slot-fill contract:
+
+| Excluded area | Reason it stays out of scope now |
+|---------------|----------------------------------|
+| Weather / forecast | Existing weather behavior already has safe defaults, including current-location handling and optional forecast fields. Adding slot continuation here would add latency without closing a correctness gap for this sprint. |
+| `create_calendar_event` | Not part of the reviewed quick-action slot contract for this sprint. |
+| `remove_from_list` | Not part of the reviewed quick-action slot contract for this sprint. |
+| Zero-slot toggles and media controls | These actions remain one-turn deterministic commands; there is no slot continuation requirement to document here. |
 
 ---
 
-## 4. Data Model
+## 4. Boundaries and honesty checks
 
-### 4.1 `DialogState` — Sealed Class
+To keep the docs aligned with the repo as it exists today:
 
-```kotlin
-package com.kernel.ai.core.skills.dialog
-
-sealed class DialogState {
-
-    /** No dialog in progress. Default state. */
-    data object Idle : DialogState()
-
-    /**
-     * Waiting for the user to fill one or more missing slots.
-     * [remainingSlots] is ordered — first entry is the one being asked about now.
-     */
-    data class SlotFilling(
-        val pendingAction: PendingAction,
-        val remainingSlots: List<SlotSpec>,
-        val promptsAsked: Int = 0,      // increments each prompt; abandon at MAX_PROMPTS
-    ) : DialogState()
-
-    /**
-     * Waiting for the user to pick from [options].
-     */
-    data class Disambiguating(
-        val pendingAction: PendingAction,
-        val slotToFill: String,         // which param the selection fills
-        val options: List<AmbiguousMatch>,
-    ) : DialogState()
-
-    /**
-     * Waiting for the user to confirm a destructive action.
-     */
-    data class Confirming(
-        val pendingAction: PendingAction,
-        val confirmPrompt: String,       // human-readable summary of what will happen
-        val reprompted: Boolean = false,  // true if we already re-prompted once
-    ) : DialogState()
-
-    /**
-     * A skill failed with a recoverable error; offering retry/fallback.
-     */
-    data class ErrorRecovery(
-        val pendingAction: PendingAction,
-        val error: String,
-        val retryable: Boolean,
-        val fallbackSuggestion: String?,
-    ) : DialogState()
-}
-```
-
-### 4.2 `PendingAction`
-
-```kotlin
-data class PendingAction(
-    val intentName: String,
-    val filledSlots: Map<String, String>,
-    val source: ActionSource,            // QIR or E4B — affects execution path
-    val createdAt: Long = System.currentTimeMillis(),
-    val missedTurns: Int = 0,            // incremented on unrelated messages; abandon at 3
-)
-
-enum class ActionSource { QIR, E4B_TOOL_CALL }
-```
-
-### 4.3 `DialogDecision`
-
-Returned by `DialogManager.process()` to tell `ChatViewModel` what to do:
-
-```kotlin
-sealed class DialogDecision {
-    /** No active dialog — proceed with normal QIR → E4B pipeline. */
-    data object PassThrough : DialogDecision()
-
-    /** Dialog resolved — execute this intent now. */
-    data class Execute(
-        val intentName: String,
-        val params: Map<String, String>,
-        val source: ActionSource,
-    ) : DialogDecision()
-
-    /** Dialog needs more input — show this question + chips. */
-    data class AskFollowUp(
-        val message: String,
-        val chips: List<ChipOption>,
-        val inputHint: String?,          // e.g. "Type your message…" for free-text slots
-    ) : DialogDecision()
-
-    /** Dialog was cancelled (by user or timeout). */
-    data class Cancel(
-        val message: String?,            // null = silent abandon (timeout)
-    ) : DialogDecision()
-}
-
-data class ChipOption(
-    val label: String,                   // display text
-    val value: String,                   // machine value (phone number, option ID, etc.)
-    val style: ChipStyle = ChipStyle.DEFAULT,
-)
-
-enum class ChipStyle { DEFAULT, PRIMARY, DESTRUCTIVE }
-```
-
-### 4.4 `AmbiguousMatch`
-
-```kotlin
-data class AmbiguousMatch(
-    val label: String,          // "John Smith (Mobile)"
-    val value: String,          // "+6421555001"
-    val metadata: Map<String, String> = emptyMap(),  // optional extra display info
-)
-```
-
-### 4.5 Persistence
-
-| Data | Survives rotation? | Survives process death? | Mechanism |
-|------|-------------------|------------------------|-----------|
-| `DialogState` | ✅ | ❌ | `@Singleton` (same as Phase 1) |
-| `ContextRing` | ✅ | ❌ | `@Singleton`, in-memory ring buffer |
-| `ConfirmationPolicy` | N/A | N/A | Static config, no state |
-
-**Rationale:** Process death during an active dialog is a rare edge case. The user
-simply re-asks. Persisting dialog state across process death would require serializing
-`PendingAction` to `SavedStateHandle` or Room, adding complexity with minimal UX benefit.
-This matches the Phase 1 design decision documented in `SlotFillerManager`.
+- Do not describe a shipped `DialogManager` for the Actions tab.
+- Do not describe a singleton `SlotFillerManager` as the owner of Actions-tab slot state.
+- Do not describe confirmation or disambiguation as already implemented for this quick-action
+  loop unless the code actually grows those paths.
+- Keep slot names aligned with current code (`contact`, `message`, `subject`, `body`,
+  `item`, `list_name`, `content`, `time`, `duration_seconds`, `app_name`, `destination`,
+  `query`).
 
 ---
 
-## 5. ChatViewModel Integration
-
-### 5.1 Injection
-
-```kotlin
-@HiltViewModel
-class ChatViewModel @Inject constructor(
-    // ... existing deps ...
-    private val dialogManager: DialogManager,   // replaces slotFillerManager
-) : ViewModel() {
-```
-
-### 5.2 sendMessage() — Updated Flow
-
-The current `sendMessage()` in `ChatViewModel` has this structure:
-
-```
-1. Append user message to UI
-2. [SlotFiller shortcut] if slotFillerManager.hasPending → onUserReply()
-3. QuickIntentRouter.route(text) → match or fall through
-4. If QIR match → execute skill immediately
-5. If fall-through → E4B inference → tool calling → response
-```
-
-Phase 2 changes step 2 and adds a post-execution gate:
-
-```kotlin
-private fun sendMessage(text: String) = viewModelScope.launch {
-    appendUserMessage(convId, text)
-
-    // ──────────────────────────────────────────────────────
-    // STEP 1: DialogManager intercept (replaces SlotFiller shortcut)
-    // ──────────────────────────────────────────────────────
-    val decision = dialogManager.process(text)
-    when (decision) {
-        is DialogDecision.Execute -> {
-            executeIntent(decision.intentName, decision.params, decision.source)
-            return@launch
-        }
-        is DialogDecision.AskFollowUp -> {
-            showDialogPrompt(convId, decision.message, decision.chips, decision.inputHint)
-            return@launch
-        }
-        is DialogDecision.Cancel -> {
-            if (decision.message != null) appendAssistantMessage(convId, decision.message)
-            return@launch
-        }
-        is DialogDecision.PassThrough -> { /* continue to QIR */ }
-    }
-
-    // ──────────────────────────────────────────────────────
-    // STEP 2: QuickIntentRouter (unchanged)
-    // ──────────────────────────────────────────────────────
-    val routeResult = quickIntentRouter.route(text)
-    when (routeResult) {
-        is RouteResult.NeedsSlot -> {
-            val followUp = dialogManager.startSlotFill(
-                intentName = routeResult.intent.intentName,
-                existingParams = routeResult.intent.params,
-                missingSlots = routeResult.allMissingSlots(),  // Phase 2: list, not single
-                source = ActionSource.QIR,
-            )
-            showDialogPrompt(convId, followUp.message, followUp.chips, followUp.inputHint)
-            return@launch
-        }
-        is RouteResult.RegexMatch, is RouteResult.ClassifierMatch -> {
-            val intent = (routeResult as? RouteResult.RegexMatch)?.intent
-                ?: (routeResult as RouteResult.ClassifierMatch).intent
-
-            // ── Post-match evaluation: does this need confirmation? ──
-            val evalDecision = dialogManager.evaluate(
-                intentName = intent.intentName,
-                params = intent.params,
-                source = ActionSource.QIR,
-            )
-            when (evalDecision) {
-                is DialogDecision.AskFollowUp -> {
-                    showDialogPrompt(convId, evalDecision.message, evalDecision.chips, evalDecision.inputHint)
-                    return@launch
-                }
-                is DialogDecision.Execute -> {
-                    executeIntent(evalDecision.intentName, evalDecision.params, evalDecision.source)
-                    return@launch
-                }
-                else -> { /* Execute immediately (no confirmation needed) */ }
-            }
-            executeQirIntent(intent)
-        }
-        is RouteResult.FallThrough -> { /* continue to E4B */ }
-    }
-
-    // ──────────────────────────────────────────────────────
-    // STEP 3: E4B Inference (unchanged, except post-execution)
-    // ──────────────────────────────────────────────────────
-    val generationResult = runInference(text, systemContext)
-
-    // ── Post-execution evaluation: disambiguation / error recovery ──
-    if (toolSet.wasToolCalled()) {
-        val skillResult = toolSet.lastToolResult()
-        val postDecision = dialogManager.evaluateResult(
-            intentName = toolSet.lastToolName(),
-            params = toolSet.lastToolParams(),
-            result = skillResult,
-            source = ActionSource.E4B_TOOL_CALL,
-        )
-        when (postDecision) {
-            is DialogDecision.AskFollowUp -> {
-                showDialogPrompt(convId, postDecision.message, postDecision.chips, postDecision.inputHint)
-                return@launch
-            }
-            is DialogDecision.Execute -> {
-                // Disambiguation resolved inline — shouldn't happen here
-            }
-            else -> { /* Normal flow — show E4B response */ }
-        }
-    }
-
-    appendAssistantResponse(convId, generationResult)
-}
-```
-
-### 5.3 Timeout Handling
-
-`DialogManager.process()` checks `PendingAction.missedTurns` on every call. If the user's
-message doesn't look like a reply to the pending dialog (doesn't match expected slot type,
-isn't a chip value, isn't a yes/no for confirmation), `missedTurns` is incremented.
-
-```kotlin
-// Inside DialogManager.process()
-if (state !is DialogState.Idle && !isRelevantReply(userMessage, state)) {
-    val newMissedTurns = currentPendingAction.missedTurns + 1
-    if (newMissedTurns >= MAX_MISSED_TURNS) {  // MAX_MISSED_TURNS = 3
-        reset()
-        return DialogDecision.PassThrough  // silent abandon
-    }
-    // Update missed turns count but still pass through
-    updateMissedTurns(newMissedTurns)
-    return DialogDecision.PassThrough
-}
-```
-
-This means:
-- Turn 1 after prompt: user says something unrelated → missedTurns=1, message processes normally
-- Turn 2: still unrelated → missedTurns=2
-- Turn 3: still unrelated → dialog silently abandoned, missedTurns reset
-
-The user never sees a "dialog timed out" message. If they come back to the original
-request, they simply start fresh.
-
-### 5.4 Multi-Turn vs Single-Turn Fast Path
-
-| Path | Latency | Mechanism |
-|------|---------|-----------|
-| QIR single-turn (e.g. "turn on torch") | <30ms | QIR match → immediate execute, no DialogManager involvement |
-| QIR + confirmation (e.g. "text Bob hello") | <30ms + 1 turn | QIR match → `evaluate()` → `AskFollowUp` → user confirms → execute |
-| QIR + slot fill (e.g. "send a text") | <30ms + N turns | QIR → `NeedsSlot` → N prompts → execute |
-| E4B single-turn (e.g. "what's the weather") | ~2s | E4B inference → tool call → response |
-| E4B + disambiguation (e.g. "email John about X") | ~2s + 1 turn | E4B → tool call → Ambiguous → chips → user picks → execute |
-
-`DialogManager.process()` is always O(1) — no inference, no I/O, just state checks and
-regex matching. It adds negligible latency to the single-turn fast path.
-
----
-
-## 6. UI Changes
-
-### 6.1 Chip Rendering
-
-Phase 1 already renders "disambig chips" for slot filling. Phase 2 extends this with
-distinct styles:
-
-| Flow | Chip style | Example chips |
-|------|-----------|---------------|
-| Slot filling | `DEFAULT` | Recent contacts, common values |
-| Disambiguation | `DEFAULT` | "John Smith (Mobile)", "John Davies (Work)" |
-| Confirmation | `PRIMARY` + `DESTRUCTIVE` | "Send ✓" (primary), "Cancel ✗" (destructive) |
-| Error recovery | `DEFAULT` + `DESTRUCTIVE` | "Try Again", "Open App", "Cancel" (destructive) |
-
-Chip colors:
-- `DEFAULT` — surface variant (current)
-- `PRIMARY` — filled primary color (green-ish tint)
-- `DESTRUCTIVE` — outlined, red text
-
-### 6.2 Input Hint Text
-
-The `TextField` placeholder dynamically changes based on dialog state:
-
-| State | Input hint |
-|-------|-----------|
-| `Idle` | "Ask me anything…" (current) |
-| `SlotFilling` (free-text slot) | "Type your answer…" |
-| `SlotFilling` (chip-expected) | "Tap a suggestion or type…" |
-| `Disambiguating` | "Tap to select…" |
-| `Confirming` | "Yes or No…" |
-| `ErrorRecovery` | "Tap an option…" |
-
-`DialogManager` exposes a `StateFlow<DialogState>` that the UI observes.
-
-### 6.3 Cancel / Dismiss
-
-- **Explicit cancel:** User types "cancel", "never mind", "forget it", or "stop" →
-  `DialogManager` returns `DialogDecision.Cancel` with message "Okay, cancelled."
-- **Chip cancel:** Every chip set includes a "Cancel" chip (except pure slot filling
-  where the user can just type something unrelated).
-- **Back-button / swipe dismiss:** If the user navigates away from the chat screen
-  during an active dialog, `DialogManager.reset()` is called in
-  `ChatViewModel.onCleared()` or `onStop()`.
-
-### 6.4 Dialog Active Indicator
-
-When `DialogState != Idle`, a subtle colored bar or dot appears above the input field
-indicating an active dialog. Tapping it shows a tooltip: "Waiting for your answer —
-tap Cancel to dismiss." This provides discoverability for the cancel mechanism.
-
----
-
-## 7. Scope & Non-Goals
-
-### In Scope (Phase 2)
-
-| Feature | Description |
-|---------|-------------|
-| Multi-slot filling | Chain multiple missing slots in sequence |
-| Disambiguation | Present options when a slot matches multiple records |
-| Confirmation | Gate destructive actions behind yes/no |
-| Error recovery | Offer retry/fallback on recoverable failures |
-| Anaphoric resolution | "call him", "do it again" via keyword + context ring |
-| Timeout / abandon | Silent abandon after 3 unrelated turns |
-| Cancel keywords | "cancel", "never mind", etc. from any dialog state |
-| Over-fill protection | Slot-fill replies bypass QIR to prevent re-routing |
-
-### Non-Goals (explicitly out of scope)
-
-| Feature | Why deferred |
-|---------|-------------|
-| **Voice input** | Voice is a separate initiative; dialog flows are text-first for now |
-| **Nested multi-turn** | "Set an alarm for… actually, what time is my meeting?" — handling digressions that *themselves* need slot filling creates combinatorial state explosion. Deferred to Phase 3. |
-| **Multi-intent parsing** | "Set an alarm for 7am and text Bob good morning" — two intents in one utterance. Requires LLM-level decomposition, not state machine. |
-| **Correction / slot update** | "Actually, send it to Alice instead" during slot fill. Requires NLU to detect *which* slot is being corrected. Deferred. |
-| **Digression stack** | Pausing an in-progress dialog to handle an unrelated request, then resuming. Phase 2 simply abandons after 3 missed turns. |
-| **Contact resolution** | The disambiguation flow assumes the *skill* returns `Ambiguous`. Building the actual contacts lookup with multi-match detection is a separate feature (#256). |
-| **Persistent dialog state** | Surviving process death. Rare edge case, complexity not justified. |
-| **Undo / rollback** | "Cancel that alarm" after it's been set — requires OS-level undo support per intent, which varies wildly. |
-| **Custom confirmation messages** | Per-intent confirmation templates. Phase 2 uses a generic template; custom messages can be added later. |
-
----
-
-## 8. Test Cases
-
-All tests use the `adb_skill_test.py` harness with `--multiturn` flag, sending sequential
-messages and validating dialog state + UI output at each step.
-
-### Slot Filling
-
-| # | Flow | Turn 1 (User) | Expected Response | Turn 2 (User) | Expected Behavior |
-|---|------|--------------|-------------------|---------------|-------------------|
-| T01 | Single missing slot | "Send a text to Bob" | "What would you like to say to Bob?" + no chips | "I'm running late" | State → CONFIRMING; shows confirm chips |
-| T02 | Two missing slots | "Send a text message" | "Who would you like to text?" + contact chips | "Bob" → "What would you like to say to Bob?" → "Hello" | State → CONFIRMING after both filled |
-| T03 | Slot fill cancel | "Send a text to Bob" | "What would you like to say to Bob?" | "Never mind" | State → IDLE; "Okay, cancelled." |
-| T04 | Over-fill protection | "Send a text to Bob" | "What would you like to say?" | "Tell him to set a timer for 5 minutes" | body = full string; does NOT trigger set_timer |
-
-### Disambiguation
-
-| # | Flow | Turn 1 (User) | Expected Response | Turn 2 (User) | Expected Behavior |
-|---|------|--------------|-------------------|---------------|-------------------|
-| T05 | Two contacts | "Call John" | "I found 2 contacts named John…" + chips ["John Smith (Mobile)", "John Davies (Work)", "Cancel"] | taps "John Smith" | Executes make_call("+6421555001") |
-| T06 | Disambig cancel | "Call John" | "I found 2 contacts…" + chips | "Cancel" | State → IDLE; "Okay, cancelled." |
-
-### Confirmation
-
-| # | Flow | Turn 1 (User) | Expected Response | Turn 2 (User) | Expected Behavior |
-|---|------|--------------|-------------------|---------------|-------------------|
-| T07 | Confirm yes | "Text Bob I'm on my way" | "Send 'I'm on my way' to Bob?" + ["Send ✓", "Cancel ✗"] | "Yes" | Executes send_sms |
-| T08 | Confirm no | "Text Bob I'm on my way" | confirm prompt | "No" | State → IDLE; "Okay, cancelled." |
-| T09 | Ambiguous confirm reply | "Text Bob hello" | confirm prompt | "Maybe" | Re-prompt: "Should I send it? Yes or no?" |
-
-### Error Recovery
-
-| # | Flow | Turn 1 (User) | Expected Response | Turn 2 (User) | Expected Behavior |
-|---|------|--------------|-------------------|---------------|-------------------|
-| T10 | Retry on failure | "Text Bob hello" → skill returns Failure(recoverable=true) | "Couldn't send that text…" + ["Try Again", "Cancel"] | "Try Again" | Re-executes send_sms with same params |
-| T11 | Non-recoverable | "Text Bob hello" → skill returns Failure(recoverable=false) | "Couldn't send that text: No SMS app found." (no chips) | — | State stays IDLE; no error recovery offered |
-
-### Anaphoric Resolution
-
-| # | Flow | Context | Turn 1 (User) | Expected Behavior |
-|---|------|---------|---------------|-------------------|
-| T12 | "Call him" | Last intent: send_sms(recipient="Bob") | "Call him" | Executes make_call(recipient="Bob") |
-| T13 | "Do it again" | Last intent: set_alarm(hours=7, minutes=0) | "Do it again" | Executes set_alarm(hours=7, minutes=0) |
-| T14 | No context | Context ring empty | "Call him" | PassThrough → QIR/E4B handles normally |
-
-### Timeout
-
-| # | Flow | Setup | Turns | Expected Behavior |
-|---|------|-------|-------|-------------------|
-| T15 | Silent abandon | State = SLOT_FILLING (asking for SMS body) | User sends 3 unrelated messages: "What time is it?", "What's the weather?", "Turn on torch" | After 3rd message: dialog silently abandoned; each message processes normally via QIR |
-
----
-
-## 9. Migration from Phase 1
-
-### Step 1: Add `DialogManager` alongside `SlotFillerManager`
-
-Both coexist. `DialogManager` handles all new flows. `SlotFillerManager` continues
-handling existing slot-fill calls. No behavior changes.
-
-### Step 2: Route slot filling through `DialogManager`
-
-`ChatViewModel` replaces the `slotFillerManager.hasPending` / `onUserReply()` block with
-`dialogManager.process()`. `SlotFillerManager` is no longer called.
-
-### Step 3: Remove `SlotFillerManager`
-
-Delete `SlotFillerManager.kt`, `PendingSlotRequest.kt`. `SlotFillResult.kt` may be kept
-if other code references it, or folded into `DialogDecision`.
-
-### Step 4: Add remaining flows
-
-Disambiguation, confirmation, error recovery, and anaphoric resolution are added
-incrementally, each behind a feature flag if needed.
-
-**Estimated migration:** Steps 1–3 in a single PR. Step 4 can be split per-flow.
-
----
-
-## 10. Open Questions
-
-| # | Question | Proposed Answer | Status |
-|---|----------|-----------------|--------|
-| Q1 | Should confirmation be skippable via a user preference? | Yes, but not in Phase 2. Add a "Don't ask me again" setting later. | Deferred |
-| Q2 | Should E4B-initiated tool calls go through confirmation? | Yes, same policy. If `send_sms` requires confirmation, it doesn't matter whether QIR or E4B triggered it. | **Decided** |
-| Q3 | What happens if QIR returns `NeedsSlot` but the intent also requires confirmation? | Slot fill first, then confirm. `SLOT_FILLING → CONFIRMING → Execute`. | **Decided** |
-| Q4 | Should `ContextRing` entries expire after some wall-clock time? | Yes, entries older than 10 minutes are evicted on read. Prevents "call him" from resolving a contact from an hour ago. | **Decided** |
-| Q5 | How does `allMissingSlots()` work for E4B tool calls? | E4B uses constrained decoding, so required params are always present (may be empty strings). Phase 2 only chains missing slots for QIR intents. E4B disambiguation/confirmation still applies. | **Decided** |
+## 5. Acceptance notes
+
+Documentation is correct for this sprint when it communicates all of the following:
+
+1. Pending quick-action slot state lives in `ActionsViewModel`.
+2. `QuickIntentRouter` defines the required-slot contract per intent.
+3. `onSlotReply()` continues prompting until every required slot is present.
+4. `send_email` needs three slots: `contact`, `subject`, `body`.
+5. `add_to_list` needs `item` plus `list_name`, with no default list fallback.
+6. Weather/forecast, `create_calendar_event`, `remove_from_list`, and zero-slot
+   toggles/media controls are explicitly excluded from this sprint.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -22,6 +22,7 @@ import com.kernel.ai.core.voice.VoiceOutputPreferences
 import com.kernel.ai.core.voice.VoiceOutputResult
 import com.kernel.ai.core.voice.VoiceSpeakRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -131,6 +132,7 @@ class ActionsViewModel @Inject constructor(
     private val _voicePlaybackState = MutableStateFlow<VoicePlaybackState>(VoicePlaybackState.Idle)
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
     private var shouldAutoStartVoiceSlotReply = false
+    private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
     private var spokenResponsesEnabled = true
 
@@ -141,6 +143,8 @@ class ActionsViewModel @Inject constructor(
                 if (enabled) {
                     voiceOutputController.warmUp()
                 } else {
+                    shouldAutoStartVoiceSlotReply = false
+                    cancelPendingVoiceSlotReplyRestart()
                     voiceOutputController.stop()
                 }
             }
@@ -194,6 +198,7 @@ class ActionsViewModel @Inject constructor(
             voiceOutputController.events.collect { event ->
                 when (event) {
                     is VoiceOutputEvent.SpeakingStarted -> {
+                        cancelPendingVoiceSlotReplyRestart()
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
@@ -204,13 +209,17 @@ class ActionsViewModel @Inject constructor(
                             _voiceCaptureState.value == VoiceCaptureState.Idle
                         ) {
                             shouldAutoStartVoiceSlotReply = false
-                            viewModelScope.launch {
+                            cancelPendingVoiceSlotReplyRestart()
+                            pendingVoiceSlotReplyRestartJob = viewModelScope.launch {
                                 delay(SLOT_REPLY_REARM_DELAY_MS)
                                 if (
                                     _pendingSlot.value?.inputMode == InputMode.Voice &&
                                     _voiceCaptureState.value == VoiceCaptureState.Idle
                                 ) {
-                                    startVoiceCapture(VoiceCaptureMode.SlotReply)
+                                    startVoiceCapture(
+                                        mode = VoiceCaptureMode.SlotReply,
+                                        interruptPlayback = false,
+                                    )
                                 }
                             }
                         }
@@ -239,12 +248,14 @@ class ActionsViewModel @Inject constructor(
 
     fun stopVoiceOutput() {
         shouldAutoStartVoiceSlotReply = false
+        cancelPendingVoiceSlotReplyRestart()
         voiceOutputController.stop()
         _voicePlaybackState.value = VoicePlaybackState.Idle
     }
 
     fun pauseTransientVoiceUi() {
         shouldAutoStartVoiceSlotReply = false
+        cancelPendingVoiceSlotReplyRestart()
         voiceInputController.stopListening()
         _voiceCaptureState.value = VoiceCaptureState.Idle
         voiceOutputController.stop()
@@ -446,6 +457,7 @@ class ActionsViewModel @Inject constructor(
     /** Silently dismiss the slot-fill sheet with no log entry. */
     fun cancelSlotFill() {
         shouldAutoStartVoiceSlotReply = false
+        cancelPendingVoiceSlotReplyRestart()
         _pendingSlot.value = null
         stopVoiceCapture()
         voiceOutputController.stop()
@@ -586,9 +598,15 @@ class ActionsViewModel @Inject constructor(
             result.error == PHONE_PERMISSION_REQUIRED_ERROR
     }
 
-    private fun startVoiceCapture(mode: VoiceCaptureMode) {
+    private fun startVoiceCapture(
+        mode: VoiceCaptureMode,
+        interruptPlayback: Boolean = true,
+    ) {
+        cancelPendingVoiceSlotReplyRestart()
         _error.value = null
-        voiceOutputController.stop()
+        if (interruptPlayback) {
+            voiceOutputController.stop()
+        }
         _voiceCaptureState.value = VoiceCaptureState.Preparing(mode)
         viewModelScope.launch {
             when (val result = voiceInputController.startListening(mode)) {
@@ -610,12 +628,18 @@ class ActionsViewModel @Inject constructor(
         if (!spokenResponsesEnabled) return
         val summary = toSpokenSummary(text)
         if (summary.isBlank()) return
+        cancelPendingVoiceSlotReplyRestart()
         viewModelScope.launch {
             when (val result = voiceOutputController.speak(VoiceSpeakRequest(text = summary))) {
                 is VoiceOutputResult.Spoken -> Unit
                 is VoiceOutputResult.Unavailable -> _error.value = result.message
             }
         }
+    }
+
+    private fun cancelPendingVoiceSlotReplyRestart() {
+        pendingVoiceSlotReplyRestartJob?.cancel()
+        pendingVoiceSlotReplyRestartJob = null
     }
 
     private fun toSpokenSummary(text: String): String {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -811,6 +811,9 @@ class ActionsViewModel @Inject constructor(
     }
 
     private fun normalizeListVoiceMishears(text: String): String {
+        VOICE_ADD_BRIDGE_ITEM_TO_LIST.matchEntire(text)?.let { match ->
+            return "add bread to ${match.groupValues[1]}list"
+        }
         VOICE_ADD_BREAD_TO_LIST_MISHEAR.matchEntire(text)?.let { match ->
             return "add bread to ${match.groupValues[1]}list"
         }
@@ -902,6 +905,10 @@ class ActionsViewModel @Inject constructor(
     private companion object {
         val VOICE_ADD_TO_LIST_WITHOUT_VERB = Regex(
             """^(.+?)\s+to\s+(?:(?:my|the)\s+)?(.+?)\s+list$""",
+            RegexOption.IGNORE_CASE,
+        )
+        val VOICE_ADD_BRIDGE_ITEM_TO_LIST = Regex(
+            """^add\s+a\s+bridge\s+to\s+((?:(?:my|the)\s+)?)list$""",
             RegexOption.IGNORE_CASE,
         )
         val VOICE_ADD_BREAD_TO_LIST_MISHEAR = Regex(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -923,7 +923,7 @@ class ActionsViewModel @Inject constructor(
             RegexOption.IGNORE_CASE,
         )
         val VOICE_ADD_TO_LIST_LEADING_AT = Regex(
-            """^at\s+(.+?)\s+to\s+((?:(?:my|the)\s+)?)last$""",
+            """^(?:at|and)\s+(.+?)\s+to\s+((?:(?:my|the)\s+)?)last$""",
             RegexOption.IGNORE_CASE,
         )
         val VOICE_ADD_TO_LIST_ENDING_LAST = Regex(
@@ -979,7 +979,10 @@ class ActionsViewModel @Inject constructor(
             Regex("""\bday\s+in\s+day\b""", RegexOption.IGNORE_CASE) to "dnd",
             Regex("""\bnext\s+drink\b""", RegexOption.IGNORE_CASE) to "next track",
             Regex("""\bget\s+system\s+far\b""", RegexOption.IGNORE_CASE) to "get system info",
-            Regex("""\bcreate\s+lust\b""", RegexOption.IGNORE_CASE) to "create list",
+            Regex(
+                """\b((?:create|make|start|new)(?:\s+(?:a|an))?(?:\s+new)?)\s+lust\b""",
+                RegexOption.IGNORE_CASE,
+            ) to "$1 list",
             Regex("""\bhuge\s+your\s+music\b""", RegexOption.IGNORE_CASE) to "youtube music",
             Regex("""\byou\s+tube\s+music\b""", RegexOption.IGNORE_CASE) to "youtube music",
             Regex("""\bnujood\s+music\b""", RegexOption.IGNORE_CASE) to "youtube music",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -36,6 +36,7 @@ import javax.inject.Inject
 
 private const val TAG = "KernelAI"
 private const val SLOT_REPLY_REARM_DELAY_MS = 350L
+private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
 
 /** Input modality for an action. Carried through slot-fill state for voice-readiness (#350/#588). */
@@ -133,6 +134,7 @@ class ActionsViewModel @Inject constructor(
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
     private var shouldAutoStartVoiceSlotReply = false
     private var pendingVoiceSlotReplyRestartJob: Job? = null
+    private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
     private var spokenResponsesEnabled = true
 
@@ -145,6 +147,7 @@ class ActionsViewModel @Inject constructor(
                 } else {
                     shouldAutoStartVoiceSlotReply = false
                     cancelPendingVoiceSlotReplyRestart()
+                    cancelPendingVoiceSpeech()
                     voiceOutputController.stop()
                 }
             }
@@ -249,6 +252,7 @@ class ActionsViewModel @Inject constructor(
     fun stopVoiceOutput() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSpeech()
         voiceOutputController.stop()
         _voicePlaybackState.value = VoicePlaybackState.Idle
     }
@@ -256,6 +260,7 @@ class ActionsViewModel @Inject constructor(
     fun pauseTransientVoiceUi() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSpeech()
         voiceInputController.stopListening()
         _voiceCaptureState.value = VoiceCaptureState.Idle
         voiceOutputController.stop()
@@ -310,6 +315,7 @@ class ActionsViewModel @Inject constructor(
     fun executeAction(query: String, inputMode: InputMode = InputMode.Text) {
         val normalizedQuery = if (inputMode == InputMode.Voice) normalizeVoiceCommand(query) else query.trim()
         if (normalizedQuery.isBlank()) return
+        cancelPendingVoiceSpeech()
         if (_pendingSlot.value != null) {
             // A slot-fill is already in progress — ignore until the user replies or cancels.
             // Voice (#350) may want to cancel-and-proceed here instead.
@@ -395,6 +401,7 @@ class ActionsViewModel @Inject constructor(
      * missing required slot or executes the intent once the slot contract is complete.
      */
     fun onSlotReply(text: String) {
+        cancelPendingVoiceSpeech()
         val pending = _pendingSlot.value ?: return
         shouldAutoStartVoiceSlotReply = false
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
@@ -420,6 +427,7 @@ class ActionsViewModel @Inject constructor(
                 missingSlot = nextMissingSlot,
                 originalQuery = pending.originalQuery,
                 inputMode = pending.inputMode,
+                delayVoicePrompt = pending.inputMode == InputMode.Voice,
             )
             return
         }
@@ -436,7 +444,11 @@ class ActionsViewModel @Inject constructor(
                     inputMode = pending.inputMode,
                 )
                 quickActionDao.insert(entity)
-                speakForVoice(pending.inputMode, entity.resultText)
+                speakForVoice(
+                    pending.inputMode,
+                    entity.resultText,
+                    delayMs = if (pending.inputMode == InputMode.Voice) VOICE_REPLY_TTS_DELAY_MS else 0L,
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onSlotReply failed — ${e.message}", e)
                 _error.value = e.message ?: "Unknown error"
@@ -446,7 +458,11 @@ class ActionsViewModel @Inject constructor(
                     isSuccess = false,
                 )
                 quickActionDao.insert(entity)
-                speakForVoice(pending.inputMode, entity.resultText)
+                speakForVoice(
+                    pending.inputMode,
+                    entity.resultText,
+                    delayMs = if (pending.inputMode == InputMode.Voice) VOICE_REPLY_TTS_DELAY_MS else 0L,
+                )
             } finally {
                 _voiceCaptureState.value = VoiceCaptureState.Idle
                 _uiState.value = UiState.Idle
@@ -458,6 +474,7 @@ class ActionsViewModel @Inject constructor(
     fun cancelSlotFill() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSpeech()
         _pendingSlot.value = null
         stopVoiceCapture()
         voiceOutputController.stop()
@@ -469,6 +486,7 @@ class ActionsViewModel @Inject constructor(
         missingSlot: com.kernel.ai.core.skills.slot.SlotSpec,
         originalQuery: String,
         inputMode: InputMode,
+        delayVoicePrompt: Boolean = false,
     ) {
         _pendingSlot.value = PendingSlotState(
             request = PendingSlotRequest(
@@ -483,7 +501,11 @@ class ActionsViewModel @Inject constructor(
         if (inputMode == InputMode.Voice) {
             _voiceCaptureState.value = VoiceCaptureState.Idle
         }
-        speakForVoice(inputMode, _pendingSlot.value?.request?.promptMessage.orEmpty())
+        speakForVoice(
+            inputMode,
+            _pendingSlot.value?.request?.promptMessage.orEmpty(),
+            delayMs = if (delayVoicePrompt) VOICE_REPLY_TTS_DELAY_MS else 0L,
+        )
     }
 
 
@@ -603,6 +625,7 @@ class ActionsViewModel @Inject constructor(
         interruptPlayback: Boolean = true,
     ) {
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSpeech()
         _error.value = null
         if (interruptPlayback) {
             voiceOutputController.stop()
@@ -623,13 +646,20 @@ class ActionsViewModel @Inject constructor(
         }
     }
 
-    private fun speakForVoice(inputMode: InputMode, text: String) {
+    private fun speakForVoice(
+        inputMode: InputMode,
+        text: String,
+        delayMs: Long = 0L,
+    ) {
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
         val summary = toSpokenSummary(text)
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
-        viewModelScope.launch {
+        cancelPendingVoiceSpeech()
+        pendingVoiceSpeechJob = viewModelScope.launch {
+            if (delayMs > 0) delay(delayMs)
+            if (!spokenResponsesEnabled) return@launch
             when (val result = voiceOutputController.speak(VoiceSpeakRequest(text = summary))) {
                 is VoiceOutputResult.Spoken -> Unit
                 is VoiceOutputResult.Unavailable -> _error.value = result.message
@@ -640,6 +670,11 @@ class ActionsViewModel @Inject constructor(
     private fun cancelPendingVoiceSlotReplyRestart() {
         pendingVoiceSlotReplyRestartJob?.cancel()
         pendingVoiceSlotReplyRestartJob = null
+    }
+
+    private fun cancelPendingVoiceSpeech() {
+        pendingVoiceSpeechJob?.cancel()
+        pendingVoiceSpeechJob = null
     }
 
     private fun toSpokenSummary(text: String): String {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -702,7 +702,11 @@ class ActionsViewModel @Inject constructor(
         if (normalized != original) {
             Log.d(TAG, "ActionsViewModel: normalized voice command \"$original\" -> \"$normalized\"")
         }
-        val listEllipsisMatch = VOICE_ADD_TO_LIST_WITHOUT_VERB.matchEntire(normalized)
+        val normalizedListCommand = normalizeListVoiceMishears(normalized)
+        if (normalizedListCommand != normalized) {
+            Log.d(TAG, "ActionsViewModel: normalized list voice command \"$normalized\" -> \"$normalizedListCommand\"")
+        }
+        val listEllipsisMatch = VOICE_ADD_TO_LIST_WITHOUT_VERB.matchEntire(normalizedListCommand)
         if (listEllipsisMatch != null) {
             val item = listEllipsisMatch.groupValues[1].trim()
             val listName = listEllipsisMatch.groupValues[2].trim()
@@ -711,7 +715,7 @@ class ActionsViewModel @Inject constructor(
                 return "add $item to $listName list"
             }
         }
-        return normalized
+        return normalizedListCommand
     }
 
     private fun normalizeAlarmTimeFragments(text: String): String {
@@ -806,6 +810,11 @@ class ActionsViewModel @Inject constructor(
         return normalized
     }
 
+    private fun normalizeListVoiceMishears(text: String): String {
+        val addToListLastMatch = VOICE_ADD_TO_LIST_ENDING_LAST.matchEntire(text) ?: return text
+        return addToListLastMatch.groupValues[1] + "list"
+    }
+
     private fun normalizeVoiceSlotReply(text: String, slotName: String): String {
         val trimmed = text.trim()
         if (trimmed.isBlank()) return trimmed
@@ -887,6 +896,10 @@ class ActionsViewModel @Inject constructor(
     private companion object {
         val VOICE_ADD_TO_LIST_WITHOUT_VERB = Regex(
             """^(.+?)\s+to\s+(?:(?:my|the)\s+)?(.+?)\s+list$""",
+            RegexOption.IGNORE_CASE,
+        )
+        val VOICE_ADD_TO_LIST_ENDING_LAST = Regex(
+            """^((?:add\s+.+?\s+to|put\s+.+?\s+on|(?:chuck|stick|bung|pop|toss)\s+.+?\s+on)\s+(?:(?:my|the)\s+)?)last$""",
             RegexOption.IGNORE_CASE,
         )
         val SPOKEN_TIME_PHRASE = Regex(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
+import com.kernel.ai.core.skills.slot.normalizeSlotReply
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
@@ -48,8 +49,8 @@ enum class InputMode { Text, Voice }
  *
  * Slot-fill state is managed locally here (not via SlotFillerManager, which is
  * ChatViewModel's concern). When QIR returns NeedsSlot, [_pendingSlot] is primed
- * and [ActionsScreen] shows a ModalBottomSheet. On reply, the merged params are
- * executed directly. See #589.
+ * and [ActionsScreen] shows a ModalBottomSheet. On reply, the merged params either
+ * continue slot-fill for the next missing value or execute the intent. See #589/#601.
  */
 @HiltViewModel
 class ActionsViewModel @Inject constructor(
@@ -330,17 +331,13 @@ class ActionsViewModel @Inject constructor(
                         // Pause execution — show slot prompt in a ModalBottomSheet.
                         // Do NOT use SlotFillerManager; state lives locally here.
                         Log.d(TAG, "ActionsViewModel: NeedsSlot for \"$normalizedQuery\" → showing slot sheet")
-                        _pendingSlot.value = PendingSlotState(
-                            request = PendingSlotRequest(
-                                intentName = routeResult.intent.intentName,
-                                existingParams = routeResult.intent.params,
-                                missingSlot = routeResult.missingSlot,
-                            ),
+                        primePendingSlot(
+                            intentName = routeResult.intent.intentName,
+                            existingParams = routeResult.intent.params,
+                            missingSlot = routeResult.missingSlot,
                             originalQuery = normalizedQuery,
                             inputMode = inputMode,
                         )
-                        shouldAutoStartVoiceSlotReply = inputMode == InputMode.Voice
-                        speakForVoice(inputMode, _pendingSlot.value?.request?.promptMessage.orEmpty())
                     }
                     is QuickIntentRouter.RouteResult.RegexMatch -> {
                         val entity = executeIntent(
@@ -383,8 +380,8 @@ class ActionsViewModel @Inject constructor(
     /**
      * Called when the user submits a reply to a slot-fill prompt.
      *
-     * Merges the reply into the existing params and executes the intent directly.
-     * For multi-slot intents (future), re-route through QIR after merging.
+     * Merges the reply into the accumulated params, then either prompts for the next
+     * missing required slot or executes the intent once the slot contract is complete.
      */
     fun onSlotReply(text: String) {
         val pending = _pendingSlot.value ?: return
@@ -392,16 +389,31 @@ class ActionsViewModel @Inject constructor(
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
             normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
         } else {
-            text.trim()
+            normalizeSlotReply(text, pending.request.missingSlot.name)
         }
         if (normalizedText.isBlank()) {
             cancelSlotFill()
             return
         }
-        _pendingSlot.value = null
-        val mergedParams = pending.request.existingParams +
-                mapOf(pending.request.missingSlot.name to normalizedText)
 
+        val mergedParams = pending.request.existingParams +
+            mapOf(pending.request.missingSlot.name to normalizedText)
+        val nextMissingSlot = quickIntentRouter.nextMissingSlot(
+            intentName = pending.request.intentName,
+            params = mergedParams,
+        )
+        if (nextMissingSlot != null) {
+            primePendingSlot(
+                intentName = pending.request.intentName,
+                existingParams = mergedParams,
+                missingSlot = nextMissingSlot,
+                originalQuery = pending.originalQuery,
+                inputMode = pending.inputMode,
+            )
+            return
+        }
+
+        _pendingSlot.value = null
         viewModelScope.launch {
             _uiState.value = UiState.Executing
             try {
@@ -438,6 +450,30 @@ class ActionsViewModel @Inject constructor(
         stopVoiceCapture()
         voiceOutputController.stop()
     }
+
+    private fun primePendingSlot(
+        intentName: String,
+        existingParams: Map<String, String>,
+        missingSlot: com.kernel.ai.core.skills.slot.SlotSpec,
+        originalQuery: String,
+        inputMode: InputMode,
+    ) {
+        _pendingSlot.value = PendingSlotState(
+            request = PendingSlotRequest(
+                intentName = intentName,
+                existingParams = existingParams,
+                missingSlot = missingSlot,
+            ),
+            originalQuery = originalQuery,
+            inputMode = inputMode,
+        )
+        shouldAutoStartVoiceSlotReply = inputMode == InputMode.Voice
+        if (inputMode == InputMode.Voice) {
+            _voiceCaptureState.value = VoiceCaptureState.Idle
+        }
+        speakForVoice(inputMode, _pendingSlot.value?.request?.promptMessage.orEmpty())
+    }
+
 
     fun deleteAction(id: String) {
         viewModelScope.launch { quickActionDao.deleteById(id) }
@@ -714,10 +750,12 @@ class ActionsViewModel @Inject constructor(
     private fun normalizeVoiceSlotReply(text: String, slotName: String): String {
         val trimmed = text.trim()
         if (trimmed.isBlank()) return trimmed
-        if (looksLikeNumericSlot(slotName) || looksLikeStandaloneNumberPhrase(trimmed)) {
-            return normalizeSpokenNumbers(trimmed)
+        val normalized = if (looksLikeNumericSlot(slotName) || looksLikeStandaloneNumberPhrase(trimmed)) {
+            normalizeSpokenNumbers(trimmed)
+        } else {
+            trimmed
         }
-        return trimmed
+        return normalizeSlotReply(normalized, slotName)
     }
 
     private fun looksLikeNumericSlot(slotName: String): Boolean {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -814,6 +814,9 @@ class ActionsViewModel @Inject constructor(
         VOICE_ADD_BRIDGE_ITEM_TO_LIST.matchEntire(text)?.let { match ->
             return "add bread to ${match.groupValues[1]}list"
         }
+        VOICE_ADD_BRED_TO_LIST_MISHEAR.matchEntire(text)?.let { match ->
+            return "add bread to ${match.groupValues[1]}list"
+        }
         VOICE_ADD_BREAD_TO_LIST_MISHEAR.matchEntire(text)?.let { match ->
             return "add bread to ${match.groupValues[1]}list"
         }
@@ -909,6 +912,10 @@ class ActionsViewModel @Inject constructor(
         )
         val VOICE_ADD_BRIDGE_ITEM_TO_LIST = Regex(
             """^add\s+a\s+bridge\s+to\s+((?:(?:my|the)\s+)?)list$""",
+            RegexOption.IGNORE_CASE,
+        )
+        val VOICE_ADD_BRED_TO_LIST_MISHEAR = Regex(
+            """^(?:and|add)\s+bred\s+to\s+((?:(?:my|the)\s+)?)last$""",
             RegexOption.IGNORE_CASE,
         )
         val VOICE_ADD_BREAD_TO_LIST_MISHEAR = Regex(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -811,6 +811,12 @@ class ActionsViewModel @Inject constructor(
     }
 
     private fun normalizeListVoiceMishears(text: String): String {
+        VOICE_ADD_BREAD_TO_LIST_MISHEAR.matchEntire(text)?.let { match ->
+            return "add bread to ${match.groupValues[1]}list"
+        }
+        VOICE_ADD_TO_LIST_LEADING_AT.matchEntire(text)?.let { match ->
+            return "add ${match.groupValues[1].trim()} to ${match.groupValues[2]}list"
+        }
         val addToListLastMatch = VOICE_ADD_TO_LIST_ENDING_LAST.matchEntire(text) ?: return text
         return addToListLastMatch.groupValues[1] + "list"
     }
@@ -896,6 +902,14 @@ class ActionsViewModel @Inject constructor(
     private companion object {
         val VOICE_ADD_TO_LIST_WITHOUT_VERB = Regex(
             """^(.+?)\s+to\s+(?:(?:my|the)\s+)?(.+?)\s+list$""",
+            RegexOption.IGNORE_CASE,
+        )
+        val VOICE_ADD_BREAD_TO_LIST_MISHEAR = Regex(
+            """^at\s+bridge\s+to\s+((?:(?:my|the)\s+)?)last$""",
+            RegexOption.IGNORE_CASE,
+        )
+        val VOICE_ADD_TO_LIST_LEADING_AT = Regex(
+            """^at\s+(.+?)\s+to\s+((?:(?:my|the)\s+)?)last$""",
             RegexOption.IGNORE_CASE,
         )
         val VOICE_ADD_TO_LIST_ENDING_LAST = Regex(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -143,8 +143,7 @@ fun ChatScreen(
                 viewModel.isConversationReady.first { it }
             }
             if (ready != null) {
-                viewModel.onInputChanged(initialQuery)
-                viewModel.sendMessage()
+                viewModel.submitInitialQueryIfNeeded(initialQuery)
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -694,13 +694,19 @@ class ChatViewModel @Inject constructor(
             // On failure or UnknownSkill: fall through to E4B unchanged.
 
             // Slot-fill shortcut: if the previous QIR match was paused awaiting a required
-            // param, route the user's reply here before touching QIR or the LLM.
-            if (slotFillerManager.hasPending) {
-                when (val fillResult = slotFillerManager.onUserReply(text)) {
+            // param for this conversation, route the user's reply here before touching QIR or the LLM.
+            if (slotFillerManager.hasPendingFor(convId)) {
+                when (val fillResult = slotFillerManager.onUserReply(convId, text)) {
                     is SlotFillResult.Completed -> {
-                        val skill = skillRegistry.get("run_intent")
+                        val directSkill = skillRegistry.get(fillResult.intentName)
+                        val (skill, callParams) = when {
+                            directSkill != null -> directSkill to fillResult.params
+                            else -> {
+                                val runIntent = skillRegistry.get("run_intent")
+                                runIntent to (mapOf("intent_name" to fillResult.intentName) + fillResult.params)
+                            }
+                        }
                         if (skill != null) {
-                            val callParams = mapOf("intent_name" to fillResult.intentName) + fillResult.params
                             val skillResult = skill.execute(SkillCall(skill.name, callParams))
                             when (skillResult) {
                                 is SkillResult.DirectReply -> {
@@ -718,6 +724,14 @@ class ChatViewModel @Inject constructor(
                                 else -> appendAssistantMessage(convId, "Something went wrong.", shouldIndex = false)
                             }
                         }
+                        return@launch
+                    }
+                    is SlotFillResult.NeedsMore -> {
+                        appendAssistantMessage(
+                            convId,
+                            fillResult.request.promptMessage,
+                            shouldIndex = false,
+                        )
                         return@launch
                     }
                     is SlotFillResult.Cancelled -> {
@@ -799,6 +813,7 @@ class ChatViewModel @Inject constructor(
                 is QuickIntentRouter.RouteResult.NeedsSlot -> {
                     // Intent matched but a required param is missing — ask the user for it.
                     slotFillerManager.startSlotFill(
+                        convId,
                         PendingSlotRequest(
                             intentName = routeResult.intent.intentName,
                             existingParams = routeResult.intent.params,
@@ -807,7 +822,7 @@ class ChatViewModel @Inject constructor(
                     )
                     appendAssistantMessage(
                         convId,
-                        slotFillerManager.pendingRequest?.promptMessage ?: "What would you like to say?",
+                        slotFillerManager.pendingRequestFor(convId)?.promptMessage ?: "What would you like to say?",
                         shouldIndex = false,
                     )
                     return@launch

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -402,51 +402,63 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun initializeConversation() {
         try {
-        val id = navConversationId ?: conversationRepository.createConversation()
-        conversationId = id
-        // Persist resolved ID so process-death recreation restores the right conversation
-        // instead of creating a fresh one on every cold start.
-        savedStateHandle["conversationId"] = id
+            val isFreshConversation = navConversationId == null
+            val id = navConversationId ?: conversationRepository.createConversation()
+            conversationId = id
+            // Persist resolved ID so process-death recreation restores the right conversation
+            // instead of creating a fresh one on every cold start.
+            savedStateHandle["conversationId"] = id
 
-        // Load persisted title immediately so UI shows it on back-navigation.
-        val conversation = conversationRepository.getConversation(id)
-        val existingTitle = conversation?.title
-        _conversationTitle.value = existingTitle
-
-        // Track lastDistilledAt for episodic distillation on close.
-        lastDistilledAt = conversation?.lastDistilledAt
-
-        val persisted = conversationRepository.getMessagesOnce(id)
-        if (persisted.isNotEmpty()) {
-            _messages.value = persisted.map { entity ->
-                ChatMessage(
-                    id = entity.id,
-                    role = if (entity.role == "user") ChatMessage.Role.USER else ChatMessage.Role.ASSISTANT,
-                    content = entity.content,
-                    thinkingText = entity.thinkingText,
-                    toolCall = entity.toolCallJson?.let(::toolCallInfoFromJson),
-                )
+            if (isFreshConversation) {
+                // A brand-new chat route must not inherit the singleton inference session's KV cache
+                // from whichever conversation ran previously. Start with an empty model session so
+                // Actions-tab fallthroughs and "new conversation" launches cannot bleed old context.
+                estimatedTokensUsed = 0
+                turnsSinceReset = 0
+                needsHistoryReplay = false
+                pendingConfirmationIntent = null
+                inferenceEngine.resetConversation()
             }
-            // History is in Room but not in LiteRT's KV cache — replay on next send.
-            needsHistoryReplay = true
-        }
 
-        // Determine whether smart-title generation should still fire on this restored session.
-        // A title that looks like a first-message placeholder (ends with '…', ≤43 chars) can
-        // still be overwritten if the conversation is long enough for a smart title.
-        if (existingTitle != null) {
-            val looksLikePlaceholder = existingTitle.endsWith("…") && existingTitle.length <= 43
-            if (looksLikePlaceholder) {
-                // Placeholder from a previous session — allow smart title to fire whenever
-                // messageCount >= 4 is reached. sendMessage() enforces that threshold.
-                titleIsPlaceholder = true
-                titleGenerationStarted = false
-                Log.d("KernelAI", "Restored session $id has placeholder title — smart title can still fire")
-            } else {
-                titleGenerationStarted = true  // real title present — never overwrite
+            // Load persisted title immediately so UI shows it on back-navigation.
+            val conversation = conversationRepository.getConversation(id)
+            val existingTitle = conversation?.title
+            _conversationTitle.value = existingTitle
+
+            // Track lastDistilledAt for episodic distillation on close.
+            lastDistilledAt = conversation?.lastDistilledAt
+
+            val persisted = conversationRepository.getMessagesOnce(id)
+            if (persisted.isNotEmpty()) {
+                _messages.value = persisted.map { entity ->
+                    ChatMessage(
+                        id = entity.id,
+                        role = if (entity.role == "user") ChatMessage.Role.USER else ChatMessage.Role.ASSISTANT,
+                        content = entity.content,
+                        thinkingText = entity.thinkingText,
+                        toolCall = entity.toolCallJson?.let(::toolCallInfoFromJson),
+                    )
+                }
+                // History is in Room but not in LiteRT's KV cache — replay on next send.
+                needsHistoryReplay = true
             }
-        }
-        // else: new conversation, both flags stay false (defaults)
+
+            // Determine whether smart-title generation should still fire on this restored session.
+            // A title that looks like a first-message placeholder (ends with '…', ≤43 chars) can
+            // still be overwritten if the conversation is long enough for a smart title.
+            if (existingTitle != null) {
+                val looksLikePlaceholder = existingTitle.endsWith("…") && existingTitle.length <= 43
+                if (looksLikePlaceholder) {
+                    // Placeholder from a previous session — allow smart title to fire whenever
+                    // messageCount >= 4 is reached. sendMessage() enforces that threshold.
+                    titleIsPlaceholder = true
+                    titleGenerationStarted = false
+                    Log.d("KernelAI", "Restored session $id has placeholder title — smart title can still fire")
+                } else {
+                    titleGenerationStarted = true  // real title present — never overwrite
+                }
+            }
+            // else: new conversation, both flags stay false (defaults)
         } finally {
             // Always unblock the Loading guard — even on DB error the engine-ready
             // path should still transition to Ready rather than freezing the screen.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -102,6 +102,11 @@ class ChatViewModel @Inject constructor(
 
     /** Passed via nav arg; null means "start a new conversation". */
     private val navConversationId: String? = savedStateHandle["conversationId"]
+    /**
+    * One-shot flag for Actions-tab LLM fallthroughs. Those handoffs must start with a minimal
+    * system prompt and skip RAG retrieval, even when the transcript no longer looks tool-like.
+    */
+    private var forceMinimalContextForNextMessage: Boolean = savedStateHandle["minimalContext"] ?: false
 
     private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
     private val _inputText = MutableStateFlow("")
@@ -400,6 +405,20 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    private suspend fun resetInferenceForFreshConversation() {
+        // A brand-new chat route must not inherit the singleton inference session's KV cache
+        // or a stripped-down temporary prompt from the previous conversation.
+        estimatedTokensUsed = 0
+        turnsSinceReset = 0
+        needsHistoryReplay = false
+        pendingConfirmationIntent = null
+        if (inferenceEngine.isReady.value) {
+            inferenceEngine.updateSystemPrompt(buildSystemPrompt())
+        } else {
+            inferenceEngine.resetConversation()
+        }
+    }
+
     private suspend fun initializeConversation() {
         try {
             val isFreshConversation = navConversationId == null
@@ -410,14 +429,7 @@ class ChatViewModel @Inject constructor(
             savedStateHandle["conversationId"] = id
 
             if (isFreshConversation) {
-                // A brand-new chat route must not inherit the singleton inference session's KV cache
-                // from whichever conversation ran previously. Start with an empty model session so
-                // Actions-tab fallthroughs and "new conversation" launches cannot bleed old context.
-                estimatedTokensUsed = 0
-                turnsSinceReset = 0
-                needsHistoryReplay = false
-                pendingConfirmationIntent = null
-                inferenceEngine.resetConversation()
+                resetInferenceForFreshConversation()
             }
 
             // Load persisted title immediately so UI shows it on back-navigation.
@@ -673,6 +685,9 @@ class ChatViewModel @Inject constructor(
             // tool (run_intent, get_weather, etc.) — suppresses RAG indexing for both the user
             // message and the LLM response to prevent stale device state in future RAG (#614).
             var isDeviceActionExchange = false
+            // Actions-tab fallthroughs temporarily swap the system prompt to MINIMAL; mark the
+            // next turn for a history replay so normal chat can restore the full prompt safely.
+            var restoreFullPromptAfterTurn = false
             // Hoisted so the Complete handler can index the user message after knowing whether
             // any device-action tools were called during LLM inference.
             var savedUserMsgId = ""
@@ -936,13 +951,6 @@ class ChatViewModel @Inject constructor(
             activeStreamingContent = accumulatedContent
             activeStreamingThinking = accumulatedThinking
 
-            val ragContext = ragRepository.getRelevantContext(
-                query = text,
-                conversationId = convId,
-                maxTokens = ContextWindowManager.episodicBudget(activeContextWindowSize),
-            )
-            val ragTokenCost = contextWindowManager.estimateTokens(ragContext)
-
             // Proactive context reset: if we're at ~75% of the token budget, reset
             // the conversation and replay history to avoid LiteRT locking up.
             val tokenBudget = activeContextWindowSize
@@ -957,20 +965,36 @@ class ChatViewModel @Inject constructor(
             // Context stripping for tool-routable queries (#438, #481).
             // When the router had a best-guess intent (FallThrough with non-null bestGuess)
             // or the query matches known tool-trigger keywords, strip the Jandal personality
-            // and RAG context to free ~1000 tokens for tool-call reasoning. These queries
-            // don't benefit from episodic memory or cultural tone — they need clear headspace.
+            // and RAG context to free ~1000 tokens for tool-call reasoning. Actions-tab
+            // fallthroughs also force this path because the transcript may already be garbled.
             val priorMessages = _messages.value.dropLast(2) // exclude just-added user + placeholder
             val previousAssistant = priorMessages.lastOrNull { it.role == ChatMessage.Role.ASSISTANT }?.content
             val previousUser = priorMessages.lastOrNull { it.role == ChatMessage.Role.USER }?.content
             val isToolFollowUp = looksLikeToolFollowUp(text, previousUser, previousAssistant)
-            val isToolQuery = (routeResult is QuickIntentRouter.RouteResult.FallThrough &&
-                routeResult.bestGuess != null) ||
+            val forceMinimalContext = forceMinimalContextForNextMessage
+            if (forceMinimalContext) {
+                forceMinimalContextForNextMessage = false
+                savedStateHandle["minimalContext"] = false
+            }
+            val isToolQuery = forceMinimalContext ||
+                (routeResult is QuickIntentRouter.RouteResult.FallThrough && routeResult.bestGuess != null) ||
                 looksLikeToolQuery(text) ||
                 isToolFollowUp
             isToolQueryForTurn = isToolQuery
             val effectiveIdentityTier = if (isToolQuery) IdentityTier.MINIMAL else IdentityTier.FULL
-            val effectiveRagContext = if (isToolQuery) "" else ragContext
-            val effectiveRagTokenCost = if (isToolQuery) 0 else ragTokenCost
+            val effectiveRagContext: String
+            val effectiveRagTokenCost: Int
+            if (isToolQuery) {
+                effectiveRagContext = ""
+                effectiveRagTokenCost = 0
+            } else {
+                effectiveRagContext = ragRepository.getRelevantContext(
+                    query = text,
+                    conversationId = convId,
+                    maxTokens = ContextWindowManager.episodicBudget(activeContextWindowSize),
+                )
+                effectiveRagTokenCost = contextWindowManager.estimateTokens(effectiveRagContext)
+            }
 
             // Anaphora handling (#491): tool queries with "save that", "look it up", etc. need
             // the previous turn to resolve what "that/it/this" refers to. Inject the last
@@ -1007,6 +1031,12 @@ class ChatViewModel @Inject constructor(
                 } + effectiveRagTokenCost
                 turnsSinceReset = 0
             } else {
+                if (forceMinimalContext) {
+                    inferenceEngine.updateSystemPrompt(
+                        buildSystemPrompt(isFirstReply = isFirstReply, identityTier = IdentityTier.MINIMAL)
+                    )
+                    restoreFullPromptAfterTurn = true
+                }
                 estimatedTokensUsed += effectiveRagTokenCost
             }
 
@@ -1287,6 +1317,10 @@ class ChatViewModel @Inject constructor(
                 activeStreamingMsgId = null
                 activeStreamingContent = StringBuilder()
                 activeStreamingThinking = StringBuilder()
+            } finally {
+                if (restoreFullPromptAfterTurn) {
+                    needsHistoryReplay = true
+                }
             }
         }
     }
@@ -1343,11 +1377,7 @@ class ChatViewModel @Inject constructor(
             _conversationTitle.value = null
             titleGenerationStarted = false
             titleIsPlaceholder = false
-            estimatedTokensUsed = 0
-            turnsSinceReset = 0
-            needsHistoryReplay = false
-            pendingConfirmationIntent = null
-            inferenceEngine.resetConversation()
+            resetInferenceForFreshConversation()
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -646,6 +646,22 @@ class ChatViewModel @Inject constructor(
         if (_error.value != null) _error.value = null
     }
 
+    fun submitInitialQueryIfNeeded(initialQuery: String) {
+        val normalized = initialQuery.trim()
+        if (normalized.isBlank()) return
+        val alreadyPresent = _messages.value.any {
+            it.role == ChatMessage.Role.USER && it.content == normalized
+        }
+        if (alreadyPresent) {
+            forceMinimalContextForNextMessage = false
+            savedStateHandle["minimalContext"] = false
+            Log.d("ChatViewModel", "Skipping duplicate initial query after restore: $normalized")
+            return
+        }
+        onInputChanged(normalized)
+        sendMessage()
+    }
+
     fun renameConversation(newTitle: String) {
         val id = conversationId ?: return
         val trimmed = newTitle.trim()

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.SkillSchema
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
@@ -20,6 +21,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -44,7 +46,9 @@ class ActionsViewModelTest {
     private val quickActionDao: QuickActionDao = mockk()
     private val voiceInputController: VoiceInputController = mockk()
     private val voiceOutputController: VoiceOutputController = mockk()
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
     private val insertedActions = mutableListOf<QuickActionEntity>()
+    private val spokenResponsesEnabled = MutableStateFlow(false)
 
     private lateinit var viewModel: ActionsViewModel
 
@@ -61,6 +65,7 @@ class ActionsViewModelTest {
         every { voiceInputController.stopListening() } just Runs
         every { voiceOutputController.events } returns emptyFlow()
         every { voiceOutputController.stop() } just Runs
+        every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
         every { skillRegistry.get(any()) } answers {
             when (firstArg<String>()) {
                 "run_intent" -> CapturingRunIntentSkill.default
@@ -73,6 +78,7 @@ class ActionsViewModelTest {
             quickActionDao = quickActionDao,
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
         )
     }
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
@@ -1,0 +1,381 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import com.kernel.ai.core.memory.dao.QuickActionDao
+import com.kernel.ai.core.memory.entity.QuickActionEntity
+import com.kernel.ai.core.skills.QuickIntentRouter
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceOutputController
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ActionsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private val quickIntentRouter = QuickIntentRouter()
+    private val skillRegistry: SkillRegistry = mockk()
+    private val quickActionDao: QuickActionDao = mockk()
+    private val voiceInputController: VoiceInputController = mockk()
+    private val voiceOutputController: VoiceOutputController = mockk()
+    private val insertedActions = mutableListOf<QuickActionEntity>()
+
+    private lateinit var viewModel: ActionsViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+        every { quickActionDao.observeAll() } returns flowOf(emptyList())
+        coEvery { quickActionDao.insert(capture(insertedActions)) } just Runs
+        every { voiceInputController.events } returns emptyFlow()
+        every { voiceInputController.stopListening() } just Runs
+        every { voiceOutputController.events } returns emptyFlow()
+        every { voiceOutputController.stop() } just Runs
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> CapturingRunIntentSkill.default
+                else -> null
+            }
+        }
+        viewModel = ActionsViewModel(
+            quickIntentRouter = quickIntentRouter,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        insertedActions.clear()
+        CapturingRunIntentSkill.default.reset()
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `send sms bare flow asks for contact then message before executing`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("send a message")
+        advanceUntilIdle()
+
+        assertEquals("Who do you want to send a message to?", viewModel.pendingSlot.value?.request?.promptMessage)
+        assertEquals(0, insertedActions.size)
+        assertEquals(0, runIntentSkill.calls.size)
+
+        viewModel.onSlotReply("Nick")
+        advanceUntilIdle()
+
+        val pendingMessage = viewModel.pendingSlot.value
+        assertNotNull(pendingMessage)
+        assertEquals("message", pendingMessage?.request?.missingSlot?.name)
+        assertEquals("What would you like to say to Nick?", pendingMessage?.request?.promptMessage)
+        assertEquals(0, insertedActions.size)
+        assertEquals(0, runIntentSkill.calls.size)
+
+        viewModel.onSlotReply("Meet me at 5")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(1, insertedActions.size)
+        assertEquals(1, runIntentSkill.calls.size)
+        assertEquals(
+            mapOf(
+                "intent_name" to "send_sms",
+                "contact" to "Nick",
+                "message" to "Meet me at 5",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+        assertEquals("send a message", insertedActions.single().userQuery)
+        assertEquals("send_sms", insertedActions.single().skillName)
+        assertEquals("Executed send_sms", insertedActions.single().resultText)
+        assertEquals(true, insertedActions.single().isSuccess)
+    }
+
+    @Test
+    fun `send email bare flow waits for contact subject and body before executing`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("send an email")
+        advanceUntilIdle()
+
+        assertEquals("Who would you like to email?", viewModel.pendingSlot.value?.request?.promptMessage)
+        assertEquals(0, insertedActions.size)
+
+        viewModel.onSlotReply("to Nick")
+        advanceUntilIdle()
+
+        assertEquals("subject", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+        assertEquals(
+            "What's the subject of your email to Nick?",
+            viewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        assertEquals(0, insertedActions.size)
+        assertEquals(0, runIntentSkill.calls.size)
+
+        viewModel.onSlotReply("Weekend plans")
+        advanceUntilIdle()
+
+        assertEquals("body", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+        assertEquals("What would you like the email to say?", viewModel.pendingSlot.value?.request?.promptMessage)
+        assertEquals(0, insertedActions.size)
+        assertEquals(0, runIntentSkill.calls.size)
+
+        viewModel.onSlotReply("Let's catch up on Saturday")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(1, insertedActions.size)
+        assertEquals(1, runIntentSkill.calls.size)
+        assertEquals(
+            mapOf(
+                "intent_name" to "send_email",
+                "contact" to "Nick",
+                "subject" to "Weekend plans",
+                "body" to "Let's catch up on Saturday",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+        assertEquals("send an email", insertedActions.single().userQuery)
+        assertEquals("send_email", insertedActions.single().skillName)
+        assertEquals("Executed send_email", insertedActions.single().resultText)
+    }
+
+    @Test
+    fun `add to list flow normalizes natural list-name replies before executing`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("add to my list")
+        advanceUntilIdle()
+
+        assertEquals("What would you like to add?", viewModel.pendingSlot.value?.request?.promptMessage)
+
+        viewModel.onSlotReply("milk")
+        advanceUntilIdle()
+
+        assertEquals("list_name", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+        assertEquals("Which list should I add it to?", viewModel.pendingSlot.value?.request?.promptMessage)
+
+        viewModel.onSlotReply("on my shopping list")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(
+            mapOf(
+                "intent_name" to "add_to_list",
+                "item" to "milk",
+                "list_name" to "shopping list",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+    }
+
+    @Test
+    fun `create list flow preserves leading words in list names`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("create a list")
+        advanceUntilIdle()
+
+        assertEquals("What would you like to call the list?", viewModel.pendingSlot.value?.request?.promptMessage)
+
+        viewModel.onSlotReply("The Boys")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(
+            mapOf(
+                "intent_name" to "create_list",
+                "list_name" to "The Boys",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+    }
+
+    @Test
+    fun `generic shopping list replies normalize without mangling named lists`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("add milk to my list")
+        advanceUntilIdle()
+        viewModel.onSlotReply("my shopping list")
+        advanceUntilIdle()
+
+        assertEquals(
+            mapOf(
+                "intent_name" to "add_to_list",
+                "item" to "milk",
+                "list_name" to "shopping list",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+
+        runIntentSkill.calls.clear()
+        viewModel.executeAction("create a list")
+        advanceUntilIdle()
+        viewModel.onSlotReply("My Tasks")
+        advanceUntilIdle()
+
+        assertEquals(
+            mapOf(
+                "intent_name" to "create_list",
+                "list_name" to "My Tasks",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+    }
+
+    @Test
+    fun `blank slot reply cancels slot fill and inserts nothing`() = runTest(dispatcher) {
+        viewModel.executeAction("send a message")
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.pendingSlot.value)
+
+        viewModel.onSlotReply("   ")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(0, insertedActions.size)
+    }
+
+    @Test
+    fun `executeAction is ignored while slot fill is pending`() = runTest(dispatcher) {
+        viewModel.executeAction("send a message")
+        advanceUntilIdle()
+
+        val pendingBefore = viewModel.pendingSlot.value
+        assertNotNull(pendingBefore)
+
+        viewModel.executeAction("send an email")
+        advanceUntilIdle()
+
+        val pendingAfter = viewModel.pendingSlot.value
+        assertNotNull(pendingAfter)
+        assertEquals(pendingBefore?.request?.intentName, pendingAfter?.request?.intentName)
+        assertEquals(pendingBefore?.request?.missingSlot?.name, pendingAfter?.request?.missingSlot?.name)
+        assertEquals(pendingBefore?.request?.promptMessage, pendingAfter?.request?.promptMessage)
+        assertEquals(0, insertedActions.size)
+    }
+
+    @Test
+    fun `onSlotReply with no pending slot is a no op`() = runTest(dispatcher) {
+        viewModel.onSlotReply("Nick")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(0, insertedActions.size)
+    }
+
+    @Test
+    fun `slot reply execution failure records truthful error state`() = runTest(dispatcher) {
+        val failingSkill = CapturingRunIntentSkill { throw IllegalStateException("Dialer exploded") }
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> failingSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("send a message")
+        advanceUntilIdle()
+        viewModel.onSlotReply("Nick")
+        advanceUntilIdle()
+        viewModel.onSlotReply("Meet me at 5")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals("Dialer exploded", viewModel.error.value)
+        assertEquals(1, insertedActions.size)
+        assertEquals("Error: Dialer exploded", insertedActions.single().resultText)
+        assertEquals(false, insertedActions.single().isSuccess)
+    }
+
+    private class CapturingRunIntentSkill(
+        private val responder: (SkillCall) -> SkillResult = {
+            SkillResult.Success("Executed ${it.arguments["intent_name"]}")
+        },
+    ) : Skill {
+        val calls = mutableListOf<SkillCall>()
+
+        override val name: String = "run_intent"
+        override val description: String = "Run intent"
+        override val schema: SkillSchema = SkillSchema()
+
+        override suspend fun execute(call: SkillCall): SkillResult {
+            calls += call
+            return responder(call)
+        }
+
+        fun reset() {
+            calls.clear()
+        }
+
+        companion object {
+            val default = CapturingRunIntentSkill()
+        }
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -181,6 +181,32 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode normalizes and bred to my last before routing`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("and bred to my last", InputMode.Voice)
+        advanceUntilIdle()
+
+        assertEquals(
+            "bread",
+            voiceViewModel.pendingSlot.value?.request?.existingParams?.get("item"),
+        )
+        assertEquals(
+            "Which list should I add it to?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
     fun `voice mode normalizes add a bridge item mishear before routing`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         val voiceViewModel = ActionsViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -156,6 +156,7 @@ class ActionsViewModelVoiceTest {
             quickActionDao = quickActionDao,
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -208,6 +209,44 @@ class ActionsViewModelVoiceTest {
         runCurrent()
 
         coVerify { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
+        verify(exactly = 1) { voiceOutputController.stop() }
+    }
+
+    @Test
+    fun `stale slot reply auto restart is cancelled when a newer follow up prompt starts`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("send an email", InputMode.Voice)
+        advanceUntilIdle()
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        runCurrent()
+
+        voiceViewModel.onSlotReply("Nick")
+        advanceUntilIdle()
+
+        advanceTimeBy(351)
+        runCurrent()
+        coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        runCurrent()
+        advanceTimeBy(351)
+        runCurrent()
+
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
     }
 
     @Test
@@ -318,6 +357,36 @@ class ActionsViewModelVoiceTest {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { voiceOutputController.speak(any()) }
+    }
+
+    @Test
+    fun `disabling spoken responses during slot prompt does not reopen microphone`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a text message to my wife") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "my wife"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text message to my wife", InputMode.Voice)
+        advanceUntilIdle()
+
+        spokenResponsesEnabled.value = false
+        runCurrent()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        runCurrent()
+        advanceTimeBy(351)
+        runCurrent()
+
+        coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
     }
 
     @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -148,6 +148,35 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode normalizes add-to-list list mishear before routing`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("add milk to my last", InputMode.Voice)
+        advanceUntilIdle()
+
+        assertEquals(
+            "Which list should I add it to?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text == "Which list should I add it to?"
+                }
+            )
+        }
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
     fun `voice mode speaks follow up slot prompt after first reply in multi slot flow`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         val voiceViewModel = ActionsViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -163,12 +163,28 @@ class ActionsViewModelVoiceTest {
         advanceUntilIdle()
 
         voiceViewModel.onSlotReply("Nick")
-        advanceUntilIdle()
+        runCurrent()
 
         assertEquals(
             "What's the subject of your email to Nick?",
             voiceViewModel.pendingSlot.value?.request?.promptMessage,
         )
+        coVerify(exactly = 0) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> {
+                it.text == "What's the subject of your email to Nick?"
+            })
+        }
+
+        advanceTimeBy(149)
+        runCurrent()
+        coVerify(exactly = 0) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> {
+                it.text == "What's the subject of your email to Nick?"
+            })
+        }
+
+        advanceTimeBy(1)
+        runCurrent()
         coVerify {
             voiceOutputController.speak(
                 match<VoiceSpeakRequest> {
@@ -177,6 +193,91 @@ class ActionsViewModelVoiceTest {
             )
         }
         coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
+    fun `cancelSlotFill drops delayed follow up prompt speech`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("send an email", InputMode.Voice)
+        advanceUntilIdle()
+
+        voiceViewModel.onSlotReply("Nick")
+        runCurrent()
+        voiceViewModel.cancelSlotFill()
+        advanceTimeBy(151)
+        runCurrent()
+
+        coVerify(exactly = 0) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> {
+                it.text == "What's the subject of your email to Nick?"
+            })
+        }
+    }
+
+    @Test
+    fun `disabling spoken responses drops delayed follow up prompt speech`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("send an email", InputMode.Voice)
+        advanceUntilIdle()
+
+        voiceViewModel.onSlotReply("Nick")
+        runCurrent()
+        spokenResponsesEnabled.value = false
+        runCurrent()
+        advanceTimeBy(151)
+        runCurrent()
+
+        coVerify(exactly = 0) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> {
+                it.text == "What's the subject of your email to Nick?"
+            })
+        }
+    }
+
+    @Test
+    fun `new input cancels delayed follow up prompt speech`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("send an email", InputMode.Voice)
+        advanceUntilIdle()
+
+        voiceViewModel.onSlotReply("Nick")
+        runCurrent()
+        voiceViewModel.executeAction("turn on flashlight", InputMode.Text)
+        advanceTimeBy(151)
+        runCurrent()
+
+        coVerify(exactly = 0) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> {
+                it.text == "What's the subject of your email to Nick?"
+            })
+        }
     }
 
     @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -181,6 +181,56 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode normalizes add a bridge item mishear before routing`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("add a bridge to my list", InputMode.Voice)
+        advanceUntilIdle()
+
+        assertEquals(
+            "bread",
+            voiceViewModel.pendingSlot.value?.request?.existingParams?.get("item"),
+        )
+        assertEquals(
+            "Which list should I add it to?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
+    fun `voice mode preserves legitimate bridge item before routing`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("add bridge to my shopping list") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "add bridge to my shopping list")
+
+        viewModel.executeAction("add bridge to my shopping list", InputMode.Voice)
+        advanceUntilIdle()
+
+        verify { quickIntentRouter.route("add bridge to my shopping list") }
+        verify(exactly = 0) { quickIntentRouter.route("add bread to my shopping list") }
+    }
+
+    @Test
+    fun `voice mode preserves explicit a bridge item before routing`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("add a bridge to my shopping list") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "add a bridge to my shopping list")
+
+        viewModel.executeAction("add a bridge to my shopping list", InputMode.Voice)
+        advanceUntilIdle()
+
+        verify { quickIntentRouter.route("add a bridge to my shopping list") }
+        verify(exactly = 0) { quickIntentRouter.route("add bread to my shopping list") }
+    }
+
+    @Test
     fun `voice mode speaks follow up slot prompt after first reply in multi slot flow`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         val voiceViewModel = ActionsViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -207,6 +207,58 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode normalizes and ice cream to my last before routing`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("and ice cream to my last", InputMode.Voice)
+        advanceUntilIdle()
+
+        assertEquals(
+            "ice cream",
+            voiceViewModel.pendingSlot.value?.request?.existingParams?.get("item"),
+        )
+        assertEquals(
+            "Which list should I add it to?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
+    fun `voice mode normalizes create a new lust into create list slot flow`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+        )
+
+        voiceViewModel.executeAction("create a new lust", InputMode.Voice)
+        advanceUntilIdle()
+
+        assertEquals(
+            "list_name",
+            voiceViewModel.pendingSlot.value?.request?.missingSlot?.name,
+        )
+        assertEquals(
+            "What would you like to call the list?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
     fun `voice mode normalizes add a bridge item mishear before routing`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         val voiceViewModel = ActionsViewModel(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -148,7 +148,7 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
-    fun `voice mode normalizes add-to-list list mishear before routing`() = runTest(dispatcher) {
+    fun `voice mode normalizes add bread list mishear before routing`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         val voiceViewModel = ActionsViewModel(
             quickIntentRouter = router,
@@ -159,9 +159,13 @@ class ActionsViewModelVoiceTest {
             voiceOutputPreferences = voiceOutputPreferences,
         )
 
-        voiceViewModel.executeAction("add milk to my last", InputMode.Voice)
+        voiceViewModel.executeAction("at bridge to my last", InputMode.Voice)
         advanceUntilIdle()
 
+        assertEquals(
+            "bread",
+            voiceViewModel.pendingSlot.value?.request?.existingParams?.get("item"),
+        )
         assertEquals(
             "Which list should I add it to?",
             voiceViewModel.pendingSlot.value?.request?.promptMessage,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -148,6 +148,37 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode speaks follow up slot prompt after first reply in multi slot flow`() = runTest(dispatcher) {
+        val router = QuickIntentRouter()
+        val voiceViewModel = ActionsViewModel(
+            quickIntentRouter = router,
+            skillRegistry = skillRegistry,
+            quickActionDao = quickActionDao,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+        )
+
+        voiceViewModel.executeAction("send an email", InputMode.Voice)
+        advanceUntilIdle()
+
+        voiceViewModel.onSlotReply("Nick")
+        advanceUntilIdle()
+
+        assertEquals(
+            "What's the subject of your email to Nick?",
+            voiceViewModel.pendingSlot.value?.request?.promptMessage,
+        )
+        coVerify {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text == "What's the subject of your email to Nick?"
+                }
+            )
+        }
+        coVerify(exactly = 0) { quickActionDao.insert(any()) }
+    }
+
+    @Test
     fun `voice mode auto starts slot reply capture after prompt finishes`() = runTest(dispatcher) {
         every { quickIntentRouter.route("send a text message to my wife") } returns
             QuickIntentRouter.RouteResult.NeedsSlot(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -276,7 +276,116 @@ class ChatViewModelInitTest {
         advanceUntilIdle()
         viewModel.startNewConversation()
         advanceUntilIdle()
-
         assertTrue(systemPrompts.last().contains(DEFAULT_SYSTEM_PROMPT), systemPrompts.joinToString(separator = "\n---\n"))
+    }
+
+    @Test
+    fun `initial query is not resent after restored conversation reload`() = runTest(dispatcher) {
+        coEvery { conversationRepository.getMessagesOnce("conv-existing") } returns listOf(
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-1",
+                conversationId = "conv-existing",
+                role = "user",
+                content = "and ice cream to my last",
+                thinkingText = null,
+                timestamp = 1L,
+            ),
+        )
+
+        val viewModel = ChatViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+        viewModel.submitInitialQueryIfNeeded("and ice cream to my last")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { conversationRepository.addMessage(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `skipping duplicate restored initial query clears minimal handoff for next send`() = runTest(dispatcher) {
+        val systemPrompts = mutableListOf<String>()
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.generate(any()) } returns
+            flowOf(GenerationResult.Token("Hi"), GenerationResult.Complete(durationMs = 1L))
+        coEvery { inferenceEngine.updateSystemPrompt(any()) } answers {
+            systemPrompts += firstArg<String>()
+        }
+        coEvery { ragRepository.getRelevantContext(any(), any(), any()) } returns "memory context"
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg-1", "assistant-msg-1", "user-msg-2", "assistant-msg-2")
+        coEvery { conversationRepository.getMessagesOnce("conv-existing") } returns listOf(
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-1",
+                conversationId = "conv-existing",
+                role = "user",
+                content = "and ice cream to my last",
+                thinkingText = null,
+                timestamp = 1L,
+            ),
+        )
+        every { quickIntentRouter.route("follow up question") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "follow up question")
+
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                "conversationId" to "conv-existing",
+                "minimalContext" to true,
+            ),
+        )
+        val viewModel = ChatViewModel(
+            savedStateHandle = savedStateHandle,
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+        viewModel.submitInitialQueryIfNeeded("and ice cream to my last")
+        assertTrue(savedStateHandle.get<Boolean>("minimalContext") == false)
+
+        viewModel.onInputChanged("follow up question")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 1) { ragRepository.getRelevantContext("follow up question", any(), any()) }
+        assertTrue(
+            systemPrompts.any { it.contains(DEFAULT_SYSTEM_PROMPT) },
+            systemPrompts.joinToString(separator = "\n---\n"),
+        )
     }
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -1,0 +1,171 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import com.google.ai.edge.litertlm.ToolProvider
+import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.JandalPersona
+import com.kernel.ai.core.inference.PersonaMode
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareTier
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
+import com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase
+import com.kernel.ai.core.skills.KernelAIToolSet
+import com.kernel.ai.core.skills.QuickIntentRouter
+import com.kernel.ai.core.skills.SkillExecutor
+import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.slot.SlotFillerManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelInitTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private val inferenceEngine: InferenceEngine = mockk(relaxed = true)
+    private val downloadManager: ModelDownloadManager = mockk(relaxed = true)
+    private val conversationRepository: ConversationRepository = mockk(relaxed = true)
+    private val ragRepository: RagRepository = mockk(relaxed = true)
+    private val userProfileRepository: UserProfileRepository = mockk(relaxed = true)
+    private val memoryRepository: MemoryRepository = mockk(relaxed = true)
+    private val episodicDistillationUseCase: EpisodicDistillationUseCase = mockk(relaxed = true)
+    private val modelSettingsRepository: ModelSettingsRepository = mockk(relaxed = true)
+    private val skillRegistry: SkillRegistry = mockk(relaxed = true)
+    private val skillExecutor: SkillExecutor = mockk(relaxed = true)
+    private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
+    private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
+    private val toolProvider: ToolProvider = mockk(relaxed = true)
+    private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
+    private val jandalPersona: JandalPersona = mockk(relaxed = true)
+    private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
+    private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+
+        every { inferenceEngine.isReady } returns MutableStateFlow(false)
+        every { inferenceEngine.isGenerating } returns MutableStateFlow(false)
+        every { inferenceEngine.activeBackend } returns MutableStateFlow<BackendType?>(null)
+        every { inferenceEngine.resolvedMaxTokens } returns MutableStateFlow(0)
+        every { inferenceEngine.evictionEvents } returns emptyFlow()
+        coEvery { inferenceEngine.resetConversation() } just runs
+
+        every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+        every { downloadManager.areRequiredModelsDownloaded() } returns false
+        every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
+
+        coEvery { conversationRepository.createConversation() } returns "conv-new"
+        coEvery { conversationRepository.getConversation(any()) } answers {
+            val id = firstArg<String>()
+            ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L)
+        }
+        coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
+
+        every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
+        every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
+        every { nzTruthSeedingService.isSeeding } returns MutableStateFlow(false)
+        every { nzTruthSeedingService.seedIfNeeded() } just runs
+        coEvery { verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference() } just runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `fresh chat initialization resets inherited inference session`() = runTest(dispatcher) {
+        ChatViewModel(
+            savedStateHandle = SavedStateHandle(),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { conversationRepository.createConversation() }
+        coVerify(exactly = 1) { inferenceEngine.resetConversation() }
+    }
+
+    @Test
+    fun `restored chat initialization does not reset current inference session`() = runTest(dispatcher) {
+        ChatViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { conversationRepository.createConversation() }
+        coVerify(exactly = 0) { inferenceEngine.resetConversation() }
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -4,9 +4,12 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import com.google.ai.edge.litertlm.ToolProvider
 import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.inference.DEFAULT_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.GenerationResult
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.inference.JandalPersona
+import com.kernel.ai.core.inference.MINIMAL_SYSTEM_PROMPT
 import com.kernel.ai.core.inference.PersonaMode
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
@@ -37,15 +40,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChatViewModelInitTest {
     private val dispatcher = StandardTestDispatcher()
@@ -167,5 +171,112 @@ class ChatViewModelInitTest {
 
         coVerify(exactly = 0) { conversationRepository.createConversation() }
         coVerify(exactly = 0) { inferenceEngine.resetConversation() }
+    }
+
+    @Test
+    fun `actions fallthrough initial query uses minimal prompt and skips rag`() = runTest(dispatcher) {
+        val systemPrompts = mutableListOf<String>()
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.generate(any()) } returns
+            flowOf(GenerationResult.Token("Hi"), GenerationResult.Complete(durationMs = 1L))
+        coEvery { inferenceEngine.updateSystemPrompt(any()) } answers {
+            systemPrompts += firstArg<String>()
+        }
+        coEvery { ragRepository.getRelevantContext(any(), any(), any()) } returns "memory context"
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg", "assistant-msg")
+        every { quickIntentRouter.route("and bred to my last") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "and bred to my last")
+
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                "minimalContext" to true,
+            ),
+        )
+
+        val viewModel = ChatViewModel(
+            savedStateHandle = savedStateHandle,
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+        viewModel.onInputChanged("and bred to my last")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertTrue(
+            systemPrompts.any { prompt ->
+                prompt.contains(MINIMAL_SYSTEM_PROMPT) &&
+                    !prompt.contains("[User Profile]") &&
+                    !prompt.contains("[Previous conversation context]")
+            },
+            systemPrompts.joinToString(separator = "\n---\n"),
+        )
+        assertTrue(savedStateHandle.get<Boolean>("minimalContext") == false)
+        coVerify(exactly = 0) { ragRepository.getRelevantContext(any(), any(), any()) }
+    }
+
+
+    @Test
+    fun `starting new conversation restores full prompt after minimal handoff`() = runTest(dispatcher) {
+        val systemPrompts = mutableListOf<String>()
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.generate(any()) } returns
+            flowOf(GenerationResult.Token("Hi"), GenerationResult.Complete(durationMs = 1L))
+        coEvery { inferenceEngine.updateSystemPrompt(any()) } answers {
+            systemPrompts += firstArg<String>()
+        }
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg", "assistant-msg")
+        every { quickIntentRouter.route("and bred to my last") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "and bred to my last")
+
+        val viewModel = ChatViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("minimalContext" to true)),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+
+        advanceUntilIdle()
+        viewModel.onInputChanged("and bred to my last")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        viewModel.startNewConversation()
+        advanceUntilIdle()
+
+        assertTrue(systemPrompts.last().contains(DEFAULT_SYSTEM_PROMPT), systemPrompts.joinToString(separator = "\n---\n"))
     }
 }


### PR DESCRIPTION
## Summary
- continue deterministic slot fill until all required params are present in both quick actions and chat
- align intent execution with the stricter slot contract for email, lists, calls, and memory capture
- normalize natural slot replies and canonicalize generic shopping-list aliases without mangling named lists
- update deterministic dialog spec docs and add regression coverage for router, slot manager, actions view model, and native intent handling

## Testing
- `./gradlew :core:skills:testDebugUnitTest --tests "*QuickIntentRouter*" --tests "*NativeIntentHandlerTest" --tests "*SlotFillerManagerTest"`
- `./gradlew :feature:chat:testDebugUnitTest --tests "*ActionsViewModel*"`

## Manual test cases
1. Actions tab: `send a message` -> reply `to Nick` -> reply `hello there` -> confirm SMS composer opens for Nick with message body filled.
2. Actions tab: `send an email` -> reply `to Nick` -> reply `Weekend plan` -> reply `Let us leave at 9` -> confirm email composer opens only after the third reply.
3. Actions tab: `add milk to my list` -> reply `my shopping list` -> then ask `what is in my shopping list` -> confirm milk appears in the same list.
4. Actions tab: `create a list` -> reply `My Tasks` -> confirm the created list keeps the leading word.
5. Chat: in conversation A start `send an email`, then switch to conversation B and send a normal message -> confirm B is not consumed by A slot fill; return to A and finish contact/subject/body normally.
6. Chat: `remember something` -> reply `pick up batteries tomorrow` -> confirm save-memory completes after the follow-up rather than falling through to run_intent.

Closes #708
Closes #600
Closes #601
Closes #599
Closes #591