### PR TITLE
feat(#752): add alert-time voice actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,12 +85,12 @@ dependencies {
     // Project modules
     implementation(project(":core:inference"))
     implementation(project(":core:memory"))
+    implementation(project(":core:voice"))
     implementation(project(":core:wasm"))
     implementation(project(":core:ui"))
     implementation(project(":core:skills"))
     implementation(project(":feature:chat"))
     implementation(project(":feature:settings"))
-
     // Compose
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/app/src/main/java/com/kernel/ai/alarm/AndroidClockAlertController.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AndroidClockAlertController.kt
@@ -1,0 +1,25 @@
+package com.kernel.ai.alarm
+
+import android.content.Context
+import android.content.Intent
+import com.kernel.ai.core.skills.natives.ClockAlertController
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidClockAlertController @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ClockAlertController {
+    override fun dismissActiveTimerAlerts(): Boolean {
+        val hadActiveTimerAlert = ClockAlertService.hasActiveTimerAlerts()
+        if (!hadActiveTimerAlert) return false
+
+        context.startService(
+            Intent(context, ClockAlertService::class.java).apply {
+                action = ClockAlertContract.ACTION_STOP_TIMER_ALERTS
+            },
+        )
+        return true
+    }
+}

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
@@ -12,6 +12,7 @@ internal object ClockAlertContract {
 
     const val ACTION_TRIGGER_ALERT = "com.kernel.ai.alarm.action.TRIGGER_ALERT"
     const val ACTION_STOP_ALERT = "com.kernel.ai.alarm.action.STOP_ALERT"
+    const val ACTION_STOP_TIMER_ALERTS = "com.kernel.ai.alarm.action.STOP_TIMER_ALERTS"
     const val ACTION_SNOOZE_ALERT = "com.kernel.ai.alarm.action.SNOOZE_ALERT"
     const val ACTION_ADD_MINUTE_ALERT = "com.kernel.ai.alarm.action.ADD_MINUTE_ALERT"
     const val ACTION_START_VOICE_CONTROL = "com.kernel.ai.alarm.action.START_VOICE_CONTROL"

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
@@ -12,6 +12,9 @@ internal object ClockAlertContract {
 
     const val ACTION_TRIGGER_ALERT = "com.kernel.ai.alarm.action.TRIGGER_ALERT"
     const val ACTION_STOP_ALERT = "com.kernel.ai.alarm.action.STOP_ALERT"
+    const val ACTION_SNOOZE_ALERT = "com.kernel.ai.alarm.action.SNOOZE_ALERT"
+    const val ACTION_ADD_MINUTE_ALERT = "com.kernel.ai.alarm.action.ADD_MINUTE_ALERT"
+    const val ACTION_START_VOICE_CONTROL = "com.kernel.ai.alarm.action.START_VOICE_CONTROL"
     const val ACTION_CANCEL_TIMER = "com.kernel.ai.alarm.action.CANCEL_TIMER"
     const val ACTION_SKIP_ALARM_OCCURRENCE = "com.kernel.ai.alarm.action.SKIP_ALARM_OCCURRENCE"
     const val ACTION_PAUSE_STOPWATCH = "com.kernel.ai.alarm.action.PAUSE_STOPWATCH"

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -19,8 +19,29 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.kernel.ai.MainActivity
 import com.kernel.ai.core.memory.clock.ClockEventType
+import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.VoiceInputStartResult
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+private const val ALARM_SNOOZE_MS = 10 * 60 * 1_000L
+private const val ALERT_ADD_MINUTE_MS = 60_000L
+
+@AndroidEntryPoint
 class ClockAlertService : Service() {
+    @Inject lateinit var clockRepository: ClockRepository
+    @Inject lateinit var voiceInputController: VoiceInputController
+
     private val notificationManager: NotificationManager
         get() = getSystemService(NotificationManager::class.java)
 
@@ -28,7 +49,19 @@ class ClockAlertService : Service() {
         get() = getSystemService(VibratorManager::class.java)
 
     private val activeAlerts = linkedSetOf<TriggeredClockAlert>()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var voiceEventsJob: Job? = null
     private var ringtone: Ringtone? = null
+    private var isVoiceListening = false
+    private var handledVoiceTranscript = false
+    private var voiceStatusMessage: String? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        voiceEventsJob = serviceScope.launch {
+            voiceInputController.events.collectLatest(::handleVoiceEvent)
+        }
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -38,21 +71,47 @@ class ClockAlertService : Service() {
                 val alert = intent.toTriggeredClockAlert() ?: return START_NOT_STICKY
                 activeAlerts.removeAll { it.ownerId == alert.ownerId }
                 activeAlerts += alert
+                isVoiceListening = false
+                handledVoiceTranscript = false
+                voiceStatusMessage = null
+                voiceInputController.stopListening()
                 ensureChannel()
-                startForeground(
-                    ClockAlertContract.ALERT_NOTIFICATION_ID,
-                    buildNotification(alert),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
-                )
+                refreshForeground()
                 startAlertPlayback()
             }
 
-            ClockAlertContract.ACTION_STOP_ALERT -> stopAlertSession()
+            ClockAlertContract.ACTION_STOP_ALERT -> {
+                intent.toTriggeredClockAlert()?.let(::dismissAlert) ?: stopAlertSession()
+            }
+
+            ClockAlertContract.ACTION_SNOOZE_ALERT -> {
+                val alert = intent.toTriggeredClockAlert()?.let { findActiveAlert(it.ownerId) } ?: currentAlert()
+                if (alert != null) {
+                    serviceScope.launch { performSnooze(alert, ALARM_SNOOZE_MS) }
+                }
+            }
+
+            ClockAlertContract.ACTION_ADD_MINUTE_ALERT -> {
+                val alert = intent.toTriggeredClockAlert()?.let { findActiveAlert(it.ownerId) } ?: currentAlert()
+                if (alert != null) {
+                    serviceScope.launch { performAddOneMinute(alert) }
+                }
+            }
+
+            ClockAlertContract.ACTION_START_VOICE_CONTROL -> {
+                val alert = intent.toTriggeredClockAlert()?.let { findActiveAlert(it.ownerId) } ?: currentAlert()
+                if (alert != null) {
+                    startVoiceControl(alert)
+                }
+            }
         }
         return START_NOT_STICKY
     }
 
     override fun onDestroy() {
+        voiceInputController.stopListening()
+        voiceEventsJob?.cancel()
+        serviceScope.cancel()
         stopPlayback()
         super.onDestroy()
     }
@@ -64,30 +123,64 @@ class ClockAlertService : Service() {
                 if (activeAlerts.size > 1) "${activeAlerts.size} active alerts"
                 else alert.title,
             )
-            .setContentText(
-                if (activeAlerts.size > 1) "${alert.label} (+${activeAlerts.size - 1} more)"
-                else alert.label,
-            )
+            .setContentText(notificationContentText(alert))
             .setCategory(NotificationCompat.CATEGORY_ALARM)
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setOngoing(true)
             .setAutoCancel(false)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setContentIntent(buildOpenAppPendingIntent())
-            .setDeleteIntent(buildStopPendingIntent())
+            .setDeleteIntent(buildServicePendingIntent(ClockAlertContract.ACTION_STOP_ALERT, alert))
             .addAction(
                 android.R.drawable.ic_menu_close_clear_cancel,
                 if (alert.type == ClockEventType.TIMER) "Dismiss" else "Stop",
-                buildStopPendingIntent(),
+                buildServicePendingIntent(ClockAlertContract.ACTION_STOP_ALERT, alert),
             )
             .apply {
+                when (alert.type) {
+                    ClockEventType.ALARM -> addAction(
+                        android.R.drawable.ic_lock_idle_alarm,
+                        "Snooze",
+                        buildServicePendingIntent(ClockAlertContract.ACTION_SNOOZE_ALERT, alert),
+                    )
+
+                    ClockEventType.TIMER -> addAction(
+                        android.R.drawable.ic_menu_recent_history,
+                        "+1 min",
+                        buildServicePendingIntent(ClockAlertContract.ACTION_ADD_MINUTE_ALERT, alert),
+                    )
+
+                    ClockEventType.PRE_ALARM -> Unit
+                }
+                addAction(
+                    android.R.drawable.ic_btn_speak_now,
+                    "Voice",
+                    buildServicePendingIntent(ClockAlertContract.ACTION_START_VOICE_CONTROL, alert),
+                )
                 if (notificationManager.canUseFullScreenIntent()) {
                     setFullScreenIntent(buildOpenAppPendingIntent(), true)
                 }
             }
             .build()
 
+    private fun notificationContentText(alert: TriggeredClockAlert): String =
+        voiceStatusMessage ?: if (activeAlerts.size > 1) {
+            "${alert.label} (+${activeAlerts.size - 1} more)"
+        } else {
+            alert.label
+        }
+
+    private fun refreshForeground() {
+        val alert = currentAlert() ?: return
+        startForeground(
+            ClockAlertContract.ALERT_NOTIFICATION_ID,
+            buildNotification(alert),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+        )
+    }
+
     private fun startAlertPlayback() {
+        if (isVoiceListening || activeAlerts.isEmpty()) return
         stopPlayback()
         startVibration()
         ringtone = RingtoneManager.getRingtone(
@@ -111,9 +204,28 @@ class ClockAlertService : Service() {
 
     private fun stopAlertSession() {
         activeAlerts.clear()
+        isVoiceListening = false
+        handledVoiceTranscript = false
+        voiceStatusMessage = null
+        voiceInputController.stopListening()
         stopPlayback()
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
+    }
+
+    private fun dismissAlert(alert: TriggeredClockAlert) {
+        activeAlerts.removeAll { it.ownerId == alert.ownerId }
+        isVoiceListening = false
+        handledVoiceTranscript = false
+        voiceStatusMessage = null
+        voiceInputController.stopListening()
+        if (activeAlerts.isEmpty()) {
+            stopAlertSession()
+        } else {
+            stopPlayback()
+            refreshForeground()
+            startAlertPlayback()
+        }
     }
 
     private fun stopPlayback() {
@@ -150,15 +262,138 @@ class ClockAlertService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
-    private fun buildStopPendingIntent(): PendingIntent =
+    private fun buildServicePendingIntent(action: String, alert: TriggeredClockAlert): PendingIntent =
         PendingIntent.getService(
             this,
-            0,
+            31 * action.hashCode() + alert.ownerId.hashCode(),
             Intent(this, ClockAlertService::class.java).apply {
-                action = ClockAlertContract.ACTION_STOP_ALERT
+                this.action = action
+                putExtra(ClockAlertContract.EXTRA_OWNER_ID, alert.ownerId)
+                putExtra(ClockAlertContract.EXTRA_LABEL, alert.label)
+                putExtra(ClockAlertContract.EXTRA_TITLE, alert.title)
+                putExtra(ClockAlertContract.EXTRA_EVENT_TYPE, alert.type.name)
+                putExtra(
+                    ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
+                    alert.occurrenceTriggerAtMillis ?: -1L,
+                )
             },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
+
+    private fun currentAlert(): TriggeredClockAlert? = activeAlerts.lastOrNull()
+
+    private fun findActiveAlert(ownerId: String): TriggeredClockAlert? =
+        activeAlerts.firstOrNull { it.ownerId == ownerId }
+
+    private fun startVoiceControl(alert: TriggeredClockAlert) {
+        if (isVoiceListening) return
+        isVoiceListening = true
+        handledVoiceTranscript = false
+        voiceStatusMessage = alertVoiceListeningPrompt(alert.type)
+        stopPlayback()
+        refreshForeground()
+        serviceScope.launch {
+            when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
+                VoiceInputStartResult.Started -> Unit
+                is VoiceInputStartResult.Unavailable -> finishVoiceCapture(
+                    result.message.ifBlank { "Voice commands are unavailable right now." },
+                )
+            }
+        }
+    }
+
+    private suspend fun handleVoiceEvent(event: VoiceInputEvent) {
+        if (!isVoiceListening) return
+        when (event) {
+            is VoiceInputEvent.ListeningStarted -> {
+                currentAlert()?.let { voiceStatusMessage = alertVoiceListeningPrompt(it.type) }
+                refreshForeground()
+            }
+
+            is VoiceInputEvent.PartialTranscript -> Unit
+
+            is VoiceInputEvent.Transcript -> {
+                handledVoiceTranscript = true
+                val alert = currentAlert() ?: return finishVoiceCapture("No active alert to control.")
+                handleVoiceTranscript(alert, event.text)
+            }
+
+            is VoiceInputEvent.Error -> {
+                handledVoiceTranscript = true
+                finishVoiceCapture(event.message)
+            }
+
+            is VoiceInputEvent.ListeningStopped -> {
+                if (!handledVoiceTranscript) {
+                    finishVoiceCapture("I didn't catch a supported alert command.")
+                }
+            }
+        }
+    }
+
+    private suspend fun handleVoiceTranscript(alert: TriggeredClockAlert, transcript: String) {
+        isVoiceListening = false
+        val command = parseClockAlertVoiceCommand(transcript)
+            ?: return finishVoiceCapture("Say stop, dismiss, snooze, or add one minute.")
+        alertVoiceUnsupportedMessage(command, alert.type)?.let { message ->
+            return finishVoiceCapture(message)
+        }
+        when (command) {
+            ClockAlertVoiceCommand.DISMISS -> dismissAlert(alert)
+            ClockAlertVoiceCommand.SNOOZE -> performSnooze(alert, ALARM_SNOOZE_MS)
+            ClockAlertVoiceCommand.ADD_ONE_MINUTE -> performAddOneMinute(alert)
+        }
+    }
+
+    private suspend fun performSnooze(alert: TriggeredClockAlert, durationMs: Long) {
+        if (alert.type != ClockEventType.ALARM) {
+            finishVoiceCapture("Snooze is only available for alarms.")
+            return
+        }
+        val success = clockRepository.snoozeAlarm(
+            alarmId = alert.ownerId,
+            snoozedUntilMillis = System.currentTimeMillis() + durationMs,
+        )
+        if (success) {
+            dismissAlert(alert)
+        } else {
+            finishVoiceCapture("Couldn't snooze the alarm.")
+        }
+    }
+
+    private suspend fun performAddOneMinute(alert: TriggeredClockAlert) {
+        val success = when (alert.type) {
+            ClockEventType.ALARM -> clockRepository.snoozeAlarm(
+                alarmId = alert.ownerId,
+                snoozedUntilMillis = System.currentTimeMillis() + ALERT_ADD_MINUTE_MS,
+            )
+
+            ClockEventType.TIMER -> clockRepository.scheduleTimer(
+                durationMs = ALERT_ADD_MINUTE_MS,
+                label = alert.label.takeIf { it.isNotBlank() },
+            ) != null
+
+            ClockEventType.PRE_ALARM -> false
+        }
+        if (success) {
+            dismissAlert(alert)
+        } else {
+            finishVoiceCapture("Couldn't add one minute.")
+        }
+    }
+
+    private fun finishVoiceCapture(message: String) {
+        isVoiceListening = false
+        handledVoiceTranscript = false
+        voiceStatusMessage = message
+        voiceInputController.stopListening()
+        if (activeAlerts.isEmpty()) {
+            stopAlertSession()
+        } else {
+            refreshForeground()
+            startAlertPlayback()
+        }
+    }
 
     private fun Intent.toTriggeredClockAlert(): TriggeredClockAlert? {
         val ownerId = getStringExtra(ClockAlertContract.EXTRA_OWNER_ID) ?: return null

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -360,6 +360,7 @@ class ClockAlertService : Service() {
         isVoiceListening = true
         handledVoiceTranscript = false
         voiceStatusMessage = if (autoStarted) "Listening for alert commands…" else alertVoiceListeningPrompt(alert.type)
+        stopPlayback()
         refreshForeground()
         serviceScope.launch {
             when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -23,6 +23,7 @@ import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoiceInputStartResult
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -36,11 +37,18 @@ import kotlinx.coroutines.launch
 
 private const val ALARM_SNOOZE_MS = 10 * 60 * 1_000L
 private const val ALERT_ADD_MINUTE_MS = 60_000L
+internal fun shouldAutoStartAlertVoiceControl(
+    enabled: Boolean,
+    type: ClockEventType,
+): Boolean = enabled && type != ClockEventType.PRE_ALARM
+
+
 
 @AndroidEntryPoint
 class ClockAlertService : Service() {
     @Inject lateinit var clockRepository: ClockRepository
     @Inject lateinit var voiceInputController: VoiceInputController
+    @Inject lateinit var voiceInputPreferences: VoiceInputPreferences
 
     private val notificationManager: NotificationManager
         get() = getSystemService(NotificationManager::class.java)
@@ -51,15 +59,22 @@ class ClockAlertService : Service() {
     private val activeAlerts = linkedSetOf<TriggeredClockAlert>()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var voiceEventsJob: Job? = null
+    private var voicePreferencesJob: Job? = null
     private var ringtone: Ringtone? = null
     private var isVoiceListening = false
     private var handledVoiceTranscript = false
+    private var autoStartAlertVoiceCommandsEnabled = true
     private var voiceStatusMessage: String? = null
 
     override fun onCreate() {
         super.onCreate()
         voiceEventsJob = serviceScope.launch {
             voiceInputController.events.collectLatest(::handleVoiceEvent)
+        }
+        voicePreferencesJob = serviceScope.launch {
+            voiceInputPreferences.autoStartAlertVoiceCommandsEnabled.collectLatest { enabled ->
+                autoStartAlertVoiceCommandsEnabled = enabled
+            }
         }
     }
 
@@ -77,7 +92,11 @@ class ClockAlertService : Service() {
                 voiceInputController.stopListening()
                 ensureChannel()
                 refreshForeground()
-                startAlertPlayback()
+                if (shouldAutoStartAlertVoiceControl(autoStartAlertVoiceCommandsEnabled, alert.type)) {
+                    startVoiceControl(alert)
+                } else {
+                    startAlertPlayback()
+                }
             }
 
             ClockAlertContract.ACTION_STOP_ALERT -> {
@@ -111,6 +130,7 @@ class ClockAlertService : Service() {
     override fun onDestroy() {
         voiceInputController.stopListening()
         voiceEventsJob?.cancel()
+        voicePreferencesJob?.cancel()
         serviceScope.cancel()
         stopPlayback()
         super.onDestroy()

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 
 private const val ALARM_SNOOZE_MS = 10 * 60 * 1_000L
 private const val ALERT_ADD_MINUTE_MS = 60_000L
+private const val AUTO_START_VOICE_DELAY_MS = 2_000L
 internal fun shouldAutoStartAlertVoiceControl(
     enabled: Boolean,
     type: ClockEventType,
@@ -60,6 +61,7 @@ class ClockAlertService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var voiceEventsJob: Job? = null
     private var voicePreferencesJob: Job? = null
+    private var autoStartVoiceJob: Job? = null
     private var ringtone: Ringtone? = null
     private var isVoiceListening = false
     private var handledVoiceTranscript = false
@@ -92,10 +94,9 @@ class ClockAlertService : Service() {
                 voiceInputController.stopListening()
                 ensureChannel()
                 refreshForeground()
+                startAlertPlayback()
                 if (shouldAutoStartAlertVoiceControl(autoStartAlertVoiceCommandsEnabled, alert.type)) {
-                    startVoiceControl(alert)
-                } else {
-                    startAlertPlayback()
+                    scheduleAutoStartVoiceControl(alert)
                 }
             }
 
@@ -131,6 +132,7 @@ class ClockAlertService : Service() {
         voiceInputController.stopListening()
         voiceEventsJob?.cancel()
         voicePreferencesJob?.cancel()
+        autoStartVoiceJob?.cancel()
         serviceScope.cancel()
         stopPlayback()
         super.onDestroy()
@@ -224,6 +226,8 @@ class ClockAlertService : Service() {
 
     private fun stopAlertSession() {
         activeAlerts.clear()
+        autoStartVoiceJob?.cancel()
+        autoStartVoiceJob = null
         isVoiceListening = false
         handledVoiceTranscript = false
         voiceStatusMessage = null
@@ -235,6 +239,7 @@ class ClockAlertService : Service() {
 
     private fun dismissAlert(alert: TriggeredClockAlert) {
         activeAlerts.removeAll { it.ownerId == alert.ownerId }
+        cancelAutoStartVoiceControl(alert.ownerId)
         isVoiceListening = false
         handledVoiceTranscript = false
         voiceStatusMessage = null
@@ -245,6 +250,9 @@ class ClockAlertService : Service() {
             stopPlayback()
             refreshForeground()
             startAlertPlayback()
+            currentAlert()
+                ?.takeIf { shouldAutoStartAlertVoiceControl(autoStartAlertVoiceCommandsEnabled, it.type) }
+                ?.let(::scheduleAutoStartVoiceControl)
         }
     }
 
@@ -300,17 +308,36 @@ class ClockAlertService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
+    private fun scheduleAutoStartVoiceControl(alert: TriggeredClockAlert) {
+        cancelAutoStartVoiceControl()
+        autoStartVoiceJob = serviceScope.launch {
+            kotlinx.coroutines.delay(AUTO_START_VOICE_DELAY_MS)
+            val current = findActiveAlert(alert.ownerId) ?: return@launch
+            if (!shouldAutoStartAlertVoiceControl(autoStartAlertVoiceCommandsEnabled, current.type) || isVoiceListening) return@launch
+            startVoiceControl(current, autoStarted = true)
+        }
+    }
+
+    private fun cancelAutoStartVoiceControl(ownerId: String? = null) {
+        val shouldCancel = ownerId == null || findActiveAlert(ownerId) == null
+        if (shouldCancel) {
+            autoStartVoiceJob?.cancel()
+            autoStartVoiceJob = null
+        }
+    }
+
+
     private fun currentAlert(): TriggeredClockAlert? = activeAlerts.lastOrNull()
 
     private fun findActiveAlert(ownerId: String): TriggeredClockAlert? =
         activeAlerts.firstOrNull { it.ownerId == ownerId }
 
-    private fun startVoiceControl(alert: TriggeredClockAlert) {
+    private fun startVoiceControl(alert: TriggeredClockAlert, autoStarted: Boolean = false) {
         if (isVoiceListening) return
+        cancelAutoStartVoiceControl()
         isVoiceListening = true
         handledVoiceTranscript = false
-        voiceStatusMessage = alertVoiceListeningPrompt(alert.type)
-        stopPlayback()
+        voiceStatusMessage = if (autoStarted) "Listening for alert commands…" else alertVoiceListeningPrompt(alert.type)
         refreshForeground()
         serviceScope.launch {
             when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
@@ -326,6 +353,7 @@ class ClockAlertService : Service() {
         if (!isVoiceListening) return
         when (event) {
             is VoiceInputEvent.ListeningStarted -> {
+                stopPlayback()
                 currentAlert()?.let { voiceStatusMessage = alertVoiceListeningPrompt(it.type) }
                 refreshForeground()
             }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -88,6 +88,7 @@ class ClockAlertService : Service() {
                 val alert = intent.toTriggeredClockAlert() ?: return START_NOT_STICKY
                 activeAlerts.removeAll { it.ownerId == alert.ownerId }
                 activeAlerts += alert
+                syncActiveAlertSnapshot()
                 isVoiceListening = false
                 handledVoiceTranscript = false
                 voiceStatusMessage = null
@@ -102,6 +103,11 @@ class ClockAlertService : Service() {
 
             ClockAlertContract.ACTION_STOP_ALERT -> {
                 intent.toTriggeredClockAlert()?.let(::dismissAlert) ?: stopAlertSession()
+            }
+
+            ClockAlertContract.ACTION_STOP_TIMER_ALERTS -> {
+                val dismissed = dismissAlertsMatching { it.type == ClockEventType.TIMER }
+                if (dismissed == 0 && activeAlerts.isEmpty()) stopSelf()
             }
 
             ClockAlertContract.ACTION_SNOOZE_ALERT -> {
@@ -135,6 +141,8 @@ class ClockAlertService : Service() {
         autoStartVoiceJob?.cancel()
         serviceScope.cancel()
         stopPlayback()
+        activeAlerts.clear()
+        syncActiveAlertSnapshot()
         super.onDestroy()
     }
 
@@ -226,6 +234,7 @@ class ClockAlertService : Service() {
 
     private fun stopAlertSession() {
         activeAlerts.clear()
+        syncActiveAlertSnapshot()
         autoStartVoiceJob?.cancel()
         autoStartVoiceJob = null
         isVoiceListening = false
@@ -238,8 +247,16 @@ class ClockAlertService : Service() {
     }
 
     private fun dismissAlert(alert: TriggeredClockAlert) {
-        activeAlerts.removeAll { it.ownerId == alert.ownerId }
-        cancelAutoStartVoiceControl(alert.ownerId)
+        dismissAlertsMatching { it.ownerId == alert.ownerId }
+    }
+
+    private fun dismissAlertsMatching(predicate: (TriggeredClockAlert) -> Boolean): Int {
+        val dismissed = activeAlerts.count(predicate)
+        if (dismissed == 0) return 0
+
+        activeAlerts.removeAll(predicate)
+        syncActiveAlertSnapshot()
+        cancelAutoStartVoiceControl()
         isVoiceListening = false
         handledVoiceTranscript = false
         voiceStatusMessage = null
@@ -254,6 +271,7 @@ class ClockAlertService : Service() {
                 ?.takeIf { shouldAutoStartAlertVoiceControl(autoStartAlertVoiceCommandsEnabled, it.type) }
                 ?.let(::scheduleAutoStartVoiceControl)
         }
+        return dismissed
     }
 
     private fun stopPlayback() {
@@ -331,6 +349,10 @@ class ClockAlertService : Service() {
 
     private fun findActiveAlert(ownerId: String): TriggeredClockAlert? =
         activeAlerts.firstOrNull { it.ownerId == ownerId }
+
+    private fun syncActiveAlertSnapshot() {
+        activeAlertSnapshot = activeAlerts.toSet()
+    }
 
     private fun startVoiceControl(alert: TriggeredClockAlert, autoStarted: Boolean = false) {
         if (isVoiceListening) return
@@ -463,6 +485,12 @@ class ClockAlertService : Service() {
     }
 
     companion object {
+        @Volatile
+        private var activeAlertSnapshot: Set<TriggeredClockAlert> = emptySet()
+
+        internal fun hasActiveTimerAlerts(): Boolean =
+            activeAlertSnapshot.any { it.type == ClockEventType.TIMER }
+
         internal fun trigger(context: Context, alert: TriggeredClockAlert) {
             ContextCompat.startForegroundService(
                 context,

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -340,7 +340,7 @@ class ClockAlertService : Service() {
         voiceStatusMessage = if (autoStarted) "Listening for alert commands…" else alertVoiceListeningPrompt(alert.type)
         refreshForeground()
         serviceScope.launch {
-            when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
+            when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
                 VoiceInputStartResult.Started -> Unit
                 is VoiceInputStartResult.Unavailable -> finishVoiceCapture(
                     result.message.ifBlank { "Voice commands are unavailable right now." },
@@ -353,7 +353,6 @@ class ClockAlertService : Service() {
         if (!isVoiceListening) return
         when (event) {
             is VoiceInputEvent.ListeningStarted -> {
-                stopPlayback()
                 currentAlert()?.let { voiceStatusMessage = alertVoiceListeningPrompt(it.type) }
                 refreshForeground()
             }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
@@ -11,10 +11,13 @@ internal enum class ClockAlertVoiceCommand {
 private val dismissCommandPhrases = listOf(
     listOf("stop"),
     listOf("dismiss"),
+    listOf("cancel"),
     listOf("stop", "alarm"),
     listOf("dismiss", "alarm"),
+    listOf("cancel", "alarm"),
     listOf("stop", "timer"),
     listOf("dismiss", "timer"),
+    listOf("cancel", "timer"),
 )
 
 private val snoozeCommandPhrases = listOf(

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
@@ -8,31 +8,70 @@ internal enum class ClockAlertVoiceCommand {
     ADD_ONE_MINUTE,
 }
 
+private val dismissCommandPhrases = listOf(
+    listOf("stop"),
+    listOf("dismiss"),
+    listOf("stop", "alarm"),
+    listOf("dismiss", "alarm"),
+    listOf("stop", "timer"),
+    listOf("dismiss", "timer"),
+)
+
+private val snoozeCommandPhrases = listOf(
+    listOf("snooze"),
+    listOf("snooze", "alarm"),
+)
+
+private val addOneMinuteCommandPhrases = listOf(
+    listOf("add", "one", "minute"),
+    listOf("add", "a", "minute"),
+    listOf("add", "1", "minute"),
+    listOf("one", "more", "minute"),
+    listOf("another", "minute"),
+)
+
+private val alertCommandPhrases = listOf(
+    ClockAlertVoiceCommand.DISMISS to dismissCommandPhrases,
+    ClockAlertVoiceCommand.SNOOZE to snoozeCommandPhrases,
+    ClockAlertVoiceCommand.ADD_ONE_MINUTE to addOneMinuteCommandPhrases,
+)
+
 internal fun parseClockAlertVoiceCommand(raw: String): ClockAlertVoiceCommand? {
-    val normalized = raw
+    val tokens = raw
         .lowercase()
         .replace(Regex("[^a-z0-9 ]"), " ")
         .replace(Regex("\\s+"), " ")
         .trim()
-    if (normalized.isBlank()) return null
-    return when {
-        normalized == "stop" ||
-            normalized == "dismiss" ||
-            normalized == "stop alarm" ||
-            normalized == "dismiss alarm" ||
-            normalized == "stop timer" ||
-            normalized == "dismiss timer" -> ClockAlertVoiceCommand.DISMISS
+        .split(" ")
+        .filter { it.isNotBlank() }
+    if (tokens.isEmpty()) return null
 
-        normalized == "snooze" || normalized == "snooze alarm" -> ClockAlertVoiceCommand.SNOOZE
+    return alertCommandPhrases
+        .flatMap { (command, phrases) ->
+            phrases.mapNotNull { phrase ->
+                findPhraseStart(tokens, phrase)?.let { start ->
+                    MatchedAlertVoiceCommand(command = command, startIndex = start, phraseLength = phrase.size)
+                }
+            }
+        }
+        .maxWithOrNull(compareBy<MatchedAlertVoiceCommand>({ it.startIndex }, { it.phraseLength }))
+        ?.command
+}
 
-        normalized == "add one minute" ||
-            normalized == "add a minute" ||
-            normalized == "add 1 minute" ||
-            normalized == "one more minute" ||
-            normalized == "another minute" -> ClockAlertVoiceCommand.ADD_ONE_MINUTE
+private data class MatchedAlertVoiceCommand(
+    val command: ClockAlertVoiceCommand,
+    val startIndex: Int,
+    val phraseLength: Int,
+    )
 
-        else -> null
+private fun findPhraseStart(tokens: List<String>, phrase: List<String>): Int? {
+    if (phrase.size > tokens.size) return null
+    for (startIndex in 0..tokens.size - phrase.size) {
+        if (tokens.subList(startIndex, startIndex + phrase.size) == phrase) {
+            return startIndex
+        }
     }
+    return null
 }
 
 internal fun alertVoiceListeningPrompt(type: ClockEventType): String =

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertVoiceCommand.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockEventType
+
+internal enum class ClockAlertVoiceCommand {
+    DISMISS,
+    SNOOZE,
+    ADD_ONE_MINUTE,
+}
+
+internal fun parseClockAlertVoiceCommand(raw: String): ClockAlertVoiceCommand? {
+    val normalized = raw
+        .lowercase()
+        .replace(Regex("[^a-z0-9 ]"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+    if (normalized.isBlank()) return null
+    return when {
+        normalized == "stop" ||
+            normalized == "dismiss" ||
+            normalized == "stop alarm" ||
+            normalized == "dismiss alarm" ||
+            normalized == "stop timer" ||
+            normalized == "dismiss timer" -> ClockAlertVoiceCommand.DISMISS
+
+        normalized == "snooze" || normalized == "snooze alarm" -> ClockAlertVoiceCommand.SNOOZE
+
+        normalized == "add one minute" ||
+            normalized == "add a minute" ||
+            normalized == "add 1 minute" ||
+            normalized == "one more minute" ||
+            normalized == "another minute" -> ClockAlertVoiceCommand.ADD_ONE_MINUTE
+
+        else -> null
+    }
+}
+
+internal fun alertVoiceListeningPrompt(type: ClockEventType): String =
+    when (type) {
+        ClockEventType.ALARM -> "Listening… Say stop, dismiss, snooze, or add one minute."
+        ClockEventType.TIMER -> "Listening… Say stop, dismiss, or add one minute."
+        ClockEventType.PRE_ALARM -> "Listening… Say stop or dismiss."
+    }
+
+internal fun alertVoiceUnsupportedMessage(
+    command: ClockAlertVoiceCommand,
+    type: ClockEventType,
+): String? =
+    when {
+        command == ClockAlertVoiceCommand.SNOOZE && type != ClockEventType.ALARM ->
+            "Snooze is only available for alarms."
+
+        command == ClockAlertVoiceCommand.ADD_ONE_MINUTE && type == ClockEventType.PRE_ALARM ->
+            "Add one minute is not available for alarm reminders."
+
+        else -> null
+    }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockSchedulerModule.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockSchedulerModule.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.alarm
 
 import com.kernel.ai.core.memory.clock.ClockScheduler
+import com.kernel.ai.core.skills.natives.ClockAlertController
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +16,10 @@ abstract class ClockSchedulerModule {
     abstract fun bindClockScheduler(
         impl: AlarmManagerClockScheduler,
     ): ClockScheduler
+
+    @Binds
+    @Singleton
+    abstract fun bindClockAlertController(
+        impl: AndroidClockAlertController,
+    ): ClockAlertController
 }

--- a/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
@@ -16,6 +16,19 @@ class ClockAlertVoiceCommandTest {
     }
 
     @Test
+    fun `parseClockAlertVoiceCommand accepts repeated accumulated transcript`() {
+        assertEquals(
+            ClockAlertVoiceCommand.DISMISS,
+            parseClockAlertVoiceCommand("Stop stop dismiss"),
+        )
+        assertEquals(
+            ClockAlertVoiceCommand.ADD_ONE_MINUTE,
+            parseClockAlertVoiceCommand("could you add one minute please"),
+        )
+    }
+
+
+    @Test
     fun `parseClockAlertVoiceCommand rejects unsupported phrases`() {
         assertNull(parseClockAlertVoiceCommand("pause stopwatch"))
         assertNull(parseClockAlertVoiceCommand("what time is it"))

--- a/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
@@ -1,0 +1,32 @@
+package com.kernel.ai.alarm
+
+import com.kernel.ai.core.memory.clock.ClockEventType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ClockAlertVoiceCommandTest {
+    @Test
+    fun `parseClockAlertVoiceCommand matches supported alert phrases`() {
+        assertEquals(ClockAlertVoiceCommand.DISMISS, parseClockAlertVoiceCommand("stop"))
+        assertEquals(ClockAlertVoiceCommand.DISMISS, parseClockAlertVoiceCommand("dismiss timer"))
+        assertEquals(ClockAlertVoiceCommand.SNOOZE, parseClockAlertVoiceCommand("snooze alarm"))
+        assertEquals(ClockAlertVoiceCommand.ADD_ONE_MINUTE, parseClockAlertVoiceCommand("add one minute"))
+        assertEquals(ClockAlertVoiceCommand.ADD_ONE_MINUTE, parseClockAlertVoiceCommand("another minute"))
+    }
+
+    @Test
+    fun `parseClockAlertVoiceCommand rejects unsupported phrases`() {
+        assertNull(parseClockAlertVoiceCommand("pause stopwatch"))
+        assertNull(parseClockAlertVoiceCommand("what time is it"))
+    }
+
+    @Test
+    fun `alertVoiceUnsupportedMessage is truthful for timer snooze`() {
+        assertEquals(
+            "Snooze is only available for alarms.",
+            alertVoiceUnsupportedMessage(ClockAlertVoiceCommand.SNOOZE, ClockEventType.TIMER),
+        )
+        assertNull(alertVoiceUnsupportedMessage(ClockAlertVoiceCommand.DISMISS, ClockEventType.TIMER))
+    }
+}

--- a/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
@@ -10,6 +10,7 @@ class ClockAlertVoiceCommandTest {
     fun `parseClockAlertVoiceCommand matches supported alert phrases`() {
         assertEquals(ClockAlertVoiceCommand.DISMISS, parseClockAlertVoiceCommand("stop"))
         assertEquals(ClockAlertVoiceCommand.DISMISS, parseClockAlertVoiceCommand("dismiss timer"))
+        assertEquals(ClockAlertVoiceCommand.DISMISS, parseClockAlertVoiceCommand("cancel"))
         assertEquals(ClockAlertVoiceCommand.SNOOZE, parseClockAlertVoiceCommand("snooze alarm"))
         assertEquals(ClockAlertVoiceCommand.ADD_ONE_MINUTE, parseClockAlertVoiceCommand("add one minute"))
         assertEquals(ClockAlertVoiceCommand.ADD_ONE_MINUTE, parseClockAlertVoiceCommand("another minute"))
@@ -20,6 +21,10 @@ class ClockAlertVoiceCommandTest {
         assertEquals(
             ClockAlertVoiceCommand.DISMISS,
             parseClockAlertVoiceCommand("Stop stop dismiss"),
+        )
+        assertEquals(
+            ClockAlertVoiceCommand.DISMISS,
+            parseClockAlertVoiceCommand("cancel cancel timer"),
         )
         assertEquals(
             ClockAlertVoiceCommand.ADD_ONE_MINUTE,

--- a/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockAlertVoiceCommandTest.kt
@@ -22,6 +22,15 @@ class ClockAlertVoiceCommandTest {
     }
 
     @Test
+    fun `shouldAutoStartAlertVoiceControl only enables ringing voice capture for alarms and timers`() {
+        assertEquals(true, shouldAutoStartAlertVoiceControl(true, ClockEventType.ALARM))
+        assertEquals(true, shouldAutoStartAlertVoiceControl(true, ClockEventType.TIMER))
+        assertEquals(false, shouldAutoStartAlertVoiceControl(false, ClockEventType.ALARM))
+        assertEquals(false, shouldAutoStartAlertVoiceControl(true, ClockEventType.PRE_ALARM))
+    }
+
+
+    @Test
     fun `alertVoiceUnsupportedMessage is truthful for timer snooze`() {
         assertEquals(
             "Snooze is only available for alarms.",

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/29.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/29.json
@@ -1,0 +1,1032 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 29,
+    "identityHash": "d5d5bf49d1eac3ae1ba9c202ef09dcdb",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd5d5bf49d1eac3ae1ba9c202ef09dcdb')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -57,7 +57,7 @@ import java.time.ZoneId
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 28,
+    version = 29,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -378,6 +378,13 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_24_25 = object : Migration(24, 25) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN completed_at_ms INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Adds snoozed_until_ms to scheduled_alarms for alert-time snooze handling (#752). */
+        val MIGRATION_28_29 = object : Migration(28, 29) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN snoozed_until_ms INTEGER DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -84,6 +84,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_25_26,
                     KernelDatabase.MIGRATION_26_27,
                     KernelDatabase.MIGRATION_27_28,
+                    KernelDatabase.MIGRATION_28_29,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -47,6 +47,7 @@ interface ClockRepository {
     suspend fun cancelNextAlarm(): ClockAlarm?
     suspend fun cancelAlarmsByLabel(label: String): Int
     suspend fun skipAlarmOccurrence(alarmId: String, occurrenceTriggerAtMillis: Long): Boolean
+    suspend fun snoozeAlarm(alarmId: String, snoozedUntilMillis: Long): Boolean
 
     suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
     suspend fun cancelTimer(timerId: String)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.map
 private const val PRE_ALARM_LEAD_MS = 30 * 60 * 1_000L
 private const val PRE_ALARM_MIN_NOTICE_MS = 1_000L
 private const val PRE_ALARM_EVENT_SUFFIX = ":pre"
+private const val SNOOZE_EVENT_SUFFIX = ":snooze"
 private const val STOPWATCH_ID = "primary"
 
 @Singleton
@@ -252,6 +253,7 @@ class ClockRepositoryImpl @Inject constructor(
             repeatDaysMask = draft.repeatDaysMask(),
             oneOffDateEpochDay = draft.oneOffDateEpochDay(),
             timeZoneId = draft.timeZoneId,
+            snoozedUntilMs = null,
         )
         cancelAlarmEvents(existing, now)
         scheduleAlarmEvents(updated, now)
@@ -287,6 +289,7 @@ class ClockRepositoryImpl @Inject constructor(
             enabled = true,
             fired = false,
             triggerAtMillis = nextTriggerAtMillis,
+            snoozedUntilMs = null,
         )
         scheduleAlarmEvents(updated, now)
         return try {
@@ -343,19 +346,42 @@ class ClockRepositoryImpl @Inject constructor(
         val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return false
         if (existing.entryType != ClockEventType.ALARM.name || !existing.enabled) return false
         if (!existing.isRepeatingAlarm() || existing.triggerAtMillis != occurrenceTriggerAtMillis) return false
+        val now = System.currentTimeMillis()
         val nextTriggerAtMillis = existing.nextRepeatingTriggerAfter(occurrenceTriggerAtMillis) ?: return false
-        val updated = existing.copy(triggerAtMillis = nextTriggerAtMillis, fired = false)
-        cancelAlarmEvents(existing, System.currentTimeMillis())
-        scheduleAlarmEvents(updated, System.currentTimeMillis())
+        val updated = existing.copy(triggerAtMillis = nextTriggerAtMillis, fired = false, snoozedUntilMs = null)
+        cancelAlarmEvents(existing, now)
+        scheduleAlarmEvents(updated, now)
         return try {
             scheduledAlarmDao.insert(updated)
             true
         } catch (_: Exception) {
-            cancelAlarmEvents(updated, System.currentTimeMillis())
-            scheduleAlarmEvents(existing, System.currentTimeMillis())
+            cancelAlarmEvents(updated, now)
+            scheduleAlarmEvents(existing, now)
             false
         }
     }
+
+    override suspend fun snoozeAlarm(alarmId: String, snoozedUntilMillis: Long): Boolean {
+        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return false
+        if (existing.entryType != ClockEventType.ALARM.name || !existing.enabled) return false
+        val now = System.currentTimeMillis()
+        if (snoozedUntilMillis <= now) return false
+        val updated = existing.copy(
+            fired = false,
+            snoozedUntilMs = snoozedUntilMillis,
+        )
+        cancelAlarmEvents(existing, now)
+        scheduleAlarmEvents(updated, now)
+        return try {
+            scheduledAlarmDao.insert(updated)
+            true
+        } catch (_: Exception) {
+            cancelAlarmEvents(updated, now)
+            scheduleAlarmEvents(existing, now)
+            false
+        }
+    }
+
 
     override suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer? {
         if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
@@ -408,15 +434,32 @@ class ClockRepositoryImpl @Inject constructor(
 
             ClockEventType.ALARM -> {
                 if (existing.entryType != ClockEventType.ALARM.name) return
+                val now = System.currentTimeMillis()
+                if (occurrenceTriggerAtMillis != null && existing.snoozedUntilMs == occurrenceTriggerAtMillis) {
+                    val updated = if (existing.isRepeatingAlarm()) {
+                        existing.copy(snoozedUntilMs = null, fired = false)
+                    } else {
+                        existing.copy(snoozedUntilMs = null, fired = true)
+                    }
+                    cancelAlarmEvents(existing, now)
+                    scheduledAlarmDao.insert(updated)
+                    scheduleAlarmEvents(updated, now)
+                    return
+                }
                 if (occurrenceTriggerAtMillis != null && existing.triggerAtMillis != occurrenceTriggerAtMillis) return
                 if (!existing.isRepeatingAlarm()) {
                     scheduledAlarmDao.markFired(ownerId)
                     return
                 }
                 val nextTriggerAtMillis = existing.nextRepeatingTriggerAfter(existing.triggerAtMillis) ?: return
-                val updated = existing.copy(triggerAtMillis = nextTriggerAtMillis, fired = false)
-                scheduleAlarmEvents(updated, System.currentTimeMillis())
+                val updated = existing.copy(
+                    triggerAtMillis = nextTriggerAtMillis,
+                    fired = false,
+                    snoozedUntilMs = existing.snoozedUntilMs,
+                )
+                cancelAlarmEvents(existing, now)
                 scheduledAlarmDao.insert(updated)
+                scheduleAlarmEvents(updated, now)
             }
         }
     }
@@ -497,7 +540,11 @@ class ClockRepositoryImpl @Inject constructor(
                         expiredCount += 1
                     } else {
                         val nextTriggerAtMillis = schedule.nextRepeatingTriggerAfter(nowMillis) ?: return@forEach
-                        val updated = schedule.copy(triggerAtMillis = nextTriggerAtMillis, fired = false)
+                        val updated = schedule.copy(
+                            triggerAtMillis = nextTriggerAtMillis,
+                            fired = false,
+                            snoozedUntilMs = null,
+                        )
                         scheduledAlarmDao.insert(updated)
                         scheduleAlarmEvents(updated, nowMillis)
                         restoredCount += 1
@@ -529,12 +576,14 @@ class ClockRepositoryImpl @Inject constructor(
     }
 
     private fun scheduleAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long) {
-        scheduler.schedule(entity.toScheduledEvent())
+        entity.toPrimaryAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
+        entity.toSnoozeScheduledEvent(nowMillis)?.let(scheduler::schedule)
         entity.toPreAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
     }
 
     private fun cancelAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long) {
-        scheduler.cancel(entity.toScheduledEvent())
+        scheduler.cancel(entity.toPrimaryAlarmCancellationEvent())
+        entity.toSnoozeCancellationEvent()?.let(scheduler::cancel)
         entity.toPreAlarmScheduledEvent(nowMillis)?.let(scheduler::cancel)
         scheduler.cancel(entity.toPreAlarmCancellationEvent())
     }
@@ -596,7 +645,7 @@ private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm? {
         minute = alarmMinute ?: trigger.minute,
         repeatRule = repeatRule,
         timeZoneId = zoneId.id,
-        triggerAtMillis = triggerAtMillis,
+        triggerAtMillis = snoozedUntilMs ?: triggerAtMillis,
     )
 }
 
@@ -625,6 +674,47 @@ private fun ScheduledAlarmEntity.toScheduledEvent(): ClockScheduledEvent =
         startedAtMillis = startedAtMs,
         occurrenceTriggerAtMillis = triggerAtMillis,
     )
+
+private fun ScheduledAlarmEntity.toPrimaryAlarmScheduledEvent(nowMillis: Long): ClockScheduledEvent? {
+    if (entryType != ClockEventType.ALARM.name || !enabled || fired || triggerAtMillis <= nowMillis) return null
+    return toScheduledEvent()
+}
+
+private fun ScheduledAlarmEntity.toPrimaryAlarmCancellationEvent(): ClockScheduledEvent =
+    ClockScheduledEvent(
+        eventId = id,
+        ownerId = ownerId ?: id,
+        type = ClockEventType.ALARM,
+        triggerAtMillis = triggerAtMillis,
+        label = label,
+        occurrenceTriggerAtMillis = triggerAtMillis,
+    )
+
+private fun ScheduledAlarmEntity.toSnoozeScheduledEvent(nowMillis: Long): ClockScheduledEvent? {
+    if (entryType != ClockEventType.ALARM.name || !enabled) return null
+    val snoozeAt = snoozedUntilMs?.takeIf { it > nowMillis } ?: return null
+    return ClockScheduledEvent(
+        eventId = "${ownerId ?: id}$SNOOZE_EVENT_SUFFIX",
+        ownerId = ownerId ?: id,
+        type = ClockEventType.ALARM,
+        triggerAtMillis = snoozeAt,
+        label = label,
+        occurrenceTriggerAtMillis = snoozeAt,
+    )
+}
+
+private fun ScheduledAlarmEntity.toSnoozeCancellationEvent(): ClockScheduledEvent? {
+    if (entryType != ClockEventType.ALARM.name) return null
+    val snoozeAt = snoozedUntilMs ?: triggerAtMillis
+    return ClockScheduledEvent(
+        eventId = "${ownerId ?: id}$SNOOZE_EVENT_SUFFIX",
+        ownerId = ownerId ?: id,
+        type = ClockEventType.ALARM,
+        triggerAtMillis = snoozeAt,
+        label = label,
+        occurrenceTriggerAtMillis = snoozeAt,
+    )
+}
 
 private fun ScheduledAlarmEntity.toPreAlarmScheduledEvent(nowMillis: Long): ClockScheduledEvent? {
     if (entryType != ClockEventType.ALARM.name || !enabled || !isRepeatingAlarm()) return null

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ScheduledAlarmDao.kt
@@ -15,13 +15,13 @@ interface ScheduledAlarmDao {
     @Query("SELECT * FROM scheduled_alarms WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): ScheduledAlarmEntity?
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis > :nowMillis ORDER BY triggerAtMillis ASC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND COALESCE(snoozed_until_ms, triggerAtMillis) > :nowMillis ORDER BY COALESCE(snoozed_until_ms, triggerAtMillis) ASC")
     suspend fun getUnfiredFuture(nowMillis: Long): List<ScheduledAlarmEntity>
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND triggerAtMillis <= :nowMillis ORDER BY triggerAtMillis ASC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND COALESCE(snoozed_until_ms, triggerAtMillis) <= :nowMillis ORDER BY COALESCE(snoozed_until_ms, triggerAtMillis) ASC")
     suspend fun getUnfiredElapsed(nowMillis: Long): List<ScheduledAlarmEntity>
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 ORDER BY triggerAtMillis ASC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 ORDER BY COALESCE(snoozed_until_ms, triggerAtMillis) ASC")
     fun observeAllUnfired(): Flow<List<ScheduledAlarmEntity>>
 
     @Query("UPDATE scheduled_alarms SET fired = 1 WHERE id = :id")
@@ -48,10 +48,10 @@ interface ScheduledAlarmDao {
     @Query("DELETE FROM scheduled_alarms WHERE entry_type = 'TIMER' AND completed_at_ms IS NOT NULL")
     suspend fun deleteCompletedTimers(): Int
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY triggerAtMillis ASC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY COALESCE(snoozed_until_ms, triggerAtMillis) ASC")
     suspend fun getActiveAlarmSchedules(): List<ScheduledAlarmEntity>
 
-    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY triggerAtMillis ASC")
+    @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND entry_type = 'ALARM' ORDER BY COALESCE(snoozed_until_ms, triggerAtMillis) ASC")
     fun observeAllAlarmSchedules(): Flow<List<ScheduledAlarmEntity>>
 
     @Query("SELECT * FROM scheduled_alarms WHERE fired = 0 AND enabled = 1 AND entry_type = 'TIMER' ORDER BY started_at_ms DESC")

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -22,5 +22,6 @@ data class ScheduledAlarmEntity(
     @ColumnInfo(name = "repeat_days_mask") val repeatDaysMask: Int? = null,
     @ColumnInfo(name = "one_off_date_epoch_day") val oneOffDateEpochDay: Long? = null,
     @ColumnInfo(name = "time_zone_id") val timeZoneId: String? = null,
+    @ColumnInfo(name = "snoozed_until_ms") val snoozedUntilMs: Long? = null,
     @ColumnInfo(name = "completed_at_ms") val completedAtMs: Long? = null,
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -155,6 +155,26 @@ class ClockRepositoryImplTest {
     }
 
     @Test
+    fun `snoozeAlarm stores one off snooze without rescheduling the expired primary alarm`() = runTest {
+        val now = System.currentTimeMillis()
+        val snoozeAt = now + 10 * 60_000L
+        val firedOneOff = scheduleRow(
+            id = "alarm-1",
+            triggerAtMillis = now - 60_000L,
+        ).copy(fired = true)
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns firedOneOff
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+
+        val snoozed = repository.snoozeAlarm("alarm-1", snoozeAt)
+
+        assertTrue(snoozed)
+        coVerify(exactly = 1) { scheduledAlarmDao.insert(match { it.snoozedUntilMs == snoozeAt && !it.fired }) }
+        verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM && it.triggerAtMillis == snoozeAt }) }
+        verify(exactly = 0) { scheduler.schedule(match { it.type == ClockEventType.ALARM && it.triggerAtMillis == firedOneOff.triggerAtMillis }) }
+    }
+
+
+    @Test
     fun `handleScheduledEvent advances repeating alarms after delivery`() = runTest {
         val weekdayMask = weekdayMaskFor(DayOfWeek.MONDAY) or weekdayMaskFor(DayOfWeek.FRIDAY)
         val repeating = scheduleRow(
@@ -184,6 +204,44 @@ class ClockRepositoryImplTest {
 
         coVerify(exactly = 1) { scheduledAlarmDao.markFired("alarm-1") }
     }
+
+    @Test
+    fun `handleScheduledEvent clears repeating alarm snooze after snoozed fire`() = runTest {
+        val now = System.currentTimeMillis()
+        val snoozeAt = now + 60_000L
+        val repeating = scheduleRow(
+            id = "alarm-1",
+            triggerAtMillis = now + 24 * 60 * 60_000L,
+            repeatType = "DAILY",
+            alarmHour = 7,
+            alarmMinute = 30,
+        ).copy(snoozedUntilMs = snoozeAt)
+        coEvery { scheduledAlarmDao.getById("alarm-1") } returns repeating
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+
+        repository.handleScheduledEvent("alarm-1", ClockEventType.ALARM, snoozeAt)
+
+        coVerify(exactly = 1) { scheduledAlarmDao.insert(match { it.snoozedUntilMs == null && !it.fired && it.triggerAtMillis == repeating.triggerAtMillis }) }
+    }
+
+    @Test
+    fun `observeActiveAlarms prefers snoozed trigger time when present`() = runTest {
+        val now = System.currentTimeMillis()
+        val snoozeAt = now + 60_000L
+        val repeating = scheduleRow(
+            id = "alarm-1",
+            triggerAtMillis = now + 24 * 60 * 60_000L,
+            repeatType = "DAILY",
+            alarmHour = 7,
+            alarmMinute = 30,
+        ).copy(snoozedUntilMs = snoozeAt)
+        every { scheduledAlarmDao.observeAllAlarmSchedules() } returns flowOf(listOf(repeating))
+
+        val alarms = repository.observeActiveAlarms().first()
+
+        assertEquals(snoozeAt, alarms.single().triggerAtMillis)
+    }
+
 
     @Test
     fun `handleScheduledEvent marks timers completed instead of deleting them`() = runTest {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -55,6 +55,11 @@ import kotlinx.coroutines.runBlocking
 private const val TAG = "KernelAI"
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
 
+interface ClockAlertController {
+    fun dismissActiveTimerAlerts(): Boolean
+}
+
+
 /**
  * Central dispatcher for all native Android operations triggered via the [run_intent][RunIntentSkill] gateway.
  *
@@ -110,6 +115,7 @@ private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is require
 class NativeIntentHandler @Inject constructor(
     @ApplicationContext private val context: Context,
     private val clockRepository: ClockRepository,
+    private val clockAlertController: ClockAlertController,
     private val listItemDao: ListItemDao,
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
@@ -398,8 +404,17 @@ class NativeIntentHandler @Inject constructor(
 
     private fun cancelTimer(): SkillResult {
         val cancelled = runBlocking { clockRepository.cancelAllTimers() }
-        if (cancelled == 0) return SkillResult.DirectReply("No timers running.")
-        return SkillResult.Success("Cancelled $cancelled timer${if (cancelled == 1) "" else "s"}.")
+        val dismissedActiveAlert = clockAlertController.dismissActiveTimerAlerts()
+        return when {
+            cancelled > 0 && dismissedActiveAlert ->
+                SkillResult.Success(
+                    "Cancelled $cancelled timer${if (cancelled == 1) "" else "s"} and dismissed the active timer alert.",
+                )
+            cancelled > 0 ->
+                SkillResult.Success("Cancelled $cancelled timer${if (cancelled == 1) "" else "s"}.")
+            dismissedActiveAlert -> SkillResult.Success("Dismissed the active timer alert.")
+            else -> SkillResult.DirectReply("No timers running.")
+        }
     }
 
     // ── Timer Registry ────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -46,12 +46,14 @@ class NativeIntentHandlerTest {
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>(relaxed = true)
+    private val clockAlertController = mockk<ClockAlertController>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
     private val listNameDao = mockk<ListNameDao>(relaxed = true)
 
     private val handler = NativeIntentHandler(
         context = context,
         clockRepository = clockRepository,
+        clockAlertController = clockAlertController,
         listItemDao = listItemDao,
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
@@ -671,6 +673,34 @@ class NativeIntentHandlerTest {
         assertEquals(SkillResult.Failure("run_intent", "Could not schedule the timer."), result)
         verify(exactly = 0) { context.startActivity(any()) }
     }
+
+    @Test
+    fun `cancel_timer dismisses active timer alert when no running timers remain`() {
+        coEvery { clockRepository.cancelAllTimers() } returns 0
+        every { clockAlertController.dismissActiveTimerAlerts() } returns true
+
+        val result = handler.handle("cancel_timer", emptyMap())
+
+        assertEquals(SkillResult.Success("Dismissed the active timer alert."), result)
+        coVerify(exactly = 1) { clockRepository.cancelAllTimers() }
+        verify(exactly = 1) { clockAlertController.dismissActiveTimerAlerts() }
+    }
+
+    @Test
+    fun `cancel_timer reports cancelling timers and dismissing active alert`() {
+        coEvery { clockRepository.cancelAllTimers() } returns 1
+        every { clockAlertController.dismissActiveTimerAlerts() } returns true
+
+        val result = handler.handle("cancel_timer", emptyMap())
+
+        assertEquals(
+            SkillResult.Success("Cancelled 1 timer and dismissed the active timer alert."),
+            result,
+        )
+        coVerify(exactly = 1) { clockRepository.cancelAllTimers() }
+        verify(exactly = 1) { clockAlertController.dismissActiveTimerAlerts() }
+    }
+
 
     @Test
     fun `cancel_timer_named matches unlabeled timer by hyphenated duration`() {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -56,10 +56,20 @@ enum class AndroidNativeRecognitionLocaleStatus {
     Unknown,
 }
 
+private data class LocaleSupportCache(
+    val languageTag: String,
+    val localeStatus: AndroidNativeRecognitionLocaleStatus,
+)
+
+
 @Singleton
 class AndroidNativeRecognitionSupport @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+    @Volatile
+    private var localeSupportCache: LocaleSupportCache? = null
+
+
     suspend fun getAvailability(): AndroidNativeRecognitionAvailability {
         val baseAvailability = currentRecognitionAvailability()
         val localeStatus = if (
@@ -71,6 +81,10 @@ class AndroidNativeRecognitionSupport @Inject constructor(
             AndroidNativeRecognitionLocaleStatus.Unknown
         }
         val availability = baseAvailability.copy(localeStatus = localeStatus)
+        localeSupportCache = LocaleSupportCache(
+            languageTag = availability.languageTag,
+            localeStatus = availability.localeStatus,
+        )
 
         Log.i(
             TAG,
@@ -85,7 +99,12 @@ class AndroidNativeRecognitionSupport @Inject constructor(
     }
 
     fun getCaptureAvailability(): AndroidNativeRecognitionAvailability {
-        val availability = currentRecognitionAvailability()
+        val baseAvailability = currentRecognitionAvailability()
+        val cachedLocaleStatus = localeSupportCache
+            ?.takeIf { it.languageTag == baseAvailability.languageTag }
+            ?.localeStatus
+            ?: AndroidNativeRecognitionLocaleStatus.Unknown
+        val availability = baseAvailability.copy(localeStatus = cachedLocaleStatus)
         Log.i(
             TAG,
             "Android native capture availability: language=${availability.languageTag} " +

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -61,6 +61,43 @@ class AndroidNativeRecognitionSupport @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     suspend fun getAvailability(): AndroidNativeRecognitionAvailability {
+        val baseAvailability = currentRecognitionAvailability()
+        val localeStatus = if (
+            baseAvailability.isRecognitionAvailable &&
+            baseAvailability.isOnDeviceRecognitionAvailable
+        ) {
+            checkLocaleSupport(baseAvailability.languageTag)
+        } else {
+            AndroidNativeRecognitionLocaleStatus.Unknown
+        }
+        val availability = baseAvailability.copy(localeStatus = localeStatus)
+
+        Log.i(
+            TAG,
+            "Android native availability: language=${availability.languageTag} " +
+                "displayName=${availability.languageDisplayName} " +
+                "recognitionAvailable=${availability.isRecognitionAvailable} " +
+                "onDeviceAvailable=${availability.isOnDeviceRecognitionAvailable} " +
+                "localeStatus=${availability.localeStatus}",
+        )
+
+        return availability
+    }
+
+    fun getCaptureAvailability(): AndroidNativeRecognitionAvailability {
+        val availability = currentRecognitionAvailability()
+        Log.i(
+            TAG,
+            "Android native capture availability: language=${availability.languageTag} " +
+                "displayName=${availability.languageDisplayName} " +
+                "recognitionAvailable=${availability.isRecognitionAvailable} " +
+                "onDeviceAvailable=${availability.isOnDeviceRecognitionAvailable} " +
+                "localeStatus=${availability.localeStatus}",
+        )
+        return availability
+    }
+
+    private fun currentRecognitionAvailability(): AndroidNativeRecognitionAvailability {
         val locale = context.resources.configuration.locales[0] ?: Locale.getDefault()
         val isRecognitionAvailable = SpeechRecognizer.isRecognitionAvailable(context)
         val isOnDeviceRecognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(context)
@@ -69,27 +106,14 @@ class AndroidNativeRecognitionSupport @Inject constructor(
             if (char.isLowerCase()) char.titlecase(locale) else char.toString()
         }
 
-        val localeStatus = if (isRecognitionAvailable && isOnDeviceRecognitionAvailable) {
-            checkLocaleSupport(languageTag)
-        } else {
-            AndroidNativeRecognitionLocaleStatus.Unknown
-        }
-
-        Log.i(
-            TAG,
-            "Android native availability: language=$languageTag displayName=$languageDisplayName " +
-                "recognitionAvailable=$isRecognitionAvailable " +
-                "onDeviceAvailable=$isOnDeviceRecognitionAvailable localeStatus=$localeStatus",
-        )
-
-        return AndroidNativeRecognitionAvailability(
+        return createRecognitionAvailability(
             isRecognitionAvailable = isRecognitionAvailable,
             isOnDeviceRecognitionAvailable = isOnDeviceRecognitionAvailable,
-            languageTag = locale.toLanguageTag(),
+            languageTag = languageTag,
             languageDisplayName = languageDisplayName,
-            localeStatus = localeStatus,
         )
     }
+
 
     fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
         SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
@@ -108,17 +132,22 @@ class AndroidNativeRecognitionSupport @Inject constructor(
                         putExtra(RecognizerIntent.EXTRA_LANGUAGE, languageTag)
                     }
 
+                    fun cleanupRecognizer() {
+                        runCatching { recognizer.cancel() }
+                        runCatching { recognizer.destroy() }
+                    }
+
                     fun complete(status: AndroidNativeRecognitionLocaleStatus) {
                         if (continuation.isActive) {
-                            recognizer.destroy()
+                            cleanupRecognizer()
                             continuation.resume(status)
                         } else {
-                            recognizer.destroy()
+                            cleanupRecognizer()
                         }
                     }
 
                     continuation.invokeOnCancellation {
-                        recognizer.destroy()
+                        cleanupRecognizer()
                     }
 
                     recognizer.checkRecognitionSupport(
@@ -158,6 +187,21 @@ class AndroidNativeRecognitionSupport @Inject constructor(
             }
         }
 }
+
+internal fun createRecognitionAvailability(
+    isRecognitionAvailable: Boolean,
+    isOnDeviceRecognitionAvailable: Boolean,
+    languageTag: String,
+    languageDisplayName: String,
+    localeStatus: AndroidNativeRecognitionLocaleStatus = AndroidNativeRecognitionLocaleStatus.Unknown,
+): AndroidNativeRecognitionAvailability = AndroidNativeRecognitionAvailability(
+    isRecognitionAvailable = isRecognitionAvailable,
+    isOnDeviceRecognitionAvailable = isOnDeviceRecognitionAvailable,
+    languageTag = languageTag,
+    languageDisplayName = languageDisplayName,
+    localeStatus = localeStatus,
+)
+
 
 internal fun resolveLocaleStatus(
     languageTag: String,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -91,7 +91,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
-            val availability = recognitionSupport.getAvailability()
+            val availability = recognitionSupport.getCaptureAvailability()
             availability.blockingReason?.let { reason ->
                 Log.w(
                     TAG,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -32,6 +32,10 @@ internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitio
         availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown
 
 
+internal fun shouldUseCachedCaptureAvailability(mode: VoiceCaptureMode): Boolean =
+    mode == VoiceCaptureMode.AlertCommand
+
+
 internal enum class RecognizerBackend {
     OnDevice,
     Platform,
@@ -91,7 +95,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
-            val availability = recognitionSupport.getCaptureAvailability()
+            val availability = if (shouldUseCachedCaptureAvailability(mode)) {
+                recognitionSupport.getCaptureAvailability()
+            } else {
+                recognitionSupport.getAvailability()
+            }
             availability.blockingReason?.let { reason ->
                 Log.w(
                     TAG,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -22,6 +22,10 @@ import kotlinx.coroutines.withContext
 
 private const val TAG = "NativeVoiceInput"
 
+internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitionAvailability): Boolean =
+    availability.languageTag.isNotBlank()
+
+
 private enum class RecognizerBackend {
     OnDevice,
     Platform,
@@ -127,7 +131,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
             putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-            if (availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown) {
+            if (shouldForceRecognizerLanguage(availability)) {
                 putExtra(RecognizerIntent.EXTRA_LANGUAGE, availability.languageTag)
             }
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
@@ -149,7 +153,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             "Starting Android native STT: sessionId=$sessionId mode=$mode " +
                 "backend=$backend language=${availability.languageSummary} " +
                 "localeStatus=${availability.localeStatus} " +
-                "forceLanguage=${availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown}",
+                "forceLanguage=${shouldForceRecognizerLanguage(availability)}",
         )
         recognizer.setRecognitionListener(
             SessionRecognitionListener(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -28,7 +28,8 @@ private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
 
 
 internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitionAvailability): Boolean =
-    availability.languageTag.isNotBlank()
+    availability.languageTag.isNotBlank() &&
+        availability.localeStatus != AndroidNativeRecognitionLocaleStatus.Unknown
 
 
 internal enum class RecognizerBackend {
@@ -90,7 +91,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
-            val availability = recognitionSupport.getCaptureAvailability()
+            val availability = recognitionSupport.getAvailability()
             availability.blockingReason?.let { reason ->
                 Log.w(
                     TAG,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -15,21 +15,29 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private const val TAG = "NativeVoiceInput"
+private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
+
 
 internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitionAvailability): Boolean =
     availability.languageTag.isNotBlank()
 
 
-private enum class RecognizerBackend {
+internal enum class RecognizerBackend {
     OnDevice,
     Platform,
 }
+
+internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBackend): Boolean =
+    backend == RecognizerBackend.OnDevice
 
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
@@ -55,6 +63,9 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
     @Volatile
     private var activeSessionId: Long = 0L
+
+    @Volatile
+    private var startupFallbackJob: Job? = null
 
     private var nextSessionId: Long = 0L
 
@@ -85,7 +96,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     availability = availability,
                     backend = RecognizerBackend.OnDevice,
                 )
-                _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
                 VoiceInputStartResult.Started
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start Android native voice capture", e)
@@ -110,6 +120,8 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
         val mode = currentMode
         val recognizer = speechRecognizer
+        startupFallbackJob?.cancel()
+        startupFallbackJob = null
         speechRecognizer = null
         currentMode = null
         activeSessionId = 0L
@@ -164,7 +176,40 @@ class NativeAndroidVoiceInputController @Inject constructor(
             ),
         )
         recognizer.startListening(buildRecognizerIntent(availability))
+        scheduleStartupFallback(sessionId, mode, availability, backend)
     }
+
+    private fun scheduleStartupFallback(
+        sessionId: Long,
+        mode: VoiceCaptureMode,
+        availability: AndroidNativeRecognitionAvailability,
+        backend: RecognizerBackend,
+    ) {
+        startupFallbackJob?.cancel()
+        if (!shouldRetryWithPlatformAfterStartupTimeout(backend)) {
+            startupFallbackJob = null
+            return
+        }
+        startupFallbackJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
+            delay(ON_DEVICE_READY_TIMEOUT_MS)
+            if (activeSessionId != sessionId) return@launch
+            Log.w(
+                TAG,
+                "On-device recognizer never became ready for sessionId=$sessionId; retrying with platform recognizer",
+            )
+            retryWithPlatformRecognizer(
+                sessionId = sessionId,
+                mode = mode,
+                availability = availability,
+            )
+        }
+    }
+
+    private fun cancelStartupFallback() {
+        startupFallbackJob?.cancel()
+        startupFallbackJob = null
+    }
+
 
     private fun retryWithPlatformRecognizer(
         sessionId: Long,
@@ -174,6 +219,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         if (activeSessionId != sessionId) return false
 
         return runCatching {
+            cancelStartupFallback()
             speechRecognizer?.apply {
                 runCatching { cancel() }
                 runCatching { destroy() }
@@ -200,7 +246,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
         private var sessionCompleted = false
 
-        override fun onReadyForSpeech(params: Bundle?) = Unit
+        override fun onReadyForSpeech(params: Bundle?) {
+            if (sessionCompleted || activeSessionId != sessionId) return
+            cancelStartupFallback()
+            Log.i(TAG, "Android native STT ready: sessionId=$sessionId mode=$mode backend=$backend")
+            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
+        }
 
         override fun onBeginningOfSpeech() = Unit
 
@@ -229,6 +280,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 return
             }
             sessionCompleted = true
+            cancelStartupFallback()
             Log.w(
                 TAG,
                 "Android native STT error: sessionId=$sessionId mode=$mode error=$error " +
@@ -249,6 +301,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(results)
             sessionCompleted = true
+            cancelStartupFallback()
             Log.i(
                 TAG,
                 "Android native STT result: sessionId=$sessionId mode=$mode transcript='$transcript' " +

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 
 private const val TAG = "NativeVoiceInput"
 private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
+private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
 
 
 internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitionAvailability): Boolean =
@@ -58,6 +59,11 @@ internal fun shouldRetryWithPlatformAfterRecognitionError(
             -> !heardSpeech && !sawPartialTranscript
             else -> false
         }
+
+internal fun shouldRetryWithPlatformAfterWatchdogTimeout(
+    backend: RecognizerBackend,
+    sawPartialTranscript: Boolean,
+): Boolean = backend == RecognizerBackend.OnDevice && !sawPartialTranscript
 
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
@@ -273,11 +279,62 @@ class NativeAndroidVoiceInputController @Inject constructor(
         private var sessionCompleted = false
         private var heardSpeech = false
         private var sawPartialTranscript = false
+        private var sessionWatchdogJob: Job? = null
+
+        private fun resetSessionWatchdog() {
+            sessionWatchdogJob?.cancel()
+            sessionWatchdogJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
+                delay(SESSION_RESULT_TIMEOUT_MS)
+                if (sessionCompleted || activeSessionId != sessionId) return@launch
+                if (
+                    shouldRetryWithPlatformAfterWatchdogTimeout(
+                        backend = backend,
+                        sawPartialTranscript = sawPartialTranscript,
+                    ) &&
+                    retryWithPlatformRecognizer(
+                        sessionId = sessionId,
+                        mode = mode,
+                        availability = availability,
+                    )
+                ) {
+                    sessionCompleted = true
+                    Log.w(
+                        TAG,
+                        "Android native STT watchdog retried with platform recognizer for sessionId=$sessionId " +
+                            "mode=$mode backend=$backend heardSpeech=$heardSpeech " +
+                            "sawPartialTranscript=$sawPartialTranscript",
+                    )
+                    return@launch
+                }
+
+                sessionCompleted = true
+                Log.w(
+                    TAG,
+                    "Android native STT stopped responding before returning a result: " +
+                        "sessionId=$sessionId mode=$mode backend=$backend heardSpeech=$heardSpeech " +
+                        "sawPartialTranscript=$sawPartialTranscript",
+                )
+                _events.tryEmit(
+                    VoiceInputEvent.Error(
+                        mode = mode,
+                        message = "Android speech recognition stopped responding before it returned a result.",
+                    ),
+                )
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
+            }
+        }
+
+        private fun cancelSessionWatchdog() {
+            sessionWatchdogJob?.cancel()
+            sessionWatchdogJob = null
+        }
 
 
         override fun onReadyForSpeech(params: Bundle?) {
             if (sessionCompleted || activeSessionId != sessionId) return
             cancelStartupFallback()
+            resetSessionWatchdog()
             Log.i(TAG, "Android native STT ready: sessionId=$sessionId mode=$mode backend=$backend")
             _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
         }
@@ -285,6 +342,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         override fun onBeginningOfSpeech() {
             if (sessionCompleted || activeSessionId != sessionId) return
             heardSpeech = true
+            resetSessionWatchdog()
             Log.d(TAG, "Android native STT speech began: sessionId=$sessionId mode=$mode backend=$backend")
         }
 
@@ -319,6 +377,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             }
             sessionCompleted = true
             cancelStartupFallback()
+            cancelSessionWatchdog()
             Log.w(
                 TAG,
                 "Android native STT error: sessionId=$sessionId mode=$mode error=$error " +
@@ -340,6 +399,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             val transcript = extractBestTranscript(results)
             sessionCompleted = true
             cancelStartupFallback()
+            cancelSessionWatchdog()
             Log.i(
                 TAG,
                 "Android native STT result: sessionId=$sessionId mode=$mode transcript='$transcript' " +
@@ -364,6 +424,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             val transcript = extractBestTranscript(partialResults)
             if (transcript.isNotBlank()) {
                 sawPartialTranscript = true
+                resetSessionWatchdog()
                 Log.d(
                     TAG,
                     "Android native STT partial: sessionId=$sessionId mode=$mode transcript='$transcript'",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -2,6 +2,10 @@ package com.kernel.ai.core.voice
 
 import android.content.Context
 import android.content.Intent
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
@@ -60,6 +64,14 @@ class NativeAndroidVoiceInputController @Inject constructor(
     override val events: Flow<VoiceInputEvent> = _events.asSharedFlow()
 
 
+    private val audioManager by lazy {
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+
+    @Volatile
+    private var audioFocusRequest: AudioFocusRequest? = null
+
+
     @Volatile
     private var speechRecognizer: SpeechRecognizer? = null
 
@@ -91,6 +103,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             }
 
             try {
+                requestAudioFocus()
                 val sessionId = ++nextSessionId
                 currentMode = mode
                 activeSessionId = sessionId
@@ -135,6 +148,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             runCatching { cancel() }
             runCatching { destroy() }
         }
+        releaseAudioFocus()
 
         if (emitStopped && mode != null) {
             _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
@@ -381,4 +395,36 @@ class NativeAndroidVoiceInputController @Inject constructor(
             else -> "Android speech recognition failed with error code $error."
         }
 
+    private fun requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                )
+                .setOnAudioFocusChangeListener { }
+                .build()
+            audioFocusRequest = request
+            audioManager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                { },
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            )
+        }
+    }
+
+    private fun releaseAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+            audioFocusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(null)
+        }
+    }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -26,6 +26,11 @@ import kotlinx.coroutines.withContext
 private const val TAG = "NativeVoiceInput"
 private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
 private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
+private const val ALERT_SESSION_RESULT_TIMEOUT_MS = 2_500L
+
+internal fun sessionResultTimeoutMs(mode: VoiceCaptureMode): Long =
+    if (mode == VoiceCaptureMode.AlertCommand) ALERT_SESSION_RESULT_TIMEOUT_MS else SESSION_RESULT_TIMEOUT_MS
+
 
 
 internal fun shouldForceRecognizerLanguage(availability: AndroidNativeRecognitionAvailability): Boolean =
@@ -290,7 +295,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         private fun resetSessionWatchdog() {
             sessionWatchdogJob?.cancel()
             sessionWatchdogJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
-                delay(SESSION_RESULT_TIMEOUT_MS)
+                delay(sessionResultTimeoutMs(mode))
                 if (sessionCompleted || activeSessionId != sessionId) return@launch
                 if (
                     shouldRetryWithPlatformAfterWatchdogTimeout(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -47,6 +47,9 @@ internal enum class RecognizerBackend {
     Platform,
 }
 
+internal fun initialRecognizerBackend(mode: VoiceCaptureMode): RecognizerBackend =
+    if (mode == VoiceCaptureMode.AlertCommand) RecognizerBackend.Platform else RecognizerBackend.OnDevice
+
 internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBackend): Boolean =
     backend == RecognizerBackend.OnDevice
 
@@ -137,7 +140,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     sessionId = sessionId,
                     mode = mode,
                     availability = availability,
-                    backend = RecognizerBackend.OnDevice,
+                    backend = initialRecognizerBackend(mode),
                 )
                 VoiceInputStartResult.Started
             } catch (e: Exception) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -58,7 +58,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
 
-            val availability = recognitionSupport.getAvailability()
+            val availability = recognitionSupport.getCaptureAvailability()
             availability.blockingReason?.let { reason ->
                 Log.w(
                     TAG,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -47,6 +47,7 @@ internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBacke
 
 internal fun shouldRetryWithPlatformAfterRecognitionError(
     backend: RecognizerBackend,
+    mode: VoiceCaptureMode,
     error: Int,
     heardSpeech: Boolean,
     sawPartialTranscript: Boolean,
@@ -56,7 +57,12 @@ internal fun shouldRetryWithPlatformAfterRecognitionError(
             SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> true
             SpeechRecognizer.ERROR_NO_MATCH,
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
-            -> !heardSpeech && !sawPartialTranscript
+            -> when (mode) {
+                VoiceCaptureMode.AlertCommand -> !sawPartialTranscript
+                VoiceCaptureMode.Command,
+                VoiceCaptureMode.SlotReply,
+                -> !heardSpeech && !sawPartialTranscript
+            }
             else -> false
         }
 
@@ -357,6 +363,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             if (
                 shouldRetryWithPlatformAfterRecognitionError(
                     backend = backend,
+                    mode = mode,
                     error = error,
                     heardSpeech = heardSpeech,
                     sawPartialTranscript = sawPartialTranscript,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -2,10 +2,6 @@ package com.kernel.ai.core.voice
 
 import android.content.Context
 import android.content.Intent
-import android.media.AudioAttributes
-import android.media.AudioFocusRequest
-import android.media.AudioManager
-import android.os.Build
 import android.os.Bundle
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
@@ -39,6 +35,21 @@ internal enum class RecognizerBackend {
 internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBackend): Boolean =
     backend == RecognizerBackend.OnDevice
 
+internal fun shouldRetryWithPlatformAfterRecognitionError(
+    backend: RecognizerBackend,
+    error: Int,
+    heardSpeech: Boolean,
+    sawPartialTranscript: Boolean,
+): Boolean =
+    backend == RecognizerBackend.OnDevice &&
+        when (error) {
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> true
+            SpeechRecognizer.ERROR_NO_MATCH,
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
+            -> !heardSpeech && !sawPartialTranscript
+            else -> false
+        }
+
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -48,12 +59,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
     private val _events = MutableSharedFlow<VoiceInputEvent>(extraBufferCapacity = 8)
     override val events: Flow<VoiceInputEvent> = _events.asSharedFlow()
 
-    private val audioManager by lazy {
-        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    }
-
-    @Volatile
-    private var audioFocusRequest: AudioFocusRequest? = null
 
     @Volatile
     private var speechRecognizer: SpeechRecognizer? = null
@@ -86,7 +91,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
             }
 
             try {
-                requestAudioFocus()
                 val sessionId = ++nextSessionId
                 currentMode = mode
                 activeSessionId = sessionId
@@ -131,7 +135,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
             runCatching { cancel() }
             runCatching { destroy() }
         }
-        releaseAudioFocus()
 
         if (emitStopped && mode != null) {
             _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
@@ -245,6 +248,9 @@ class NativeAndroidVoiceInputController @Inject constructor(
     ) : RecognitionListener {
 
         private var sessionCompleted = false
+        private var heardSpeech = false
+        private var sawPartialTranscript = false
+
 
         override fun onReadyForSpeech(params: Bundle?) {
             if (sessionCompleted || activeSessionId != sessionId) return
@@ -253,7 +259,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
             _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
         }
 
-        override fun onBeginningOfSpeech() = Unit
+        override fun onBeginningOfSpeech() {
+            if (sessionCompleted || activeSessionId != sessionId) return
+            heardSpeech = true
+            Log.d(TAG, "Android native STT speech began: sessionId=$sessionId mode=$mode backend=$backend")
+        }
 
         override fun onRmsChanged(rmsdB: Float) = Unit
 
@@ -264,8 +274,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
         override fun onError(error: Int) {
             if (sessionCompleted || activeSessionId != sessionId) return
             if (
-                backend == RecognizerBackend.OnDevice &&
-                error == SpeechRecognizer.ERROR_SERVER_DISCONNECTED &&
+                shouldRetryWithPlatformAfterRecognitionError(
+                    backend = backend,
+                    error = error,
+                    heardSpeech = heardSpeech,
+                    sawPartialTranscript = sawPartialTranscript,
+                ) &&
                 retryWithPlatformRecognizer(
                     sessionId = sessionId,
                     mode = mode,
@@ -275,7 +289,8 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 sessionCompleted = true
                 Log.w(
                     TAG,
-                    "On-device recognizer disconnected for sessionId=$sessionId; retried with platform recognizer",
+                    "Android native STT retried with platform recognizer after error=$error for sessionId=$sessionId " +
+                        "heardSpeech=$heardSpeech sawPartialTranscript=$sawPartialTranscript",
                 )
                 return
             }
@@ -325,6 +340,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             if (sessionCompleted || activeSessionId != sessionId) return
             val transcript = extractBestTranscript(partialResults)
             if (transcript.isNotBlank()) {
+                sawPartialTranscript = true
                 Log.d(
                     TAG,
                     "Android native STT partial: sessionId=$sessionId mode=$mode transcript='$transcript'",
@@ -365,36 +381,4 @@ class NativeAndroidVoiceInputController @Inject constructor(
             else -> "Android speech recognition failed with error code $error."
         }
 
-    private fun requestAudioFocus() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
-                .setAudioAttributes(
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                        .build(),
-                )
-                .setOnAudioFocusChangeListener { }
-                .build()
-            audioFocusRequest = request
-            audioManager.requestAudioFocus(request)
-        } else {
-            @Suppress("DEPRECATION")
-            audioManager.requestAudioFocus(
-                { },
-                AudioManager.STREAM_MUSIC,
-                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
-            )
-        }
-    }
-
-    private fun releaseAudioFocus() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
-            audioFocusRequest = null
-        } else {
-            @Suppress("DEPRECATION")
-            audioManager.abandonAudioFocus(null)
-        }
-    }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceCaptureMode.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceCaptureMode.kt
@@ -3,4 +3,5 @@ package com.kernel.ai.core.voice
 enum class VoiceCaptureMode {
     Command,
     SlotReply,
+    AlertCommand,
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputPreferences.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.core.voice
 
 import android.content.Context
 import android.util.Log
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -22,6 +23,8 @@ class VoiceInputPreferences @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     private val selectedEngineKey = stringPreferencesKey("selected_voice_input_engine")
+    private val autoStartAlertVoiceCommandsEnabledKey =
+        booleanPreferencesKey("auto_start_alert_voice_commands_enabled")
 
     val selectedEngine: Flow<VoiceInputEngine> = context.voiceInputPrefsDataStore.data
         .catch { e ->
@@ -34,9 +37,26 @@ class VoiceInputPreferences @Inject constructor(
         }
         .map { prefs -> VoiceInputEngine.fromStorage(prefs[selectedEngineKey]) }
 
+    val autoStartAlertVoiceCommandsEnabled: Flow<Boolean> = context.voiceInputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice input preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> prefs[autoStartAlertVoiceCommandsEnabledKey] ?: true }
+
     suspend fun setSelectedEngine(engine: VoiceInputEngine) {
         context.voiceInputPrefsDataStore.edit { prefs ->
             prefs[selectedEngineKey] = engine.name
+        }
+    }
+
+    suspend fun setAutoStartAlertVoiceCommandsEnabled(enabled: Boolean) {
+        context.voiceInputPrefsDataStore.edit { prefs ->
+            prefs[autoStartAlertVoiceCommandsEnabledKey] = enabled
         }
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -97,6 +97,19 @@ class AndroidNativeRecognitionSupportTest {
     }
 
     @Test
+    fun `capture startup still forces the requested language when locale support is unknown`() {
+        val availability = createRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-NZ",
+            languageDisplayName = "English (New Zealand)",
+        )
+
+        assertEquals(true, shouldForceRecognizerLanguage(availability))
+    }
+
+
+    @Test
     fun `ready locale has no warning or blocking reason`() {
         val availability = AndroidNativeRecognitionAvailability(
             isRecognitionAvailable = true,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -97,7 +97,7 @@ class AndroidNativeRecognitionSupportTest {
     }
 
     @Test
-    fun `capture startup still forces the requested language when locale support is unknown`() {
+    fun `capture startup does not force locale when support is still unknown`() {
         val availability = createRecognitionAvailability(
             isRecognitionAvailable = true,
             isOnDeviceRecognitionAvailable = true,
@@ -105,7 +105,7 @@ class AndroidNativeRecognitionSupportTest {
             languageDisplayName = "English (New Zealand)",
         )
 
-        assertEquals(true, shouldForceRecognizerLanguage(availability))
+        assertEquals(false, shouldForceRecognizerLanguage(availability))
     }
 
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -49,6 +49,20 @@ class AndroidNativeRecognitionSupportTest {
     }
 
     @Test
+    fun `createRecognitionAvailability defaults locale status to unknown for capture startup`() {
+        val availability = createRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-NZ",
+            languageDisplayName = "English (New Zealand)",
+        )
+
+        assertEquals(AndroidNativeRecognitionLocaleStatus.Unknown, availability.localeStatus)
+        assertNull(availability.blockingReason)
+    }
+
+
+    @Test
     fun `unknown locale support warns without blocking start`() {
         val availability = AndroidNativeRecognitionAvailability(
             isRecognitionAvailable = true,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -13,6 +13,14 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
+    fun `sessionResultTimeoutMs shortens alert command watchdog`() {
+        assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.Command))
+        assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.SlotReply))
+        assertEquals(2_500L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand))
+    }
+
+
+    @Test
     fun `shouldRetryWithPlatformAfterWatchdogTimeout retries only on-device sessions without partials`() {
         assertEquals(true, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.OnDevice, false))
         assertEquals(false, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.OnDevice, true))

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -42,14 +42,22 @@ class NativeAndroidVoiceInputControllerTest {
     }
 
     @Test
-    fun `shouldForceRecognizerLanguage keeps requested locale for native capture`() {
-        val availability = createRecognitionAvailability(
+    fun `shouldForceRecognizerLanguage only forces verified locale`() {
+        val unknownAvailability = createRecognitionAvailability(
             isRecognitionAvailable = true,
             isOnDeviceRecognitionAvailable = true,
             languageTag = "en-AU",
             languageDisplayName = "English (Australia)",
         )
+        val readyAvailability = createRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-AU",
+            languageDisplayName = "English (Australia)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
+        )
 
-        assertEquals(true, shouldForceRecognizerLanguage(availability))
+        assertEquals(false, shouldForceRecognizerLanguage(unknownAvailability))
+        assertEquals(true, shouldForceRecognizerLanguage(readyAvailability))
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -27,11 +27,12 @@ class NativeAndroidVoiceInputControllerTest {
     }
 
     @Test
-    fun `shouldRetryWithPlatformAfterRecognitionError retries startup silence on-device only`() {
+    fun `shouldRetryWithPlatformAfterRecognitionError keeps normal command fallback conservative`() {
         assertEquals(
             true,
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
+                mode = VoiceCaptureMode.Command,
                 error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = false,
                 sawPartialTranscript = false,
@@ -41,6 +42,7 @@ class NativeAndroidVoiceInputControllerTest {
             false,
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
+                mode = VoiceCaptureMode.Command,
                 error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = true,
                 sawPartialTranscript = false,
@@ -50,9 +52,34 @@ class NativeAndroidVoiceInputControllerTest {
             false,
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.Platform,
+                mode = VoiceCaptureMode.Command,
                 error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = false,
                 sawPartialTranscript = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `shouldRetryWithPlatformAfterRecognitionError retries alert no-match after speech without partials`() {
+        assertEquals(
+            true,
+            shouldRetryWithPlatformAfterRecognitionError(
+                backend = RecognizerBackend.OnDevice,
+                mode = VoiceCaptureMode.AlertCommand,
+                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                heardSpeech = true,
+                sawPartialTranscript = false,
+            ),
+        )
+        assertEquals(
+            false,
+            shouldRetryWithPlatformAfterRecognitionError(
+                backend = RecognizerBackend.OnDevice,
+                mode = VoiceCaptureMode.AlertCommand,
+                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                heardSpeech = true,
+                sawPartialTranscript = true,
             ),
         )
     }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -11,6 +11,37 @@ class NativeAndroidVoiceInputControllerTest {
     }
 
     @Test
+    fun `shouldRetryWithPlatformAfterRecognitionError retries startup silence on-device only`() {
+        assertEquals(
+            true,
+            shouldRetryWithPlatformAfterRecognitionError(
+                backend = RecognizerBackend.OnDevice,
+                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                heardSpeech = false,
+                sawPartialTranscript = false,
+            ),
+        )
+        assertEquals(
+            false,
+            shouldRetryWithPlatformAfterRecognitionError(
+                backend = RecognizerBackend.OnDevice,
+                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                heardSpeech = true,
+                sawPartialTranscript = false,
+            ),
+        )
+        assertEquals(
+            false,
+            shouldRetryWithPlatformAfterRecognitionError(
+                backend = RecognizerBackend.Platform,
+                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                heardSpeech = false,
+                sawPartialTranscript = false,
+            ),
+        )
+    }
+
+    @Test
     fun `shouldForceRecognizerLanguage keeps requested locale for native capture`() {
         val availability = createRecognitionAvailability(
             isRecognitionAvailable = true,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -13,6 +13,14 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
+    fun `shouldRetryWithPlatformAfterWatchdogTimeout retries only on-device sessions without partials`() {
+        assertEquals(true, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.OnDevice, false))
+        assertEquals(false, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.OnDevice, true))
+        assertEquals(false, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.Platform, false))
+    }
+
+
+    @Test
     fun `shouldRetryWithPlatformAfterStartupTimeout retries only on-device recognizer`() {
         assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.OnDevice))
         assertEquals(false, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.Platform))

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -13,6 +13,14 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
+    fun `initialRecognizerBackend starts alert commands on platform`() {
+        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.Command))
+        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.SlotReply))
+        assertEquals(RecognizerBackend.Platform, initialRecognizerBackend(VoiceCaptureMode.AlertCommand))
+    }
+
+
+    @Test
     fun `sessionResultTimeoutMs shortens alert command watchdog`() {
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.Command))
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.SlotReply))

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -5,6 +5,14 @@ import org.junit.jupiter.api.Test
 
 class NativeAndroidVoiceInputControllerTest {
     @Test
+    fun `shouldUseCachedCaptureAvailability only for alert commands`() {
+        assertEquals(false, shouldUseCachedCaptureAvailability(VoiceCaptureMode.Command))
+        assertEquals(false, shouldUseCachedCaptureAvailability(VoiceCaptureMode.SlotReply))
+        assertEquals(true, shouldUseCachedCaptureAvailability(VoiceCaptureMode.AlertCommand))
+    }
+
+
+    @Test
     fun `shouldRetryWithPlatformAfterStartupTimeout retries only on-device recognizer`() {
         assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.OnDevice))
         assertEquals(false, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.Platform))

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -1,0 +1,24 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NativeAndroidVoiceInputControllerTest {
+    @Test
+    fun `shouldRetryWithPlatformAfterStartupTimeout retries only on-device recognizer`() {
+        assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.OnDevice))
+        assertEquals(false, shouldRetryWithPlatformAfterStartupTimeout(RecognizerBackend.Platform))
+    }
+
+    @Test
+    fun `shouldForceRecognizerLanguage keeps requested locale for native capture`() {
+        val availability = createRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-AU",
+            languageDisplayName = "English (Australia)",
+        )
+
+        assertEquals(true, shouldForceRecognizerLanguage(availability))
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -140,6 +140,7 @@ fun ActionsScreen(
         when (mode) {
             VoiceCaptureMode.Command -> viewModel.startVoiceCommand()
             VoiceCaptureMode.SlotReply -> viewModel.startVoiceSlotReply()
+            VoiceCaptureMode.AlertCommand -> Unit
             null -> Unit
         }
     }
@@ -162,6 +163,7 @@ fun ActionsScreen(
             when (mode) {
                 VoiceCaptureMode.Command -> viewModel.startVoiceCommand()
                 VoiceCaptureMode.SlotReply -> viewModel.startVoiceSlotReply()
+                VoiceCaptureMode.AlertCommand -> Unit
             }
             return
         }
@@ -861,6 +863,7 @@ private fun VoiceCaptureCard(
         is ActionsViewModel.VoiceCaptureState.Listening -> when (state.mode) {
             VoiceCaptureMode.Command -> "Ready — speak your quick action"
             VoiceCaptureMode.SlotReply -> "Ready — speak your reply"
+            VoiceCaptureMode.AlertCommand -> "Listening for alert command…"
         }
         is ActionsViewModel.VoiceCaptureState.Processing -> "Processing speech…"
         ActionsViewModel.VoiceCaptureState.Idle -> return

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -159,7 +159,7 @@ class ActionsViewModel @Inject constructor(
             voiceInputController.events.collect { event ->
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
-                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
+                        if (!ownsVoiceCapture(event.mode)) return@collect
                         val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
                             ?.takeIf { it.mode == event.mode }
                             ?.transcript
@@ -167,11 +167,11 @@ class ActionsViewModel @Inject constructor(
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, currentTranscript)
                     }
                     is VoiceInputEvent.PartialTranscript -> {
-                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
+                        if (!ownsVoiceCapture(event.mode)) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, event.text)
                     }
                     is VoiceInputEvent.Transcript -> {
-                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
+                        if (!ownsVoiceCapture(event.mode)) return@collect
                         val normalizedTranscript = normalizeVoiceCommand(event.text)
                         _voiceCaptureState.value = VoiceCaptureState.Processing(event.mode, normalizedTranscript)
                         when (event.mode) {
@@ -181,12 +181,12 @@ class ActionsViewModel @Inject constructor(
                         }
                     }
                     is VoiceInputEvent.Error -> {
-                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
+                        if (!ownsVoiceCapture(event.mode)) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Idle
                         _error.value = event.message
                     }
                     is VoiceInputEvent.ListeningStopped -> {
-                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
+                        if (!ownsVoiceCapture(event.mode)) return@collect
                         val currentState = _voiceCaptureState.value
                         when (currentState) {
                             is VoiceCaptureState.Listening -> {
@@ -633,6 +633,15 @@ class ActionsViewModel @Inject constructor(
             result is SkillResult.Failure &&
             result.error == PHONE_PERMISSION_REQUIRED_ERROR
     }
+
+
+    private fun ownsVoiceCapture(mode: VoiceCaptureMode): Boolean =
+        when (val state = _voiceCaptureState.value) {
+            is VoiceCaptureState.Preparing -> state.mode == mode
+            is VoiceCaptureState.Listening -> state.mode == mode
+            is VoiceCaptureState.Processing -> state.mode == mode
+            VoiceCaptureState.Idle -> false
+        }
 
 
     private fun startVoiceCapture(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -159,6 +159,7 @@ class ActionsViewModel @Inject constructor(
             voiceInputController.events.collect { event ->
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
+                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
                         val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
                             ?.takeIf { it.mode == event.mode }
                             ?.transcript
@@ -166,21 +167,26 @@ class ActionsViewModel @Inject constructor(
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, currentTranscript)
                     }
                     is VoiceInputEvent.PartialTranscript -> {
+                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, event.text)
                     }
                     is VoiceInputEvent.Transcript -> {
+                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
                         val normalizedTranscript = normalizeVoiceCommand(event.text)
                         _voiceCaptureState.value = VoiceCaptureState.Processing(event.mode, normalizedTranscript)
                         when (event.mode) {
                             VoiceCaptureMode.Command -> executeAction(normalizedTranscript, InputMode.Voice)
                             VoiceCaptureMode.SlotReply -> onSlotReply(normalizedTranscript)
+                            VoiceCaptureMode.AlertCommand -> Unit
                         }
                     }
                     is VoiceInputEvent.Error -> {
+                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Idle
                         _error.value = event.message
                     }
                     is VoiceInputEvent.ListeningStopped -> {
+                        if (event.mode == VoiceCaptureMode.AlertCommand) return@collect
                         val currentState = _voiceCaptureState.value
                         when (currentState) {
                             is VoiceCaptureState.Listening -> {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -327,22 +327,22 @@ class ChatViewModel @Inject constructor(
             voiceInputController.events.collect { event ->
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
-                        if (event.mode != VoiceCaptureMode.Command) return@collect
+                        if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
                             ?.transcript
                             .orEmpty()
                         _voiceCaptureState.value = VoiceCaptureState.Listening(currentTranscript)
                     }
                     is VoiceInputEvent.PartialTranscript -> {
-                        if (event.mode != VoiceCaptureMode.Command) return@collect
+                        if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.text)
                     }
                     is VoiceInputEvent.Transcript -> {
-                        if (event.mode != VoiceCaptureMode.Command) return@collect
+                        if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         submitVoiceTranscript(event.text)
                     }
                     is VoiceInputEvent.Error -> {
-                        if (event.mode != VoiceCaptureMode.Command) return@collect
+                        if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         awaitingVoicePlaybackCompletion = false
                         pendingVoiceReply = false
                         _voiceMode.value = null
@@ -350,7 +350,7 @@ class ChatViewModel @Inject constructor(
                         _error.value = withVoiceSettingsHint(event.message)
                     }
                     is VoiceInputEvent.ListeningStopped -> {
-                        if (event.mode != VoiceCaptureMode.Command) return@collect
+                        if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         when (val currentState = _voiceCaptureState.value) {
                             is VoiceCaptureState.Listening -> {
                                 if (currentState.transcript.isBlank()) {
@@ -793,6 +793,10 @@ class ChatViewModel @Inject constructor(
      * re-arms automatically until the user explicitly stops or leaves the conversation.
      */
     fun startBackAndForthVoiceInput() = startVoiceInput(VoiceMode.BackAndForth)
+
+    private fun ownsCommandVoiceCapture(): Boolean =
+        _voiceCaptureState.value != VoiceCaptureState.Idle
+
 
     private fun startVoiceInput(mode: VoiceMode) {
         if (inferenceEngine.isGenerating.value || _isLoadingModel.value) return

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -327,18 +327,22 @@ class ChatViewModel @Inject constructor(
             voiceInputController.events.collect { event ->
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
+                        if (event.mode != VoiceCaptureMode.Command) return@collect
                         val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
                             ?.transcript
                             .orEmpty()
                         _voiceCaptureState.value = VoiceCaptureState.Listening(currentTranscript)
                     }
                     is VoiceInputEvent.PartialTranscript -> {
+                        if (event.mode != VoiceCaptureMode.Command) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.text)
                     }
                     is VoiceInputEvent.Transcript -> {
+                        if (event.mode != VoiceCaptureMode.Command) return@collect
                         submitVoiceTranscript(event.text)
                     }
                     is VoiceInputEvent.Error -> {
+                        if (event.mode != VoiceCaptureMode.Command) return@collect
                         awaitingVoicePlaybackCompletion = false
                         pendingVoiceReply = false
                         _voiceMode.value = null
@@ -346,6 +350,7 @@ class ChatViewModel @Inject constructor(
                         _error.value = withVoiceSettingsHint(event.message)
                     }
                     is VoiceInputEvent.ListeningStopped -> {
+                        if (event.mode != VoiceCaptureMode.Command) return@collect
                         when (val currentState = _voiceCaptureState.value) {
                             is VoiceCaptureState.Listening -> {
                                 if (currentState.transcript.isBlank()) {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -126,6 +126,16 @@ class ActionsViewModelVoiceTest {
 
 
     @Test
+    fun `idle actions viewmodel ignores command transcript it did not start`() = runTest(dispatcher) {
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "cancel timer"))
+        advanceUntilIdle()
+
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        verify(exactly = 0) { quickIntentRouter.route(any()) }
+    }
+
+
+    @Test
     fun `executeAction in voice mode speaks slot prompt for NeedsSlot`() = runTest(dispatcher) {
         every { quickIntentRouter.route("send a message to Laurelle") } returns
             QuickIntentRouter.RouteResult.NeedsSlot(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -116,6 +116,16 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `alert command transcript does not execute quick actions`() = runTest(dispatcher) {
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "stop"))
+        advanceUntilIdle()
+
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        verify(exactly = 0) { quickIntentRouter.route(any()) }
+    }
+
+
+    @Test
     fun `executeAction in voice mode speaks slot prompt for NeedsSlot`() = runTest(dispatcher) {
         every { quickIntentRouter.route("send a message to Laurelle") } returns
             QuickIntentRouter.RouteResult.NeedsSlot(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -161,6 +161,19 @@ class ChatViewModelVoiceTest {
 
 
     @Test
+    fun `idle chat viewmodel ignores command transcript it did not start`() = runTest(dispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "cancel timer"))
+        advanceUntilIdle()
+
+        assertEquals("", viewModel.getConversationAsText())
+        verify(exactly = 0) { quickIntentRouter.route(any()) }
+    }
+
+
+    @Test
     fun `voice transcript submits chat message and speaks assistant reply`() = runTest(dispatcher) {
         every { quickIntentRouter.route("Hello there") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "Hello there")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -148,6 +148,19 @@ class ChatViewModelVoiceTest {
     }
 
     @Test
+    fun `alert command transcript does not reach chat llm flow`() = runTest(dispatcher) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "stop"))
+        advanceUntilIdle()
+
+        assertEquals("", viewModel.getConversationAsText())
+        verify(exactly = 0) { quickIntentRouter.route(any()) }
+    }
+
+
+    @Test
     fun `voice transcript submits chat message and speaks assistant reply`() = runTest(dispatcher) {
         every { quickIntentRouter.route("Hello there") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "Hello there")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -119,6 +119,28 @@ fun VoiceScreen(
             }
 
             Text(
+                text = "Clock alerts",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text("Automatically listen when alarms or timers ring") },
+                supportingContent = {
+                    Text("Start local voice command capture for stop, dismiss, snooze, or add one minute as soon as an alert begins")
+                },
+                trailingContent = {
+                    Switch(
+                        checked = uiState.autoStartAlertVoiceCommandsEnabled,
+                        onCheckedChange = { viewModel.setAutoStartAlertVoiceCommandsEnabled(it) },
+                    )
+                },
+            )
+            HorizontalDivider()
+
+            Text(
                 text = "Quick Actions output",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -17,6 +17,7 @@ import javax.inject.Inject
 data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
     val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
+    val autoStartAlertVoiceCommandsEnabled: Boolean = true,
     val androidNativeAvailabilityMessage: String? = null,
     val androidNativeLanguageSummary: String? = null,
 )
@@ -51,6 +52,11 @@ class VoiceViewModel @Inject constructor(
                 _uiState.update { it.copy(spokenResponsesEnabled = enabled) }
             }
         }
+        viewModelScope.launch {
+            voiceInputPreferences.autoStartAlertVoiceCommandsEnabled.collect { enabled ->
+                _uiState.update { it.copy(autoStartAlertVoiceCommandsEnabled = enabled) }
+            }
+        }
     }
 
     fun setVoiceInputEngine(engine: VoiceInputEngine) {
@@ -64,6 +70,13 @@ class VoiceViewModel @Inject constructor(
         _uiState.update { it.copy(spokenResponsesEnabled = enabled) }
         viewModelScope.launch {
             voiceOutputPreferences.setSpokenResponsesEnabled(enabled)
+        }
+    }
+
+    fun setAutoStartAlertVoiceCommandsEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(autoStartAlertVoiceCommandsEnabled = enabled) }
+        viewModelScope.launch {
+            voiceInputPreferences.setAutoStartAlertVoiceCommandsEnabled(enabled)
         }
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -33,6 +33,7 @@ class VoiceViewModelTest {
     private val voiceInputPreferences: VoiceInputPreferences = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
     private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
+    private val autoStartAlertVoiceCommandsEnabled = MutableStateFlow(true)
     private val spokenResponsesEnabled = MutableStateFlow(true)
 
     private lateinit var viewModel: VoiceViewModel
@@ -49,7 +50,9 @@ class VoiceViewModelTest {
                 localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
             )
         every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
+        every { voiceInputPreferences.autoStartAlertVoiceCommandsEnabled } returns autoStartAlertVoiceCommandsEnabled
         coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
+        coEvery { voiceInputPreferences.setAutoStartAlertVoiceCommandsEnabled(any()) } just Runs
         every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
         viewModel = VoiceViewModel(
@@ -63,6 +66,13 @@ class VoiceViewModelTest {
     fun tearDown() {
         Dispatchers.resetMain()
     }
+
+    @Test
+    fun `alert voice auto start defaults to enabled when preference flow emits true`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.autoStartAlertVoiceCommandsEnabled)
+    }
+
 
     @Test
     fun `spoken responses default to enabled when preference flow emits true`() = runTest {
@@ -166,6 +176,16 @@ class VoiceViewModelTest {
         assertEquals(VoiceInputEngine.AndroidNative, viewModel.uiState.value.selectedInputEngine)
         coVerify { voiceInputPreferences.setSelectedEngine(VoiceInputEngine.AndroidNative) }
     }
+
+    @Test
+    fun `setAutoStartAlertVoiceCommandsEnabled updates ui state immediately`() = runTest {
+        viewModel.setAutoStartAlertVoiceCommandsEnabled(false)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(false, viewModel.uiState.value.autoStartAlertVoiceCommandsEnabled)
+        coVerify { voiceInputPreferences.setAutoStartAlertVoiceCommandsEnabled(false) }
+    }
+
 
     @Test
     fun `setSpokenResponsesEnabled updates ui state immediately`() = runTest {


### PR DESCRIPTION
## Summary
- add explicit alert-time voice control in `ClockAlertService` with notification actions for voice, snooze, and add-one-minute
- add repository-backed alarm snooze scheduling so alert snoozes stay alarm-owned instead of leaking into timers
- add focused parser and repository regression tests for ringing voice actions and snooze state handling

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :app:testDebugUnitTest --tests "*ClockAlertVoiceCommandTest" :app:compileDebugKotlin`

## Manual checks
1. Trigger an internal alarm and confirm the ringing notification shows **Stop**, **Snooze**, and **Voice**.
2. Tap **Voice** and say:
   - `stop`
   - `dismiss`
   - `snooze`
   - `add one minute`
3. Confirm alarm `snooze` keeps the alarm in the alarm domain and rings again after the requested delay.
4. Trigger an internal timer and confirm the ringing notification shows **Dismiss**, **+1 min**, and **Voice**.
5. Tap **Voice** during the timer alert and say:
   - `dismiss`
   - `add one minute`
6. Confirm `snooze` during a timer alert fails truthfully without breaking the active alert.

Closes #752
