### PR TITLE
fix(#717): harden Android native STT on-device path

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -3,12 +3,15 @@ package com.kernel.ai.core.voice
 import android.content.Context
 import android.speech.SpeechRecognizer
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
 data class AndroidNativeRecognitionAvailability(
     val isRecognitionAvailable: Boolean,
     val isOnDeviceRecognitionAvailable: Boolean,
+    val languageTag: String,
+    val languageDisplayName: String,
 ) {
     val unavailableReason: String?
         get() = when {
@@ -16,17 +19,26 @@ data class AndroidNativeRecognitionAvailability(
             !isOnDeviceRecognitionAvailable -> "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input."
             else -> null
         }
+
+    val languageSummary: String
+        get() = "$languageDisplayName ($languageTag)"
 }
 
 @Singleton
 class AndroidNativeRecognitionSupport @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
-    fun getAvailability(): AndroidNativeRecognitionAvailability =
-        AndroidNativeRecognitionAvailability(
+    fun getAvailability(): AndroidNativeRecognitionAvailability {
+        val locale = context.resources.configuration.locales[0] ?: Locale.getDefault()
+        return AndroidNativeRecognitionAvailability(
             isRecognitionAvailable = SpeechRecognizer.isRecognitionAvailable(context),
             isOnDeviceRecognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(context),
+            languageTag = locale.toLanguageTag(),
+            languageDisplayName = locale.getDisplayName(locale).replaceFirstChar { char ->
+                if (char.isLowerCase()) char.titlecase(locale) else char.toString()
+            },
         )
+    }
 
     fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
         SpeechRecognizer.createOnDeviceSpeechRecognizer(context)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -1,22 +1,35 @@
 package com.kernel.ai.core.voice
 
 import android.content.Context
+import android.content.Intent
+import android.speech.RecognitionSupport
+import android.speech.RecognitionSupportCallback
+import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
 
 data class AndroidNativeRecognitionAvailability(
     val isRecognitionAvailable: Boolean,
     val isOnDeviceRecognitionAvailable: Boolean,
     val languageTag: String,
     val languageDisplayName: String,
+    val localeStatus: AndroidNativeRecognitionLocaleStatus = AndroidNativeRecognitionLocaleStatus.Ready,
 ) {
     val unavailableReason: String?
         get() = when {
             !isRecognitionAvailable -> "Android speech recognition is not available on this device."
             !isOnDeviceRecognitionAvailable -> "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input."
+            localeStatus == AndroidNativeRecognitionLocaleStatus.NotSupported ->
+                "$languageDisplayName is not supported by Android native speech recognition on this device."
+            localeStatus == AndroidNativeRecognitionLocaleStatus.Unavailable ->
+                "$languageDisplayName is supported, but its Android native speech recognition language pack is not available on this device yet."
             else -> null
         }
 
@@ -24,22 +37,115 @@ data class AndroidNativeRecognitionAvailability(
         get() = "$languageDisplayName ($languageTag)"
 }
 
+enum class AndroidNativeRecognitionLocaleStatus {
+    Ready,
+    NotSupported,
+    Unavailable,
+    Unknown,
+}
+
 @Singleton
 class AndroidNativeRecognitionSupport @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
-    fun getAvailability(): AndroidNativeRecognitionAvailability {
+    suspend fun getAvailability(): AndroidNativeRecognitionAvailability {
         val locale = context.resources.configuration.locales[0] ?: Locale.getDefault()
+        val isRecognitionAvailable = SpeechRecognizer.isRecognitionAvailable(context)
+        val isOnDeviceRecognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(context)
+        val languageTag = locale.toLanguageTag()
+        val languageDisplayName = locale.getDisplayName(locale).replaceFirstChar { char ->
+            if (char.isLowerCase()) char.titlecase(locale) else char.toString()
+        }
+
+        val localeStatus = if (isRecognitionAvailable && isOnDeviceRecognitionAvailable) {
+            checkLocaleSupport(languageTag)
+        } else {
+            AndroidNativeRecognitionLocaleStatus.Unknown
+        }
+
         return AndroidNativeRecognitionAvailability(
-            isRecognitionAvailable = SpeechRecognizer.isRecognitionAvailable(context),
-            isOnDeviceRecognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(context),
+            isRecognitionAvailable = isRecognitionAvailable,
+            isOnDeviceRecognitionAvailable = isOnDeviceRecognitionAvailable,
             languageTag = locale.toLanguageTag(),
-            languageDisplayName = locale.getDisplayName(locale).replaceFirstChar { char ->
-                if (char.isLowerCase()) char.titlecase(locale) else char.toString()
-            },
+            languageDisplayName = languageDisplayName,
+            localeStatus = localeStatus,
         )
     }
 
     fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
         SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
+
+    private suspend fun checkLocaleSupport(languageTag: String): AndroidNativeRecognitionLocaleStatus =
+        withContext(Dispatchers.Main.immediate) {
+            suspendCancellableCoroutine { continuation ->
+                val recognizer = createOnDeviceSpeechRecognizer()
+                val supportIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                    putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
+                }
+
+                fun complete(status: AndroidNativeRecognitionLocaleStatus) {
+                    if (continuation.isActive) {
+                        recognizer.destroy()
+                        continuation.resume(status)
+                    } else {
+                        recognizer.destroy()
+                    }
+                }
+
+                continuation.invokeOnCancellation {
+                    recognizer.destroy()
+                }
+
+                recognizer.checkRecognitionSupport(
+                    supportIntent,
+                    context.mainExecutor,
+                    object : RecognitionSupportCallback {
+                        override fun onSupportResult(recognitionSupport: RecognitionSupport) {
+                            complete(mapSupportResult(languageTag, recognitionSupport))
+                        }
+
+                        override fun onError(error: Int) {
+                            complete(
+                                when (error) {
+                                    SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ->
+                                        AndroidNativeRecognitionLocaleStatus.NotSupported
+                                    SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE ->
+                                        AndroidNativeRecognitionLocaleStatus.Unavailable
+                                    else -> AndroidNativeRecognitionLocaleStatus.Unknown
+                                },
+                            )
+                        }
+                    },
+                )
+            }
+        }
+
+    private fun mapSupportResult(
+        languageTag: String,
+        recognitionSupport: RecognitionSupport,
+    ): AndroidNativeRecognitionLocaleStatus {
+        val normalizedLanguageTag = Locale.forLanguageTag(languageTag).toLanguageTag()
+        val installedLanguages = recognitionSupport.getInstalledOnDeviceLanguages().map {
+            Locale.forLanguageTag(it).toLanguageTag()
+        }
+        val supportedLanguages = recognitionSupport.getSupportedOnDeviceLanguages().map {
+            Locale.forLanguageTag(it).toLanguageTag()
+        }
+        val pendingLanguages = recognitionSupport.getPendingOnDeviceLanguages().map {
+            Locale.forLanguageTag(it).toLanguageTag()
+        }
+        val onlineLanguages = recognitionSupport.getOnlineLanguages().map {
+            Locale.forLanguageTag(it).toLanguageTag()
+        }
+
+        return when {
+            normalizedLanguageTag in installedLanguages -> AndroidNativeRecognitionLocaleStatus.Ready
+            normalizedLanguageTag in supportedLanguages -> AndroidNativeRecognitionLocaleStatus.Unavailable
+            normalizedLanguageTag in pendingLanguages -> AndroidNativeRecognitionLocaleStatus.Unavailable
+            normalizedLanguageTag in onlineLanguages -> AndroidNativeRecognitionLocaleStatus.NotSupported
+            else -> AndroidNativeRecognitionLocaleStatus.Unknown
+        }
+    }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -1,0 +1,33 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.speech.SpeechRecognizer
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class AndroidNativeRecognitionAvailability(
+    val isRecognitionAvailable: Boolean,
+    val isOnDeviceRecognitionAvailable: Boolean,
+) {
+    val unavailableReason: String?
+        get() = when {
+            !isRecognitionAvailable -> "Android speech recognition is not available on this device."
+            !isOnDeviceRecognitionAvailable -> "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input."
+            else -> null
+        }
+}
+
+@Singleton
+class AndroidNativeRecognitionSupport @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun getAvailability(): AndroidNativeRecognitionAvailability =
+        AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = SpeechRecognizer.isRecognitionAvailable(context),
+            isOnDeviceRecognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(context),
+        )
+
+    fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
+        SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -6,6 +6,7 @@ import android.speech.RecognitionSupport
 import android.speech.RecognitionSupportCallback
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
@@ -15,6 +16,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
+
+private const val TAG = "NativeVoiceInput"
 
 data class AndroidNativeRecognitionAvailability(
     val isRecognitionAvailable: Boolean,
@@ -72,6 +75,13 @@ class AndroidNativeRecognitionSupport @Inject constructor(
             AndroidNativeRecognitionLocaleStatus.Unknown
         }
 
+        Log.i(
+            TAG,
+            "Android native availability: language=$languageTag displayName=$languageDisplayName " +
+                "recognitionAvailable=$isRecognitionAvailable " +
+                "onDeviceAvailable=$isOnDeviceRecognitionAvailable localeStatus=$localeStatus",
+        )
+
         return AndroidNativeRecognitionAvailability(
             isRecognitionAvailable = isRecognitionAvailable,
             isOnDeviceRecognitionAvailable = isOnDeviceRecognitionAvailable,
@@ -113,10 +123,19 @@ class AndroidNativeRecognitionSupport @Inject constructor(
                         context.mainExecutor,
                         object : RecognitionSupportCallback {
                             override fun onSupportResult(recognitionSupport: RecognitionSupport) {
+                                Log.i(
+                                    TAG,
+                                    "Recognition support result for $languageTag: " +
+                                        "installed=${recognitionSupport.getInstalledOnDeviceLanguages()} " +
+                                        "supported=${recognitionSupport.getSupportedOnDeviceLanguages()} " +
+                                        "pending=${recognitionSupport.getPendingOnDeviceLanguages()} " +
+                                        "online=${recognitionSupport.getOnlineLanguages()}",
+                                )
                                 complete(resolveLocaleStatus(languageTag, recognitionSupport))
                             }
 
                             override fun onError(error: Int) {
+                                Log.w(TAG, "Recognition support check failed for $languageTag with error=$error")
                                 complete(
                                     when (error) {
                                         SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ->
@@ -130,7 +149,10 @@ class AndroidNativeRecognitionSupport @Inject constructor(
                         },
                     )
                 }
-            } ?: AndroidNativeRecognitionLocaleStatus.Unknown
+            } ?: run {
+                Log.w(TAG, "Recognition support check timed out for $languageTag")
+                AndroidNativeRecognitionLocaleStatus.Unknown
+            }
         }
 }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -23,7 +23,7 @@ data class AndroidNativeRecognitionAvailability(
     val languageDisplayName: String,
     val localeStatus: AndroidNativeRecognitionLocaleStatus = AndroidNativeRecognitionLocaleStatus.Ready,
 ) {
-    val unavailableReason: String?
+    val blockingReason: String?
         get() = when {
             !isRecognitionAvailable -> "Android speech recognition is not available on this device."
             !isOnDeviceRecognitionAvailable -> "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input."
@@ -31,6 +31,12 @@ data class AndroidNativeRecognitionAvailability(
                 "$languageDisplayName is not supported by Android native speech recognition on this device."
             localeStatus == AndroidNativeRecognitionLocaleStatus.Unavailable ->
                 "$languageDisplayName is supported, but its Android native speech recognition language pack is not available on this device yet."
+            else -> null
+        }
+
+    val warningMessage: String?
+        get() = when {
+            blockingReason != null -> blockingReason
             localeStatus == AndroidNativeRecognitionLocaleStatus.Unknown ->
                 "Android native speech recognition could not verify on-device support for $languageDisplayName on this device. It may fail unless that language is supported and installed locally."
             else -> null

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -30,6 +30,8 @@ data class AndroidNativeRecognitionAvailability(
                 "$languageDisplayName is not supported by Android native speech recognition on this device."
             localeStatus == AndroidNativeRecognitionLocaleStatus.Unavailable ->
                 "$languageDisplayName is supported, but its Android native speech recognition language pack is not available on this device yet."
+            localeStatus == AndroidNativeRecognitionLocaleStatus.Unknown ->
+                "Android native speech recognition could not verify on-device support for $languageDisplayName on this device. It may fail unless that language is supported and installed locally."
             else -> null
         }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -94,6 +94,9 @@ class AndroidNativeRecognitionSupport @Inject constructor(
     fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
         SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
 
+    fun createPlatformSpeechRecognizer(): SpeechRecognizer =
+        SpeechRecognizer.createSpeechRecognizer(context)
+
     private suspend fun checkLocaleSupport(languageTag: String): AndroidNativeRecognitionLocaleStatus =
         withContext(Dispatchers.Main.immediate) {
             withTimeoutOrNull(5_000) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 
@@ -79,75 +80,100 @@ class AndroidNativeRecognitionSupport @Inject constructor(
 
     private suspend fun checkLocaleSupport(languageTag: String): AndroidNativeRecognitionLocaleStatus =
         withContext(Dispatchers.Main.immediate) {
-            suspendCancellableCoroutine { continuation ->
-                val recognizer = createOnDeviceSpeechRecognizer()
-                val supportIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-                    putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
-                }
+            withTimeoutOrNull(5_000) {
+                suspendCancellableCoroutine { continuation ->
+                    val recognizer = createOnDeviceSpeechRecognizer()
+                    val supportIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                        putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+                        putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
+                    }
 
-                fun complete(status: AndroidNativeRecognitionLocaleStatus) {
-                    if (continuation.isActive) {
-                        recognizer.destroy()
-                        continuation.resume(status)
-                    } else {
+                    fun complete(status: AndroidNativeRecognitionLocaleStatus) {
+                        if (continuation.isActive) {
+                            recognizer.destroy()
+                            continuation.resume(status)
+                        } else {
+                            recognizer.destroy()
+                        }
+                    }
+
+                    continuation.invokeOnCancellation {
                         recognizer.destroy()
                     }
+
+                    recognizer.checkRecognitionSupport(
+                        supportIntent,
+                        context.mainExecutor,
+                        object : RecognitionSupportCallback {
+                            override fun onSupportResult(recognitionSupport: RecognitionSupport) {
+                                complete(resolveLocaleStatus(languageTag, recognitionSupport))
+                            }
+
+                            override fun onError(error: Int) {
+                                complete(
+                                    when (error) {
+                                        SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ->
+                                            AndroidNativeRecognitionLocaleStatus.NotSupported
+                                        SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE ->
+                                            AndroidNativeRecognitionLocaleStatus.Unavailable
+                                        else -> AndroidNativeRecognitionLocaleStatus.Unknown
+                                    },
+                                )
+                            }
+                        },
+                    )
                 }
+            } ?: AndroidNativeRecognitionLocaleStatus.Unknown
+        }
+}
 
-                continuation.invokeOnCancellation {
-                    recognizer.destroy()
-                }
+internal fun resolveLocaleStatus(
+    languageTag: String,
+    recognitionSupport: RecognitionSupport,
+): AndroidNativeRecognitionLocaleStatus =
+    resolveLocaleStatus(
+        languageTag = languageTag,
+        installedLanguages = recognitionSupport.getInstalledOnDeviceLanguages(),
+        supportedLanguages = recognitionSupport.getSupportedOnDeviceLanguages(),
+        pendingLanguages = recognitionSupport.getPendingOnDeviceLanguages(),
+        onlineLanguages = recognitionSupport.getOnlineLanguages(),
+    )
 
-                recognizer.checkRecognitionSupport(
-                    supportIntent,
-                    context.mainExecutor,
-                    object : RecognitionSupportCallback {
-                        override fun onSupportResult(recognitionSupport: RecognitionSupport) {
-                            complete(mapSupportResult(languageTag, recognitionSupport))
-                        }
+internal fun resolveLocaleStatus(
+    languageTag: String,
+    installedLanguages: List<String>,
+    supportedLanguages: List<String>,
+    pendingLanguages: List<String>,
+    onlineLanguages: List<String>,
+): AndroidNativeRecognitionLocaleStatus {
+    return when {
+        matchesRequestedLanguage(languageTag, installedLanguages) -> AndroidNativeRecognitionLocaleStatus.Ready
+        matchesRequestedLanguage(languageTag, supportedLanguages) -> AndroidNativeRecognitionLocaleStatus.Unavailable
+        matchesRequestedLanguage(languageTag, pendingLanguages) -> AndroidNativeRecognitionLocaleStatus.Unavailable
+        matchesRequestedLanguage(languageTag, onlineLanguages) -> AndroidNativeRecognitionLocaleStatus.NotSupported
+        else -> AndroidNativeRecognitionLocaleStatus.Unknown
+    }
+}
 
-                        override fun onError(error: Int) {
-                            complete(
-                                when (error) {
-                                    SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ->
-                                        AndroidNativeRecognitionLocaleStatus.NotSupported
-                                    SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE ->
-                                        AndroidNativeRecognitionLocaleStatus.Unavailable
-                                    else -> AndroidNativeRecognitionLocaleStatus.Unknown
-                                },
-                            )
-                        }
-                    },
-                )
-            }
-        }
+private fun matchesRequestedLanguage(
+    requestedLanguageTag: String,
+    availableLanguageTags: List<String>,
+): Boolean {
+    val requestedLocale = Locale.forLanguageTag(requestedLanguageTag)
+    val requestedNormalizedTag = requestedLocale.toLanguageTag()
+    val requestedBaseLanguage = requestedLocale.language
 
-    private fun mapSupportResult(
-        languageTag: String,
-        recognitionSupport: RecognitionSupport,
-    ): AndroidNativeRecognitionLocaleStatus {
-        val normalizedLanguageTag = Locale.forLanguageTag(languageTag).toLanguageTag()
-        val installedLanguages = recognitionSupport.getInstalledOnDeviceLanguages().map {
-            Locale.forLanguageTag(it).toLanguageTag()
-        }
-        val supportedLanguages = recognitionSupport.getSupportedOnDeviceLanguages().map {
-            Locale.forLanguageTag(it).toLanguageTag()
-        }
-        val pendingLanguages = recognitionSupport.getPendingOnDeviceLanguages().map {
-            Locale.forLanguageTag(it).toLanguageTag()
-        }
-        val onlineLanguages = recognitionSupport.getOnlineLanguages().map {
-            Locale.forLanguageTag(it).toLanguageTag()
-        }
+    return availableLanguageTags.any { availableLanguageTag ->
+        val availableLocale = Locale.forLanguageTag(availableLanguageTag)
+        val availableNormalizedTag = availableLocale.toLanguageTag()
+        val availableBaseLanguage = availableLocale.language
 
-        return when {
-            normalizedLanguageTag in installedLanguages -> AndroidNativeRecognitionLocaleStatus.Ready
-            normalizedLanguageTag in supportedLanguages -> AndroidNativeRecognitionLocaleStatus.Unavailable
-            normalizedLanguageTag in pendingLanguages -> AndroidNativeRecognitionLocaleStatus.Unavailable
-            normalizedLanguageTag in onlineLanguages -> AndroidNativeRecognitionLocaleStatus.NotSupported
-            else -> AndroidNativeRecognitionLocaleStatus.Unknown
-        }
+        availableNormalizedTag == requestedNormalizedTag ||
+            (
+                requestedBaseLanguage.isNotBlank() &&
+                    availableBaseLanguage.isNotBlank() &&
+                    requestedBaseLanguage == availableBaseLanguage
+            )
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -47,20 +47,17 @@ class NativeAndroidVoiceInputController @Inject constructor(
     @Volatile
     private var sessionCompleted = false
 
+    @Volatile
+    private var currentAvailability: AndroidNativeRecognitionAvailability? = null
+
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
             val availability = recognitionSupport.getAvailability()
-            if (!availability.isRecognitionAvailable) {
+            availability.unavailableReason?.let { reason ->
                 return@withContext VoiceInputStartResult.Unavailable(
-                    "Android speech recognition is not available on this device.",
-                )
-            }
-            if (!availability.isOnDeviceRecognitionAvailable) {
-                return@withContext VoiceInputStartResult.Unavailable(
-                    availability.unavailableReason
-                        ?: "On-device Android speech recognition is unavailable on this device.",
+                    reason,
                 )
             }
 
@@ -68,6 +65,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 requestAudioFocus()
                 val recognizer = recognitionSupport.createOnDeviceSpeechRecognizer()
                 currentMode = mode
+                currentAvailability = availability
                 sessionCompleted = false
                 speechRecognizer = recognizer
                 recognizer.setRecognitionListener(SessionRecognitionListener(mode))
@@ -95,6 +93,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         val recognizer = speechRecognizer
         speechRecognizer = null
         currentMode = null
+        currentAvailability = null
         sessionCompleted = true
 
         recognizer?.apply {
@@ -194,7 +193,14 @@ class NativeAndroidVoiceInputController @Inject constructor(
             SpeechRecognizer.ERROR_NO_MATCH -> "Android speech recognition couldn't match what you said."
             SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Android speech recognition is already busy."
             SpeechRecognizer.ERROR_SERVER -> "Android speech recognition hit a service error."
-            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "Android speech recognition disconnected unexpectedly."
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> {
+                val languageSummary = currentAvailability?.languageSummary
+                if (languageSummary != null) {
+                    "Android speech recognition disconnected unexpectedly while using $languageSummary. This can happen when that on-device language is unsupported or not installed."
+                } else {
+                    "Android speech recognition disconnected unexpectedly. This can happen when the selected on-device language is unsupported or not installed."
+                }
+            }
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "I didn't catch anything before Android speech recognition timed out."
             else -> "Android speech recognition failed with error code $error."
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -25,6 +25,7 @@ private const val TAG = "NativeVoiceInput"
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val recognitionSupport: AndroidNativeRecognitionSupport,
 ) : VoiceInputController {
 
     private val _events = MutableSharedFlow<VoiceInputEvent>(extraBufferCapacity = 8)
@@ -50,15 +51,22 @@ class NativeAndroidVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
-            if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+            val availability = recognitionSupport.getAvailability()
+            if (!availability.isRecognitionAvailable) {
                 return@withContext VoiceInputStartResult.Unavailable(
                     "Android speech recognition is not available on this device.",
+                )
+            }
+            if (!availability.isOnDeviceRecognitionAvailable) {
+                return@withContext VoiceInputStartResult.Unavailable(
+                    availability.unavailableReason
+                        ?: "On-device Android speech recognition is unavailable on this device.",
                 )
             }
 
             try {
                 requestAudioFocus()
-                val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+                val recognizer = recognitionSupport.createOnDeviceSpeechRecognizer()
                 currentMode = mode
                 sessionCompleted = false
                 speechRecognizer = recognizer
@@ -180,7 +188,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission is required for Android speech recognition."
             SpeechRecognizer.ERROR_NETWORK,
             SpeechRecognizer.ERROR_NETWORK_TIMEOUT,
-            -> "Android speech recognition needs network access or timed out while contacting the recognizer."
+            -> "Android speech recognition unexpectedly requested network access or timed out."
             SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED -> "The current language is not supported by Android speech recognition."
             SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE -> "The current language pack is unavailable for Android speech recognition."
             SpeechRecognizer.ERROR_NO_MATCH -> "Android speech recognition couldn't match what you said."

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -55,6 +55,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
             val availability = recognitionSupport.getAvailability()
             availability.blockingReason?.let { reason ->
+                Log.w(
+                    TAG,
+                    "Blocking Android native STT start: language=${availability.languageSummary} " +
+                        "localeStatus=${availability.localeStatus} reason=$reason",
+                )
                 return@withContext VoiceInputStartResult.Unavailable(
                     reason,
                 )
@@ -67,6 +72,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 currentMode = mode
                 activeSessionId = sessionId
                 speechRecognizer = recognizer
+                Log.i(
+                    TAG,
+                    "Starting Android native STT: sessionId=$sessionId mode=$mode " +
+                        "language=${availability.languageSummary} localeStatus=${availability.localeStatus} " +
+                        "forceLanguage=${availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown}",
+                )
                 recognizer.setRecognitionListener(
                     SessionRecognitionListener(
                         sessionId = sessionId,
@@ -148,6 +159,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
         override fun onError(error: Int) {
             if (sessionCompleted || activeSessionId != sessionId) return
             sessionCompleted = true
+            Log.w(
+                TAG,
+                "Android native STT error: sessionId=$sessionId mode=$mode error=$error " +
+                    "language=${availability.languageSummary} localeStatus=${availability.localeStatus}",
+            )
             _events.tryEmit(
                 VoiceInputEvent.Error(
                     mode = mode,
@@ -162,6 +178,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
             if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(results)
             sessionCompleted = true
+            Log.i(
+                TAG,
+                "Android native STT result: sessionId=$sessionId mode=$mode transcript='$transcript' " +
+                    "language=${availability.languageSummary}",
+            )
             if (transcript.isBlank()) {
                 _events.tryEmit(
                     VoiceInputEvent.Error(
@@ -180,6 +201,10 @@ class NativeAndroidVoiceInputController @Inject constructor(
             if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(partialResults)
             if (transcript.isNotBlank()) {
+                Log.d(
+                    TAG,
+                    "Android native STT partial: sessionId=$sessionId mode=$mode transcript='$transcript'",
+                )
                 _events.tryEmit(VoiceInputEvent.PartialTranscript(mode = mode, text = transcript))
             }
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -45,10 +45,9 @@ class NativeAndroidVoiceInputController @Inject constructor(
     private var currentMode: VoiceCaptureMode? = null
 
     @Volatile
-    private var sessionCompleted = false
+    private var activeSessionId: Long = 0L
 
-    @Volatile
-    private var currentAvailability: AndroidNativeRecognitionAvailability? = null
+    private var nextSessionId: Long = 0L
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         return withContext(Dispatchers.Main.immediate) {
@@ -64,11 +63,17 @@ class NativeAndroidVoiceInputController @Inject constructor(
             try {
                 requestAudioFocus()
                 val recognizer = recognitionSupport.createOnDeviceSpeechRecognizer()
+                val sessionId = ++nextSessionId
                 currentMode = mode
-                currentAvailability = availability
-                sessionCompleted = false
+                activeSessionId = sessionId
                 speechRecognizer = recognizer
-                recognizer.setRecognitionListener(SessionRecognitionListener(mode))
+                recognizer.setRecognitionListener(
+                    SessionRecognitionListener(
+                        sessionId = sessionId,
+                        mode = mode,
+                        availability = availability,
+                    ),
+                )
                 recognizer.startListening(buildRecognizerIntent(availability.languageTag))
                 _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
                 VoiceInputStartResult.Started
@@ -84,17 +89,20 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
     override fun stopListening() {
         context.mainExecutor.execute {
-            stopListeningInternal(emitStopped = true)
+            stopListeningInternal(emitStopped = true, expectedSessionId = activeSessionId)
         }
     }
 
-    private fun stopListeningInternal(emitStopped: Boolean) {
+    private fun stopListeningInternal(emitStopped: Boolean, expectedSessionId: Long? = null) {
+        if (expectedSessionId != null && activeSessionId != expectedSessionId) {
+            return
+        }
+
         val mode = currentMode
         val recognizer = speechRecognizer
         speechRecognizer = null
         currentMode = null
-        currentAvailability = null
-        sessionCompleted = true
+        activeSessionId = 0L
 
         recognizer?.apply {
             runCatching { stopListening() }
@@ -118,8 +126,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
         }
 
     private inner class SessionRecognitionListener(
+        private val sessionId: Long,
         private val mode: VoiceCaptureMode,
+        private val availability: AndroidNativeRecognitionAvailability,
     ) : RecognitionListener {
+
+        private var sessionCompleted = false
 
         override fun onReadyForSpeech(params: Bundle?) = Unit
 
@@ -132,20 +144,20 @@ class NativeAndroidVoiceInputController @Inject constructor(
         override fun onEndOfSpeech() = Unit
 
         override fun onError(error: Int) {
-            if (sessionCompleted) return
+            if (sessionCompleted || activeSessionId != sessionId) return
             sessionCompleted = true
             _events.tryEmit(
                 VoiceInputEvent.Error(
                     mode = mode,
-                    message = mapError(error),
+                    message = mapError(error, availability),
                 ),
             )
             _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
-            stopListeningInternal(emitStopped = false)
+            stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
         }
 
         override fun onResults(results: Bundle?) {
-            if (sessionCompleted) return
+            if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(results)
             sessionCompleted = true
             if (transcript.isBlank()) {
@@ -159,11 +171,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 _events.tryEmit(VoiceInputEvent.Transcript(mode = mode, text = transcript))
             }
             _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
-            stopListeningInternal(emitStopped = false)
+            stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
         }
 
         override fun onPartialResults(partialResults: Bundle?) {
-            if (sessionCompleted) return
+            if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(partialResults)
             if (transcript.isNotBlank()) {
                 _events.tryEmit(VoiceInputEvent.PartialTranscript(mode = mode, text = transcript))
@@ -180,7 +192,10 @@ class NativeAndroidVoiceInputController @Inject constructor(
             ?.trim()
             .orEmpty()
 
-    private fun mapError(error: Int): String =
+    private fun mapError(
+        error: Int,
+        availability: AndroidNativeRecognitionAvailability,
+    ): String =
         when (error) {
             SpeechRecognizer.ERROR_AUDIO -> "Android speech recognition had an audio input problem."
             SpeechRecognizer.ERROR_CLIENT -> "Android speech recognition was interrupted by the app."
@@ -193,14 +208,8 @@ class NativeAndroidVoiceInputController @Inject constructor(
             SpeechRecognizer.ERROR_NO_MATCH -> "Android speech recognition couldn't match what you said."
             SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Android speech recognition is already busy."
             SpeechRecognizer.ERROR_SERVER -> "Android speech recognition hit a service error."
-            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> {
-                val languageSummary = currentAvailability?.languageSummary
-                if (languageSummary != null) {
-                    "Android speech recognition disconnected unexpectedly while using $languageSummary. This can happen when that on-device language is unsupported or not installed."
-                } else {
-                    "Android speech recognition disconnected unexpectedly. This can happen when the selected on-device language is unsupported or not installed."
-                }
-            }
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED ->
+                "Android speech recognition disconnected unexpectedly while using ${availability.languageSummary}. This can happen when that on-device language is unsupported or not installed."
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "I didn't catch anything before Android speech recognition timed out."
             else -> "Android speech recognition failed with error code $error."
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -71,7 +71,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 sessionCompleted = false
                 speechRecognizer = recognizer
                 recognizer.setRecognitionListener(SessionRecognitionListener(mode))
-                recognizer.startListening(buildRecognizerIntent())
+                recognizer.startListening(buildRecognizerIntent(availability.languageTag))
                 _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
                 VoiceInputStartResult.Started
             } catch (e: Exception) {
@@ -109,13 +109,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
         }
     }
 
-    private fun buildRecognizerIntent(): Intent =
+    private fun buildRecognizerIntent(languageTag: String): Intent =
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-            val availability = recognitionSupport.getAvailability()
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
             putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, availability.languageTag)
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
         }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -111,10 +111,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
     private fun buildRecognizerIntent(): Intent =
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            val availability = recognitionSupport.getAvailability()
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
             putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, context.resources.configuration.locales[0].toLanguageTag())
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, availability.languageTag)
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
         }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -74,7 +74,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         availability = availability,
                     ),
                 )
-                recognizer.startListening(buildRecognizerIntent(availability.languageTag))
+                recognizer.startListening(buildRecognizerIntent(availability))
                 _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
                 VoiceInputStartResult.Started
             } catch (e: Exception) {
@@ -116,12 +116,14 @@ class NativeAndroidVoiceInputController @Inject constructor(
         }
     }
 
-    private fun buildRecognizerIntent(languageTag: String): Intent =
+    private fun buildRecognizerIntent(availability: AndroidNativeRecognitionAvailability): Intent =
         Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
             putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
+            if (availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown) {
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, availability.languageTag)
+            }
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
         }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -22,6 +22,11 @@ import kotlinx.coroutines.withContext
 
 private const val TAG = "NativeVoiceInput"
 
+private enum class RecognizerBackend {
+    OnDevice,
+    Platform,
+}
+
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -67,25 +72,15 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
             try {
                 requestAudioFocus()
-                val recognizer = recognitionSupport.createOnDeviceSpeechRecognizer()
                 val sessionId = ++nextSessionId
                 currentMode = mode
                 activeSessionId = sessionId
-                speechRecognizer = recognizer
-                Log.i(
-                    TAG,
-                    "Starting Android native STT: sessionId=$sessionId mode=$mode " +
-                        "language=${availability.languageSummary} localeStatus=${availability.localeStatus} " +
-                        "forceLanguage=${availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown}",
+                startRecognizer(
+                    sessionId = sessionId,
+                    mode = mode,
+                    availability = availability,
+                    backend = RecognizerBackend.OnDevice,
                 )
-                recognizer.setRecognitionListener(
-                    SessionRecognitionListener(
-                        sessionId = sessionId,
-                        mode = mode,
-                        availability = availability,
-                    ),
-                )
-                recognizer.startListening(buildRecognizerIntent(availability))
                 _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
                 VoiceInputStartResult.Started
             } catch (e: Exception) {
@@ -138,10 +133,65 @@ class NativeAndroidVoiceInputController @Inject constructor(
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
         }
 
+    private fun startRecognizer(
+        sessionId: Long,
+        mode: VoiceCaptureMode,
+        availability: AndroidNativeRecognitionAvailability,
+        backend: RecognizerBackend,
+    ) {
+        val recognizer = when (backend) {
+            RecognizerBackend.OnDevice -> recognitionSupport.createOnDeviceSpeechRecognizer()
+            RecognizerBackend.Platform -> recognitionSupport.createPlatformSpeechRecognizer()
+        }
+        speechRecognizer = recognizer
+        Log.i(
+            TAG,
+            "Starting Android native STT: sessionId=$sessionId mode=$mode " +
+                "backend=$backend language=${availability.languageSummary} " +
+                "localeStatus=${availability.localeStatus} " +
+                "forceLanguage=${availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown}",
+        )
+        recognizer.setRecognitionListener(
+            SessionRecognitionListener(
+                sessionId = sessionId,
+                mode = mode,
+                availability = availability,
+                backend = backend,
+            ),
+        )
+        recognizer.startListening(buildRecognizerIntent(availability))
+    }
+
+    private fun retryWithPlatformRecognizer(
+        sessionId: Long,
+        mode: VoiceCaptureMode,
+        availability: AndroidNativeRecognitionAvailability,
+    ): Boolean {
+        if (activeSessionId != sessionId) return false
+
+        return runCatching {
+            speechRecognizer?.apply {
+                runCatching { cancel() }
+                runCatching { destroy() }
+            }
+            startRecognizer(
+                sessionId = sessionId,
+                mode = mode,
+                availability = availability,
+                backend = RecognizerBackend.Platform,
+            )
+            true
+        }.getOrElse { error ->
+            Log.e(TAG, "Failed to retry Android native STT with platform recognizer", error)
+            false
+        }
+    }
+
     private inner class SessionRecognitionListener(
         private val sessionId: Long,
         private val mode: VoiceCaptureMode,
         private val availability: AndroidNativeRecognitionAvailability,
+        private val backend: RecognizerBackend,
     ) : RecognitionListener {
 
         private var sessionCompleted = false
@@ -158,11 +208,28 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
         override fun onError(error: Int) {
             if (sessionCompleted || activeSessionId != sessionId) return
+            if (
+                backend == RecognizerBackend.OnDevice &&
+                error == SpeechRecognizer.ERROR_SERVER_DISCONNECTED &&
+                retryWithPlatformRecognizer(
+                    sessionId = sessionId,
+                    mode = mode,
+                    availability = availability,
+                )
+            ) {
+                sessionCompleted = true
+                Log.w(
+                    TAG,
+                    "On-device recognizer disconnected for sessionId=$sessionId; retried with platform recognizer",
+                )
+                return
+            }
             sessionCompleted = true
             Log.w(
                 TAG,
                 "Android native STT error: sessionId=$sessionId mode=$mode error=$error " +
-                    "language=${availability.languageSummary} localeStatus=${availability.localeStatus}",
+                    "backend=$backend language=${availability.languageSummary} " +
+                    "localeStatus=${availability.localeStatus}",
             )
             _events.tryEmit(
                 VoiceInputEvent.Error(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -54,7 +54,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             stopListeningInternal(emitStopped = false)
 
             val availability = recognitionSupport.getAvailability()
-            availability.unavailableReason?.let { reason ->
+            availability.blockingReason?.let { reason ->
                 return@withContext VoiceInputStartResult.Unavailable(
                     reason,
                 )

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.voice
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class AndroidNativeRecognitionSupportTest {
@@ -45,5 +46,39 @@ class AndroidNativeRecognitionSupportTest {
                 onlineLanguages = emptyList(),
             ),
         )
+    }
+
+    @Test
+    fun `unknown locale support warns without blocking start`() {
+        val availability = AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-AU",
+            languageDisplayName = "English (Australia)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.Unknown,
+        )
+
+        assertNull(availability.blockingReason)
+        assertEquals(
+            "Android native speech recognition could not verify on-device support for English (Australia) on this device. It may fail unless that language is supported and installed locally.",
+            availability.warningMessage,
+        )
+    }
+
+    @Test
+    fun `unsupported locale still blocks start`() {
+        val availability = AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-NZ",
+            languageDisplayName = "English (New Zealand)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.NotSupported,
+        )
+
+        assertEquals(
+            "English (New Zealand) is not supported by Android native speech recognition on this device.",
+            availability.blockingReason,
+        )
+        assertEquals(availability.blockingReason, availability.warningMessage)
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -81,4 +81,18 @@ class AndroidNativeRecognitionSupportTest {
         )
         assertEquals(availability.blockingReason, availability.warningMessage)
     }
+
+    @Test
+    fun `ready locale has no warning or blocking reason`() {
+        val availability = AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-AU",
+            languageDisplayName = "English (Australia)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
+        )
+
+        assertNull(availability.blockingReason)
+        assertNull(availability.warningMessage)
+    }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AndroidNativeRecognitionSupportTest {
+
+    @Test
+    fun `resolveLocaleStatus treats base language fallback as ready`() {
+        assertEquals(
+            AndroidNativeRecognitionLocaleStatus.Ready,
+            resolveLocaleStatus(
+                languageTag = "en-NZ",
+                installedLanguages = listOf("en-US"),
+                supportedLanguages = emptyList(),
+                pendingLanguages = emptyList(),
+                onlineLanguages = emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveLocaleStatus treats same-language downloadable variant as unavailable`() {
+        assertEquals(
+            AndroidNativeRecognitionLocaleStatus.Unavailable,
+            resolveLocaleStatus(
+                languageTag = "en-NZ",
+                installedLanguages = emptyList(),
+                supportedLanguages = listOf("en-GB"),
+                pendingLanguages = emptyList(),
+                onlineLanguages = emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveLocaleStatus returns unknown when no matching language exists`() {
+        assertEquals(
+            AndroidNativeRecognitionLocaleStatus.Unknown,
+            resolveLocaleStatus(
+                languageTag = "en-NZ",
+                installedLanguages = listOf("de-DE"),
+                supportedLanguages = listOf("fr-FR"),
+                pendingLanguages = emptyList(),
+                onlineLanguages = emptyList(),
+            ),
+        )
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -66,12 +66,24 @@ fun VoiceScreen(
                         uiState.androidNativeAvailabilityMessage ?: engine.warning
                     else -> engine.warning
                 }
+                val languageSummary = when (engine) {
+                    VoiceInputEngine.AndroidNative -> uiState.androidNativeLanguageSummary
+                    else -> null
+                }
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
                     supportingContent = {
                         Column {
                             Text(engine.description)
+                            if (languageSummary != null) {
+                                Text(
+                                    text = "Language: $languageSummary",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
                             if (engine == VoiceInputEngine.AndroidNative && warning != null) {
                                 Text(
                                     text = warning,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -61,11 +61,27 @@ fun VoiceScreen(
             )
 
             VoiceInputEngine.entries.forEach { engine ->
-                val warning = engine.warning
+                val warning = when (engine) {
+                    VoiceInputEngine.AndroidNative ->
+                        uiState.androidNativeAvailabilityMessage ?: engine.warning
+                    else -> engine.warning
+                }
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
-                    supportingContent = { Text(engine.description) },
+                    supportingContent = {
+                        Column {
+                            Text(engine.description)
+                            if (engine == VoiceInputEngine.AndroidNative && warning != null) {
+                                Text(
+                                    text = warning,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                        }
+                    },
                     trailingContent = {
                         RadioButton(
                             selected = uiState.selectedInputEngine == engine,
@@ -73,7 +89,11 @@ fun VoiceScreen(
                         )
                     },
                 )
-                if (uiState.selectedInputEngine == engine && warning != null) {
+                if (
+                    engine != VoiceInputEngine.AndroidNative &&
+                    uiState.selectedInputEngine == engine &&
+                    warning != null
+                ) {
                     Text(
                         text = warning,
                         style = MaterialTheme.typography.bodySmall,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -1,13 +1,17 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -85,11 +89,9 @@ fun VoiceScreen(
                                 )
                             }
                             if (engine == VoiceInputEngine.AndroidNative && warning != null) {
-                                Text(
-                                    text = warning,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(top = 4.dp),
+                                VoiceWarningCard(
+                                    message = warning,
+                                    modifier = Modifier.padding(top = 8.dp),
                                 )
                             }
                         }
@@ -137,6 +139,39 @@ fun VoiceScreen(
                 },
             )
             HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun VoiceWarningCard(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "Warning",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -36,7 +36,7 @@ class VoiceViewModel @Inject constructor(
             val availability = androidNativeRecognitionSupport.getAvailability()
             _uiState.update {
                 it.copy(
-                    androidNativeAvailabilityMessage = availability.unavailableReason,
+                    androidNativeAvailabilityMessage = availability.warningMessage,
                     androidNativeLanguageSummary = availability.languageSummary,
                 )
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -18,6 +18,7 @@ data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
     val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
     val androidNativeAvailabilityMessage: String? = null,
+    val androidNativeLanguageSummary: String? = null,
 )
 
 @HiltViewModel
@@ -32,10 +33,10 @@ class VoiceViewModel @Inject constructor(
 
     init {
         _uiState.update {
+            val availability = androidNativeRecognitionSupport.getAvailability()
             it.copy(
-                androidNativeAvailabilityMessage = androidNativeRecognitionSupport
-                    .getAvailability()
-                    .unavailableReason,
+                androidNativeAvailabilityMessage = availability.unavailableReason,
+                androidNativeLanguageSummary = availability.languageSummary,
             )
         }
         viewModelScope.launch {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -16,10 +17,12 @@ import javax.inject.Inject
 data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
     val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
+    val androidNativeAvailabilityMessage: String? = null,
 )
 
 @HiltViewModel
 class VoiceViewModel @Inject constructor(
+    private val androidNativeRecognitionSupport: AndroidNativeRecognitionSupport,
     private val voiceInputPreferences: VoiceInputPreferences,
     private val voiceOutputPreferences: VoiceOutputPreferences,
 ) : ViewModel() {
@@ -28,6 +31,13 @@ class VoiceViewModel @Inject constructor(
     val uiState: StateFlow<VoiceUiState> = _uiState.asStateFlow()
 
     init {
+        _uiState.update {
+            it.copy(
+                androidNativeAvailabilityMessage = androidNativeRecognitionSupport
+                    .getAvailability()
+                    .unavailableReason,
+            )
+        }
         viewModelScope.launch {
             voiceInputPreferences.selectedEngine.collect { engine ->
                 _uiState.update { it.copy(selectedInputEngine = engine) }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -32,12 +32,14 @@ class VoiceViewModel @Inject constructor(
     val uiState: StateFlow<VoiceUiState> = _uiState.asStateFlow()
 
     init {
-        _uiState.update {
+        viewModelScope.launch {
             val availability = androidNativeRecognitionSupport.getAvailability()
-            it.copy(
-                androidNativeAvailabilityMessage = availability.unavailableReason,
-                androidNativeLanguageSummary = availability.languageSummary,
-            )
+            _uiState.update {
+                it.copy(
+                    androidNativeAvailabilityMessage = availability.unavailableReason,
+                    androidNativeLanguageSummary = availability.languageSummary,
+                )
+            }
         }
         viewModelScope.launch {
             voiceInputPreferences.selectedEngine.collect { engine ->

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -135,6 +135,30 @@ class VoiceViewModelTest {
     }
 
     @Test
+    fun `android native availability message is exposed when locale support cannot be verified`() = runTest {
+        coEvery { androidNativeRecognitionSupport.getAvailability() } returns
+            AndroidNativeRecognitionAvailability(
+                isRecognitionAvailable = true,
+                isOnDeviceRecognitionAvailable = true,
+                languageTag = "en-NZ",
+                languageDisplayName = "English (New Zealand)",
+                localeStatus = AndroidNativeRecognitionLocaleStatus.Unknown,
+            )
+
+        viewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "Android native speech recognition could not verify on-device support for English (New Zealand) on this device. It may fail unless that language is supported and installed locally.",
+            viewModel.uiState.value.androidNativeAvailabilityMessage,
+        )
+    }
+
+    @Test
     fun `setVoiceInputEngine updates ui state immediately`() = runTest {
         viewModel.setVoiceInputEngine(VoiceInputEngine.AndroidNative)
         testDispatcher.scheduler.advanceUntilIdle()

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.feature.settings
 
 import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
+import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
@@ -39,12 +40,13 @@ class VoiceViewModelTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        every { androidNativeRecognitionSupport.getAvailability() } returns
+        coEvery { androidNativeRecognitionSupport.getAvailability() } returns
             AndroidNativeRecognitionAvailability(
                 isRecognitionAvailable = true,
                 isOnDeviceRecognitionAvailable = true,
                 languageTag = "en-NZ",
                 languageDisplayName = "English (New Zealand)",
+                localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
             )
         every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
         coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
@@ -86,12 +88,13 @@ class VoiceViewModelTest {
 
     @Test
     fun `android native availability message is exposed when on-device recognizer is unavailable`() = runTest {
-        every { androidNativeRecognitionSupport.getAvailability() } returns
+        coEvery { androidNativeRecognitionSupport.getAvailability() } returns
             AndroidNativeRecognitionAvailability(
                 isRecognitionAvailable = true,
                 isOnDeviceRecognitionAvailable = false,
                 languageTag = "en-US",
                 languageDisplayName = "English (United States)",
+                localeStatus = AndroidNativeRecognitionLocaleStatus.Unknown,
             )
 
         viewModel = VoiceViewModel(
@@ -103,6 +106,30 @@ class VoiceViewModelTest {
 
         assertEquals(
             "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input.",
+            viewModel.uiState.value.androidNativeAvailabilityMessage,
+        )
+    }
+
+    @Test
+    fun `android native availability message is exposed when locale is unsupported`() = runTest {
+        coEvery { androidNativeRecognitionSupport.getAvailability() } returns
+            AndroidNativeRecognitionAvailability(
+                isRecognitionAvailable = true,
+                isOnDeviceRecognitionAvailable = true,
+                languageTag = "en-NZ",
+                languageDisplayName = "English (New Zealand)",
+                localeStatus = AndroidNativeRecognitionLocaleStatus.NotSupported,
+            )
+
+        viewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "English (New Zealand) is not supported by Android native speech recognition on this device.",
             viewModel.uiState.value.androidNativeAvailabilityMessage,
         )
     }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -43,6 +43,8 @@ class VoiceViewModelTest {
             AndroidNativeRecognitionAvailability(
                 isRecognitionAvailable = true,
                 isOnDeviceRecognitionAvailable = true,
+                languageTag = "en-NZ",
+                languageDisplayName = "English (New Zealand)",
             )
         every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
         coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
@@ -73,11 +75,23 @@ class VoiceViewModelTest {
     }
 
     @Test
+    fun `android native language summary is exposed from recognizer support`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "English (New Zealand) (en-NZ)",
+            viewModel.uiState.value.androidNativeLanguageSummary,
+        )
+    }
+
+    @Test
     fun `android native availability message is exposed when on-device recognizer is unavailable`() = runTest {
         every { androidNativeRecognitionSupport.getAvailability() } returns
             AndroidNativeRecognitionAvailability(
                 isRecognitionAvailable = true,
                 isOnDeviceRecognitionAvailable = false,
+                languageTag = "en-US",
+                languageDisplayName = "English (United States)",
             )
 
         viewModel = VoiceViewModel(

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.feature.settings
 
+import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
+import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.Test
 class VoiceViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val androidNativeRecognitionSupport: AndroidNativeRecognitionSupport = mockk()
     private val voiceInputPreferences: VoiceInputPreferences = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
     private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
@@ -36,11 +39,20 @@ class VoiceViewModelTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        every { androidNativeRecognitionSupport.getAvailability() } returns
+            AndroidNativeRecognitionAvailability(
+                isRecognitionAvailable = true,
+                isOnDeviceRecognitionAvailable = true,
+            )
         every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
         coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
         every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
-        viewModel = VoiceViewModel(voiceInputPreferences, voiceOutputPreferences)
+        viewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+        )
     }
 
     @AfterEach
@@ -58,6 +70,27 @@ class VoiceViewModelTest {
     fun `voice input engine defaults to vosk when preference flow emits vosk`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(VoiceInputEngine.Vosk, viewModel.uiState.value.selectedInputEngine)
+    }
+
+    @Test
+    fun `android native availability message is exposed when on-device recognizer is unavailable`() = runTest {
+        every { androidNativeRecognitionSupport.getAvailability() } returns
+            AndroidNativeRecognitionAvailability(
+                isRecognitionAvailable = true,
+                isOnDeviceRecognitionAvailable = false,
+            )
+
+        viewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input.",
+            viewModel.uiState.value.androidNativeAvailabilityMessage,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
Harden the Android native STT option by preferring the explicit on-device recognizer path, surfacing availability clearly in **Settings -> Voice**, showing which language the recognizer is currently using, and making the locale support check conservative and actionable before push-to-talk starts.

## Changes
- add `AndroidNativeRecognitionSupport` to centralize Android recognizer availability checks and on-device recognizer creation
- switch `NativeAndroidVoiceInputController` to `SpeechRecognizer.createOnDeviceSpeechRecognizer()`
- use `SpeechRecognizer.checkRecognitionSupport(...)` to preflight the exact locale request before Android native STT starts listening
- add a timeout around the Android support callback so availability checks fail safely instead of hanging
- treat unknown locale support as a warning/unavailable state instead of showing Android native STT as healthy
- use base-language fallback matching for locale support checks so variants like `en-NZ` can match installed/supportable English variants
- isolate recognizer callbacks per active session so stale callbacks cannot terminate a newer listening session
- show Android native recognizer availability messaging directly in **Settings -> Voice**
- show the current Android native STT language in **Settings -> Voice** using the same locale metadata that is passed to the recognizer intent
- render Android native STT warnings as a highlighted warning card instead of plain supporting text
- add `core:voice` unit coverage for locale fallback matching and keep the settings view-model coverage for the exposed warning states

## Testing
- [x] `:core:voice:testDebugUnitTest`
- [x] `:feature:settings:testDebugUnitTest`
- [x] `:feature:chat:testDebugUnitTest --tests '*ActionsViewModelVoiceTest'`
- [x] `:app:assembleDebug`
- [x] Manual device testing (warning state shown, push-to-talk failure message improved for unsupported/unverifiable language support)

## Related issues
Closes #717
