### PR TITLE
feat(#727): add chat voice push-to-talk

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CheckCircle
@@ -129,6 +130,8 @@ fun ChatScreen(
     viewModel: ChatViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val voiceCaptureState by viewModel.voiceCaptureState.collectAsStateWithLifecycle()
+    val voicePlaybackState by viewModel.voicePlaybackState.collectAsStateWithLifecycle()
     val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -170,6 +173,11 @@ fun ChatScreen(
                     onNewConversation()
                 },
                 onRenameConversation = viewModel::renameConversation,
+                voiceCaptureState = voiceCaptureState,
+                voicePlaybackState = voicePlaybackState,
+                onStartVoiceInput = viewModel::startVoiceInput,
+                onStopVoiceInput = viewModel::stopVoiceInput,
+                onStopVoiceOutput = viewModel::stopVoiceOutput,
                 snackbarHostState = snackbarHostState,
                 onCopyMessage = { content ->
                     clipboardManager.setText(AnnotatedString(stripMarkdownForClipboard(content)))
@@ -200,6 +208,11 @@ private fun ChatContent(
     onBack: () -> Unit,
     onNewConversation: () -> Unit,
     onRenameConversation: (String) -> Unit,
+    voiceCaptureState: ChatViewModel.VoiceCaptureState,
+    voicePlaybackState: ChatViewModel.VoicePlaybackState,
+    onStartVoiceInput: () -> Unit,
+    onStopVoiceInput: () -> Unit,
+    onStopVoiceOutput: () -> Unit,
     snackbarHostState: SnackbarHostState,
     onCopyMessage: (String) -> Unit,
     onCopyAll: () -> Unit,
@@ -380,10 +393,15 @@ private fun ChatContent(
             InputBar(
                 text = state.inputText,
                 isGenerating = state.isGenerating,
+                voiceCaptureState = voiceCaptureState,
+                voicePlaybackState = voicePlaybackState,
                 onTextChanged = onInputChanged,
                 onSend = onSend,
                 onCancel = onCancel,
-            modifier = Modifier.navigationBarsPadding(),
+                onStartVoiceInput = onStartVoiceInput,
+                onStopVoiceInput = onStopVoiceInput,
+                onStopVoiceOutput = onStopVoiceOutput,
+                modifier = Modifier.navigationBarsPadding(),
             )
         }
     }
@@ -605,48 +623,132 @@ private fun MessageBubble(
 private fun InputBar(
     text: String,
     isGenerating: Boolean,
+    voiceCaptureState: ChatViewModel.VoiceCaptureState,
+    voicePlaybackState: ChatViewModel.VoicePlaybackState,
     onTextChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
+    onStartVoiceInput: () -> Unit,
+    onStopVoiceInput: () -> Unit,
+    onStopVoiceOutput: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val voiceStatusText = when (voiceCaptureState) {
+        ChatViewModel.VoiceCaptureState.Idle -> when (voicePlaybackState) {
+            ChatViewModel.VoicePlaybackState.Idle -> null
+            is ChatViewModel.VoicePlaybackState.Speaking -> "Speaking: ${voicePlaybackState.text}"
+        }
+        ChatViewModel.VoiceCaptureState.Preparing -> "Starting voice input…"
+        is ChatViewModel.VoiceCaptureState.Listening -> {
+            if (voiceCaptureState.transcript.isBlank()) {
+                "Listening…"
+            } else {
+                "Listening: ${voiceCaptureState.transcript}"
+            }
+        }
+        is ChatViewModel.VoiceCaptureState.Processing -> "Processing: ${voiceCaptureState.transcript}"
+    }
+
     Surface(
         tonalElevation = 4.dp,
         modifier = modifier.fillMaxWidth(),
     ) {
-        Row(
-            modifier = Modifier
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            TextField(
-                value = text,
-                onValueChange = onTextChanged,
-                placeholder = { Text("Message Jandal…") },
-                modifier = Modifier.weight(1f),
-                maxLines = 5,
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                ),
-                keyboardOptions = KeyboardOptions(
-                    capitalization = KeyboardCapitalization.Sentences,
-                    imeAction = ImeAction.Send,
-                ),
-                keyboardActions = KeyboardActions(onSend = { if (!isGenerating) onSend() }),
-            )
-
-            AnimatedVisibility(visible = isGenerating, enter = fadeIn(), exit = fadeOut()) {
-                IconButton(onClick = onCancel) {
-                    Icon(Icons.Default.Close, contentDescription = "Stop generation")
+        Column {
+            AnimatedVisibility(
+                visible = voiceStatusText != null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                voiceStatusText?.let { status ->
+                    Text(
+                        text = status,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .testTag("chat_voice_status"),
+                    )
                 }
             }
 
-            AnimatedVisibility(visible = !isGenerating && text.isNotBlank(), enter = fadeIn(), exit = fadeOut()) {
-                IconButton(onClick = onSend) {
-                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextField(
+                    value = text,
+                    onValueChange = onTextChanged,
+                    placeholder = { Text("Message Jandal…") },
+                    modifier = Modifier.weight(1f),
+                    maxLines = 5,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                    ),
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Send,
+                    ),
+                    keyboardActions = KeyboardActions(onSend = { if (!isGenerating) onSend() }),
+                )
+
+                AnimatedVisibility(visible = isGenerating, enter = fadeIn(), exit = fadeOut()) {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.Default.Close, contentDescription = "Stop generation")
+                    }
+                }
+
+                AnimatedVisibility(visible = !isGenerating && text.isNotBlank(), enter = fadeIn(), exit = fadeOut()) {
+                    IconButton(onClick = onSend) {
+                        Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = !isGenerating &&
+                        text.isBlank() &&
+                        voiceCaptureState == ChatViewModel.VoiceCaptureState.Idle &&
+                        voicePlaybackState == ChatViewModel.VoicePlaybackState.Idle,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    IconButton(
+                        onClick = onStartVoiceInput,
+                        modifier = Modifier.testTag("chat_voice_start"),
+                    ) {
+                        Icon(Icons.Default.Mic, contentDescription = "Start voice input")
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = !isGenerating && voiceCaptureState != ChatViewModel.VoiceCaptureState.Idle,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    IconButton(
+                        onClick = onStopVoiceInput,
+                        modifier = Modifier.testTag("chat_voice_stop_input"),
+                    ) {
+                        Icon(Icons.Default.Close, contentDescription = "Stop voice input")
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = !isGenerating &&
+                        voiceCaptureState == ChatViewModel.VoiceCaptureState.Idle &&
+                        voicePlaybackState != ChatViewModel.VoicePlaybackState.Idle,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    IconButton(
+                        onClick = onStopVoiceOutput,
+                        modifier = Modifier.testTag("chat_voice_stop_output"),
+                    ) {
+                        Icon(Icons.Default.Close, contentDescription = "Stop spoken reply")
+                    }
                 }
             }
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -48,6 +48,15 @@ import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import com.kernel.ai.feature.chat.model.ToolCallInfo
 import com.kernel.ai.feature.chat.model.toJsonString
 import com.kernel.ai.feature.chat.model.toolCallInfoFromJson
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.VoiceInputStartResult
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputEvent
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.VoiceOutputResult
+import com.kernel.ai.core.voice.VoiceSpeakRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -93,10 +102,26 @@ class ChatViewModel @Inject constructor(
     private val kernelAIToolSet: KernelAIToolSet,
     private val toolProvider: ToolProvider,
     private val embeddingEngine: EmbeddingEngine,
+    private val voiceInputController: VoiceInputController,
+    private val voiceOutputController: VoiceOutputController,
+    private val voiceOutputPreferences: VoiceOutputPreferences,
     private val jandalPersona: JandalPersona,
     private val nzTruthSeedingService: NzTruthSeedingService,
     private val verboseLoggingPreferenceUseCase: com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase,
 ) : ViewModel() {
+    private enum class SubmitMode { Text, Voice }
+
+    sealed interface VoiceCaptureState {
+        data object Idle : VoiceCaptureState
+        data object Preparing : VoiceCaptureState
+        data class Listening(val transcript: String = "") : VoiceCaptureState
+        data class Processing(val transcript: String) : VoiceCaptureState
+    }
+
+    sealed interface VoicePlaybackState {
+        data object Idle : VoicePlaybackState
+        data class Speaking(val text: String) : VoicePlaybackState
+    }
 
     val isSeeding: StateFlow<Boolean> = nzTruthSeedingService.isSeeding
 
@@ -165,6 +190,15 @@ class ChatViewModel @Inject constructor(
 
     /** True while Gemma-4 is being lazily initialised in response to a [sendMessage] call. */
     private val _isLoadingModel = MutableStateFlow(false)
+
+    private val _voiceCaptureState = MutableStateFlow<VoiceCaptureState>(VoiceCaptureState.Idle)
+    val voiceCaptureState: StateFlow<VoiceCaptureState> = _voiceCaptureState.asStateFlow()
+
+    private val _voicePlaybackState = MutableStateFlow<VoicePlaybackState>(VoicePlaybackState.Idle)
+    val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
+
+    private var spokenResponsesEnabled = true
+    private var pendingVoiceReply = false
 
     /** True once [initializeConversation] has completed and [conversationId] is set. */
     private val _conversationInitialized = MutableStateFlow(false)
@@ -260,6 +294,72 @@ class ChatViewModel @Inject constructor(
         // Load verbose logging preference from DataStore (safe in core:memory module)
         viewModelScope.launch {
             verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference()
+        }
+        viewModelScope.launch {
+            voiceOutputPreferences.spokenResponsesEnabled.collect { enabled ->
+                spokenResponsesEnabled = enabled
+                if (enabled) {
+                    voiceOutputController.warmUp()
+                } else {
+                    pendingVoiceReply = false
+                    _voicePlaybackState.value = VoicePlaybackState.Idle
+                    voiceOutputController.stop()
+                }
+            }
+        }
+        viewModelScope.launch {
+            voiceInputController.events.collect { event ->
+                when (event) {
+                    is VoiceInputEvent.ListeningStarted -> {
+                        val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
+                            ?.transcript
+                            .orEmpty()
+                        _voiceCaptureState.value = VoiceCaptureState.Listening(currentTranscript)
+                    }
+                    is VoiceInputEvent.PartialTranscript -> {
+                        _voiceCaptureState.value = VoiceCaptureState.Listening(event.text)
+                    }
+                    is VoiceInputEvent.Transcript -> {
+                        submitVoiceTranscript(event.text)
+                    }
+                    is VoiceInputEvent.Error -> {
+                        pendingVoiceReply = false
+                        _voiceCaptureState.value = VoiceCaptureState.Idle
+                        _error.value = event.message
+                    }
+                    is VoiceInputEvent.ListeningStopped -> {
+                        when (val currentState = _voiceCaptureState.value) {
+                            is VoiceCaptureState.Listening -> {
+                                if (currentState.transcript.isBlank()) {
+                                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                                } else {
+                                    submitVoiceTranscript(currentState.transcript)
+                                }
+                            }
+                            is VoiceCaptureState.Processing -> Unit
+                            else -> _voiceCaptureState.value = VoiceCaptureState.Idle
+                        }
+                    }
+                }
+            }
+        }
+        viewModelScope.launch {
+            voiceOutputController.events.collect { event ->
+                when (event) {
+                    is VoiceOutputEvent.SpeakingStarted -> {
+                        if (
+                            _voiceCaptureState.value !is VoiceCaptureState.Preparing &&
+                            _voiceCaptureState.value !is VoiceCaptureState.Listening
+                        ) {
+                            _voiceCaptureState.value = VoiceCaptureState.Idle
+                        }
+                        _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
+                    }
+                    VoiceOutputEvent.SpeakingStopped -> {
+                        _voicePlaybackState.value = VoicePlaybackState.Idle
+                    }
+                }
+            }
         }
         viewModelScope.launch { initializeConversation() }
         nzTruthSeedingService.seedIfNeeded()
@@ -602,6 +702,7 @@ class ChatViewModel @Inject constructor(
         _messages.update { it + msg }
         val savedId = conversationRepository.addMessage(convId, "assistant", content)
         if (shouldIndex) ragRepository.indexMessage(savedId, convId, content)
+        speakAssistantReplyIfNeeded(content)
     }
 
     /** Like [appendAssistantMessage] but also attaches a [ToolCallInfo] chip so the UI shows
@@ -635,6 +736,7 @@ class ChatViewModel @Inject constructor(
             toolCallJson = toolCall.toJsonString(),
         )
         if (shouldIndexToolCallResult(skillName)) ragRepository.indexMessage(savedId, convId, content)
+        speakAssistantReplyIfNeeded(content)
     }
 
     fun retryDownload(model: KernelModel) {
@@ -644,6 +746,42 @@ class ChatViewModel @Inject constructor(
     fun onInputChanged(text: String) {
         _inputText.value = text
         if (_error.value != null) _error.value = null
+    }
+
+    fun startVoiceInput() {
+        if (inferenceEngine.isGenerating.value || _isLoadingModel.value) return
+        if (_voiceCaptureState.value != VoiceCaptureState.Idle) return
+        viewModelScope.launch {
+            if (_voicePlaybackState.value != VoicePlaybackState.Idle) {
+                voiceOutputController.stop()
+            }
+            _error.value = null
+            _voiceCaptureState.value = VoiceCaptureState.Preparing
+            when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
+                VoiceInputStartResult.Started -> {
+                    if (_voiceCaptureState.value == VoiceCaptureState.Preparing) {
+                        _voiceCaptureState.value = VoiceCaptureState.Listening()
+                    }
+                }
+                is VoiceInputStartResult.Unavailable -> {
+                    pendingVoiceReply = false
+                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                    _error.value = result.message
+                }
+            }
+        }
+    }
+
+    fun stopVoiceInput() {
+        pendingVoiceReply = false
+        voiceInputController.stopListening()
+        _voiceCaptureState.value = VoiceCaptureState.Idle
+    }
+
+    fun stopVoiceOutput() {
+        pendingVoiceReply = false
+        voiceOutputController.stop()
+        _voicePlaybackState.value = VoicePlaybackState.Idle
     }
 
     fun submitInitialQueryIfNeeded(initialQuery: String) {
@@ -675,11 +813,22 @@ class ChatViewModel @Inject constructor(
     }
 
     fun sendMessage() {
+        sendMessage(SubmitMode.Text)
+    }
+
+    private fun sendMessage(submitMode: SubmitMode) {
         val text = _inputText.value.trim()
-        if (text.isBlank() || inferenceEngine.isGenerating.value || _isLoadingModel.value) return
+        if (text.isBlank() || inferenceEngine.isGenerating.value || _isLoadingModel.value) {
+            if (submitMode == SubmitMode.Voice) {
+                pendingVoiceReply = false
+                _voiceCaptureState.value = VoiceCaptureState.Idle
+            }
+            return
+        }
 
         _inputText.value = ""
         val convId = conversationId ?: return
+        pendingVoiceReply = submitMode == SubmitMode.Voice
 
         // Synchronous flag set — collapses the TOCTOU window before coroutine dispatch
         if (!inferenceEngine.isReady.value) {
@@ -1193,6 +1342,7 @@ class ChatViewModel @Inject constructor(
                                     contextWindowManager.estimateTokens(resultContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
                                 turnsSinceReset++
+                                speakAssistantReplyIfNeeded(resultContent)
                                 // Do NOT set needsHistoryReplay here — KV cache remains valid after
                                 // native tool calls and forcing a replay drops prior turns from the
                                 // tight history budget, causing context amnesia (#446).
@@ -1282,6 +1432,7 @@ class ChatViewModel @Inject constructor(
                                     contextWindowManager.estimateTokens(displayContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
                                 turnsSinceReset++
+                                speakAssistantReplyIfNeeded(displayContent)
                             }
 
                             // Clear streaming tracking now that the message is fully persisted.
@@ -1306,6 +1457,8 @@ class ChatViewModel @Inject constructor(
                         }
 
                         is GenerationResult.Error -> {
+                            pendingVoiceReply = false
+                            _voiceCaptureState.value = VoiceCaptureState.Idle
                             _messages.update { msgs ->
                                 msgs.map { msg ->
                                     if (msg.id == assistantMsgId) {
@@ -1323,6 +1476,8 @@ class ChatViewModel @Inject constructor(
             } while (needsHallucinationRetry)
 
             } catch (e: Exception) {
+                pendingVoiceReply = false
+                _voiceCaptureState.value = VoiceCaptureState.Idle
                 _messages.update { msgs ->
                     msgs.map { msg ->
                         if (msg.id == assistantMsgId) {
@@ -1342,6 +1497,8 @@ class ChatViewModel @Inject constructor(
     }
 
     fun cancelGeneration() {
+        pendingVoiceReply = false
+        _voiceCaptureState.value = VoiceCaptureState.Idle
         inferenceEngine.cancelGeneration()
         val partialContent = activeStreamingContent.toString()
         val partialThinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
@@ -1387,6 +1544,11 @@ class ChatViewModel @Inject constructor(
 
     fun startNewConversation() {
         viewModelScope.launch {
+            pendingVoiceReply = false
+            voiceInputController.stopListening()
+            voiceOutputController.stop()
+            _voiceCaptureState.value = VoiceCaptureState.Idle
+            _voicePlaybackState.value = VoicePlaybackState.Idle
             val id = conversationRepository.createConversation()
             conversationId = id
             _messages.value = emptyList()
@@ -1534,6 +1696,9 @@ class ChatViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        pendingVoiceReply = false
+        voiceInputController.stopListening()
+        voiceOutputController.stop()
         // Flush any in-progress streamed content to Room before the ViewModel is destroyed.
         // runBlocking is acceptable here — called once on ViewModel teardown,
         // Room insert is fast (<10ms), main thread briefly blocked on nav back.
@@ -1557,6 +1722,33 @@ class ChatViewModel @Inject constructor(
             }
         }
         viewModelScope.launch { inferenceEngine.shutdown() }
+    }
+
+    private fun submitVoiceTranscript(rawTranscript: String) {
+        val transcript = rawTranscript.trim()
+        if (transcript.isBlank()) {
+            pendingVoiceReply = false
+            _voiceCaptureState.value = VoiceCaptureState.Idle
+            return
+        }
+        _voiceCaptureState.value = VoiceCaptureState.Processing(transcript)
+        onInputChanged(transcript)
+        sendMessage(SubmitMode.Voice)
+    }
+
+    private suspend fun speakAssistantReplyIfNeeded(content: String) {
+        val shouldSpeak = pendingVoiceReply
+        pendingVoiceReply = false
+        _voiceCaptureState.value = VoiceCaptureState.Idle
+        if (!shouldSpeak || !spokenResponsesEnabled) return
+
+        val spokenText = stripMarkdownForClipboard(content).trim()
+        if (spokenText.isBlank()) return
+
+        when (val result = voiceOutputController.speak(VoiceSpeakRequest(text = spokenText))) {
+            VoiceOutputResult.Spoken -> Unit
+            is VoiceOutputResult.Unavailable -> _error.value = result.message
+        }
     }
 
     /**

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -28,6 +28,9 @@ import com.kernel.ai.core.skills.QuickIntentRouter
 import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -69,6 +72,9 @@ class ChatViewModelInitTest {
     private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
     private val toolProvider: ToolProvider = mockk(relaxed = true)
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
+    private val voiceInputController: VoiceInputController = mockk(relaxed = true)
+    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
     private val jandalPersona: JandalPersona = mockk(relaxed = true)
     private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
     private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
@@ -102,6 +108,7 @@ class ChatViewModelInitTest {
 
         every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
         every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
+        every { voiceOutputPreferences.spokenResponsesEnabled } returns MutableStateFlow(false)
         every { nzTruthSeedingService.isSeeding } returns MutableStateFlow(false)
         every { nzTruthSeedingService.seedIfNeeded() } just runs
         coEvery { verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference() } just runs
@@ -132,6 +139,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
@@ -162,6 +172,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
@@ -211,6 +224,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
@@ -265,6 +281,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
@@ -309,6 +328,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
@@ -369,6 +391,9 @@ class ChatViewModelInitTest {
             kernelAIToolSet = kernelAIToolSet,
             toolProvider = toolProvider,
             embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
             jandalPersona = jandalPersona,
             nzTruthSeedingService = nzTruthSeedingService,
             verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -1,0 +1,234 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import com.google.ai.edge.litertlm.ToolProvider
+import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.GenerationResult
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.JandalPersona
+import com.kernel.ai.core.inference.PersonaMode
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareTier
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
+import com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase
+import com.kernel.ai.core.skills.KernelAIToolSet
+import com.kernel.ai.core.skills.QuickIntentRouter
+import com.kernel.ai.core.skills.SkillExecutor
+import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.VoiceInputStartResult
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputEvent
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.VoiceOutputResult
+import com.kernel.ai.core.voice.VoiceSpeakRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelVoiceTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private val inferenceEngine: InferenceEngine = mockk(relaxed = true)
+    private val downloadManager: ModelDownloadManager = mockk(relaxed = true)
+    private val conversationRepository: ConversationRepository = mockk(relaxed = true)
+    private val ragRepository: RagRepository = mockk(relaxed = true)
+    private val userProfileRepository: UserProfileRepository = mockk(relaxed = true)
+    private val memoryRepository: MemoryRepository = mockk(relaxed = true)
+    private val episodicDistillationUseCase: EpisodicDistillationUseCase = mockk(relaxed = true)
+    private val modelSettingsRepository: ModelSettingsRepository = mockk(relaxed = true)
+    private val skillRegistry: SkillRegistry = mockk(relaxed = true)
+    private val skillExecutor: SkillExecutor = mockk(relaxed = true)
+    private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
+    private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
+    private val toolProvider: ToolProvider = mockk(relaxed = true)
+    private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
+    private val voiceInputController: VoiceInputController = mockk(relaxed = true)
+    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
+    private val jandalPersona: JandalPersona = mockk(relaxed = true)
+    private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
+    private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+
+    private val voiceInputEvents = MutableSharedFlow<VoiceInputEvent>()
+    private val voiceOutputEvents = MutableSharedFlow<VoiceOutputEvent>()
+    private val spokenResponsesEnabled = MutableStateFlow(true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.isGenerating } returns MutableStateFlow(false)
+        every { inferenceEngine.activeBackend } returns MutableStateFlow<BackendType?>(null)
+        every { inferenceEngine.resolvedMaxTokens } returns MutableStateFlow(0)
+        every { inferenceEngine.evictionEvents } returns emptyFlow()
+        every { inferenceEngine.generate(any()) } returns
+            flowOf(GenerationResult.Token("Hi back"), GenerationResult.Complete(durationMs = 1L))
+        coEvery { inferenceEngine.updateSystemPrompt(any()) } just runs
+        coEvery { inferenceEngine.resetConversation() } just runs
+
+        every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
+
+        coEvery { conversationRepository.getConversation(any()) } answers {
+            val id = firstArg<String>()
+            ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L)
+        }
+        coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg", "assistant-msg")
+
+        every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
+        every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
+        every { voiceInputController.events } returns voiceInputEvents
+        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+        every { voiceInputController.stopListening() } just runs
+        every { voiceOutputController.events } returns voiceOutputEvents
+        coEvery { voiceOutputController.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { voiceOutputController.speak(any()) } returns VoiceOutputResult.Spoken
+        every { voiceOutputController.stop() } just runs
+        every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
+        every { nzTruthSeedingService.isSeeding } returns MutableStateFlow(false)
+        every { nzTruthSeedingService.seedIfNeeded() } just runs
+        coEvery { verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference() } just runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `voice transcript submits chat message and speaks assistant reply`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Hello there") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Hello there")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello there"))
+        advanceUntilIdle()
+
+        assertEquals("You: Hello there\nJandal: Hi back", viewModel.getConversationAsText())
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text == "Hi back" }
+            )
+        }
+    }
+
+    @Test
+    fun `typed chat message stays silent`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Hello there") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Hello there")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onInputChanged("Hello there")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals("You: Hello there\nJandal: Hi back", viewModel.getConversationAsText())
+        coVerify(exactly = 0) { voiceOutputController.speak(any()) }
+    }
+
+    @Test
+    fun `startVoiceInput surfaces unavailable recognizer state`() = runTest(dispatcher) {
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.Command)
+        } returns VoiceInputStartResult.Unavailable("Voice input is unavailable.")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startVoiceInput()
+        advanceUntilIdle()
+
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify(exactly = 0) { voiceOutputController.speak(any()) }
+    }
+
+    @Test
+    fun `speaking started event does not clobber active voice input`() = runTest(dispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startVoiceInput()
+        advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Previous reply"))
+        advanceUntilIdle()
+
+        assertEquals(ChatViewModel.VoiceCaptureState.Listening(), viewModel.voiceCaptureState.value)
+    }
+
+    private fun createViewModel(): ChatViewModel = ChatViewModel(
+        savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+    )
+}


### PR DESCRIPTION
## Summary
Add the first chat voice foundation slice for `#727`.

This keeps the initial implementation intentionally small: one-shot push-to-talk in chat, chat-local voice state, and spoken replies only for voice-originated turns.

## Changes
- add chat-local voice capture/playback state to `ChatViewModel`
- reuse `VoiceInputController` and `VoiceOutputController` for chat voice
- add a chat mic entry point, inline voice status text, and stop controls in `ChatScreen`
- speak assistant replies for voice-originated chat turns while keeping typed chat silent
- add focused `ChatViewModelVoiceTest` coverage and extend `ChatViewModelInitTest`
- fix the reviewed race where a queued TTS event could clobber a newly started voice input session

## Testing
- [x] `./gradlew :feature:chat:testDebugUnitTest --tests '*ChatViewModel*'`
- [x] `./gradlew :app:assembleDebug`
- [ ] Manual device testing

## Related issues
Closes #727
