### PR TITLE
feat(#678): add native Android STT engine selector

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -1,0 +1,226 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.withContext
+
+private const val TAG = "NativeVoiceInput"
+
+@Singleton
+class NativeAndroidVoiceInputController @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : VoiceInputController {
+
+    private val _events = MutableSharedFlow<VoiceInputEvent>(extraBufferCapacity = 8)
+    override val events: Flow<VoiceInputEvent> = _events.asSharedFlow()
+
+    private val audioManager by lazy {
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+
+    @Volatile
+    private var audioFocusRequest: AudioFocusRequest? = null
+
+    @Volatile
+    private var speechRecognizer: SpeechRecognizer? = null
+
+    @Volatile
+    private var currentMode: VoiceCaptureMode? = null
+
+    @Volatile
+    private var sessionCompleted = false
+
+    override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
+        return withContext(Dispatchers.Main.immediate) {
+            stopListeningInternal(emitStopped = false)
+
+            if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+                return@withContext VoiceInputStartResult.Unavailable(
+                    "Android speech recognition is not available on this device.",
+                )
+            }
+
+            try {
+                requestAudioFocus()
+                val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+                currentMode = mode
+                sessionCompleted = false
+                speechRecognizer = recognizer
+                recognizer.setRecognitionListener(SessionRecognitionListener(mode))
+                recognizer.startListening(buildRecognizerIntent())
+                _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
+                VoiceInputStartResult.Started
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start Android native voice capture", e)
+                stopListeningInternal(emitStopped = false)
+                VoiceInputStartResult.Unavailable(
+                    e.message ?: "Failed to start Android speech recognition.",
+                )
+            }
+        }
+    }
+
+    override fun stopListening() {
+        context.mainExecutor.execute {
+            stopListeningInternal(emitStopped = true)
+        }
+    }
+
+    private fun stopListeningInternal(emitStopped: Boolean) {
+        val mode = currentMode
+        val recognizer = speechRecognizer
+        speechRecognizer = null
+        currentMode = null
+        sessionCompleted = true
+
+        recognizer?.apply {
+            runCatching { stopListening() }
+            runCatching { cancel() }
+            runCatching { destroy() }
+        }
+        releaseAudioFocus()
+
+        if (emitStopped && mode != null) {
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+        }
+    }
+
+    private fun buildRecognizerIntent(): Intent =
+        Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+            putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, context.resources.configuration.locales[0].toLanguageTag())
+            putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+        }
+
+    private inner class SessionRecognitionListener(
+        private val mode: VoiceCaptureMode,
+    ) : RecognitionListener {
+
+        override fun onReadyForSpeech(params: Bundle?) = Unit
+
+        override fun onBeginningOfSpeech() = Unit
+
+        override fun onRmsChanged(rmsdB: Float) = Unit
+
+        override fun onBufferReceived(buffer: ByteArray?) = Unit
+
+        override fun onEndOfSpeech() = Unit
+
+        override fun onError(error: Int) {
+            if (sessionCompleted) return
+            sessionCompleted = true
+            _events.tryEmit(
+                VoiceInputEvent.Error(
+                    mode = mode,
+                    message = mapError(error),
+                ),
+            )
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            stopListeningInternal(emitStopped = false)
+        }
+
+        override fun onResults(results: Bundle?) {
+            if (sessionCompleted) return
+            val transcript = extractBestTranscript(results)
+            sessionCompleted = true
+            if (transcript.isBlank()) {
+                _events.tryEmit(
+                    VoiceInputEvent.Error(
+                        mode = mode,
+                        message = "I didn't catch anything from Android speech recognition.",
+                    ),
+                )
+            } else {
+                _events.tryEmit(VoiceInputEvent.Transcript(mode = mode, text = transcript))
+            }
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            stopListeningInternal(emitStopped = false)
+        }
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            if (sessionCompleted) return
+            val transcript = extractBestTranscript(partialResults)
+            if (transcript.isNotBlank()) {
+                _events.tryEmit(VoiceInputEvent.PartialTranscript(mode = mode, text = transcript))
+            }
+        }
+
+        override fun onEvent(eventType: Int, params: Bundle?) = Unit
+    }
+
+    private fun extractBestTranscript(results: Bundle?): String =
+        results
+            ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+            ?.firstOrNull()
+            ?.trim()
+            .orEmpty()
+
+    private fun mapError(error: Int): String =
+        when (error) {
+            SpeechRecognizer.ERROR_AUDIO -> "Android speech recognition had an audio input problem."
+            SpeechRecognizer.ERROR_CLIENT -> "Android speech recognition was interrupted by the app."
+            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission is required for Android speech recognition."
+            SpeechRecognizer.ERROR_NETWORK,
+            SpeechRecognizer.ERROR_NETWORK_TIMEOUT,
+            -> "Android speech recognition needs network access or timed out while contacting the recognizer."
+            SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED -> "The current language is not supported by Android speech recognition."
+            SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE -> "The current language pack is unavailable for Android speech recognition."
+            SpeechRecognizer.ERROR_NO_MATCH -> "Android speech recognition couldn't match what you said."
+            SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Android speech recognition is already busy."
+            SpeechRecognizer.ERROR_SERVER -> "Android speech recognition hit a service error."
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "Android speech recognition disconnected unexpectedly."
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "I didn't catch anything before Android speech recognition timed out."
+            else -> "Android speech recognition failed with error code $error."
+        }
+
+    private fun requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                )
+                .setOnAudioFocusChangeListener { }
+                .build()
+            audioFocusRequest = request
+            audioManager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                { },
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            )
+        }
+    }
+
+    private fun releaseAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+            audioFocusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(null)
+        }
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
@@ -1,0 +1,36 @@
+package com.kernel.ai.core.voice
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.first
+
+@Singleton
+class SelectableVoiceInputController @Inject constructor(
+    private val voiceInputPreferences: VoiceInputPreferences,
+    private val voskOfflineVoiceInputController: VoskOfflineVoiceInputController,
+    private val nativeAndroidVoiceInputController: NativeAndroidVoiceInputController,
+) : VoiceInputController {
+
+    override val events: Flow<VoiceInputEvent> = merge(
+        voskOfflineVoiceInputController.events,
+        nativeAndroidVoiceInputController.events,
+    )
+
+    @Volatile
+    private var activeController: VoiceInputController = voskOfflineVoiceInputController
+
+    override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
+        val controller = when (voiceInputPreferences.selectedEngine.first()) {
+            VoiceInputEngine.Vosk -> voskOfflineVoiceInputController
+            VoiceInputEngine.AndroidNative -> nativeAndroidVoiceInputController
+        }
+        activeController = controller
+        return controller.startListening(mode)
+    }
+
+    override fun stopListening() {
+        activeController.stopListening()
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputEngine.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputEngine.kt
@@ -1,0 +1,23 @@
+package com.kernel.ai.core.voice
+
+enum class VoiceInputEngine(
+    val displayName: String,
+    val description: String,
+    val warning: String? = null,
+) {
+    Vosk(
+        displayName = "Vosk (Recommended)",
+        description = "Offline-first voice recognition using the bundled local model.",
+    ),
+    AndroidNative(
+        displayName = "Android native (Experimental)",
+        description = "Uses the platform speech recognizer and may work better for some accents or devices.",
+        warning = "Android native speech recognition may depend on device support, installed language packs, and recognizer availability. Offline behavior is not guaranteed on all devices.",
+    ),
+    ;
+
+    companion object {
+        fun fromStorage(value: String?): VoiceInputEngine =
+            entries.firstOrNull { it.name == value } ?: Vosk
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputEngine.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputEngine.kt
@@ -10,7 +10,7 @@ enum class VoiceInputEngine(
         description = "Offline-first voice recognition using the bundled local model.",
     ),
     AndroidNative(
-        displayName = "Android native (Experimental)",
+        displayName = "Android native",
         description = "Uses the platform speech recognizer and may work better for some accents or devices.",
         warning = "Android native speech recognition may depend on device support, installed language packs, and recognizer availability. Offline behavior is not guaranteed on all devices.",
     ),

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputPreferences.kt
@@ -1,0 +1,42 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+private const val TAG = "VoiceInputPrefs"
+private val Context.voiceInputPrefsDataStore by preferencesDataStore(name = "voice_input_preferences")
+
+@Singleton
+class VoiceInputPreferences @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val selectedEngineKey = stringPreferencesKey("selected_voice_input_engine")
+
+    val selectedEngine: Flow<VoiceInputEngine> = context.voiceInputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice input preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> VoiceInputEngine.fromStorage(prefs[selectedEngineKey]) }
+
+    suspend fun setSelectedEngine(engine: VoiceInputEngine) {
+        context.voiceInputPrefsDataStore.edit { prefs ->
+            prefs[selectedEngineKey] = engine.name
+        }
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
@@ -1,7 +1,7 @@
 package com.kernel.ai.core.voice.di
 
 import com.kernel.ai.core.voice.AndroidTextToSpeechController
-import com.kernel.ai.core.voice.VoskOfflineVoiceInputController
+import com.kernel.ai.core.voice.SelectableVoiceInputController
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import dagger.Binds
@@ -17,7 +17,7 @@ abstract class VoiceModule {
     @Binds
     @Singleton
     abstract fun bindVoiceInputController(
-        impl: VoskOfflineVoiceInputController,
+        impl: SelectableVoiceInputController,
     ): VoiceInputController
 
     @Binds

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -274,9 +274,9 @@ Lower-priority skill additions — third-party integrations and local utilities.
 |-----------|-------|--------|----------|
 | [#671](https://github.com/NickMonrad/kernel-ai-assistant/issues/671) | Offline push-to-talk voice input foundation | ✅ Done — PR #711 | 🟡 Medium |
 | [#672](https://github.com/NickMonrad/kernel-ai-assistant/issues/672) | Generic spoken response / TTS foundation | ✅ Done — PR #711 | 🟡 Medium |
-| [#678](https://github.com/NickMonrad/kernel-ai-assistant/issues/678) | Optional native Android STT engine alongside Vosk | ⬜ Pending | 🟡 Medium |
+| [#678](https://github.com/NickMonrad/kernel-ai-assistant/issues/678) | Optional native Android STT engine alongside Vosk | 🔄 In Progress — PR #714 | 🟡 Medium |
 | [#700](https://github.com/NickMonrad/kernel-ai-assistant/issues/700) | Parakeet CTC STT evaluation | ⬜ Pending | 🟡 Medium |
-| [#703](https://github.com/NickMonrad/kernel-ai-assistant/issues/703) | Whisper.cpp vs Vosk + staged vision follow-up | ⬜ Pending | 🟡 Medium |
+| [#703](https://github.com/NickMonrad/kernel-ai-assistant/issues/703) | Whisper.cpp vs Vosk STT evaluation | ⬜ Pending | 🟡 Medium |
 | [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | ⬜ Pending | 🟡 Medium |
 | [#659](https://github.com/NickMonrad/kernel-ai-assistant/issues/659) | Translator skill with multilingual TTS | ⬜ Pending | 🟡 Medium |
 | [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word — Picovoice Porcupine | ⬜ Pending | 🟡 Medium |

--- a/docs/research/stt-engine-comparison.md
+++ b/docs/research/stt-engine-comparison.md
@@ -1,0 +1,96 @@
+# STT engine comparison — Android native vs Vosk vs whisper.cpp vs Parakeet
+
+## Summary
+
+This note captures the current speech-to-text research findings for the Phase 3F STT wave:
+
+- `#678` — optional native Android STT alongside Vosk
+- `#700` — Parakeet CTC evaluation
+- `#703` — whisper.cpp vs Vosk evaluation
+
+Current product signal:
+
+- on the Samsung Galaxy S23 Ultra test device, **Android native STT is a clear improvement over Vosk for Kiwi-accent speech**
+- **Vosk** still has the strongest privacy/offline guarantees today
+- **whisper.cpp** looks like a realistic medium-term candidate for push-to-talk quality experiments
+- **Parakeet CTC** should remain research-only for now
+
+## Engine comparison
+
+| Engine | Strengths | Weaknesses | Recommendation |
+| --- | --- | --- | --- |
+| **Vosk** | Fully local, deterministic offline behavior, already integrated, low package/runtime cost | Weaker recognition quality for NZ/Kiwi accent on the tested device | Keep as the current privacy/offline baseline and fallback |
+| **Android native STT** | Best observed recognition quality so far on S23 Ultra, fast partial results, no model download in app | Privacy/offline guarantees depend on recognizer implementation and language-pack availability | Keep non-default for now, but continue QA as the leading quality option |
+| **whisper.cpp** | Stronger general STT quality potential, fully local, proven Android integration pattern in Box | Higher integration complexity, larger models, more RAM/CPU cost, no streaming partials | Proceed with a scoped spike in `#703`, starting with tiny/base push-to-talk only |
+| **Parakeet CTC** | Potential long-term local STT candidate | No clean Android path, large model/runtime footprint, higher integration risk, unclear mobile fit | Keep deferred to research-only in `#700` |
+
+## Findings
+
+### Android native STT
+
+- The current manual device result is strong enough to justify `#678` as a real product path rather than a speculative fallback.
+- Android native STT should remain **non-default** for now because privacy and offline guarantees are still weaker than Vosk.
+- Follow-up work should focus on broader device QA and on-device/offline behavior validation before any default-engine decision.
+
+### Vosk
+
+- Vosk remains the safest baseline where a guaranteed local path matters more than recognition quality.
+- It still makes sense as the default while the STT wave is in progress, especially until broader QA confirms how well Android native behaves across devices and language-pack states.
+
+### whisper.cpp
+
+- `jegly/Box` demonstrates a viable Android integration pattern using a dedicated JNI/NDK bridge:
+  - Box whisper module: https://github.com/jegly/Box/tree/3f973472b46f610e085d7e7cebaad4afbe3bc944/Android/src/whisper
+  - Box whisper engine wrapper: https://github.com/jegly/Box/blob/3f973472b46f610e085d7e7cebaad4afbe3bc944/Android/src/whisper/src/main/java/com/google/ai/edge/gallery/whisper/WhisperEngine.kt
+- whisper.cpp is realistic enough to spike, but should be treated as:
+  - **push-to-talk first**
+  - **tiny/base class models first**
+  - **not a default-engine candidate yet**
+- Main tradeoffs versus the current engines:
+  - heavier memory/runtime cost than Vosk and Android native
+  - no equivalent streaming partial-result UX
+  - extra NDK/JNI/build complexity
+
+### Parakeet CTC
+
+- Parakeet may still be worth watching, but it is not the best next implementation candidate.
+- Main blockers right now:
+  - no straightforward Android integration path
+  - larger model/runtime burden
+  - more uncertain maintainability than whisper.cpp or Android native STT
+
+## Recommendations
+
+1. **Merge and harden `#678` first**
+   - keep `Vosk` as default
+   - keep `Android native` available but non-default
+   - expand structured QA while users test on real devices
+
+2. **Use Android native as the current quality benchmark**
+   - it is now the strongest tested engine for Kiwi-accent speech on the target device
+   - future engine candidates should be judged against it, not just against Vosk
+
+3. **Run `#703` next as the main research spike**
+   - scope it to whisper.cpp only
+   - focus on whether whisper tiny/base is viable on S23 Ultra for push-to-talk quality
+
+4. **Keep `#700` research-only for now**
+   - document blockers
+   - revisit only if the Android/LiteRT path becomes materially clearer
+
+## Product direction for now
+
+- **Default engine:** Vosk
+- **Best tested quality path:** Android native STT on S23 Ultra
+- **Next research candidate:** whisper.cpp
+- **Deferred candidate:** Parakeet CTC
+
+## References
+
+- Android `SpeechRecognizer` docs: https://developer.android.com/reference/android/speech/SpeechRecognizer
+- whisper.cpp models and Android example:
+  - https://github.com/ggerganov/whisper.cpp/blob/master/models/README.md
+  - https://github.com/ggerganov/whisper.cpp/tree/master/examples/whisper.android
+- Box reference implementation:
+  - https://github.com/jegly/Box
+  - https://github.com/jegly/Box/tree/3f973472b46f610e085d7e7cebaad4afbe3bc944/Android/src/whisper

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -24,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.voice.VoiceInputEngine
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +55,37 @@ fun VoiceScreen(
         ) {
             Text(
                 text = "Quick Actions",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            VoiceInputEngine.entries.forEach { engine ->
+                val warning = engine.warning
+                ListItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    headlineContent = { Text(engine.displayName) },
+                    supportingContent = { Text(engine.description) },
+                    trailingContent = {
+                        RadioButton(
+                            selected = uiState.selectedInputEngine == engine,
+                            onClick = { viewModel.setVoiceInputEngine(engine) },
+                        )
+                    },
+                )
+                if (uiState.selectedInputEngine == engine && warning != null) {
+                    Text(
+                        text = warning,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
+                }
+                HorizontalDivider()
+            }
+
+            Text(
+                text = "Quick Actions output",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -2,6 +2,8 @@ package com.kernel.ai.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.voice.VoiceInputEngine
+import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,10 +15,12 @@ import javax.inject.Inject
 
 data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
+    val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
 )
 
 @HiltViewModel
 class VoiceViewModel @Inject constructor(
+    private val voiceInputPreferences: VoiceInputPreferences,
     private val voiceOutputPreferences: VoiceOutputPreferences,
 ) : ViewModel() {
 
@@ -25,9 +29,21 @@ class VoiceViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            voiceInputPreferences.selectedEngine.collect { engine ->
+                _uiState.update { it.copy(selectedInputEngine = engine) }
+            }
+        }
+        viewModelScope.launch {
             voiceOutputPreferences.spokenResponsesEnabled.collect { enabled ->
                 _uiState.update { it.copy(spokenResponsesEnabled = enabled) }
             }
+        }
+    }
+
+    fun setVoiceInputEngine(engine: VoiceInputEngine) {
+        _uiState.update { it.copy(selectedInputEngine = engine) }
+        viewModelScope.launch {
+            voiceInputPreferences.setSelectedEngine(engine)
         }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.feature.settings
 
+import com.kernel.ai.core.voice.VoiceInputEngine
+import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -24,7 +26,9 @@ import org.junit.jupiter.api.Test
 class VoiceViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val voiceInputPreferences: VoiceInputPreferences = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
+    private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
     private val spokenResponsesEnabled = MutableStateFlow(true)
 
     private lateinit var viewModel: VoiceViewModel
@@ -32,9 +36,11 @@ class VoiceViewModelTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
+        coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
         every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
-        viewModel = VoiceViewModel(voiceOutputPreferences)
+        viewModel = VoiceViewModel(voiceInputPreferences, voiceOutputPreferences)
     }
 
     @AfterEach
@@ -46,6 +52,21 @@ class VoiceViewModelTest {
     fun `spoken responses default to enabled when preference flow emits true`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(viewModel.uiState.value.spokenResponsesEnabled)
+    }
+
+    @Test
+    fun `voice input engine defaults to vosk when preference flow emits vosk`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(VoiceInputEngine.Vosk, viewModel.uiState.value.selectedInputEngine)
+    }
+
+    @Test
+    fun `setVoiceInputEngine updates ui state immediately`() = runTest {
+        viewModel.setVoiceInputEngine(VoiceInputEngine.AndroidNative)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(VoiceInputEngine.AndroidNative, viewModel.uiState.value.selectedInputEngine)
+        coVerify { voiceInputPreferences.setSelectedEngine(VoiceInputEngine.AndroidNative) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
Start `#678` by adding the shared STT-engine selection seam and the first Android native speech-recognition path behind it.

## Changes
- add persisted `VoiceInputEngine` preferences with `Vosk` as the default
- add `Android native` as a selectable voice input engine
- add warning copy in **Settings -> Voice** about Android native recognizer/offline variability
- add `SelectableVoiceInputController` so Quick Actions voice stays behind the shared `VoiceInputController` seam
- add an initial `NativeAndroidVoiceInputController` using `SpeechRecognizer`
- update the Voice settings view model/tests for engine selection

## Testing
- [x] `:feature:settings:testDebugUnitTest`
- [x] `:feature:chat:testDebugUnitTest --tests '*ActionsViewModelVoiceTest'`
- [x] `:app:assembleDebug`
- [x] Manual device testing

## Manual device testing
- confirmed the engine selector is visible in **Settings -> Voice**
- confirmed Android native STT works on device
- observed that Android native STT is a **clear improvement over Vosk for Kiwi-accent speech** on the S23 Ultra test device

## Notes
- Vosk remains the default / recommended engine in this PR because privacy/offline guarantees are still stronger there.
- Android native is intentionally **non-default** for now even though recognition quality is better on the tested device.
- This PR is the first `#678` slice only; the next step is broader real-device comparison and QA between Vosk and Android native, followed by `#700` / `#703` research.

## Related issues
Closes #678
