### PR TITLE
feat(#742): ship world clock tab

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -144,7 +144,7 @@ fun KernelNavHost(
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
                 )
                 NavigationDrawerItem(
-                    label = { Text("Timers & Alarms") },
+                    label = { Text("Clock") },
                     icon = { Icon(Icons.Default.Timer, contentDescription = null) },
                     selected = currentBaseRoute == ROUTE_SIDE_PANEL,
                     onClick = {
@@ -440,7 +440,7 @@ fun KernelNavHost(
                 }
 
                 composable(ROUTE_SCHEDULED_ALARMS) {
-                    // Redirected to the unified Timers & Alarms screen (#574)
+                    // Redirected to the unified Clock screen (#574 / #742)
                     SidePanelScreen(
                         onBack = { navController.popBackStack() },
                     )

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/27.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/27.json
@@ -1,0 +1,899 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 27,
+    "identityHash": "c6562d366172d8cca055d189e9269f27",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c6562d366172d8cca055d189e9269f27')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -17,6 +17,7 @@ import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.KiwiMemoryEntity
@@ -30,6 +31,7 @@ import com.kernel.ai.core.memory.entity.MessageEntity
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.entity.QuickActionEntity
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.WorldClockEntity
 import com.kernel.ai.core.memory.entity.UserProfileEntity
 import java.time.ZoneId
 
@@ -45,11 +47,12 @@ import java.time.ZoneId
         ModelSettingsEntity::class,
         QuickActionEntity::class,
         ScheduledAlarmEntity::class,
+        WorldClockEntity::class,
         ContactAliasEntity::class,
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 26,
+    version = 27,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -65,6 +68,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun modelSettingsDao(): ModelSettingsDao
     abstract fun quickActionDao(): QuickActionDao
     abstract fun scheduledAlarmDao(): ScheduledAlarmDao
+    abstract fun worldClockDao(): WorldClockDao
     abstract fun contactAliasDao(): ContactAliasDao
     abstract fun listItemDao(): ListItemDao
     abstract fun listNameDao(): ListNameDao
@@ -308,6 +312,25 @@ abstract class KernelDatabase : RoomDatabase() {
                     WHERE entry_type = 'ALARM'
                     """.trimIndent(),
                 )
+            }
+        }
+
+        /** Creates world_clocks for first-class world clock favorites (#742). */
+        val MIGRATION_26_27 = object : Migration(26, 27) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `world_clocks` (
+                        `id` TEXT NOT NULL,
+                        `zone_id` TEXT NOT NULL,
+                        `display_name` TEXT NOT NULL,
+                        `sort_order` INTEGER NOT NULL,
+                        `created_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `world_clocks` (`zone_id`)")
             }
         }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -14,6 +14,7 @@ import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockRepositoryImpl
@@ -80,6 +81,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_23_24,
                     KernelDatabase.MIGRATION_24_25,
                     KernelDatabase.MIGRATION_25_26,
+                    KernelDatabase.MIGRATION_26_27,
                 )
                 .build()
 
@@ -109,6 +111,9 @@ abstract class MemoryModule {
 
         @Provides
         fun provideScheduledAlarmDao(db: KernelDatabase): ScheduledAlarmDao = db.scheduledAlarmDao()
+
+        @Provides
+        fun provideWorldClockDao(db: KernelDatabase): WorldClockDao = db.worldClockDao()
 
         @Provides
         fun provideContactAliasDao(db: KernelDatabase): ContactAliasDao = db.contactAliasDao()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -53,6 +53,14 @@ data class ClockTimer(
     val completedAtMillis: Long? = null,
  )
 
+data class WorldClock(
+    val id: String,
+    val zoneId: String,
+    val displayName: String,
+    val sortOrder: Int,
+    val createdAtMillis: Long,
+ )
+
 data class ClockScheduledEvent(
     val eventId: String,
     val ownerId: String,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -8,6 +8,11 @@ interface ClockRepository {
     fun observeUpcomingAlarms(): Flow<List<ClockAlarm>>
     fun observeActiveTimers(): Flow<List<ClockTimer>>
     fun observeRecentCompletedTimers(): Flow<List<ClockTimer>>
+    fun observeWorldClocks(): Flow<List<WorldClock>>
+
+    suspend fun addWorldClock(zoneId: String, displayName: String): WorldClock?
+    suspend fun removeWorldClock(worldClockId: String): Boolean
+    suspend fun reorderWorldClocks(orderedIds: List<String>): Boolean
 
     fun getPlatformState(): ClockPlatformState
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.kernel.ai.core.memory.clock
 
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.WorldClockEntity
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -21,6 +23,7 @@ private const val PRE_ALARM_EVENT_SUFFIX = ":pre"
 @Singleton
 class ClockRepositoryImpl @Inject constructor(
     private val scheduledAlarmDao: ScheduledAlarmDao,
+    private val worldClockDao: WorldClockDao,
     private val scheduler: ClockScheduler,
  ) : ClockRepository {
     override fun observeManageableAlarms(): Flow<List<ClockAlarm>> =
@@ -51,6 +54,49 @@ class ClockRepositoryImpl @Inject constructor(
         scheduledAlarmDao.observeRecentCompletedTimers().map { schedules ->
             schedules.mapNotNull { it.toClockTimer() }
         }
+
+    override fun observeWorldClocks(): Flow<List<WorldClock>> =
+        worldClockDao.observeAll().map { clocks ->
+            clocks.map { it.toWorldClock() }
+        }
+
+
+    override suspend fun addWorldClock(zoneId: String, displayName: String): WorldClock? {
+        worldClockDao.getByZoneId(zoneId)?.let { return it.toWorldClock() }
+        val entity = WorldClockEntity(
+            id = UUID.randomUUID().toString(),
+            zoneId = zoneId,
+            displayName = displayName,
+            sortOrder = (worldClockDao.getMaxSortOrder() ?: -1) + 1,
+            createdAt = System.currentTimeMillis(),
+        )
+        return try {
+            worldClockDao.insert(entity)
+            entity.toWorldClock()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override suspend fun removeWorldClock(worldClockId: String): Boolean =
+        worldClockDao.delete(worldClockId) > 0
+
+    override suspend fun reorderWorldClocks(orderedIds: List<String>): Boolean {
+        val existing = worldClockDao.getAll()
+        val byId = existing.associateBy { it.id }
+        if (existing.isEmpty()) return orderedIds.isEmpty()
+        if (orderedIds.size != existing.size || orderedIds.toSet() != byId.keys) return false
+        return try {
+            worldClockDao.updateAll(
+                orderedIds.mapIndexed { index, id ->
+                    byId.getValue(id).copy(sortOrder = index)
+                },
+            )
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
 
     override fun getPlatformState(): ClockPlatformState = scheduler.getPlatformState()
 
@@ -390,6 +436,15 @@ class ClockRepositoryImpl @Inject constructor(
 private fun ScheduledAlarmEntity.withDefaultOwnerId(): ScheduledAlarmEntity =
     if (ownerId.isNullOrBlank()) copy(ownerId = id) else this
 
+
+private fun WorldClockEntity.toWorldClock(): WorldClock =
+    WorldClock(
+        id = id,
+        zoneId = zoneId,
+        displayName = displayName,
+        sortOrder = sortOrder,
+        createdAtMillis = createdAt,
+    )
 private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm? {
     if (entryType != ClockEventType.ALARM.name) return null
     val zoneId = ZoneId.of(timeZoneId ?: ZoneId.systemDefault().id)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/WorldClockCatalog.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/WorldClockCatalog.kt
@@ -1,0 +1,142 @@
+package com.kernel.ai.core.memory.clock
+
+import java.time.ZoneId
+import java.util.Locale
+
+data class WorldClockCandidate(
+    val zoneId: String,
+    val displayName: String,
+    val subtitle: String,
+)
+
+sealed interface WorldClockResolution {
+    data class Resolved(val candidate: WorldClockCandidate) : WorldClockResolution
+    data class Ambiguous(val options: List<WorldClockCandidate>) : WorldClockResolution
+    data object Unknown : WorldClockResolution
+}
+
+object WorldClockCatalog {
+    private val aliasMap = mapOf(
+        "jst" to "Asia/Tokyo",
+        "utc" to "UTC",
+        "gmt" to "Etc/GMT",
+    )
+
+    private val popularZoneIds = listOf(
+        "UTC",
+        "Europe/London",
+        "America/New_York",
+        "America/Los_Angeles",
+        "Europe/Paris",
+        "Asia/Tokyo",
+        "Australia/Sydney",
+        "Pacific/Auckland",
+        "Asia/Singapore",
+        "Asia/Dubai",
+    )
+
+    private data class IndexedCandidate(
+        val candidate: WorldClockCandidate,
+        val exactTerms: Set<String>,
+        val fuzzyText: String,
+    )
+
+    private val indexedCandidates: List<IndexedCandidate> by lazy {
+        ZoneId.getAvailableZoneIds()
+            .asSequence()
+            .map { zoneId ->
+                val candidate = WorldClockCandidate(
+                    zoneId = zoneId,
+                    displayName = zoneDisplayName(zoneId),
+                    subtitle = zoneId.replace('_', ' '),
+                )
+                IndexedCandidate(
+                    candidate = candidate,
+                    exactTerms = buildSet {
+                        add(normalize(zoneId))
+                        add(normalize(candidate.displayName))
+                        zoneId.split('/', '_').forEach { part ->
+                            val normalized = normalize(part)
+                            if (normalized.isNotBlank()) add(normalized)
+                        }
+                        aliasMap.forEach { (alias, mappedZoneId) ->
+                            if (mappedZoneId == zoneId) add(alias)
+                        }
+                    },
+                    fuzzyText = normalize("${candidate.displayName} ${candidate.subtitle}"),
+                )
+            }
+            .sortedWith(compareBy<IndexedCandidate> { it.candidate.displayName }.thenBy { it.candidate.zoneId })
+            .toList()
+    }
+
+    private val candidateByZoneId: Map<String, WorldClockCandidate> by lazy {
+        indexedCandidates.associate { it.candidate.zoneId to it.candidate }
+    }
+
+    fun search(query: String, limit: Int = 12): List<WorldClockCandidate> {
+        val normalized = normalize(query)
+        if (normalized.isBlank()) {
+            return popularZoneIds.mapNotNull(candidateByZoneId::get)
+        }
+
+        val exact = indexedCandidates.filter { normalized in it.exactTerms }
+        if (exact.isNotEmpty()) return exact.take(limit).map { it.candidate }
+
+        val prefix = indexedCandidates.filter {
+            it.candidate.displayName.startsWith(query.trim(), ignoreCase = true) ||
+                it.candidate.zoneId.startsWith(query.trim(), ignoreCase = true) ||
+                it.exactTerms.any { term -> term.startsWith(normalized) }
+        }
+        if (prefix.isNotEmpty()) return prefix.take(limit).map { it.candidate }
+
+        return indexedCandidates
+            .asSequence()
+            .filter { normalized in it.fuzzyText }
+            .take(limit)
+            .map { it.candidate }
+            .toList()
+    }
+
+    fun resolve(query: String): WorldClockResolution {
+        val normalized = normalize(query)
+        if (normalized.isBlank()) return WorldClockResolution.Unknown
+
+        aliasMap[normalized]?.let { zoneId ->
+            candidateByZoneId[zoneId]?.let { return WorldClockResolution.Resolved(it) }
+        }
+
+        val exact = indexedCandidates.filter { normalized in it.exactTerms }
+        if (exact.size == 1) return WorldClockResolution.Resolved(exact.single().candidate)
+        if (exact.size > 1) return WorldClockResolution.Ambiguous(exact.take(5).map { it.candidate })
+
+        val prefix = indexedCandidates.filter {
+            it.candidate.displayName.startsWith(query.trim(), ignoreCase = true) ||
+                it.candidate.zoneId.startsWith(query.trim(), ignoreCase = true)
+        }
+        if (prefix.size == 1) return WorldClockResolution.Resolved(prefix.single().candidate)
+        if (prefix.size > 1) return WorldClockResolution.Ambiguous(prefix.take(5).map { it.candidate })
+
+        val contains = indexedCandidates.filter { normalized in it.fuzzyText }
+        if (contains.size == 1) return WorldClockResolution.Resolved(contains.single().candidate)
+        if (contains.size > 1) return WorldClockResolution.Ambiguous(contains.take(5).map { it.candidate })
+
+        return WorldClockResolution.Unknown
+    }
+
+    private fun zoneDisplayName(zoneId: String): String {
+        if ('/' !in zoneId) return zoneId.replace('_', ' ')
+        val parts = zoneId.split('/')
+        val city = parts.last().replace('_', ' ')
+        val qualifiers = parts.drop(1).dropLast(1).joinToString(" / ") { it.replace('_', ' ') }
+        return if (qualifiers.isBlank()) city else "$city ($qualifiers)"
+    }
+
+    private fun normalize(value: String): String =
+        value.lowercase(Locale.ROOT)
+            .replace('_', ' ')
+            .replace('/', ' ')
+            .replace(Regex("[^a-z0-9+ -]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/WorldClockCatalog.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/WorldClockCatalog.kt
@@ -20,6 +20,7 @@ object WorldClockCatalog {
         "jst" to "Asia/Tokyo",
         "utc" to "UTC",
         "gmt" to "Etc/GMT",
+        "ottawa" to "America/Toronto",
     )
 
     private val popularZoneIds = listOf(

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/WorldClockDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/WorldClockDao.kt
@@ -1,0 +1,36 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.kernel.ai.core.memory.entity.WorldClockEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WorldClockDao {
+    @Query("SELECT * FROM world_clocks ORDER BY sort_order ASC, created_at ASC")
+    fun observeAll(): Flow<List<WorldClockEntity>>
+
+    @Query("SELECT * FROM world_clocks ORDER BY sort_order ASC, created_at ASC")
+    suspend fun getAll(): List<WorldClockEntity>
+
+    @Query("SELECT * FROM world_clocks WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): WorldClockEntity?
+
+    @Query("SELECT * FROM world_clocks WHERE zone_id = :zoneId LIMIT 1")
+    suspend fun getByZoneId(zoneId: String): WorldClockEntity?
+
+    @Query("SELECT MAX(sort_order) FROM world_clocks")
+    suspend fun getMaxSortOrder(): Int?
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(entity: WorldClockEntity)
+
+    @Update
+    suspend fun updateAll(entities: List<WorldClockEntity>)
+
+    @Query("DELETE FROM world_clocks WHERE id = :id")
+    suspend fun delete(id: String): Int
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/WorldClockEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/WorldClockEntity.kt
@@ -1,0 +1,18 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "world_clocks",
+    indices = [Index(value = ["zone_id"], unique = true)],
+)
+data class WorldClockEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo(name = "zone_id") val zoneId: String,
+    @ColumnInfo(name = "display_name") val displayName: String,
+    @ColumnInfo(name = "sort_order") val sortOrder: Int,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -1,7 +1,9 @@
 package com.kernel.ai.core.memory.clock
 
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.WorldClockEntity
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -28,12 +30,13 @@ import java.time.ZoneId
 class ClockRepositoryImplTest {
     private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
     private val scheduler = mockk<ClockScheduler>(relaxed = true)
+    private val worldClockDao = mockk<WorldClockDao>()
 
     private lateinit var repository: ClockRepositoryImpl
 
     @BeforeEach
     fun setUp() {
-        repository = ClockRepositoryImpl(scheduledAlarmDao, scheduler)
+        repository = ClockRepositoryImpl(scheduledAlarmDao, worldClockDao, scheduler)
         every {
             scheduler.getPlatformState()
         } returns ClockPlatformState(
@@ -241,6 +244,42 @@ class ClockRepositoryImplTest {
 
         assertEquals(2, deleted)
         coVerify(exactly = 1) { scheduledAlarmDao.deleteCompletedTimers() }
+    }
+
+    @Test
+    fun `addWorldClock inserts ordered favorite and returns model`() = runTest {
+        coEvery { worldClockDao.getByZoneId("Europe/London") } returns null
+        coEvery { worldClockDao.getMaxSortOrder() } returns 2
+        coEvery { worldClockDao.insert(any()) } just Runs
+
+        val result = repository.addWorldClock("Europe/London", "London")
+
+        assertEquals("London", result?.displayName)
+        coVerify(exactly = 1) {
+            worldClockDao.insert(match {
+                it.zoneId == "Europe/London" &&
+                    it.displayName == "London" &&
+                    it.sortOrder == 3
+            })
+        }
+    }
+
+    @Test
+    fun `reorderWorldClocks rewrites sort order in requested order`() = runTest {
+        val first = WorldClockEntity("1", "Europe/London", "London", 0, 1_000L)
+        val second = WorldClockEntity("2", "Asia/Tokyo", "Tokyo", 1, 2_000L)
+        coEvery { worldClockDao.getAll() } returns listOf(first, second)
+        coEvery { worldClockDao.updateAll(any()) } just Runs
+
+        val reordered = repository.reorderWorldClocks(listOf("2", "1"))
+
+        assertTrue(reordered)
+        coVerify(exactly = 1) {
+            worldClockDao.updateAll(match { entities ->
+                entities[0].id == "2" && entities[0].sortOrder == 0 &&
+                    entities[1].id == "1" && entities[1].sortOrder == 1
+            })
+        }
     }
 
     private fun dailyDraft(label: String, hour: Int, minute: Int) = AlarmDraft(

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/WorldClockCatalogTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/WorldClockCatalogTest.kt
@@ -1,0 +1,28 @@
+package com.kernel.ai.core.memory.clock
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WorldClockCatalogTest {
+    @Test
+    fun `resolve handles city example from issue`() {
+        val resolution = WorldClockCatalog.resolve("London")
+        assertTrue(resolution is WorldClockResolution.Resolved)
+        assertEquals("Europe/London", (resolution as WorldClockResolution.Resolved).candidate.zoneId)
+    }
+
+    @Test
+    fun `resolve handles unambiguous timezone abbreviation`() {
+        val resolution = WorldClockCatalog.resolve("JST")
+        assertTrue(resolution is WorldClockResolution.Resolved)
+        assertEquals("Asia/Tokyo", (resolution as WorldClockResolution.Resolved).candidate.zoneId)
+    }
+
+    @Test
+    fun `search returns popular clocks when blank`() {
+        val results = WorldClockCatalog.search("")
+        assertTrue(results.isNotEmpty())
+        assertTrue(results.any { it.zoneId == "Pacific/Auckland" })
+    }
+}

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/WorldClockCatalogTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/WorldClockCatalogTest.kt
@@ -20,6 +20,13 @@ class WorldClockCatalogTest {
     }
 
     @Test
+    fun `resolve handles ottawa city alias`() {
+        val resolution = WorldClockCatalog.resolve("Ottawa")
+        assertTrue(resolution is WorldClockResolution.Resolved)
+        assertEquals("America/Toronto", (resolution as WorldClockResolution.Resolved).candidate.zoneId)
+    }
+
+    @Test
     fun `search returns popular clocks when blank`() {
         val results = WorldClockCatalog.search("")
         assertTrue(results.isNotEmpty())

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -740,6 +740,42 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_time",
             regex = Regex(
+                """what\s+time\s+is\s+it\s+in\s+(.+?)\s*[?!.]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                parseWorldTimeLocation(match.groupValues[1])?.let { location ->
+                    mapOf("query_type" to "time", "location" to location)
+                } ?: mapOf("query_type" to "time")
+            },
+        ),
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?time\s+in\s+(.+?)\s*[?!.]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                parseWorldTimeLocation(match.groupValues[1])?.let { location ->
+                    mapOf("query_type" to "time", "location" to location)
+                } ?: mapOf("query_type" to "time")
+            },
+        ),
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
+                """(?:current\s+)?time\s+in\s+(.+?)\s*[?!.]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                parseWorldTimeLocation(match.groupValues[1])?.let { location ->
+                    mapOf("query_type" to "time", "location" to location)
+                } ?: mapOf("query_type" to "time")
+            },
+        ),
+        IntentPattern(
+            intentName = "get_time",
+            regex = Regex(
                 """what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(time|date|day)""",
                 RegexOption.IGNORE_CASE,
             ),
@@ -2900,6 +2936,13 @@ class QuickIntentRouter(
             "sun" -> "sunday"
             else -> day
         }
+
+        private fun parseWorldTimeLocation(raw: String): String? =
+            raw
+                .replace(Regex("""\b(right\s+now|currently|now)\b""", RegexOption.IGNORE_CASE), "")
+                .replace(Regex("""[?!.]+$"""), "")
+                .trim()
+                .takeIf { it.isNotBlank() }
 
         // ── Public surface for tests and callers ─────────────────────────────
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -21,6 +21,8 @@ import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
+import com.kernel.ai.core.memory.clock.WorldClockCatalog
+import com.kernel.ai.core.memory.clock.WorldClockResolution
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -555,6 +557,35 @@ class NativeIntentHandler @Inject constructor(
     // ── Time / Date ───────────────────────────────────────────────────────────
 
     private fun getTime(params: Map<String, String> = emptyMap()): SkillResult {
+        val location = params["location"]?.trim()?.takeIf { it.isNotBlank() }
+        if (location != null) {
+            return when (val resolution = WorldClockCatalog.resolve(location)) {
+                is WorldClockResolution.Resolved -> {
+                    val zonedNow = Instant.ofEpochMilli(System.currentTimeMillis())
+                        .atZone(ZoneId.of(resolution.candidate.zoneId))
+                    when (params["query_type"]) {
+                        "date" -> SkillResult.DirectReply(
+                            "In ${resolution.candidate.displayName}, today is ${zonedNow.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy"))}",
+                        )
+
+                        else -> SkillResult.DirectReply(
+                            "In ${resolution.candidate.displayName}, it's ${zonedNow.format(DateTimeFormatter.ofPattern("h:mm a"))} on ${zonedNow.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy"))}",
+                        )
+                    }
+                }
+
+                is WorldClockResolution.Ambiguous -> SkillResult.Failure(
+                    "run_intent",
+                    "I found multiple matches for '$location': ${resolution.options.joinToString { it.displayName }}. Try a more specific timezone.",
+                )
+
+                WorldClockResolution.Unknown -> SkillResult.Failure(
+                    "run_intent",
+                    "I couldn't find a timezone for '$location'. Try a city like London or a timezone like Europe/Paris.",
+                )
+            }
+        }
+
         val now = LocalDateTime.now()
         // DirectReply: factual time/date data — LLM wrapping risks corrupting values
         // (e.g. "3:47 PM" → "nearly four o'clock") and adds no value for a simple query.

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -585,6 +585,16 @@ class QuickIntentRouterTest {
         }
     }
 
+        @Test
+        fun `should extract location for world time query`() {
+            val result = regexOnlyRouter.route("what time is it in London right now")
+            assertRegexMatch(result, "get_time", "what time is it in London right now")
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("time", intent.params["query_type"])
+            assertEquals("London", intent.params["location"])
+        }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // E4B FALLTHROUGH — these should NEVER match Tier 2
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1884,6 +1894,9 @@ class QuickIntentRouterTest {
             Arguments.of("what time is it"),
             Arguments.of("what's the time"),
             Arguments.of("what is the time"),
+            Arguments.of("what time is it in London"),
+            Arguments.of("what time is it in New York right now"),
+            Arguments.of("current time in Auckland"),
             Arguments.of("what's the date"),
             Arguments.of("what is the date"),
             Arguments.of("what's the current time"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -159,6 +159,22 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `get_time resolves world clock city queries`() {
+        val result = handler.handle("get_time", mapOf("query_type" to "time", "location" to "London"))
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertTrue((result as SkillResult.DirectReply).content.contains("In London"))
+    }
+
+    @Test
+    fun `get_time reports unknown world clock locations truthfully`() {
+        val result = handler.handle("get_time", mapOf("query_type" to "time", "location" to "Middle Earth"))
+
+        assertTrue(result is SkillResult.Failure)
+        assertTrue((result as SkillResult.Failure).error.contains("couldn't find a timezone", ignoreCase = true))
+    }
+
+    @Test
     fun `make_call resolves direct contact names with punctuation-insensitive matching`() {
         coEvery { contactAliasRepository.getByAlias(any()) } returns null
         every {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.*
@@ -18,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -69,6 +71,9 @@ import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.WorldClock
+import com.kernel.ai.core.memory.clock.WorldClockCandidate
+import com.kernel.ai.core.memory.clock.WorldClockCatalog
 import kotlinx.coroutines.delay
 import kotlin.math.abs
 import java.time.DayOfWeek
@@ -87,6 +92,7 @@ fun SidePanelScreen(
     val alarms by viewModel.alarms.collectAsStateWithLifecycle()
     val timers by viewModel.timers.collectAsStateWithLifecycle()
     val recentCompletedTimers by viewModel.recentCompletedTimers.collectAsStateWithLifecycle()
+    val worldClocks by viewModel.worldClocks.collectAsStateWithLifecycle()
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedIds by viewModel.selectedIds.collectAsStateWithLifecycle()
@@ -95,9 +101,11 @@ fun SidePanelScreen(
     var pendingCancel by remember { mutableStateOf<ClockTimer?>(null) }
     var pendingDeleteCompleted by remember { mutableStateOf<ClockTimer?>(null) }
     var pendingClearCompleted by remember { mutableStateOf(false) }
+    var pendingRemoveWorldClock by remember { mutableStateOf<WorldClock?>(null) }
     var editingAlarm by remember { mutableStateOf<ClockAlarm?>(null) }
     var showCreateAlarmDialog by remember { mutableStateOf(false) }
     var showCreateTimerDialog by remember { mutableStateOf(false) }
+    var showAddWorldClockDialog by remember { mutableStateOf(false) }
     var schedulingError by remember { mutableStateOf<String?>(null) }
 
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
@@ -115,6 +123,7 @@ fun SidePanelScreen(
     val visibleSelectionIds = when (selectedTab) {
         ClockSurfaceTab.TIMERS -> timers.map { it.id }
         ClockSurfaceTab.ALARMS -> alarms.map { it.id }
+        ClockSurfaceTab.WORLD_CLOCK -> emptyList()
     }
 
     fun onTimerScheduled(success: Boolean, closeDialog: Boolean = false) {
@@ -157,7 +166,7 @@ fun SidePanelScreen(
                 )
             } else {
                 TopAppBar(
-                    title = { Text("Timers & Alarms") },
+                    title = { Text("Clock") },
                     navigationIcon = {
                         IconButton(onClick = onBack) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -167,12 +176,22 @@ fun SidePanelScreen(
             }
         },
         floatingActionButton = {
-            if (!isInSelectionMode && selectedTab == ClockSurfaceTab.ALARMS) {
-                ExtendedFloatingActionButton(
-                    text = { Text("New Alarm") },
-                    icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                    onClick = { showCreateAlarmDialog = true },
-                )
+            if (!isInSelectionMode) {
+                when (selectedTab) {
+                    ClockSurfaceTab.ALARMS -> ExtendedFloatingActionButton(
+                        text = { Text("New Alarm") },
+                        icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                        onClick = { showCreateAlarmDialog = true },
+                    )
+
+                    ClockSurfaceTab.WORLD_CLOCK -> ExtendedFloatingActionButton(
+                        text = { Text("Add City") },
+                        icon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+                        onClick = { showAddWorldClockDialog = true },
+                    )
+
+                    ClockSurfaceTab.TIMERS -> Unit
+                }
             }
         },
     ) { innerPadding ->
@@ -196,6 +215,12 @@ fun SidePanelScreen(
                     onClick = { viewModel.setTab(ClockSurfaceTab.ALARMS) },
                     label = { Text("Alarms") },
                     leadingIcon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+                )
+                FilterChip(
+                    selected = selectedTab == ClockSurfaceTab.WORLD_CLOCK,
+                    onClick = { viewModel.setTab(ClockSurfaceTab.WORLD_CLOCK) },
+                    label = { Text("World Clock") },
+                    leadingIcon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
                 )
             }
 
@@ -246,6 +271,15 @@ fun SidePanelScreen(
                         }
                     },
                 )
+
+                ClockSurfaceTab.WORLD_CLOCK -> WorldClockDashboard(
+                    worldClocks = worldClocks,
+                    nowMs = nowMs,
+                    onAddWorldClock = { showAddWorldClockDialog = true },
+                    onMoveUp = { worldClock -> viewModel.moveWorldClock(worldClock, direction = -1) },
+                    onMoveDown = { worldClock -> viewModel.moveWorldClock(worldClock, direction = 1) },
+                    onRemove = { worldClock -> pendingRemoveWorldClock = worldClock },
+                )
             }
         }
     }
@@ -282,6 +316,24 @@ fun SidePanelScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pendingDeleteCompleted = null }) { Text("Keep") }
+            },
+        )
+    }
+
+    pendingRemoveWorldClock?.let { worldClock ->
+        AlertDialog(
+            onDismissRequest = { pendingRemoveWorldClock = null },
+            icon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+            title = { Text("Remove city?") },
+            text = { Text("Remove ${worldClock.displayName} from World Clock?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.removeWorldClock(worldClock)
+                    pendingRemoveWorldClock = null
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemoveWorldClock = null }) { Text("Keep") }
             },
         )
     }
@@ -392,11 +444,28 @@ fun SidePanelScreen(
         )
     }
 
+    if (showAddWorldClockDialog) {
+        AddWorldClockDialog(
+            existingZoneIds = worldClocks.map { it.zoneId }.toSet(),
+            onConfirm = { candidate ->
+                viewModel.addWorldClock(candidate) { success ->
+                    if (success) {
+                        schedulingError = null
+                        showAddWorldClockDialog = false
+                    } else {
+                        schedulingError = "Couldn't add that city to World Clock."
+                    }
+                }
+            },
+            onDismiss = { showAddWorldClockDialog = false },
+        )
+    }
+
     schedulingError?.let { message ->
         AlertDialog(
             onDismissRequest = { schedulingError = null },
-            icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-            title = { Text("Couldn't save timer or alarm") },
+            icon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+            title = { Text("Couldn't update the clock") },
             text = { Text(message) },
             confirmButton = {
                 TextButton(onClick = { schedulingError = null }) { Text("OK") }
@@ -720,6 +789,182 @@ private fun AlarmDashboard(
 }
 
 @Composable
+private fun WorldClockDashboard(
+    worldClocks: List<WorldClock>,
+    nowMs: Long,
+    onAddWorldClock: () -> Unit,
+    onMoveUp: (WorldClock) -> Unit,
+    onMoveDown: (WorldClock) -> Unit,
+    onRemove: (WorldClock) -> Unit,
+ ) {
+    if (worldClocks.isEmpty()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            SectionHeader(title = "World Clock")
+            EmptyStateCard(
+                title = "No saved cities",
+                body = "Add cities here to track their local time and date in one place.",
+                actionLabel = "Add city",
+                onAction = onAddWorldClock,
+            )
+        }
+        return
+    }
+
+    LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 24.dp)) {
+        item {
+            SectionHeader(
+                title = "World Clock",
+                supportingText = "Saved cities update live.",
+            )
+        }
+        items(worldClocks, key = { it.id }) { worldClock ->
+            WorldClockCard(
+                worldClock = worldClock,
+                nowMs = nowMs,
+                canMoveUp = worldClocks.firstOrNull()?.id != worldClock.id,
+                canMoveDown = worldClocks.lastOrNull()?.id != worldClock.id,
+                onMoveUp = { onMoveUp(worldClock) },
+                onMoveDown = { onMoveDown(worldClock) },
+                onRemove = { onRemove(worldClock) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WorldClockCard(
+    worldClock: WorldClock,
+    nowMs: Long,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: () -> Unit,
+ ) {
+    val instant = remember(nowMs) { Instant.ofEpochMilli(nowMs) }
+    val zone = remember(worldClock.zoneId) { ZoneId.of(worldClock.zoneId) }
+    val zonedNow = remember(instant, zone) { instant.atZone(zone) }
+    val localNow = remember(instant) { instant.atZone(ZoneId.systemDefault()) }
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(worldClock.displayName, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = zonedNow.format(DateTimeFormatter.ofPattern("h:mm a")),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Text(
+                text = buildString {
+                    append(zonedNow.format(DateTimeFormatter.ofPattern("EEE, d MMM")))
+                    append(" · ")
+                    append(formatUtcOffset(zonedNow.offset.id))
+                    worldClockRelativeDayLabel(localNow.toLocalDate(), zonedNow.toLocalDate())?.let {
+                        append(" · ")
+                        append(it)
+                    }
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = worldClock.zoneId,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(
+                    onClick = onMoveUp,
+                    enabled = canMoveUp,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Move up") }
+                TextButton(
+                    onClick = onMoveDown,
+                    enabled = canMoveDown,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Move down") }
+                TextButton(
+                    onClick = onRemove,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Remove") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddWorldClockDialog(
+    existingZoneIds: Set<String>,
+    onConfirm: (WorldClockCandidate) -> Unit,
+    onDismiss: () -> Unit,
+ ) {
+    var query by remember { mutableStateOf("") }
+    var selectedCandidate by remember { mutableStateOf<WorldClockCandidate?>(null) }
+    val results = remember(query, existingZoneIds) {
+        WorldClockCatalog.search(query).filterNot { it.zoneId in existingZoneIds }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+        title = { Text("Add city") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = {
+                        query = it
+                        selectedCandidate = null
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Search by city or timezone") },
+                    singleLine = true,
+                )
+                if (results.isEmpty()) {
+                    Text(
+                        text = "No matching cities or timezones.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.heightIn(max = 280.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(results, key = { it.zoneId }) { candidate ->
+                            val selected = candidate.zoneId == selectedCandidate?.zoneId
+                            ListItem(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(
+                                        if (selected) MaterialTheme.colorScheme.secondaryContainer
+                                        else MaterialTheme.colorScheme.surface,
+                                    )
+                                    .clickable { selectedCandidate = candidate },
+                                headlineContent = { Text(candidate.displayName) },
+                                supportingContent = { Text(candidate.subtitle) },
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { selectedCandidate?.let(onConfirm) },
+                enabled = selectedCandidate != null,
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
 private fun EmptyStateCard(
     title: String,
     body: String,
@@ -789,6 +1034,16 @@ private fun formatRelativeTimestamp(epochMillis: Long, nowMillis: Long = System.
         else -> "${totalMinutes / 1_440L} day ago"
     }
 }
+
+private fun formatUtcOffset(offsetId: String): String =
+    if (offsetId == "Z") "UTC" else "UTC$offsetId"
+
+private fun worldClockRelativeDayLabel(localDate: LocalDate, targetDate: LocalDate): String? =
+    when {
+        targetDate.isEqual(localDate) -> null
+        targetDate.isAfter(localDate) -> "Tomorrow"
+        else -> "Yesterday"
+    }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -7,6 +7,8 @@ import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.WorldClock
+import com.kernel.ai.core.memory.clock.WorldClockCandidate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Instant
 import java.time.ZoneId
@@ -18,7 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-enum class ClockSurfaceTab { TIMERS, ALARMS }
+enum class ClockSurfaceTab { TIMERS, ALARMS, WORLD_CLOCK }
 
 @HiltViewModel
 class SidePanelViewModel @Inject constructor(
@@ -34,6 +36,10 @@ class SidePanelViewModel @Inject constructor(
 
     val recentCompletedTimers: StateFlow<List<ClockTimer>> =
         clockRepository.observeRecentCompletedTimers()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val worldClocks: StateFlow<List<WorldClock>> =
+        clockRepository.observeWorldClocks()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _selectedTab = MutableStateFlow(ClockSurfaceTab.TIMERS)
@@ -201,6 +207,38 @@ class SidePanelViewModel @Inject constructor(
     fun scheduleTimer(durationMs: Long, label: String?, onResult: (Boolean) -> Unit = {}) {
         viewModelScope.launch {
             onResult(tryScheduleTimer(durationMs, label))
+        }
+    }
+
+    fun addWorldClock(candidate: WorldClockCandidate, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(clockRepository.addWorldClock(candidate.zoneId, candidate.displayName) != null)
+        }
+    }
+
+    fun removeWorldClock(worldClock: WorldClock, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            onResult(clockRepository.removeWorldClock(worldClock.id))
+        }
+    }
+
+    fun moveWorldClock(worldClock: WorldClock, direction: Int, onResult: (Boolean) -> Unit = {}) {
+        val clocks = worldClocks.value
+        val currentIndex = clocks.indexOfFirst { it.id == worldClock.id }
+        if (currentIndex == -1) {
+            onResult(false)
+            return
+        }
+        val targetIndex = currentIndex + direction
+        if (targetIndex !in clocks.indices) {
+            onResult(false)
+            return
+        }
+        val reordered = clocks.map { it.id }.toMutableList()
+        val moved = reordered.removeAt(currentIndex)
+        reordered.add(targetIndex, moved)
+        viewModelScope.launch {
+            onResult(clockRepository.reorderWorldClocks(reordered))
         }
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -3,10 +3,13 @@ package com.kernel.ai.feature.settings
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.WorldClock
+import com.kernel.ai.core.memory.clock.WorldClockCandidate
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -30,6 +33,7 @@ class SidePanelViewModelTest {
         every { clockRepository.observeManageableAlarms() } returns emptyFlow()
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
         every { clockRepository.observeRecentCompletedTimers() } returns emptyFlow()
+        every { clockRepository.observeWorldClocks() } returns emptyFlow()
     }
 
     @AfterEach
@@ -120,6 +124,46 @@ class SidePanelViewModelTest {
         val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
 
         assertEquals(false, result)
+    }
+
+    @Test
+    fun `addWorldClock forwards candidate to repository`() = runTest {
+        coEvery { clockRepository.addWorldClock("Europe/London", "London") } returns WorldClock(
+            id = "clock-1",
+            zoneId = "Europe/London",
+            displayName = "London",
+            sortOrder = 0,
+            createdAtMillis = 1_000L,
+        )
+        val viewModel = SidePanelViewModel(clockRepository)
+        var success: Boolean? = null
+
+        viewModel.addWorldClock(WorldClockCandidate("Europe/London", "London", "Europe/London")) {
+            success = it
+        }
+        advanceUntilIdle()
+
+        assertEquals(true, success)
+        coVerify(exactly = 1) { clockRepository.addWorldClock("Europe/London", "London") }
+    }
+
+    @Test
+    fun `moveWorldClock reorders current favorites`() = runTest {
+        val london = WorldClock("1", "Europe/London", "London", 0, 1_000L)
+        val tokyo = WorldClock("2", "Asia/Tokyo", "Tokyo", 1, 2_000L)
+        every { clockRepository.observeWorldClocks() } returns kotlinx.coroutines.flow.flowOf(listOf(london, tokyo))
+        coEvery { clockRepository.reorderWorldClocks(listOf("2", "1")) } returns true
+        val viewModel = SidePanelViewModel(clockRepository)
+        val collectionJob = launch { viewModel.worldClocks.collect {} }
+        advanceUntilIdle()
+        var success: Boolean? = null
+
+        viewModel.moveWorldClock(tokyo, direction = -1) { success = it }
+        advanceUntilIdle()
+        collectionJob.cancel()
+
+        assertEquals(true, success)
+        coVerify(exactly = 1) { clockRepository.reorderWorldClocks(listOf("2", "1")) }
     }
 }
 


### PR DESCRIPTION
## Summary
- add persisted world clock favorites with a shared timezone catalog/resolver and Room migration 26→27
- expand the unified Clock surface into Timers, Alarms, and World Clock with add/remove/reorder city flows
- extend deterministic `get_time` handling so world-time queries like `what time is it in London` resolve through the same clock domain

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" --tests "*WorldClockCatalogTest" :feature:settings:testDebugUnitTest --tests "*SidePanelViewModelTest" :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" :feature:settings:compileDebugAndroidTestKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin`

## Manual device tests
1. Install and open the debug build:
   - `./gradlew installDebug`
2. Clock surface world clock tab:
   - open **Clock** from the drawer
   - switch to **World Clock**
   - verify the empty state offers **Add city**
3. Add/remove cities:
   - add `London`, `Tokyo`, and `Auckland`
   - verify each card shows live local time/date and timezone ID
   - remove one city and confirm it disappears immediately
4. Reorder favorites:
   - use **Move up** / **Move down** on the cards
   - leave and re-open the Clock screen
   - verify the saved order persists
5. Deterministic time queries:
   - ask `what time is it in London?`
   - ask `current time in Auckland`
   - ask `what time is it in JST?`
   - verify each returns a direct factual answer, not a fallback clock-app action
6. Unknown location handling:
   - ask `what time is it in Middle Earth?`
   - verify the failure is explicit rather than a fabricated answer

Closes #742
Closes #677
