### PR TITLE
docs(#700): refine Parakeet STT findings

### DIFF
--- a/docs/phase-3f-voice-foundations-plan.md
+++ b/docs/phase-3f-voice-foundations-plan.md
@@ -135,6 +135,19 @@ Only after the baseline voice slice is stable:
 
 These should remain behind the same shared controller/session architecture.
 
+#### STT model allocation guidance
+
+The STT wave should avoid assuming one engine/model is ideal for every voice surface.
+
+- **push-to-talk** and future **wake-word / instant voice entry** should prefer a **small, fast-loading STT path**
+- that path should minimise cold-start time and reduce memory/runtime conflict with the main resident reasoning model
+- heavier model-assisted voice handling may still make sense later for richer **chat voice** flows, but it should not drive the quick-entry STT choice by default
+
+Practical implication:
+
+- evaluate Vosk, Android native STT, whisper tiny/base, and Parakeet as candidates for the **fast entry STT layer**
+- keep the main Gemma reasoning model focused on downstream reasoning and response generation rather than treating it as the default quick-load transcription engine
+
 ## Follow-on work after the foundation
 
 ### Next consumer surfaces

--- a/docs/research/stt-engine-comparison.md
+++ b/docs/research/stt-engine-comparison.md
@@ -13,7 +13,8 @@ Current product signal:
 - on the Samsung Galaxy S23 Ultra test device, **Android native STT is a clear improvement over Vosk for Kiwi-accent speech**
 - **Vosk** still has the strongest privacy/offline guarantees today
 - **whisper.cpp** looks like a realistic medium-term candidate for push-to-talk quality experiments
-- **Parakeet CTC** should remain research-only for now
+- **Parakeet CTC** is more credible than a purely theoretical candidate because a LiteRT-community artifact exists with Qualcomm-specific builds, including **SM8550**
+- **Parakeet CTC** should still remain research-only for now until runtime/backend behavior is validated on device
 
 ## Engine comparison
 
@@ -22,7 +23,7 @@ Current product signal:
 | **Vosk** | Fully local, deterministic offline behavior, already integrated, low package/runtime cost | Weaker recognition quality for NZ/Kiwi accent on the tested device | Keep as the current privacy/offline baseline and fallback |
 | **Android native STT** | Best observed recognition quality so far on S23 Ultra, fast partial results, no model download in app | Privacy/offline guarantees depend on recognizer implementation and language-pack availability | Keep non-default for now, but continue QA as the leading quality option |
 | **whisper.cpp** | Stronger general STT quality potential, fully local, proven Android integration pattern in Box | Higher integration complexity, larger models, more RAM/CPU cost, no streaming partials | Proceed with a scoped spike in `#703`, starting with tiny/base push-to-talk only |
-| **Parakeet CTC** | Potential long-term local STT candidate | No clean Android path, large model/runtime footprint, higher integration risk, unclear mobile fit | Keep deferred to research-only in `#700` |
+| **Parakeet CTC** | LiteRT-community artifact exists, Qualcomm-specific variants exist including SM8550, could be a strong dedicated STT path if backend/runtime works well | Published card is sparse, runtime backend is unclear from files alone, very large model sizes, higher integration risk than Android native | Keep deferred to research-only in `#700`, but track it as a more credible Android candidate than before |
 
 ## Findings
 
@@ -53,11 +54,59 @@ Current product signal:
 
 ### Parakeet CTC
 
-- Parakeet may still be worth watching, but it is not the best next implementation candidate.
-- Main blockers right now:
-  - no straightforward Android integration path
-  - larger model/runtime burden
-  - more uncertain maintainability than whisper.cpp or Android native STT
+- `litert-community/parakeet-ctc-0.6b` now provides stronger Android evidence than the first pass assumed:
+  - model page: https://huggingface.co/litert-community/parakeet-ctc-0.6b
+  - files page: https://huggingface.co/litert-community/parakeet-ctc-0.6b/tree/main
+- The file list includes Qualcomm-targeted variants for:
+  - `SA8255`
+  - `SA8295`
+  - `SM8450`
+  - `SM8550`
+  - `SM8650`
+  - `SM8750`
+  - `SM8850`
+- That means **SM8550 is explicitly in the target set**, which is directly relevant to the S23 Ultra test device.
+- The files also suggest multiple packaging modes:
+  - generic `parakeet_ctc_0.6b_5s_f32.tflite`
+  - chipset-specific `..._Qualcomm_<chip>.tflite`
+  - generic quantized `parakeet_ctc_0.6b_5s_i8.tflite`
+- What this strongly suggests:
+  - Parakeet is now a **real LiteRT Android candidate**
+  - Qualcomm-specific optimisation work has already been done
+  - the model appears to be packaged as a **5-second bounded inference path**, not obviously a continuous streaming path
+- What we still **cannot** conclude from the filenames alone:
+  - whether the Qualcomm files are intended for CPU, GPU, or QNN/NPU execution
+  - whether they require special delegate/runtime setup beyond normal LiteRT APIs
+  - actual RAM, latency, and battery behavior on device
+  - whether partial-result UX is feasible in practice
+- Model size remains a major concern:
+  - generic FP32: ~2.35 GB
+  - Qualcomm-specific FP32 variants: ~1.19–1.2 GB
+  - generic INT8: ~596 MB
+- Net result:
+  - Parakeet is **more credible than previously documented**
+  - but it still does **not** outrank Android native as the best current quality path or whisper.cpp as the next research spike with the clearest integration story
+
+## Architecture note — keep fast STT separate from the main LLM
+
+There is an important product/architecture consideration for future voice work:
+
+- **push-to-talk** and especially future **wake-word / always-ready voice entry** should prefer a **small, fast-loading dedicated STT path**
+- that STT path should minimise load-time, RAM pressure, and runtime conflict with the main resident reasoning model
+
+Implications:
+
+- Vosk, Android native STT, whisper tiny, or a suitably optimised Parakeet variant are all candidates for the **fast voice-entry path**
+- a heavier model-assisted path may still make sense later for **chat voice** or richer conversational voice handling
+- but the repo should avoid assuming that the same heavy model is ideal for:
+  - wake word
+  - quick push-to-talk commands
+  - long-form chat voice
+
+The practical design goal should be:
+
+- **lightweight STT for quick entry surfaces**
+- **heavier reasoning/model work after transcription**, not as the always-on or quick-load transcription engine
 
 ## Recommendations
 
@@ -75,19 +124,23 @@ Current product signal:
    - focus on whether whisper tiny/base is viable on S23 Ultra for push-to-talk quality
 
 4. **Keep `#700` research-only for now**
-   - document blockers
-   - revisit only if the Android/LiteRT path becomes materially clearer
+   - it is now worth tracking as a credible Qualcomm/LiteRT candidate because SM8550-targeted artifacts exist
+   - but it should still wait behind broader Android native QA and the whisper.cpp spike
+   - revisit once we know more about backend/runtime behavior and memory cost on the target device
 
 ## Product direction for now
 
 - **Default engine:** Vosk
 - **Best tested quality path:** Android native STT on S23 Ultra
 - **Next research candidate:** whisper.cpp
-- **Deferred candidate:** Parakeet CTC
+- **More credible but still deferred candidate:** Parakeet CTC
 
 ## References
 
 - Android `SpeechRecognizer` docs: https://developer.android.com/reference/android/speech/SpeechRecognizer
+- LiteRT-community Parakeet artifact:
+  - https://huggingface.co/litert-community/parakeet-ctc-0.6b
+  - https://huggingface.co/litert-community/parakeet-ctc-0.6b/tree/main
 - whisper.cpp models and Android example:
   - https://github.com/ggerganov/whisper.cpp/blob/master/models/README.md
   - https://github.com/ggerganov/whisper.cpp/tree/master/examples/whisper.android


### PR DESCRIPTION
## Summary
Refine the STT research notes after `#714` by incorporating the LiteRT-community Parakeet artifact details and the updated STT architecture guidance.

## Changes
- add the `litert-community/parakeet-ctc-0.6b` links to the STT research doc
- document the Qualcomm-specific Parakeet artifact set, including explicit `SM8550` support
- clarify what the artifact filenames do and do not prove about backend/chipset support
- add the design guidance that push-to-talk and wake-word STT should stay lightweight to avoid resource conflict with the main resident reasoning model
- update the Phase 3F planning doc with the same STT surface-allocation guidance

## Testing
- [x] Documentation only

## Related issues
Relates to #700
Relates to #703
