### PR TITLE
feat(#749): add stopwatch quick intents

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -551,6 +551,57 @@ class QuickIntentRouter(
         ),
 
 
+        // ── Stopwatch ──
+        IntentPattern(
+            intentName = "start_stopwatch",
+            regex = Regex(
+                """(?:start|begin|create|launch)\s+(?:the\s+)?stopwatch\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "pause_stopwatch",
+            regex = Regex(
+                """(?:pause|stop)\s+(?:the\s+)?stopwatch\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "resume_stopwatch",
+            regex = Regex(
+                """(?:resume|continue)\s+(?:the\s+)?stopwatch\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "lap_stopwatch",
+            regex = Regex(
+                """(?:(?:record|take|capture)\s+(?:a\s+)?)?(?:lap|split)\s+(?:the\s+)?stopwatch\b|(?:record|take|capture)\s+(?:a\s+)?(?:lap|split)\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "reset_stopwatch",
+            regex = Regex(
+                """(?:reset|clear)\s+(?:the\s+)?stopwatch\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "get_stopwatch_status",
+            regex = Regex(
+                """(?:what(?:'s|\s+is)\s+(?:my\s+|the\s+)stopwatch(?:\s+status)?|stopwatch\s+status|how\s+long\s+has\s+(?:my\s+|the\s+)?stopwatch\s+been\s+running|elapsed\s+time\s+(?:on|for)\s+(?:my\s+|the\s+)?stopwatch)\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+
+
 
         // ── Calendar ──
         // "add/create/schedule/set up a [dentist/gym/meeting/event] [for/on] [date] [at time]"
@@ -2662,6 +2713,9 @@ class QuickIntentRouter(
             // Timer / Alarm — query and cancel (no required params)
             "list_timers", "get_timer_remaining",
             "cancel_alarm", "cancel_timer",
+            // Stopwatch
+            "start_stopwatch", "pause_stopwatch", "resume_stopwatch",
+            "lap_stopwatch", "reset_stopwatch", "get_stopwatch_status",
         )
 
         /**

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -10,6 +10,7 @@ import android.hardware.camera2.CameraManager
 import android.media.AudioManager
 import android.net.Uri
 import android.os.BatteryManager
+import android.os.SystemClock
 import android.provider.CalendarContract
 import android.provider.ContactsContract
 import android.provider.MediaStore
@@ -48,6 +49,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 private const val TAG = "KernelAI"
@@ -66,8 +68,9 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
  *   send_sms                — ACTION_SENDTO SMS composer (params: message)
  *   set_alarm               — App-owned alarm scheduling (params: hours, minutes, label)
  *   set_timer               — App-owned timer scheduling (params: duration_seconds, label)
- *   create_calendar_event   — CalendarContract ACTION_INSERT edit screen (params: title, date, time?, duration_minutes?, description?)
- *   get_battery             — BatteryManager capacity + charging state
+ *   start_stopwatch         — Start a new app-owned stopwatch
+ *   pause_stopwatch         — Pause the active app-owned stopwatch
+ *   resume_stopwatch        — Resume the paused app-owned stopwatch
  *   get_time / get_date     — LocalDateTime formatted display
  *   toggle_dnd_on/off       — NotificationManager interruption filter (requests permission if needed)
  *   set_volume              — AudioManager STREAM_MUSIC (params: value, is_percent)
@@ -132,6 +135,12 @@ class NativeIntentHandler @Inject constructor(
                 "list_timers" -> listTimers()
                 "cancel_timer_named" -> cancelTimerNamed(params)
                 "get_timer_remaining" -> getTimerRemaining(params)
+                "start_stopwatch" -> startStopwatch()
+                "pause_stopwatch" -> pauseStopwatch()
+                "resume_stopwatch" -> resumeStopwatch()
+                "lap_stopwatch" -> lapStopwatch()
+                "reset_stopwatch" -> resetStopwatch()
+                "get_stopwatch_status" -> getStopwatchStatus()
                 "cancel_alarm" -> cancelAlarm(params)
                 "create_calendar_event" -> createCalendarEvent(params)
                 "get_battery" -> getBattery()
@@ -211,6 +220,7 @@ class NativeIntentHandler @Inject constructor(
             "send_email", "send_sms", "make_call",
             "set_alarm", "cancel_alarm",
             "set_timer", "cancel_timer", "cancel_timer_named", "list_timers", "get_timer_remaining",
+            "start_stopwatch", "pause_stopwatch", "resume_stopwatch", "lap_stopwatch", "reset_stopwatch", "get_stopwatch_status",
             "create_calendar_event",
             "get_battery", "get_time", "get_date",
             "toggle_dnd_on", "toggle_dnd_off",
@@ -435,6 +445,115 @@ class NativeIntentHandler @Inject constructor(
             SkillResult.DirectReply("Timer has finished.")
         }
     }
+
+    // ── Stopwatch ─────────────────────────────────────────────────────────────
+
+    private fun startStopwatch(): SkillResult {
+        val existing = currentStopwatch()
+        if (existing.status == com.kernel.ai.core.memory.clock.StopwatchStatus.RUNNING) {
+            return SkillResult.DirectReply(
+                "Stopwatch is already running at ${formatStopwatchElapsed(existing.elapsedMs(SystemClock.elapsedRealtime(), System.currentTimeMillis()))}.",
+            )
+        }
+        runBlocking {
+            clockRepository.startStopwatch(
+                nowWallClockMillis = System.currentTimeMillis(),
+                nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+            )
+        }
+        return SkillResult.Success("Started the stopwatch.")
+    }
+
+    private fun pauseStopwatch(): SkillResult {
+        val existing = currentStopwatch()
+        if (existing.status != com.kernel.ai.core.memory.clock.StopwatchStatus.RUNNING) {
+            return SkillResult.Failure("pause_stopwatch", "No running stopwatch to pause.")
+        }
+        val paused = runBlocking {
+            clockRepository.pauseStopwatch(
+                nowWallClockMillis = System.currentTimeMillis(),
+                nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+            )
+        }
+        return SkillResult.Success("Paused the stopwatch at ${formatStopwatchElapsed(paused.accumulatedElapsedMs)}.")
+    }
+
+    private fun resumeStopwatch(): SkillResult {
+        val existing = currentStopwatch()
+        if (existing.status != com.kernel.ai.core.memory.clock.StopwatchStatus.PAUSED) {
+            return SkillResult.Failure("resume_stopwatch", "No paused stopwatch to resume.")
+        }
+        runBlocking {
+            clockRepository.resumeStopwatch(
+                nowWallClockMillis = System.currentTimeMillis(),
+                nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+            )
+        }
+        return SkillResult.Success("Resumed the stopwatch.")
+    }
+
+    private fun lapStopwatch(): SkillResult {
+        val existing = currentStopwatch()
+        if (existing.status != com.kernel.ai.core.memory.clock.StopwatchStatus.RUNNING) {
+            return SkillResult.Failure("lap_stopwatch", "No running stopwatch to record a lap.")
+        }
+        val lap = runBlocking {
+            clockRepository.recordStopwatchLap(
+                nowWallClockMillis = System.currentTimeMillis(),
+                nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+            )
+        } ?: return SkillResult.Failure("lap_stopwatch", "Could not record a lap.")
+        return SkillResult.Success(
+            "Recorded lap ${lap.lapNumber} at ${formatStopwatchElapsed(lap.elapsedMs)}. Split ${formatStopwatchElapsed(lap.splitMs)}.",
+        )
+    }
+
+    private fun resetStopwatch(): SkillResult {
+        val existing = currentStopwatch()
+        if (existing.status == com.kernel.ai.core.memory.clock.StopwatchStatus.IDLE) {
+            return SkillResult.DirectReply("Stopwatch is already cleared.")
+        }
+        runBlocking { clockRepository.resetStopwatch() }
+        return SkillResult.Success("Reset the stopwatch.")
+    }
+
+    private fun getStopwatchStatus(): SkillResult {
+        val stopwatch = currentStopwatch()
+        return when (stopwatch.status) {
+            com.kernel.ai.core.memory.clock.StopwatchStatus.IDLE -> SkillResult.DirectReply("No active stopwatch.")
+            com.kernel.ai.core.memory.clock.StopwatchStatus.RUNNING -> {
+                val elapsed = stopwatch.elapsedMs(SystemClock.elapsedRealtime(), System.currentTimeMillis())
+                SkillResult.DirectReply(
+                    "Stopwatch running for ${formatStopwatchElapsed(elapsed)}${formatStopwatchLapSuffix(stopwatch.laps.size)}.",
+                )
+            }
+            com.kernel.ai.core.memory.clock.StopwatchStatus.PAUSED -> SkillResult.DirectReply(
+                "Stopwatch paused at ${formatStopwatchElapsed(stopwatch.accumulatedElapsedMs)}${formatStopwatchLapSuffix(stopwatch.laps.size)}.",
+            )
+        }
+    }
+
+    private fun currentStopwatch(): com.kernel.ai.core.memory.clock.ClockStopwatch =
+        runBlocking { clockRepository.observeStopwatch().first() }
+
+    private fun formatStopwatchLapSuffix(lapCount: Int): String = when (lapCount) {
+        0 -> ""
+        1 -> " with 1 lap recorded"
+        else -> " with $lapCount laps recorded"
+    }
+
+    private fun formatStopwatchElapsed(elapsedMs: Long): String {
+        val totalSeconds = elapsedMs.coerceAtLeast(0L) / 1_000L
+        val hours = totalSeconds / 3_600L
+        val minutes = (totalSeconds % 3_600L) / 60L
+        val seconds = totalSeconds % 60L
+        return if (hours > 0L) {
+            "%d:%02d:%02d".format(hours, minutes, seconds)
+        } else {
+            "%02d:%02d".format(minutes, seconds)
+        }
+    }
+
 
     private fun formatDuration(seconds: Long): String {
         val hrs = seconds / 3600

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -56,6 +56,25 @@ class QuickIntentRouterTest {
                 "set a timer", "start a countdown", "timer for", "countdown",
                 "start timer", "time me for", "count down",
             ),
+            "start_stopwatch" to listOf(
+                "start the stopwatch", "begin stopwatch", "launch stopwatch",
+            ),
+            "pause_stopwatch" to listOf(
+                "pause the stopwatch", "stop the stopwatch",
+            ),
+            "resume_stopwatch" to listOf(
+                "resume the stopwatch", "continue stopwatch",
+            ),
+            "lap_stopwatch" to listOf(
+                "record lap", "lap stopwatch", "split the stopwatch",
+            ),
+            "reset_stopwatch" to listOf(
+                "reset stopwatch", "clear the stopwatch",
+            ),
+            "get_stopwatch_status" to listOf(
+                "stopwatch status", "what's my stopwatch status", "how long has the stopwatch been running",
+            ),
+
             "toggle_dnd_on" to listOf(
                 "do not disturb", "silent mode", "quiet mode", "mute notifications",
                 "dnd on", "silence my phone", "go quiet", "no notifications",
@@ -466,6 +485,36 @@ class QuickIntentRouterTest {
             assertRegexMatch(result, "set_timer", "10 minute tea timer")
         }
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // STOPWATCH TESTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Stopwatch")
+    inner class Stopwatch {
+
+        @Test
+        fun `start stopwatch routes via regex`() {
+            assertRegexMatch(regexOnlyRouter.route("start the stopwatch"), "start_stopwatch", "start the stopwatch")
+        }
+
+        @Test
+        fun `pause stopwatch routes via regex before media pause fallback`() {
+            assertRegexMatch(regexOnlyRouter.route("pause the stopwatch"), "pause_stopwatch", "pause the stopwatch")
+        }
+
+        @Test
+        fun `record lap routes to stopwatch lap intent`() {
+            assertRegexMatch(regexOnlyRouter.route("record lap"), "lap_stopwatch", "record lap")
+        }
+
+        @Test
+        fun `stopwatch status routes via regex`() {
+            assertRegexMatch(regexOnlyRouter.route("what's my stopwatch status"), "get_stopwatch_status", "what's my stopwatch status")
+        }
+    }
+
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VOICE REGRESSION TESTS

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -7,12 +7,16 @@ import android.content.pm.PackageManager
 import android.database.Cursor
 import android.media.AudioManager
 import android.net.Uri
+import android.os.SystemClock
 import android.provider.ContactsContract
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchLap
+import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalTime
+import kotlinx.coroutines.flow.flowOf
 
 class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
@@ -58,6 +63,7 @@ class NativeIntentHandlerTest {
     fun setUp() {
         mockkStatic(Log::class)
         mockkStatic(Uri::class)
+        mockkStatic(SystemClock::class)
         every { Uri.encode(any()) } answers {
             java.net.URLEncoder.encode(firstArg<String>(), java.nio.charset.StandardCharsets.UTF_8)
                 .replace("+", "%20")
@@ -73,10 +79,22 @@ class NativeIntentHandlerTest {
         every { Log.e(any<String>(), any<String>(), any()) } returns 0
         every { context.contentResolver } returns contentResolver
         every { context.startActivity(any()) } just Runs
+        every { SystemClock.elapsedRealtime() } returns 12_000L
+
+        every { clockRepository.observeStopwatch() } returns flowOf(
+            ClockStopwatch(
+                id = "primary",
+                status = StopwatchStatus.IDLE,
+                accumulatedElapsedMs = 0L,
+                updatedAtMillis = 0L,
+            ),
+        )
+
     }
 
     @AfterEach
     fun tearDown() {
+        unmockkStatic(SystemClock::class)
         unmockkStatic(Uri::class)
         unmockkStatic(Log::class)
     }
@@ -558,6 +576,86 @@ class NativeIntentHandlerTest {
         assertEquals(SkillResult.Failure("run_intent", "Could not schedule the alarm."), result)
         verify(exactly = 0) { context.startActivity(any()) }
     }
+
+    @Test
+    fun `start_stopwatch starts a new stopwatch when idle`() {
+        coEvery { clockRepository.startStopwatch(any(), any()) } returns ClockStopwatch(
+            id = "primary",
+            status = StopwatchStatus.RUNNING,
+            accumulatedElapsedMs = 0L,
+            runningSinceElapsedRealtimeMs = 10_000L,
+            runningSinceWallClockMs = 20_000L,
+            updatedAtMillis = 20_000L,
+        )
+
+        val result = handler.handle("start_stopwatch", emptyMap())
+
+        assertEquals(SkillResult.Success("Started the stopwatch."), result)
+        coVerify(exactly = 1) { clockRepository.startStopwatch(any(), any()) }
+    }
+
+    @Test
+    fun `lap_stopwatch records a lap when stopwatch is running`() {
+        every { clockRepository.observeStopwatch() } returns flowOf(
+            ClockStopwatch(
+                id = "primary",
+                status = StopwatchStatus.RUNNING,
+                accumulatedElapsedMs = 3_000L,
+                runningSinceElapsedRealtimeMs = 10_000L,
+                runningSinceWallClockMs = 20_000L,
+                updatedAtMillis = 20_000L,
+            ),
+        )
+        coEvery { clockRepository.recordStopwatchLap(any(), any()) } returns StopwatchLap(
+            id = 1L,
+            lapNumber = 1,
+            elapsedMs = 7_500L,
+            splitMs = 7_500L,
+            createdAtMillis = 27_500L,
+        )
+
+        val result = handler.handle("lap_stopwatch", emptyMap())
+
+        assertEquals(SkillResult.Success("Recorded lap 1 at 00:07. Split 00:07."), result)
+        coVerify(exactly = 1) { clockRepository.recordStopwatchLap(any(), any()) }
+    }
+
+    @Test
+    fun `lap_stopwatch fails truthfully when stopwatch is not running`() {
+        every { clockRepository.observeStopwatch() } returns flowOf(
+            ClockStopwatch(
+                id = "primary",
+                status = StopwatchStatus.PAUSED,
+                accumulatedElapsedMs = 7_500L,
+                updatedAtMillis = 27_500L,
+            ),
+        )
+
+        val result = handler.handle("lap_stopwatch", emptyMap())
+
+        assertEquals(SkillResult.Failure("lap_stopwatch", "No running stopwatch to record a lap."), result)
+        coVerify(exactly = 0) { clockRepository.recordStopwatchLap(any(), any()) }
+    }
+
+    @Test
+    fun `get_stopwatch_status reports paused stopwatch with lap count`() {
+        every { clockRepository.observeStopwatch() } returns flowOf(
+            ClockStopwatch(
+                id = "primary",
+                status = StopwatchStatus.PAUSED,
+                accumulatedElapsedMs = 12_000L,
+                updatedAtMillis = 12_000L,
+                laps = listOf(
+                    StopwatchLap(id = 1L, lapNumber = 1, elapsedMs = 12_000L, splitMs = 12_000L, createdAtMillis = 12_000L),
+                ),
+            ),
+        )
+
+        val result = handler.handle("get_stopwatch_status", emptyMap())
+
+        assertEquals(SkillResult.DirectReply("Stopwatch paused at 00:12 with 1 lap recorded."), result)
+    }
+
 
     @Test
     fun `set_timer returns generic failure when repository rejects despite exact alarm availability`() {


### PR DESCRIPTION
## Summary
- add stopwatch quick-intent routing for start, pause, resume, lap, reset, and status queries
- wire stopwatch native intent handling through the existing app-owned stopwatch repository with truthful state checks
- add regression coverage for stopwatch routing and native handler behavior

## Verification
- `./gradlew :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" :feature:chat:compileDebugKotlin`

## Manual checks
1. Open chat or Actions and try:
   - `start stopwatch`
   - `pause stopwatch`
   - `resume stopwatch`
   - `record lap`
   - `reset stopwatch`
   - `what's my stopwatch status`
2. Confirm the replies match the visible stopwatch state in the Clock surface.
3. Confirm invalid actions fail truthfully:
   - `record lap` with no running stopwatch
   - `resume stopwatch` with no paused stopwatch

Closes #749
