### PR TITLE
fix(#745): restore stopwatch tab visibility

### DIFF
--- a/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
@@ -40,10 +40,16 @@ class AndroidClockStopwatchNotificationSink @Inject constructor(
         val nowWallClockMs = System.currentTimeMillis()
         val nowElapsedRealtimeMs = android.os.SystemClock.elapsedRealtime()
         val elapsedMs = stopwatch.elapsedMs(nowElapsedRealtimeMs, nowWallClockMs)
+        val latestLap = stopwatch.laps.firstOrNull()
         val contentText = when (stopwatch.status) {
-            StopwatchStatus.RUNNING -> "${formatStopwatchElapsed(elapsedMs)} elapsed"
-            StopwatchStatus.PAUSED -> "Paused at ${formatStopwatchElapsed(elapsedMs)}"
-            StopwatchStatus.IDLE -> formatStopwatchElapsed(elapsedMs)
+            StopwatchStatus.RUNNING -> latestLap?.let {
+                "Lap ${it.lapNumber} · split ${formatStopwatchElapsed(it.splitMs)}"
+            } ?: "Tap Lap to capture a split"
+            StopwatchStatus.PAUSED -> buildString {
+                append("Paused at ${formatStopwatchElapsed(elapsedMs)}")
+                if (stopwatch.laps.isNotEmpty()) append(" · ${stopwatch.laps.size} laps")
+            }
+            StopwatchStatus.IDLE -> "Ready"
         }
         return NotificationCompat.Builder(context, ClockAlertContract.ACTIVE_STOPWATCH_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
@@ -59,6 +65,11 @@ class AndroidClockStopwatchNotificationSink @Inject constructor(
             .apply {
                 when (stopwatch.status) {
                     StopwatchStatus.RUNNING -> {
+                        addAction(
+                            android.R.drawable.ic_menu_recent_history,
+                            "Lap",
+                            buildBroadcastPendingIntent(ClockAlertContract.ACTION_LAP_STOPWATCH),
+                        )
                         addAction(
                             android.R.drawable.ic_media_pause,
                             "Pause",

--- a/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AndroidClockStopwatchNotificationSink.kt
@@ -40,27 +40,18 @@ class AndroidClockStopwatchNotificationSink @Inject constructor(
         val nowWallClockMs = System.currentTimeMillis()
         val nowElapsedRealtimeMs = android.os.SystemClock.elapsedRealtime()
         val elapsedMs = stopwatch.elapsedMs(nowElapsedRealtimeMs, nowWallClockMs)
-        val latestLap = stopwatch.laps.firstOrNull()
-        val contentText = when (stopwatch.status) {
-            StopwatchStatus.RUNNING -> latestLap?.let {
-                "Lap ${it.lapNumber} · split ${formatStopwatchElapsed(it.splitMs)}"
-            } ?: "Tap Lap to capture a split"
-            StopwatchStatus.PAUSED -> buildString {
-                append("Paused at ${formatStopwatchElapsed(elapsedMs)}")
-                if (stopwatch.laps.isNotEmpty()) append(" · ${stopwatch.laps.size} laps")
-            }
-            StopwatchStatus.IDLE -> "Ready"
-        }
+        val contentText = stopwatchNotificationText(stopwatch, elapsedMs)
         return NotificationCompat.Builder(context, ClockAlertContract.ACTIVE_STOPWATCH_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle("Stopwatch")
-            .setContentText(contentText)
+            .setContentTitle(stopwatchNotificationTitle(stopwatch))
+            .apply { if (contentText != null) setContentText(contentText) }
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(stopwatch.status == StopwatchStatus.RUNNING)
             .setWhen(nowWallClockMs - elapsedMs)
             .setUsesChronometer(stopwatch.status == StopwatchStatus.RUNNING)
+            .setChronometerCountDown(false)
             .setContentIntent(buildOpenAppPendingIntent())
             .apply {
                 when (stopwatch.status) {
@@ -148,5 +139,33 @@ class AndroidClockStopwatchNotificationSink @Inject constructor(
                 enableVibration(false)
             },
         )
+    }
+}
+
+internal fun stopwatchNotificationTitle(stopwatch: ClockStopwatch): String = when (stopwatch.status) {
+    StopwatchStatus.RUNNING -> stopwatch.laps.firstOrNull()?.let { "Stopwatch · Lap ${it.lapNumber}" } ?: "Stopwatch"
+    StopwatchStatus.PAUSED -> "Stopwatch paused"
+    StopwatchStatus.IDLE -> "Stopwatch"
+}
+
+internal fun stopwatchNotificationText(stopwatch: ClockStopwatch, elapsedMs: Long): String? = when (stopwatch.status) {
+    StopwatchStatus.RUNNING -> null
+    StopwatchStatus.PAUSED -> buildString {
+        append("Paused at ${formatStopwatchElapsedForNotification(elapsedMs)}")
+        if (stopwatch.laps.isNotEmpty()) append(" · ${stopwatch.laps.size} ${if (stopwatch.laps.size == 1) "lap" else "laps"}")
+    }
+    StopwatchStatus.IDLE -> "Ready"
+}
+
+private fun formatStopwatchElapsedForNotification(elapsedMs: Long): String {
+    val safeElapsedMs = elapsedMs.coerceAtLeast(0L)
+    val totalSeconds = safeElapsedMs / 1_000L
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    val seconds = totalSeconds % 60L
+    return if (hours > 0L) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%02d:%02d".format(minutes, seconds)
     }
 }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
@@ -16,8 +16,8 @@ internal object ClockAlertContract {
     const val ACTION_SKIP_ALARM_OCCURRENCE = "com.kernel.ai.alarm.action.SKIP_ALARM_OCCURRENCE"
     const val ACTION_PAUSE_STOPWATCH = "com.kernel.ai.alarm.action.PAUSE_STOPWATCH"
     const val ACTION_RESUME_STOPWATCH = "com.kernel.ai.alarm.action.RESUME_STOPWATCH"
+    const val ACTION_LAP_STOPWATCH = "com.kernel.ai.alarm.action.LAP_STOPWATCH"
     const val ACTION_RESET_STOPWATCH = "com.kernel.ai.alarm.action.RESET_STOPWATCH"
-
     const val ALERT_CHANNEL_ID = "kernel_clock_alerts"
     const val ACTIVE_TIMER_CHANNEL_ID = "kernel_clock_timers"
     const val ACTIVE_STOPWATCH_CHANNEL_ID = "kernel_clock_stopwatch"

--- a/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchActionReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockStopwatchActionReceiver.kt
@@ -36,6 +36,13 @@ class ClockStopwatchActionReceiver : BroadcastReceiver() {
                         )
                     }
 
+                    ClockAlertContract.ACTION_LAP_STOPWATCH -> {
+                        clockRepository.recordStopwatchLap(
+                            nowWallClockMillis = System.currentTimeMillis(),
+                            nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+                        )
+                    }
+
                     ClockAlertContract.ACTION_RESET_STOPWATCH -> {
                         context.getSystemService(NotificationManager::class.java)
                             .cancel(ClockAlertContract.STOPWATCH_NOTIFICATION_ID)

--- a/app/src/test/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncerTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockStopwatchNotificationSyncerTest.kt
@@ -1,9 +1,12 @@
 package com.kernel.ai.alarm
 
 import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchLap
 import com.kernel.ai.core.memory.clock.StopwatchStatus
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class ClockStopwatchNotificationSyncerTest {
@@ -27,13 +30,43 @@ class ClockStopwatchNotificationSyncerTest {
         verify(exactly = 0) { transport.cancel(any()) }
     }
 
+    @Test
+    fun `running stopwatch notification keeps chronometer prominent and surfaces latest lap in title`() {
+        val stopwatch = stopwatch(
+            status = StopwatchStatus.RUNNING,
+            laps = listOf(
+                StopwatchLap(id = 2L, lapNumber = 2, elapsedMs = 8_000L, splitMs = 3_000L, createdAtMillis = 12_000L),
+            ),
+        )
+
+        assertEquals("Stopwatch · Lap 2", stopwatchNotificationTitle(stopwatch))
+        assertNull(stopwatchNotificationText(stopwatch, elapsedMs = 8_000L))
+    }
+
+    @Test
+    fun `paused stopwatch notification summarizes elapsed time and lap count`() {
+        val stopwatch = stopwatch(
+            status = StopwatchStatus.PAUSED,
+            accumulatedElapsedMs = 12_000L,
+            laps = listOf(
+                StopwatchLap(id = 1L, lapNumber = 1, elapsedMs = 12_000L, splitMs = 12_000L, createdAtMillis = 12_000L),
+            ),
+        )
+
+        assertEquals("Stopwatch paused", stopwatchNotificationTitle(stopwatch))
+        assertEquals("Paused at 00:12 · 1 lap", stopwatchNotificationText(stopwatch, elapsedMs = 12_000L))
+    }
+
+
     private fun stopwatch(
         status: StopwatchStatus,
         accumulatedElapsedMs: Long = 0L,
+        laps: List<StopwatchLap> = emptyList(),
     ) = ClockStopwatch(
         id = "primary",
         status = status,
         accumulatedElapsedMs = accumulatedElapsedMs,
         updatedAtMillis = 1_000L,
+        laps = laps,
     )
 }

--- a/core/memory/build.gradle.kts
+++ b/core/memory/build.gradle.kts
@@ -72,6 +72,11 @@ dependencies {
     implementation(libs.hilt.work)
     ksp(libs.hilt.work.compiler)
 
+    androidTestImplementation("androidx.test:runner:1.5.2")
+    androidTestImplementation("androidx.test:core:1.5.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+
+
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)

--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/dao/StopwatchDaoTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/dao/StopwatchDaoTest.kt
@@ -1,0 +1,77 @@
+package com.kernel.ai.core.memory.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kernel.ai.core.memory.KernelDatabase
+import com.kernel.ai.core.memory.entity.StopwatchLapEntity
+import com.kernel.ai.core.memory.entity.StopwatchStateEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StopwatchDaoTest {
+    private lateinit var database: KernelDatabase
+    private lateinit var stopwatchDao: StopwatchDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, KernelDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        stopwatchDao = database.stopwatchDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun upsertState_preservesExistingLaps() = runBlocking {
+        stopwatchDao.upsertState(
+            StopwatchStateEntity(
+                id = "primary",
+                status = "RUNNING",
+                accumulatedElapsedMs = 3_000L,
+                runningSinceElapsedRealtimeMs = 10_000L,
+                runningSinceWallClockMs = 50_000L,
+                updatedAt = 50_000L,
+            ),
+        )
+        stopwatchDao.insertLap(
+            StopwatchLapEntity(
+                stopwatchId = "primary",
+                lapNumber = 1,
+                elapsedMs = 7_500L,
+                splitMs = 7_500L,
+                createdAt = 56_000L,
+            ),
+        )
+
+        stopwatchDao.upsertState(
+            StopwatchStateEntity(
+                id = "primary",
+                status = "PAUSED",
+                accumulatedElapsedMs = 7_500L,
+                runningSinceElapsedRealtimeMs = null,
+                runningSinceWallClockMs = null,
+                updatedAt = 56_000L,
+            ),
+        )
+
+        val laps = stopwatchDao.getLaps("primary")
+        val state = stopwatchDao.getState("primary")
+
+        assertEquals(1, laps.size)
+        assertEquals(1, laps.single().lapNumber)
+        assertEquals("PAUSED", state?.status)
+        assertEquals(7_500L, state?.accumulatedElapsedMs)
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/StopwatchDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/StopwatchDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Upsert
 import com.kernel.ai.core.memory.entity.StopwatchLapEntity
 import com.kernel.ai.core.memory.entity.StopwatchStateEntity
 import kotlinx.coroutines.flow.Flow
@@ -29,7 +30,7 @@ interface StopwatchDao {
     @Query("SELECT elapsed_ms FROM stopwatch_laps WHERE stopwatch_id = :stopwatchId ORDER BY lap_number DESC, id DESC LIMIT 1")
     suspend fun getLastLapElapsedMs(stopwatchId: String): Long?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertState(entity: StopwatchStateEntity)
 
     @Insert(onConflict = OnConflictStrategy.ABORT)

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceTabsTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceTabsTest.kt
@@ -1,0 +1,42 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import org.junit.Rule
+import org.junit.Test
+
+class ClockSurfaceTabsTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun clockTabsAreHorizontallyScrollableAndReachStopwatch() {
+        composeTestRule.setContent {
+            var selectedTab by mutableStateOf(ClockSurfaceTab.TIMERS)
+            Column {
+                ClockSurfaceTabs(
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                )
+                Text("Selected: ${selectedTab.name}")
+            }
+        }
+
+        composeTestRule.onNodeWithTag("clock_surface_tabs").assert(hasScrollAction())
+        composeTestRule.onNodeWithTag("clock_surface_tabs").performScrollToNode(hasText("Stopwatch"))
+        composeTestRule.onNodeWithText("Stopwatch").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Selected: STOPWATCH").assertIsDisplayed()
+    }
+}

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceTabsTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceTabsTest.kt
@@ -5,15 +5,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasScrollAction
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
 import org.junit.Rule
 import org.junit.Test
 
@@ -22,7 +18,7 @@ class ClockSurfaceTabsTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun clockTabsAreHorizontallyScrollableAndReachStopwatch() {
+    fun clockTabsShowAllFourSurfacesWithoutScrolling() {
         composeTestRule.setContent {
             var selectedTab by mutableStateOf(ClockSurfaceTab.TIMERS)
             Column {
@@ -34,8 +30,10 @@ class ClockSurfaceTabsTest {
             }
         }
 
-        composeTestRule.onNodeWithTag("clock_surface_tabs").assert(hasScrollAction())
-        composeTestRule.onNodeWithTag("clock_surface_tabs").performScrollToNode(hasText("Stopwatch"))
+        composeTestRule.onNodeWithTag("clock_surface_tabs").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Timers").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Alarms").assertIsDisplayed()
+        composeTestRule.onNodeWithText("World Clock").assertIsDisplayed()
         composeTestRule.onNodeWithText("Stopwatch").assertIsDisplayed().performClick()
         composeTestRule.onNodeWithText("Selected: STOPWATCH").assertIsDisplayed()
     }

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/StopwatchDashboardTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/StopwatchDashboardTest.kt
@@ -1,0 +1,60 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchLap
+import com.kernel.ai.core.memory.clock.StopwatchStatus
+import org.junit.Rule
+import org.junit.Test
+
+class StopwatchDashboardTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun runningStopwatchShowsLapsInsideActiveCard() {
+        composeTestRule.setContent {
+            StopwatchDashboard(
+                stopwatch = ClockStopwatch(
+                    id = "primary",
+                    status = StopwatchStatus.RUNNING,
+                    accumulatedElapsedMs = 5_000L,
+                    runningSinceElapsedRealtimeMs = 1_000L,
+                    runningSinceWallClockMs = 10_000L,
+                    updatedAtMillis = 10_000L,
+                    laps = listOf(
+                        StopwatchLap(
+                            id = 2L,
+                            lapNumber = 2,
+                            elapsedMs = 8_000L,
+                            splitMs = 3_000L,
+                            createdAtMillis = 12_000L,
+                        ),
+                        StopwatchLap(
+                            id = 1L,
+                            lapNumber = 1,
+                            elapsedMs = 5_000L,
+                            splitMs = 5_000L,
+                            createdAtMillis = 11_000L,
+                        ),
+                    ),
+                ),
+                nowElapsedRealtimeMs = 2_000L,
+                nowWallClockMs = 11_000L,
+                onStart = {},
+                onPause = {},
+                onResume = {},
+                onReset = {},
+                onLap = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("active_stopwatch_card").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lap 2").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Split 00:03").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lap 1").assertIsDisplayed()
+    }
+}

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/StopwatchDashboardTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/StopwatchDashboardTest.kt
@@ -1,7 +1,9 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.kernel.ai.core.memory.clock.ClockStopwatch
@@ -53,8 +55,12 @@ class StopwatchDashboardTest {
         }
 
         composeTestRule.onNodeWithTag("active_stopwatch_card").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("stopwatch_lap_summary").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2 laps recorded · latest split 00:03").assertIsDisplayed()
         composeTestRule.onNodeWithText("Lap 2").assertIsDisplayed()
         composeTestRule.onNodeWithText("Split 00:03").assertIsDisplayed()
         composeTestRule.onNodeWithText("Lap 1").assertIsDisplayed()
-    }
+        composeTestRule.onAllNodesWithText("Record lap").assertCountEquals(0)
+}
+
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -853,7 +853,6 @@ internal fun StopwatchDashboard(
                 stopwatch = stopwatch,
                 onStart = onStart,
                 onResume = onResume,
-                onLap = onLap,
             )
         }
         item {
@@ -861,7 +860,10 @@ internal fun StopwatchDashboard(
                 title = "Active stopwatch",
                 supportingText = when (stopwatch.status) {
                     StopwatchStatus.IDLE -> "Jandal currently keeps one app-owned stopwatch active at a time."
-                    StopwatchStatus.RUNNING -> "1 stopwatch running now"
+                    StopwatchStatus.RUNNING -> {
+                        val lapCount = stopwatch.laps.size
+                        if (lapCount == 0) "1 stopwatch running now" else "1 stopwatch running now · $lapCount ${if (lapCount == 1) "lap" else "laps"} recorded"
+                    }
                     StopwatchStatus.PAUSED -> "Paused — resume it or clear it when you're done"
                 },
             )
@@ -893,8 +895,7 @@ private fun StopwatchQuickActionCard(
     stopwatch: ClockStopwatch,
     onStart: () -> Unit,
     onResume: () -> Unit,
-    onLap: () -> Unit,
- ) {
+) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -908,7 +909,7 @@ private fun StopwatchQuickActionCard(
             Text(
                 text = when (stopwatch.status) {
                     StopwatchStatus.IDLE -> "Start a stopwatch and keep its controls and laps in one place."
-                    StopwatchStatus.RUNNING -> "Your active stopwatch stays below as a card with live controls and laps."
+                    StopwatchStatus.RUNNING -> "Your active stopwatch stays below as a card with live controls, visible lap history, and reset."
                     StopwatchStatus.PAUSED -> "Resume the active stopwatch or clear it when you're finished."
                 },
                 style = MaterialTheme.typography.bodyMedium,
@@ -923,10 +924,11 @@ private fun StopwatchQuickActionCard(
                     onClick = onResume,
                     modifier = Modifier.fillMaxWidth(),
                 ) { Text("Resume stopwatch") }
-                StopwatchStatus.RUNNING -> Button(
-                    onClick = onLap,
-                    modifier = Modifier.fillMaxWidth(),
-                ) { Text("Record lap") }
+                StopwatchStatus.RUNNING -> Text(
+                    text = "Use the active stopwatch card below to record laps, pause, or clear it.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }
@@ -940,7 +942,7 @@ private fun StopwatchActiveCard(
     onResume: () -> Unit,
     onReset: () -> Unit,
     onLap: () -> Unit,
- ) {
+) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -971,6 +973,14 @@ private fun StopwatchActiveCard(
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    stopwatchLatestLapSummary(stopwatch)?.let { summary ->
+                        Text(
+                            text = summary,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("stopwatch_lap_summary"),
+                        )
+                    }
                 }
                 IconButton(onClick = onReset) {
                     Icon(Icons.Default.Delete, contentDescription = "Reset stopwatch")
@@ -1019,6 +1029,14 @@ private fun StopwatchActiveCard(
         }
     }
 }
+
+private fun stopwatchLatestLapSummary(stopwatch: ClockStopwatch): String? {
+    val latestLap = stopwatch.laps.firstOrNull() ?: return null
+    val lapCount = stopwatch.laps.size
+    val lapLabel = if (lapCount == 1) "lap" else "laps"
+    return "$lapCount $lapLabel recorded · latest split ${formatStopwatchElapsed(latestLap.splitMs)}"
+}
+
 
 @Composable
 private fun StopwatchLapRow(lap: StopwatchLap) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -207,35 +207,11 @@ fun SidePanelScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                FilterChip(
-                    selected = selectedTab == ClockSurfaceTab.TIMERS,
-                    onClick = { viewModel.setTab(ClockSurfaceTab.TIMERS) },
-                    label = { Text("Timers") },
-                    leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
-                )
-                FilterChip(
-                    selected = selectedTab == ClockSurfaceTab.ALARMS,
-                    onClick = { viewModel.setTab(ClockSurfaceTab.ALARMS) },
-                    label = { Text("Alarms") },
-                    leadingIcon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                )
-                FilterChip(
-                    selected = selectedTab == ClockSurfaceTab.WORLD_CLOCK,
-                    onClick = { viewModel.setTab(ClockSurfaceTab.WORLD_CLOCK) },
-                    label = { Text("World Clock") },
-                    leadingIcon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
-                )
-                FilterChip(
-                    selected = selectedTab == ClockSurfaceTab.STOPWATCH,
-                    onClick = { viewModel.setTab(ClockSurfaceTab.STOPWATCH) },
-                    label = { Text("Stopwatch") },
-                    leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
-                )
-            }
+            ClockSurfaceTabs(
+                selectedTab = selectedTab,
+                onTabSelected = viewModel::setTab,
+            )
+
 
             when (selectedTab) {
                 ClockSurfaceTab.TIMERS -> TimerDashboard(
@@ -530,6 +506,55 @@ private val TIMER_PRESETS = listOf(
     TimerPreset("10 min", 10 * 60_000L),
     TimerPreset("15 min", 15 * 60_000L),
 )
+
+@Composable
+internal fun ClockSurfaceTabs(
+    selectedTab: ClockSurfaceTab,
+    onTabSelected: (ClockSurfaceTab) -> Unit,
+    modifier: Modifier = Modifier,
+ ) {
+    LazyRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("clock_surface_tabs"),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            FilterChip(
+                selected = selectedTab == ClockSurfaceTab.TIMERS,
+                onClick = { onTabSelected(ClockSurfaceTab.TIMERS) },
+                label = { Text("Timers") },
+                leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
+            )
+        }
+        item {
+            FilterChip(
+                selected = selectedTab == ClockSurfaceTab.ALARMS,
+                onClick = { onTabSelected(ClockSurfaceTab.ALARMS) },
+                label = { Text("Alarms") },
+                leadingIcon = { Icon(Icons.Default.Alarm, contentDescription = null) },
+            )
+        }
+        item {
+            FilterChip(
+                selected = selectedTab == ClockSurfaceTab.WORLD_CLOCK,
+                onClick = { onTabSelected(ClockSurfaceTab.WORLD_CLOCK) },
+                label = { Text("World Clock") },
+                leadingIcon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
+            )
+        }
+        item {
+            FilterChip(
+                selected = selectedTab == ClockSurfaceTab.STOPWATCH,
+                onClick = { onTabSelected(ClockSurfaceTab.STOPWATCH) },
+                label = { Text("Stopwatch") },
+                leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
+            )
+        }
+    }
+}
+
 
 @Composable
 private fun SectionHeader(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
@@ -63,6 +62,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -507,52 +507,68 @@ private val TIMER_PRESETS = listOf(
     TimerPreset("15 min", 15 * 60_000L),
 )
 
+private data class ClockSurfaceOption(
+    val tab: ClockSurfaceTab,
+    val label: String,
+    val icon: ImageVector,
+ )
+
+private val CLOCK_SURFACE_OPTIONS = listOf(
+    ClockSurfaceOption(ClockSurfaceTab.TIMERS, "Timers", Icons.Default.Timer),
+    ClockSurfaceOption(ClockSurfaceTab.ALARMS, "Alarms", Icons.Default.Alarm),
+    ClockSurfaceOption(ClockSurfaceTab.WORLD_CLOCK, "World Clock", Icons.Default.AccessTime),
+    ClockSurfaceOption(ClockSurfaceTab.STOPWATCH, "Stopwatch", Icons.Default.Timer),
+)
+
+
 @Composable
 internal fun ClockSurfaceTabs(
     selectedTab: ClockSurfaceTab,
     onTabSelected: (ClockSurfaceTab) -> Unit,
     modifier: Modifier = Modifier,
  ) {
-    LazyRow(
+    Column(
         modifier = modifier
             .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
             .testTag("clock_surface_tabs"),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        item {
-            FilterChip(
-                selected = selectedTab == ClockSurfaceTab.TIMERS,
-                onClick = { onTabSelected(ClockSurfaceTab.TIMERS) },
-                label = { Text("Timers") },
-                leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
-            )
-        }
-        item {
-            FilterChip(
-                selected = selectedTab == ClockSurfaceTab.ALARMS,
-                onClick = { onTabSelected(ClockSurfaceTab.ALARMS) },
-                label = { Text("Alarms") },
-                leadingIcon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-            )
-        }
-        item {
-            FilterChip(
-                selected = selectedTab == ClockSurfaceTab.WORLD_CLOCK,
-                onClick = { onTabSelected(ClockSurfaceTab.WORLD_CLOCK) },
-                label = { Text("World Clock") },
-                leadingIcon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
-            )
-        }
-        item {
-            FilterChip(
-                selected = selectedTab == ClockSurfaceTab.STOPWATCH,
-                onClick = { onTabSelected(ClockSurfaceTab.STOPWATCH) },
-                label = { Text("Stopwatch") },
-                leadingIcon = { Icon(Icons.Default.Timer, contentDescription = null) },
-            )
+        CLOCK_SURFACE_OPTIONS.chunked(2).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row.forEach { option ->
+                    ClockSurfaceTabChip(
+                        option = option,
+                        selected = selectedTab == option.tab,
+                        onClick = { onTabSelected(option.tab) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                repeat(2 - row.size) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
         }
     }
+}
+
+@Composable
+private fun ClockSurfaceTabChip(
+    option: ClockSurfaceOption,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+ ) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier.heightIn(min = 56.dp),
+        label = { Text(option.label, maxLines = 1) },
+        leadingIcon = { Icon(option.icon, contentDescription = null) },
+    )
 }
 
 
@@ -814,7 +830,7 @@ private fun CompletedTimerCard(
 }
 
 @Composable
-private fun StopwatchDashboard(
+internal fun StopwatchDashboard(
     stopwatch: ClockStopwatch,
     nowElapsedRealtimeMs: Long,
     nowWallClockMs: Long,
@@ -823,7 +839,7 @@ private fun StopwatchDashboard(
     onResume: () -> Unit,
     onReset: () -> Unit,
     onLap: () -> Unit,
-) {
+ ) {
     val elapsedMs = stopwatch.elapsedMs(
         nowElapsedRealtimeMs = nowElapsedRealtimeMs,
         nowWallClockMillis = nowWallClockMs,
@@ -833,132 +849,196 @@ private fun StopwatchDashboard(
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
         item {
-            SectionHeader(
-                title = "Stopwatch",
-                supportingText = when (stopwatch.status) {
-                    StopwatchStatus.IDLE -> "Start a stopwatch and record laps without leaving Jandal's Clock surface."
-                    StopwatchStatus.RUNNING -> "Running now"
-                    StopwatchStatus.PAUSED -> "Paused — resume or reset when you're ready"
-                },
+            StopwatchQuickActionCard(
+                stopwatch = stopwatch,
+                onStart = onStart,
+                onResume = onResume,
+                onLap = onLap,
             )
         }
         item {
-            ElevatedCard(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Icon(Icons.Default.Timer, contentDescription = null)
-                    Text(
-                        text = formatStopwatchElapsed(elapsedMs),
-                        style = MaterialTheme.typography.displaySmall,
-                    )
-                    Text(
-                        text = when (stopwatch.status) {
-                            StopwatchStatus.IDLE -> "Ready"
-                            StopwatchStatus.RUNNING -> "Running"
-                            StopwatchStatus.PAUSED -> "Paused"
-                        },
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        when (stopwatch.status) {
-                            StopwatchStatus.IDLE -> {
-                                Button(
-                                    onClick = onStart,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Start") }
-                            }
-                            StopwatchStatus.RUNNING -> {
-                                Button(
-                                    onClick = onLap,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Lap") }
-                                Button(
-                                    onClick = onPause,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Pause") }
-                                TextButton(
-                                    onClick = onReset,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Reset") }
-                            }
-                            StopwatchStatus.PAUSED -> {
-                                Button(
-                                    onClick = onResume,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Resume") }
-                                TextButton(
-                                    onClick = onReset,
-                                    modifier = Modifier.weight(1f),
-                                ) { Text("Reset") }
-                            }
-                        }
-                    }
-                }
-            }
+            SectionHeader(
+                title = "Active stopwatch",
+                supportingText = when (stopwatch.status) {
+                    StopwatchStatus.IDLE -> "Jandal currently keeps one app-owned stopwatch active at a time."
+                    StopwatchStatus.RUNNING -> "1 stopwatch running now"
+                    StopwatchStatus.PAUSED -> "Paused — resume it or clear it when you're done"
+                },
+            )
         }
-        if (stopwatch.laps.isEmpty()) {
+        if (stopwatch.status == StopwatchStatus.IDLE) {
             item {
                 EmptyStateCard(
-                    title = "No laps yet",
-                    body = if (stopwatch.status == StopwatchStatus.IDLE) {
-                        "Start the stopwatch to track elapsed time, then tap Lap to capture splits here."
-                    } else {
-                        "Tap Lap while the stopwatch is running to capture split times."
-                    },
+                    title = "No active stopwatch",
+                    body = "Start the stopwatch from the card above. Laps will appear directly inside the active stopwatch card.",
                 )
             }
         } else {
             item {
-                SectionHeader(
-                    title = "Laps",
-                    supportingText = "Latest lap first.",
+                StopwatchActiveCard(
+                    stopwatch = stopwatch,
+                    elapsedMs = elapsedMs,
+                    onPause = onPause,
+                    onResume = onResume,
+                    onReset = onReset,
+                    onLap = onLap,
                 )
-            }
-            items(stopwatch.laps, key = { it.id }) { lap ->
-                StopwatchLapCard(lap = lap)
             }
         }
     }
 }
 
 @Composable
-private fun StopwatchLapCard(lap: StopwatchLap) {
+private fun StopwatchQuickActionCard(
+    stopwatch: ClockStopwatch,
+    onStart: () -> Unit,
+    onResume: () -> Unit,
+    onLap: () -> Unit,
+ ) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text("Lap ${lap.lapNumber}", style = MaterialTheme.typography.titleMedium)
+            Text("Stopwatch", style = MaterialTheme.typography.headlineSmall)
+            Text(
+                text = when (stopwatch.status) {
+                    StopwatchStatus.IDLE -> "Start a stopwatch and keep its controls and laps in one place."
+                    StopwatchStatus.RUNNING -> "Your active stopwatch stays below as a card with live controls and laps."
+                    StopwatchStatus.PAUSED -> "Resume the active stopwatch or clear it when you're finished."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            when (stopwatch.status) {
+                StopwatchStatus.IDLE -> Button(
+                    onClick = onStart,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Start stopwatch") }
+                StopwatchStatus.PAUSED -> Button(
+                    onClick = onResume,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Resume stopwatch") }
+                StopwatchStatus.RUNNING -> Button(
+                    onClick = onLap,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Record lap") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StopwatchActiveCard(
+    stopwatch: ClockStopwatch,
+    elapsedMs: Long,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onReset: () -> Unit,
+    onLap: () -> Unit,
+ ) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("active_stopwatch_card"),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.Default.Timer, contentDescription = null)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = formatStopwatchElapsed(elapsedMs),
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                    Text(
+                        text = when (stopwatch.status) {
+                            StopwatchStatus.RUNNING -> "Running"
+                            StopwatchStatus.PAUSED -> "Paused"
+                            StopwatchStatus.IDLE -> "Ready"
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = onReset) {
+                    Icon(Icons.Default.Delete, contentDescription = "Reset stopwatch")
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                when (stopwatch.status) {
+                    StopwatchStatus.RUNNING -> {
+                        Button(
+                            onClick = onLap,
+                            modifier = Modifier.weight(1f),
+                        ) { Text("Lap") }
+                        Button(
+                            onClick = onPause,
+                            modifier = Modifier.weight(1f),
+                        ) { Text("Pause") }
+                    }
+                    StopwatchStatus.PAUSED -> {
+                        Button(
+                            onClick = onResume,
+                            modifier = Modifier.weight(1f),
+                        ) { Text("Resume") }
+                    }
+                    StopwatchStatus.IDLE -> Unit
+                }
+            }
+            HorizontalDivider()
+            if (stopwatch.laps.isEmpty()) {
                 Text(
-                    text = "Split ${formatStopwatchElapsed(lap.splitMs)}",
+                    text = "No laps yet. Tap Lap and each split will appear here in the active stopwatch card.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+            } else {
+                Text("Laps", style = MaterialTheme.typography.titleMedium)
+                stopwatch.laps.forEachIndexed { index, lap ->
+                    StopwatchLapRow(lap = lap)
+                    if (index != stopwatch.laps.lastIndex) {
+                        HorizontalDivider()
+                    }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun StopwatchLapRow(lap: StopwatchLap) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Lap ${lap.lapNumber}", style = MaterialTheme.typography.titleMedium)
             Text(
-                text = formatStopwatchElapsed(lap.elapsedMs),
-                style = MaterialTheme.typography.headlineSmall,
+                text = "Split ${formatStopwatchElapsed(lap.splitMs)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        Text(
+            text = formatStopwatchElapsed(lap.elapsedMs),
+            style = MaterialTheme.typography.headlineSmall,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the fixed Clock tab row with a horizontally scrollable `LazyRow`
- restore access to the `Stopwatch` tab on devices where the fourth chip rendered off-screen
- add a UI regression test that verifies the tab strip can scroll to and select `Stopwatch`

## Root cause
`feat(#745)` added a fourth Clock surface chip (`Stopwatch`) but the tab strip in `SidePanelScreen.kt` still used a fixed `Row`. On narrower devices the rightmost chip could render outside the viewport, leaving no way to reach Stopwatch even though the feature code was present.

## Verification
- `./gradlew :feature:settings:testDebugUnitTest --tests "*SidePanelViewModelTest" :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :app:testDebugUnitTest --tests "*ClockStopwatchNotificationSyncerTest" :feature:settings:compileDebugAndroidTestKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin`

## Manual follow-up
- Run `ClockSurfaceTabsTest` on a connected device or emulator to validate the scroll path end-to-end.

Fixes #745
