### PR TITLE
feat(#737): ship first-class timer ux

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/25.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/25.json
@@ -1,0 +1,816 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "7cd6b003e2cc463fbf0ca9f0cd12ac19",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7cd6b003e2cc463fbf0ca9f0cd12ac19')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -48,7 +48,7 @@ import com.kernel.ai.core.memory.entity.UserProfileEntity
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 24,
+    version = 25,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -283,6 +283,13 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN owner_id TEXT DEFAULT NULL")
                 db.execSQL("UPDATE scheduled_alarms SET owner_id = id WHERE owner_id IS NULL")
+            }
+        }
+
+        /** Adds completed_at_ms to scheduled_alarms so fired timers can appear in recent history (#737). */
+        val MIGRATION_24_25 = object : Migration(24, 25) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN completed_at_ms INTEGER DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -78,6 +78,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_21_22,
                     KernelDatabase.MIGRATION_22_23,
                     KernelDatabase.MIGRATION_23_24,
+                    KernelDatabase.MIGRATION_24_25,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -21,7 +21,8 @@ data class ClockTimer(
     val createdAtMillis: Long,
     val durationMs: Long,
     val startedAtMillis: Long,
-)
+    val completedAtMillis: Long? = null,
+ )
 
 data class ClockScheduledEvent(
     val eventId: String,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -9,6 +9,7 @@ interface ClockRepository {
 
     fun observeUpcomingAlarms(): Flow<List<ClockAlarm>>
     fun observeActiveTimers(): Flow<List<ClockTimer>>
+    fun observeRecentCompletedTimers(): Flow<List<ClockTimer>>
 
     fun getPlatformState(): ClockPlatformState
 
@@ -28,6 +29,8 @@ interface ClockRepository {
 
     suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
     suspend fun cancelTimer(timerId: String)
+    suspend fun deleteCompletedTimer(timerId: String): Boolean
+    suspend fun clearCompletedTimers(): Int
     suspend fun recordDeliveredEvent(eventId: String)
     suspend fun cancelTimers(timerIds: Collection<String>)
     suspend fun cancelAllTimers(): Int

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -39,6 +39,11 @@ class ClockRepositoryImpl @Inject constructor(
                 .mapNotNull { it.toClockTimer() }
         }
 
+    override fun observeRecentCompletedTimers(): Flow<List<ClockTimer>> =
+        scheduledAlarmDao.observeRecentCompletedTimers().map { schedules ->
+            schedules.mapNotNull { it.toClockTimer() }
+        }
+
     override fun getPlatformState(): ClockPlatformState = scheduler.getPlatformState()
 
     override suspend fun scheduleAlarm(triggerAtMillis: Long, label: String?): ClockAlarm? {
@@ -181,10 +186,16 @@ class ClockRepositoryImpl @Inject constructor(
         scheduledAlarmDao.delete(timerId)
     }
 
+    override suspend fun deleteCompletedTimer(timerId: String): Boolean =
+        scheduledAlarmDao.deleteCompletedTimer(timerId) > 0
+
+    override suspend fun clearCompletedTimers(): Int =
+        scheduledAlarmDao.deleteCompletedTimers()
+
     override suspend fun recordDeliveredEvent(eventId: String) {
         val existing = scheduledAlarmDao.getById(eventId)?.withDefaultOwnerId() ?: return
         if (existing.entryType == ClockEventType.TIMER.name) {
-            scheduledAlarmDao.delete(eventId)
+            scheduledAlarmDao.markTimerCompleted(eventId, System.currentTimeMillis())
         } else {
             scheduledAlarmDao.markFired(eventId)
         }
@@ -278,6 +289,7 @@ private fun ScheduledAlarmEntity.toClockTimer(): ClockTimer? {
         createdAtMillis = createdAt,
         durationMs = duration,
         startedAtMillis = startedAt,
+        completedAtMillis = completedAtMs,
     )
 }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -27,6 +27,9 @@ interface ScheduledAlarmDao {
     @Query("UPDATE scheduled_alarms SET fired = 1 WHERE id = :id")
     suspend fun markFired(id: String)
 
+    @Query("UPDATE scheduled_alarms SET fired = 1, completed_at_ms = :completedAtMillis WHERE id = :id")
+    suspend fun markTimerCompleted(id: String, completedAtMillis: Long)
+
     @Query("DELETE FROM scheduled_alarms WHERE id = :id")
     suspend fun delete(id: String)
 
@@ -35,6 +38,15 @@ interface ScheduledAlarmDao {
 
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND enabled = 1 AND entry_type = 'TIMER' ORDER BY started_at_ms DESC")
     suspend fun getAllTimers(): List<ScheduledAlarmEntity>
+
+    @Query("SELECT * FROM scheduled_alarms WHERE entry_type = 'TIMER' AND completed_at_ms IS NOT NULL ORDER BY completed_at_ms DESC")
+    fun observeRecentCompletedTimers(): Flow<List<ScheduledAlarmEntity>>
+
+    @Query("DELETE FROM scheduled_alarms WHERE id = :id AND entry_type = 'TIMER' AND completed_at_ms IS NOT NULL")
+    suspend fun deleteCompletedTimer(id: String): Int
+
+    @Query("DELETE FROM scheduled_alarms WHERE entry_type = 'TIMER' AND completed_at_ms IS NOT NULL")
+    suspend fun deleteCompletedTimers(): Int
 
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY triggerAtMillis ASC")
     suspend fun getActiveAlarmSchedules(): List<ScheduledAlarmEntity>

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -16,4 +16,5 @@ data class ScheduledAlarmEntity(
     @ColumnInfo(name = "entry_type") val entryType: String = "ALARM",
     @ColumnInfo(name = "duration_ms") val durationMs: Long? = null,
     @ColumnInfo(name = "started_at_ms") val startedAtMs: Long? = null,
+    @ColumnInfo(name = "completed_at_ms") val completedAtMs: Long? = null,
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -205,6 +205,39 @@ class ClockRepositoryImplTest {
     }
 
     @Test
+    fun `recordDeliveredEvent marks timers completed instead of deleting them`() = runTest {
+        val existing = scheduleRow(
+            id = "timer-1",
+            triggerAtMillis = 6_000L,
+            enabled = true,
+            entryType = ClockEventType.TIMER.name,
+        ).copy(durationMs = 60_000L, startedAtMs = 1_000L)
+        coEvery { scheduledAlarmDao.getById("timer-1") } returns existing
+        coEvery { scheduledAlarmDao.markTimerCompleted(eq("timer-1"), any()) } just Runs
+
+        repository.recordDeliveredEvent("timer-1")
+
+        coVerify(exactly = 1) { scheduledAlarmDao.markTimerCompleted(eq("timer-1"), any()) }
+        coVerify(exactly = 0) { scheduledAlarmDao.delete("timer-1") }
+    }
+
+    @Test
+    fun `observeRecentCompletedTimers maps completed timer history`() = runTest {
+        val completed = scheduleRow(
+            id = "timer-history",
+            triggerAtMillis = 8_000L,
+            enabled = true,
+            entryType = ClockEventType.TIMER.name,
+        ).copy(durationMs = 120_000L, startedAtMs = 6_000L, completedAtMs = 8_100L)
+        every { scheduledAlarmDao.observeRecentCompletedTimers() } returns flowOf(listOf(completed))
+
+        val timers = repository.observeRecentCompletedTimers().first()
+
+        assertEquals(listOf("timer-history"), timers.map { it.id })
+        assertEquals(8_100L, timers.single().completedAtMillis)
+    }
+
+    @Test
     fun `editAlarm returns null when row is already gone`() = runTest {
         coEvery { scheduledAlarmDao.getById("missing") } returns null
 
@@ -248,6 +281,16 @@ class ClockRepositoryImplTest {
         coVerify(exactly = 1) { scheduledAlarmDao.setEnabled("future-alarm", false) }
         coVerify(exactly = 1) { scheduledAlarmDao.markFired("future-timer") }
         verify(exactly = 0) { scheduler.schedule(any()) }
+    }
+
+    @Test
+    fun `clearCompletedTimers delegates to dao delete completed timers`() = runTest {
+        coEvery { scheduledAlarmDao.deleteCompletedTimers() } returns 2
+
+        val deleted = repository.clearCompletedTimers()
+
+        assertEquals(2, deleted)
+        coVerify(exactly = 1) { scheduledAlarmDao.deleteCompletedTimers() }
     }
     private fun scheduleRow(
         id: String,

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/TimerCreateDialogTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/TimerCreateDialogTest.kt
@@ -1,0 +1,130 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class TimerCreateDialogTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun timerDialogShowsThreeWheelPickers() {
+        setDialogContent()
+
+        composeTestRule.onNodeWithTag("timer_hours_picker").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("timer_minutes_picker").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("timer_seconds_picker").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("timer_start_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun defaultTimerSelectionConfirmsFiveMinutes() {
+        var confirmedDurationMs: Long? = null
+        var confirmedLabel: String? = "unexpected"
+        setDialogContent(
+            onConfirm = { durationMs, label ->
+                confirmedDurationMs = durationMs
+                confirmedLabel = label
+            },
+        )
+
+        composeTestRule.onNodeWithTag("timer_start_button").performClick()
+
+        assertEquals(5 * 60 * 1_000L, confirmedDurationMs)
+        assertNull(confirmedLabel)
+    }
+
+    @Test
+    fun labelIsReturnedOnConfirm() {
+        var confirmedLabel: String? = null
+        setDialogContent(onConfirm = { _, label -> confirmedLabel = label })
+
+        composeTestRule.onNodeWithTag("timer_label_input").performTextInput("Pasta")
+        composeTestRule.onNodeWithTag("timer_start_button").performClick()
+
+        assertEquals("Pasta", confirmedLabel)
+    }
+
+    private fun setDialogContent(
+        onConfirm: (Long, String?) -> Unit = { _, _ -> },
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            TimerDialogTestContent(onConfirm = onConfirm, onDismiss = onDismiss)
+        }
+    }
+}
+
+@Composable
+private fun TimerDialogTestContent(
+    onConfirm: (Long, String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var hours by remember { mutableIntStateOf(0) }
+    var minutes by remember { mutableIntStateOf(5) }
+    var seconds by remember { mutableIntStateOf(0) }
+    var label by remember { mutableStateOf("") }
+    val durationMs = (((hours * 60L) + minutes) * 60L + seconds) * 1_000L
+
+    AlertDialog(
+        modifier = Modifier.testTag("timer_dialog"),
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Timer, contentDescription = null) },
+        title = { Text("New Timer") },
+        text = {
+            Column {
+                TimerDurationPicker(
+                    hours = hours,
+                    minutes = minutes,
+                    seconds = seconds,
+                    onHoursChanged = { hours = it },
+                    onMinutesChanged = { minutes = it },
+                    onSecondsChanged = { seconds = it },
+                )
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("timer_label_input"),
+                    placeholder = { Text("Label (optional)") },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(durationMs, label.takeIf { it.isNotBlank() }) },
+                enabled = durationMs > 0,
+                modifier = Modifier.testTag("timer_start_button"),
+            ) {
+                Text("Start Timer")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -8,20 +8,12 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -32,13 +24,14 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -75,7 +68,6 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -85,19 +77,20 @@ fun SidePanelScreen(
 ) {
     val alarms by viewModel.alarms.collectAsStateWithLifecycle()
     val timers by viewModel.timers.collectAsStateWithLifecycle()
-    val filterType by viewModel.filterType.collectAsStateWithLifecycle()
+    val recentCompletedTimers by viewModel.recentCompletedTimers.collectAsStateWithLifecycle()
+    val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedIds by viewModel.selectedIds.collectAsStateWithLifecycle()
     val showBulkDeleteConfirmation by viewModel.showBulkDeleteConfirmation.collectAsStateWithLifecycle()
     var pendingDismiss by remember { mutableStateOf<ClockAlarm?>(null) }
     var pendingCancel by remember { mutableStateOf<ClockTimer?>(null) }
+    var pendingDeleteCompleted by remember { mutableStateOf<ClockTimer?>(null) }
+    var pendingClearCompleted by remember { mutableStateOf(false) }
     var editingAlarm by remember { mutableStateOf<ClockAlarm?>(null) }
     var showCreateAlarmDialog by remember { mutableStateOf(false) }
     var showCreateTimerDialog by remember { mutableStateOf(false) }
-    var fabExpanded by remember { mutableStateOf(false) }
     var schedulingError by remember { mutableStateOf<String?>(null) }
 
-    // Tick every second so countdown labels stay live
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
     LaunchedEffect(Unit) {
         while (true) {
@@ -110,9 +103,19 @@ fun SidePanelScreen(
         viewModel.clearSelection()
     }
 
-    val visibleTimers = if (filterType != AlarmTimerFilter.ALARMS) timers else emptyList()
-    val visibleAlarms = if (filterType != AlarmTimerFilter.TIMERS) alarms else emptyList()
-    val allVisibleIds = visibleTimers.map { it.id } + visibleAlarms.map { it.id }
+    val visibleSelectionIds = when (selectedTab) {
+        ClockSurfaceTab.TIMERS -> timers.map { it.id }
+        ClockSurfaceTab.ALARMS -> alarms.map { it.id }
+    }
+
+    fun onTimerScheduled(success: Boolean, closeDialog: Boolean = false) {
+        if (success) {
+            schedulingError = null
+            if (closeDialog) showCreateTimerDialog = false
+        } else {
+            schedulingError = "Couldn't schedule the timer."
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -120,7 +123,7 @@ fun SidePanelScreen(
                 TopAppBar(
                     title = {
                         val n = selectedIds.size
-                        Text("$n / ${allVisibleIds.size} ${if (n == 1) "item" else "items"} selected")
+                        Text("$n / ${visibleSelectionIds.size} ${if (n == 1) "item" else "items"} selected")
                     },
                     navigationIcon = {
                         IconButton(onClick = viewModel::clearSelection) {
@@ -128,7 +131,7 @@ fun SidePanelScreen(
                         }
                     },
                     actions = {
-                        TextButton(onClick = { viewModel.selectAll(allVisibleIds) }) {
+                        TextButton(onClick = { viewModel.selectAll(visibleSelectionIds) }) {
                             Text("Select All")
                         }
                         Button(
@@ -155,43 +158,12 @@ fun SidePanelScreen(
             }
         },
         floatingActionButton = {
-            if (!isInSelectionMode) {
-                Column(
-                    horizontalAlignment = Alignment.End,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    AnimatedVisibility(
-                        visible = fabExpanded,
-                        enter = fadeIn() + expandVertically(expandFrom = Alignment.Bottom),
-                        exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Bottom),
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.End,
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            ExtendedFloatingActionButton(
-                                text = { Text("New Alarm") },
-                                icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                                onClick = { fabExpanded = false; showCreateAlarmDialog = true },
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                            ExtendedFloatingActionButton(
-                                text = { Text("New Timer") },
-                                icon = { Icon(Icons.Default.Timer, contentDescription = null) },
-                                onClick = { fabExpanded = false; showCreateTimerDialog = true },
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                        }
-                    }
-                    FloatingActionButton(onClick = { fabExpanded = !fabExpanded }) {
-                        Icon(
-                            if (fabExpanded) Icons.Default.Close else Icons.Default.Add,
-                            contentDescription = if (fabExpanded) "Close" else "New alarm or timer",
-                        )
-                    }
-                }
+            if (!isInSelectionMode && selectedTab == ClockSurfaceTab.ALARMS) {
+                ExtendedFloatingActionButton(
+                    text = { Text("New Alarm") },
+                    icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                    onClick = { showCreateAlarmDialog = true },
+                )
             }
         },
     ) { innerPadding ->
@@ -200,119 +172,71 @@ fun SidePanelScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // Filter chips
-            LazyRow(
+            Row(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                item {
-                    FilterChip(
-                        selected = filterType == AlarmTimerFilter.ALL,
-                        onClick = { viewModel.setFilter(AlarmTimerFilter.ALL) },
-                        label = { Text("All") },
-                    )
-                }
-                item {
-                    FilterChip(
-                        selected = filterType == AlarmTimerFilter.TIMERS,
-                        onClick = { viewModel.setFilter(AlarmTimerFilter.TIMERS) },
-                        label = { Text("Timers") },
-                        leadingIcon = {
-                            Icon(Icons.Default.Timer, contentDescription = null)
-                        },
-                    )
-                }
-                item {
-                    FilterChip(
-                        selected = filterType == AlarmTimerFilter.ALARMS,
-                        onClick = { viewModel.setFilter(AlarmTimerFilter.ALARMS) },
-                        label = { Text("Alarms") },
-                        leadingIcon = {
-                            Icon(Icons.Default.Alarm, contentDescription = null)
-                        },
-                    )
-                }
+                FilterChip(
+                    selected = selectedTab == ClockSurfaceTab.TIMERS,
+                    onClick = { viewModel.setTab(ClockSurfaceTab.TIMERS) },
+                    label = { Text("Timers") },
+                    leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
+                )
+                FilterChip(
+                    selected = selectedTab == ClockSurfaceTab.ALARMS,
+                    onClick = { viewModel.setTab(ClockSurfaceTab.ALARMS) },
+                    label = { Text("Alarms") },
+                    leadingIcon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                )
             }
 
-            val hasContent = visibleTimers.isNotEmpty() || visibleAlarms.isNotEmpty()
-            if (!hasContent) {
-                Spacer(modifier = Modifier.height(32.dp))
-                Text(
-                    text = when (filterType) {
-                        AlarmTimerFilter.ALL -> "No active timers or alarms."
-                        AlarmTimerFilter.ALARMS -> "No active alarms."
-                        AlarmTimerFilter.TIMERS -> "No active timers."
+            when (selectedTab) {
+                ClockSurfaceTab.TIMERS -> TimerDashboard(
+                    timers = timers,
+                    recentCompletedTimers = recentCompletedTimers,
+                    nowMs = nowMs,
+                    inSelectionMode = isInSelectionMode,
+                    selectedIds = selectedIds,
+                    onCreateCustomTimer = { showCreateTimerDialog = true },
+                    onPresetTimer = { durationMs ->
+                        viewModel.scheduleTimer(durationMs, null) { success ->
+                            onTimerScheduled(success)
+                        }
                     },
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Ask Jandal to set a timer or alarm — they'll appear here while running.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                )
-            } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    if (visibleTimers.isNotEmpty()) {
-                        item { SectionHeader(title = "Timers") }
-                        items(visibleTimers, key = { it.id }) { timer ->
-                            TimerRow(
-                                timer = timer,
-                                nowMs = nowMs,
-                                inSelectionMode = isInSelectionMode,
-                                isSelected = timer.id in selectedIds,
-                                onTap = {
-                                    if (isInSelectionMode) {
-                                        viewModel.toggleSelection(timer.id)
-                                    } else {
-                                        pendingCancel = timer
-                                    }
-                                },
-                                onLongPress = {
-                                    if (!isInSelectionMode) viewModel.enterSelectionMode(timer.id)
-                                },
-                                onCancel = { pendingCancel = timer },
-                            )
-                            HorizontalDivider()
+                    onTimerTap = { timer ->
+                        if (isInSelectionMode) viewModel.toggleSelection(timer.id) else pendingCancel = timer
+                    },
+                    onTimerLongPress = { timer ->
+                        if (!isInSelectionMode) viewModel.enterSelectionMode(timer.id)
+                    },
+                    onCancelTimer = { timer -> pendingCancel = timer },
+                    onRestartTimer = { timer ->
+                        viewModel.restartTimer(timer) { success ->
+                            onTimerScheduled(success)
                         }
-                    }
+                    },
+                    onDeleteCompletedTimer = { timer -> pendingDeleteCompleted = timer },
+                    onClearCompletedTimers = { pendingClearCompleted = true },
+                )
 
-                    if (visibleAlarms.isNotEmpty()) {
-                        item {
-                            if (visibleTimers.isNotEmpty()) Spacer(modifier = Modifier.height(8.dp))
-                            SectionHeader(title = "Alarms")
+                ClockSurfaceTab.ALARMS -> AlarmDashboard(
+                    alarms = alarms,
+                    inSelectionMode = isInSelectionMode,
+                    selectedIds = selectedIds,
+                    onNewAlarm = { showCreateAlarmDialog = true },
+                    onAlarmTap = { alarm ->
+                        if (isInSelectionMode) viewModel.toggleSelection(alarm.id) else editingAlarm = alarm
+                    },
+                    onAlarmLongPress = { alarm ->
+                        if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
+                    },
+                    onDismissAlarm = { alarm -> pendingDismiss = alarm },
+                    onToggleAlarm = { alarm ->
+                        viewModel.toggleEnabled(alarm) { success ->
+                            if (!success) schedulingError = "Couldn't update the alarm."
                         }
-                        items(visibleAlarms, key = { it.id }) { alarm ->
-                            AlarmPanelRow(
-                                alarm = alarm,
-                                inSelectionMode = isInSelectionMode,
-                                isSelected = alarm.id in selectedIds,
-                                onTap = {
-                                    if (isInSelectionMode) {
-                                        viewModel.toggleSelection(alarm.id)
-                                    } else {
-                                        editingAlarm = alarm
-                                    }
-                                },
-                                onLongPress = {
-                                    if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
-                                },
-                                onDismiss = { pendingDismiss = alarm },
-                                onToggle = {
-                                    viewModel.toggleEnabled(alarm) { success ->
-                                        if (!success) {
-                                            schedulingError = "Couldn't update the alarm."
-                                        }
-                                    }
-                                },
-                            )
-                            HorizontalDivider()
-                        }
-                    }
-                }
+                    },
+                )
             }
         }
     }
@@ -322,7 +246,7 @@ fun SidePanelScreen(
             onDismissRequest = { pendingCancel = null },
             icon = { Icon(Icons.Default.Timer, contentDescription = null) },
             title = { Text("Cancel timer?") },
-            text = { Text("Cancel \"${timer.label ?: "Timer"}\"?") },
+            text = { Text("Cancel \"${timer.label ?: defaultTimerTitle(timer)}\"?") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.cancelTimer(timer)
@@ -331,6 +255,42 @@ fun SidePanelScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pendingCancel = null }) { Text("Keep") }
+            },
+        )
+    }
+
+    pendingDeleteCompleted?.let { timer ->
+        AlertDialog(
+            onDismissRequest = { pendingDeleteCompleted = null },
+            icon = { Icon(Icons.Default.Delete, contentDescription = null) },
+            title = { Text("Remove timer from history?") },
+            text = { Text("Remove \"${timer.label ?: defaultTimerTitle(timer)}\" from Recent & Completed?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteCompletedTimer(timer)
+                    pendingDeleteCompleted = null
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteCompleted = null }) { Text("Keep") }
+            },
+        )
+    }
+
+    if (pendingClearCompleted) {
+        AlertDialog(
+            onDismissRequest = { pendingClearCompleted = false },
+            icon = { Icon(Icons.Default.Delete, contentDescription = null) },
+            title = { Text("Clear completed timers?") },
+            text = { Text("Remove all completed timers from Recent & Completed?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.clearCompletedTimers()
+                    pendingClearCompleted = false
+                }) { Text("Clear") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingClearCompleted = false }) { Text("Cancel") }
             },
         )
     }
@@ -364,7 +324,7 @@ fun SidePanelScreen(
             onDismissRequest = viewModel::dismissBulkDeleteConfirmation,
             icon = { Icon(Icons.Default.Delete, contentDescription = null) },
             title = { Text("Delete $count ${if (count == 1) "item" else "items"}?") },
-            text = { Text("This will permanently cancel the selected timers and alarms.") },
+            text = { Text("This will permanently cancel the selected timers or alarms.") },
             confirmButton = {
                 TextButton(onClick = viewModel::deleteSelected) {
                     Text("Delete", color = MaterialTheme.colorScheme.error)
@@ -386,9 +346,7 @@ fun SidePanelScreen(
                             schedulingError = null
                             showCreateAlarmDialog = false
                         }
-                        AlarmSaveResult.FAILED -> {
-                            schedulingError = "Couldn't save the alarm."
-                        }
+                        AlarmSaveResult.FAILED -> schedulingError = "Couldn't save the alarm."
                     }
                 }
             },
@@ -406,9 +364,7 @@ fun SidePanelScreen(
                             schedulingError = null
                             editingAlarm = null
                         }
-                        AlarmSaveResult.FAILED -> {
-                            schedulingError = "Couldn't save the alarm."
-                        }
+                        AlarmSaveResult.FAILED -> schedulingError = "Couldn't save the alarm."
                     }
                 }
             },
@@ -420,12 +376,7 @@ fun SidePanelScreen(
         TimerCreateDialog(
             onConfirm = { durationMs, label ->
                 viewModel.scheduleTimer(durationMs, label) { success ->
-                    if (success) {
-                        schedulingError = null
-                        showCreateTimerDialog = false
-                    } else {
-                        schedulingError = "Couldn't schedule the timer."
-                    }
+                    onTimerScheduled(success, closeDialog = true)
                 }
             },
             onDismiss = { showCreateTimerDialog = false },
@@ -445,19 +396,179 @@ fun SidePanelScreen(
     }
 }
 
+private data class TimerPreset(
+    val label: String,
+    val durationMs: Long,
+)
+
+private val TIMER_PRESETS = listOf(
+    TimerPreset("1 min", 60_000L),
+    TimerPreset("5 min", 5 * 60_000L),
+    TimerPreset("10 min", 10 * 60_000L),
+    TimerPreset("15 min", 15 * 60_000L),
+)
+
 @Composable
-private fun SectionHeader(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-    )
+private fun SectionHeader(
+    title: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+    supportingText: String? = null,
+ ) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (supportingText != null) {
+                Text(
+                    text = supportingText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (actionLabel != null && onAction != null) {
+            TextButton(onClick = onAction) { Text(actionLabel) }
+        }
+    }
+}
+
+@Composable
+private fun TimerDashboard(
+    timers: List<ClockTimer>,
+    recentCompletedTimers: List<ClockTimer>,
+    nowMs: Long,
+    inSelectionMode: Boolean,
+    selectedIds: Set<String>,
+    onCreateCustomTimer: () -> Unit,
+    onPresetTimer: (Long) -> Unit,
+    onTimerTap: (ClockTimer) -> Unit,
+    onTimerLongPress: (ClockTimer) -> Unit,
+    onCancelTimer: (ClockTimer) -> Unit,
+    onRestartTimer: (ClockTimer) -> Unit,
+    onDeleteCompletedTimer: (ClockTimer) -> Unit,
+    onClearCompletedTimers: () -> Unit,
+ ) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        item {
+            TimerQuickStartCard(
+                onCreateCustomTimer = onCreateCustomTimer,
+                onPresetTimer = onPresetTimer,
+            )
+        }
+
+        item {
+            SectionHeader(
+                title = "Active timers",
+                supportingText = if (timers.isEmpty()) null else "${timers.size} running now",
+            )
+        }
+
+        if (timers.isEmpty()) {
+            item {
+                EmptyStateCard(
+                    title = "No active timers",
+                    body = "Start a preset or custom timer and it will appear here with live progress.",
+                )
+            }
+        } else {
+            items(timers, key = { it.id }) { timer ->
+                TimerCard(
+                    timer = timer,
+                    nowMs = nowMs,
+                    inSelectionMode = inSelectionMode,
+                    isSelected = timer.id in selectedIds,
+                    onTap = { onTimerTap(timer) },
+                    onLongPress = { onTimerLongPress(timer) },
+                    onCancel = { onCancelTimer(timer) },
+                )
+            }
+        }
+
+        if (recentCompletedTimers.isNotEmpty()) {
+            item {
+                SectionHeader(
+                    title = "Recent & Completed",
+                    supportingText = "Completed timers stay here until you restart or clear them.",
+                    actionLabel = "Clear all",
+                    onAction = onClearCompletedTimers,
+                )
+            }
+            items(recentCompletedTimers, key = { it.id }) { timer ->
+                CompletedTimerCard(
+                    timer = timer,
+                    onRestart = { onRestartTimer(timer) },
+                    onDelete = { onDeleteCompletedTimer(timer) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimerQuickStartCard(
+    onCreateCustomTimer: () -> Unit,
+    onPresetTimer: (Long) -> Unit,
+ ) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Timers", style = MaterialTheme.typography.headlineSmall)
+            Text(
+                text = "Start a timer fast, keep multiple timers running, and revisit finished timers without retyping durations.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TIMER_PRESETS.take(2).forEach { preset ->
+                    Button(
+                        onClick = { onPresetTimer(preset.durationMs) },
+                        modifier = Modifier.weight(1f),
+                    ) { Text(preset.label) }
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TIMER_PRESETS.drop(2).forEach { preset ->
+                    Button(
+                        onClick = { onPresetTimer(preset.durationMs) },
+                        modifier = Modifier.weight(1f),
+                    ) { Text(preset.label) }
+                }
+            }
+            Button(
+                onClick = onCreateCustomTimer,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+            ) {
+                Text("Custom timer")
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun TimerRow(
+private fun TimerCard(
     timer: ClockTimer,
     nowMs: Long,
     inSelectionMode: Boolean,
@@ -465,54 +576,210 @@ private fun TimerRow(
     onTap: () -> Unit,
     onLongPress: () -> Unit,
     onCancel: () -> Unit,
-) {
-    val startedAtMs = timer.startedAtMillis
-    val durationMs = timer.durationMs
-    val remainingMs = startedAtMs + durationMs - nowMs
-    val countdownText = if (remainingMs <= 0) {
-        "Time's up!"
-    } else {
-        val totalSeconds = remainingMs / 1_000
-        val hours = totalSeconds / 3600
-        val minutes = (totalSeconds % 3600) / 60
-        val seconds = totalSeconds % 60
-        if (hours > 0) "%d:%02d:%02d".format(hours, minutes, seconds)
-        else "%d:%02d".format(minutes, seconds)
-    }
+ ) {
+    val remainingMs = (timer.triggerAtMillis - nowMs).coerceAtLeast(0L)
+    val elapsedMs = (nowMs - timer.startedAtMillis).coerceAtLeast(0L)
+    val progress = if (timer.durationMs <= 0) 0f else (elapsedMs.toFloat() / timer.durationMs.toFloat()).coerceIn(0f, 1f)
 
-    ListItem(
+    ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
             .combinedClickable(onClick = onTap, onLongClick = onLongPress),
-        headlineContent = { Text(timer.label ?: "Timer") },
-        supportingContent = {
-            Text(
-                text = countdownText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (remainingMs <= 0) MaterialTheme.colorScheme.error
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-        leadingContent = {
-            if (inSelectionMode) {
-                Checkbox(checked = isSelected, onCheckedChange = { onTap() })
-            } else {
-                Icon(
-                    Icons.Default.Timer,
-                    contentDescription = null,
-                    tint = if (remainingMs <= 0) MaterialTheme.colorScheme.error
-                           else MaterialTheme.colorScheme.primary,
-                )
-            }
-        },
-        trailingContent = {
-            if (!inSelectionMode) {
-                IconButton(onClick = onCancel) {
-                    Icon(Icons.Default.Delete, contentDescription = "Cancel timer")
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (inSelectionMode) {
+                    Checkbox(checked = isSelected, onCheckedChange = { onTap() })
+                } else {
+                    Icon(Icons.Default.Timer, contentDescription = null)
+                }
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(timer.label ?: defaultTimerTitle(timer), style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        text = "${formatDuration(timer.durationMs)} total · ends ${formatClockTime(timer.triggerAtMillis)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                if (!inSelectionMode) {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.Default.Delete, contentDescription = "Cancel timer")
+                    }
                 }
             }
-        },
-    )
+
+            Text(formatCountdown(remainingMs), style = MaterialTheme.typography.headlineMedium)
+            LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+            Text(
+                text = if (remainingMs > 0) "${formatDuration(remainingMs)} remaining" else "Time's up!",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompletedTimerCard(
+    timer: ClockTimer,
+    onRestart: () -> Unit,
+    onDelete: () -> Unit,
+ ) {
+    val completedAt = timer.completedAtMillis ?: timer.triggerAtMillis
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(timer.label ?: defaultTimerTitle(timer), style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = "Completed ${formatRelativeTimestamp(completedAt)} · ${formatDuration(timer.durationMs)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = onRestart,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Restart") }
+                TextButton(
+                    onClick = onDelete,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Remove") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlarmDashboard(
+    alarms: List<ClockAlarm>,
+    inSelectionMode: Boolean,
+    selectedIds: Set<String>,
+    onNewAlarm: () -> Unit,
+    onAlarmTap: (ClockAlarm) -> Unit,
+    onAlarmLongPress: (ClockAlarm) -> Unit,
+    onDismissAlarm: (ClockAlarm) -> Unit,
+    onToggleAlarm: (ClockAlarm) -> Unit,
+ ) {
+    if (alarms.isEmpty()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            SectionHeader(title = "Alarms")
+            EmptyStateCard(
+                title = "No active alarms",
+                body = "Create an alarm and it will appear here for edit, toggle, and dismissal.",
+                actionLabel = "New alarm",
+                onAction = onNewAlarm,
+            )
+        }
+        return
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 24.dp)) {
+        item {
+            SectionHeader(
+                title = "Alarms",
+                supportingText = "${alarms.size} scheduled",
+            )
+        }
+        items(alarms, key = { it.id }) { alarm ->
+            AlarmPanelRow(
+                alarm = alarm,
+                inSelectionMode = inSelectionMode,
+                isSelected = alarm.id in selectedIds,
+                onTap = { onAlarmTap(alarm) },
+                onLongPress = { onAlarmLongPress(alarm) },
+                onDismiss = { onDismissAlarm(alarm) },
+                onToggle = { onToggleAlarm(alarm) },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun EmptyStateCard(
+    title: String,
+    body: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+ ) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (actionLabel != null && onAction != null) {
+                Button(onClick = onAction) { Text(actionLabel) }
+            }
+        }
+    }
+}
+
+private fun defaultTimerTitle(timer: ClockTimer): String =
+    formatDuration(timer.durationMs).removeSuffix(" remaining")
+
+private fun formatCountdown(remainingMs: Long): String {
+    val totalSeconds = remainingMs / 1_000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) "%d:%02d:%02d".format(hours, minutes, seconds)
+    else "%d:%02d".format(minutes, seconds)
+}
+
+private fun formatDuration(durationMs: Long): String {
+    val totalSeconds = (durationMs / 1_000).coerceAtLeast(0L)
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return when {
+        hours > 0L && seconds == 0L -> "%dh %02dm".format(hours, minutes)
+        hours > 0L -> "%dh %02dm %02ds".format(hours, minutes, seconds)
+        minutes > 0L && seconds == 0L -> "%dm".format(minutes)
+        minutes > 0L -> "%dm %02ds".format(minutes, seconds)
+        else -> "%ds".format(seconds)
+    }
+}
+
+private fun formatClockTime(epochMillis: Long): String =
+    DateTimeFormatter.ofPattern("h:mma")
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.ofEpochMilli(epochMillis))
+
+private fun formatRelativeTimestamp(epochMillis: Long, nowMillis: Long = System.currentTimeMillis()): String {
+    val deltaMs = (nowMillis - epochMillis).coerceAtLeast(0L)
+    val totalMinutes = deltaMs / 60_000L
+    return when {
+        totalMinutes <= 0L -> "just now"
+        totalMinutes < 60L -> "$totalMinutes min ago"
+        totalMinutes < 1_440L -> "${totalMinutes / 60L} hr ago"
+        else -> "${totalMinutes / 1_440L} day ago"
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Alarm
@@ -45,17 +49,18 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -63,6 +68,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockTimer
 import kotlinx.coroutines.delay
+import kotlin.math.abs
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -935,67 +941,248 @@ private fun AlarmCreateEditDialog(
     }
 }
 
+private const val TimerWheelVisibleItems = 5
+private const val TimerWheelCenterItem = TimerWheelVisibleItems / 2
+private const val TimerWheelRepeatCount = 100
+private val TimerHourRange = 0..99
+private val TimerMinuteSecondRange = 0..59
+private val TimerWheelItemHeight = 44.dp
+
 @Composable
 private fun TimerCreateDialog(
     onConfirm: (durationMs: Long, label: String?) -> Unit,
     onDismiss: () -> Unit,
-) {
+ ) {
+    var hours by remember { mutableIntStateOf(0) }
     var minutes by remember { mutableIntStateOf(5) }
     var seconds by remember { mutableIntStateOf(0) }
     var label by remember { mutableStateOf("") }
-    var minutesText by remember { mutableStateOf("5") }
-    var secondsText by remember { mutableStateOf("0") }
+    val durationMs = remember(hours, minutes, seconds) {
+        (((hours * 60L) + minutes) * 60L + seconds) * 1_000L
+    }
 
     AlertDialog(
+        modifier = Modifier.testTag("timer_dialog"),
         onDismissRequest = onDismiss,
         icon = { Icon(Icons.Default.Timer, contentDescription = null) },
         title = { Text("New Timer") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = minutesText,
-                        onValueChange = { v ->
-                            minutesText = v
-                            minutes = v.toIntOrNull()?.coerceIn(0, 999) ?: 0
-                        },
-                        modifier = Modifier.weight(1f),
-                        label = { Text("Minutes") },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(
-                            keyboardType = KeyboardType.Number,
-                        ),
-                    )
-                    OutlinedTextField(
-                        value = secondsText,
-                        onValueChange = { v ->
-                            secondsText = v
-                            seconds = v.toIntOrNull()?.coerceIn(0, 59) ?: 0
-                        },
-                        modifier = Modifier.weight(1f),
-                        label = { Text("Seconds") },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(
-                            keyboardType = KeyboardType.Number,
-                        ),
-                    )
-                }
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = "Spin to set hours, minutes, and seconds.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                TimerDurationPicker(
+                    hours = hours,
+                    minutes = minutes,
+                    seconds = seconds,
+                    onHoursChanged = { hours = it },
+                    onMinutesChanged = { minutes = it },
+                    onSecondsChanged = { seconds = it },
+                )
+                Text(
+                    text = "Selected duration: ${formatDuration(durationMs)}",
+                    style = MaterialTheme.typography.titleSmall,
+                )
                 OutlinedTextField(
                     value = label,
                     onValueChange = { label = it },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("timer_label_input"),
                     placeholder = { Text("Label (optional)") },
                     singleLine = true,
                 )
             }
         },
         confirmButton = {
-            val durationMs = (minutes * 60L + seconds) * 1_000L
             TextButton(
                 onClick = { onConfirm(durationMs, label.takeIf { it.isNotBlank() }) },
                 enabled = durationMs > 0,
+                modifier = Modifier.testTag("timer_start_button"),
             ) { Text("Start Timer") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
+}
+
+@Composable
+internal fun TimerDurationPicker(
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+    onHoursChanged: (Int) -> Unit,
+    onMinutesChanged: (Int) -> Unit,
+    onSecondsChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+ ) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TimerUnitWheel(
+            label = "Hours",
+            value = hours,
+            range = TimerHourRange,
+            onValueChange = onHoursChanged,
+            modifier = Modifier.weight(1f),
+            testTag = "timer_hours_picker",
+        )
+        Text(
+	        text = ":",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TimerUnitWheel(
+            label = "Minutes",
+            value = minutes,
+            range = TimerMinuteSecondRange,
+            onValueChange = onMinutesChanged,
+            modifier = Modifier.weight(1f),
+            testTag = "timer_minutes_picker",
+        )
+        Text(
+            text = ":",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TimerUnitWheel(
+            label = "Seconds",
+            value = seconds,
+            range = TimerMinuteSecondRange,
+            onValueChange = onSecondsChanged,
+            modifier = Modifier.weight(1f),
+            testTag = "timer_seconds_picker",
+        )
+    }
+}
+
+@Composable
+private fun TimerUnitWheel(
+    label: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    testTag: String,
+ ) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TimerNumberWheel(
+            value = value,
+            range = range,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            formatValue = { "%02d".format(it) },
+            testTag = testTag,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun TimerNumberWheel(
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    formatValue: (Int) -> String,
+    testTag: String,
+ ) {
+    val values = remember(range.first, range.last) { range.toList() }
+    val repeatedItemCount = remember(values) { values.size * TimerWheelRepeatCount }
+    val middleRepeatStart = remember(values) { values.size * (TimerWheelRepeatCount / 2) }
+    val initialCenteredIndex = remember(value, values) {
+        middleRepeatStart + (value - range.first)
+    }
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = (initialCenteredIndex - TimerWheelCenterItem).coerceAtLeast(0),
+    )
+    val selectedIndex by remember(listState) {
+        derivedStateOf { centeredTimerWheelIndex(listState) }
+    }
+
+    LaunchedEffect(listState, values) {
+        snapshotFlow { centeredTimerWheelIndex(listState) }
+            .collect { centeredIndex ->
+                if (centeredIndex != null) {
+                    onValueChange(values[centeredIndex % values.size])
+                }
+            }
+    }
+
+    LaunchedEffect(value, values) {
+        val centeredIndex = centeredTimerWheelIndex(listState) ?: return@LaunchedEffect
+        val centeredValue = values[centeredIndex % values.size]
+        if (centeredValue != value) {
+            val targetCenteredIndex = middleRepeatStart + (value - range.first)
+            listState.scrollToItem((targetCenteredIndex - TimerWheelCenterItem).coerceAtLeast(0))
+        }
+    }
+
+    Box(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
+                .height(TimerWheelItemHeight)
+                .background(
+                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.45f),
+                ),
+        )
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(TimerWheelItemHeight * TimerWheelVisibleItems)
+                .testTag(testTag),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            contentPadding = PaddingValues(vertical = TimerWheelItemHeight * TimerWheelCenterItem),
+            flingBehavior = rememberSnapFlingBehavior(lazyListState = listState),
+        ) {
+            items(count = repeatedItemCount, key = { it }) { index ->
+                val wheelValue = values[index % values.size]
+                val isSelected = index == selectedIndex
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(TimerWheelItemHeight),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = formatValue(wheelValue),
+                        style = if (isSelected) {
+                            MaterialTheme.typography.titleLarge
+                        } else {
+                            MaterialTheme.typography.titleMedium
+                        },
+                        color = if (isSelected) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.alpha(if (isSelected) 1f else 0.55f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun centeredTimerWheelIndex(listState: LazyListState): Int? {
+    val layoutInfo = listState.layoutInfo
+    val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2
+    return layoutInfo.visibleItemsInfo.minByOrNull { item ->
+        abs((item.offset + item.size / 2) - viewportCenter)
+    }?.index
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -15,13 +15,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-enum class AlarmTimerFilter { ALL, ALARMS, TIMERS }
+enum class ClockSurfaceTab { TIMERS, ALARMS }
 
 @HiltViewModel
 class SidePanelViewModel @Inject constructor(
     private val clockRepository: ClockRepository,
-) : ViewModel() {
-
+ ) : ViewModel() {
     val alarms: StateFlow<List<ClockAlarm>> =
         clockRepository.observeManageableAlarms()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -30,9 +29,12 @@ class SidePanelViewModel @Inject constructor(
         clockRepository.observeActiveTimers()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    private val _filterType = MutableStateFlow(AlarmTimerFilter.ALL)
-    val filterType: StateFlow<AlarmTimerFilter> = _filterType.asStateFlow()
+    val recentCompletedTimers: StateFlow<List<ClockTimer>> =
+        clockRepository.observeRecentCompletedTimers()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    private val _selectedTab = MutableStateFlow(ClockSurfaceTab.TIMERS)
+    val selectedTab: StateFlow<ClockSurfaceTab> = _selectedTab.asStateFlow()
     private val _isInSelectionMode = MutableStateFlow(false)
     val isInSelectionMode: StateFlow<Boolean> = _isInSelectionMode.asStateFlow()
 
@@ -42,8 +44,8 @@ class SidePanelViewModel @Inject constructor(
     private val _showBulkDeleteConfirmation = MutableStateFlow(false)
     val showBulkDeleteConfirmation: StateFlow<Boolean> = _showBulkDeleteConfirmation.asStateFlow()
 
-    fun setFilter(filter: AlarmTimerFilter) {
-        _filterType.value = filter
+    fun setTab(tab: ClockSurfaceTab) {
+        _selectedTab.value = tab
         clearSelection()
     }
 
@@ -109,6 +111,24 @@ class SidePanelViewModel @Inject constructor(
     fun cancelTimer(timer: ClockTimer) {
         viewModelScope.launch {
             clockRepository.cancelTimer(timer.id)
+        }
+    }
+
+    fun restartTimer(timer: ClockTimer, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(tryScheduleTimer(timer.durationMs, timer.label))
+        }
+    }
+
+    fun deleteCompletedTimer(timer: ClockTimer) {
+        viewModelScope.launch {
+            clockRepository.deleteCompletedTimer(timer.id)
+        }
+    }
+
+    fun clearCompletedTimers(onResult: (Int) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(clockRepository.clearCompletedTimers())
         }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -4,6 +4,7 @@ import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -26,6 +27,9 @@ class SidePanelViewModelTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
+        every { clockRepository.observeActiveTimers() } returns emptyFlow()
+        every { clockRepository.observeRecentCompletedTimers() } returns emptyFlow()
     }
 
     @AfterEach
@@ -35,8 +39,6 @@ class SidePanelViewModelTest {
 
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
-        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
-        every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
         val viewModel = SidePanelViewModel(clockRepository)
 
@@ -47,8 +49,6 @@ class SidePanelViewModelTest {
 
     @Test
     fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
-        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
-        every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.scheduleAlarm(any(), any()) } returns null
         val viewModel = SidePanelViewModel(clockRepository)
         var result: AlarmSaveResult? = null
@@ -61,8 +61,6 @@ class SidePanelViewModelTest {
 
     @Test
     fun `scheduleTimer returns true when repository accepts timer`() = runTest {
-        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
-        every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.scheduleTimer(any(), any()) } returns ClockTimer(
             id = "timer-1",
             triggerAtMillis = 5_000L,
@@ -79,6 +77,41 @@ class SidePanelViewModelTest {
     }
 
     @Test
+    fun `restartTimer reuses timer duration and label`() = runTest {
+        val timer = ClockTimer(
+            id = "timer-1",
+            triggerAtMillis = 5_000L,
+            label = "Tea",
+            createdAtMillis = 1_000L,
+            durationMs = 60_000L,
+            startedAtMillis = 2_000L,
+            completedAtMillis = 5_000L,
+        )
+        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns timer
+        val viewModel = SidePanelViewModel(clockRepository)
+        var success: Boolean? = null
+
+        viewModel.restartTimer(timer) { success = it }
+        advanceUntilIdle()
+
+        assertEquals(true, success)
+        coVerify(exactly = 1) { clockRepository.scheduleTimer(60_000L, "Tea") }
+    }
+
+    @Test
+    fun `clearCompletedTimers reports deleted count`() = runTest {
+        coEvery { clockRepository.clearCompletedTimers() } returns 3
+        val viewModel = SidePanelViewModel(clockRepository)
+        var deleted: Int? = null
+
+        viewModel.clearCompletedTimers { deleted = it }
+        advanceUntilIdle()
+
+        assertEquals(3, deleted)
+        coVerify(exactly = 1) { clockRepository.clearCompletedTimers() }
+    }
+
+    @Test
     fun `editAlarm returns false when repository rejects update`() = runTest {
         val alarm = ClockAlarm(
             id = "alarm-1",
@@ -87,8 +120,6 @@ class SidePanelViewModelTest {
             createdAtMillis = 100L,
             enabled = true,
         )
-        every { clockRepository.observeManageableAlarms() } returns emptyFlow()
-        every { clockRepository.observeActiveTimers() } returns emptyFlow()
         coEvery { clockRepository.editAlarm(alarm.id, any(), any()) } returns null
         val viewModel = SidePanelViewModel(clockRepository)
 


### PR DESCRIPTION
## Summary
- persist completed timer history in the internal clock store instead of dropping fired timers immediately
- redesign **Timers & Alarms** into dedicated Timers and Alarms surfaces, with rich timer cards, preset starts, and Recent & Completed actions
- add timer UX view-model/repository coverage for restart and completed-history flows

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :feature:settings:testDebugUnitTest --tests "*SidePanelViewModelTest" :feature:settings:compileDebugKotlin`
- `./gradlew :app:compileDebugKotlin`

## Manual device tests
1. Install and open the debug build:
   - `./gradlew installDebug`
2. Timer presets and custom creation:
   - open **Timers & Alarms**
   - verify the default surface opens on **Timers**
   - start timers from multiple presets and from **Custom timer**
   - verify each active timer appears as a rich card with live countdown/progress
3. Multi-timer behavior:
   - start at least two timers with different durations
   - verify both remain visible and independently update
   - cancel one timer from its card and verify only that timer disappears and its countdown notification is canceled
4. Completed timer history:
   - let a short timer finish
   - verify it moves from **Active timers** into **Recent & Completed**
   - tap **Restart** and verify a new active timer starts with the same duration/label
   - tap **Remove** and verify the completed-history entry disappears
   - let multiple timers complete, tap **Clear all**, and verify history clears
5. Alarms tab regression smoke test:
   - switch to **Alarms**
   - create, edit, toggle, and dismiss an alarm
   - verify existing alarm management still works

Closes #737
