### PR TITLE
feat(#741): add chat back-and-forth voice mode

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -232,19 +232,30 @@ private fun ChatContent(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
-    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_NOTIFICATION, 55) }
+    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 65) }
     var lastVoiceCaptureState by remember { mutableStateOf<ChatViewModel.VoiceCaptureState>(ChatViewModel.VoiceCaptureState.Idle) }
+    val view = androidx.compose.ui.platform.LocalView.current
+    val keepScreenAwake = voiceMode == ChatViewModel.VoiceMode.BackAndForth
 
     DisposableEffect(Unit) {
         onDispose { loopListeningCue.release() }
     }
 
+    DisposableEffect(view, keepScreenAwake) {
+        val previousKeepScreenOn = view.keepScreenOn
+        view.keepScreenOn = keepScreenAwake || previousKeepScreenOn
+        onDispose {
+            view.keepScreenOn = previousKeepScreenOn
+        }
+    }
+
     LaunchedEffect(voiceCaptureState, voiceMode) {
-        val enteredListening =
+        val startedLoopListening =
             voiceMode == ChatViewModel.VoiceMode.BackAndForth &&
-                voiceCaptureState is ChatViewModel.VoiceCaptureState.Listening &&
+                voiceCaptureState is ChatViewModel.VoiceCaptureState.Preparing &&
+                lastVoiceCaptureState !is ChatViewModel.VoiceCaptureState.Preparing &&
                 lastVoiceCaptureState !is ChatViewModel.VoiceCaptureState.Listening
-        if (enteredListening) {
+        if (startedLoopListening) {
             loopListeningCue.startTone(ToneGenerator.TONE_PROP_BEEP2, 120)
         }
         lastVoiceCaptureState = voiceCaptureState

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -50,8 +50,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Memory
@@ -67,6 +67,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -779,21 +780,47 @@ private fun InputBar(
                     enter = fadeIn(),
                     exit = fadeOut(),
                 ) {
-                    // Two distinct voice-entry controls (#741):
-                    //   • filled Mic  → one-shot (speak once, done)
-                    //   • outlined Mic → back-and-forth (auto-rearming conversation)
-                    Row {
-                        IconButton(
+                    // Make the difference explicit in the idle composer: "PTT" vs "Loop".
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Surface(
                             onClick = onStartVoiceInput,
+                            shape = RoundedCornerShape(18.dp),
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            tonalElevation = 1.dp,
                             modifier = Modifier.testTag("chat_voice_start"),
                         ) {
-                            Icon(Icons.Default.Mic, contentDescription = "Start one-shot voice input")
+                            Row(
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                Icon(
+                                    Icons.Default.Mic,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                )
+                                Text(
+                                    text = "PTT",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                )
+                            }
                         }
-                        IconButton(
+
+                        OutlinedButton(
                             onClick = onStartBackAndForthVoiceInput,
                             modifier = Modifier.testTag("chat_voice_start_loop"),
                         ) {
-                            Icon(Icons.Outlined.Mic, contentDescription = "Start back-and-forth voice conversation")
+                            Icon(
+                                Icons.Default.Repeat,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                text = "Loop",
+                                modifier = Modifier.padding(start = 4.dp),
+                            )
                         }
                     }
                 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CheckCircle
@@ -134,6 +135,7 @@ fun ChatScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val voiceCaptureState by viewModel.voiceCaptureState.collectAsStateWithLifecycle()
     val voicePlaybackState by viewModel.voicePlaybackState.collectAsStateWithLifecycle()
+    val voiceMode by viewModel.voiceMode.collectAsStateWithLifecycle()
     val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -177,7 +179,9 @@ fun ChatScreen(
                 onRenameConversation = viewModel::renameConversation,
                 voiceCaptureState = voiceCaptureState,
                 voicePlaybackState = voicePlaybackState,
+                voiceMode = voiceMode,
                 onStartVoiceInput = viewModel::startVoiceInput,
+                onStartBackAndForthVoiceInput = viewModel::startBackAndForthVoiceInput,
                 onStopVoiceInput = viewModel::stopVoiceInput,
                 onStopVoiceOutput = viewModel::stopVoiceOutput,
                 snackbarHostState = snackbarHostState,
@@ -212,7 +216,9 @@ private fun ChatContent(
     onRenameConversation: (String) -> Unit,
     voiceCaptureState: ChatViewModel.VoiceCaptureState,
     voicePlaybackState: ChatViewModel.VoicePlaybackState,
+    voiceMode: ChatViewModel.VoiceMode?,
     onStartVoiceInput: () -> Unit,
+    onStartBackAndForthVoiceInput: () -> Unit,
     onStopVoiceInput: () -> Unit,
     onStopVoiceOutput: () -> Unit,
     snackbarHostState: SnackbarHostState,
@@ -397,10 +403,12 @@ private fun ChatContent(
                 isGenerating = state.isGenerating,
                 voiceCaptureState = voiceCaptureState,
                 voicePlaybackState = voicePlaybackState,
+                voiceMode = voiceMode,
                 onTextChanged = onInputChanged,
                 onSend = onSend,
                 onCancel = onCancel,
                 onStartVoiceInput = onStartVoiceInput,
+                onStartBackAndForthVoiceInput = onStartBackAndForthVoiceInput,
                 onStopVoiceInput = onStopVoiceInput,
                 onStopVoiceOutput = onStopVoiceOutput,
                 modifier = Modifier.navigationBarsPadding(),
@@ -627,32 +635,48 @@ private fun InputBar(
     isGenerating: Boolean,
     voiceCaptureState: ChatViewModel.VoiceCaptureState,
     voicePlaybackState: ChatViewModel.VoicePlaybackState,
+    voiceMode: ChatViewModel.VoiceMode?,
     onTextChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
     onStartVoiceInput: () -> Unit,
+    onStartBackAndForthVoiceInput: () -> Unit,
     onStopVoiceInput: () -> Unit,
     onStopVoiceOutput: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val voiceStatus = remember(voiceCaptureState, voicePlaybackState) {
+    val voiceStatus = remember(voiceCaptureState, voicePlaybackState, voiceMode) {
         when (voiceCaptureState) {
             ChatViewModel.VoiceCaptureState.Idle -> when (voicePlaybackState) {
                 ChatViewModel.VoicePlaybackState.Idle -> null
                 is ChatViewModel.VoicePlaybackState.Speaking -> VoiceStatusUiModel(
                     title = "Speaking reply",
-                    subtitle = voicePlaybackState.text,
+                    subtitle = if (voiceMode == ChatViewModel.VoiceMode.BackAndForth) {
+                        "Listening again when done…"
+                    } else {
+                        voicePlaybackState.text
+                    },
                     icon = Icons.Outlined.CheckCircle,
                 )
             }
             ChatViewModel.VoiceCaptureState.Preparing -> VoiceStatusUiModel(
                 title = "Starting voice input",
-                subtitle = "One-shot push-to-talk",
+                subtitle = if (voiceMode == ChatViewModel.VoiceMode.BackAndForth) {
+                    "Back-and-forth mode"
+                } else {
+                    "One-shot push-to-talk"
+                },
                 icon = Icons.Default.Mic,
             )
             is ChatViewModel.VoiceCaptureState.Listening -> VoiceStatusUiModel(
                 title = "Listening",
-                subtitle = voiceCaptureState.transcript.ifBlank { "One-shot push-to-talk" },
+                subtitle = voiceCaptureState.transcript.ifBlank {
+                    if (voiceMode == ChatViewModel.VoiceMode.BackAndForth) {
+                        "Back-and-forth mode"
+                    } else {
+                        "One-shot push-to-talk"
+                    }
+                },
                 icon = Icons.Default.Mic,
             )
             is ChatViewModel.VoiceCaptureState.Processing -> VoiceStatusUiModel(
@@ -755,11 +779,22 @@ private fun InputBar(
                     enter = fadeIn(),
                     exit = fadeOut(),
                 ) {
-                    IconButton(
-                        onClick = onStartVoiceInput,
-                        modifier = Modifier.testTag("chat_voice_start"),
-                    ) {
-                        Icon(Icons.Default.Mic, contentDescription = "Start one-shot voice input")
+                    // Two distinct voice-entry controls (#741):
+                    //   • filled Mic  → one-shot (speak once, done)
+                    //   • outlined Mic → back-and-forth (auto-rearming conversation)
+                    Row {
+                        IconButton(
+                            onClick = onStartVoiceInput,
+                            modifier = Modifier.testTag("chat_voice_start"),
+                        ) {
+                            Icon(Icons.Default.Mic, contentDescription = "Start one-shot voice input")
+                        }
+                        IconButton(
+                            onClick = onStartBackAndForthVoiceInput,
+                            modifier = Modifier.testTag("chat_voice_start_loop"),
+                        ) {
+                            Icon(Icons.Outlined.Mic, contentDescription = "Start back-and-forth voice conversation")
+                        }
                     }
                 }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.feature.chat
 
+import android.media.AudioManager
+import android.media.ToneGenerator
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -85,6 +87,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -229,6 +232,23 @@ private fun ChatContent(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
+    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_NOTIFICATION, 55) }
+    var lastVoiceCaptureState by remember { mutableStateOf<ChatViewModel.VoiceCaptureState>(ChatViewModel.VoiceCaptureState.Idle) }
+
+    DisposableEffect(Unit) {
+        onDispose { loopListeningCue.release() }
+    }
+
+    LaunchedEffect(voiceCaptureState, voiceMode) {
+        val enteredListening =
+            voiceMode == ChatViewModel.VoiceMode.BackAndForth &&
+                voiceCaptureState is ChatViewModel.VoiceCaptureState.Listening &&
+                lastVoiceCaptureState !is ChatViewModel.VoiceCaptureState.Listening
+        if (enteredListening) {
+            loopListeningCue.startTone(ToneGenerator.TONE_PROP_BEEP2, 120)
+        }
+        lastVoiceCaptureState = voiceCaptureState
+    }
 
     // Auto-scroll when a new message is appended, but only if the user is already
     // near the bottom (within 2 items). If they've scrolled up to read history,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -111,6 +111,15 @@ class ChatViewModel @Inject constructor(
 ) : ViewModel() {
     private enum class SubmitMode { Text, Voice }
 
+    /**
+     * The explicit voice-interaction mode chosen by the user for the current session.
+     *
+     * - [OneShot]: user speaks once → transcript sends → reply may be spoken → loop ends.
+     * - [BackAndForth]: after the spoken reply finishes, listening re-arms automatically
+     *   until the user explicitly stops the loop or leaves the conversation.
+     */
+    enum class VoiceMode { OneShot, BackAndForth }
+
     sealed interface VoiceCaptureState {
         data object Idle : VoiceCaptureState
         data object Preparing : VoiceCaptureState
@@ -199,6 +208,11 @@ class ChatViewModel @Inject constructor(
 
     private var spokenResponsesEnabled = true
     private var pendingVoiceReply = false
+    private var awaitingVoicePlaybackCompletion = false
+
+    /** Active voice interaction mode, or null when no voice session is running (#741). */
+    private val _voiceMode = MutableStateFlow<VoiceMode?>(null)
+    val voiceMode: StateFlow<VoiceMode?> = _voiceMode.asStateFlow()
 
     /** True once [initializeConversation] has completed and [conversationId] is set. */
     private val _conversationInitialized = MutableStateFlow(false)
@@ -301,7 +315,9 @@ class ChatViewModel @Inject constructor(
                 if (enabled) {
                     voiceOutputController.warmUp()
                 } else {
+                    awaitingVoicePlaybackCompletion = false
                     pendingVoiceReply = false
+                    _voiceMode.value = null
                     _voicePlaybackState.value = VoicePlaybackState.Idle
                     voiceOutputController.stop()
                 }
@@ -323,7 +339,9 @@ class ChatViewModel @Inject constructor(
                         submitVoiceTranscript(event.text)
                     }
                     is VoiceInputEvent.Error -> {
+                        awaitingVoicePlaybackCompletion = false
                         pendingVoiceReply = false
+                        _voiceMode.value = null
                         _voiceCaptureState.value = VoiceCaptureState.Idle
                         _error.value = withVoiceSettingsHint(event.message)
                     }
@@ -331,13 +349,19 @@ class ChatViewModel @Inject constructor(
                         when (val currentState = _voiceCaptureState.value) {
                             is VoiceCaptureState.Listening -> {
                                 if (currentState.transcript.isBlank()) {
+                                    // Blank transcript — conservatively stop the loop even in
+                                    // back-and-forth mode rather than spinning indefinitely.
+                                    _voiceMode.value = null
                                     _voiceCaptureState.value = VoiceCaptureState.Idle
                                 } else {
                                     submitVoiceTranscript(currentState.transcript)
                                 }
                             }
                             is VoiceCaptureState.Processing -> Unit
-                            else -> _voiceCaptureState.value = VoiceCaptureState.Idle
+                            else -> {
+                                _voiceMode.value = null
+                                _voiceCaptureState.value = VoiceCaptureState.Idle
+                            }
                         }
                     }
                 }
@@ -357,6 +381,14 @@ class ChatViewModel @Inject constructor(
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
                         _voicePlaybackState.value = VoicePlaybackState.Idle
+                        val shouldHandleCompletion = awaitingVoicePlaybackCompletion
+                        awaitingVoicePlaybackCompletion = false
+                        if (!shouldHandleCompletion) return@collect
+                        if (_voiceMode.value == VoiceMode.BackAndForth) {
+                            rearmVoiceInput()
+                        } else {
+                            _voiceMode.value = null
+                        }
                     }
                 }
             }
@@ -748,9 +780,20 @@ class ChatViewModel @Inject constructor(
         if (_error.value != null) _error.value = null
     }
 
-    fun startVoiceInput() {
+    /** Starts a one-shot voice capture: user speaks once, reply may be spoken, then loop ends. */
+    fun startVoiceInput() = startVoiceInput(VoiceMode.OneShot)
+
+    /**
+     * Starts back-and-forth conversational voice: after each spoken reply the microphone
+     * re-arms automatically until the user explicitly stops or leaves the conversation.
+     */
+    fun startBackAndForthVoiceInput() = startVoiceInput(VoiceMode.BackAndForth)
+
+    private fun startVoiceInput(mode: VoiceMode) {
         if (inferenceEngine.isGenerating.value || _isLoadingModel.value) return
         if (_voiceCaptureState.value != VoiceCaptureState.Idle) return
+        awaitingVoicePlaybackCompletion = false
+        _voiceMode.value = mode
         viewModelScope.launch {
             if (_voicePlaybackState.value != VoicePlaybackState.Idle) {
                 voiceOutputController.stop()
@@ -764,6 +807,8 @@ class ChatViewModel @Inject constructor(
                     }
                 }
                 is VoiceInputStartResult.Unavailable -> {
+                    awaitingVoicePlaybackCompletion = false
+                    _voiceMode.value = null
                     pendingVoiceReply = false
                     _voiceCaptureState.value = VoiceCaptureState.Idle
                     _error.value = withVoiceSettingsHint(result.message)
@@ -772,13 +817,43 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Re-arms voice listening for the next back-and-forth turn. Only called internally after a
+     * spoken reply finishes; guards against starting if the mode was cleared in the interim.
+     */
+    private fun rearmVoiceInput() {
+        if (_voiceMode.value != VoiceMode.BackAndForth) return
+        if (_voiceCaptureState.value != VoiceCaptureState.Idle) return
+        viewModelScope.launch {
+            _error.value = null
+            _voiceCaptureState.value = VoiceCaptureState.Preparing
+            when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
+                VoiceInputStartResult.Started -> {
+                    if (_voiceCaptureState.value == VoiceCaptureState.Preparing) {
+                        _voiceCaptureState.value = VoiceCaptureState.Listening()
+                    }
+                }
+                is VoiceInputStartResult.Unavailable -> {
+                    awaitingVoicePlaybackCompletion = false
+                    _voiceMode.value = null
+                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                    _error.value = withVoiceSettingsHint(result.message)
+                }
+            }
+        }
+    }
+
     fun stopVoiceInput() {
+        awaitingVoicePlaybackCompletion = false
+        _voiceMode.value = null
         pendingVoiceReply = false
         voiceInputController.stopListening()
         _voiceCaptureState.value = VoiceCaptureState.Idle
     }
 
     fun stopVoiceOutput() {
+        awaitingVoicePlaybackCompletion = false
+        _voiceMode.value = null
         pendingVoiceReply = false
         voiceOutputController.stop()
         _voicePlaybackState.value = VoicePlaybackState.Idle
@@ -820,6 +895,7 @@ class ChatViewModel @Inject constructor(
         val text = _inputText.value.trim()
         if (text.isBlank() || inferenceEngine.isGenerating.value || _isLoadingModel.value) {
             if (submitMode == SubmitMode.Voice) {
+                _voiceMode.value = null
                 pendingVoiceReply = false
                 _voiceCaptureState.value = VoiceCaptureState.Idle
             }
@@ -1468,6 +1544,7 @@ class ChatViewModel @Inject constructor(
                         }
 
                         is GenerationResult.Error -> {
+                            _voiceMode.value = null
                             pendingVoiceReply = false
                             _voiceCaptureState.value = VoiceCaptureState.Idle
                             _messages.update { msgs ->
@@ -1487,6 +1564,7 @@ class ChatViewModel @Inject constructor(
             } while (needsHallucinationRetry)
 
             } catch (e: Exception) {
+                _voiceMode.value = null
                 pendingVoiceReply = false
                 _voiceCaptureState.value = VoiceCaptureState.Idle
                 _messages.update { msgs ->
@@ -1508,6 +1586,8 @@ class ChatViewModel @Inject constructor(
     }
 
     fun cancelGeneration() {
+        awaitingVoicePlaybackCompletion = false
+        _voiceMode.value = null
         pendingVoiceReply = false
         _voiceCaptureState.value = VoiceCaptureState.Idle
         inferenceEngine.cancelGeneration()
@@ -1555,6 +1635,8 @@ class ChatViewModel @Inject constructor(
 
     fun startNewConversation() {
         viewModelScope.launch {
+            awaitingVoicePlaybackCompletion = false
+            _voiceMode.value = null
             pendingVoiceReply = false
             voiceInputController.stopListening()
             voiceOutputController.stop()
@@ -1707,6 +1789,8 @@ class ChatViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
+        awaitingVoicePlaybackCompletion = false
+        _voiceMode.value = null
         pendingVoiceReply = false
         voiceInputController.stopListening()
         voiceOutputController.stop()
@@ -1738,6 +1822,9 @@ class ChatViewModel @Inject constructor(
     private fun submitVoiceTranscript(rawTranscript: String) {
         val transcript = rawTranscript.trim()
         if (transcript.isBlank()) {
+            // Nothing useful captured — stop the loop conservatively regardless of mode.
+            awaitingVoicePlaybackCompletion = false
+            _voiceMode.value = null
             pendingVoiceReply = false
             _voiceCaptureState.value = VoiceCaptureState.Idle
             return
@@ -1747,18 +1834,32 @@ class ChatViewModel @Inject constructor(
         sendMessage(SubmitMode.Voice)
     }
 
+    /** Speaks the assistant reply if this was a voice-originated turn. */
     private suspend fun speakAssistantReplyIfNeeded(content: String) {
         val shouldSpeak = pendingVoiceReply
         pendingVoiceReply = false
         _voiceCaptureState.value = VoiceCaptureState.Idle
-        if (!shouldSpeak || !spokenResponsesEnabled) return
+        if (!shouldSpeak || !spokenResponsesEnabled) {
+            awaitingVoicePlaybackCompletion = false
+            _voiceMode.value = null
+            return
+        }
 
         val spokenText = stripMarkdownForClipboard(content).trim()
-        if (spokenText.isBlank()) return
+        if (spokenText.isBlank()) {
+            awaitingVoicePlaybackCompletion = false
+            _voiceMode.value = null
+            return
+        }
 
+        awaitingVoicePlaybackCompletion = true
         when (val result = voiceOutputController.speak(VoiceSpeakRequest(text = spokenText))) {
             VoiceOutputResult.Spoken -> Unit
-            is VoiceOutputResult.Unavailable -> _error.value = withVoiceSettingsHint(result.message)
+            is VoiceOutputResult.Unavailable -> {
+                awaitingVoicePlaybackCompletion = false
+                _voiceMode.value = null
+                _error.value = withVoiceSettingsHint(result.message)
+            }
         }
     }
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -47,6 +47,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -56,6 +57,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
@@ -243,6 +245,114 @@ class ChatViewModelVoiceTest {
             viewModel.getConversationAsText(),
         )
         verify(exactly = 0) { inferenceEngine.generate(any()) }
+    }
+
+    @Test
+    fun `one-shot voice stays idle after spoken reply playback stops`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Hello one shot") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Hello one shot")
+        coEvery { voiceOutputController.speak(any()) } returns VoiceOutputResult.Spoken
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello one shot"))
+        advanceUntilIdle()
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+        advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceUntilIdle()
+
+        assertEquals("You: Hello one shot\nJandal: Hi back", viewModel.getConversationAsText())
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+    }
+
+    @Test
+    fun `back-and-forth voice re-arms listening after spoken reply playback stops`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Hello loop") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Hello loop")
+        coEvery { voiceOutputController.speak(any()) } returns VoiceOutputResult.Spoken
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startBackAndForthVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello loop"))
+        advanceUntilIdle()
+
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+        advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceUntilIdle()
+
+        assertEquals("You: Hello loop\nJandal: Hi back", viewModel.getConversationAsText())
+        assertEquals(ChatViewModel.VoiceCaptureState.Listening(), viewModel.voiceCaptureState.value)
+        coVerify(exactly = 2) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(match<VoiceSpeakRequest> { it.text == "Hi back" })
+        }
+    }
+
+    @Test
+    fun `stopVoiceOutput prevents speaking stopped from restarting back-and-forth capture`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Stop speaking") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Stop speaking")
+        val speakGate = CompletableDeferred<Unit>()
+        coEvery { voiceOutputController.speak(any()) } coAnswers {
+            voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+            speakGate.await()
+            VoiceOutputResult.Spoken
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startBackAndForthVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Stop speaking"))
+        runCurrent()
+
+        viewModel.stopVoiceOutput()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        speakGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+        verify(exactly = 1) { voiceOutputController.stop() }
+    }
+
+    @Test
+    fun `stopVoiceInput clears the back-and-forth loop before a pending re-arm`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Stop listening") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Stop listening")
+        val speakGate = CompletableDeferred<Unit>()
+        coEvery { voiceOutputController.speak(any()) } coAnswers {
+            voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+            speakGate.await()
+            VoiceOutputResult.Spoken
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startBackAndForthVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Stop listening"))
+        runCurrent()
+
+        viewModel.stopVoiceInput()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        speakGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+        verify(exactly = 1) { voiceInputController.stopListening() }
     }
 
     private fun createViewModel(): ChatViewModel = ChatViewModel(


### PR DESCRIPTION
## Summary
Add the missing chat voice follow-up from `#741`: an explicit choice between **one-shot** voice input and a lightweight **back-and-forth** conversational loop.

## Changes
- replace the single chat mic entry with separate **one-shot** and **back-and-forth** voice controls
- add conversation-scoped `VoiceMode` state in `ChatViewModel`
- re-arm listening for back-and-forth only after the real `VoiceOutputEvent.SpeakingStopped` completion event
- clear the armed loop conservatively on stop, cancel, new conversation, and teardown paths
- update chat voice status text so the active mode is visible while preparing, listening, and speaking
- add regression coverage for one-shot non-rearm, back-and-forth auto-rearm, and stop/cancel loop clearing

## Testing
- [x] `./gradlew :feature:chat:testDebugUnitTest --tests '*ChatViewModelVoiceTest*'`
- [x] `./gradlew :feature:chat:compileDebugKotlin`
- [ ] `./gradlew :feature:chat:testDebugUnitTest` *(still blocked by unrelated pre-existing `LatexConversionTest > nested fractions are handled()` failure)*
- [ ] Manual device testing

## Related issues
Closes #741
