### PR TITLE
chore(#720): unify clock scheduling foundation

### DIFF
--- a/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
@@ -8,7 +8,14 @@ import android.content.Intent
 import android.media.AudioAttributes
 import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
+import com.kernel.ai.core.memory.clock.ClockRepository
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class AlarmBroadcastReceiver : BroadcastReceiver() {
     companion object {
         const val EXTRA_LABEL = "alarm_label"
@@ -17,10 +24,23 @@ class AlarmBroadcastReceiver : BroadcastReceiver() {
         const val NOTIFICATION_CHANNEL_ID = "kernel_alarm"
     }
 
+    @Inject lateinit var clockRepository: ClockRepository
+
     override fun onReceive(context: Context, intent: Intent) {
         val label = intent.getStringExtra(EXTRA_LABEL) ?: "Alarm"
         val alarmId = intent.getStringExtra(EXTRA_ALARM_ID) ?: return
         val title = intent.getStringExtra(EXTRA_TITLE) ?: "Alarm"
+
+        if (title == "Timer") {
+            val pendingResult = goAsync()
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    clockRepository.cancelTimer(alarmId)
+                } finally {
+                    pendingResult.finish()
+                }
+            }
+        }
 
         val notificationManager = context.getSystemService(NotificationManager::class.java)
 

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
@@ -31,14 +31,12 @@ class AlarmBroadcastReceiver : BroadcastReceiver() {
         val alarmId = intent.getStringExtra(EXTRA_ALARM_ID) ?: return
         val title = intent.getStringExtra(EXTRA_TITLE) ?: "Alarm"
 
-        if (title == "Timer") {
-            val pendingResult = goAsync()
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
-                    clockRepository.cancelTimer(alarmId)
-                } finally {
-                    pendingResult.finish()
-                }
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                clockRepository.recordDeliveredEvent(alarmId)
+            } finally {
+                pendingResult.finish()
             }
         }
 

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
@@ -1,0 +1,80 @@
+package com.kernel.ai.alarm
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.kernel.ai.core.memory.clock.ClockEventType
+import com.kernel.ai.core.memory.clock.ClockPlatformState
+import com.kernel.ai.core.memory.clock.ClockScheduledEvent
+import com.kernel.ai.core.memory.clock.ClockScheduler
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AlarmManagerClockScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ClockScheduler {
+    private val alarmManager: AlarmManager
+        get() = context.getSystemService(AlarmManager::class.java)
+
+    private val notificationManager: NotificationManager
+        get() = context.getSystemService(NotificationManager::class.java)
+
+    override fun getPlatformState(): ClockPlatformState =
+        ClockPlatformState(
+            canScheduleExactAlarms = alarmManager.canScheduleExactAlarms(),
+            notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled(),
+            canUseFullScreenIntent = notificationManager.canUseFullScreenIntent(),
+        )
+
+    override fun schedule(event: ClockScheduledEvent) {
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            event.eventId.hashCode(),
+            buildBroadcastIntent(event),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            event.triggerAtMillis,
+            pendingIntent,
+        )
+    }
+
+    override fun cancel(event: ClockScheduledEvent) {
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            event.eventId.hashCode(),
+            buildBroadcastIntent(event),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+        pendingIntent?.let(alarmManager::cancel)
+    }
+
+    private fun buildBroadcastIntent(event: ClockScheduledEvent): Intent =
+        Intent().apply {
+            component = ComponentName(context.packageName, "com.kernel.ai.alarm.AlarmBroadcastReceiver")
+            putExtra(AlarmBroadcastReceiver.EXTRA_LABEL, event.label ?: defaultLabel(event.type))
+            putExtra(AlarmBroadcastReceiver.EXTRA_ALARM_ID, event.ownerId)
+            putExtra(AlarmBroadcastReceiver.EXTRA_TITLE, defaultTitle(event.type))
+        }
+
+    private fun defaultLabel(type: ClockEventType): String =
+        when (type) {
+            ClockEventType.ALARM -> "Alarm"
+            ClockEventType.TIMER -> "Timer"
+            ClockEventType.PRE_ALARM -> "Alarm reminder"
+        }
+
+    private fun defaultTitle(type: ClockEventType): String =
+        when (type) {
+            ClockEventType.TIMER -> "Timer"
+            ClockEventType.PRE_ALARM -> "Alarm reminder"
+            ClockEventType.ALARM -> "Alarm"
+        }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
@@ -1,21 +1,19 @@
 package com.kernel.ai.alarm
 
-import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.clock.ClockRepository
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class BootCompletedReceiver : BroadcastReceiver() {
 
-    @Inject lateinit var scheduledAlarmDao: ScheduledAlarmDao
+    @Inject lateinit var clockRepository: ClockRepository
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
@@ -23,27 +21,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
         val pendingResult = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val alarmManager = context.getSystemService(AlarmManager::class.java)
-                val now = System.currentTimeMillis()
-                val unfiredAlarms = scheduledAlarmDao.getUnfiredFuture(now)
-
-                unfiredAlarms.forEach { alarm ->
-                    val alarmIntent = Intent(context, AlarmBroadcastReceiver::class.java).apply {
-                        putExtra(AlarmBroadcastReceiver.EXTRA_LABEL, alarm.label ?: "Alarm")
-                        putExtra(AlarmBroadcastReceiver.EXTRA_ALARM_ID, alarm.id)
-                    }
-                    val pendingIntent = PendingIntent.getBroadcast(
-                        context,
-                        alarm.id.hashCode(),
-                        alarmIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-                    )
-                    alarmManager.setExactAndAllowWhileIdle(
-                        AlarmManager.RTC_WAKEUP,
-                        alarm.triggerAtMillis,
-                        pendingIntent,
-                    )
-                }
+                clockRepository.restoreScheduledEntries()
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockSchedulerModule.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockSchedulerModule.kt
@@ -1,0 +1,18 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockScheduler
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ClockSchedulerModule {
+    @Binds
+    @Singleton
+    abstract fun bindClockScheduler(
+        impl: AlarmManagerClockScheduler,
+    ): ClockScheduler
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/24.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/24.json
@@ -1,0 +1,811 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "29e337ebb25a83a10dda618b69dfd651",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '29e337ebb25a83a10dda618b69dfd651')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -48,7 +48,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 23,
+    version = 24,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -275,6 +275,14 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_22_23 = object : Migration(22, 23) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE quick_actions ADD COLUMN presentationJson TEXT DEFAULT NULL")
+            }
+        }
+
+        /** Adds owner_id to scheduled_alarms so reminder events can point at their owning clock item (#720). */
+        val MIGRATION_23_24 = object : Migration(23, 24) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN owner_id TEXT DEFAULT NULL")
+                db.execSQL("UPDATE scheduled_alarms SET owner_id = id WHERE owner_id IS NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -15,6 +15,8 @@ import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
+import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockRepositoryImpl
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.MemoryRepositoryImpl
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
@@ -40,6 +42,10 @@ abstract class MemoryModule {
     @Binds
     @Singleton
     abstract fun bindMemoryRepository(impl: MemoryRepositoryImpl): MemoryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindClockRepository(impl: ClockRepositoryImpl): ClockRepository
 
     @Binds
     @Singleton
@@ -71,6 +77,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_20_21,
                     KernelDatabase.MIGRATION_21_22,
                     KernelDatabase.MIGRATION_22_23,
+                    KernelDatabase.MIGRATION_23_24,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -1,0 +1,47 @@
+package com.kernel.ai.core.memory.clock
+
+enum class ClockEventType {
+    ALARM,
+    TIMER,
+    PRE_ALARM,
+}
+
+data class ClockAlarm(
+    val id: String,
+    val triggerAtMillis: Long,
+    val label: String?,
+    val createdAtMillis: Long,
+    val enabled: Boolean,
+)
+
+data class ClockTimer(
+    val id: String,
+    val triggerAtMillis: Long,
+    val label: String?,
+    val createdAtMillis: Long,
+    val durationMs: Long,
+    val startedAtMillis: Long,
+)
+
+data class ClockScheduledEvent(
+    val eventId: String,
+    val ownerId: String,
+    val type: ClockEventType,
+    val triggerAtMillis: Long,
+    val label: String?,
+    val durationMs: Long? = null,
+    val startedAtMillis: Long? = null,
+)
+
+data class ClockPlatformState(
+    val canScheduleExactAlarms: Boolean,
+    val notificationsEnabled: Boolean,
+    val canUseFullScreenIntent: Boolean,
+)
+
+data class ClockRestoreReport(
+    val restoredCount: Int,
+    val expiredCount: Int,
+    val disabledCount: Int,
+    val blockedByExactAlarmCapability: Boolean,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -27,16 +27,12 @@ interface ClockRepository {
     suspend fun cancelAlarmsByLabel(label: String): Int
 
     suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
-
     suspend fun cancelTimer(timerId: String)
-
+    suspend fun recordDeliveredEvent(eventId: String)
     suspend fun cancelTimers(timerIds: Collection<String>)
-
     suspend fun cancelAllTimers(): Int
-
     suspend fun cancelTimersMatching(name: String?, durationMs: Long?): Int
-
     suspend fun getAllTimers(): List<ClockTimer>
-
     suspend fun restoreScheduledEntries(nowMillis: Long = System.currentTimeMillis()): ClockRestoreReport
+
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -1,0 +1,42 @@
+package com.kernel.ai.core.memory.clock
+
+import kotlinx.coroutines.flow.Flow
+
+interface ClockRepository {
+    fun observeManageableAlarms(): Flow<List<ClockAlarm>>
+
+    fun observeActiveAlarms(): Flow<List<ClockAlarm>>
+
+    fun observeUpcomingAlarms(): Flow<List<ClockAlarm>>
+    fun observeActiveTimers(): Flow<List<ClockTimer>>
+
+    fun getPlatformState(): ClockPlatformState
+
+    suspend fun scheduleAlarm(triggerAtMillis: Long, label: String?): ClockAlarm?
+
+    suspend fun editAlarm(alarmId: String, newTriggerAtMillis: Long, newLabel: String?): ClockAlarm?
+
+    suspend fun setAlarmEnabled(alarmId: String, enabled: Boolean): Boolean
+
+    suspend fun cancelAlarm(alarmId: String)
+
+    suspend fun cancelAlarms(alarmIds: Collection<String>)
+
+    suspend fun cancelNextAlarm(): ClockAlarm?
+
+    suspend fun cancelAlarmsByLabel(label: String): Int
+
+    suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
+
+    suspend fun cancelTimer(timerId: String)
+
+    suspend fun cancelTimers(timerIds: Collection<String>)
+
+    suspend fun cancelAllTimers(): Int
+
+    suspend fun cancelTimersMatching(name: String?, durationMs: Long?): Int
+
+    suspend fun getAllTimers(): List<ClockTimer>
+
+    suspend fun restoreScheduledEntries(nowMillis: Long = System.currentTimeMillis()): ClockRestoreReport
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -33,8 +33,10 @@ class ClockRepositoryImpl @Inject constructor(
         }
 
     override fun observeActiveTimers(): Flow<List<ClockTimer>> =
-        scheduledAlarmDao.observeActiveTimers().map { schedules ->
-            schedules.mapNotNull { it.toClockTimer() }
+        combine(scheduledAlarmDao.observeActiveTimers(), clockNowFlow()) { schedules, now ->
+            schedules
+                .filter { it.triggerAtMillis > now }
+                .mapNotNull { it.toClockTimer() }
         }
 
     override fun getPlatformState(): ClockPlatformState = scheduler.getPlatformState()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -90,12 +90,22 @@ class ClockRepositoryImpl @Inject constructor(
         val updated = existing.copy(enabled = enabled)
         if (enabled) {
             if (!scheduler.getPlatformState().canScheduleExactAlarms) return false
+            if (updated.triggerAtMillis <= System.currentTimeMillis()) return false
             scheduler.schedule(updated.toScheduledEvent())
         } else {
             scheduler.cancel(existing.toScheduledEvent())
         }
-        scheduledAlarmDao.setEnabled(alarmId, enabled)
-        return true
+        return try {
+            scheduledAlarmDao.setEnabled(alarmId, enabled)
+            true
+        } catch (_: Exception) {
+            if (enabled) {
+                scheduler.cancel(updated.toScheduledEvent())
+            } else if (existing.enabled) {
+                scheduler.schedule(existing.toScheduledEvent())
+            }
+            false
+        }
     }
 
     override suspend fun cancelAlarm(alarmId: String) {
@@ -128,6 +138,7 @@ class ClockRepositoryImpl @Inject constructor(
         val matches = scheduledAlarmDao.getUnfiredFuture(now)
             .asSequence()
             .filter { it.entryType == ClockEventType.ALARM.name }
+            .filter { it.enabled }
             .filter { it.label?.equals(label, ignoreCase = true) == true }
             .map { it.withDefaultOwnerId() }
             .toList()
@@ -166,6 +177,15 @@ class ClockRepositoryImpl @Inject constructor(
         val existing = scheduledAlarmDao.getById(timerId)?.withDefaultOwnerId() ?: return
         scheduler.cancel(existing.toScheduledEvent())
         scheduledAlarmDao.delete(timerId)
+    }
+
+    override suspend fun recordDeliveredEvent(eventId: String) {
+        val existing = scheduledAlarmDao.getById(eventId)?.withDefaultOwnerId() ?: return
+        if (existing.entryType == ClockEventType.TIMER.name) {
+            scheduledAlarmDao.delete(eventId)
+        } else {
+            scheduledAlarmDao.markFired(eventId)
+        }
     }
 
     override suspend fun cancelTimers(timerIds: Collection<String>) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -1,0 +1,278 @@
+package com.kernel.ai.core.memory.clock
+
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+@Singleton
+class ClockRepositoryImpl @Inject constructor(
+    private val scheduledAlarmDao: ScheduledAlarmDao,
+    private val scheduler: ClockScheduler,
+) : ClockRepository {
+    override fun observeManageableAlarms(): Flow<List<ClockAlarm>> =
+        scheduledAlarmDao.observeAllAlarmSchedules().map { schedules ->
+            schedules.map { it.toClockAlarm() }
+        }
+
+    override fun observeActiveAlarms(): Flow<List<ClockAlarm>> =
+        scheduledAlarmDao.observeAllAlarmSchedules().map { schedules ->
+            schedules.filter { it.enabled }.map { it.toClockAlarm() }
+        }
+
+    override fun observeUpcomingAlarms(): Flow<List<ClockAlarm>> =
+        combine(scheduledAlarmDao.observeAllAlarmSchedules(), clockNowFlow()) { alarms, now ->
+            alarms
+                .filter { it.triggerAtMillis > now }
+                .map { it.toClockAlarm() }
+        }
+
+    override fun observeActiveTimers(): Flow<List<ClockTimer>> =
+        scheduledAlarmDao.observeActiveTimers().map { schedules ->
+            schedules.mapNotNull { it.toClockTimer() }
+        }
+
+    override fun getPlatformState(): ClockPlatformState = scheduler.getPlatformState()
+
+    override suspend fun scheduleAlarm(triggerAtMillis: Long, label: String?): ClockAlarm? {
+        if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
+        val entity = ScheduledAlarmEntity(
+            id = UUID.randomUUID().toString(),
+            ownerId = null,
+            triggerAtMillis = triggerAtMillis,
+            label = label?.takeIf { it.isNotBlank() },
+            createdAt = System.currentTimeMillis(),
+            enabled = true,
+            entryType = ClockEventType.ALARM.name,
+        ).withDefaultOwnerId()
+        scheduler.schedule(entity.toScheduledEvent())
+        return try {
+            scheduledAlarmDao.insert(entity)
+            entity.toClockAlarm()
+        } catch (_: Exception) {
+            scheduler.cancel(entity.toScheduledEvent())
+            null
+        }
+    }
+
+    override suspend fun editAlarm(alarmId: String, newTriggerAtMillis: Long, newLabel: String?): ClockAlarm? {
+        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return null
+        val updated = existing.copy(
+            triggerAtMillis = newTriggerAtMillis,
+            label = newLabel?.takeIf { it.isNotBlank() },
+        )
+        if (updated.enabled) {
+            if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
+            scheduler.schedule(updated.toScheduledEvent())
+        } else if (existing.enabled) {
+            scheduler.cancel(existing.toScheduledEvent())
+        }
+        return try {
+            scheduledAlarmDao.insert(updated)
+            updated.toClockAlarm()
+        } catch (_: Exception) {
+            if (existing.enabled) {
+                scheduler.schedule(existing.toScheduledEvent())
+            } else if (updated.enabled) {
+                scheduler.cancel(updated.toScheduledEvent())
+            }
+            null
+        }
+    }
+
+    override suspend fun setAlarmEnabled(alarmId: String, enabled: Boolean): Boolean {
+        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return false
+        val updated = existing.copy(enabled = enabled)
+        if (enabled) {
+            if (!scheduler.getPlatformState().canScheduleExactAlarms) return false
+            scheduler.schedule(updated.toScheduledEvent())
+        } else {
+            scheduler.cancel(existing.toScheduledEvent())
+        }
+        scheduledAlarmDao.setEnabled(alarmId, enabled)
+        return true
+    }
+
+    override suspend fun cancelAlarm(alarmId: String) {
+        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return
+        scheduler.cancel(existing.toScheduledEvent())
+        scheduledAlarmDao.delete(alarmId)
+    }
+
+    override suspend fun cancelAlarms(alarmIds: Collection<String>) {
+        alarmIds.forEach { cancelAlarm(it) }
+    }
+
+    override suspend fun cancelNextAlarm(): ClockAlarm? {
+        val now = System.currentTimeMillis()
+        val nextAlarm = scheduledAlarmDao.getUnfiredFuture(now)
+            .asSequence()
+            .filter { it.entryType == ClockEventType.ALARM.name }
+            .filter { it.enabled }
+            .sortedBy { it.triggerAtMillis }
+            .map { it.withDefaultOwnerId() }
+            .firstOrNull()
+            ?: return null
+        scheduler.cancel(nextAlarm.toScheduledEvent())
+        scheduledAlarmDao.delete(nextAlarm.id)
+        return nextAlarm.toClockAlarm()
+    }
+
+    override suspend fun cancelAlarmsByLabel(label: String): Int {
+        val now = System.currentTimeMillis()
+        val matches = scheduledAlarmDao.getUnfiredFuture(now)
+            .asSequence()
+            .filter { it.entryType == ClockEventType.ALARM.name }
+            .filter { it.label?.equals(label, ignoreCase = true) == true }
+            .map { it.withDefaultOwnerId() }
+            .toList()
+        matches.forEach { schedule ->
+            scheduler.cancel(schedule.toScheduledEvent())
+            scheduledAlarmDao.delete(schedule.id)
+        }
+        return matches.size
+    }
+
+    override suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer? {
+        if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
+        val now = System.currentTimeMillis()
+        val entity = ScheduledAlarmEntity(
+            id = UUID.randomUUID().toString(),
+            ownerId = null,
+            triggerAtMillis = now + durationMs,
+            label = label?.takeIf { it.isNotBlank() },
+            createdAt = now,
+            enabled = true,
+            entryType = ClockEventType.TIMER.name,
+            durationMs = durationMs,
+            startedAtMs = now,
+        ).withDefaultOwnerId()
+        scheduler.schedule(entity.toScheduledEvent())
+        return try {
+            scheduledAlarmDao.insert(entity)
+            entity.toClockTimer() ?: error("Timer schedule missing duration metadata")
+        } catch (_: Exception) {
+            scheduler.cancel(entity.toScheduledEvent())
+            null
+        }
+    }
+
+    override suspend fun cancelTimer(timerId: String) {
+        val existing = scheduledAlarmDao.getById(timerId)?.withDefaultOwnerId() ?: return
+        scheduler.cancel(existing.toScheduledEvent())
+        scheduledAlarmDao.delete(timerId)
+    }
+
+    override suspend fun cancelTimers(timerIds: Collection<String>) {
+        timerIds.forEach { cancelTimer(it) }
+    }
+
+    override suspend fun cancelAllTimers(): Int {
+        val timers = scheduledAlarmDao.getAllTimers().map { it.withDefaultOwnerId() }
+        timers.forEach { timer ->
+            scheduler.cancel(timer.toScheduledEvent())
+            scheduledAlarmDao.delete(timer.id)
+        }
+        return timers.size
+    }
+
+    override suspend fun cancelTimersMatching(name: String?, durationMs: Long?): Int {
+        val matches = scheduledAlarmDao.getAllTimers()
+            .filter { timer ->
+                val nameMatches = name != null && timer.label?.equals(name, ignoreCase = true) == true
+                val durationMatches = durationMs != null && timer.durationMs == durationMs
+                nameMatches || durationMatches
+            }
+            .map { it.withDefaultOwnerId() }
+        matches.forEach { timer ->
+            scheduler.cancel(timer.toScheduledEvent())
+            scheduledAlarmDao.delete(timer.id)
+        }
+        return matches.size
+    }
+
+    override suspend fun getAllTimers(): List<ClockTimer> =
+        scheduledAlarmDao.getAllTimers().mapNotNull { it.toClockTimer() }
+
+    override suspend fun restoreScheduledEntries(nowMillis: Long): ClockRestoreReport {
+        val platformState = scheduler.getPlatformState()
+        val expired = scheduledAlarmDao.getUnfiredElapsed(nowMillis).map { it.withDefaultOwnerId() }
+        expired.forEach { scheduledAlarmDao.markFired(it.id) }
+
+        val future = scheduledAlarmDao.getUnfiredFuture(nowMillis).map { it.withDefaultOwnerId() }
+        val disabled = future.filterNot { it.enabled }
+        val enabled = future.filter { it.enabled }
+
+        if (!platformState.canScheduleExactAlarms) {
+            enabled.forEach { schedule ->
+                if (schedule.entryType == ClockEventType.TIMER.name) {
+                    scheduledAlarmDao.markFired(schedule.id)
+                } else {
+                    scheduledAlarmDao.setEnabled(schedule.id, false)
+                }
+            }
+            return ClockRestoreReport(
+                restoredCount = 0,
+                expiredCount = expired.size,
+                disabledCount = disabled.size + enabled.count { it.entryType == ClockEventType.ALARM.name },
+                blockedByExactAlarmCapability = true,
+            )
+        }
+
+        enabled.forEach { scheduler.schedule(it.toScheduledEvent()) }
+        return ClockRestoreReport(
+            restoredCount = enabled.size,
+            expiredCount = expired.size,
+            disabledCount = disabled.size,
+            blockedByExactAlarmCapability = false,
+        )
+    }
+}
+
+private fun ScheduledAlarmEntity.withDefaultOwnerId(): ScheduledAlarmEntity =
+    if (ownerId.isNullOrBlank()) copy(ownerId = id) else this
+
+private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm =
+    ClockAlarm(
+        id = id,
+        triggerAtMillis = triggerAtMillis,
+        label = label,
+        createdAtMillis = createdAt,
+        enabled = enabled,
+    )
+
+private fun ScheduledAlarmEntity.toClockTimer(): ClockTimer? {
+    val duration = durationMs ?: return null
+    val startedAt = startedAtMs ?: return null
+    return ClockTimer(
+        id = id,
+        triggerAtMillis = triggerAtMillis,
+        label = label,
+        createdAtMillis = createdAt,
+        durationMs = duration,
+        startedAtMillis = startedAt,
+    )
+}
+
+private fun ScheduledAlarmEntity.toScheduledEvent(): ClockScheduledEvent =
+    ClockScheduledEvent(
+        eventId = id,
+        ownerId = ownerId ?: id,
+        type = ClockEventType.valueOf(entryType),
+        triggerAtMillis = triggerAtMillis,
+        label = label,
+        durationMs = durationMs,
+        startedAtMillis = startedAtMs,
+    )
+
+private fun clockNowFlow(intervalMs: Long = 1_000L): Flow<Long> = flow {
+    while (true) {
+        emit(System.currentTimeMillis())
+        delay(intervalMs)
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockScheduler.kt
@@ -1,0 +1,9 @@
+package com.kernel.ai.core.memory.clock
+
+interface ClockScheduler {
+    fun getPlatformState(): ClockPlatformState
+
+    fun schedule(event: ClockScheduledEvent)
+
+    fun cancel(event: ClockScheduledEvent)
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -12,13 +12,15 @@ interface ScheduledAlarmDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(alarm: ScheduledAlarmEntity)
 
+    @Query("SELECT * FROM scheduled_alarms WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): ScheduledAlarmEntity?
+
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
     suspend fun getUnfiredFuture(nowMillis: Long): List<ScheduledAlarmEntity>
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
-    fun observeUnfiredFuture(nowMillis: Long): Flow<List<ScheduledAlarmEntity>>
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis <= :nowMillis ORDER BY triggerAtMillis ASC")
+    suspend fun getUnfiredElapsed(nowMillis: Long): List<ScheduledAlarmEntity>
 
-    /** Observe all unfired alarms with no time filter — callers apply their own time cutoff. */
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 ORDER BY triggerAtMillis ASC")
     fun observeAllUnfired(): Flow<List<ScheduledAlarmEntity>>
 
@@ -31,21 +33,15 @@ interface ScheduledAlarmDao {
     @Query("UPDATE scheduled_alarms SET enabled = :enabled WHERE id = :id")
     suspend fun setEnabled(id: String, enabled: Boolean)
 
-    @Query("SELECT * FROM scheduled_alarms WHERE entry_type = 'TIMER' ORDER BY started_at_ms DESC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND enabled = 1 AND entry_type = 'TIMER' ORDER BY started_at_ms DESC")
     suspend fun getAllTimers(): List<ScheduledAlarmEntity>
 
-    @Query("DELETE FROM scheduled_alarms WHERE entry_type = 'TIMER' AND label = :name")
-    suspend fun deleteTimerByName(name: String): Int
-
-    @Query("DELETE FROM scheduled_alarms WHERE entry_type = 'TIMER' AND duration_ms = :durationMs")
-    suspend fun deleteTimerByDuration(durationMs: Long): Int
-
-    @Query("SELECT * FROM scheduled_alarms WHERE entry_type = 'TIMER' AND label = :name LIMIT 1")
-    suspend fun getTimerByName(name: String): ScheduledAlarmEntity?
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY triggerAtMillis ASC")
+    suspend fun getActiveAlarmSchedules(): List<ScheduledAlarmEntity>
 
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY triggerAtMillis ASC")
-    fun observeActiveAlarms(): Flow<List<ScheduledAlarmEntity>>
+    fun observeAllAlarmSchedules(): Flow<List<ScheduledAlarmEntity>>
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'TIMER' ORDER BY started_at_ms DESC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND enabled = 1 AND entry_type = 'TIMER' ORDER BY started_at_ms DESC")
     fun observeActiveTimers(): Flow<List<ScheduledAlarmEntity>>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -1,17 +1,19 @@
 package com.kernel.ai.core.memory.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity(tableName = "scheduled_alarms")
 data class ScheduledAlarmEntity(
     @PrimaryKey val id: String,
+    @ColumnInfo(name = "owner_id") val ownerId: String? = null,
     val triggerAtMillis: Long,
     val label: String?,
     val createdAt: Long,
     val fired: Boolean = false,
     val enabled: Boolean = true,
-    @androidx.room.ColumnInfo(name = "entry_type") val entryType: String = "ALARM",
-    @androidx.room.ColumnInfo(name = "duration_ms") val durationMs: Long? = null,
-    @androidx.room.ColumnInfo(name = "started_at_ms") val startedAtMs: Long? = null,
+    @ColumnInfo(name = "entry_type") val entryType: String = "ALARM",
+    @ColumnInfo(name = "duration_ms") val durationMs: Long? = null,
+    @ColumnInfo(name = "started_at_ms") val startedAtMs: Long? = null,
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -10,6 +10,8 @@ import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -63,6 +65,27 @@ class ClockRepositoryImplTest {
                 }
             )
         }
+    }
+
+    @Test
+    fun `observeActiveTimers filters expired timers from the main list`() = runTest {
+        val expired = scheduleRow(
+            id = "expired-timer",
+            triggerAtMillis = System.currentTimeMillis() - 60_000L,
+            enabled = true,
+            entryType = ClockEventType.TIMER.name,
+        ).copy(durationMs = 60_000L, startedAtMs = System.currentTimeMillis() - 120_000L)
+        val active = scheduleRow(
+            id = "active-timer",
+            triggerAtMillis = System.currentTimeMillis() + 60_000L,
+            enabled = true,
+            entryType = ClockEventType.TIMER.name,
+        ).copy(durationMs = 60_000L, startedAtMs = System.currentTimeMillis())
+        every { scheduledAlarmDao.observeActiveTimers() } returns flowOf(listOf(expired, active))
+
+        val timers = repository.observeActiveTimers().first()
+
+        assertEquals(listOf("active-timer"), timers.map { it.id })
     }
 
     @Test

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -1,0 +1,168 @@
+package com.kernel.ai.core.memory.clock
+
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class ClockRepositoryImplTest {
+    private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
+    private val scheduler = mockk<ClockScheduler>(relaxed = true)
+
+    private lateinit var repository: ClockRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        repository = ClockRepositoryImpl(scheduledAlarmDao, scheduler)
+        every {
+            scheduler.getPlatformState()
+        } returns ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+    }
+
+    @Test
+    fun `scheduleAlarm inserts schedule row and delegates scheduling`() = runTest {
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+
+        val result = repository.scheduleAlarm(triggerAtMillis = 1_234_567L, label = "Morning")
+
+        assertEquals("Morning", result?.label)
+        assertEquals(1_234_567L, result?.triggerAtMillis)
+        coVerify(exactly = 1) {
+            scheduledAlarmDao.insert(
+                match {
+                    it.ownerId == it.id &&
+                        it.entryType == ClockEventType.ALARM.name &&
+                        it.triggerAtMillis == 1_234_567L &&
+                        it.label == "Morning"
+                }
+            )
+        }
+        verify(exactly = 1) {
+            scheduler.schedule(
+                match {
+                    it.ownerId == it.eventId &&
+                        it.type == ClockEventType.ALARM &&
+                        it.triggerAtMillis == 1_234_567L &&
+                        it.label == "Morning"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `restoreScheduledEntries marks expired rows and restores only enabled future rows`() = runTest {
+        val now = 5_000L
+        val expired = scheduleRow(id = "expired", triggerAtMillis = 4_000L)
+        val enabledFuture = scheduleRow(id = "future-enabled", triggerAtMillis = 6_000L)
+        val disabledFuture = scheduleRow(id = "future-disabled", triggerAtMillis = 7_000L, enabled = false)
+
+        coEvery { scheduledAlarmDao.getUnfiredElapsed(now) } returns listOf(expired)
+        coEvery { scheduledAlarmDao.getUnfiredFuture(now) } returns listOf(enabledFuture, disabledFuture)
+        coEvery { scheduledAlarmDao.markFired(expired.id) } just Runs
+
+        val report = repository.restoreScheduledEntries(nowMillis = now)
+
+        assertEquals(
+            ClockRestoreReport(
+                restoredCount = 1,
+                expiredCount = 1,
+                disabledCount = 1,
+                blockedByExactAlarmCapability = false,
+            ),
+            report,
+        )
+        coVerify(exactly = 1) { scheduledAlarmDao.markFired("expired") }
+        verify(exactly = 1) { scheduler.schedule(match { it.eventId == "future-enabled" }) }
+        verify(exactly = 0) { scheduler.schedule(match { it.eventId == "future-disabled" }) }
+    }
+
+    @Test
+    fun `cancelNextAlarm cancels and deletes the earliest enabled alarm`() = runTest {
+        val later = scheduleRow(id = "later", triggerAtMillis = 8_000L)
+        val earlier = scheduleRow(id = "earlier", triggerAtMillis = 6_000L)
+        coEvery { scheduledAlarmDao.getUnfiredFuture(any()) } returns listOf(earlier, later)
+        coEvery { scheduledAlarmDao.delete("earlier") } just Runs
+
+        val cancelled = repository.cancelNextAlarm()
+
+        assertEquals("earlier", cancelled?.id)
+        verify(exactly = 1) { scheduler.cancel(match { it.eventId == "earlier" }) }
+        coVerify(exactly = 1) { scheduledAlarmDao.delete("earlier") }
+    }
+
+    @Test
+    fun `editAlarm returns null when row is already gone`() = runTest {
+        coEvery { scheduledAlarmDao.getById("missing") } returns null
+
+        val result = repository.editAlarm("missing", newTriggerAtMillis = 9_000L, newLabel = "Updated")
+
+        assertEquals(null, result)
+        verify(exactly = 0) { scheduler.cancel(any()) }
+    }
+
+    @Test
+    fun `restoreScheduledEntries disables unrecoverable alarms and expires timers when exact alarms are unavailable`() = runTest {
+        val now = 5_000L
+        val futureAlarm = scheduleRow(id = "future-alarm", triggerAtMillis = 6_000L)
+        val futureTimer = scheduleRow(
+            id = "future-timer",
+            triggerAtMillis = 7_000L,
+            entryType = ClockEventType.TIMER.name,
+        ).copy(durationMs = 60_000L, startedAtMs = 1_000L)
+
+        every { scheduler.getPlatformState() } returns ClockPlatformState(
+            canScheduleExactAlarms = false,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+        coEvery { scheduledAlarmDao.getUnfiredElapsed(now) } returns emptyList()
+        coEvery { scheduledAlarmDao.getUnfiredFuture(now) } returns listOf(futureAlarm, futureTimer)
+        coEvery { scheduledAlarmDao.setEnabled("future-alarm", false) } just Runs
+        coEvery { scheduledAlarmDao.markFired("future-timer") } just Runs
+
+        val report = repository.restoreScheduledEntries(nowMillis = now)
+
+        assertEquals(
+            ClockRestoreReport(
+                restoredCount = 0,
+                expiredCount = 0,
+                disabledCount = 1,
+                blockedByExactAlarmCapability = true,
+            ),
+            report,
+        )
+        coVerify(exactly = 1) { scheduledAlarmDao.setEnabled("future-alarm", false) }
+        coVerify(exactly = 1) { scheduledAlarmDao.markFired("future-timer") }
+        verify(exactly = 0) { scheduler.schedule(any()) }
+    }
+    private fun scheduleRow(
+        id: String,
+        triggerAtMillis: Long,
+        enabled: Boolean = true,
+        entryType: String = ClockEventType.ALARM.name,
+    ): ScheduledAlarmEntity = ScheduledAlarmEntity(
+        id = id,
+        ownerId = id,
+        triggerAtMillis = triggerAtMillis,
+        label = id,
+        createdAt = 1_000L,
+        enabled = enabled,
+        entryType = entryType,
+    )
+}

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -107,6 +107,81 @@ class ClockRepositoryImplTest {
     }
 
     @Test
+    fun `cancelAlarmsByLabel cancels only enabled alarms`() = runTest {
+        val enabledMatch = scheduleRow(id = "enabled", triggerAtMillis = 6_000L).copy(label = "Wake")
+        val disabledMatch = scheduleRow(id = "disabled", triggerAtMillis = 7_000L, enabled = false).copy(label = "Wake")
+        val other = scheduleRow(id = "other", triggerAtMillis = 8_000L).copy(label = "Other")
+        coEvery { scheduledAlarmDao.getUnfiredFuture(any()) } returns listOf(enabledMatch, disabledMatch, other)
+        coEvery { scheduledAlarmDao.delete("enabled") } just Runs
+
+        val cancelled = repository.cancelAlarmsByLabel("wake")
+
+        assertEquals(1, cancelled)
+        verify(exactly = 1) { scheduler.cancel(match { it.eventId == "enabled" }) }
+        verify(exactly = 0) { scheduler.cancel(match { it.eventId == "disabled" }) }
+        coVerify(exactly = 1) { scheduledAlarmDao.delete("enabled") }
+        coVerify(exactly = 0) { scheduledAlarmDao.delete("disabled") }
+    }
+
+    @Test
+    fun `setAlarmEnabled rolls back scheduler cancel when disable write fails`() = runTest {
+        val existing = scheduleRow(id = "alarm-1", triggerAtMillis = 6_000L, enabled = true)
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns existing
+        coEvery { scheduledAlarmDao.setEnabled("alarm-1", false) } throws IllegalStateException("db")
+
+        val result = repository.setAlarmEnabled("alarm-1", enabled = false)
+
+        assertEquals(false, result)
+        verify(exactly = 1) { scheduler.cancel(match { it.eventId == "alarm-1" }) }
+        verify(exactly = 1) { scheduler.schedule(match { it.eventId == "alarm-1" }) }
+    }
+
+    @Test
+    fun `setAlarmEnabled rejects enabling a past due alarm`() = runTest {
+        val existing = scheduleRow(
+            id = "alarm-1",
+            triggerAtMillis = System.currentTimeMillis() - 1_000L,
+            enabled = false,
+        )
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns existing
+
+        val result = repository.setAlarmEnabled("alarm-1", enabled = true)
+
+        assertEquals(false, result)
+        verify(exactly = 0) { scheduler.schedule(any()) }
+        coVerify(exactly = 0) { scheduledAlarmDao.setEnabled(any(), any()) }
+    }
+
+    @Test
+    fun `setAlarmEnabled rolls back scheduler schedule when enable write fails`() = runTest {
+        val existing = scheduleRow(
+            id = "alarm-1",
+            triggerAtMillis = System.currentTimeMillis() + 60_000L,
+            enabled = false,
+        )
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns existing
+        coEvery { scheduledAlarmDao.setEnabled("alarm-1", true) } throws IllegalStateException("db")
+
+        val result = repository.setAlarmEnabled("alarm-1", enabled = true)
+
+        assertEquals(false, result)
+        verify(exactly = 1) { scheduler.schedule(match { it.eventId == "alarm-1" }) }
+        verify(exactly = 1) { scheduler.cancel(match { it.eventId == "alarm-1" }) }
+    }
+
+    @Test
+    fun `recordDeliveredEvent marks alarms fired`() = runTest {
+        val existing = scheduleRow(id = "alarm-1", triggerAtMillis = 6_000L, enabled = true)
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns existing
+        coEvery { scheduledAlarmDao.markFired("alarm-1") } just Runs
+
+        repository.recordDeliveredEvent("alarm-1")
+
+        coVerify(exactly = 1) { scheduledAlarmDao.markFired("alarm-1") }
+        coVerify(exactly = 0) { scheduledAlarmDao.delete("alarm-1") }
+    }
+
+    @Test
     fun `editAlarm returns null when row is already gone`() = runTest {
         coEvery { scheduledAlarmDao.getById("missing") } returns null
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2764,6 +2764,21 @@ class QuickIntentRouter(
             val labelMatch = labelRegex.find(cleaned)
             if (labelMatch != null) {
                 params["label"] = labelMatch.groupValues[1].trim()
+            } else {
+                val earliestStructuredIndex = listOfNotNull(
+                    dayMatch?.range?.first,
+                    match.range.first.takeIf { it > 0 },
+                ).minOrNull()
+                val implicitLabel = earliestStructuredIndex
+                    ?.let { cleaned.substring(0, it).trim() }
+                    ?.replace(Regex("""^(?:for|on|at|by)\s+"""), "")
+                    ?.replace(Regex("""\s+(?:for|on|at|by)$"""), "")
+                    ?.replace(Regex("""^(?:the|an?)\s+"""), "")
+                    ?.trim()
+                    ?.takeIf { it.isNotBlank() }
+                if (implicitLabel != null) {
+                    params["label"] = implicitLabel
+                }
             }
 
             return params

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -247,6 +247,16 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_alarm",
             regex = Regex(
+                """(?:set|create|make)\s+(?:an?\s+)?alarm\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s+(?:for|at|by)\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                parseAlarmTime("${match.groupValues[1]} ${match.groupValues[2]}")
+            },
+        ),
+        IntentPattern(
+            intentName = "set_alarm",
+            regex = Regex(
                 """(?:set|create|make)\s+(?:an?\s+)?alarm\s+(?:for|at)\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
@@ -454,7 +464,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_timer",
             regex = Regex(
-                """(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)(?:\s+(?:and\s+)?(\d+)\s*(minutes?|mins?|seconds?|secs?|m|s))?""",
+                """(?:set|start|create)\s+(?:a\s+)?(?:timer|countdown)\s+(?:for\s+)?(\d+)(?:\s*|-)(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)(?:\s+(?:and\s+)?(\d+)(?:\s*|-)(minutes?|mins?|seconds?|secs?|m|s))?""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, input -> parseTimerDuration(match, input) },
@@ -462,7 +472,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_timer",
             regex = Regex(
-                """(?:timer|countdown)\s+(?:for\s+)?(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                """(?:timer|countdown)\s+(?:for\s+)?(\d+)(?:\s*|-)(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, input -> parseTimerDuration(match, input) },
@@ -471,7 +481,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_timer",
             regex = Regex(
-                """(\d+)\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)\s+.*?timer""",
+                """(\d+)(?:\s*|-)(hours?|hrs?|minutes?|mins?|seconds?|secs?|h|m|s)\s+.*?timer""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, input -> parseTimerDuration(match, input) },
@@ -480,7 +490,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_timer",
             regex = Regex(
-                """remind\s+me\s+in\s+(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                """remind\s+me\s+in\s+(\d+)(?:\s*|-)(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, input -> parseTimerDuration(match, input) },
@@ -489,7 +499,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "set_timer",
             regex = Regex(
-                """time\s+me\s+(?:for\s+)?(\d+)\s*(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
+                """time\s+me\s+(?:for\s+)?(\d+)(?:\s*|-)(hours?|minutes?|mins?|seconds?|secs?|h|m|s)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, input -> parseTimerDuration(match, input) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -10,7 +10,6 @@ import android.hardware.camera2.CameraManager
 import android.media.AudioManager
 import android.net.Uri
 import android.os.BatteryManager
-import android.provider.AlarmClock
 import android.provider.CalendarContract
 import android.provider.ContactsContract
 import android.provider.MediaStore
@@ -93,7 +92,7 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
  *   get_list_items          — Retrieve unchecked items from a list (params: list_name?)
  *   remove_from_list        — Remove an item from a list (params: item, list_name?)
  *   smart_home_on/off       — Stub pending HA/Google Home (#311/#312) (params: device)
- *   cancel_alarm            — AlarmClock.ACTION_DISMISS_ALARM (params: label?)
+ *   cancel_alarm            — App-owned alarm cancellation (params: label?)
  *   get_weather             — Opens Google search for weather (params: location?)
  *   get_system_info         — Returns storage and RAM info — returns DirectReply
  *   get_date_diff           — Native date arithmetic: days/weeks until or since a date (params: target_date, from_date?) — returns DirectReply
@@ -352,35 +351,14 @@ class NativeIntentHandler @Inject constructor(
                 "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
             )
         }
-        if (clockRepository.getPlatformState().canScheduleExactAlarms) {
-            return SkillResult.Failure("run_intent", "Could not schedule the alarm.")
+        if (!clockRepository.getPlatformState().canScheduleExactAlarms) {
+            return SkillResult.Failure(
+                "run_intent",
+                "Exact alarms are unavailable right now.",
+            )
         }
 
-        val (hours, minutes) = resolvedTime.hour to resolvedTime.minute
-        val dayDisplay = day?.replaceFirstChar { it.uppercase() }
-        val messageLabel = when {
-            dayDisplay != null && label != null -> "$dayDisplay: $label"
-            dayDisplay != null -> dayDisplay
-            else -> label
-        }
-        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
-            putExtra(AlarmClock.EXTRA_HOUR, hours)
-            putExtra(AlarmClock.EXTRA_MINUTES, minutes)
-            messageLabel?.let { putExtra(AlarmClock.EXTRA_MESSAGE, it) }
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        return try {
-            context.startActivity(intent)
-            val dayLabel = dayDisplay?.let { " for $it" } ?: ""
-            val dayWarning = dayDisplay?.let {
-                " Exact alarms are unavailable, so please verify the date is set to $it before confirming."
-            } ?: ""
-            SkillResult.Success(
-                "Clock app opened — alarm$dayLabel at %02d:%02d.$dayWarning".format(hours, minutes)
-            )
-        } catch (e: ActivityNotFoundException) {
-            SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
-        }
+        return SkillResult.Failure("run_intent", "Could not schedule the alarm.")
     }
 
     // ── Timer ─────────────────────────────────────────────────────────────────
@@ -1529,47 +1507,18 @@ class NativeIntentHandler @Inject constructor(
         val label = params["label"]?.takeIf { it.isNotBlank() }
         if (label != null) {
             val cancelled = runBlocking { clockRepository.cancelAlarmsByLabel(label) }
-            if (cancelled > 0) {
-                val internalMessage = if (cancelled > 1) {
-                    "Cancelled $cancelled app alarms matching $label."
-                } else {
-                    "Cancelled app alarm: $label."
-                }
-                return dismissAlarmInClockApp(label, internalMessage)
-            }
-        } else {
-            val nextAlarm = runBlocking { clockRepository.cancelNextAlarm() }
-            if (nextAlarm != null) {
-                val internalMessage = "Cancelled next app alarm${nextAlarm.label?.let { value -> ": $value" } ?: ""}."
-                return nextAlarm.label?.let { dismissAlarmInClockApp(it, internalMessage) }
-                    ?: SkillResult.Success(internalMessage)
+            return when {
+                cancelled > 1 -> SkillResult.Success("Cancelled $cancelled app alarms matching $label.")
+                cancelled == 1 -> SkillResult.Success("Cancelled app alarm: $label.")
+                else -> SkillResult.Failure("cancel_alarm", "No app alarm named $label found")
             }
         }
-        return dismissAlarmInClockApp(label)
-    }
 
-    private fun dismissAlarmInClockApp(label: String?, prefixMessage: String? = null): SkillResult {
-        val intent = Intent(AlarmClock.ACTION_DISMISS_ALARM).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            if (label != null) {
-                putExtra(AlarmClock.EXTRA_ALARM_SEARCH_MODE, AlarmClock.ALARM_SEARCH_MODE_LABEL)
-                putExtra(AlarmClock.EXTRA_MESSAGE, label)
-            } else {
-                putExtra(AlarmClock.EXTRA_ALARM_SEARCH_MODE, AlarmClock.ALARM_SEARCH_MODE_NEXT)
-            }
-        }
-        return try {
-            context.startActivity(intent)
-            val clockMessage = if (label != null) {
-                "Cancelling alarm in clock app: $label"
-            } else {
-                "Opening alarms to cancel"
-            }
-            SkillResult.Success(listOfNotNull(prefixMessage, clockMessage).joinToString(" "))
-        } catch (e: ActivityNotFoundException) {
-            prefixMessage?.let { SkillResult.Success(it) }
-                ?: SkillResult.Failure("cancel_alarm", "No clock app found")
-        }
+        val nextAlarm = runBlocking { clockRepository.cancelNextAlarm() }
+            ?: return SkillResult.Failure("cancel_alarm", "No app alarms to cancel")
+        return SkillResult.Success(
+            "Cancelled next app alarm${nextAlarm.label?.let { value -> ": $value" } ?: ""}.",
+        )
     }
 
     // ── Get Weather ───────────────────────────────────────────────────────────

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -392,7 +392,11 @@ class NativeIntentHandler @Inject constructor(
         val label = params["label"]?.takeIf { it.isNotBlank() }
         val scheduled = runBlocking {
             clockRepository.scheduleTimer(durationMs, label)
-        } ?: return SkillResult.Failure("run_intent", "Exact alarms are unavailable right now.")
+        } ?: return if (!clockRepository.getPlatformState().canScheduleExactAlarms) {
+            SkillResult.Failure("run_intent", "Exact alarms are unavailable right now.")
+        } else {
+            SkillResult.Failure("run_intent", "Could not schedule the timer.")
+        }
         val mins = (scheduled.durationMs / 1000) / 60
         val secs = (scheduled.durationMs / 1000) % 60
         val labelStr = when {
@@ -1526,20 +1530,25 @@ class NativeIntentHandler @Inject constructor(
         if (label != null) {
             val cancelled = runBlocking { clockRepository.cancelAlarmsByLabel(label) }
             if (cancelled > 0) {
-                return SkillResult.Success(
-                    if (cancelled > 1) "Cancelled $cancelled app alarms matching $label."
-                    else "Cancelled app alarm: $label."
-                )
+                val internalMessage = if (cancelled > 1) {
+                    "Cancelled $cancelled app alarms matching $label."
+                } else {
+                    "Cancelled app alarm: $label."
+                }
+                return dismissAlarmInClockApp(label, internalMessage)
             }
         } else {
             val nextAlarm = runBlocking { clockRepository.cancelNextAlarm() }
             if (nextAlarm != null) {
-                return SkillResult.Success(
-                    "Cancelled next app alarm${nextAlarm.label?.let { value -> ": $value" } ?: ""}."
-                )
+                val internalMessage = "Cancelled next app alarm${nextAlarm.label?.let { value -> ": $value" } ?: ""}."
+                return nextAlarm.label?.let { dismissAlarmInClockApp(it, internalMessage) }
+                    ?: SkillResult.Success(internalMessage)
             }
         }
+        return dismissAlarmInClockApp(label)
+    }
 
+    private fun dismissAlarmInClockApp(label: String?, prefixMessage: String? = null): SkillResult {
         val intent = Intent(AlarmClock.ACTION_DISMISS_ALARM).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             if (label != null) {
@@ -1556,9 +1565,10 @@ class NativeIntentHandler @Inject constructor(
             } else {
                 "Opening alarms to cancel"
             }
-            SkillResult.Success(clockMessage)
+            SkillResult.Success(listOfNotNull(prefixMessage, clockMessage).joinToString(" "))
         } catch (e: ActivityNotFoundException) {
-            SkillResult.Failure("cancel_alarm", "No clock app found")
+            prefixMessage?.let { SkillResult.Success(it) }
+                ?: SkillResult.Failure("cancel_alarm", "No clock app found")
         }
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -410,7 +410,7 @@ class NativeIntentHandler @Inject constructor(
         val name = params["name"] ?: return cancelTimer()
         val durationMs = parseDurationToMs(name)
         val cancelled = runBlocking { clockRepository.cancelTimersMatching(name, durationMs) }
-        if (cancelled == 0) return SkillResult.Failure("cancel_timer_named", "No timer named '$name' found")
+        if (cancelled == 0) return SkillResult.Failure("cancel_timer_named", "No timer matching '$name' found")
         return SkillResult.Success(
             if (cancelled == 1) "Cancelled the $name timer"
             else "Cancelled $cancelled timers matching $name"
@@ -461,12 +461,15 @@ class NativeIntentHandler @Inject constructor(
     }
 
     private fun parseDurationToMs(text: String): Long? {
-        val match = Regex("""(\d+)\s*(minute|min|hour|hr|second|sec)""", RegexOption.IGNORE_CASE).find(text)
-            ?: return null
+        val normalized = text.replace('-', ' ').trim()
+        val match = Regex(
+            """(\d+)\s*(hours?|hrs?|hr|minutes?|mins?|min|seconds?|secs?|sec)""",
+            RegexOption.IGNORE_CASE,
+        ).find(normalized) ?: return null
         val amount = match.groupValues[1].toLongOrNull() ?: return null
         return when (match.groupValues[2].lowercase()) {
-            "hour", "hr" -> amount * 3_600_000L
-            "minute", "min" -> amount * 60_000L
+            "hour", "hours", "hr", "hrs" -> amount * 3_600_000L
+            "minute", "minutes", "min", "mins" -> amount * 60_000L
             else -> amount * 1_000L
         }
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1945,12 +1945,24 @@ class NativeIntentHandler @Inject constructor(
             "${m.groupValues[1]}:0${m.groupValues[2]}${m.groupValues[3]}"
         }
 
-        // 3. Insert ":00" for bare hour+meridiem — only for valid 12h range (1-12).
+        // 3. Normalize dotted meridiem and insert ":00" for bare hour+meridiem — only for valid 12h range (1-12).
         //    Reject "13pm" / "0am" here so we don't produce a string that silently fails later.
-        val input = Regex("""^(\d{1,2})\s*(am|pm|AM|PM)$""").replace(padded) { m ->
-            val h = m.groupValues[1].toIntOrNull() ?: 0
-            if (h in 1..12) "${m.groupValues[1]}:00${m.groupValues[2]}" else m.value
-        }.trim()
+        val input = padded
+            .replace(Regex("""a\.m\.|p\.m\.""", RegexOption.IGNORE_CASE)) {
+                it.value.replace(".", "")
+            }
+            .let { normalized ->
+                Regex("""\b(am|pm)\b""", RegexOption.IGNORE_CASE).replace(normalized) {
+                    it.value.uppercase()
+                }
+            }
+            .let { normalized ->
+                Regex("""^(\d{1,2})\s*(AM|PM)$""").replace(normalized) { m ->
+                    val h = m.groupValues[1].toIntOrNull() ?: 0
+                    if (h in 1..12) "${m.groupValues[1]}:00${m.groupValues[2]}" else m.value
+                }
+            }
+            .trim()
 
         val formatters = listOf(
             DateTimeFormatter.ofPattern("HH:mm"),
@@ -1981,9 +1993,10 @@ class NativeIntentHandler @Inject constructor(
             }
         }
 
-        val flattenedOclock = Regex("""^([1-9]|1[0-2])0:00(\s*(?:am|pm|AM|PM))?$""")
+        val flattenedOclock = Regex("""^((?:[3-9]|1[0-2])0):00(\s*(?:am|pm|AM|PM))?$""")
         flattenedOclock.matchEntire(input)?.let { match ->
-            val hour = match.groupValues[1].toIntOrNull() ?: return@let
+            val flattenedHour = match.groupValues[1].toIntOrNull() ?: return@let
+            val hour = flattenedHour / 10
             val meridiem = match.groupValues[2]
             return "$hour:00$meridiem"
         }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1,8 +1,6 @@
 package com.kernel.ai.core.skills.natives
 
-import android.app.AlarmManager
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.app.SearchManager
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -22,12 +20,11 @@ import android.util.Log
 import android.view.KeyEvent
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
-import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
-import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.ToolPresentation
@@ -45,17 +42,12 @@ import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
 import java.util.Locale
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
 import kotlinx.coroutines.runBlocking
 
 private const val TAG = "KernelAI"
-private const val ALARM_RECEIVER_CLASS = "com.kernel.ai.alarm.AlarmBroadcastReceiver"
-private const val EXTRA_ALARM_LABEL = "alarm_label"
-private const val EXTRA_ALARM_ID = "alarm_id"
-private const val EXTRA_ALARM_TITLE = "alarm_title"
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
 
 /**
@@ -69,8 +61,8 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
  *   toggle_flashlight_off   — Camera2 torch off
  *   send_email              — ACTION_SENDTO mailto: URI (params: contact, subject, body)
  *   send_sms                — ACTION_SENDTO SMS composer (params: message)
- *   set_alarm               — AlarmClock.ACTION_SET_ALARM (params: hours, minutes, label)
- *   set_timer               — Built-in timer via AlarmManager (params: duration_seconds, label)
+ *   set_alarm               — App-owned alarm scheduling (params: hours, minutes, label)
+ *   set_timer               — App-owned timer scheduling (params: duration_seconds, label)
  *   create_calendar_event   — CalendarContract ACTION_INSERT edit screen (params: title, date, time?, duration_minutes?, description?)
  *   get_battery             — BatteryManager capacity + charging state
  *   get_time / get_date     — LocalDateTime formatted display
@@ -111,7 +103,7 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
 @Singleton
 class NativeIntentHandler @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val scheduledAlarmDao: ScheduledAlarmDao,
+    private val clockRepository: ClockRepository,
     private val listItemDao: ListItemDao,
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
@@ -324,89 +316,67 @@ class NativeIntentHandler @Inject constructor(
         val label = params["label"]?.takeIf { it.isNotBlank() }
         val day = params["day"]?.trim()?.takeIf { it.isNotBlank() }
         val resolvedDate = day?.let { resolveDate(it) }
+        if (day != null && resolvedDate == null) {
+            return SkillResult.Failure("run_intent", "Couldn't parse day: $day")
+        }
 
-        if (resolvedDate != null) {
-            // Schedule a real exact alarm via AlarmManager
-            val triggerAt = resolvedDate
+        val triggerAt = if (resolvedDate != null) {
+            resolvedDate
                 .atTime(resolvedTime)
                 .atZone(ZoneId.systemDefault())
                 .toInstant()
                 .toEpochMilli()
-
-            if (triggerAt <= System.currentTimeMillis()) {
-                return SkillResult.Failure("run_intent", "That time has already passed.")
+        } else {
+            val zone = ZoneId.systemDefault()
+            val now = Instant.ofEpochMilli(System.currentTimeMillis()).atZone(zone)
+            val candidate = now.toLocalDate().atTime(resolvedTime).atZone(zone)
+            if (candidate.toInstant().toEpochMilli() > System.currentTimeMillis()) {
+                candidate.toInstant().toEpochMilli()
+            } else {
+                candidate.plusDays(1).toInstant().toEpochMilli()
             }
+        }
 
-            val alarmId = UUID.randomUUID().toString()
-            val alarmEntity = ScheduledAlarmEntity(
-                id = alarmId,
-                triggerAtMillis = triggerAt,
-                label = label,
-                createdAt = System.currentTimeMillis(),
-            )
-            runBlocking { scheduledAlarmDao.insert(alarmEntity) }
+        if (triggerAt <= System.currentTimeMillis()) {
+            return SkillResult.Failure("run_intent", "That time has already passed.")
+        }
 
-            val alarmManager = context.getSystemService(AlarmManager::class.java)
-            val alarmIntent = Intent().apply {
-                component = android.content.ComponentName(
-                    context.packageName,
-                    "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-                )
-                putExtra("alarm_label", label ?: "Alarm")
-                putExtra("alarm_id", alarmId)
-            }
-            val pendingIntent = PendingIntent.getBroadcast(
-                context,
-                alarmId.hashCode(),
-                alarmIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-            )
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
-
+        val scheduled = runBlocking {
+            clockRepository.scheduleAlarm(triggerAt, label)
+        }
+        if (scheduled != null) {
             val formatter = DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
                 .withZone(ZoneId.systemDefault())
-            val formattedTime = formatter.format(Instant.ofEpochMilli(triggerAt))
+            val formattedTime = formatter.format(Instant.ofEpochMilli(scheduled.triggerAtMillis))
             return SkillResult.Success(
                 "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
             )
         }
-
-        // No date resolved — fall back to clock app intent (existing behaviour)
-        val (hours, minutes) = resolvedTime.hour to resolvedTime.minute
-        val dayDisplay = day?.replaceFirstChar { it.uppercase() }
-        val isWeekday = day?.lowercase() in setOf(
-            "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"
-        )
-        val isTomorrow = day?.lowercase() == "tomorrow"
-        val messageLabel = when {
-            isTomorrow && label != null -> "TOMORROW: $label"
-            isTomorrow -> "TOMORROW"
-            isWeekday && label != null -> "$dayDisplay: $label"
-            isWeekday -> dayDisplay
-            else -> label
+        if (clockRepository.getPlatformState().canScheduleExactAlarms) {
+            return SkillResult.Failure("run_intent", "Could not schedule the alarm.")
         }
 
+        val (hours, minutes) = resolvedTime.hour to resolvedTime.minute
+        val dayDisplay = day?.replaceFirstChar { it.uppercase() }
+        val messageLabel = when {
+            dayDisplay != null && label != null -> "$dayDisplay: $label"
+            dayDisplay != null -> dayDisplay
+            else -> label
+        }
         val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
             putExtra(AlarmClock.EXTRA_HOUR, hours)
             putExtra(AlarmClock.EXTRA_MINUTES, minutes)
             messageLabel?.let { putExtra(AlarmClock.EXTRA_MESSAGE, it) }
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
-        if (context.packageManager.resolveActivity(intent, 0) == null) {
-            return SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
-        }
         return try {
             context.startActivity(intent)
-            val dayLabel = day?.takeIf { it.isNotBlank() }
-                ?.let { " for ${it.replaceFirstChar { c -> c.uppercase() }}" } ?: ""
-            val dayWarning = when {
-                isTomorrow -> " ⚠ Your clock app schedules by time only — please verify the date is set to tomorrow before confirming."
-                isWeekday -> " ⚠ Your clock app schedules by time only — please verify the date is set to $dayDisplay before confirming."
-                else -> ""
-            }
+            val dayLabel = dayDisplay?.let { " for $it" } ?: ""
+            val dayWarning = dayDisplay?.let {
+                " Exact alarms are unavailable, so please verify the date is set to $it before confirming."
+            } ?: ""
             SkillResult.Success(
-                "Clock app opened — alarm$dayLabel at %02d:%02d. Please confirm in your clock app.$dayWarning"
-                    .format(hours, minutes)
+                "Clock app opened — alarm$dayLabel at %02d:%02d.$dayWarning".format(hours, minutes)
             )
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("run_intent", "No clock app found to set an alarm.")
@@ -420,59 +390,35 @@ class NativeIntentHandler @Inject constructor(
             ?: return SkillResult.Failure("run_intent", "duration_seconds is required and must be an integer.")
         val durationMs = seconds * 1000L
         val label = params["label"]?.takeIf { it.isNotBlank() }
-        val now = System.currentTimeMillis()
-        val timer = ScheduledAlarmEntity(
-            id = UUID.randomUUID().toString(),
-            entryType = "TIMER",
-            label = label,
-            durationMs = durationMs,
-            startedAtMs = now,
-            triggerAtMillis = now + durationMs,
-            createdAt = now,
-        )
-        return try {
-            runBlocking { scheduledAlarmDao.insert(timer) }
-            scheduleTimerBroadcast(timer)
-            val mins = seconds / 60
-            val secs = seconds % 60
-            val labelStr = when {
-                mins > 0 && secs > 0 -> "$mins min $secs sec"
-                mins > 0 -> "$mins minute${if (mins != 1) "s" else ""}"
-                else -> "$seconds seconds"
-            }
-            SkillResult.Success("Timer set for $labelStr.")
-        } catch (e: Exception) {
-            SkillResult.Failure("run_intent", "Could not set the timer.")
+        val scheduled = runBlocking {
+            clockRepository.scheduleTimer(durationMs, label)
+        } ?: return SkillResult.Failure("run_intent", "Exact alarms are unavailable right now.")
+        val mins = (scheduled.durationMs / 1000) / 60
+        val secs = (scheduled.durationMs / 1000) % 60
+        val labelStr = when {
+            mins > 0 && secs > 0 -> "$mins min $secs sec"
+            mins > 0 -> "$mins minute${if (mins != 1L) "s" else ""}"
+            else -> "${scheduled.durationMs / 1000} seconds"
         }
+        return SkillResult.Success("Timer set for $labelStr.")
     }
 
     private fun cancelTimer(): SkillResult {
-        val timers = runBlocking { scheduledAlarmDao.getAllTimers() }
-        if (timers.isEmpty()) return SkillResult.DirectReply("No timers running.")
-        runBlocking {
-            timers.forEach { timer ->
-                cancelTimerBroadcast(timer)
-                scheduledAlarmDao.delete(timer.id)
-            }
-        }
-        val count = timers.size
-        return SkillResult.Success("Cancelled $count timer${if (count == 1) "" else "s"}.")
+        val cancelled = runBlocking { clockRepository.cancelAllTimers() }
+        if (cancelled == 0) return SkillResult.DirectReply("No timers running.")
+        return SkillResult.Success("Cancelled $cancelled timer${if (cancelled == 1) "" else "s"}.")
     }
 
     // ── Timer Registry ────────────────────────────────────────────────────────
 
     private fun listTimers(): SkillResult {
-        val timers = runBlocking { scheduledAlarmDao.getAllTimers() }
+        val timers = runBlocking { clockRepository.getAllTimers() }
         if (timers.isEmpty()) return SkillResult.DirectReply("No timers running.")
         val now = System.currentTimeMillis()
         val lines = timers.mapIndexed { i, t ->
             val label = t.label ?: "Timer ${i + 1}"
-            val remaining = t.durationMs?.let { dur ->
-                t.startedAtMs?.let { start ->
-                    val remMs = (start + dur) - now
-                    if (remMs > 0) formatDuration(remMs / 1000) else "finished"
-                }
-            } ?: "unknown"
+            val remMs = (t.startedAtMillis + t.durationMs) - now
+            val remaining = if (remMs > 0) formatDuration(remMs / 1000) else "finished"
             "• $label — $remaining remaining"
         }
         return SkillResult.DirectReply(lines.joinToString("\n"))
@@ -481,34 +427,25 @@ class NativeIntentHandler @Inject constructor(
     private fun cancelTimerNamed(params: Map<String, String>): SkillResult {
         val name = params["name"] ?: return cancelTimer()
         val durationMs = parseDurationToMs(name)
-        val timers = runBlocking { scheduledAlarmDao.getAllTimers() }
-        val matches = timers.filter { timer ->
-            timer.label?.equals(name, ignoreCase = true) == true ||
-                (durationMs != null && timer.durationMs == durationMs)
-        }
-        if (matches.isEmpty()) return SkillResult.Failure("cancel_timer_named", "No timer named '$name' found")
-        runBlocking {
-            matches.forEach { timer ->
-                cancelTimerBroadcast(timer)
-                scheduledAlarmDao.delete(timer.id)
-            }
-        }
-        return SkillResult.Success("Cancelled the $name timer")
+        val cancelled = runBlocking { clockRepository.cancelTimersMatching(name, durationMs) }
+        if (cancelled == 0) return SkillResult.Failure("cancel_timer_named", "No timer named '$name' found")
+        return SkillResult.Success(
+            if (cancelled == 1) "Cancelled the $name timer"
+            else "Cancelled $cancelled timers matching $name"
+        )
     }
 
     private fun getTimerRemaining(params: Map<String, String>): SkillResult {
         val name = params["name"]
-        val timers = runBlocking { scheduledAlarmDao.getAllTimers() }
+        val timers = runBlocking { clockRepository.getAllTimers() }
         if (timers.isEmpty()) return SkillResult.DirectReply("No timers running.")
         val timer = if (name != null) {
             timers.firstOrNull { it.label?.contains(name, ignoreCase = true) == true }
                 ?: timers.first()
         } else timers.first()
         val now = System.currentTimeMillis()
-        val remMs = timer.durationMs?.let { dur ->
-            timer.startedAtMs?.let { start -> (start + dur) - now }
-        }
-        return if (remMs != null && remMs > 0) {
+        val remMs = (timer.startedAtMillis + timer.durationMs) - now
+        return if (remMs > 0) {
             val label = timer.label ?: "Timer"
             SkillResult.DirectReply("$label — ${formatSpokenDuration(remMs / 1000)} remaining")
         } else {
@@ -550,46 +487,6 @@ class NativeIntentHandler @Inject constructor(
             "minute", "min" -> amount * 60_000L
             else -> amount * 1_000L
         }
-    }
-
-    private fun scheduleTimerBroadcast(timer: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                ALARM_RECEIVER_CLASS,
-            )
-            putExtra(EXTRA_ALARM_LABEL, timer.label ?: "Timer")
-            putExtra(EXTRA_ALARM_ID, timer.id)
-            putExtra(EXTRA_ALARM_TITLE, "Timer")
-        }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            timer.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timer.triggerAtMillis, pendingIntent)
-    }
-
-    private fun cancelTimerBroadcast(timer: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                ALARM_RECEIVER_CLASS,
-            )
-            putExtra(EXTRA_ALARM_LABEL, timer.label ?: "Timer")
-            putExtra(EXTRA_ALARM_ID, timer.id)
-            putExtra(EXTRA_ALARM_TITLE, "Timer")
-        }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            timer.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
-        )
-        pendingIntent?.let { alarmManager.cancel(it) }
     }
 
     // ── Calendar ──────────────────────────────────────────────────────────────
@@ -1625,7 +1522,24 @@ class NativeIntentHandler @Inject constructor(
     // ── Cancel Alarm ──────────────────────────────────────────────────────────
 
     private fun cancelAlarm(params: Map<String, String>): SkillResult {
-        val label = params["label"]
+        val label = params["label"]?.takeIf { it.isNotBlank() }
+        if (label != null) {
+            val cancelled = runBlocking { clockRepository.cancelAlarmsByLabel(label) }
+            if (cancelled > 0) {
+                return SkillResult.Success(
+                    if (cancelled > 1) "Cancelled $cancelled app alarms matching $label."
+                    else "Cancelled app alarm: $label."
+                )
+            }
+        } else {
+            val nextAlarm = runBlocking { clockRepository.cancelNextAlarm() }
+            if (nextAlarm != null) {
+                return SkillResult.Success(
+                    "Cancelled next app alarm${nextAlarm.label?.let { value -> ": $value" } ?: ""}."
+                )
+            }
+        }
+
         val intent = Intent(AlarmClock.ACTION_DISMISS_ALARM).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             if (label != null) {
@@ -1637,7 +1551,12 @@ class NativeIntentHandler @Inject constructor(
         }
         return try {
             context.startActivity(intent)
-            SkillResult.Success(if (label != null) "Cancelling alarm: $label" else "Opening alarms to cancel")
+            val clockMessage = if (label != null) {
+                "Cancelling alarm in clock app: $label"
+            } else {
+                "Opening alarms to cancel"
+            }
+            SkillResult.Success(clockMessage)
         } catch (e: ActivityNotFoundException) {
             SkillResult.Failure("cancel_alarm", "No clock app found")
         }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -429,6 +429,14 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `cancel the 10-minute timer should keep the hyphenated duration name`() {
+            val result = regexOnlyRouter.route("cancel the 10-minute timer")
+            assertRegexMatch(result, "cancel_timer_named", "cancel the 10-minute timer")
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("10-minute", intent.params["name"], "name param should preserve the spoken duration token")
+        }
+
+        @Test
         fun `stop the pasta timer should route to cancel_timer_named`() {
             val result = regexOnlyRouter.route("stop the pasta timer")
             assertRegexMatch(result, "cancel_timer_named", "stop the pasta timer")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -283,6 +283,29 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `should parse dotted meridiem alarm times`() {
+            val result = regexOnlyRouter.route("set an alarm for 10:00 a.m.")
+            assertRegexMatch(result, "set_alarm", "set an alarm for 10:00 a.m.")
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("10", intent.params["hours"])
+            assertEquals("0", intent.params["minutes"])
+            assertEquals("10:00", intent.params["time"])
+        }
+
+        @Test
+        fun `should match alarm phrases with day before preposition`() {
+            val result = regexOnlyRouter.route("set an alarm tomorrow for 7:30 a.m. called rugby")
+            assertRegexMatch(result, "set_alarm", "set an alarm tomorrow for 7:30 a.m. called rugby")
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("7", intent.params["hours"])
+            assertEquals("30", intent.params["minutes"])
+            assertEquals("tomorrow", intent.params["day"])
+            assertEquals("rugby", intent.params["label"])
+        }
+
+        @Test
         fun `should recover compact alarm times`() {
             val result = regexOnlyRouter.route("set an alarm for 730am")
             assertRegexMatch(result, "set_alarm", "set an alarm for 730am")
@@ -1731,6 +1754,8 @@ class QuickIntentRouterTest {
             Arguments.of("timer for 15 minutes", "900"),
             Arguments.of("5 minute timer", "300"),
             Arguments.of("10 second timer", "10"),
+            Arguments.of("set a 2-minute timer", "120"),
+            Arguments.of("start a 45-second timer", "45"),
             Arguments.of("set a timer for 1 hour and 30 minutes", "5400"),
             Arguments.of("set timer for 2 hours and 15 minutes", "8100"),
         )

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -306,6 +306,19 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `should infer alarm label before tomorrow time phrase`() {
+            val result = regexOnlyRouter.route("set an alarm for the gym tomorrow at 5:00 a.m.")
+            assertRegexMatch(result, "set_alarm", "set an alarm for the gym tomorrow at 5:00 a.m.")
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("5", intent.params["hours"])
+            assertEquals("0", intent.params["minutes"])
+            assertEquals("5:00", intent.params["time"])
+            assertEquals("tomorrow", intent.params["day"])
+            assertEquals("gym", intent.params["label"])
+        }
+
+        @Test
         fun `should recover compact alarm times`() {
             val result = regexOnlyRouter.route("set an alarm for 730am")
             assertRegexMatch(result, "set_alarm", "set an alarm for 730am")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -555,12 +555,28 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `cancel_timer_named matches unlabeled timer by hyphenated duration`() {
+        coEvery { clockRepository.cancelTimersMatching("10-minute", 600_000L) } returns 1
+        val result = handler.handle("cancel_timer_named", mapOf("name" to "10-minute"))
+        assertEquals(SkillResult.Success("Cancelled the 10-minute timer"), result)
+        coVerify(exactly = 1) { clockRepository.cancelTimersMatching("10-minute", 600_000L) }
+    }
+
+    @Test
     fun `set_alarm with unparseable explicit day fails instead of shifting dates`() {
         val result = handler.handle("set_alarm", mapOf("time" to "07:00", "day" to "blursday"))
 
         assertEquals(SkillResult.Failure("run_intent", "Couldn't parse day: blursday"), result)
         coVerify(exactly = 0) { clockRepository.scheduleAlarm(any(), any()) }
         verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `cancel_timer_named uses truthful failure when no duration match exists`() {
+        coEvery { clockRepository.cancelTimersMatching("10-minute", 600_000L) } returns 0
+        val result = handler.handle("cancel_timer_named", mapOf("name" to "10-minute"))
+        assertEquals(SkillResult.Failure("cancel_timer_named", "No timer matching '10-minute' found"), result)
+        coVerify(exactly = 1) { clockRepository.cancelTimersMatching("10-minute", 600_000L) }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -19,13 +19,15 @@ import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
@@ -471,6 +473,36 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `set_alarm returns failure when repository rejects alarm despite exact alarm availability`() {
+        coEvery { clockRepository.scheduleAlarm(any(), "Wake") } returns null
+        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+
+        val result = handler.handle("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+
+        assertEquals(SkillResult.Failure("run_intent", "Could not schedule the alarm."), result)
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `set_timer returns generic failure when repository rejects despite exact alarm availability`() {
+        coEvery { clockRepository.scheduleTimer(any(), any()) } returns null
+        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+
+        val result = handler.handle("set_timer", mapOf("duration_seconds" to "60"))
+
+        assertEquals(SkillResult.Failure("run_intent", "Could not schedule the timer."), result)
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
     fun `set_alarm with unparseable explicit day fails instead of shifting dates`() {
         val result = handler.handle("set_alarm", mapOf("time" to "07:00", "day" to "blursday"))
 
@@ -480,7 +512,7 @@ class NativeIntentHandlerTest {
     }
 
     @Test
-    fun `cancel_alarm without label stays internal when app alarm exists`() {
+    fun `cancel_alarm without label dismisses matching clock alarm when label is known`() {
         coEvery { clockRepository.cancelNextAlarm() } returns ClockAlarm(
             id = "alarm-1",
             triggerAtMillis = 1_700_000_000_000L,
@@ -488,20 +520,42 @@ class NativeIntentHandlerTest {
             createdAtMillis = 1_699_000_000_000L,
             enabled = true,
         )
-        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
-            canScheduleExactAlarms = true,
-            notificationsEnabled = true,
-            canUseFullScreenIntent = false,
-        )
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setFlags(any()) } answers { self as Intent }
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { self as Intent }
+        try {
+            val result = handler.handle("cancel_alarm", emptyMap())
 
-        val result = handler.handle("cancel_alarm", emptyMap())
+            assertEquals(
+                SkillResult.Success("Cancelled next app alarm: Wake. Cancelling alarm in clock app: Wake"),
+                result,
+            )
+            coVerify(exactly = 1) { clockRepository.cancelNextAlarm() }
+            verify(exactly = 1) { context.startActivity(any()) }
+        } finally {
+            unmockkConstructor(Intent::class)
+        }
+    }
 
-        assertEquals(
-            SkillResult.Success("Cancelled next app alarm: Wake."),
-            result,
-        )
-        coVerify(exactly = 1) { clockRepository.cancelNextAlarm() }
-        verify(exactly = 0) { context.startActivity(any()) }
+
+    @Test
+    fun `cancel_alarm with label preserves clock app dismissal in mixed state`() {
+        coEvery { clockRepository.cancelAlarmsByLabel("Wake") } returns 1
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setFlags(any()) } answers { self as Intent }
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { self as Intent }
+        try {
+            val result = handler.handle("cancel_alarm", mapOf("label" to "Wake"))
+
+            assertEquals(
+                SkillResult.Success("Cancelled app alarm: Wake. Cancelling alarm in clock app: Wake"),
+                result,
+            )
+            coVerify(exactly = 1) { clockRepository.cancelAlarmsByLabel("Wake") }
+            verify(exactly = 1) { context.startActivity(any()) }
+        } finally {
+            unmockkConstructor(Intent::class)
+        }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -11,9 +11,10 @@ import android.provider.ContactsContract
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
-import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
@@ -30,6 +31,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalTime
@@ -38,13 +40,13 @@ class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
-    private val scheduledAlarmDao = mockk<ScheduledAlarmDao>(relaxed = true)
+    private val clockRepository = mockk<ClockRepository>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
     private val listNameDao = mockk<ListNameDao>(relaxed = true)
 
     private val handler = NativeIntentHandler(
         context = context,
-        scheduledAlarmDao = scheduledAlarmDao,
+        clockRepository = clockRepository,
         listItemDao = listItemDao,
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
@@ -447,8 +449,59 @@ class NativeIntentHandlerTest {
             com.kernel.ai.core.skills.SkillResult.Success("Opening YouTube Music and starting playback"),
             result,
         )
-        verify { context.startActivity(launchIntent) }
         verify(exactly = 2) { audioManager.dispatchMediaKeyEvent(any()) }
+    }
+
+    @Test
+    fun `set_alarm without explicit date uses internal clock repository`() {
+        coEvery { clockRepository.scheduleAlarm(any(), "Wake") } returns ClockAlarm(
+            id = "alarm-1",
+            triggerAtMillis = 1_700_000_000_000L,
+            label = "Wake",
+            createdAtMillis = 1_699_000_000_000L,
+            enabled = true,
+        )
+
+        val result = handler.handle("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+
+        assertTrue(result is SkillResult.Success)
+        assertTrue((result as SkillResult.Success).content.contains("Alarm set for"))
+        coVerify(exactly = 1) { clockRepository.scheduleAlarm(any(), "Wake") }
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `set_alarm with unparseable explicit day fails instead of shifting dates`() {
+        val result = handler.handle("set_alarm", mapOf("time" to "07:00", "day" to "blursday"))
+
+        assertEquals(SkillResult.Failure("run_intent", "Couldn't parse day: blursday"), result)
+        coVerify(exactly = 0) { clockRepository.scheduleAlarm(any(), any()) }
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `cancel_alarm without label stays internal when app alarm exists`() {
+        coEvery { clockRepository.cancelNextAlarm() } returns ClockAlarm(
+            id = "alarm-1",
+            triggerAtMillis = 1_700_000_000_000L,
+            label = "Wake",
+            createdAtMillis = 1_699_000_000_000L,
+            enabled = true,
+        )
+        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+
+        val result = handler.handle("cancel_alarm", emptyMap())
+
+        assertEquals(
+            SkillResult.Success("Cancelled next app alarm: Wake."),
+            result,
+        )
+        coVerify(exactly = 1) { clockRepository.cancelNextAlarm() }
+        verify(exactly = 0) { context.startActivity(any()) }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -25,9 +25,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
-import io.mockk.unmockkConstructor
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
@@ -512,6 +510,21 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `set_alarm returns exact alarm unavailable failure when platform scheduling is off`() {
+        coEvery { clockRepository.scheduleAlarm(any(), "Wake") } returns null
+        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
+            canScheduleExactAlarms = false,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+
+        val result = handler.handle("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
+
+        assertEquals(SkillResult.Failure("run_intent", "Exact alarms are unavailable right now."), result)
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
     fun `set_alarm returns failure when repository rejects alarm despite exact alarm availability`() {
         coEvery { clockRepository.scheduleAlarm(any(), "Wake") } returns null
         every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
@@ -551,7 +564,7 @@ class NativeIntentHandlerTest {
     }
 
     @Test
-    fun `cancel_alarm without label dismisses matching clock alarm when label is known`() {
+    fun `cancel_alarm without label cancels next app alarm only`() {
         coEvery { clockRepository.cancelNextAlarm() } returns ClockAlarm(
             id = "alarm-1",
             triggerAtMillis = 1_700_000_000_000L,
@@ -559,42 +572,43 @@ class NativeIntentHandlerTest {
             createdAtMillis = 1_699_000_000_000L,
             enabled = true,
         )
-        mockkConstructor(Intent::class)
-        every { anyConstructed<Intent>().setFlags(any()) } answers { self as Intent }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { self as Intent }
-        try {
-            val result = handler.handle("cancel_alarm", emptyMap())
 
-            assertEquals(
-                SkillResult.Success("Cancelled next app alarm: Wake. Cancelling alarm in clock app: Wake"),
-                result,
-            )
-            coVerify(exactly = 1) { clockRepository.cancelNextAlarm() }
-            verify(exactly = 1) { context.startActivity(any()) }
-        } finally {
-            unmockkConstructor(Intent::class)
-        }
+        val result = handler.handle("cancel_alarm", emptyMap())
+
+        assertEquals(
+            SkillResult.Success("Cancelled next app alarm: Wake."),
+            result,
+        )
+        coVerify(exactly = 1) { clockRepository.cancelNextAlarm() }
+        verify(exactly = 0) { context.startActivity(any()) }
     }
 
+    @Test
+    fun `cancel_alarm with label cancels internal alarm only`() {
+        coEvery { clockRepository.cancelAlarmsByLabel("Wake") } returns 1
+
+        val result = handler.handle("cancel_alarm", mapOf("label" to "Wake"))
+
+        assertEquals(
+            SkillResult.Success("Cancelled app alarm: Wake."),
+            result,
+        )
+        coVerify(exactly = 1) { clockRepository.cancelAlarmsByLabel("Wake") }
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
 
     @Test
-    fun `cancel_alarm with label preserves clock app dismissal in mixed state`() {
-        coEvery { clockRepository.cancelAlarmsByLabel("Wake") } returns 1
-        mockkConstructor(Intent::class)
-        every { anyConstructed<Intent>().setFlags(any()) } answers { self as Intent }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { self as Intent }
-        try {
-            val result = handler.handle("cancel_alarm", mapOf("label" to "Wake"))
+    fun `cancel_alarm with label reports missing internal alarm`() {
+        coEvery { clockRepository.cancelAlarmsByLabel("Wake") } returns 0
 
-            assertEquals(
-                SkillResult.Success("Cancelled app alarm: Wake. Cancelling alarm in clock app: Wake"),
-                result,
-            )
-            coVerify(exactly = 1) { clockRepository.cancelAlarmsByLabel("Wake") }
-            verify(exactly = 1) { context.startActivity(any()) }
-        } finally {
-            unmockkConstructor(Intent::class)
-        }
+        val result = handler.handle("cancel_alarm", mapOf("label" to "Wake"))
+
+        assertEquals(
+            SkillResult.Failure("cancel_alarm", "No app alarm named Wake found"),
+            result,
+        )
+        coVerify(exactly = 1) { clockRepository.cancelAlarmsByLabel("Wake") }
+        verify(exactly = 0) { context.startActivity(any()) }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -109,6 +109,45 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `resolveTime preserves valid dotted meridiem times`() {
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveTime",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "10:00 a.m.") as LocalTime?
+
+        assertNotNull(resolved)
+        assertEquals(LocalTime.of(10, 0), resolved)
+    }
+
+    @Test
+    fun `resolveTime recovers flattened seven oclock format`() {
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveTime",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "70:00") as LocalTime?
+
+        assertNotNull(resolved)
+        assertEquals(LocalTime.of(7, 0), resolved)
+    }
+
+    @Test
+    fun `resolveTime recovers flattened three oclock format`() {
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveTime",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "30:00") as LocalTime?
+
+        assertNotNull(resolved)
+        assertEquals(LocalTime.of(3, 0), resolved)
+    }
+
+    @Test
     fun `resolveTime recovers flattened oclock format`() {
         val method = NativeIntentHandler::class.java.getDeclaredMethod(
             "resolveTime",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
@@ -2,10 +2,13 @@ package com.kernel.ai.core.voice
 
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class SelectableVoiceInputController @Inject constructor(
     private val voiceInputPreferences: VoiceInputPreferences,
@@ -13,24 +16,33 @@ class SelectableVoiceInputController @Inject constructor(
     private val nativeAndroidVoiceInputController: NativeAndroidVoiceInputController,
 ) : VoiceInputController {
 
-    override val events: Flow<VoiceInputEvent> = merge(
-        voskOfflineVoiceInputController.events,
-        nativeAndroidVoiceInputController.events,
-    )
+    private val activeController = MutableStateFlow<VoiceInputController>(voskOfflineVoiceInputController)
 
-    @Volatile
-    private var activeController: VoiceInputController = voskOfflineVoiceInputController
+    override val events: Flow<VoiceInputEvent> = activeController.flatMapLatest { controller ->
+        controller.events
+    }
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         val controller = when (voiceInputPreferences.selectedEngine.first()) {
             VoiceInputEngine.Vosk -> voskOfflineVoiceInputController
             VoiceInputEngine.AndroidNative -> nativeAndroidVoiceInputController
         }
-        activeController = controller
+        activeController.value = controller
+        stopInactiveControllers(controller)
         return controller.startListening(mode)
     }
 
     override fun stopListening() {
-        activeController.stopListening()
+        stopAllControllers()
+    }
+
+    private fun stopInactiveControllers(active: VoiceInputController) {
+        if (active !== voskOfflineVoiceInputController) voskOfflineVoiceInputController.stopListening()
+        if (active !== nativeAndroidVoiceInputController) nativeAndroidVoiceInputController.stopListening()
+    }
+
+    private fun stopAllControllers() {
+        voskOfflineVoiceInputController.stopListening()
+        nativeAndroidVoiceInputController.stopListening()
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
@@ -1,0 +1,78 @@
+package com.kernel.ai.core.voice
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SelectableVoiceInputControllerTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val voiceInputPreferences: VoiceInputPreferences = mockk()
+    private val voskOfflineVoiceInputController: VoskOfflineVoiceInputController = mockk()
+    private val nativeAndroidVoiceInputController: NativeAndroidVoiceInputController = mockk()
+
+    @Test
+    fun `events only flow from the selected controller`() = runTest(dispatcher) {
+        val selectedEngine = MutableStateFlow(VoiceInputEngine.AndroidNative)
+        val voskEvents = MutableSharedFlow<VoiceInputEvent>()
+        val nativeEvents = MutableSharedFlow<VoiceInputEvent>()
+        val received = mutableListOf<VoiceInputEvent>()
+        every { voiceInputPreferences.selectedEngine } returns selectedEngine
+        every { voskOfflineVoiceInputController.events } returns voskEvents
+        every { nativeAndroidVoiceInputController.events } returns nativeEvents
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+        coEvery { nativeAndroidVoiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+        )
+        val collectJob = launch { controller.events.collect { received += it } }
+
+        controller.startListening(VoiceCaptureMode.Command)
+        advanceUntilIdle()
+        voskEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "stale vosk"))
+        nativeEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "fresh native"))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "fresh native")),
+            received,
+        )
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `stopListening stops both controllers to avoid orphaned sessions`() = runTest(dispatcher) {
+        every { voiceInputPreferences.selectedEngine } returns MutableStateFlow(VoiceInputEngine.Vosk)
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+        )
+
+        controller.stopListening()
+
+        verify(exactly = 1) { voskOfflineVoiceInputController.stopListening() }
+        verify(exactly = 1) { nativeAndroidVoiceInputController.stopListening() }
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -381,8 +381,8 @@ has safe defaults, including current-location behavior and optional forecast fie
 | Pattern | Action | OS API |
 |---------|--------|--------|
 | "turn on/off torch/flashlight" | Torch toggle | `CameraManager.setTorchMode()` |
-| "set a timer for X minutes" | Timer | `AlarmClock.ACTION_SET_TIMER` + `EXTRA_SKIP_UI` |
-| "set an alarm for X:XX" | Alarm | `AlarmClock.ACTION_SET_ALARM` |
+| "set a timer for X minutes" | Timer | App-owned clock scheduler + notification pipeline |
+| "set an alarm for X:XX" | Alarm | App-owned clock scheduler + notification pipeline |
 | "turn on/off do not disturb/dnd" | DND | `NotificationManager.setInterruptionFilter()` |
 | "turn on/off bluetooth" | Bluetooth | `BluetoothAdapter.enable()/disable()` |
 | "turn on/off wifi" | Wi-Fi | `WifiManager.setWifiEnabled()` |
@@ -471,8 +471,8 @@ fallback exists for edge cases where the model emits raw JSON outside the SDK pa
 | `send_email` | Email composer | `ACTION_SEND` + `message/rfc822` | ✅ |
 | `send_sms` | SMS composer | `ACTION_SENDTO` + `smsto:` | ✅ |
 | `make_call` | Dialer / call handoff | `ACTION_DIAL` | ✅ |
-| `set_alarm` | Set alarm | `AlarmClock.ACTION_SET_ALARM` | ✅ |
-| `set_timer` | Countdown timer | `AlarmClock.ACTION_SET_TIMER` | ✅ |
+| `set_alarm` | Set alarm | `ClockRepository.scheduleAlarm()` | ✅ |
+| `set_timer` | Countdown timer | `ClockRepository.scheduleTimer()` | ✅ |
 | `create_calendar_event` | Add calendar event | `ACTION_INSERT` + `CONTENT_URI` | ✅ |
 | `toggle_dnd_on/off` | Do Not Disturb | `NotificationManager.setInterruptionFilter()` | ✅ |
 | `toggle_wifi` / `toggle_bluetooth` | Connectivity toggles | Settings / adapter bridge | ✅ |
@@ -484,21 +484,9 @@ fallback exists for edge cases where the model emits raw JSON outside the SDK pa
 | `get_date_diff` | Deterministic date arithmetic | `LocalDate` calculation | ✅ |
 | `add_to_list` / `bulk_add_to_list` / `create_list` / `get_list_items` / `remove_from_list` | Room-backed list management | `NativeIntentHandler` + Room DAOs | ✅ |
 
-> **Package visibility (Android 11+):** `ACTION_SET_ALARM` and `ACTION_SET_TIMER` are declared
-> in a `<queries>` block in `AndroidManifest.xml` so `PackageManager.resolveActivity()` returns
-> non-null (#262). Without this, the guard always triggers "No clock app found" regardless of
-> whether a clock app is installed.
-
-> **Alarm hallucination guard:** The per-turn `[Tool Use]` section includes an explicit
-> "Alarm rule" forcing `run_intent` for alarm requests (#263), matching the pattern used for
-> `save_memory`. The model's Siri/Google training bias would otherwise cause it to verbally
-> confirm alarms without ever calling the tool.
-
-> **`set_alarm` tomorrow limitation:** `ACTION_SET_ALARM` has no date parameter — only hour and
-> minute. When the model passes `day: "tomorrow"`, `NativeIntentHandler` prefixes the alarm
-> label with "TOMORROW:" and returns a ⚠ warning in the success message. A full date-specific
-> alarm (#327) requires `AlarmManager.setExact()` + BroadcastReceiver + BOOT_COMPLETED receiver
-> and is tracked as a separate feature.
+> **Alarm/timer ownership:** Core alarm and timer behavior now stays inside the app-owned
+> clock backend. If exact alarms are unavailable, the action fails truthfully instead of
+> bouncing the user into a system clock app that Jandal cannot track.
 
 > **`resolveDate` / `resolveTime` natural language parsing:** `NativeIntentHandler` normalises
 > free-text date/time before passing to `SimpleDateFormat`. `resolveDate` handles formats like

--- a/docs/research/clock-system-spec.md
+++ b/docs/research/clock-system-spec.md
@@ -45,12 +45,12 @@ Current implementation anchors:
 
 ### 2.2 Why the current behavior is insufficient
 
-The current repo still uses a hybrid model:
+The current repo has completed the core alarm/timer ownership cutover, but alert-path gaps remain:
 
-- alarms still fall back to `AlarmClock.ACTION_SET_ALARM`
-- alarm cancellation still uses `AlarmClock.ACTION_DISMISS_ALARM`
-- scheduling/cancellation logic is duplicated in multiple call sites
-- `AlarmBroadcastReceiver` posts a notification but does not own a long-lived ringing session
+- alarm and timer creation/cancellation now stay inside the app-owned clock backend
+- `AlarmBroadcastReceiver` still posts a notification but does not own a long-lived ringing session
+- active timer countdown notifications are still missing
+- full-screen alarm/timer parity still needs a dedicated alert service
 
 This explains the current user-visible problem for the internal alert path:
 
@@ -664,13 +664,12 @@ This must be productized before OEM `AlarmClock.*` fallback removal for core ala
 
 ### 12.1 Required cleanup
 
-When the new clock domain is ready, delete hybrid behavior as part of the cutover wave:
+When the new alert domain is ready, delete the remaining lightweight fallback behavior as part of the next wave:
 
-- `AlarmClock.ACTION_SET_ALARM` for core alarm creation
-- `AlarmClock.ACTION_DISMISS_ALARM` for core alarm cancellation
-- duplicated raw scheduling code in view models and native handlers
-
-UI waves should build on the fully internal backend rather than extending the hybrid model.
+- notification-only trigger handling in `AlarmBroadcastReceiver`
+- duplicated alert UX responsibilities that should move into a dedicated alert service
+- any remaining gaps between alarms and timers for ringing/full-screen/countdown UX
+UI waves should build on the fully internal backend rather than extending the current lightweight trigger path.
 
 ### 12.2 Migration note
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -136,6 +136,7 @@ class ActionsViewModel @Inject constructor(
     private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
+    private val inFlightQueries = mutableSetOf<String>()
     private var spokenResponsesEnabled = true
 
     init {
@@ -322,6 +323,7 @@ class ActionsViewModel @Inject constructor(
             Log.w(TAG, "ActionsViewModel: executeAction called while slot-fill pending — ignoring \"$normalizedQuery\"")
             return
         }
+        if (!registerInFlightQuery("executeAction", normalizedQuery)) return
         _error.value = null
 
         viewModelScope.launch {
@@ -390,6 +392,7 @@ class ActionsViewModel @Inject constructor(
             } finally {
                 _voiceCaptureState.value = VoiceCaptureState.Idle
                 _uiState.value = UiState.Idle
+                inFlightQueries.remove(normalizedQuery)
             }
         }
     }
@@ -618,6 +621,14 @@ class ActionsViewModel @Inject constructor(
         return intentName == "make_call" &&
             result is SkillResult.Failure &&
             result.error == PHONE_PERMISSION_REQUIRED_ERROR
+    }
+
+    private fun registerInFlightQuery(source: String, query: String): Boolean {
+        if (!inFlightQueries.add(query)) {
+            Log.w(TAG, "ActionsViewModel: $source ignored duplicate in-flight query — \"$query\"")
+            return false
+        }
+        return true
     }
 
     private fun startVoiceCapture(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -136,7 +136,6 @@ class ActionsViewModel @Inject constructor(
     private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
-    private val inFlightQueries = mutableSetOf<String>()
     private var spokenResponsesEnabled = true
 
     init {
@@ -323,7 +322,6 @@ class ActionsViewModel @Inject constructor(
             Log.w(TAG, "ActionsViewModel: executeAction called while slot-fill pending — ignoring \"$normalizedQuery\"")
             return
         }
-        if (!registerInFlightQuery("executeAction", normalizedQuery)) return
         _error.value = null
 
         viewModelScope.launch {
@@ -392,7 +390,6 @@ class ActionsViewModel @Inject constructor(
             } finally {
                 _voiceCaptureState.value = VoiceCaptureState.Idle
                 _uiState.value = UiState.Idle
-                inFlightQueries.remove(normalizedQuery)
             }
         }
     }
@@ -623,13 +620,6 @@ class ActionsViewModel @Inject constructor(
             result.error == PHONE_PERMISSION_REQUIRED_ERROR
     }
 
-    private fun registerInFlightQuery(source: String, query: String): Boolean {
-        if (!inFlightQueries.add(query)) {
-            Log.w(TAG, "ActionsViewModel: $source ignored duplicate in-flight query — \"$query\"")
-            return false
-        }
-        return true
-    }
 
     private fun startVoiceCapture(
         mode: VoiceCaptureMode,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -29,6 +29,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -893,6 +894,40 @@ class ActionsViewModelVoiceTest {
         verify { quickIntentRouter.route("set an alarm for 17:30") }
         verify { quickIntentRouter.route("set an alarm for 19:30") }
         verify { quickIntentRouter.route("set an alarm for 2:30 called dentist") }
+    }
+
+    @Test
+    fun `duplicate voice transcripts do not execute the same action twice`() = runTest(dispatcher) {
+        val directSkill = mockk<Skill>()
+        every { quickIntentRouter.route(any()) } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "set_alarm",
+                    params = mapOf("time" to "11:00 a.m."),
+                ),
+            )
+        every { skillRegistry.get("set_alarm") } returns directSkill
+        every { directSkill.name } returns "set_alarm"
+        every { directSkill.description } returns "Set alarm"
+        every { directSkill.schema } returns SkillSchema()
+        coEvery { directSkill.execute(any()) } coAnswers {
+            delay(100)
+            SkillResult.Success("Alarm set for 11:00am")
+        }
+
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Set an alarm for 11:00 a.m."))
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Set an alarm for 11:00 a.m."))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { directSkill.execute(any()) }
+        coVerify(exactly = 1) {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "set_alarm" &&
+                        it.resultText == "Alarm set for 11:00am"
+                },
+            )
+        }
     }
 
     @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -29,7 +29,6 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -894,40 +893,6 @@ class ActionsViewModelVoiceTest {
         verify { quickIntentRouter.route("set an alarm for 17:30") }
         verify { quickIntentRouter.route("set an alarm for 19:30") }
         verify { quickIntentRouter.route("set an alarm for 2:30 called dentist") }
-    }
-
-    @Test
-    fun `duplicate voice transcripts do not execute the same action twice`() = runTest(dispatcher) {
-        val directSkill = mockk<Skill>()
-        every { quickIntentRouter.route(any()) } returns
-            QuickIntentRouter.RouteResult.RegexMatch(
-                QuickIntentRouter.MatchedIntent(
-                    intentName = "set_alarm",
-                    params = mapOf("time" to "11:00 a.m."),
-                ),
-            )
-        every { skillRegistry.get("set_alarm") } returns directSkill
-        every { directSkill.name } returns "set_alarm"
-        every { directSkill.description } returns "Set alarm"
-        every { directSkill.schema } returns SkillSchema()
-        coEvery { directSkill.execute(any()) } coAnswers {
-            delay(100)
-            SkillResult.Success("Alarm set for 11:00am")
-        }
-
-        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Set an alarm for 11:00 a.m."))
-        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Set an alarm for 11:00 a.m."))
-        advanceUntilIdle()
-
-        coVerify(exactly = 1) { directSkill.execute(any()) }
-        coVerify(exactly = 1) {
-            quickActionDao.insert(
-                match {
-                    it.skillName == "set_alarm" &&
-                        it.resultText == "Alarm set for 11:00am"
-                },
-            )
-        }
     }
 
     @Test

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -27,6 +27,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    testOptions {
+        unitTests.all { it.useJUnitPlatform() }
+    }
 }
 
 dependencies {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -1,0 +1,7 @@
+package com.kernel.ai.feature.settings
+
+enum class AlarmSaveResult {
+    STORED,
+    CLOCK_APP_FALLBACK,
+    FAILED,
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -2,6 +2,5 @@ package com.kernel.ai.feature.settings
 
 enum class AlarmSaveResult {
     STORED,
-    CLOCK_APP_FALLBACK,
     FAILED,
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.clock.ClockAlarm
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -66,11 +66,12 @@ fun ScheduledAlarmsScreen(
     viewModel: ScheduledAlarmsViewModel = hiltViewModel(),
 ) {
     val alarms by viewModel.alarms.collectAsStateWithLifecycle()
-    var pendingCancel by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var pendingCancel by remember { mutableStateOf<ClockAlarm?>(null) }
     var pendingCancelIds by remember { mutableStateOf<Set<String>?>(null) }
-    var editingAlarm by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var editingAlarm by remember { mutableStateOf<ClockAlarm?>(null) }
     var showCreateDialog by remember { mutableStateOf(false) }
     var selectedIds by remember { mutableStateOf(emptySet<String>()) }
+    var schedulingError by remember { mutableStateOf<String?>(null) }
     val inSelectionMode = selectedIds.isNotEmpty()
 
     Scaffold(
@@ -157,7 +158,13 @@ fun ScheduledAlarmsScreen(
                             selectedIds = selectedIds + alarm.id
                         },
                         onCancel = { pendingCancel = alarm },
-                        onToggle = { viewModel.toggleEnabled(alarm) },
+                        onToggle = {
+                            viewModel.toggleEnabled(alarm) { success ->
+                                if (!success) {
+                                    schedulingError = "Exact alarms are unavailable right now."
+                                }
+                            }
+                        },
                     )
                     HorizontalDivider()
                 }
@@ -169,8 +176,21 @@ fun ScheduledAlarmsScreen(
         AlarmCreateEditDialog(
             existingAlarm = null,
             onConfirm = { triggerAtMillis, label ->
-                viewModel.scheduleAlarm(triggerAtMillis, label)
-                showCreateDialog = false
+                viewModel.scheduleAlarm(triggerAtMillis, label) { result ->
+                    when (result) {
+                        AlarmSaveResult.STORED -> {
+                            schedulingError = null
+                            showCreateDialog = false
+                        }
+                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
+                            showCreateDialog = false
+                            schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
+                        }
+                        AlarmSaveResult.FAILED -> {
+                            schedulingError = "Exact alarms are unavailable right now."
+                        }
+                    }
+                }
             },
             onDismiss = { showCreateDialog = false },
         )
@@ -180,8 +200,21 @@ fun ScheduledAlarmsScreen(
         AlarmCreateEditDialog(
             existingAlarm = alarm,
             onConfirm = { triggerAtMillis, label ->
-                viewModel.editAlarm(alarm, triggerAtMillis, label)
-                editingAlarm = null
+                viewModel.editAlarm(alarm, triggerAtMillis, label) { result ->
+                    when (result) {
+                        AlarmSaveResult.STORED -> {
+                            schedulingError = null
+                            editingAlarm = null
+                        }
+                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
+                            editingAlarm = null
+                            schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
+                        }
+                        AlarmSaveResult.FAILED -> {
+                            schedulingError = "Exact alarms are unavailable right now."
+                        }
+                    }
+                }
             },
             onDismiss = { editingAlarm = null },
         )
@@ -230,12 +263,23 @@ fun ScheduledAlarmsScreen(
             },
         )
     }
+    schedulingError?.let { message ->
+        AlertDialog(
+            onDismissRequest = { schedulingError = null },
+            icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+            title = { Text("Couldn't save alarm") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { schedulingError = null }) { Text("OK") }
+            },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AlarmCreateEditDialog(
-    existingAlarm: ScheduledAlarmEntity?,
+    existingAlarm: ClockAlarm?,
     onConfirm: (triggerAtMillis: Long, label: String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -353,7 +397,7 @@ private fun AlarmCreateEditDialog(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlarmRow(
-    alarm: ScheduledAlarmEntity,
+    alarm: ClockAlarm,
     inSelectionMode: Boolean,
     isSelected: Boolean,
     onTap: () -> Unit,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -161,7 +161,7 @@ fun ScheduledAlarmsScreen(
                         onToggle = {
                             viewModel.toggleEnabled(alarm) { success ->
                                 if (!success) {
-                                    schedulingError = "Exact alarms are unavailable right now."
+                                    schedulingError = "Couldn't update the alarm."
                                 }
                             }
                         },
@@ -187,7 +187,7 @@ fun ScheduledAlarmsScreen(
                             schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
                         }
                         AlarmSaveResult.FAILED -> {
-                            schedulingError = "Exact alarms are unavailable right now."
+                            schedulingError = "Couldn't save the alarm."
                         }
                     }
                 }
@@ -211,7 +211,7 @@ fun ScheduledAlarmsScreen(
                             schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
                         }
                         AlarmSaveResult.FAILED -> {
-                            schedulingError = "Exact alarms are unavailable right now."
+                            schedulingError = "Couldn't save the alarm."
                         }
                     }
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -182,10 +182,6 @@ fun ScheduledAlarmsScreen(
                             schedulingError = null
                             showCreateDialog = false
                         }
-                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
-                            showCreateDialog = false
-                            schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
-                        }
                         AlarmSaveResult.FAILED -> {
                             schedulingError = "Couldn't save the alarm."
                         }
@@ -205,10 +201,6 @@ fun ScheduledAlarmsScreen(
                         AlarmSaveResult.STORED -> {
                             schedulingError = null
                             editingAlarm = null
-                        }
-                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
-                            editingAlarm = null
-                            schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
                         }
                         AlarmSaveResult.FAILED -> {
                             schedulingError = "Couldn't save the alarm."

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -1,117 +1,99 @@
 package com.kernel.ai.feature.settings
 
-import android.app.AlarmManager
-import android.app.PendingIntent
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.provider.AlarmClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
-import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import java.util.UUID
-import javax.inject.Inject
 
 @HiltViewModel
 class ScheduledAlarmsViewModel @Inject constructor(
-    private val dao: ScheduledAlarmDao,
+    private val clockRepository: ClockRepository,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
-    // Filter by current time on every emission so past-due alarms disappear immediately
-    val alarms: StateFlow<List<ScheduledAlarmEntity>> =
-        dao.observeAllUnfired()
-            .map { list -> list.filter { it.triggerAtMillis > System.currentTimeMillis() } }
+    val alarms: StateFlow<List<ClockAlarm>> =
+        clockRepository.observeUpcomingAlarms()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    fun scheduleAlarm(triggerAtMillis: Long, label: String?) {
-        viewModelScope.launch {
-            val alarmId = UUID.randomUUID().toString()
-            val entity = ScheduledAlarmEntity(
-                id = alarmId,
-                triggerAtMillis = triggerAtMillis,
-                label = label?.takeIf { it.isNotBlank() },
-                createdAt = System.currentTimeMillis(),
-                enabled = true,
-            )
-            dao.insert(entity)
-            scheduleAlarmBroadcast(entity)
-        }
-    }
+    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): Boolean =
+        clockRepository.scheduleAlarm(triggerAtMillis, label) != null
 
-    fun editAlarm(alarm: ScheduledAlarmEntity, newTriggerAtMillis: Long, newLabel: String?) {
+    fun scheduleAlarm(triggerAtMillis: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            cancelAlarmBroadcast(alarm)
-            val updated = alarm.copy(
-                triggerAtMillis = newTriggerAtMillis,
-                label = newLabel?.takeIf { it.isNotBlank() },
-            )
-            dao.insert(updated)
-            if (updated.enabled) scheduleAlarmBroadcast(updated)
-        }
-    }
-
-    fun toggleEnabled(alarm: ScheduledAlarmEntity) {
-        viewModelScope.launch {
-            val newEnabled = !alarm.enabled
-            dao.setEnabled(alarm.id, newEnabled)
-            if (newEnabled) {
-                scheduleAlarmBroadcast(alarm.copy(enabled = true))
-            } else {
-                cancelAlarmBroadcast(alarm)
+            val result = when {
+                tryScheduleAlarm(triggerAtMillis, label) -> AlarmSaveResult.STORED
+                !clockRepository.getPlatformState().canScheduleExactAlarms &&
+                    openClockAppAlarm(triggerAtMillis, label) -> AlarmSaveResult.CLOCK_APP_FALLBACK
+                else -> AlarmSaveResult.FAILED
             }
+            onResult(result)
         }
     }
 
-    fun cancelAlarm(alarm: ScheduledAlarmEntity) {
+    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): Boolean =
+        clockRepository.editAlarm(alarm.id, newTriggerAtMillis, newLabel) != null
+
+    fun editAlarm(
+        alarm: ClockAlarm,
+        newTriggerAtMillis: Long,
+        newLabel: String?,
+        onResult: (AlarmSaveResult) -> Unit = {},
+    ) {
         viewModelScope.launch {
-            cancelAlarmBroadcast(alarm)
-            dao.delete(alarm.id)
+            val result = when {
+                tryEditAlarm(alarm, newTriggerAtMillis, newLabel) -> AlarmSaveResult.STORED
+                !clockRepository.getPlatformState().canScheduleExactAlarms &&
+                    openClockAppAlarm(newTriggerAtMillis, newLabel) -> AlarmSaveResult.CLOCK_APP_FALLBACK
+                else -> AlarmSaveResult.FAILED
+            }
+            onResult(result)
         }
     }
 
-    private fun scheduleAlarmBroadcast(alarm: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-            )
-            putExtra("alarm_label", alarm.label ?: "Alarm")
-            putExtra("alarm_id", alarm.id)
+    suspend fun tryToggleEnabled(alarm: ClockAlarm): Boolean =
+        clockRepository.setAlarmEnabled(alarm.id, !alarm.enabled)
+
+    fun toggleEnabled(alarm: ClockAlarm, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(tryToggleEnabled(alarm))
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            alarm.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, alarm.triggerAtMillis, pendingIntent)
     }
 
-    private fun cancelAlarmBroadcast(alarm: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-            )
-            putExtra("alarm_label", alarm.label ?: "Alarm")
-            putExtra("alarm_id", alarm.id)
+    fun cancelAlarm(alarm: ClockAlarm) {
+        viewModelScope.launch {
+            clockRepository.cancelAlarm(alarm.id)
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            alarm.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
-        )
-        pendingIntent?.let { alarmManager.cancel(it) }
+    }
+
+    private fun openClockAppAlarm(triggerAtMillis: Long, label: String?): Boolean {
+        val scheduledTime = Instant.ofEpochMilli(triggerAtMillis).atZone(ZoneId.systemDefault())
+        val datePrefix = scheduledTime.toLocalDate().format(DateTimeFormatter.ofPattern("EEE d MMM"))
+        val message = label?.let { "$datePrefix: $it" } ?: datePrefix
+        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
+            putExtra(AlarmClock.EXTRA_HOUR, scheduledTime.hour)
+            putExtra(AlarmClock.EXTRA_MINUTES, scheduledTime.minute)
+            putExtra(AlarmClock.EXTRA_MESSAGE, message)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
+        }
     }
 }
-

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -1,18 +1,10 @@
 package com.kernel.ai.feature.settings
 
-import android.content.ActivityNotFoundException
-import android.content.Context
-import android.content.Intent
-import android.provider.AlarmClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +14,6 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class ScheduledAlarmsViewModel @Inject constructor(
     private val clockRepository: ClockRepository,
-    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     val alarms: StateFlow<List<ClockAlarm>> =
@@ -34,11 +25,10 @@ class ScheduledAlarmsViewModel @Inject constructor(
 
     fun scheduleAlarm(triggerAtMillis: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            val result = when {
-                tryScheduleAlarm(triggerAtMillis, label) -> AlarmSaveResult.STORED
-                !clockRepository.getPlatformState().canScheduleExactAlarms &&
-                    openClockAppAlarm(triggerAtMillis, label) -> AlarmSaveResult.CLOCK_APP_FALLBACK
-                else -> AlarmSaveResult.FAILED
+            val result = if (tryScheduleAlarm(triggerAtMillis, label)) {
+                AlarmSaveResult.STORED
+            } else {
+                AlarmSaveResult.FAILED
             }
             onResult(result)
         }
@@ -54,11 +44,10 @@ class ScheduledAlarmsViewModel @Inject constructor(
         onResult: (AlarmSaveResult) -> Unit = {},
     ) {
         viewModelScope.launch {
-            val result = when {
-                tryEditAlarm(alarm, newTriggerAtMillis, newLabel) -> AlarmSaveResult.STORED
-                !clockRepository.getPlatformState().canScheduleExactAlarms &&
-                    openClockAppAlarm(newTriggerAtMillis, newLabel) -> AlarmSaveResult.CLOCK_APP_FALLBACK
-                else -> AlarmSaveResult.FAILED
+            val result = if (tryEditAlarm(alarm, newTriggerAtMillis, newLabel)) {
+                AlarmSaveResult.STORED
+            } else {
+                AlarmSaveResult.FAILED
             }
             onResult(result)
         }
@@ -76,24 +65,6 @@ class ScheduledAlarmsViewModel @Inject constructor(
     fun cancelAlarm(alarm: ClockAlarm) {
         viewModelScope.launch {
             clockRepository.cancelAlarm(alarm.id)
-        }
-    }
-
-    private fun openClockAppAlarm(triggerAtMillis: Long, label: String?): Boolean {
-        val scheduledTime = Instant.ofEpochMilli(triggerAtMillis).atZone(ZoneId.systemDefault())
-        val datePrefix = scheduledTime.toLocalDate().format(DateTimeFormatter.ofPattern("EEE d MMM"))
-        val message = label?.let { "$datePrefix: $it" } ?: datePrefix
-        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
-            putExtra(AlarmClock.EXTRA_HOUR, scheduledTime.hour)
-            putExtra(AlarmClock.EXTRA_MINUTES, scheduledTime.minute)
-            putExtra(AlarmClock.EXTRA_MESSAGE, message)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        return try {
-            context.startActivity(intent)
-            true
-        } catch (_: ActivityNotFoundException) {
-            false
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -67,13 +67,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockTimer
 import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -87,12 +89,13 @@ fun SidePanelScreen(
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedIds by viewModel.selectedIds.collectAsStateWithLifecycle()
     val showBulkDeleteConfirmation by viewModel.showBulkDeleteConfirmation.collectAsStateWithLifecycle()
-    var pendingDismiss by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
-    var pendingCancel by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
-    var editingAlarm by remember { mutableStateOf<ScheduledAlarmEntity?>(null) }
+    var pendingDismiss by remember { mutableStateOf<ClockAlarm?>(null) }
+    var pendingCancel by remember { mutableStateOf<ClockTimer?>(null) }
+    var editingAlarm by remember { mutableStateOf<ClockAlarm?>(null) }
     var showCreateAlarmDialog by remember { mutableStateOf(false) }
     var showCreateTimerDialog by remember { mutableStateOf(false) }
     var fabExpanded by remember { mutableStateOf(false) }
+    var schedulingError by remember { mutableStateOf<String?>(null) }
 
     // Tick every second so countdown labels stay live
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
@@ -109,7 +112,7 @@ fun SidePanelScreen(
 
     val visibleTimers = if (filterType != AlarmTimerFilter.ALARMS) timers else emptyList()
     val visibleAlarms = if (filterType != AlarmTimerFilter.TIMERS) alarms else emptyList()
-    val allVisibleIds = (visibleTimers + visibleAlarms).map { it.id }
+    val allVisibleIds = visibleTimers.map { it.id } + visibleAlarms.map { it.id }
 
     Scaffold(
         topBar = {
@@ -298,7 +301,13 @@ fun SidePanelScreen(
                                     if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
                                 },
                                 onDismiss = { pendingDismiss = alarm },
-                                onToggle = { viewModel.toggleEnabled(alarm) },
+                                onToggle = {
+                                    viewModel.toggleEnabled(alarm) { success ->
+                                        if (!success) {
+                                            schedulingError = "Exact alarms are unavailable right now."
+                                        }
+                                    }
+                                },
                             )
                             HorizontalDivider()
                         }
@@ -371,8 +380,21 @@ fun SidePanelScreen(
         AlarmCreateEditDialog(
             existingAlarm = null,
             onConfirm = { triggerAtMillis, label ->
-                viewModel.scheduleAlarm(triggerAtMillis, label)
-                showCreateAlarmDialog = false
+                viewModel.scheduleAlarm(triggerAtMillis, label) { result ->
+                    when (result) {
+                        AlarmSaveResult.STORED -> {
+                            schedulingError = null
+                            showCreateAlarmDialog = false
+                        }
+                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
+                            showCreateAlarmDialog = false
+                            schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
+                        }
+                        AlarmSaveResult.FAILED -> {
+                            schedulingError = "Exact alarms are unavailable right now."
+                        }
+                    }
+                }
             },
             onDismiss = { showCreateAlarmDialog = false },
         )
@@ -382,8 +404,21 @@ fun SidePanelScreen(
         AlarmCreateEditDialog(
             existingAlarm = alarm,
             onConfirm = { triggerAtMillis, label ->
-                viewModel.editAlarm(alarm, triggerAtMillis, label)
-                editingAlarm = null
+                viewModel.editAlarm(alarm, triggerAtMillis, label) { result ->
+                    when (result) {
+                        AlarmSaveResult.STORED -> {
+                            schedulingError = null
+                            editingAlarm = null
+                        }
+                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
+                            editingAlarm = null
+                            schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
+                        }
+                        AlarmSaveResult.FAILED -> {
+                            schedulingError = "Exact alarms are unavailable right now."
+                        }
+                    }
+                }
             },
             onDismiss = { editingAlarm = null },
         )
@@ -392,10 +427,28 @@ fun SidePanelScreen(
     if (showCreateTimerDialog) {
         TimerCreateDialog(
             onConfirm = { durationMs, label ->
-                viewModel.scheduleTimer(durationMs, label)
-                showCreateTimerDialog = false
+                viewModel.scheduleTimer(durationMs, label) { success ->
+                    if (success) {
+                        schedulingError = null
+                        showCreateTimerDialog = false
+                    } else {
+                        schedulingError = "Exact alarms are unavailable right now."
+                    }
+                }
             },
             onDismiss = { showCreateTimerDialog = false },
+        )
+    }
+
+    schedulingError?.let { message ->
+        AlertDialog(
+            onDismissRequest = { schedulingError = null },
+            icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+            title = { Text("Couldn't save timer or alarm") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { schedulingError = null }) { Text("OK") }
+            },
         )
     }
 }
@@ -413,7 +466,7 @@ private fun SectionHeader(title: String) {
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TimerRow(
-    timer: ScheduledAlarmEntity,
+    timer: ClockTimer,
     nowMs: Long,
     inSelectionMode: Boolean,
     isSelected: Boolean,
@@ -421,13 +474,9 @@ private fun TimerRow(
     onLongPress: () -> Unit,
     onCancel: () -> Unit,
 ) {
-    val startedAtMs = timer.startedAtMs
+    val startedAtMs = timer.startedAtMillis
     val durationMs = timer.durationMs
-    val remainingMs = if (startedAtMs != null && durationMs != null) {
-        startedAtMs + durationMs - nowMs
-    } else {
-        -1L
-    }
+    val remainingMs = startedAtMs + durationMs - nowMs
     val countdownText = if (remainingMs <= 0) {
         "Time's up!"
     } else {
@@ -477,7 +526,7 @@ private fun TimerRow(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlarmPanelRow(
-    alarm: ScheduledAlarmEntity,
+    alarm: ClockAlarm,
     inSelectionMode: Boolean,
     isSelected: Boolean,
     onTap: () -> Unit,
@@ -531,7 +580,7 @@ private fun AlarmPanelRow(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AlarmCreateEditDialog(
-    existingAlarm: ScheduledAlarmEntity?,
+    existingAlarm: ClockAlarm?,
     onConfirm: (triggerAtMillis: Long, label: String?) -> Unit,
     onDismiss: () -> Unit,
 ) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -304,7 +304,7 @@ fun SidePanelScreen(
                                 onToggle = {
                                     viewModel.toggleEnabled(alarm) { success ->
                                         if (!success) {
-                                            schedulingError = "Exact alarms are unavailable right now."
+                                            schedulingError = "Couldn't update the alarm."
                                         }
                                     }
                                 },
@@ -391,7 +391,7 @@ fun SidePanelScreen(
                             schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
                         }
                         AlarmSaveResult.FAILED -> {
-                            schedulingError = "Exact alarms are unavailable right now."
+                            schedulingError = "Couldn't save the alarm."
                         }
                     }
                 }
@@ -415,7 +415,7 @@ fun SidePanelScreen(
                             schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
                         }
                         AlarmSaveResult.FAILED -> {
-                            schedulingError = "Exact alarms are unavailable right now."
+                            schedulingError = "Couldn't save the alarm."
                         }
                     }
                 }
@@ -432,7 +432,7 @@ fun SidePanelScreen(
                         schedulingError = null
                         showCreateTimerDialog = false
                     } else {
-                        schedulingError = "Exact alarms are unavailable right now."
+                        schedulingError = "Couldn't schedule the timer."
                     }
                 }
             },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -386,10 +386,6 @@ fun SidePanelScreen(
                             schedulingError = null
                             showCreateAlarmDialog = false
                         }
-                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
-                            showCreateAlarmDialog = false
-                            schedulingError = "Clock app opened. Because exact alarms are unavailable, this alarm will be managed by your system clock and won't appear in Jandal's managed list."
-                        }
                         AlarmSaveResult.FAILED -> {
                             schedulingError = "Couldn't save the alarm."
                         }
@@ -409,10 +405,6 @@ fun SidePanelScreen(
                         AlarmSaveResult.STORED -> {
                             schedulingError = null
                             editingAlarm = null
-                        }
-                        AlarmSaveResult.CLOCK_APP_FALLBACK -> {
-                            editingAlarm = null
-                            schedulingError = "Clock app opened. The existing Jandal alarm was left unchanged; delete or disable it manually if you no longer want it."
                         }
                         AlarmSaveResult.FAILED -> {
                             schedulingError = "Couldn't save the alarm."

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -1,19 +1,11 @@
 package com.kernel.ai.feature.settings
 
-import android.content.ActivityNotFoundException
-import android.content.Context
-import android.content.Intent
-import android.provider.AlarmClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -28,7 +20,6 @@ enum class AlarmTimerFilter { ALL, ALARMS, TIMERS }
 @HiltViewModel
 class SidePanelViewModel @Inject constructor(
     private val clockRepository: ClockRepository,
-    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     val alarms: StateFlow<List<ClockAlarm>> =
@@ -126,11 +117,10 @@ class SidePanelViewModel @Inject constructor(
 
     fun scheduleAlarm(triggerAtMillis: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            val result = when {
-                tryScheduleAlarm(triggerAtMillis, label) -> AlarmSaveResult.STORED
-                !clockRepository.getPlatformState().canScheduleExactAlarms &&
-                    openClockAppAlarm(triggerAtMillis, label) -> AlarmSaveResult.CLOCK_APP_FALLBACK
-                else -> AlarmSaveResult.FAILED
+            val result = if (tryScheduleAlarm(triggerAtMillis, label)) {
+                AlarmSaveResult.STORED
+            } else {
+                AlarmSaveResult.FAILED
             }
             onResult(result)
         }
@@ -146,11 +136,10 @@ class SidePanelViewModel @Inject constructor(
         onResult: (AlarmSaveResult) -> Unit = {},
     ) {
         viewModelScope.launch {
-            val result = when {
-                tryEditAlarm(alarm, newTriggerAtMillis, newLabel) -> AlarmSaveResult.STORED
-                !clockRepository.getPlatformState().canScheduleExactAlarms &&
-                    openClockAppAlarm(newTriggerAtMillis, newLabel) -> AlarmSaveResult.CLOCK_APP_FALLBACK
-                else -> AlarmSaveResult.FAILED
+            val result = if (tryEditAlarm(alarm, newTriggerAtMillis, newLabel)) {
+                AlarmSaveResult.STORED
+            } else {
+                AlarmSaveResult.FAILED
             }
             onResult(result)
         }
@@ -171,24 +160,6 @@ class SidePanelViewModel @Inject constructor(
     fun scheduleTimer(durationMs: Long, label: String?, onResult: (Boolean) -> Unit = {}) {
         viewModelScope.launch {
             onResult(tryScheduleTimer(durationMs, label))
-        }
-    }
-
-    private fun openClockAppAlarm(triggerAtMillis: Long, label: String?): Boolean {
-        val scheduledTime = Instant.ofEpochMilli(triggerAtMillis).atZone(ZoneId.systemDefault())
-        val datePrefix = scheduledTime.toLocalDate().format(DateTimeFormatter.ofPattern("EEE d MMM"))
-        val message = label?.let { "$datePrefix: $it" } ?: datePrefix
-        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
-            putExtra(AlarmClock.EXTRA_HOUR, scheduledTime.hour)
-            putExtra(AlarmClock.EXTRA_MINUTES, scheduledTime.minute)
-            putExtra(AlarmClock.EXTRA_MESSAGE, message)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        return try {
-            context.startActivity(intent)
-            true
-        } catch (_: ActivityNotFoundException) {
-            false
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -1,15 +1,20 @@
 package com.kernel.ai.feature.settings
 
-import android.app.AlarmManager
-import android.app.PendingIntent
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.provider.AlarmClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
-import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockTimer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -17,30 +22,21 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.UUID
-import javax.inject.Inject
-
-private const val ALARM_RECEIVER_CLASS = "com.kernel.ai.alarm.AlarmBroadcastReceiver"
-private const val EXTRA_ALARM_LABEL = "alarm_label"
-private const val EXTRA_ALARM_ID = "alarm_id"
-private const val EXTRA_ALARM_TITLE = "alarm_title"
 
 enum class AlarmTimerFilter { ALL, ALARMS, TIMERS }
 
 @HiltViewModel
 class SidePanelViewModel @Inject constructor(
-    private val dao: ScheduledAlarmDao,
+    private val clockRepository: ClockRepository,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
-    /** All unfired ALARM-type entries, ordered by trigger time. */
-    val alarms: StateFlow<List<ScheduledAlarmEntity>> =
-        dao.observeActiveAlarms()
+    val alarms: StateFlow<List<ClockAlarm>> =
+        clockRepository.observeManageableAlarms()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    /** All unfired TIMER-type entries, ordered by start time. */
-    val timers: StateFlow<List<ScheduledAlarmEntity>> =
-        dao.observeActiveTimers()
+    val timers: StateFlow<List<ClockTimer>> =
+        clockRepository.observeActiveTimers()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _filterType = MutableStateFlow(AlarmTimerFilter.ALL)
@@ -97,16 +93,14 @@ class SidePanelViewModel @Inject constructor(
         _showBulkDeleteConfirmation.value = false
     }
 
-    /** Delete all selected items, cancelling AlarmManager broadcasts for alarm/timer entries. */
     fun deleteSelected() {
         val ids = _selectedIds.value
-        val toDelete = (alarms.value + timers.value).filter { it.id in ids }
+        val alarmIds = alarms.value.filter { it.id in ids }.map { it.id }
+        val timerIds = timers.value.filter { it.id in ids }.map { it.id }
         viewModelScope.launch {
             try {
-                toDelete.forEach { item ->
-                    if (item.entryType == "ALARM") cancelAlarmBroadcast(item) else cancelTimerBroadcast(item)
-                    dao.delete(item.id)
-                }
+                clockRepository.cancelAlarms(alarmIds)
+                clockRepository.cancelTimers(timerIds)
             } finally {
                 _showBulkDeleteConfirmation.value = false
                 _isInSelectionMode.value = false
@@ -115,156 +109,86 @@ class SidePanelViewModel @Inject constructor(
         }
     }
 
-    /** Dismiss an alarm: cancel any pending AlarmManager broadcast and delete from DB. */
-    fun dismissAlarm(alarm: ScheduledAlarmEntity) {
+    fun dismissAlarm(alarm: ClockAlarm) {
         viewModelScope.launch {
-            cancelAlarmBroadcast(alarm)
-            dao.delete(alarm.id)
+            clockRepository.cancelAlarm(alarm.id)
         }
     }
 
-    /** Cancel a running timer: cancel its pending broadcast and delete from DB. */
-    fun cancelTimer(timer: ScheduledAlarmEntity) {
+    fun cancelTimer(timer: ClockTimer) {
         viewModelScope.launch {
-            cancelTimerBroadcast(timer)
-            dao.delete(timer.id)
+            clockRepository.cancelTimer(timer.id)
         }
     }
 
-    /** Schedule a new alarm and persist it. */
-    fun scheduleAlarm(triggerAtMillis: Long, label: String?) {
-        viewModelScope.launch {
-            val alarmId = UUID.randomUUID().toString()
-            val entity = ScheduledAlarmEntity(
-                id = alarmId,
-                triggerAtMillis = triggerAtMillis,
-                label = label?.takeIf { it.isNotBlank() },
-                createdAt = System.currentTimeMillis(),
-                enabled = true,
-            )
-            dao.insert(entity)
-            scheduleAlarmBroadcast(entity)
-        }
-    }
+    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): Boolean =
+        clockRepository.scheduleAlarm(triggerAtMillis, label) != null
 
-    /** Edit an existing alarm's time and label, rescheduling the broadcast. */
-    fun editAlarm(alarm: ScheduledAlarmEntity, newTriggerAtMillis: Long, newLabel: String?) {
+    fun scheduleAlarm(triggerAtMillis: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            cancelAlarmBroadcast(alarm)
-            val updated = alarm.copy(
-                triggerAtMillis = newTriggerAtMillis,
-                label = newLabel?.takeIf { it.isNotBlank() },
-            )
-            dao.insert(updated)
-            if (updated.enabled) scheduleAlarmBroadcast(updated)
-        }
-    }
-
-    /** Toggle an alarm enabled/disabled, cancelling or rescheduling its broadcast accordingly. */
-    fun toggleEnabled(alarm: ScheduledAlarmEntity) {
-        viewModelScope.launch {
-            val newEnabled = !alarm.enabled
-            dao.setEnabled(alarm.id, newEnabled)
-            if (newEnabled) {
-                scheduleAlarmBroadcast(alarm.copy(enabled = true))
-            } else {
-                cancelAlarmBroadcast(alarm)
+            val result = when {
+                tryScheduleAlarm(triggerAtMillis, label) -> AlarmSaveResult.STORED
+                !clockRepository.getPlatformState().canScheduleExactAlarms &&
+                    openClockAppAlarm(triggerAtMillis, label) -> AlarmSaveResult.CLOCK_APP_FALLBACK
+                else -> AlarmSaveResult.FAILED
             }
+            onResult(result)
         }
     }
 
-    /** Create a new built-in timer — persists to DB and schedules a local broadcast. */
-    fun scheduleTimer(durationMs: Long, label: String?) {
+    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): Boolean =
+        clockRepository.editAlarm(alarm.id, newTriggerAtMillis, newLabel) != null
+
+    fun editAlarm(
+        alarm: ClockAlarm,
+        newTriggerAtMillis: Long,
+        newLabel: String?,
+        onResult: (AlarmSaveResult) -> Unit = {},
+    ) {
         viewModelScope.launch {
-            val timerId = UUID.randomUUID().toString()
-            val now = System.currentTimeMillis()
-            val entity = ScheduledAlarmEntity(
-                id = timerId,
-                triggerAtMillis = now + durationMs,
-                label = label?.takeIf { it.isNotBlank() },
-                createdAt = now,
-                entryType = "TIMER",
-                durationMs = durationMs,
-                startedAtMs = now,
-            )
-            dao.insert(entity)
-            scheduleTimerBroadcast(entity)
+            val result = when {
+                tryEditAlarm(alarm, newTriggerAtMillis, newLabel) -> AlarmSaveResult.STORED
+                !clockRepository.getPlatformState().canScheduleExactAlarms &&
+                    openClockAppAlarm(newTriggerAtMillis, newLabel) -> AlarmSaveResult.CLOCK_APP_FALLBACK
+                else -> AlarmSaveResult.FAILED
+            }
+            onResult(result)
         }
     }
 
-    private fun scheduleAlarmBroadcast(alarm: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-            )
-            putExtra("alarm_label", alarm.label ?: "Alarm")
-            putExtra("alarm_id", alarm.id)
+    suspend fun tryToggleEnabled(alarm: ClockAlarm): Boolean =
+        clockRepository.setAlarmEnabled(alarm.id, !alarm.enabled)
+
+    fun toggleEnabled(alarm: ClockAlarm, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(tryToggleEnabled(alarm))
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            alarm.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, alarm.triggerAtMillis, pendingIntent)
     }
 
-    private fun cancelAlarmBroadcast(alarm: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                "com.kernel.ai.alarm.AlarmBroadcastReceiver",
-            )
+    suspend fun tryScheduleTimer(durationMs: Long, label: String?): Boolean =
+        clockRepository.scheduleTimer(durationMs, label) != null
+
+    fun scheduleTimer(durationMs: Long, label: String?, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(tryScheduleTimer(durationMs, label))
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            alarm.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
-        )
-        pendingIntent?.let { alarmManager.cancel(it) }
     }
 
-    private fun scheduleTimerBroadcast(timer: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                ALARM_RECEIVER_CLASS,
-            )
-            putExtra(EXTRA_ALARM_LABEL, timer.label ?: "Timer")
-            putExtra(EXTRA_ALARM_ID, timer.id)
-            putExtra(EXTRA_ALARM_TITLE, "Timer")
+    private fun openClockAppAlarm(triggerAtMillis: Long, label: String?): Boolean {
+        val scheduledTime = Instant.ofEpochMilli(triggerAtMillis).atZone(ZoneId.systemDefault())
+        val datePrefix = scheduledTime.toLocalDate().format(DateTimeFormatter.ofPattern("EEE d MMM"))
+        val message = label?.let { "$datePrefix: $it" } ?: datePrefix
+        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
+            putExtra(AlarmClock.EXTRA_HOUR, scheduledTime.hour)
+            putExtra(AlarmClock.EXTRA_MINUTES, scheduledTime.minute)
+            putExtra(AlarmClock.EXTRA_MESSAGE, message)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            timer.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timer.triggerAtMillis, pendingIntent)
-    }
-
-    private fun cancelTimerBroadcast(timer: ScheduledAlarmEntity) {
-        val alarmManager = context.getSystemService(AlarmManager::class.java)
-        val broadcastIntent = Intent().apply {
-            component = android.content.ComponentName(
-                context.packageName,
-                ALARM_RECEIVER_CLASS,
-            )
-            putExtra(EXTRA_ALARM_LABEL, timer.label ?: "Timer")
-            putExtra(EXTRA_ALARM_ID, timer.id)
-            putExtra(EXTRA_ALARM_TITLE, "Timer")
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            timer.id.hashCode(),
-            broadcastIntent,
-            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
-        )
-        pendingIntent?.let { alarmManager.cancel(it) }
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
@@ -2,27 +2,78 @@ package com.kernel.ai.feature.settings
 
 import android.content.Context
 import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockPlatformState
 import com.kernel.ai.core.memory.clock.ClockRepository
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ScheduledAlarmsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
     private val context = mockk<Context>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>()
 
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
-        io.mockk.every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
+        every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
         val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
 
         val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
 
         assertEquals(false, result)
+    }
+
+    @Test
+    fun `scheduleAlarm reports clock app fallback when exact alarms are unavailable`() = runTest {
+        every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
+        every { clockRepository.getPlatformState() } returns ClockPlatformState(
+            canScheduleExactAlarms = false,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+        coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
+        mockkConstructor(android.content.Intent::class)
+        every { anyConstructed<android.content.Intent>().setFlags(any()) } answers { self as android.content.Intent }
+        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<Int>()) } answers { self as android.content.Intent }
+        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<String>()) } answers { self as android.content.Intent }
+        try {
+            val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
+            var result: AlarmSaveResult? = null
+
+            viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
+            advanceUntilIdle()
+
+            assertEquals(AlarmSaveResult.CLOCK_APP_FALLBACK, result)
+            verify(exactly = 1) { context.startActivity(any()) }
+        } finally {
+            unmockkConstructor(android.content.Intent::class)
+        }
     }
 
     @Test
@@ -34,7 +85,7 @@ class ScheduledAlarmsViewModelTest {
             createdAtMillis = 100L,
             enabled = true,
         )
-        io.mockk.every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
+        every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
         coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns alarm
         val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
@@ -1,0 +1,45 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ScheduledAlarmsViewModelTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val clockRepository = mockk<ClockRepository>()
+
+    @Test
+    fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
+        io.mockk.every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
+        coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
+        val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
+
+        val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `editAlarm returns true when repository accepts update`() = runTest {
+        val alarm = ClockAlarm(
+            id = "alarm-1",
+            triggerAtMillis = 1_234L,
+            label = "Wake",
+            createdAtMillis = 100L,
+            enabled = true,
+        )
+        io.mockk.every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
+        coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns alarm
+        val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
+
+        val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
+
+        assertEquals(true, result)
+    }
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
@@ -1,15 +1,10 @@
 package com.kernel.ai.feature.settings
 
-import android.content.Context
 import com.kernel.ai.core.memory.clock.ClockAlarm
-import com.kernel.ai.core.memory.clock.ClockPlatformState
 import com.kernel.ai.core.memory.clock.ClockRepository
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.unmockkConstructor
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -25,7 +20,6 @@ import org.junit.jupiter.api.Test
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ScheduledAlarmsViewModelTest {
     private val dispatcher = StandardTestDispatcher()
-    private val context = mockk<Context>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>()
 
     @BeforeEach
@@ -42,7 +36,7 @@ class ScheduledAlarmsViewModelTest {
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
-        val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
+        val viewModel = ScheduledAlarmsViewModel(clockRepository)
 
         val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
 
@@ -50,30 +44,16 @@ class ScheduledAlarmsViewModelTest {
     }
 
     @Test
-    fun `scheduleAlarm reports clock app fallback when exact alarms are unavailable`() = runTest {
+    fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
-        every { clockRepository.getPlatformState() } returns ClockPlatformState(
-            canScheduleExactAlarms = false,
-            notificationsEnabled = true,
-            canUseFullScreenIntent = false,
-        )
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
-        mockkConstructor(android.content.Intent::class)
-        every { anyConstructed<android.content.Intent>().setFlags(any()) } answers { self as android.content.Intent }
-        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<Int>()) } answers { self as android.content.Intent }
-        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<String>()) } answers { self as android.content.Intent }
-        try {
-            val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
-            var result: AlarmSaveResult? = null
+        val viewModel = ScheduledAlarmsViewModel(clockRepository)
+        var result: AlarmSaveResult? = null
 
-            viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
-            advanceUntilIdle()
+        viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
+        advanceUntilIdle()
 
-            assertEquals(AlarmSaveResult.CLOCK_APP_FALLBACK, result)
-            verify(exactly = 1) { context.startActivity(any()) }
-        } finally {
-            unmockkConstructor(android.content.Intent::class)
-        }
+        assertEquals(AlarmSaveResult.FAILED, result)
     }
 
     @Test
@@ -87,7 +67,7 @@ class ScheduledAlarmsViewModelTest {
         )
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
         coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns alarm
-        val viewModel = ScheduledAlarmsViewModel(clockRepository, context)
+        val viewModel = ScheduledAlarmsViewModel(clockRepository)
 
         val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -1,0 +1,68 @@
+package com.kernel.ai.feature.settings
+
+import android.content.Context
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockTimer
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SidePanelViewModelTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val clockRepository = mockk<ClockRepository>()
+
+    @Test
+    fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
+        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
+        every { clockRepository.observeActiveTimers() } returns emptyFlow()
+        coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
+        val viewModel = SidePanelViewModel(clockRepository, context)
+
+        val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `scheduleTimer returns true when repository accepts timer`() = runTest {
+        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
+        every { clockRepository.observeActiveTimers() } returns emptyFlow()
+        coEvery { clockRepository.scheduleTimer(any(), any()) } returns ClockTimer(
+            id = "timer-1",
+            triggerAtMillis = 5_000L,
+            label = "Tea",
+            createdAtMillis = 1_000L,
+            durationMs = 60_000L,
+            startedAtMillis = 2_000L,
+        )
+        val viewModel = SidePanelViewModel(clockRepository, context)
+
+        val result = viewModel.tryScheduleTimer(60_000L, "Tea")
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `editAlarm returns false when repository rejects update`() = runTest {
+        val alarm = ClockAlarm(
+            id = "alarm-1",
+            triggerAtMillis = 1_234L,
+            label = "Wake",
+            createdAtMillis = 100L,
+            enabled = true,
+        )
+        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
+        every { clockRepository.observeActiveTimers() } returns emptyFlow()
+        coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns null
+        val viewModel = SidePanelViewModel(clockRepository, context)
+
+        val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
+
+        assertEquals(false, result)
+    }
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -2,19 +2,42 @@ package com.kernel.ai.feature.settings
 
 import android.content.Context
 import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockPlatformState
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class SidePanelViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
     private val context = mockk<Context>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
@@ -26,6 +49,34 @@ class SidePanelViewModelTest {
         val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
 
         assertEquals(false, result)
+    }
+
+    @Test
+    fun `scheduleAlarm reports clock app fallback when exact alarms are unavailable`() = runTest {
+        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
+        every { clockRepository.observeActiveTimers() } returns emptyFlow()
+        every { clockRepository.getPlatformState() } returns ClockPlatformState(
+            canScheduleExactAlarms = false,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+        coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
+        mockkConstructor(android.content.Intent::class)
+        every { anyConstructed<android.content.Intent>().setFlags(any()) } answers { self as android.content.Intent }
+        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<Int>()) } answers { self as android.content.Intent }
+        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<String>()) } answers { self as android.content.Intent }
+        try {
+            val viewModel = SidePanelViewModel(clockRepository, context)
+            var result: AlarmSaveResult? = null
+
+            viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
+            advanceUntilIdle()
+
+            assertEquals(AlarmSaveResult.CLOCK_APP_FALLBACK, result)
+            verify(exactly = 1) { context.startActivity(any()) }
+        } finally {
+            unmockkConstructor(android.content.Intent::class)
+        }
     }
 
     @Test

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -1,16 +1,11 @@
 package com.kernel.ai.feature.settings
 
-import android.content.Context
 import com.kernel.ai.core.memory.clock.ClockAlarm
-import com.kernel.ai.core.memory.clock.ClockPlatformState
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.unmockkConstructor
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,7 +21,6 @@ import org.junit.jupiter.api.Test
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class SidePanelViewModelTest {
     private val dispatcher = StandardTestDispatcher()
-    private val context = mockk<Context>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>()
 
     @BeforeEach
@@ -44,7 +38,7 @@ class SidePanelViewModelTest {
         every { clockRepository.observeManageableAlarms() } returns emptyFlow()
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
-        val viewModel = SidePanelViewModel(clockRepository, context)
+        val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
 
@@ -52,31 +46,17 @@ class SidePanelViewModelTest {
     }
 
     @Test
-    fun `scheduleAlarm reports clock app fallback when exact alarms are unavailable`() = runTest {
+    fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
         every { clockRepository.observeManageableAlarms() } returns emptyFlow()
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
-        every { clockRepository.getPlatformState() } returns ClockPlatformState(
-            canScheduleExactAlarms = false,
-            notificationsEnabled = true,
-            canUseFullScreenIntent = false,
-        )
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
-        mockkConstructor(android.content.Intent::class)
-        every { anyConstructed<android.content.Intent>().setFlags(any()) } answers { self as android.content.Intent }
-        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<Int>()) } answers { self as android.content.Intent }
-        every { anyConstructed<android.content.Intent>().putExtra(any<String>(), any<String>()) } answers { self as android.content.Intent }
-        try {
-            val viewModel = SidePanelViewModel(clockRepository, context)
-            var result: AlarmSaveResult? = null
+        val viewModel = SidePanelViewModel(clockRepository)
+        var result: AlarmSaveResult? = null
 
-            viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
-            advanceUntilIdle()
+        viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
+        advanceUntilIdle()
 
-            assertEquals(AlarmSaveResult.CLOCK_APP_FALLBACK, result)
-            verify(exactly = 1) { context.startActivity(any()) }
-        } finally {
-            unmockkConstructor(android.content.Intent::class)
-        }
+        assertEquals(AlarmSaveResult.FAILED, result)
     }
 
     @Test
@@ -91,7 +71,7 @@ class SidePanelViewModelTest {
             durationMs = 60_000L,
             startedAtMillis = 2_000L,
         )
-        val viewModel = SidePanelViewModel(clockRepository, context)
+        val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryScheduleTimer(60_000L, "Tea")
 
@@ -110,7 +90,7 @@ class SidePanelViewModelTest {
         every { clockRepository.observeManageableAlarms() } returns emptyFlow()
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns null
-        val viewModel = SidePanelViewModel(clockRepository, context)
+        val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
 

--- a/specification.md
+++ b/specification.md
@@ -54,9 +54,8 @@ To ensure the assistant can perform tasks, it uses a decoupled skill registry.
 Zero-overhead deterministic matching for simple device actions. A pure-Kotlin `QuickIntentRouter` uses regex/keyword patterns to match user input without loading any ML model. Matched actions execute directly via OS APIs. Latency: <5ms from text to action.
 
 **Supported actions:**
-* Flashlight on/off (`CameraManager.setTorchMode`)
-* Timer (`AlarmClock.ACTION_SET_TIMER`)
-* Alarm (`AlarmClock.ACTION_SET_ALARM`)
+* Timer (app-owned clock scheduler + notification pipeline)
+* Alarm (app-owned clock scheduler + notification pipeline)
 * Do Not Disturb toggle (`NotificationManager.setInterruptionFilter`)
 * Bluetooth / Wi-Fi toggle
 * Get current time / date


### PR DESCRIPTION
## Summary
- add a canonical `ClockRepository` / `ClockScheduler` seam for internal alarms and timers
- centralize `AlarmManager` scheduling, cancellation, and boot restore behind the app scheduler implementation
- migrate skills and settings alarm/timer flows onto the shared repository and add exact-alarm fallback handling plus targeted tests

Closes #720

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :core:skills:testDebugUnitTest --tests "*NativeIntentHandlerTest" :feature:settings:testDebugUnitTest --tests "*ScheduledAlarmsViewModelTest" --tests "*SidePanelViewModelTest" :feature:settings:compileDebugKotlin :app:compileDebugKotlin`

## Manual test cases
1. Settings -> Scheduled alarms: create a new internal alarm, verify it appears in the list, survives app restart, and still appears after reboot restore.
2. Settings -> Scheduled alarms: edit an existing internal alarm label/time and verify the updated entry remains manageable from the list.
3. Side panel: create or toggle an alarm and verify the upcoming/manageable alarm section updates immediately.
4. Actions/chat: `set alarm for 7:30 tomorrow called gym` and then `cancel my gym alarm`; verify the alarm is scheduled internally and removed truthfully.
5. Actions/chat with exact alarms unavailable: `set alarm for 7:30` should open the system Clock app instead of silently claiming success.
6. Actions/chat: `set a timer for 2 minutes`; when it fires, confirm the active timer entry is retired.
