### PR TITLE
feat(#745): ship stopwatch tab

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,6 +137,10 @@
             android:name=".alarm.ClockTimerActionReceiver"
             android:exported="false" />
 
+        <receiver
+            android:name=".alarm.ClockStopwatchActionReceiver"
+            android:exported="false" />
+
         <!-- Re-schedules exact alarms after device reboot (#327) -->
         <receiver
             android:name=".alarm.BootCompletedReceiver"

--- a/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
+++ b/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
@@ -8,6 +8,7 @@ import androidx.work.Configuration
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import com.kernel.ai.alarm.ClockStopwatchNotificationCoordinator
 import com.kernel.ai.alarm.ClockTimerNotificationCoordinator
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.memory.worker.MemoryEmbeddingWorker
@@ -28,6 +29,7 @@ class KernelAIApplication : Application(), Configuration.Provider {
     @Inject lateinit var workerFactory: HiltWorkerFactory
     @Inject lateinit var inferenceEngine: InferenceEngine
     @Inject lateinit var clockTimerNotificationCoordinator: ClockTimerNotificationCoordinator
+    @Inject lateinit var clockStopwatchNotificationCoordinator: ClockStopwatchNotificationCoordinator
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
@@ -37,6 +39,7 @@ class KernelAIApplication : Application(), Configuration.Provider {
     override fun onCreate() {
         super.onCreate()
         clockTimerNotificationCoordinator.start()
+        clockStopwatchNotificationCoordinator.start()
         WorkManager.getInstance(this).enqueueUniqueWork(
             WORK_NAME_BACKFILL,
             ExistingWorkPolicy.KEEP,

--- a/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
@@ -1,0 +1,141 @@
+package com.kernel.ai.alarm
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.kernel.ai.MainActivity
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidClockStopwatchNotificationSink @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ClockStopwatchNotificationTransport {
+    private val syncer = ClockStopwatchNotificationSyncer(this)
+
+    fun sync(stopwatch: ClockStopwatch) {
+        syncer.sync(stopwatch)
+    }
+
+    override fun show(stopwatch: ClockStopwatch) {
+        ensureChannel()
+        NotificationManagerCompat.from(context).notify(
+            ClockAlertContract.STOPWATCH_NOTIFICATION_ID,
+            buildStopwatchNotification(stopwatch),
+        )
+    }
+
+    override fun cancel(notificationId: Int) {
+        NotificationManagerCompat.from(context).cancel(notificationId)
+    }
+
+    private fun buildStopwatchNotification(stopwatch: ClockStopwatch): android.app.Notification {
+        val nowWallClockMs = System.currentTimeMillis()
+        val nowElapsedRealtimeMs = android.os.SystemClock.elapsedRealtime()
+        val elapsedMs = stopwatch.elapsedMs(nowElapsedRealtimeMs, nowWallClockMs)
+        val contentText = when (stopwatch.status) {
+            StopwatchStatus.RUNNING -> "${formatStopwatchElapsed(elapsedMs)} elapsed"
+            StopwatchStatus.PAUSED -> "Paused at ${formatStopwatchElapsed(elapsedMs)}"
+            StopwatchStatus.IDLE -> formatStopwatchElapsed(elapsedMs)
+        }
+        return NotificationCompat.Builder(context, ClockAlertContract.ACTIVE_STOPWATCH_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle("Stopwatch")
+            .setContentText(contentText)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(stopwatch.status == StopwatchStatus.RUNNING)
+            .setWhen(nowWallClockMs - elapsedMs)
+            .setUsesChronometer(stopwatch.status == StopwatchStatus.RUNNING)
+            .setContentIntent(buildOpenAppPendingIntent())
+            .apply {
+                when (stopwatch.status) {
+                    StopwatchStatus.RUNNING -> {
+                        addAction(
+                            android.R.drawable.ic_media_pause,
+                            "Pause",
+                            buildBroadcastPendingIntent(ClockAlertContract.ACTION_PAUSE_STOPWATCH),
+                        )
+                        addAction(
+                            android.R.drawable.ic_menu_revert,
+                            "Reset",
+                            buildBroadcastPendingIntent(ClockAlertContract.ACTION_RESET_STOPWATCH),
+                        )
+                    }
+
+                    StopwatchStatus.PAUSED -> {
+                        addAction(
+                            android.R.drawable.ic_media_play,
+                            "Resume",
+                            buildBroadcastPendingIntent(ClockAlertContract.ACTION_RESUME_STOPWATCH),
+                        )
+                        addAction(
+                            android.R.drawable.ic_menu_revert,
+                            "Reset",
+                            buildBroadcastPendingIntent(ClockAlertContract.ACTION_RESET_STOPWATCH),
+                        )
+                    }
+
+                    StopwatchStatus.IDLE -> Unit
+                }
+            }
+            .build()
+    }
+
+    private fun formatStopwatchElapsed(elapsedMs: Long): String {
+        val safeElapsedMs = elapsedMs.coerceAtLeast(0L)
+        val totalSeconds = safeElapsedMs / 1_000L
+        val hours = totalSeconds / 3_600L
+        val minutes = (totalSeconds % 3_600L) / 60L
+        val seconds = totalSeconds % 60L
+        return if (hours > 0L) {
+            "%d:%02d:%02d".format(hours, minutes, seconds)
+        } else {
+            "%02d:%02d".format(minutes, seconds)
+        }
+    }
+
+    private fun buildOpenAppPendingIntent(): PendingIntent =
+        PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    private fun buildBroadcastPendingIntent(action: String): PendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            action.hashCode(),
+            Intent(context, ClockStopwatchActionReceiver::class.java).apply {
+                this.action = action
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    private fun ensureChannel() {
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        if (notificationManager.getNotificationChannel(ClockAlertContract.ACTIVE_STOPWATCH_CHANNEL_ID) != null) return
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                ClockAlertContract.ACTIVE_STOPWATCH_CHANNEL_ID,
+                "Stopwatch",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Ongoing stopwatch notifications and controls"
+                setSound(null, null)
+                enableVibration(false)
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
@@ -14,11 +14,16 @@ internal object ClockAlertContract {
     const val ACTION_STOP_ALERT = "com.kernel.ai.alarm.action.STOP_ALERT"
     const val ACTION_CANCEL_TIMER = "com.kernel.ai.alarm.action.CANCEL_TIMER"
     const val ACTION_SKIP_ALARM_OCCURRENCE = "com.kernel.ai.alarm.action.SKIP_ALARM_OCCURRENCE"
+    const val ACTION_PAUSE_STOPWATCH = "com.kernel.ai.alarm.action.PAUSE_STOPWATCH"
+    const val ACTION_RESUME_STOPWATCH = "com.kernel.ai.alarm.action.RESUME_STOPWATCH"
+    const val ACTION_RESET_STOPWATCH = "com.kernel.ai.alarm.action.RESET_STOPWATCH"
 
     const val ALERT_CHANNEL_ID = "kernel_clock_alerts"
     const val ACTIVE_TIMER_CHANNEL_ID = "kernel_clock_timers"
+    const val ACTIVE_STOPWATCH_CHANNEL_ID = "kernel_clock_stopwatch"
     const val PRE_ALARM_CHANNEL_ID = "kernel_clock_pre_alarms"
     const val ALERT_NOTIFICATION_ID = 9_300
+    const val STOPWATCH_NOTIFICATION_ID = 40_000
 
     fun timerNotificationId(timerId: String): Int = 20_000 + timerId.hashCode()
     fun preAlarmNotificationId(ownerId: String): Int = 30_000 + ownerId.hashCode()

--- a/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchActionReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchActionReceiver.kt
@@ -1,0 +1,52 @@
+package com.kernel.ai.alarm
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import com.kernel.ai.core.memory.clock.ClockRepository
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ClockStopwatchActionReceiver : BroadcastReceiver() {
+    @Inject lateinit var clockRepository: ClockRepository
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                when (action) {
+                    ClockAlertContract.ACTION_PAUSE_STOPWATCH -> {
+                        clockRepository.pauseStopwatch(
+                            nowWallClockMillis = System.currentTimeMillis(),
+                            nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+                        )
+                    }
+
+                    ClockAlertContract.ACTION_RESUME_STOPWATCH -> {
+                        clockRepository.resumeStopwatch(
+                            nowWallClockMillis = System.currentTimeMillis(),
+                            nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+                        )
+                    }
+
+                    ClockAlertContract.ACTION_RESET_STOPWATCH -> {
+                        context.getSystemService(NotificationManager::class.java)
+                            .cancel(ClockAlertContract.STOPWATCH_NOTIFICATION_ID)
+                        clockRepository.resetStopwatch()
+                    }
+
+                    else -> Unit
+                }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchNotificationCoordinator.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchNotificationCoordinator.kt
@@ -1,0 +1,32 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+@Singleton
+class ClockStopwatchNotificationCoordinator @Inject constructor(
+    private val clockRepository: ClockRepository,
+    private val notificationSink: AndroidClockStopwatchNotificationSink,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    @Volatile
+    private var started = false
+
+    fun start() {
+        if (started) return
+        started = true
+        scope.launch {
+            clockRepository.observeStopwatch()
+                .distinctUntilChanged()
+                .collect(notificationSink::sync)
+        }
+    }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncer.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncer.kt
@@ -1,0 +1,27 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchStatus
+
+internal interface ClockStopwatchNotificationTransport {
+    fun show(stopwatch: ClockStopwatch)
+    fun cancel(notificationId: Int)
+}
+
+internal class ClockStopwatchNotificationSyncer(
+    private val transport: ClockStopwatchNotificationTransport,
+) {
+    private var visible = false
+
+    fun sync(stopwatch: ClockStopwatch) {
+        if (stopwatch.status == StopwatchStatus.IDLE) {
+            if (visible) {
+                transport.cancel(ClockAlertContract.STOPWATCH_NOTIFICATION_ID)
+                visible = false
+            }
+            return
+        }
+        transport.show(stopwatch)
+        visible = true
+    }
+}

--- a/app/src/test/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncerTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncerTest.kt
@@ -1,0 +1,39 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchStatus
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class ClockStopwatchNotificationSyncerTest {
+    private val transport = mockk<ClockStopwatchNotificationTransport>(relaxed = true)
+    private val syncer = ClockStopwatchNotificationSyncer(transport)
+
+    @Test
+    fun `sync shows running stopwatch and cancels when reset to idle`() {
+        syncer.sync(stopwatch(status = StopwatchStatus.RUNNING))
+        syncer.sync(stopwatch(status = StopwatchStatus.IDLE))
+
+        verify(exactly = 1) { transport.show(match { it.status == StopwatchStatus.RUNNING }) }
+        verify(exactly = 1) { transport.cancel(ClockAlertContract.STOPWATCH_NOTIFICATION_ID) }
+    }
+
+    @Test
+    fun `sync keeps paused stopwatch visible without cancelling`() {
+        syncer.sync(stopwatch(status = StopwatchStatus.PAUSED, accumulatedElapsedMs = 12_000L))
+
+        verify(exactly = 1) { transport.show(match { it.status == StopwatchStatus.PAUSED }) }
+        verify(exactly = 0) { transport.cancel(any()) }
+    }
+
+    private fun stopwatch(
+        status: StopwatchStatus,
+        accumulatedElapsedMs: Long = 0L,
+    ) = ClockStopwatch(
+        id = "primary",
+        status = status,
+        accumulatedElapsedMs = accumulatedElapsedMs,
+        updatedAtMillis = 1_000L,
+    )
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/28.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/28.json
@@ -1,0 +1,1027 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 28,
+    "identityHash": "ff258db34bab25d135e58cd4ff2f639d",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ff258db34bab25d135e58cd4ff2f639d')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -17,6 +17,7 @@ import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
@@ -31,6 +32,8 @@ import com.kernel.ai.core.memory.entity.MessageEntity
 import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.entity.QuickActionEntity
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.StopwatchLapEntity
+import com.kernel.ai.core.memory.entity.StopwatchStateEntity
 import com.kernel.ai.core.memory.entity.WorldClockEntity
 import com.kernel.ai.core.memory.entity.UserProfileEntity
 import java.time.ZoneId
@@ -48,11 +51,13 @@ import java.time.ZoneId
         QuickActionEntity::class,
         ScheduledAlarmEntity::class,
         WorldClockEntity::class,
+        StopwatchStateEntity::class,
+        StopwatchLapEntity::class,
         ContactAliasEntity::class,
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 27,
+    version = 28,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -69,6 +74,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun quickActionDao(): QuickActionDao
     abstract fun scheduledAlarmDao(): ScheduledAlarmDao
     abstract fun worldClockDao(): WorldClockDao
+    abstract fun stopwatchDao(): StopwatchDao
     abstract fun contactAliasDao(): ContactAliasDao
     abstract fun listItemDao(): ListItemDao
     abstract fun listNameDao(): ListNameDao
@@ -331,6 +337,40 @@ abstract class KernelDatabase : RoomDatabase() {
                     """.trimIndent()
                 )
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `world_clocks` (`zone_id`)")
+            }
+        }
+
+        /** Creates stopwatch state + lap tables for first-class stopwatch UI (#745). */
+        val MIGRATION_27_28 = object : Migration(27, 28) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `stopwatch_state` (
+                        `id` TEXT NOT NULL,
+                        `status` TEXT NOT NULL,
+                        `accumulated_elapsed_ms` INTEGER NOT NULL,
+                        `running_since_elapsed_realtime_ms` INTEGER,
+                        `running_since_wall_clock_ms` INTEGER,
+                        `updated_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent(),
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `stopwatch_laps` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `stopwatch_id` TEXT NOT NULL,
+                        `lap_number` INTEGER NOT NULL,
+                        `elapsed_ms` INTEGER NOT NULL,
+                        `split_ms` INTEGER NOT NULL,
+                        `created_at` INTEGER NOT NULL,
+                        FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent(),
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `stopwatch_laps` (`stopwatch_id`)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `stopwatch_laps` (`stopwatch_id`, `lap_number`)")
             }
         }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -14,6 +14,7 @@ import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
 import com.kernel.ai.core.memory.dao.ModelSettingsDao
 import com.kernel.ai.core.memory.dao.QuickActionDao
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.clock.ClockRepository
@@ -82,6 +83,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_24_25,
                     KernelDatabase.MIGRATION_25_26,
                     KernelDatabase.MIGRATION_26_27,
+                    KernelDatabase.MIGRATION_27_28,
                 )
                 .build()
 
@@ -114,6 +116,10 @@ abstract class MemoryModule {
 
         @Provides
         fun provideWorldClockDao(db: KernelDatabase): WorldClockDao = db.worldClockDao()
+
+        @Provides
+        fun provideStopwatchDao(db: KernelDatabase): StopwatchDao = db.stopwatchDao()
+
 
         @Provides
         fun provideContactAliasDao(db: KernelDatabase): ContactAliasDao = db.contactAliasDao()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -8,6 +8,8 @@ enum class ClockEventType {
     PRE_ALARM,
 }
 
+enum class StopwatchStatus { IDLE, RUNNING, PAUSED }
+
 sealed interface AlarmRepeatRule {
     data class OneOff(val dateEpochDay: Long) : AlarmRepeatRule
     data object Daily : AlarmRepeatRule
@@ -52,6 +54,48 @@ data class ClockTimer(
     val startedAtMillis: Long,
     val completedAtMillis: Long? = null,
  )
+
+data class StopwatchLap(
+    val id: Long,
+    val lapNumber: Int,
+    val elapsedMs: Long,
+    val splitMs: Long,
+    val createdAtMillis: Long,
+)
+
+data class ClockStopwatch(
+    val id: String,
+    val status: StopwatchStatus,
+    val accumulatedElapsedMs: Long,
+    val runningSinceElapsedRealtimeMs: Long? = null,
+    val runningSinceWallClockMs: Long? = null,
+    val updatedAtMillis: Long,
+    val laps: List<StopwatchLap> = emptyList(),
+) {
+    fun elapsedMs(
+        nowElapsedRealtimeMs: Long,
+        nowWallClockMillis: Long,
+    ): Long = when (status) {
+        StopwatchStatus.IDLE -> 0L
+        StopwatchStatus.PAUSED -> accumulatedElapsedMs
+        StopwatchStatus.RUNNING -> accumulatedElapsedMs + runningSegmentElapsedMs(
+            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            nowWallClockMillis = nowWallClockMillis,
+        )
+    }
+
+    private fun runningSegmentElapsedMs(
+        nowElapsedRealtimeMs: Long,
+        nowWallClockMillis: Long,
+    ): Long {
+        val elapsedRealtimeAnchor = runningSinceElapsedRealtimeMs
+        if (elapsedRealtimeAnchor != null && nowElapsedRealtimeMs >= elapsedRealtimeAnchor) {
+            return nowElapsedRealtimeMs - elapsedRealtimeAnchor
+        }
+        val wallClockAnchor = runningSinceWallClockMs ?: return 0L
+        return (nowWallClockMillis - wallClockAnchor).coerceAtLeast(0L)
+    }
+}
 
 data class WorldClock(
     val id: String,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -8,7 +8,30 @@ interface ClockRepository {
     fun observeUpcomingAlarms(): Flow<List<ClockAlarm>>
     fun observeActiveTimers(): Flow<List<ClockTimer>>
     fun observeRecentCompletedTimers(): Flow<List<ClockTimer>>
+    fun observeStopwatch(): Flow<ClockStopwatch>
     fun observeWorldClocks(): Flow<List<WorldClock>>
+
+    suspend fun startStopwatch(
+        nowWallClockMillis: Long = System.currentTimeMillis(),
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch
+
+    suspend fun pauseStopwatch(
+        nowWallClockMillis: Long = System.currentTimeMillis(),
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch
+
+    suspend fun resumeStopwatch(
+        nowWallClockMillis: Long = System.currentTimeMillis(),
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch
+
+    suspend fun resetStopwatch()
+
+    suspend fun recordStopwatchLap(
+        nowWallClockMillis: Long = System.currentTimeMillis(),
+        nowElapsedRealtimeMs: Long,
+    ): StopwatchLap?
 
     suspend fun addWorldClock(zoneId: String, displayName: String): WorldClock?
     suspend fun removeWorldClock(worldClockId: String): Boolean

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.kernel.ai.core.memory.clock
 
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.StopwatchLapEntity
+import com.kernel.ai.core.memory.entity.StopwatchStateEntity
 import com.kernel.ai.core.memory.entity.WorldClockEntity
 import java.time.Instant
 import java.time.ZoneId
@@ -19,11 +22,13 @@ import kotlinx.coroutines.flow.map
 private const val PRE_ALARM_LEAD_MS = 30 * 60 * 1_000L
 private const val PRE_ALARM_MIN_NOTICE_MS = 1_000L
 private const val PRE_ALARM_EVENT_SUFFIX = ":pre"
+private const val STOPWATCH_ID = "primary"
 
 @Singleton
 class ClockRepositoryImpl @Inject constructor(
     private val scheduledAlarmDao: ScheduledAlarmDao,
     private val worldClockDao: WorldClockDao,
+    private val stopwatchDao: StopwatchDao,
     private val scheduler: ClockScheduler,
  ) : ClockRepository {
     override fun observeManageableAlarms(): Flow<List<ClockAlarm>> =
@@ -55,11 +60,113 @@ class ClockRepositoryImpl @Inject constructor(
             schedules.mapNotNull { it.toClockTimer() }
         }
 
+    override fun observeStopwatch(): Flow<ClockStopwatch> =
+        combine(
+            stopwatchDao.observeState(STOPWATCH_ID),
+            stopwatchDao.observeLaps(STOPWATCH_ID),
+        ) { state, laps ->
+            state?.toClockStopwatch(laps.map { it.toStopwatchLap() }) ?: defaultStopwatch()
+        }
+
     override fun observeWorldClocks(): Flow<List<WorldClock>> =
         worldClockDao.observeAll().map { clocks ->
             clocks.map { it.toWorldClock() }
         }
 
+
+    override suspend fun startStopwatch(
+        nowWallClockMillis: Long,
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch {
+        val existing = stopwatchDao.getState(STOPWATCH_ID)
+        if (existing?.status == StopwatchStatus.RUNNING.name) {
+            return existing.toClockStopwatch(stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() })
+        }
+        val state = StopwatchStateEntity(
+            id = STOPWATCH_ID,
+            status = StopwatchStatus.RUNNING.name,
+            accumulatedElapsedMs = 0L,
+            runningSinceElapsedRealtimeMs = nowElapsedRealtimeMs,
+            runningSinceWallClockMs = nowWallClockMillis,
+            updatedAt = nowWallClockMillis,
+        )
+        stopwatchDao.deleteLaps(STOPWATCH_ID)
+        stopwatchDao.upsertState(state)
+        return state.toClockStopwatch(emptyList())
+    }
+
+    override suspend fun pauseStopwatch(
+        nowWallClockMillis: Long,
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch {
+        val existing = stopwatchDao.getState(STOPWATCH_ID) ?: return defaultStopwatch()
+        if (existing.status != StopwatchStatus.RUNNING.name) {
+            return existing.toClockStopwatch(stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() })
+        }
+        val laps = stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() }
+        val updated = existing.copy(
+            status = StopwatchStatus.PAUSED.name,
+            accumulatedElapsedMs = existing.toClockStopwatch(laps).elapsedMs(
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                nowWallClockMillis = nowWallClockMillis,
+            ),
+            runningSinceElapsedRealtimeMs = null,
+            runningSinceWallClockMs = null,
+            updatedAt = nowWallClockMillis,
+        )
+        stopwatchDao.upsertState(updated)
+        return updated.toClockStopwatch(laps)
+    }
+
+    override suspend fun resumeStopwatch(
+        nowWallClockMillis: Long,
+        nowElapsedRealtimeMs: Long,
+    ): ClockStopwatch {
+        val existing = stopwatchDao.getState(STOPWATCH_ID) ?: return startStopwatch(
+            nowWallClockMillis = nowWallClockMillis,
+            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+        )
+        if (existing.status != StopwatchStatus.PAUSED.name) {
+            return existing.toClockStopwatch(stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() })
+        }
+        val laps = stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() }
+        val updated = existing.copy(
+            status = StopwatchStatus.RUNNING.name,
+            runningSinceElapsedRealtimeMs = nowElapsedRealtimeMs,
+            runningSinceWallClockMs = nowWallClockMillis,
+            updatedAt = nowWallClockMillis,
+        )
+        stopwatchDao.upsertState(updated)
+        return updated.toClockStopwatch(laps)
+    }
+
+    override suspend fun resetStopwatch() {
+        stopwatchDao.resetStopwatch(STOPWATCH_ID)
+    }
+
+    override suspend fun recordStopwatchLap(
+        nowWallClockMillis: Long,
+        nowElapsedRealtimeMs: Long,
+    ): StopwatchLap? {
+        val existing = stopwatchDao.getState(STOPWATCH_ID) ?: return null
+        if (existing.status != StopwatchStatus.RUNNING.name) return null
+        val laps = stopwatchDao.getLaps(STOPWATCH_ID).map { it.toStopwatchLap() }
+        val elapsedMs = existing.toClockStopwatch(laps).elapsedMs(
+            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            nowWallClockMillis = nowWallClockMillis,
+        )
+        val lastElapsedMs = stopwatchDao.getLastLapElapsedMs(STOPWATCH_ID) ?: 0L
+        val lap = StopwatchLapEntity(
+            stopwatchId = STOPWATCH_ID,
+            lapNumber = (stopwatchDao.getMaxLapNumber(STOPWATCH_ID) ?: 0) + 1,
+            elapsedMs = elapsedMs,
+            splitMs = (elapsedMs - lastElapsedMs).coerceAtLeast(0L),
+            createdAt = nowWallClockMillis,
+        )
+        val lapId = stopwatchDao.insertLap(lap)
+        stopwatchDao.upsertState(existing.copy(updatedAt = nowWallClockMillis))
+        return lap.copy(id = lapId).toStopwatchLap()
+    }
 
     override suspend fun addWorldClock(zoneId: String, displayName: String): WorldClock? {
         worldClockDao.getByZoneId(zoneId)?.let { return it.toWorldClock() }
@@ -445,6 +552,36 @@ private fun WorldClockEntity.toWorldClock(): WorldClock =
         sortOrder = sortOrder,
         createdAtMillis = createdAt,
     )
+
+private fun defaultStopwatch(): ClockStopwatch =
+    ClockStopwatch(
+        id = STOPWATCH_ID,
+        status = StopwatchStatus.IDLE,
+        accumulatedElapsedMs = 0L,
+        updatedAtMillis = 0L,
+        laps = emptyList(),
+    )
+
+private fun StopwatchStateEntity.toClockStopwatch(laps: List<StopwatchLap>): ClockStopwatch =
+    ClockStopwatch(
+        id = id,
+        status = StopwatchStatus.valueOf(status),
+        accumulatedElapsedMs = accumulatedElapsedMs,
+        runningSinceElapsedRealtimeMs = runningSinceElapsedRealtimeMs,
+        runningSinceWallClockMs = runningSinceWallClockMs,
+        updatedAtMillis = updatedAt,
+        laps = laps,
+    )
+
+private fun StopwatchLapEntity.toStopwatchLap(): StopwatchLap =
+    StopwatchLap(
+        id = id,
+        lapNumber = lapNumber,
+        elapsedMs = elapsedMs,
+        splitMs = splitMs,
+        createdAtMillis = createdAt,
+    )
+
 private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm? {
     if (entryType != ClockEventType.ALARM.name) return null
     val zoneId = ZoneId.of(timeZoneId ?: ZoneId.systemDefault().id)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/StopwatchDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/StopwatchDao.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.kernel.ai.core.memory.entity.StopwatchLapEntity
+import com.kernel.ai.core.memory.entity.StopwatchStateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface StopwatchDao {
+    @Query("SELECT * FROM stopwatch_state WHERE id = :id LIMIT 1")
+    fun observeState(id: String): Flow<StopwatchStateEntity?>
+
+    @Query("SELECT * FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId ORDER BY lap_number DESC, id DESC")
+    fun observeLaps(stopwatchId: String): Flow<List<StopwatchLapEntity>>
+
+    @Query("SELECT * FROM stopwatch_state WHERE id = :id LIMIT 1")
+    suspend fun getState(id: String): StopwatchStateEntity?
+
+    @Query("SELECT * FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId ORDER BY lap_number DESC, id DESC")
+    suspend fun getLaps(stopwatchId: String): List<StopwatchLapEntity>
+
+    @Query("SELECT MAX(lap_number) FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId")
+    suspend fun getMaxLapNumber(stopwatchId: String): Int?
+
+    @Query("SELECT elapsed_ms FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId ORDER BY lap_number DESC, id DESC LIMIT 1")
+    suspend fun getLastLapElapsedMs(stopwatchId: String): Long?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertState(entity: StopwatchStateEntity)
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertLap(entity: StopwatchLapEntity): Long
+
+    @Query("DELETE FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId")
+    suspend fun deleteLaps(stopwatchId: String)
+
+    @Query("DELETE FROM stopwatch_state WHERE id = :id")
+    suspend fun deleteState(id: String)
+
+    @Transaction
+    suspend fun resetStopwatch(id: String) {
+        deleteLaps(id)
+        deleteState(id)
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/StopwatchLapEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/StopwatchLapEntity.kt
@@ -1,0 +1,31 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "stopwatch_laps",
+    foreignKeys = [
+        ForeignKey(
+            entity = StopwatchStateEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["stopwatch_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index(value = ["stopwatch_id"]),
+        Index(value = ["stopwatch_id", "lap_number"], unique = true),
+    ],
+)
+data class StopwatchLapEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "stopwatch_id") val stopwatchId: String,
+    @ColumnInfo(name = "lap_number") val lapNumber: Int,
+    @ColumnInfo(name = "elapsed_ms") val elapsedMs: Long,
+    @ColumnInfo(name = "split_ms") val splitMs: Long,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/StopwatchStateEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/StopwatchStateEntity.kt
@@ -1,0 +1,15 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "stopwatch_state")
+data class StopwatchStateEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo(name = "status") val status: String,
+    @ColumnInfo(name = "accumulated_elapsed_ms") val accumulatedElapsedMs: Long,
+    @ColumnInfo(name = "running_since_elapsed_realtime_ms") val runningSinceElapsedRealtimeMs: Long?,
+    @ColumnInfo(name = "running_since_wall_clock_ms") val runningSinceWallClockMs: Long?,
+    @ColumnInfo(name = "updated_at") val updatedAt: Long,
+)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -1,8 +1,11 @@
 package com.kernel.ai.core.memory.clock
 
 import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import com.kernel.ai.core.memory.entity.StopwatchLapEntity
+import com.kernel.ai.core.memory.entity.StopwatchStateEntity
 import com.kernel.ai.core.memory.entity.WorldClockEntity
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -30,13 +33,14 @@ import java.time.ZoneId
 class ClockRepositoryImplTest {
     private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
     private val scheduler = mockk<ClockScheduler>(relaxed = true)
+    private val stopwatchDao = mockk<StopwatchDao>()
     private val worldClockDao = mockk<WorldClockDao>()
 
     private lateinit var repository: ClockRepositoryImpl
 
     @BeforeEach
     fun setUp() {
-        repository = ClockRepositoryImpl(scheduledAlarmDao, worldClockDao, scheduler)
+        repository = ClockRepositoryImpl(scheduledAlarmDao, worldClockDao, stopwatchDao, scheduler)
         every {
             scheduler.getPlatformState()
         } returns ClockPlatformState(
@@ -245,6 +249,103 @@ class ClockRepositoryImplTest {
         assertEquals(2, deleted)
         coVerify(exactly = 1) { scheduledAlarmDao.deleteCompletedTimers() }
     }
+
+    @Test
+    fun `observeStopwatch falls back to idle state when nothing is persisted`() = runTest {
+        every { stopwatchDao.observeState("primary") } returns flowOf(null)
+        every { stopwatchDao.observeLaps("primary") } returns flowOf(emptyList())
+
+        val stopwatch = repository.observeStopwatch().first()
+
+        assertEquals(StopwatchStatus.IDLE, stopwatch.status)
+        assertTrue(stopwatch.laps.isEmpty())
+        assertEquals(0L, stopwatch.accumulatedElapsedMs)
+    }
+
+    @Test
+    fun `startStopwatch clears old laps and persists running anchors`() = runTest {
+        coEvery { stopwatchDao.getState("primary") } returns null
+        coEvery { stopwatchDao.deleteLaps("primary") } just Runs
+        coEvery { stopwatchDao.upsertState(any()) } just Runs
+
+        val stopwatch = repository.startStopwatch(
+            nowWallClockMillis = 100_000L,
+            nowElapsedRealtimeMs = 25_000L,
+        )
+
+        assertEquals(StopwatchStatus.RUNNING, stopwatch.status)
+        assertEquals(0L, stopwatch.accumulatedElapsedMs)
+        coVerify(exactly = 1) { stopwatchDao.deleteLaps("primary") }
+        coVerify(exactly = 1) {
+            stopwatchDao.upsertState(match {
+                it.status == StopwatchStatus.RUNNING.name &&
+                    it.accumulatedElapsedMs == 0L &&
+                    it.runningSinceElapsedRealtimeMs == 25_000L &&
+                    it.runningSinceWallClockMs == 100_000L
+            })
+        }
+    }
+
+    @Test
+    fun `pauseStopwatch snapshots elapsed time truthfully`() = runTest {
+        val running = StopwatchStateEntity(
+            id = "primary",
+            status = StopwatchStatus.RUNNING.name,
+            accumulatedElapsedMs = 2_000L,
+            runningSinceElapsedRealtimeMs = 10_000L,
+            runningSinceWallClockMs = 90_000L,
+            updatedAt = 90_000L,
+        )
+        coEvery { stopwatchDao.getState("primary") } returns running
+        coEvery { stopwatchDao.getLaps("primary") } returns emptyList()
+        coEvery { stopwatchDao.upsertState(any()) } just Runs
+
+        val stopwatch = repository.pauseStopwatch(
+            nowWallClockMillis = 112_000L,
+            nowElapsedRealtimeMs = 20_500L,
+        )
+
+        assertEquals(StopwatchStatus.PAUSED, stopwatch.status)
+        assertEquals(12_500L, stopwatch.accumulatedElapsedMs)
+        coVerify(exactly = 1) {
+            stopwatchDao.upsertState(match {
+                it.status == StopwatchStatus.PAUSED.name &&
+                    it.accumulatedElapsedMs == 12_500L &&
+                    it.runningSinceElapsedRealtimeMs == null &&
+                    it.runningSinceWallClockMs == null
+            })
+        }
+    }
+
+    @Test
+    fun `recordStopwatchLap stores cumulative and split times`() = runTest {
+        val running = StopwatchStateEntity(
+            id = "primary",
+            status = StopwatchStatus.RUNNING.name,
+            accumulatedElapsedMs = 3_000L,
+            runningSinceElapsedRealtimeMs = 10_000L,
+            runningSinceWallClockMs = 50_000L,
+            updatedAt = 50_000L,
+        )
+        coEvery { stopwatchDao.getState("primary") } returns running
+        coEvery { stopwatchDao.getLaps("primary") } returns emptyList()
+        coEvery { stopwatchDao.getLastLapElapsedMs("primary") } returns 0L
+        coEvery { stopwatchDao.getMaxLapNumber("primary") } returns 0
+        coEvery { stopwatchDao.insertLap(any()) } returns 42L
+        coEvery { stopwatchDao.upsertState(any()) } just Runs
+
+        val lap = repository.recordStopwatchLap(
+            nowWallClockMillis = 56_000L,
+            nowElapsedRealtimeMs = 14_500L,
+        )
+
+        assertNotNull(lap)
+        assertEquals(42L, lap?.id)
+        assertEquals(1, lap?.lapNumber)
+        assertEquals(7_500L, lap?.elapsedMs)
+        assertEquals(7_500L, lap?.splitMs)
+    }
+
 
     @Test
     fun `addWorldClock inserts ordered favorite and returns model`() = runTest {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import android.os.SystemClock
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
@@ -71,6 +72,9 @@ import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchLap
+import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.clock.WorldClock
 import com.kernel.ai.core.memory.clock.WorldClockCandidate
 import com.kernel.ai.core.memory.clock.WorldClockCatalog
@@ -92,6 +96,7 @@ fun SidePanelScreen(
     val alarms by viewModel.alarms.collectAsStateWithLifecycle()
     val timers by viewModel.timers.collectAsStateWithLifecycle()
     val recentCompletedTimers by viewModel.recentCompletedTimers.collectAsStateWithLifecycle()
+    val stopwatch by viewModel.stopwatch.collectAsStateWithLifecycle()
     val worldClocks by viewModel.worldClocks.collectAsStateWithLifecycle()
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
@@ -109,10 +114,12 @@ fun SidePanelScreen(
     var schedulingError by remember { mutableStateOf<String?>(null) }
 
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var nowElapsedRealtimeMs by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
     LaunchedEffect(Unit) {
         while (true) {
-            delay(1_000)
+            delay(100L)
             nowMs = System.currentTimeMillis()
+            nowElapsedRealtimeMs = SystemClock.elapsedRealtime()
         }
     }
 
@@ -123,7 +130,7 @@ fun SidePanelScreen(
     val visibleSelectionIds = when (selectedTab) {
         ClockSurfaceTab.TIMERS -> timers.map { it.id }
         ClockSurfaceTab.ALARMS -> alarms.map { it.id }
-        ClockSurfaceTab.WORLD_CLOCK -> emptyList()
+        ClockSurfaceTab.WORLD_CLOCK, ClockSurfaceTab.STOPWATCH -> emptyList()
     }
 
     fun onTimerScheduled(success: Boolean, closeDialog: Boolean = false) {
@@ -190,7 +197,7 @@ fun SidePanelScreen(
                         onClick = { showAddWorldClockDialog = true },
                     )
 
-                    ClockSurfaceTab.TIMERS -> Unit
+                    ClockSurfaceTab.TIMERS, ClockSurfaceTab.STOPWATCH -> Unit
                 }
             }
         },
@@ -221,6 +228,12 @@ fun SidePanelScreen(
                     onClick = { viewModel.setTab(ClockSurfaceTab.WORLD_CLOCK) },
                     label = { Text("World Clock") },
                     leadingIcon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+                )
+                FilterChip(
+                    selected = selectedTab == ClockSurfaceTab.STOPWATCH,
+                    onClick = { viewModel.setTab(ClockSurfaceTab.STOPWATCH) },
+                    label = { Text("Stopwatch") },
+                    leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
                 )
             }
 
@@ -271,6 +284,38 @@ fun SidePanelScreen(
                         }
                     },
                 )
+
+                ClockSurfaceTab.STOPWATCH -> StopwatchDashboard(
+                    stopwatch = stopwatch,
+                    nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                    nowWallClockMs = nowMs,
+                    onStart = {
+                        viewModel.startStopwatch(
+                            nowWallClockMillis = nowMs,
+                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                        )
+                    },
+                    onPause = {
+                        viewModel.pauseStopwatch(
+                            nowWallClockMillis = nowMs,
+                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                        )
+                    },
+                    onResume = {
+                        viewModel.resumeStopwatch(
+                            nowWallClockMillis = nowMs,
+                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                        )
+                    },
+                    onReset = viewModel::resetStopwatch,
+                    onLap = {
+                        viewModel.recordStopwatchLap(
+                            nowWallClockMillis = nowMs,
+                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                        )
+                    },
+                )
+
 
                 ClockSurfaceTab.WORLD_CLOCK -> WorldClockDashboard(
                     worldClocks = worldClocks,
@@ -744,6 +789,156 @@ private fun CompletedTimerCard(
 }
 
 @Composable
+private fun StopwatchDashboard(
+    stopwatch: ClockStopwatch,
+    nowElapsedRealtimeMs: Long,
+    nowWallClockMs: Long,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onReset: () -> Unit,
+    onLap: () -> Unit,
+) {
+    val elapsedMs = stopwatch.elapsedMs(
+        nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+        nowWallClockMillis = nowWallClockMs,
+    )
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        item {
+            SectionHeader(
+                title = "Stopwatch",
+                supportingText = when (stopwatch.status) {
+                    StopwatchStatus.IDLE -> "Start a stopwatch and record laps without leaving Jandal's Clock surface."
+                    StopwatchStatus.RUNNING -> "Running now"
+                    StopwatchStatus.PAUSED -> "Paused — resume or reset when you're ready"
+                },
+            )
+        }
+        item {
+            ElevatedCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Icon(Icons.Default.Timer, contentDescription = null)
+                    Text(
+                        text = formatStopwatchElapsed(elapsedMs),
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                    Text(
+                        text = when (stopwatch.status) {
+                            StopwatchStatus.IDLE -> "Ready"
+                            StopwatchStatus.RUNNING -> "Running"
+                            StopwatchStatus.PAUSED -> "Paused"
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        when (stopwatch.status) {
+                            StopwatchStatus.IDLE -> {
+                                Button(
+                                    onClick = onStart,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Start") }
+                            }
+                            StopwatchStatus.RUNNING -> {
+                                Button(
+                                    onClick = onLap,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Lap") }
+                                Button(
+                                    onClick = onPause,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Pause") }
+                                TextButton(
+                                    onClick = onReset,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Reset") }
+                            }
+                            StopwatchStatus.PAUSED -> {
+                                Button(
+                                    onClick = onResume,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Resume") }
+                                TextButton(
+                                    onClick = onReset,
+                                    modifier = Modifier.weight(1f),
+                                ) { Text("Reset") }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (stopwatch.laps.isEmpty()) {
+            item {
+                EmptyStateCard(
+                    title = "No laps yet",
+                    body = if (stopwatch.status == StopwatchStatus.IDLE) {
+                        "Start the stopwatch to track elapsed time, then tap Lap to capture splits here."
+                    } else {
+                        "Tap Lap while the stopwatch is running to capture split times."
+                    },
+                )
+            }
+        } else {
+            item {
+                SectionHeader(
+                    title = "Laps",
+                    supportingText = "Latest lap first.",
+                )
+            }
+            items(stopwatch.laps, key = { it.id }) { lap ->
+                StopwatchLapCard(lap = lap)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StopwatchLapCard(lap: StopwatchLap) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Lap ${lap.lapNumber}", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = "Split ${formatStopwatchElapsed(lap.splitMs)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = formatStopwatchElapsed(lap.elapsedMs),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        }
+    }
+}
+
+
+@Composable
 private fun AlarmDashboard(
     alarms: List<ClockAlarm>,
     inSelectionMode: Boolean,
@@ -992,6 +1187,21 @@ private fun EmptyStateCard(
         }
     }
 }
+
+private fun formatStopwatchElapsed(elapsedMs: Long): String {
+    val safeElapsedMs = elapsedMs.coerceAtLeast(0L)
+    val totalSeconds = safeElapsedMs / 1_000L
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    val seconds = totalSeconds % 60L
+    val tenths = (safeElapsedMs % 1_000L) / 100L
+    return if (hours > 0L) {
+        "%d:%02d:%02d.%01d".format(hours, minutes, seconds, tenths)
+    } else {
+        "%02d:%02d.%01d".format(minutes, seconds, tenths)
+    }
+}
+
 
 private fun defaultTimerTitle(timer: ClockTimer): String =
     formatDuration(timer.durationMs).removeSuffix(" remaining")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -6,6 +6,7 @@ import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.ClockTimer
 import com.kernel.ai.core.memory.clock.WorldClock
 import com.kernel.ai.core.memory.clock.WorldClockCandidate
@@ -20,7 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-enum class ClockSurfaceTab { TIMERS, ALARMS, WORLD_CLOCK }
+enum class ClockSurfaceTab { TIMERS, ALARMS, WORLD_CLOCK, STOPWATCH }
 
 @HiltViewModel
 class SidePanelViewModel @Inject constructor(
@@ -37,6 +38,20 @@ class SidePanelViewModel @Inject constructor(
     val recentCompletedTimers: StateFlow<List<ClockTimer>> =
         clockRepository.observeRecentCompletedTimers()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val stopwatch: StateFlow<ClockStopwatch> =
+        clockRepository.observeStopwatch()
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5_000),
+                ClockStopwatch(
+                    id = "primary",
+                    status = com.kernel.ai.core.memory.clock.StopwatchStatus.IDLE,
+                    accumulatedElapsedMs = 0L,
+                    updatedAtMillis = 0L,
+                ),
+            )
+
 
     val worldClocks: StateFlow<List<WorldClock>> =
         clockRepository.observeWorldClocks()
@@ -209,6 +224,49 @@ class SidePanelViewModel @Inject constructor(
             onResult(tryScheduleTimer(durationMs, label))
         }
     }
+
+    fun startStopwatch(nowWallClockMillis: Long, nowElapsedRealtimeMs: Long) {
+        viewModelScope.launch {
+            clockRepository.startStopwatch(
+                nowWallClockMillis = nowWallClockMillis,
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            )
+        }
+    }
+
+    fun pauseStopwatch(nowWallClockMillis: Long, nowElapsedRealtimeMs: Long) {
+        viewModelScope.launch {
+            clockRepository.pauseStopwatch(
+                nowWallClockMillis = nowWallClockMillis,
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            )
+        }
+    }
+
+    fun resumeStopwatch(nowWallClockMillis: Long, nowElapsedRealtimeMs: Long) {
+        viewModelScope.launch {
+            clockRepository.resumeStopwatch(
+                nowWallClockMillis = nowWallClockMillis,
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            )
+        }
+    }
+
+    fun resetStopwatch() {
+        viewModelScope.launch {
+            clockRepository.resetStopwatch()
+        }
+    }
+
+    fun recordStopwatchLap(nowWallClockMillis: Long, nowElapsedRealtimeMs: Long) {
+        viewModelScope.launch {
+            clockRepository.recordStopwatchLap(
+                nowWallClockMillis = nowWallClockMillis,
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            )
+        }
+    }
+
 
     fun addWorldClock(candidate: WorldClockCandidate, onResult: (Boolean) -> Unit = {}) {
         viewModelScope.launch {

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -2,7 +2,9 @@ package com.kernel.ai.feature.settings
 
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.clock.WorldClock
 import com.kernel.ai.core.memory.clock.WorldClockCandidate
 import io.mockk.coEvery
@@ -34,6 +36,14 @@ class SidePanelViewModelTest {
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
         every { clockRepository.observeRecentCompletedTimers() } returns emptyFlow()
         every { clockRepository.observeWorldClocks() } returns emptyFlow()
+        every { clockRepository.observeStopwatch() } returns kotlinx.coroutines.flow.flowOf(
+            ClockStopwatch(
+                id = "primary",
+                status = StopwatchStatus.IDLE,
+                accumulatedElapsedMs = 0L,
+                updatedAtMillis = 0L,
+            ),
+        )
     }
 
     @AfterEach
@@ -43,21 +53,23 @@ class SidePanelViewModelTest {
 
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        val draft = sampleAlarmDraft(label = "Wake")
+        coEvery { clockRepository.createAlarm(draft) } returns null
         val viewModel = SidePanelViewModel(clockRepository)
 
-        val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
+        val result = viewModel.tryScheduleAlarm(draft)
 
         assertEquals(false, result)
     }
 
     @Test
     fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        val draft = sampleAlarmDraft(label = "Wake")
+        coEvery { clockRepository.createAlarm(draft) } returns null
         val viewModel = SidePanelViewModel(clockRepository)
         var result: AlarmSaveResult? = null
 
-        viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
+        viewModel.scheduleAlarm(draft) { result = it }
         advanceUntilIdle()
 
         assertEquals(AlarmSaveResult.FAILED, result)
@@ -65,7 +77,7 @@ class SidePanelViewModelTest {
 
     @Test
     fun `scheduleTimer returns true when repository accepts timer`() = runTest {
-        coEvery { clockRepository.scheduleTimer(any(), any()) } returns ClockTimer(
+        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns ClockTimer(
             id = "timer-1",
             triggerAtMillis = 5_000L,
             label = "Tea",
@@ -116,12 +128,43 @@ class SidePanelViewModelTest {
     }
 
     @Test
-    fun `editAlarm returns false when repository rejects update`() = runTest {
-        val alarm = sampleAlarm()
-        coEvery { clockRepository.updateAlarm(alarm.id, any()) } returns null
+    fun `startStopwatch forwards wall and elapsed clocks to repository`() = runTest {
+        coEvery { clockRepository.startStopwatch(10_000L, 5_000L) } returns ClockStopwatch(
+            id = "primary",
+            status = StopwatchStatus.RUNNING,
+            accumulatedElapsedMs = 0L,
+            runningSinceElapsedRealtimeMs = 5_000L,
+            runningSinceWallClockMs = 10_000L,
+            updatedAtMillis = 10_000L,
+        )
         val viewModel = SidePanelViewModel(clockRepository)
 
-        val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
+        viewModel.startStopwatch(nowWallClockMillis = 10_000L, nowElapsedRealtimeMs = 5_000L)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { clockRepository.startStopwatch(10_000L, 5_000L) }
+    }
+
+    @Test
+    fun `recordStopwatchLap delegates to repository`() = runTest {
+        coEvery { clockRepository.recordStopwatchLap(12_000L, 6_000L) } returns null
+        val viewModel = SidePanelViewModel(clockRepository)
+
+        viewModel.recordStopwatchLap(nowWallClockMillis = 12_000L, nowElapsedRealtimeMs = 6_000L)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { clockRepository.recordStopwatchLap(12_000L, 6_000L) }
+    }
+
+
+    @Test
+    fun `editAlarm returns false when repository rejects update`() = runTest {
+        val alarm = sampleAlarm()
+        val draft = sampleAlarmDraft(label = "Updated")
+        coEvery { clockRepository.updateAlarm(alarm.id, draft) } returns null
+        val viewModel = SidePanelViewModel(clockRepository)
+
+        val result = viewModel.tryEditAlarm(alarm, draft)
 
         assertEquals(false, result)
     }
@@ -166,6 +209,15 @@ class SidePanelViewModelTest {
         coVerify(exactly = 1) { clockRepository.reorderWorldClocks(listOf("2", "1")) }
     }
 }
+
+private fun sampleAlarmDraft(label: String?) = com.kernel.ai.core.memory.clock.AlarmDraft(
+    label = label,
+    hour = 7,
+    minute = 0,
+    repeatRule = com.kernel.ai.core.memory.clock.AlarmRepeatRule.OneOff(19_000L),
+    timeZoneId = java.time.ZoneId.systemDefault().id,
+ )
+
 
 private fun sampleAlarm() = ClockAlarm(
     id = "alarm-1",


### PR DESCRIPTION
## Summary
- add app-owned stopwatch state and lap persistence with a Room migration for the Clock domain
- expand the unified Clock surface with a Stopwatch tab for start, pause, resume, reset, and lap capture
- add an ongoing stopwatch notification with pause, resume, and reset actions wired through the same repository state

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :feature:settings:testDebugUnitTest --tests "*SidePanelViewModelTest" :app:testDebugUnitTest --tests "*ClockStopwatchNotificationSyncerTest" :feature:settings:compileDebugAndroidTestKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin`

## Manual device tests
1. Install and open the debug build:
   - `./gradlew installDebug`
2. Stopwatch tab basics:
   - open **Clock** from the drawer
   - switch to **Stopwatch**
   - verify the idle state shows `Ready` with a single **Start** action
3. Run / pause / resume / reset:
   - start the stopwatch and let it run for a few seconds
   - verify elapsed time advances live in-app
   - tap **Pause**, confirm the elapsed time stops advancing
   - tap **Resume**, confirm it continues from the paused value
   - tap **Reset**, confirm elapsed time returns to zero and laps clear
4. Lap capture:
   - start again and record at least three laps
   - verify the lap list shows latest lap first with split and total elapsed values
5. Notification controls:
   - leave the app while the stopwatch is running
   - verify an ongoing stopwatch notification appears
   - use **Pause** from the notification and confirm the in-app stopwatch pauses
   - use **Resume** from the notification and confirm the in-app stopwatch resumes
   - use **Reset** from the notification and confirm the notification disappears

Closes #745
