### PR TITLE
feat(#729): add sherpa piper tts spike

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,25 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Cache Sherpa-ONNX AAR
+        uses: actions/cache@v4
+        with:
+          path: third_party/sherpa-onnx
+          key: sherpa-onnx-aar-1.13.0
+
+      - name: Download Sherpa-ONNX AAR
+        run: |
+          mkdir -p third_party/sherpa-onnx
+          AAR=third_party/sherpa-onnx/sherpa-onnx-1.13.0.aar
+          if [ ! -f "$AAR" ]; then
+            echo "Downloading Sherpa-ONNX AAR…"
+            curl -fL -o "$AAR" \
+              https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.0/sherpa-onnx-1.13.0.aar
+            echo "Downloaded $(du -sh "$AAR" | cut -f1) AAR"
+          else
+            echo "AAR already present (cached)"
+          fi
+
       - name: Build (debug)
         run: ./gradlew assembleDebug -PversionCode=${{ github.run_number }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ google-services.json
 # docs/testing/
 local.properties
 debug/*.hprof
+
+# ── Sherpa-ONNX spike — local-only, NOT committed ────────────────────────────
+# Download via: scripts/setup-sherpa-tts-spike.sh
+# AAR binary
+third_party/sherpa-onnx/
+
+# Piper / Sherpa-ONNX model assets bundled into APK only after running setup.
+core/voice/src/main/assets/sherpa-tts/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,7 +98,11 @@ dependencies {
     // produces an APK, not an AAR, so local AAR deps are permitted) so Sherpa classes
     // are present on the runtime classpath when the APK runs on device.
     //
-    // Requires: bash scripts/setup-sherpa-tts-spike.sh   (downloads third_party/ + assets)
+    // CI: The "Download Sherpa-ONNX AAR" workflow step fetches the file automatically
+    //     before assembleDebug so CI APKs always include the Sherpa runtime.
+    // Local dev: Run `bash scripts/setup-sherpa-tts-spike.sh` to obtain the AAR, or
+    //     leave it absent — SherpaOnnxVoiceOutputController returns Unavailable and
+    //     Android TTS is used as the runtime fallback.
     // Absent AAR → SherpaOnnxVoiceOutputController returns Unavailable → Android TTS used.
     val sherpaAar = rootProject.file("third_party/sherpa-onnx/sherpa-onnx-1.13.0.aar")
     if (sherpaAar.exists()) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,20 @@ dependencies {
     implementation(project(":feature:chat"))
     implementation(project(":feature:settings"))
 
+    // ── Sherpa-ONNX spike — runtime AAR for SherpaOnnxVoiceOutputController ──────────
+    // SherpaOnnxVoiceOutputController (core:voice) uses Class.forName() reflection; no
+    // compile-time dependency is needed in core:voice.  The AAR is added here (:app
+    // produces an APK, not an AAR, so local AAR deps are permitted) so Sherpa classes
+    // are present on the runtime classpath when the APK runs on device.
+    //
+    // Requires: bash scripts/setup-sherpa-tts-spike.sh   (downloads third_party/ + assets)
+    // Absent AAR → SherpaOnnxVoiceOutputController returns Unavailable → Android TTS used.
+    val sherpaAar = rootProject.file("third_party/sherpa-onnx/sherpa-onnx-1.13.0.aar")
+    if (sherpaAar.exists()) {
+        implementation(files(sherpaAar.absolutePath))
+    }
+    // ────────────────────────────────────────────────────────────────────────────────
+
     // Compose
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/core/voice/build.gradle.kts
+++ b/core/voice/build.gradle.kts
@@ -44,6 +44,12 @@ dependencies {
     implementation(libs.datastore.preferences)
     implementation(libs.vosk.android)
 
+    // WorkManager — required for VoicePackDownloadWorker / SherpaVoicePackDownloadManager
+    implementation(libs.work.runtime.ktx)
+
+    // Apache Commons Compress — BZip2 + Tar extraction for Sherpa Piper voice packs
+    implementation(libs.commons.compress)
+
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/core/voice/build.gradle.kts
+++ b/core/voice/build.gradle.kts
@@ -24,9 +24,19 @@ android {
     }
 
     testOptions {
-        unitTests.all { it.useJUnitPlatform() }
+        unitTests {
+            // Allow Android framework stubs (e.g. android.util.Log) to return default
+            // values in JVM unit tests rather than throwing "not mocked" RuntimeExceptions.
+            isReturnDefaultValues = true
+            all { it.useJUnitPlatform() }
+        }
     }
 }
+
+// ── Sherpa-ONNX spike (reflection-only — no compile-time dependency on Sherpa) ──────
+// SherpaOnnxVoiceOutputController uses Class.forName() for all Sherpa access so this
+// module compiles without the AAR.  Add the AAR to :app so it is included in the APK
+// at runtime; see :app/build.gradle.kts for the conditional implementation block.
 
 dependencies {
     implementation(libs.core.ktx)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -1,0 +1,111 @@
+package com.kernel.ai.core.voice
+
+import android.util.Log
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+
+/**
+ * Fallback/selector [VoiceOutputController] that respects [VoiceOutputPreferences].
+ *
+ * - [VoiceOutputEngine.AndroidTts] routes directly to [AndroidTextToSpeechController].
+ * - [VoiceOutputEngine.SherpaExperimental] tries [SherpaOnnxVoiceOutputController] first, but
+ *   still falls back to Android TTS if Sherpa assets/runtime are missing or if synthesis fails.
+ *
+ * Events are forwarded from whichever backend is active via [flatMapLatest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Singleton
+class FallbackVoiceOutputController @Inject constructor(
+    private val voiceOutputPreferences: VoiceOutputPreferences,
+    private val sherpa: SherpaOnnxVoiceOutputController,
+    private val androidTts: AndroidTextToSpeechController,
+) : VoiceOutputController {
+    private val activeController = MutableStateFlow<VoiceOutputController>(androidTts)
+
+    override val events: Flow<VoiceOutputEvent> = activeController.flatMapLatest { it.events }
+
+    override suspend fun warmUp(): VoiceOutputResult = when (voiceOutputPreferences.selectedEngine.first()) {
+        VoiceOutputEngine.AndroidTts -> warmUpAndroidTts()
+        VoiceOutputEngine.SherpaExperimental -> warmUpSherpaOrFallback()
+    }
+
+    override suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult =
+        when (voiceOutputPreferences.selectedEngine.first()) {
+            VoiceOutputEngine.AndroidTts -> {
+                activate(androidTts)
+                androidTts.speak(request)
+            }
+
+            VoiceOutputEngine.SherpaExperimental -> speakWithSherpaFallback(request)
+        }
+
+    override fun stop() {
+        sherpa.stop()
+        androidTts.stop()
+    }
+
+    private suspend fun warmUpAndroidTts(): VoiceOutputResult {
+        activate(androidTts)
+        return androidTts.warmUp()
+    }
+
+    private suspend fun warmUpSherpaOrFallback(): VoiceOutputResult {
+        val sherpaResult = sherpa.warmUp()
+        return if (sherpaResult !is VoiceOutputResult.Unavailable) {
+            Log.i(TAG, "Sherpa-ONNX TTS selected as active voice output backend.")
+            activate(sherpa)
+            sherpaResult
+        } else {
+            Log.i(
+                TAG,
+                "Sherpa-ONNX TTS unavailable (${sherpaResult.message}); routing to Android TTS fallback.",
+            )
+            activate(androidTts)
+            androidTts.warmUp()
+        }
+    }
+
+    private suspend fun speakWithSherpaFallback(request: VoiceSpeakRequest): VoiceOutputResult {
+        val warmUpResult = sherpa.warmUp()
+        if (warmUpResult !is VoiceOutputResult.Unavailable) {
+            activate(sherpa)
+            val sherpaResult = sherpa.speak(request)
+            if (sherpaResult !is VoiceOutputResult.Unavailable) {
+                return sherpaResult
+            }
+            Log.w(
+                TAG,
+                "Sherpa-ONNX TTS speak failed (${sherpaResult.message}); routing to Android TTS fallback.",
+            )
+        } else {
+            Log.i(
+                TAG,
+                "Sherpa-ONNX TTS unavailable (${warmUpResult.message}); routing to Android TTS fallback.",
+            )
+        }
+
+        activate(androidTts)
+        val androidWarmUpResult = androidTts.warmUp()
+        if (androidWarmUpResult is VoiceOutputResult.Unavailable) {
+            return androidWarmUpResult
+        }
+        return androidTts.speak(request)
+    }
+
+    private fun activate(controller: VoiceOutputController) {
+        activeController.value = controller
+        stopInactiveControllers(controller)
+    }
+
+    private fun stopInactiveControllers(active: VoiceOutputController) {
+        if (active !== sherpa) sherpa.stop()
+        if (active !== androidTts) androidTts.stop()
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -243,9 +243,9 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
         // OfflineTtsVitsModelConfig — all-defaults constructor
         val vitsConfig = newInstance(vitsClass)
-        setProperty(vitsConfig, "model", File(modelDir, MODEL_ONNX_FILE).absolutePath)
-        setProperty(vitsConfig, "tokens", File(modelDir, TOKENS_FILE).absolutePath)
-        setProperty(vitsConfig, "dataDir", File(modelDir, ESPEAK_DATA_DIR).absolutePath)
+        setProperty(vitsConfig, "model", File(modelDir, SHERPA_MODEL_ONNX_FILE).absolutePath)
+        setProperty(vitsConfig, "tokens", File(modelDir, SHERPA_TOKENS_FILE).absolutePath)
+        setProperty(vitsConfig, "dataDir", File(modelDir, SHERPA_ESPEAK_DATA_DIR).absolutePath)
 
         // OfflineTtsModelConfig
         val modelConfig = newInstance(modelConfigClass)
@@ -469,10 +469,6 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         const val SHERPA_OFFLINE_TTS_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsConfig"
         const val SHERPA_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsModelConfig"
         const val SHERPA_VITS_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsVitsModelConfig"
-
-        const val MODEL_ONNX_FILE = "model.onnx"
-        const val TOKENS_FILE = "tokens.txt"
-        const val ESPEAK_DATA_DIR = "espeak-ng-data"
 
         /** Floats per AudioTrack write chunk (~92 ms at 22050 Hz). */
         const val AUDIO_CHUNK_FLOATS = 2048

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -1,0 +1,454 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioFocusRequest
+import android.media.AudioTrack
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Spike implementation of [VoiceOutputController] backed by Sherpa-ONNX + locally prepared Piper
+ * English voices.
+ *
+ * **Design goals (spike):**
+ * - Zero direct imports from `com.k2fsa.sherpa.onnx.*` — all Sherpa access goes through
+ *   Java reflection so this file compiles even when the AAR has not been downloaded yet.
+ * - Graceful [VoiceOutputResult.Unavailable] when either the AAR or the model assets are absent.
+ * - Streams PCM floats to [AudioTrack] in chunks so the audio focus and stop() interruptibility
+ *   work the same way as [AndroidTextToSpeechController].
+ * - Extracts `espeak-ng-data` (and the model itself) from APK assets to [Context.getFilesDir]
+ *   because Sherpa-ONNX needs real filesystem paths, not `AssetManager` URIs for those files.
+ *
+ * **Prerequisites (not committed):**
+ * Run `scripts/setup-sherpa-tts-spike.sh` to:
+ *   1. Download `sherpa-onnx-1.13.0.aar` → `third_party/sherpa-onnx/`
+ *   2. Download Piper voice assets → `core/voice/src/main/assets/sherpa-tts/...`
+ *
+ * When the AAR/assets are absent the class initialises cleanly to [InitState.UNAVAILABLE] and
+ * [FallbackVoiceOutputController] will route to [AndroidTextToSpeechController] instead.
+ */
+@Singleton
+class SherpaOnnxVoiceOutputController @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val voiceOutputPreferences: VoiceOutputPreferences,
+) : VoiceOutputController {
+
+    // ── Coroutine scope on IO — never Main ──────────────────────────────────
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _events = MutableSharedFlow<VoiceOutputEvent>(extraBufferCapacity = 8)
+    override val events: Flow<VoiceOutputEvent> = _events.asSharedFlow()
+
+    // ── Lifecycle state ──────────────────────────────────────────────────────
+    private enum class InitState { UNINITIALIZED, AVAILABLE, UNAVAILABLE }
+
+    @Volatile private var initState = InitState.UNINITIALIZED
+    @Volatile private var initializedVoice: SherpaPiperVoice? = null
+
+    /** Reflected handle to `OfflineTts` instance; non-null iff [initState] == AVAILABLE. */
+    @Volatile private var ttsInstance: Any? = null
+
+    /** Reflected `generate(String, Int, Float): GeneratedAudio` method. */
+    @Volatile private var generateMethod: java.lang.reflect.Method? = null
+
+    // ── Playback cancellation ────────────────────────────────────────────────
+    @Volatile private var stopped = false
+
+    // ── AudioFocus ───────────────────────────────────────────────────────────
+    private val audioManager by lazy {
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+    @Volatile private var audioFocusRequest: AudioFocusRequest? = null
+
+    // ── VoiceOutputController ────────────────────────────────────────────────
+
+    override suspend fun warmUp(): VoiceOutputResult = withContext(Dispatchers.IO) {
+        initialize(voiceOutputPreferences.selectedSherpaVoice.first())
+    }
+
+    override suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult =
+        withContext(Dispatchers.IO) {
+            val voice = voiceOutputPreferences.selectedSherpaVoice.first()
+            val initResult = initialize(voice)
+            if (initResult is VoiceOutputResult.Unavailable) return@withContext initResult
+
+            val tts = ttsInstance
+                ?: return@withContext VoiceOutputResult.Unavailable("Sherpa TTS instance missing.")
+            val genMethod = generateMethod
+                ?: return@withContext VoiceOutputResult.Unavailable("Sherpa generate() not found.")
+
+            stopped = false
+            requestAudioFocus()
+            _events.emit(VoiceOutputEvent.SpeakingStarted(request.text))
+
+            return@withContext try {
+                // Reflect: GeneratedAudio audio = tts.generate(text, sid=0, speed=1.0f)
+                val audioResult = genMethod.invoke(tts, request.text, 0, 1.0f)
+                    ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
+
+                val samples = reflectGetSamples(audioResult)
+                val sampleRate = reflectGetSampleRate(audioResult)
+
+                if (!stopped) {
+                    playOnAudioTrack(samples, sampleRate)
+                }
+                releaseAudioFocus()
+                _events.emit(VoiceOutputEvent.SpeakingStopped)
+                VoiceOutputResult.Spoken
+            } catch (e: Exception) {
+                Log.e(TAG, "Sherpa generate() failed", e)
+                releaseAudioFocus()
+                _events.emit(VoiceOutputEvent.SpeakingStopped)
+                VoiceOutputResult.Unavailable("Sherpa generate failed: ${e.message}")
+            }
+        }
+
+    override fun stop() {
+        stopped = true
+        releaseAudioFocus()
+        scope.launch { _events.emit(VoiceOutputEvent.SpeakingStopped) }
+    }
+
+    // ── Initialisation ───────────────────────────────────────────────────────
+
+    /**
+     * Idempotent lazy initialisation.  Cached in [initState] after first attempt.
+     * Returns [VoiceOutputResult.Spoken] when Sherpa is ready, [VoiceOutputResult.Unavailable]
+     * otherwise (AAR missing, assets missing, or any reflection error).
+     */
+    private fun initialize(voice: SherpaPiperVoice): VoiceOutputResult {
+        if (initializedVoice != voice) {
+            resetForVoice(voice)
+        }
+        return when (initState) {
+            InitState.AVAILABLE -> VoiceOutputResult.Spoken
+            InitState.UNAVAILABLE -> VoiceOutputResult.Unavailable(unavailableMessage(voice))
+            InitState.UNINITIALIZED -> doInitialize(voice)
+        }
+    }
+
+    private fun doInitialize(voice: SherpaPiperVoice): VoiceOutputResult {
+        val assetsSubdir = voice.assetsSubdirectory
+
+        // 1. Check AAR is on classpath via Class.forName (no import needed)
+        val ttsClass = try {
+            Class.forName(SHERPA_OFFLINE_TTS_CLASS)
+        } catch (e: ClassNotFoundException) {
+            Log.i(TAG, "Sherpa-ONNX not on classpath — AAR not downloaded. " +
+                "Run scripts/setup-sherpa-tts-spike.sh then rebuild.")
+            initState = InitState.UNAVAILABLE
+            return VoiceOutputResult.Unavailable(
+                "Sherpa-ONNX AAR not present for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
+            )
+        }
+
+        // 2. Check model assets are bundled in APK
+        val assetsPresent = runCatching {
+            context.assets.list(assetsSubdir)?.isNotEmpty() == true
+        }.getOrDefault(false)
+
+        if (!assetsPresent) {
+            Log.i(TAG, "Sherpa-ONNX model assets missing at assets/$assetsSubdir. " +
+                "Run scripts/setup-sherpa-tts-spike.sh then rebuild.")
+            initState = InitState.UNAVAILABLE
+            return VoiceOutputResult.Unavailable(
+                "Sherpa-ONNX model assets missing for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
+            )
+        }
+
+        // 3. Extract assets to filesystem (Sherpa needs real paths)
+        val modelDir = File(context.filesDir, assetsSubdir)
+        return try {
+            extractAssetsIfNeeded(assetsSubdir, modelDir)
+            val config = buildOfflineTtsConfig(modelDir)
+            val configClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
+            val ctor = ttsClass.getConstructor(
+                android.content.res.AssetManager::class.java,
+                configClass,
+            )
+            val instance = ctor.newInstance(context.assets, config)
+            // Cache reflected generate() — signature: generate(String, int, float)
+            val gen = ttsClass.getDeclaredMethod(
+                "generate",
+                String::class.java,
+                Int::class.javaPrimitiveType,
+                Float::class.javaPrimitiveType,
+            )
+            ttsInstance = instance
+            generateMethod = gen
+            initState = InitState.AVAILABLE
+            Log.i(TAG, "Sherpa-ONNX TTS initialised — voice: ${voice.downloadKey}")
+            VoiceOutputResult.Spoken
+        } catch (e: Exception) {
+            Log.e(TAG, "Sherpa-ONNX TTS init failed", e)
+            initState = InitState.UNAVAILABLE
+            VoiceOutputResult.Unavailable("Sherpa-ONNX init failed for ${voice.displayName}: ${e.message}")
+        }
+    }
+
+    private fun resetForVoice(voice: SherpaPiperVoice) {
+        ttsInstance = null
+        generateMethod = null
+        initState = InitState.UNINITIALIZED
+        initializedVoice = voice
+    }
+
+    // ── Config construction via reflection ───────────────────────────────────
+
+    /**
+     * Builds `OfflineTtsConfig` entirely through reflection so no Sherpa import is needed.
+     *
+     * Sherpa-ONNX Kotlin data classes all have Kotlin-default–value constructors (every field
+     * has a default), so we call the no-arg/all-defaults constructor then mutate the mutable
+     * (`var`) properties via their setter methods (`setModel(String)`, etc.).
+     *
+     * Field layout targeted:
+     * ```
+     * OfflineTtsVitsModelConfig { model, tokens, dataDir, noiseScale, noiseScaleW, lengthScale }
+     * OfflineTtsModelConfig     { vits, numThreads, debug, provider }
+     * OfflineTtsConfig          { model, ruleFsts, maxNumSentences }
+     * ```
+     */
+    private fun buildOfflineTtsConfig(modelDir: File): Any {
+        val vitsClass = Class.forName(SHERPA_VITS_MODEL_CONFIG_CLASS)
+        val modelConfigClass = Class.forName(SHERPA_MODEL_CONFIG_CLASS)
+        val configClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
+
+        // OfflineTtsVitsModelConfig — all-defaults constructor
+        val vitsConfig = newInstance(vitsClass)
+        setProperty(vitsConfig, "model", File(modelDir, MODEL_ONNX_FILE).absolutePath)
+        setProperty(vitsConfig, "tokens", File(modelDir, TOKENS_FILE).absolutePath)
+        setProperty(vitsConfig, "dataDir", File(modelDir, ESPEAK_DATA_DIR).absolutePath)
+
+        // OfflineTtsModelConfig
+        val modelConfig = newInstance(modelConfigClass)
+        setProperty(modelConfig, "vits", vitsConfig)
+        setProperty(modelConfig, "numThreads", 2)
+        setProperty(modelConfig, "debug", false)
+
+        // OfflineTtsConfig
+        val config = newInstance(configClass)
+        setProperty(config, "model", modelConfig)
+        return config
+    }
+
+    /**
+     * Instantiates a Kotlin class whose constructor has all-default parameters.
+     * Tries the no-arg form first; if absent (Kotlin doesn't generate a *true* no-arg unless
+     * annotated with `@JvmOverloads` or no-arg Gradle plugin) falls back to the Kotlin synthetic
+     * default constructor `(…, int mask, DefaultConstructorMarker marker)`.
+     */
+    private fun newInstance(cls: Class<*>): Any {
+        // Attempt 1: genuine no-arg constructor (generated by no-arg compiler plugin or @JvmOverloads)
+        cls.declaredConstructors.firstOrNull { it.parameterCount == 0 }?.let { ctor ->
+            ctor.isAccessible = true
+            return ctor.newInstance()
+        }
+        // Attempt 2: Kotlin synthetic default constructor with trailing (int, DefaultConstructorMarker?)
+        // Signature: (T1, T2, ..., int, DefaultConstructorMarker?) where int is the bit-mask.
+        val synthetic = cls.declaredConstructors.minByOrNull { it.parameterCount }
+            ?: error("No usable constructor found for ${cls.name}")
+        synthetic.isAccessible = true
+        val argCount = synthetic.parameterCount
+        // Fill leading params with null/0/false; second-to-last is the int mask (0 = use all defaults);
+        // last is DefaultConstructorMarker (pass null — Kotlin accepts null for the marker).
+        val args = arrayOfNulls<Any>(argCount).also { it[argCount - 2] = 0 }
+        return synthetic.newInstance(*args)
+    }
+
+    /**
+     * Sets a mutable Kotlin property on [obj] via its generated JVM setter (`setXxx`).
+     * Falls back to direct field access if no setter is found.
+     */
+    private fun setProperty(obj: Any, name: String, value: Any) {
+        val setterName = "set${name.replaceFirstChar { it.uppercase() }}"
+        val valueClass: Class<*> = when (value) {
+            is String -> String::class.java
+            is Int -> Int::class.javaPrimitiveType!!
+            is Float -> Float::class.javaPrimitiveType!!
+            is Boolean -> Boolean::class.javaPrimitiveType!!
+            else -> value.javaClass
+        }
+        try {
+            val setter = obj.javaClass.getDeclaredMethod(setterName, valueClass)
+            setter.isAccessible = true
+            setter.invoke(obj, value)
+        } catch (_: NoSuchMethodException) {
+            // Fall back to direct field mutation (Kotlin backing field)
+            try {
+                val field = obj.javaClass.getDeclaredField(name)
+                field.isAccessible = true
+                field.set(obj, value)
+            } catch (e2: Exception) {
+                Log.w(TAG, "setProperty($name) failed on ${obj.javaClass.simpleName}", e2)
+            }
+        }
+    }
+
+    // ── GeneratedAudio reflection helpers ────────────────────────────────────
+
+    private fun reflectGetSamples(audio: Any): FloatArray {
+        return try {
+            audio.javaClass.getDeclaredMethod("getSamples")
+                .also { it.isAccessible = true }
+                .invoke(audio) as FloatArray
+        } catch (_: NoSuchMethodException) {
+            audio.javaClass.getDeclaredField("samples")
+                .also { it.isAccessible = true }
+                .get(audio) as FloatArray
+        }
+    }
+
+    private fun reflectGetSampleRate(audio: Any): Int {
+        return try {
+            audio.javaClass.getDeclaredMethod("getSampleRate")
+                .also { it.isAccessible = true }
+                .invoke(audio) as Int
+        } catch (_: NoSuchMethodException) {
+            audio.javaClass.getDeclaredField("sampleRate")
+                .also { it.isAccessible = true }
+                .getInt(audio)
+        }
+    }
+
+    // ── Asset extraction ─────────────────────────────────────────────────────
+
+    /**
+     * Copies the Piper model directory from APK assets to [destDir] on the real filesystem.
+     * Skips individual files that already exist so subsequent launches are fast.
+     * espeak-ng-data/ is recursed because Sherpa requires it as a real directory tree.
+     */
+    private fun extractAssetsIfNeeded(assetSubdir: String, destDir: File) {
+        destDir.mkdirs()
+        extractAssetsRecursive(assetSubdir, destDir)
+    }
+
+    private fun extractAssetsRecursive(assetPath: String, destDir: File) {
+        val children = context.assets.list(assetPath) ?: return
+        destDir.mkdirs()
+        for (child in children) {
+            val childAssetPath = "$assetPath/$child"
+            val childDest = File(destDir, child)
+            val isDir = context.assets.list(childAssetPath)?.isNotEmpty() == true
+            if (isDir) {
+                extractAssetsRecursive(childAssetPath, childDest)
+            } else if (!childDest.exists()) {
+                copyAsset(childAssetPath, childDest)
+            }
+        }
+    }
+
+    private fun copyAsset(assetPath: String, destFile: File) {
+        context.assets.open(assetPath).use { inp ->
+            FileOutputStream(destFile).use { out -> inp.copyTo(out) }
+        }
+    }
+
+    // ── AudioTrack playback ──────────────────────────────────────────────────
+
+    /**
+     * Writes [samples] (PCM Float32, mono) to an [AudioTrack] in streaming chunks.
+     * Checks [stopped] between chunks so [stop] can interrupt mid-utterance quickly.
+     */
+    private fun playOnAudioTrack(samples: FloatArray, sampleRate: Int) {
+        val minBuf = AudioTrack.getMinBufferSize(
+            sampleRate,
+            AudioFormat.CHANNEL_OUT_MONO,
+            AudioFormat.ENCODING_PCM_FLOAT,
+        )
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setBufferSizeInBytes(maxOf(minBuf, AUDIO_CHUNK_FLOATS * Float.SIZE_BYTES * 2))
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .build()
+
+        track.play()
+        try {
+            var offset = 0
+            while (offset < samples.size && !stopped) {
+                val end = minOf(offset + AUDIO_CHUNK_FLOATS, samples.size)
+                track.write(samples, offset, end - offset, AudioTrack.WRITE_BLOCKING)
+                offset = end
+            }
+            if (!stopped) track.stop() else track.pause()
+        } finally {
+            track.release()
+        }
+    }
+
+    // ── AudioFocus ───────────────────────────────────────────────────────────
+
+    private fun requestAudioFocus() {
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            )
+            .setAcceptsDelayedFocusGain(false)
+            .setWillPauseWhenDucked(false)
+            .setOnAudioFocusChangeListener { }
+            .build()
+        audioFocusRequest = request
+        val result = audioManager.requestAudioFocus(request)
+        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            Log.w(TAG, "SherpaOnnx audio focus not granted: $result")
+        }
+    }
+
+    private fun releaseAudioFocus() {
+        audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        audioFocusRequest = null
+    }
+
+    private fun unavailableMessage(voice: SherpaPiperVoice): String =
+        "Sherpa-ONNX TTS is not available for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
+
+    // ── Constants ────────────────────────────────────────────────────────────
+
+    private companion object {
+        const val TAG = "KernelAI"
+        // Sherpa-ONNX class names — accessed only via reflection so no AAR import required
+        const val SHERPA_PKG = "com.k2fsa.sherpa.onnx"
+        const val SHERPA_OFFLINE_TTS_CLASS = "$SHERPA_PKG.OfflineTts"
+        const val SHERPA_OFFLINE_TTS_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsConfig"
+        const val SHERPA_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsModelConfig"
+        const val SHERPA_VITS_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsVitsModelConfig"
+
+        const val MODEL_ONNX_FILE = "model.onnx"
+        const val TOKENS_FILE = "tokens.txt"
+        const val ESPEAK_DATA_DIR = "espeak-ng-data"
+
+        /** Floats per AudioTrack write chunk (~92 ms at 22050 Hz). */
+        const val AUDIO_CHUNK_FLOATS = 2048
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -193,7 +193,9 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 android.content.res.AssetManager::class.java,
                 configClass,
             )
-            val instance = ctor.newInstance(context.assets, config)
+            // Always use Sherpa's file-backed native path. Both downloaded packs and legacy
+            // asset packs are normalised onto the real filesystem before init.
+            val instance = ctor.newInstance(null, config)
             // Cache reflected generate() — signature: generate(String, int, float)
             val gen = ttsClass.getDeclaredMethod(
                 "generate",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -144,38 +144,49 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     }
 
     private fun doInitialize(voice: SherpaPiperVoice): VoiceOutputResult {
-        val assetsSubdir = voice.assetsSubdirectory
-
         // 1. Check AAR is on classpath via Class.forName (no import needed)
         val ttsClass = try {
             Class.forName(SHERPA_OFFLINE_TTS_CLASS)
         } catch (e: ClassNotFoundException) {
-            Log.i(TAG, "Sherpa-ONNX not on classpath — AAR not downloaded. " +
-                "Run scripts/setup-sherpa-tts-spike.sh then rebuild.")
+            Log.i(TAG, "Sherpa-ONNX not on classpath — AAR not present in APK.")
             initState = InitState.UNAVAILABLE
             return VoiceOutputResult.Unavailable(
-                "Sherpa-ONNX AAR not present for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
+                "Sherpa-ONNX runtime not available for ${voice.displayName}."
             )
         }
 
-        // 2. Check model assets are bundled in APK
-        val assetsPresent = runCatching {
-            context.assets.list(assetsSubdir)?.isNotEmpty() == true
-        }.getOrDefault(false)
+        // 2. Prefer voice pack downloaded to internal storage over APK assets
+        val downloadedDir = voice.voiceDir(context)
+        val modelDir: File = when {
+            voice.isDownloaded(context) -> {
+                Log.i(TAG, "Using downloaded voice pack at ${downloadedDir.absolutePath}")
+                downloadedDir
+            }
+            else -> {
+                // 3. Fall back to APK assets (local dev path — assets are gitignored)
+                val assetsSubdir = voice.assetsSubdirectory
+                val assetsPresent = runCatching {
+                    context.assets.list(assetsSubdir)?.isNotEmpty() == true
+                }.getOrDefault(false)
 
-        if (!assetsPresent) {
-            Log.i(TAG, "Sherpa-ONNX model assets missing at assets/$assetsSubdir. " +
-                "Run scripts/setup-sherpa-tts-spike.sh then rebuild.")
-            initState = InitState.UNAVAILABLE
-            return VoiceOutputResult.Unavailable(
-                "Sherpa-ONNX model assets missing for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
-            )
+                if (!assetsPresent) {
+                    Log.i(TAG, "Voice pack not downloaded and not in APK assets: $assetsSubdir. " +
+                        "Use Settings → Voice to download the voice pack.")
+                    initState = InitState.UNAVAILABLE
+                    return VoiceOutputResult.Unavailable(
+                        "Voice pack not yet downloaded for ${voice.displayName}. " +
+                            "Tap Download in Settings → Voice."
+                    )
+                }
+
+                // Extract assets to filesystem so Sherpa gets real paths
+                val extractedDir = File(context.filesDir, assetsSubdir)
+                extractAssetsIfNeeded(assetsSubdir, extractedDir)
+                extractedDir
+            }
         }
 
-        // 3. Extract assets to filesystem (Sherpa needs real paths)
-        val modelDir = File(context.filesDir, assetsSubdir)
         return try {
-            extractAssetsIfNeeded(assetsSubdir, modelDir)
             val config = buildOfflineTtsConfig(modelDir)
             val configClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
             val ctor = ttsClass.getConstructor(
@@ -193,7 +204,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             ttsInstance = instance
             generateMethod = gen
             initState = InitState.AVAILABLE
-            Log.i(TAG, "Sherpa-ONNX TTS initialised — voice: ${voice.downloadKey}")
+            Log.i(TAG, "Sherpa-ONNX TTS initialised — voice: ${voice.downloadKey} at ${modelDir.absolutePath}")
             VoiceOutputResult.Spoken
         } catch (e: Exception) {
             Log.e(TAG, "Sherpa-ONNX TTS init failed", e)
@@ -431,7 +442,22 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     }
 
     private fun unavailableMessage(voice: SherpaPiperVoice): String =
-        "Sherpa-ONNX TTS is not available for ${voice.displayName}. Run scripts/setup-sherpa-tts-spike.sh."
+        "Sherpa-ONNX TTS is not available for ${voice.displayName}. " +
+            "Download the voice pack in Settings → Voice."
+
+    /**
+     * Called by [SherpaVoicePackDownloadManager] after a voice pack is successfully downloaded.
+     *
+     * If this voice was previously [InitState.UNAVAILABLE] (pack was missing), resets the
+     * state to [InitState.UNINITIALIZED] so the next [speak] call re-initialises Sherpa
+     * using the newly extracted files — without requiring a voice-selection change.
+     */
+    fun markVoiceAvailable(voice: SherpaPiperVoice) {
+        if (initState == InitState.UNAVAILABLE && (initializedVoice == voice || initializedVoice == null)) {
+            Log.i(TAG, "Voice pack available for ${voice.displayName} — resetting init state for retry.")
+            resetForVoice(voice)
+        }
+    }
 
     // ── Constants ────────────────────────────────────────────────────────────
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -1,33 +1,59 @@
 package com.kernel.ai.core.voice
 
+import android.content.Context
+import java.io.File
+
 enum class SherpaPiperVoice(
     val displayName: String,
     val description: String,
     val assetDirectoryName: String,
     val downloadKey: String,
+    /** Approximate compressed download size in bytes (used for progress UI). */
+    val approxDownloadBytes: Long,
 ) {
     JennyDioco(
         displayName = "Jenny Dioco",
         description = "Balanced medium-quality British English voice and the default Sherpa option for this spike.",
         assetDirectoryName = "vits-piper-en_GB-jenny_dioco-medium",
         downloadKey = "en_GB-jenny_dioco-medium",
+        approxDownloadBytes = 73_000_000L,
     ),
     SouthernEnglishFemale(
         displayName = "Southern English Female",
         description = "Closest publicly available southern-English Piper pack for this spike setup.",
         assetDirectoryName = "vits-piper-en_GB-southern_english_female-low",
         downloadKey = "en_GB-southern_english_female-low",
+        approxDownloadBytes = 64_000_000L,
     ),
     NorthernEnglishMale(
         displayName = "Northern English Male",
         description = "Medium-quality northern British English voice.",
         assetDirectoryName = "vits-piper-en_GB-northern_english_male-medium",
         downloadKey = "en_GB-northern_english_male-medium",
+        approxDownloadBytes = 74_000_000L,
     ),
     ;
 
+    /** URL to the pre-converted Sherpa-ONNX voice pack tarball on GitHub releases. */
+    val downloadUrl: String
+        get() = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/$assetDirectoryName.tar.bz2"
+
+    /** Legacy asset sub-path (used if the voice is still bundled as an APK asset). */
     val assetsSubdirectory: String
         get() = "sherpa-tts/$assetDirectoryName"
+
+    /** Returns the directory where this voice pack is extracted on internal storage. */
+    fun voiceDir(context: Context): File =
+        File(context.filesDir, "sherpa-tts/$assetDirectoryName")
+
+    /** Returns true when the voice pack is fully extracted to internal storage. */
+    fun isDownloaded(context: Context): Boolean {
+        val dir = voiceDir(context)
+        return dir.isDirectory &&
+            File(dir, "model.onnx").exists() &&
+            File(dir, "tokens.txt").exists() &&
+            File(dir, "espeak-ng-data").isDirectory
+    }
 
     companion object {
         fun fromStorage(value: String?): SherpaPiperVoice =

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -1,0 +1,36 @@
+package com.kernel.ai.core.voice
+
+enum class SherpaPiperVoice(
+    val displayName: String,
+    val description: String,
+    val assetDirectoryName: String,
+    val downloadKey: String,
+) {
+    JennyDioco(
+        displayName = "Jenny Dioco",
+        description = "Balanced medium-quality British English voice and the default Sherpa option for this spike.",
+        assetDirectoryName = "vits-piper-en_GB-jenny_dioco-medium",
+        downloadKey = "en_GB-jenny_dioco-medium",
+    ),
+    SouthernEnglishFemale(
+        displayName = "Southern English Female",
+        description = "Closest publicly available southern-English Piper pack for this spike setup.",
+        assetDirectoryName = "vits-piper-en_GB-southern_english_female-low",
+        downloadKey = "en_GB-southern_english_female-low",
+    ),
+    NorthernEnglishMale(
+        displayName = "Northern English Male",
+        description = "Medium-quality northern British English voice.",
+        assetDirectoryName = "vits-piper-en_GB-northern_english_male-medium",
+        downloadKey = "en_GB-northern_english_male-medium",
+    ),
+    ;
+
+    val assetsSubdirectory: String
+        get() = "sherpa-tts/$assetDirectoryName"
+
+    companion object {
+        fun fromStorage(value: String?): SherpaPiperVoice =
+            entries.firstOrNull { it.name == value } ?: JennyDioco
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -49,10 +49,7 @@ enum class SherpaPiperVoice(
     /** Returns true when the voice pack is fully extracted to internal storage. */
     fun isDownloaded(context: Context): Boolean {
         val dir = voiceDir(context)
-        return dir.isDirectory &&
-            File(dir, "model.onnx").exists() &&
-            File(dir, "tokens.txt").exists() &&
-            File(dir, "espeak-ng-data").isDirectory
+        return hasRequiredSherpaVoicePackFiles(dir)
     }
 
     companion object {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
@@ -1,0 +1,238 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val TAG = "KernelAI"
+
+/**
+ * Hilt singleton that manages the download lifecycle of all [SherpaPiperVoice] packs.
+ *
+ * - Persists download state in [WorkManager] so downloads survive process death.
+ * - Exposes [downloadStates] as a [StateFlow] for Compose UI observation.
+ * - Checks internal storage on startup to detect already-extracted voice packs.
+ * - Supports resume: the [VoicePackDownloadWorker] appends to the `.tmp` byte offset.
+ * - Calls [SherpaOnnxVoiceOutputController.markVoiceAvailable] after a successful download
+ *   so a voice becomes usable without restarting the app or re-selecting the voice.
+ */
+@Singleton
+class SherpaVoicePackDownloadManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val sherpaController: SherpaOnnxVoiceOutputController,
+) {
+    private val workManager = WorkManager.getInstance(context)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val observerJobs = ConcurrentHashMap<SherpaPiperVoice, Job>()
+
+    private val _downloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
+        MutableStateFlow(
+            SherpaPiperVoice.entries.associateWith { voice ->
+                if (voice.isDownloaded(context)) {
+                    VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                } else {
+                    VoicePackDownloadState.NotDownloaded
+                }
+            }
+        )
+
+    val downloadStates: StateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
+        _downloadStates.asStateFlow()
+
+    init {
+        // Resume observing any in-progress workers from a previous process lifecycle
+        SherpaPiperVoice.entries.forEach { voice -> ensureObserving(voice) }
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Enqueue a download for [voice]. No-op if already downloaded.
+     * Pass [force] = true to re-download.
+     */
+    fun startDownload(voice: SherpaPiperVoice, force: Boolean = false) {
+        if (!force && voice.isDownloaded(context)) {
+            updateState(voice, VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath))
+            return
+        }
+
+        Log.i(TAG, "Enqueuing voice pack download: ${voice.displayName}")
+
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val existingInfos = workManager.getWorkInfosForUniqueWork(voice.workerTag).get()
+                val policy = when {
+                    force -> ExistingWorkPolicy.REPLACE
+                    existingInfos.any { it.state == WorkInfo.State.RUNNING } -> ExistingWorkPolicy.KEEP
+                    else -> ExistingWorkPolicy.REPLACE
+                }
+
+                if (policy == ExistingWorkPolicy.REPLACE) {
+                    updateState(voice, VoicePackDownloadState.Downloading())
+                }
+
+                val request = OneTimeWorkRequestBuilder<VoicePackDownloadWorker>()
+                    .setInputData(
+                        Data.Builder()
+                            .putString(KEY_VOICE_NAME, voice.name)
+                            .putString(KEY_VOICE_DISPLAY_NAME, voice.displayName)
+                            .putString(KEY_VOICE_DOWNLOAD_URL, voice.downloadUrl)
+                            .putLong(KEY_VOICE_TOTAL_BYTES, voice.approxDownloadBytes)
+                            .build()
+                    )
+                    .addTag(voice.workerTag)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .setConstraints(
+                        Constraints.Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build()
+                    )
+                    .build()
+
+                workManager.enqueueUniqueWork(voice.workerTag, policy, request)
+            }
+        }
+
+        ensureObserving(voice)
+    }
+
+    /** Cancel an in-progress download. The partial `.tmp` file is preserved for resumption. */
+    fun cancelDownload(voice: SherpaPiperVoice) {
+        workManager.cancelUniqueWork(voice.workerTag)
+        updateState(voice, VoicePackDownloadState.NotDownloaded)
+        Log.i(TAG, "Cancelled voice pack download: ${voice.displayName}")
+    }
+
+    /**
+     * Delete the extracted voice pack from internal storage.
+     * Safe to call even if no pack is present (no-op).
+     */
+    fun deleteVoice(voice: SherpaPiperVoice) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val dir = voice.voiceDir(context)
+                if (dir.exists()) {
+                    dir.deleteRecursively()
+                    Log.i(TAG, "Deleted voice pack: ${dir.absolutePath}")
+                }
+            }
+            updateState(voice, VoicePackDownloadState.NotDownloaded)
+        }
+    }
+
+    /**
+     * Re-checks the filesystem for [voice] and updates [downloadStates].
+     * Call this after manual installation via ADB to reflect the new state in the UI.
+     */
+    fun refreshState(voice: SherpaPiperVoice) {
+        val newState = if (voice.isDownloaded(context)) {
+            VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+        } else {
+            VoicePackDownloadState.NotDownloaded
+        }
+        updateState(voice, newState)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private fun updateState(voice: SherpaPiperVoice, state: VoicePackDownloadState) {
+        _downloadStates.value = _downloadStates.value.toMutableMap().apply { put(voice, state) }
+    }
+
+    private fun ensureObserving(voice: SherpaPiperVoice) {
+        observerJobs.compute(voice) { _, existing ->
+            if (existing?.isActive == true) existing
+            else scope.launch { observeWorkInfo(voice) }
+        }
+    }
+
+    private suspend fun observeWorkInfo(voice: SherpaPiperVoice) {
+        workManager
+            .getWorkInfosByTagFlow(voice.workerTag)
+            .collect { infoList ->
+                val info = infoList.firstOrNull() ?: return@collect
+                val newState: VoicePackDownloadState = when (info.state) {
+                    WorkInfo.State.RUNNING, WorkInfo.State.ENQUEUED -> {
+                        // Guard: don't show Downloading if the pack is already present
+                        if (voice.isDownloaded(context)) {
+                            workManager.cancelUniqueWork(voice.workerTag)
+                            return@collect
+                        }
+                        val progress = info.progress
+                        val totalBytes = voice.approxDownloadBytes
+                        val downloadedBytes = progress.getLong(KEY_VOICE_PROGRESS_BYTES, 0L)
+                        val bps = progress.getLong(KEY_VOICE_DOWNLOAD_RATE, 0L)
+                        val remainingMs = progress.getLong(KEY_VOICE_REMAINING_MS, 0L)
+                        val fraction = if (totalBytes > 0) {
+                            // Map download progress to 0–0.9 (extraction is 0.9–1.0)
+                            (downloadedBytes.toFloat() / totalBytes).coerceIn(0f, 1f) * 0.9f
+                        } else 0f
+                        VoicePackDownloadState.Downloading(
+                            progress = fraction,
+                            downloadedBytes = downloadedBytes,
+                            bytesPerSecond = bps,
+                            remainingMs = remainingMs,
+                        )
+                    }
+
+                    WorkInfo.State.SUCCEEDED -> {
+                        val dir = withContext(Dispatchers.IO) { voice.voiceDir(context) }
+                        Log.i(TAG, "Voice pack download succeeded: ${dir.absolutePath}")
+                        // Notify the TTS controller so it can re-init without a voice change
+                        sherpaController.markVoiceAvailable(voice)
+                        VoicePackDownloadState.Downloaded(dir.absolutePath)
+                    }
+
+                    WorkInfo.State.FAILED -> {
+                        // Trust filesystem over worker state — pack may have been pushed via ADB
+                        val isPresent = withContext(Dispatchers.IO) { voice.isDownloaded(context) }
+                        if (isPresent) {
+                            Log.i(TAG, "Worker failed but pack present — treating as Downloaded: ${voice.displayName}")
+                            sherpaController.markVoiceAvailable(voice)
+                            VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                        } else {
+                            val msg = info.outputData.getString(KEY_VOICE_ERROR_MESSAGE) ?: "Download failed"
+                            Log.w(TAG, "Voice pack download failed for ${voice.displayName}: $msg")
+                            VoicePackDownloadState.Error(msg)
+                        }
+                    }
+
+                    WorkInfo.State.CANCELLED -> {
+                        val isPresent = withContext(Dispatchers.IO) { voice.isDownloaded(context) }
+                        if (isPresent) {
+                            VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                        } else {
+                            VoicePackDownloadState.NotDownloaded
+                        }
+                    }
+
+                    else -> return@collect
+                }
+                updateState(voice, newState)
+            }
+    }
+}
+
+/** Unique WorkManager work name for this voice. */
+private val SherpaPiperVoice.workerTag: String get() = "voice_pack_${name.lowercase()}"
+

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackFiles.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackFiles.kt
@@ -1,0 +1,51 @@
+package com.kernel.ai.core.voice
+
+import java.io.File
+
+internal const val SHERPA_MODEL_ONNX_FILE = "model.onnx"
+internal const val SHERPA_MODEL_JSON_FILE = "model.onnx.json"
+internal const val SHERPA_TOKENS_FILE = "tokens.txt"
+internal const val SHERPA_ESPEAK_DATA_DIR = "espeak-ng-data"
+
+internal fun hasRequiredSherpaVoicePackFiles(dir: File): Boolean =
+    dir.isDirectory &&
+        File(dir, SHERPA_MODEL_ONNX_FILE).isFile &&
+        File(dir, SHERPA_TOKENS_FILE).isFile &&
+        File(dir, SHERPA_ESPEAK_DATA_DIR).isDirectory
+
+internal fun normalizeExtractedSherpaVoicePack(dir: File) {
+    renameFirstMatch(
+        dir = dir,
+        targetName = SHERPA_MODEL_ONNX_FILE,
+        candidates = dir.listFiles { file ->
+            file.isFile &&
+                file.extension == "onnx" &&
+                file.name != SHERPA_MODEL_ONNX_FILE &&
+                !file.name.endsWith(".onnx.json")
+        }.orEmpty(),
+    )
+    renameFirstMatch(
+        dir = dir,
+        targetName = SHERPA_MODEL_JSON_FILE,
+        candidates = dir.listFiles { file ->
+            file.isFile &&
+                file.name.endsWith(".onnx.json") &&
+                file.name != SHERPA_MODEL_JSON_FILE
+        }.orEmpty(),
+    )
+}
+
+private fun renameFirstMatch(
+    dir: File,
+    targetName: String,
+    candidates: Array<out File>,
+) {
+    val target = File(dir, targetName)
+    if (target.exists()) return
+
+    val source = candidates.firstOrNull() ?: return
+    if (!source.renameTo(target)) {
+        source.copyTo(target, overwrite = true)
+        source.delete()
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
@@ -1,0 +1,21 @@
+package com.kernel.ai.core.voice
+
+enum class VoiceOutputEngine(
+    val displayName: String,
+    val description: String,
+) {
+    AndroidTts(
+        displayName = "Android TTS",
+        description = "Uses the platform text-to-speech engine and works without local Sherpa assets.",
+    ),
+    SherpaExperimental(
+        displayName = "Sherpa Piper (Experimental)",
+        description = "Uses locally prepared Sherpa-ONNX Piper voices and falls back to Android TTS if setup is missing or playback fails.",
+    ),
+    ;
+
+    companion object {
+        fun fromStorage(value: String?): VoiceOutputEngine =
+            entries.firstOrNull { it.name == value } ?: AndroidTts
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
@@ -14,7 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
-private const val TAG = "VoiceOutputPrefs"
+private const val TAG = "KernelAI"
 private val Context.voiceOutputPrefsDataStore by preferencesDataStore(name = "voice_output_preferences")
 
 @Singleton
@@ -23,6 +24,8 @@ class VoiceOutputPreferences @Inject constructor(
 ) {
     private val spokenResponsesEnabledKey =
         booleanPreferencesKey("quick_actions_spoken_responses_enabled")
+    private val selectedEngineKey = stringPreferencesKey("selected_voice_output_engine")
+    private val selectedSherpaVoiceKey = stringPreferencesKey("selected_sherpa_piper_voice")
 
     val spokenResponsesEnabled: Flow<Boolean> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
@@ -35,9 +38,43 @@ class VoiceOutputPreferences @Inject constructor(
         }
         .map { prefs -> prefs[spokenResponsesEnabledKey] ?: true }
 
+    val selectedEngine: Flow<VoiceOutputEngine> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> VoiceOutputEngine.fromStorage(prefs[selectedEngineKey]) }
+
+    val selectedSherpaVoice: Flow<SherpaPiperVoice> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey]) }
+
     suspend fun setSpokenResponsesEnabled(enabled: Boolean) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
             prefs[spokenResponsesEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setSelectedEngine(engine: VoiceOutputEngine) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[selectedEngineKey] = engine.name
+        }
+    }
+
+    suspend fun setSelectedSherpaVoice(voice: SherpaPiperVoice) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[selectedSherpaVoiceKey] = voice.name
         }
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadState.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadState.kt
@@ -1,0 +1,37 @@
+package com.kernel.ai.core.voice
+
+/** Represents the current download state of a [SherpaPiperVoice] pack. */
+sealed class VoicePackDownloadState {
+
+    /** Voice pack is not present on-device. */
+    data object NotDownloaded : VoicePackDownloadState()
+
+    /**
+     * Download or extraction is in progress.
+     *
+     * @param progress 0.0–1.0 completion fraction (download + extraction combined).
+     * @param downloadedBytes Bytes received so far (download phase).
+     * @param bytesPerSecond Current download rate; 0 if not yet measured.
+     * @param remainingMs Estimated milliseconds to completion; 0 if unknown.
+     */
+    data class Downloading(
+        val progress: Float = 0f,
+        val downloadedBytes: Long = 0L,
+        val bytesPerSecond: Long = 0L,
+        val remainingMs: Long = 0L,
+    ) : VoicePackDownloadState()
+
+    /**
+     * Voice pack is fully extracted and ready to use.
+     *
+     * @param localDir Absolute path to the extracted voice directory.
+     */
+    data class Downloaded(val localDir: String) : VoicePackDownloadState()
+
+    /**
+     * Download or extraction failed.
+     *
+     * @param message Human-readable error description.
+     */
+    data class Error(val message: String) : VoicePackDownloadState()
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -1,0 +1,299 @@
+package com.kernel.ai.core.voice
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+
+private const val TAG = "KernelAI"
+private const val NOTIFICATION_CHANNEL_ID = "kernel_voice_download"
+private const val TMP_SUFFIX = ".tmp"
+
+// WorkManager Data keys
+const val KEY_VOICE_NAME = "voice_name"
+const val KEY_VOICE_DISPLAY_NAME = "voice_display_name"
+const val KEY_VOICE_DOWNLOAD_URL = "voice_download_url"
+const val KEY_VOICE_TOTAL_BYTES = "voice_total_bytes"
+const val KEY_VOICE_PROGRESS_BYTES = "voice_progress_bytes"
+const val KEY_VOICE_DOWNLOAD_RATE = "voice_download_rate_bps"
+const val KEY_VOICE_REMAINING_MS = "voice_remaining_ms"
+const val KEY_VOICE_ERROR_MESSAGE = "voice_error_message"
+
+/**
+ * WorkManager [CoroutineWorker] that downloads and extracts a Sherpa-ONNX Piper voice pack.
+ *
+ * The pack is a `.tar.bz2` archive hosted on the sherpa-onnx GitHub releases page.  After
+ * extraction the voice directory is available at [Context.getFilesDir]/sherpa-tts/<name>/.
+ *
+ * Progress is reported in two phases:
+ *  - Download: 0 → 90% of the total progress bar.
+ *  - Extraction: 90 → 100%.
+ *
+ * Input keys: [KEY_VOICE_NAME], [KEY_VOICE_DISPLAY_NAME], [KEY_VOICE_DOWNLOAD_URL],
+ *   [KEY_VOICE_TOTAL_BYTES].
+ * Progress keys: [KEY_VOICE_PROGRESS_BYTES], [KEY_VOICE_DOWNLOAD_RATE], [KEY_VOICE_REMAINING_MS].
+ * Output on failure: [KEY_VOICE_ERROR_MESSAGE].
+ */
+class VoicePackDownloadWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    private val notificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    private val notificationId = params.id.hashCode()
+
+    init {
+        ensureNotificationChannel()
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val voiceName = inputData.getString(KEY_VOICE_NAME)
+            ?: return@withContext Result.failure(errorData("Missing voice name"))
+        val displayName = inputData.getString(KEY_VOICE_DISPLAY_NAME) ?: voiceName
+        val downloadUrl = inputData.getString(KEY_VOICE_DOWNLOAD_URL)
+            ?: return@withContext Result.failure(errorData("Missing download URL"))
+        val totalBytes = inputData.getLong(KEY_VOICE_TOTAL_BYTES, 0L)
+
+        val voice = SherpaPiperVoice.entries.firstOrNull { it.name == voiceName }
+            ?: return@withContext Result.failure(errorData("Unknown voice: $voiceName"))
+
+        val destDir = voice.voiceDir(applicationContext)
+        val cacheDir = File(applicationContext.cacheDir, "sherpa-pack").also { it.mkdirs() }
+        val tmpFile = File(cacheDir, "$voiceName.tar.bz2$TMP_SUFFIX")
+
+        trySetForeground(buildForegroundInfo(displayName, 0))
+
+        return@withContext try {
+            // Phase 1: Download (0–90%)
+            downloadFile(
+                url = downloadUrl,
+                tmpFile = tmpFile,
+                totalBytes = totalBytes,
+                displayName = displayName,
+            )
+
+            if (!coroutineContext.isActive) {
+                tmpFile.delete()
+                return@withContext Result.failure(errorData("Cancelled during download"))
+            }
+
+            // Phase 2: Extract (90–100%)
+            trySetForeground(buildForegroundInfo(displayName, 90))
+            extractTarBz2(tmpFile, destDir)
+            tmpFile.delete()
+
+            if (!voice.isDownloaded(applicationContext)) {
+                Log.e(TAG, "Extraction appeared to succeed but required files are missing for $voiceName")
+                return@withContext Result.failure(errorData("Extraction incomplete — required files missing"))
+            }
+
+            Log.i(TAG, "Voice pack ready: ${destDir.absolutePath}")
+            Result.success()
+        } catch (e: IOException) {
+            Log.e(TAG, "Voice pack download/extraction failed for $voiceName", e)
+            tmpFile.delete()
+            Result.failure(errorData(e.message ?: "Unknown I/O error"))
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected failure for voice $voiceName", e)
+            tmpFile.delete()
+            Result.failure(errorData(e.message ?: "Unexpected error"))
+        }
+    }
+
+    // ── Download ─────────────────────────────────────────────────────────────
+
+    private suspend fun downloadFile(
+        url: String,
+        tmpFile: File,
+        totalBytes: Long,
+        displayName: String,
+    ) {
+        val connection = URL(url).openConnection() as HttpURLConnection
+
+        // Resume from partial download if tmp file already has data
+        val resumeFrom = tmpFile.length()
+        if (resumeFrom > 0) {
+            Log.i(TAG, "Resuming voice pack download from byte $resumeFrom for $displayName")
+            connection.setRequestProperty("Range", "bytes=$resumeFrom-")
+            connection.setRequestProperty("Accept-Encoding", "identity")
+        }
+        connection.connect()
+
+        val responseCode = connection.responseCode
+        if (responseCode != HttpURLConnection.HTTP_OK && responseCode != HttpURLConnection.HTTP_PARTIAL) {
+            throw IOException("HTTP $responseCode for $url")
+        }
+
+        var downloadedBytes = resumeFrom
+        val sizeWindow = ArrayDeque<Long>(5)
+        val latencyWindow = ArrayDeque<Long>(5)
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var lastProgressTs = 0L
+        var deltaBytes = 0L
+
+        connection.inputStream.use { input ->
+            FileOutputStream(tmpFile, /* append */ true).use { output ->
+                var bytesRead: Int
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    downloadedBytes += bytesRead
+                    deltaBytes += bytesRead
+
+                    val now = System.currentTimeMillis()
+                    if (lastProgressTs == 0L || now - lastProgressTs >= 200) {
+                        var bps = 0L
+                        if (lastProgressTs != 0L) {
+                            if (sizeWindow.size == 5) sizeWindow.removeFirst()
+                            if (latencyWindow.size == 5) latencyWindow.removeFirst()
+                            sizeWindow.addLast(deltaBytes)
+                            latencyWindow.addLast(now - lastProgressTs)
+                            deltaBytes = 0L
+                            val totalMs = latencyWindow.sum()
+                            if (totalMs > 0) bps = sizeWindow.sum() * 1000L / totalMs
+                        }
+                        val remainingMs = if (bps > 0 && totalBytes > 0) {
+                            (totalBytes - downloadedBytes) * 1000L / bps
+                        } else 0L
+
+                        // Map download progress to 0–90% of total
+                        val dlFraction = if (totalBytes > 0) downloadedBytes.toFloat() / totalBytes else 0f
+                        val overallPct = (dlFraction * 90).toInt()
+                        setProgress(
+                            Data.Builder()
+                                .putLong(KEY_VOICE_PROGRESS_BYTES, downloadedBytes)
+                                .putLong(KEY_VOICE_DOWNLOAD_RATE, bps)
+                                .putLong(KEY_VOICE_REMAINING_MS, remainingMs)
+                                .build()
+                        )
+                        trySetForeground(buildForegroundInfo(displayName, overallPct))
+                        lastProgressTs = now
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Extraction ───────────────────────────────────────────────────────────
+
+    /**
+     * Extracts [tarBz2] into [destDir].
+     *
+     * The tarball typically contains a top-level directory matching [SherpaPiperVoice.assetDirectoryName].
+     * We strip this single top-level component so the contents land directly in [destDir]:
+     *   `vits-piper-en_GB-jenny_dioco-medium/model.onnx` → `destDir/model.onnx`
+     */
+    private fun extractTarBz2(tarBz2: File, destDir: File) {
+        destDir.mkdirs()
+        tarBz2.inputStream().buffered().use { fis ->
+            BZip2CompressorInputStream(fis).use { bzip2 ->
+                TarArchiveInputStream(bzip2).use { tar ->
+                    var entry = tar.nextEntry
+                    while (entry != null) {
+                        if (!tar.canReadEntryData(entry)) {
+                            entry = tar.nextEntry
+                            continue
+                        }
+                        // Strip leading top-level directory component
+                        val entryPath = entry.name.removePrefix("./")
+                        val pathParts = entryPath.split("/").filter { it.isNotEmpty() }
+                        if (pathParts.isEmpty()) {
+                            entry = tar.nextEntry
+                            continue
+                        }
+                        // Drop the first component (e.g. "vits-piper-en_GB-jenny_dioco-medium")
+                        val strippedParts = if (pathParts.size > 1) pathParts.drop(1) else pathParts
+                        val relativePath = strippedParts.joinToString(File.separator)
+
+                        val outFile = File(destDir, relativePath)
+                        if (entry.isDirectory) {
+                            outFile.mkdirs()
+                        } else {
+                            outFile.parentFile?.mkdirs()
+                            FileOutputStream(outFile).use { out -> tar.copyTo(out) }
+                        }
+                        entry = tar.nextEntry
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Foreground / notification ─────────────────────────────────────────────
+
+    private suspend fun trySetForeground(info: ForegroundInfo) {
+        try {
+            setForeground(info)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not set foreground for voice download: ${e.message}")
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        buildForegroundInfo("Voice pack", 0)
+
+    private fun buildForegroundInfo(displayName: String, progressPct: Int): ForegroundInfo {
+        val title = "Downloading $displayName voice"
+        val text = when {
+            progressPct >= 90 -> "Extracting…"
+            progressPct > 0 -> "$progressPct% complete"
+            else -> "Starting download…"
+        }
+
+        val launchIntent = applicationContext.packageManager
+            .getLaunchIntentForPackage(applicationContext.packageName)
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val notification = NotificationCompat
+            .Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .setProgress(100, progressPct, progressPct == 0)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        return ForegroundInfo(
+            notificationId,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        )
+    }
+
+    private fun ensureNotificationChannel() {
+        if (notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Voice Pack Downloads",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Progress notifications for Sherpa Piper voice pack downloads" }
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun errorData(message: String): Data =
+        Data.Builder().putString(KEY_VOICE_ERROR_MESSAGE, message).build()
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -101,7 +101,7 @@ class VoicePackDownloadWorker(
             extractTarBz2(tmpFile, destDir)
             tmpFile.delete()
 
-            if (!voice.isDownloaded(applicationContext)) {
+            if (!hasRequiredSherpaVoicePackFiles(destDir)) {
                 Log.e(TAG, "Extraction appeared to succeed but required files are missing for $voiceName")
                 return@withContext Result.failure(errorData("Extraction incomplete — required files missing"))
             }
@@ -202,6 +202,9 @@ class VoicePackDownloadWorker(
      *   `vits-piper-en_GB-jenny_dioco-medium/model.onnx` → `destDir/model.onnx`
      */
     private fun extractTarBz2(tarBz2: File, destDir: File) {
+        if (destDir.exists()) {
+            destDir.deleteRecursively()
+        }
         destDir.mkdirs()
         tarBz2.inputStream().buffered().use { fis ->
             BZip2CompressorInputStream(fis).use { bzip2 ->
@@ -235,6 +238,7 @@ class VoicePackDownloadWorker(
                 }
             }
         }
+        normalizeExtractedSherpaVoicePack(destDir)
     }
 
     // ── Foreground / notification ─────────────────────────────────────────────

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
@@ -1,6 +1,6 @@
 package com.kernel.ai.core.voice.di
 
-import com.kernel.ai.core.voice.AndroidTextToSpeechController
+import com.kernel.ai.core.voice.FallbackVoiceOutputController
 import com.kernel.ai.core.voice.SelectableVoiceInputController
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
@@ -20,9 +20,20 @@ abstract class VoiceModule {
         impl: SelectableVoiceInputController,
     ): VoiceInputController
 
+    /**
+     * Binds [FallbackVoiceOutputController] as the active [VoiceOutputController].
+     *
+     * [FallbackVoiceOutputController] respects the selected voice output engine preference:
+     * Android TTS routes directly to [com.kernel.ai.core.voice.AndroidTextToSpeechController],
+     * while Sherpa Piper tries the local experimental backend and transparently falls back to
+     * Android TTS if the runtime assets are missing or fail.
+     *
+     * To restore the Android-TTS-only binding, change `impl` back to
+     * `AndroidTextToSpeechController`.
+     */
     @Binds
     @Singleton
     abstract fun bindVoiceOutputController(
-        impl: AndroidTextToSpeechController,
+        impl: FallbackVoiceOutputController,
     ): VoiceOutputController
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
@@ -144,6 +144,24 @@ class FallbackVoiceOutputControllerTest {
     }
 
     @Test
+    fun `speak falls back to Android TTS when the selected Sherpa voice pack is not downloaded`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+            val request = VoiceSpeakRequest("Fallback voice pack")
+            coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("Voice pack not downloaded")
+            coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { androidTts.speak(request) } returns VoiceOutputResult.Spoken
+
+            val controller = buildController()
+            val result = controller.speak(request)
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            coVerify(exactly = 1) { sherpa.warmUp() }
+            coVerify(exactly = 1) { androidTts.warmUp() }
+            coVerify(exactly = 1) { androidTts.speak(request) }
+        }
+
+    @Test
     fun `speak falls back to Android TTS when Sherpa speak fails`() = runTest(dispatcher) {
         selectedEngine.value = VoiceOutputEngine.SherpaExperimental
         val request = VoiceSpeakRequest("Fallback after Sherpa error")

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
@@ -1,0 +1,226 @@
+package com.kernel.ai.core.voice
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FallbackVoiceOutputControllerTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
+    private val sherpa: SherpaOnnxVoiceOutputController = mockk(relaxed = true)
+    private val androidTts: AndroidTextToSpeechController = mockk(relaxed = true)
+    private val selectedEngine = MutableStateFlow(VoiceOutputEngine.AndroidTts)
+
+    private val sherpaEvents = MutableSharedFlow<VoiceOutputEvent>(extraBufferCapacity = 8)
+    private val androidEvents = MutableSharedFlow<VoiceOutputEvent>(extraBufferCapacity = 8)
+
+    @BeforeEach
+    fun setup() {
+        every { voiceOutputPreferences.selectedEngine } returns selectedEngine
+        every { sherpa.events } returns sherpaEvents
+        every { androidTts.events } returns androidEvents
+    }
+
+    @Test
+    fun `warmUp selects Android TTS when Android engine is preferred`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.AndroidTts
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        val result = controller.warmUp()
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 0) { sherpa.warmUp() }
+        coVerify(exactly = 1) { androidTts.warmUp() }
+    }
+
+    @Test
+    fun `warmUp selects Sherpa when Sherpa engine is preferred and available`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+            coEvery { sherpa.warmUp() } returns VoiceOutputResult.Spoken
+
+            val controller = buildController()
+            val result = controller.warmUp()
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            coVerify(exactly = 1) { sherpa.warmUp() }
+            coVerify(exactly = 0) { androidTts.warmUp() }
+        }
+
+    @Test
+    fun `warmUp falls back to Android TTS when Sherpa is unavailable`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("AAR missing")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        val result = controller.warmUp()
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 1) { sherpa.warmUp() }
+        coVerify(exactly = 1) { androidTts.warmUp() }
+    }
+
+    @Test
+    fun `warmUp returns Unavailable when both backends fail`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("no AAR")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Unavailable("no TTS engine")
+
+        val controller = buildController()
+        val result = controller.warmUp()
+
+        assertInstanceOf(VoiceOutputResult.Unavailable::class.java, result)
+        coVerify(exactly = 1) { sherpa.warmUp() }
+        coVerify(exactly = 1) { androidTts.warmUp() }
+    }
+
+    @Test
+    fun `speak routes to Android TTS when Android engine is selected`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.AndroidTts
+        val request = VoiceSpeakRequest("Hello fallback")
+        coEvery { androidTts.speak(request) } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        val result = controller.speak(request)
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 0) { sherpa.warmUp() }
+        coVerify(exactly = 0) { sherpa.speak(any()) }
+        coVerify(exactly = 1) { androidTts.speak(request) }
+    }
+
+    @Test
+    fun `speak routes to Sherpa when Sherpa engine is selected and available`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+            val request = VoiceSpeakRequest("Kia ora")
+            coEvery { sherpa.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { sherpa.speak(request) } returns VoiceOutputResult.Spoken
+
+            val controller = buildController()
+            val result = controller.speak(request)
+
+            assertEquals(VoiceOutputResult.Spoken, result)
+            coVerify(exactly = 1) { sherpa.warmUp() }
+            coVerify(exactly = 1) { sherpa.speak(request) }
+            coVerify(exactly = 0) { androidTts.speak(any()) }
+        }
+
+    @Test
+    fun `speak falls back to Android TTS when Sherpa warmUp is unavailable`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        val request = VoiceSpeakRequest("Lazy init")
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("no AAR")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { androidTts.speak(request) } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        val result = controller.speak(request)
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 1) { sherpa.warmUp() }
+        coVerify(exactly = 1) { androidTts.warmUp() }
+        coVerify(exactly = 1) { androidTts.speak(request) }
+    }
+
+    @Test
+    fun `speak falls back to Android TTS when Sherpa speak fails`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        val request = VoiceSpeakRequest("Fallback after Sherpa error")
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { sherpa.speak(request) } returns VoiceOutputResult.Unavailable("generation failed")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+        coEvery { androidTts.speak(request) } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        val result = controller.speak(request)
+
+        assertEquals(VoiceOutputResult.Spoken, result)
+        coVerify(exactly = 1) { sherpa.speak(request) }
+        coVerify(exactly = 1) { androidTts.speak(request) }
+    }
+
+    @Test
+    fun `stop stops both controllers defensively`() = runTest(dispatcher) {
+        every { sherpa.stop() } just runs
+        every { androidTts.stop() } just runs
+
+        val controller = buildController()
+        controller.stop()
+
+        verify(exactly = 1) { sherpa.stop() }
+        verify(exactly = 1) { androidTts.stop() }
+    }
+
+    @Test
+    fun `events come from Sherpa when Sherpa is selected`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        controller.warmUp()
+        advanceUntilIdle()
+
+        val received = mutableListOf<VoiceOutputEvent>()
+        val collectJob = launch { controller.events.collect { received += it } }
+        advanceUntilIdle()
+
+        sherpaEvents.emit(VoiceOutputEvent.SpeakingStarted("Sherpa speaking"))
+        androidEvents.emit(VoiceOutputEvent.SpeakingStarted("Android speaking"))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(VoiceOutputEvent.SpeakingStarted("Sherpa speaking")),
+            received,
+        )
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `events come from Android TTS when it is the fallback`() = runTest(dispatcher) {
+        selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+        coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("no AAR")
+        coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+
+        val controller = buildController()
+        controller.warmUp()
+        advanceUntilIdle()
+
+        val received = mutableListOf<VoiceOutputEvent>()
+        val collectJob = launch { controller.events.collect { received += it } }
+        advanceUntilIdle()
+
+        sherpaEvents.emit(VoiceOutputEvent.SpeakingStarted("Sherpa (should be ignored)"))
+        androidEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceUntilIdle()
+
+        assertEquals(listOf(VoiceOutputEvent.SpeakingStopped), received)
+        collectJob.cancel()
+    }
+
+    private fun buildController() = FallbackVoiceOutputController(
+        voiceOutputPreferences = voiceOutputPreferences,
+        sherpa = sherpa,
+        androidTts = androidTts,
+    )
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaVoicePackFilesTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaVoicePackFilesTest.kt
@@ -1,0 +1,37 @@
+package com.kernel.ai.core.voice
+
+import kotlin.io.path.createTempDirectory
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SherpaVoicePackFilesTest {
+
+    @Test
+    fun `normalize extracted pack renames raw sherpa files to stable names`() {
+        val dir = createTempDirectory("sherpa-pack-test").toFile()
+        dir.resolve("en_GB-jenny_dioco-medium.onnx").writeText("onnx")
+        dir.resolve("en_GB-jenny_dioco-medium.onnx.json").writeText("{}")
+        dir.resolve(SHERPA_TOKENS_FILE).writeText("a 1\n")
+        dir.resolve(SHERPA_ESPEAK_DATA_DIR).mkdirs()
+
+        normalizeExtractedSherpaVoicePack(dir)
+
+        assertTrue(dir.resolve(SHERPA_MODEL_ONNX_FILE).isFile)
+        assertTrue(dir.resolve(SHERPA_MODEL_JSON_FILE).isFile)
+        assertTrue(hasRequiredSherpaVoicePackFiles(dir))
+
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `required pack check fails when canonical model file is missing`() {
+        val dir = createTempDirectory("sherpa-pack-missing").toFile()
+        dir.resolve(SHERPA_TOKENS_FILE).writeText("a 1\n")
+        dir.resolve(SHERPA_ESPEAK_DATA_DIR).mkdirs()
+
+        assertFalse(hasRequiredSherpaVoicePackFiles(dir))
+
+        dir.deleteRecursively()
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -2,37 +2,47 @@ package com.kernel.ai.feature.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceOutputEngine
+import com.kernel.ai.core.voice.VoicePackDownloadState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,6 +60,9 @@ fun VoiceScreen(
         onSpokenResponsesEnabledChanged = viewModel::setSpokenResponsesEnabled,
         onVoiceOutputEngineSelected = viewModel::setVoiceOutputEngine,
         onSherpaVoiceSelected = viewModel::setSherpaVoice,
+        onDownloadVoice = viewModel::downloadSherpaVoice,
+        onCancelVoiceDownload = viewModel::cancelSherpaVoiceDownload,
+        onDeleteVoice = viewModel::deleteSherpaVoice,
     )
 }
 
@@ -63,6 +76,9 @@ private fun VoiceScreenContent(
     onSpokenResponsesEnabledChanged: (Boolean) -> Unit,
     onVoiceOutputEngineSelected: (VoiceOutputEngine) -> Unit,
     onSherpaVoiceSelected: (SherpaPiperVoice) -> Unit,
+    onDownloadVoice: (SherpaPiperVoice) -> Unit,
+    onCancelVoiceDownload: (SherpaPiperVoice) -> Unit,
+    onDeleteVoice: (SherpaPiperVoice) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -191,22 +207,7 @@ private fun VoiceScreenContent(
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
-                    supportingContent = {
-                        Column {
-                            Text(engine.description)
-                            if (
-                                engine == VoiceOutputEngine.SherpaExperimental &&
-                                uiState.selectedOutputEngine == engine
-                            ) {
-                                Text(
-                                    text = "Run scripts/setup-sherpa-tts-spike.sh to prepare local Piper voices. Android TTS remains the runtime fallback if Sherpa is unavailable.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(top = 4.dp),
-                                )
-                            }
-                        }
-                    },
+                    supportingContent = { Text(engine.description) },
                     trailingContent = {
                         RadioButton(
                             selected = uiState.selectedOutputEngine == engine,
@@ -225,23 +226,119 @@ private fun VoiceScreenContent(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
-                SherpaPiperVoice.entries.forEach { voice ->
-                    ListItem(
-                        modifier = Modifier.fillMaxWidth(),
-                        headlineContent = { Text(voice.displayName) },
-                        supportingContent = { Text(voice.description) },
-                        trailingContent = {
-                            RadioButton(
-                                selected = uiState.selectedSherpaVoice == voice,
-                                onClick = { onSherpaVoiceSelected(voice) },
-                            )
-                        },
+                uiState.sherpaVoices.forEach { voiceRow ->
+                    SherpaVoiceRow(
+                        rowState = voiceRow,
+                        isSelected = uiState.selectedSherpaVoice == voiceRow.voice,
+                        onSelect = { onSherpaVoiceSelected(voiceRow.voice) },
+                        onDownload = { onDownloadVoice(voiceRow.voice) },
+                        onCancel = { onCancelVoiceDownload(voiceRow.voice) },
+                        onDelete = { onDeleteVoice(voiceRow.voice) },
                     )
                     HorizontalDivider()
                 }
             }
         }
     }
+}
+
+/**
+ * A single Sherpa Piper voice row with download/cancel/delete controls and progress indicator.
+ * Mirrors [ModelRow] in [ModelManagementScreen] for visual consistency.
+ */
+@Composable
+private fun SherpaVoiceRow(
+    rowState: SherpaVoiceRowUiState,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+    onDownload: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val voice = rowState.voice
+    val state = rowState.downloadState
+
+    ListItem(
+        modifier = modifier.fillMaxWidth(),
+        headlineContent = { Text(voice.displayName) },
+        supportingContent = {
+            Column {
+                Text(
+                    text = voice.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = formatBytes(voice.approxDownloadBytes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                when (state) {
+                    is VoicePackDownloadState.Downloading -> {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        LinearProgressIndicator(
+                            progress = { state.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        val pct = (state.progress * 100).toInt()
+                        val mbps = state.bytesPerSecond / 1_000_000.0
+                        val etaSec = state.remainingMs / 1000
+                        Text(
+                            text = buildString {
+                                if (pct >= 90) append("Extracting…")
+                                else {
+                                    append("$pct%")
+                                    if (state.bytesPerSecond > 0) append(" · ${"%.1f".format(mbps)} MB/s")
+                                    if (etaSec > 0) append(" · ${etaSec}s remaining")
+                                }
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    is VoicePackDownloadState.Error -> {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    else -> Unit
+                }
+            }
+        },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                when (state) {
+                    is VoicePackDownloadState.NotDownloaded, is VoicePackDownloadState.Error -> {
+                        TextButton(onClick = onDownload) { Text("Download") }
+                    }
+                    is VoicePackDownloadState.Downloading -> {
+                        TextButton(onClick = onCancel) { Text("Cancel") }
+                    }
+                    is VoicePackDownloadState.Downloaded -> {
+                        Icon(
+                            Icons.Default.CheckCircle,
+                            contentDescription = "Downloaded",
+                            tint = Color(0xFF4CAF50),
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        // Allow selecting AND deleting when downloaded
+                        RadioButton(selected = isSelected, onClick = onSelect)
+                        TextButton(onClick = onDelete) {
+                            Text("Delete", color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+                // Show radio button to select voice when downloaded; also allow selection intent
+                // when not yet downloaded (selection happens, but Sherpa won't activate until ready)
+                if (state !is VoicePackDownloadState.Downloaded) {
+                    RadioButton(selected = isSelected, onClick = onSelect)
+                }
+            }
+        },
+    )
 }
 
 @Composable
@@ -277,6 +374,13 @@ private fun VoiceWarningCard(
     }
 }
 
+private fun formatBytes(bytes: Long): String = when {
+    bytes >= 1_000_000_000L -> "${"%.1f".format(bytes / 1_000_000_000.0)} GB"
+    bytes >= 1_000_000L -> "${"%.0f".format(bytes / 1_000_000.0)} MB"
+    bytes >= 1_000L -> "${"%.0f".format(bytes / 1_000.0)} KB"
+    else -> "$bytes B"
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun VoiceScreenPreview() {
@@ -285,6 +389,20 @@ private fun VoiceScreenPreview() {
             uiState = VoiceUiState(
                 selectedOutputEngine = VoiceOutputEngine.SherpaExperimental,
                 selectedSherpaVoice = SherpaPiperVoice.NorthernEnglishMale,
+                sherpaVoices = listOf(
+                    SherpaVoiceRowUiState(
+                        voice = SherpaPiperVoice.JennyDioco,
+                        downloadState = VoicePackDownloadState.Downloaded("/data/user/0/com.kernel.ai.debug/files/sherpa-tts/vits-piper-en_GB-jenny_dioco-medium"),
+                    ),
+                    SherpaVoiceRowUiState(
+                        voice = SherpaPiperVoice.SouthernEnglishFemale,
+                        downloadState = VoicePackDownloadState.Downloading(progress = 0.42f, bytesPerSecond = 3_500_000L, remainingMs = 15_000L),
+                    ),
+                    SherpaVoiceRowUiState(
+                        voice = SherpaPiperVoice.NorthernEnglishMale,
+                        downloadState = VoicePackDownloadState.NotDownloaded,
+                    ),
+                ),
             ),
             onBack = {},
             onVoiceInputEngineSelected = {},
@@ -292,6 +410,10 @@ private fun VoiceScreenPreview() {
             onSpokenResponsesEnabledChanged = {},
             onVoiceOutputEngineSelected = {},
             onSherpaVoiceSelected = {},
+            onDownloadVoice = {},
+            onCancelVoiceDownload = {},
+            onDeleteVoice = {},
         )
     }
 }
+

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -25,11 +25,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VoiceInputEngine
+import com.kernel.ai.core.voice.VoiceOutputEngine
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,6 +42,26 @@ fun VoiceScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    VoiceScreenContent(
+        uiState = uiState,
+        onBack = onBack,
+        onVoiceInputEngineSelected = viewModel::setVoiceInputEngine,
+        onSpokenResponsesEnabledChanged = viewModel::setSpokenResponsesEnabled,
+        onVoiceOutputEngineSelected = viewModel::setVoiceOutputEngine,
+        onSherpaVoiceSelected = viewModel::setSherpaVoice,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VoiceScreenContent(
+    uiState: VoiceUiState,
+    onBack: () -> Unit,
+    onVoiceInputEngineSelected: (VoiceInputEngine) -> Unit,
+    onSpokenResponsesEnabledChanged: (Boolean) -> Unit,
+    onVoiceOutputEngineSelected: (VoiceOutputEngine) -> Unit,
+    onSherpaVoiceSelected: (SherpaPiperVoice) -> Unit,
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -99,7 +122,7 @@ fun VoiceScreen(
                     trailingContent = {
                         RadioButton(
                             selected = uiState.selectedInputEngine == engine,
-                            onClick = { viewModel.setVoiceInputEngine(engine) },
+                            onClick = { onVoiceInputEngineSelected(engine) },
                         )
                     },
                 )
@@ -134,11 +157,65 @@ fun VoiceScreen(
                 trailingContent = {
                     Switch(
                         checked = uiState.spokenResponsesEnabled,
-                        onCheckedChange = { viewModel.setSpokenResponsesEnabled(it) },
+                        onCheckedChange = onSpokenResponsesEnabledChanged,
                     )
                 },
             )
             HorizontalDivider()
+
+            VoiceOutputEngine.entries.forEach { engine ->
+                ListItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    headlineContent = { Text(engine.displayName) },
+                    supportingContent = {
+                        Column {
+                            Text(engine.description)
+                            if (
+                                engine == VoiceOutputEngine.SherpaExperimental &&
+                                uiState.selectedOutputEngine == engine
+                            ) {
+                                Text(
+                                    text = "Run scripts/setup-sherpa-tts-spike.sh to prepare local Piper voices. Android TTS remains the runtime fallback if Sherpa is unavailable.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                        }
+                    },
+                    trailingContent = {
+                        RadioButton(
+                            selected = uiState.selectedOutputEngine == engine,
+                            onClick = { onVoiceOutputEngineSelected(engine) },
+                        )
+                    },
+                )
+                HorizontalDivider()
+            }
+
+            if (uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental) {
+                Text(
+                    text = "Sherpa Piper voice",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+
+                SherpaPiperVoice.entries.forEach { voice ->
+                    ListItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        headlineContent = { Text(voice.displayName) },
+                        supportingContent = { Text(voice.description) },
+                        trailingContent = {
+                            RadioButton(
+                                selected = uiState.selectedSherpaVoice == voice,
+                                onClick = { onSherpaVoiceSelected(voice) },
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
         }
     }
 }
@@ -173,5 +250,23 @@ private fun VoiceWarningCard(
                 color = MaterialTheme.colorScheme.onTertiaryContainer,
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun VoiceScreenPreview() {
+    MaterialTheme {
+        VoiceScreenContent(
+            uiState = VoiceUiState(
+                selectedOutputEngine = VoiceOutputEngine.SherpaExperimental,
+                selectedSherpaVoice = SherpaPiperVoice.NorthernEnglishMale,
+            ),
+            onBack = {},
+            onVoiceInputEngineSelected = {},
+            onSpokenResponsesEnabledChanged = {},
+            onVoiceOutputEngineSelected = {},
+            onSherpaVoiceSelected = {},
+        )
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -3,8 +3,10 @@ package com.kernel.ai.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
+import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +19,8 @@ import javax.inject.Inject
 data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
     val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
+    val selectedOutputEngine: VoiceOutputEngine = VoiceOutputEngine.AndroidTts,
+    val selectedSherpaVoice: SherpaPiperVoice = SherpaPiperVoice.JennyDioco,
     val androidNativeAvailabilityMessage: String? = null,
     val androidNativeLanguageSummary: String? = null,
 )
@@ -51,6 +55,16 @@ class VoiceViewModel @Inject constructor(
                 _uiState.update { it.copy(spokenResponsesEnabled = enabled) }
             }
         }
+        viewModelScope.launch {
+            voiceOutputPreferences.selectedEngine.collect { engine ->
+                _uiState.update { it.copy(selectedOutputEngine = engine) }
+            }
+        }
+        viewModelScope.launch {
+            voiceOutputPreferences.selectedSherpaVoice.collect { voice ->
+                _uiState.update { it.copy(selectedSherpaVoice = voice) }
+            }
+        }
     }
 
     fun setVoiceInputEngine(engine: VoiceInputEngine) {
@@ -64,6 +78,20 @@ class VoiceViewModel @Inject constructor(
         _uiState.update { it.copy(spokenResponsesEnabled = enabled) }
         viewModelScope.launch {
             voiceOutputPreferences.setSpokenResponsesEnabled(enabled)
+        }
+    }
+
+    fun setVoiceOutputEngine(engine: VoiceOutputEngine) {
+        _uiState.update { it.copy(selectedOutputEngine = engine) }
+        viewModelScope.launch {
+            voiceOutputPreferences.setSelectedEngine(engine)
+        }
+    }
+
+    fun setSherpaVoice(voice: SherpaPiperVoice) {
+        _uiState.update { it.copy(selectedSherpaVoice = voice) }
+        viewModelScope.launch {
+            voiceOutputPreferences.setSelectedSherpaVoice(voice)
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.SherpaPiperVoice
+import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
+import com.kernel.ai.core.voice.VoicePackDownloadState
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,11 +18,19 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class SherpaVoiceRowUiState(
+    val voice: SherpaPiperVoice,
+    val downloadState: VoicePackDownloadState = VoicePackDownloadState.NotDownloaded,
+)
+
 data class VoiceUiState(
     val spokenResponsesEnabled: Boolean = true,
     val selectedInputEngine: VoiceInputEngine = VoiceInputEngine.Vosk,
     val selectedOutputEngine: VoiceOutputEngine = VoiceOutputEngine.AndroidTts,
     val selectedSherpaVoice: SherpaPiperVoice = SherpaPiperVoice.JennyDioco,
+    val sherpaVoices: List<SherpaVoiceRowUiState> = SherpaPiperVoice.entries.map { voice ->
+        SherpaVoiceRowUiState(voice = voice)
+    },
     val autoStartAlertVoiceCommandsEnabled: Boolean = true,
     val androidNativeAvailabilityMessage: String? = null,
     val androidNativeLanguageSummary: String? = null,
@@ -31,6 +41,7 @@ class VoiceViewModel @Inject constructor(
     private val androidNativeRecognitionSupport: AndroidNativeRecognitionSupport,
     private val voiceInputPreferences: VoiceInputPreferences,
     private val voiceOutputPreferences: VoiceOutputPreferences,
+    private val sherpaVoicePackDownloadManager: SherpaVoicePackDownloadManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(VoiceUiState())
@@ -67,6 +78,20 @@ class VoiceViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            sherpaVoicePackDownloadManager.downloadStates.collect { states ->
+                _uiState.update {
+                    it.copy(
+                        sherpaVoices = SherpaPiperVoice.entries.map { voice ->
+                            SherpaVoiceRowUiState(
+                                voice = voice,
+                                downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
+                            )
+                        },
+                    )
+                }
+            }
+        }
+        viewModelScope.launch {
             voiceInputPreferences.autoStartAlertVoiceCommandsEnabled.collect { enabled ->
                 _uiState.update { it.copy(autoStartAlertVoiceCommandsEnabled = enabled) }
             }
@@ -99,6 +124,18 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             voiceOutputPreferences.setSelectedSherpaVoice(voice)
         }
+    }
+
+    fun downloadSherpaVoice(voice: SherpaPiperVoice) {
+        sherpaVoicePackDownloadManager.startDownload(voice)
+    }
+
+    fun cancelSherpaVoiceDownload(voice: SherpaPiperVoice) {
+        sherpaVoicePackDownloadManager.cancelDownload(voice)
+    }
+
+    fun deleteSherpaVoice(voice: SherpaPiperVoice) {
+        sherpaVoicePackDownloadManager.deleteVoice(voice)
     }
 
     fun setAutoStartAlertVoiceCommandsEnabled(enabled: Boolean) {

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -4,8 +4,10 @@ import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
 import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.SherpaPiperVoice
+import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
+import com.kernel.ai.core.voice.VoicePackDownloadState
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.Runs
@@ -34,11 +36,18 @@ class VoiceViewModelTest {
     private val androidNativeRecognitionSupport: AndroidNativeRecognitionSupport = mockk()
     private val voiceInputPreferences: VoiceInputPreferences = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
+    private val sherpaVoicePackDownloadManager: SherpaVoicePackDownloadManager = mockk()
     private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
     private val autoStartAlertVoiceCommandsEnabled = MutableStateFlow(true)
     private val spokenResponsesEnabled = MutableStateFlow(true)
     private val selectedOutputEngine = MutableStateFlow(VoiceOutputEngine.AndroidTts)
     private val selectedSherpaVoice = MutableStateFlow(SherpaPiperVoice.JennyDioco)
+    private val sherpaDownloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
+        MutableStateFlow(
+            SherpaPiperVoice.entries.associateWith {
+                VoicePackDownloadState.NotDownloaded
+            },
+        )
 
     private lateinit var viewModel: VoiceViewModel
 
@@ -63,10 +72,15 @@ class VoiceViewModelTest {
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedEngine(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedSherpaVoice(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.downloadStates } returns sherpaDownloadStates
+        every { sherpaVoicePackDownloadManager.startDownload(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.cancelDownload(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.deleteVoice(any()) } just Runs
         viewModel = VoiceViewModel(
             androidNativeRecognitionSupport,
             voiceInputPreferences,
             voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
         )
     }
 
@@ -119,6 +133,7 @@ class VoiceViewModelTest {
             androidNativeRecognitionSupport,
             voiceInputPreferences,
             voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -143,6 +158,7 @@ class VoiceViewModelTest {
             androidNativeRecognitionSupport,
             voiceInputPreferences,
             voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -167,6 +183,7 @@ class VoiceViewModelTest {
             androidNativeRecognitionSupport,
             voiceInputPreferences,
             voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -223,6 +240,29 @@ class VoiceViewModelTest {
     }
 
     @Test
+    fun `Sherpa voice download states are exposed for each voice row`() = runTest {
+        sherpaDownloadStates.value = mapOf(
+            SherpaPiperVoice.JennyDioco to VoicePackDownloadState.Downloaded("/voices/jenny"),
+            SherpaPiperVoice.SouthernEnglishFemale to VoicePackDownloadState.Downloading(progress = 0.5f),
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            VoicePackDownloadState.Downloaded("/voices/jenny"),
+            viewModel.uiState.value.sherpaVoices.first { it.voice == SherpaPiperVoice.JennyDioco }.downloadState,
+        )
+        assertEquals(
+            VoicePackDownloadState.Downloading(progress = 0.5f),
+            viewModel.uiState.value.sherpaVoices.first { it.voice == SherpaPiperVoice.SouthernEnglishFemale }.downloadState,
+        )
+        assertEquals(
+            VoicePackDownloadState.NotDownloaded,
+            viewModel.uiState.value.sherpaVoices.first { it.voice == SherpaPiperVoice.NorthernEnglishMale }.downloadState,
+        )
+    }
+
+    @Test
     fun `setVoiceOutputEngine updates ui state immediately`() = runTest {
         viewModel.setVoiceOutputEngine(VoiceOutputEngine.SherpaExperimental)
         testDispatcher.scheduler.advanceUntilIdle()
@@ -244,5 +284,28 @@ class VoiceViewModelTest {
             viewModel.uiState.value.selectedSherpaVoice,
         )
         coVerify { voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.NorthernEnglishMale) }
+    }
+
+    @Test
+    fun `downloadSherpaVoice delegates to the voice pack download manager`() = runTest {
+        viewModel.downloadSherpaVoice(SherpaPiperVoice.JennyDioco)
+
+        io.mockk.verify { sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.JennyDioco) }
+    }
+
+    @Test
+    fun `cancelSherpaVoiceDownload delegates to the voice pack download manager`() = runTest {
+        viewModel.cancelSherpaVoiceDownload(SherpaPiperVoice.SouthernEnglishFemale)
+
+        io.mockk.verify {
+            sherpaVoicePackDownloadManager.cancelDownload(SherpaPiperVoice.SouthernEnglishFemale)
+        }
+    }
+
+    @Test
+    fun `deleteSherpaVoice delegates to the voice pack download manager`() = runTest {
+        viewModel.deleteSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
+
+        io.mockk.verify { sherpaVoicePackDownloadManager.deleteVoice(SherpaPiperVoice.NorthernEnglishMale) }
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -3,8 +3,10 @@ package com.kernel.ai.feature.settings
 import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
 import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
+import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -34,6 +36,8 @@ class VoiceViewModelTest {
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
     private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
     private val spokenResponsesEnabled = MutableStateFlow(true)
+    private val selectedOutputEngine = MutableStateFlow(VoiceOutputEngine.AndroidTts)
+    private val selectedSherpaVoice = MutableStateFlow(SherpaPiperVoice.JennyDioco)
 
     private lateinit var viewModel: VoiceViewModel
 
@@ -51,7 +55,11 @@ class VoiceViewModelTest {
         every { voiceInputPreferences.selectedEngine } returns selectedInputEngine
         coEvery { voiceInputPreferences.setSelectedEngine(any()) } just Runs
         every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
+        every { voiceOutputPreferences.selectedEngine } returns selectedOutputEngine
+        every { voiceOutputPreferences.selectedSherpaVoice } returns selectedSherpaVoice
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
+        coEvery { voiceOutputPreferences.setSelectedEngine(any()) } just Runs
+        coEvery { voiceOutputPreferences.setSelectedSherpaVoice(any()) } just Runs
         viewModel = VoiceViewModel(
             androidNativeRecognitionSupport,
             voiceInputPreferences,
@@ -174,5 +182,47 @@ class VoiceViewModelTest {
 
         assertEquals(false, viewModel.uiState.value.spokenResponsesEnabled)
         coVerify { voiceOutputPreferences.setSpokenResponsesEnabled(false) }
+    }
+
+    @Test
+    fun `voice output engine defaults to Android TTS when preference flow emits Android TTS`() =
+        runTest {
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                VoiceOutputEngine.AndroidTts,
+                viewModel.uiState.value.selectedOutputEngine,
+            )
+        }
+
+    @Test
+    fun `selected Sherpa voice defaults to Jenny when preference flow emits Jenny`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(SherpaPiperVoice.JennyDioco, viewModel.uiState.value.selectedSherpaVoice)
+    }
+
+    @Test
+    fun `setVoiceOutputEngine updates ui state immediately`() = runTest {
+        viewModel.setVoiceOutputEngine(VoiceOutputEngine.SherpaExperimental)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            VoiceOutputEngine.SherpaExperimental,
+            viewModel.uiState.value.selectedOutputEngine,
+        )
+        coVerify { voiceOutputPreferences.setSelectedEngine(VoiceOutputEngine.SherpaExperimental) }
+    }
+
+    @Test
+    fun `setSherpaVoice updates ui state immediately`() = runTest {
+        viewModel.setSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            SherpaPiperVoice.NorthernEnglishMale,
+            viewModel.uiState.value.selectedSherpaVoice,
+        )
+        coVerify { voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.NorthernEnglishMale) }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ securityCrypto = "1.1.0-alpha06"
 okhttp = "4.12.0"
 playServicesLocation = "21.3.0"
 vosk = "0.3.75"
+commonsCompress = "1.27.1"
 
 [libraries]
 # Compose BOM
@@ -118,6 +119,7 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 vosk-android = { group = "com.alphacephei", name = "vosk-android", version.ref = "vosk" }
+commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
 
 # Testing — UIAutomator
 uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }

--- a/scripts/convert_piper_voice.py
+++ b/scripts/convert_piper_voice.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Converts a raw Piper voice (model + .onnx.json) into the minimal Sherpa-ONNX
+directory layout used by the Android TTS spike:
+
+  output-dir/
+    model.onnx
+    tokens.txt
+    model.onnx.json
+
+`tokens.txt` is generated from Piper's `phoneme_id_map`, matching the format
+used by sherpa-onnx/scripts/piper/add_meta_data.py: one `token id` pair per line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--voice-key", required=True)
+    parser.add_argument("--input-model", required=True)
+    parser.add_argument("--input-config", required=True)
+    parser.add_argument("--output-dir", required=True)
+    return parser.parse_args()
+
+
+def build_tokens_lines(config: dict) -> list[str]:
+    phoneme_id_map = config.get("phoneme_id_map")
+    if not isinstance(phoneme_id_map, dict) or not phoneme_id_map:
+        raise ValueError("Piper config is missing phoneme_id_map")
+
+    tokens: list[tuple[int, str]] = []
+    for symbol, raw_id in phoneme_id_map.items():
+        token_id = raw_id[0] if isinstance(raw_id, list) else raw_id
+        if not isinstance(token_id, int):
+            raise ValueError(f"Unexpected token id for {symbol!r}: {raw_id!r}")
+        if symbol == "\n":
+            continue
+        tokens.append((token_id, symbol))
+
+    tokens.sort(key=lambda item: item[0])
+    return [f"{symbol} {token_id}" for token_id, symbol in tokens]
+
+
+def main() -> None:
+    args = parse_args()
+
+    input_model = Path(args.input_model)
+    input_config = Path(args.input_config)
+    output_dir = Path(args.output_dir)
+
+    if not input_model.is_file():
+        raise SystemExit(f"Missing Piper model: {input_model}")
+    if not input_config.is_file():
+        raise SystemExit(f"Missing Piper config: {input_config}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with input_config.open("r", encoding="utf-8") as file:
+        config = json.load(file)
+
+    tokens_lines = build_tokens_lines(config)
+
+    shutil.copy2(input_model, output_dir / "model.onnx")
+    shutil.copy2(input_config, output_dir / "model.onnx.json")
+
+    with (output_dir / "tokens.txt").open("w", encoding="utf-8") as file:
+        file.write("\n".join(tokens_lines))
+        file.write("\n")
+
+    print(f"Converted {args.voice_key} into {output_dir}")
+    print(f"Generated {len(tokens_lines)} token lines")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-sherpa-tts-spike.sh
+++ b/scripts/setup-sherpa-tts-spike.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/setup-sherpa-tts-spike.sh
+#
+# Downloads the Sherpa-ONNX AAR and prepares a small locally converted en_GB
+# Piper voice pack so the Sherpa TTS spike can be compiled and exercised.
+#
+# NOTHING downloaded here is committed to git — see .gitignore patterns:
+#   third_party/sherpa-onnx/
+#   core/voice/src/main/assets/sherpa-tts/
+#
+# Usage (run from repo root):
+#   bash scripts/setup-sherpa-tts-spike.sh
+#
+# Optional overrides:
+#   PIPER_BASE_URL=https://huggingface.co/rhasspy/piper-voices/resolve/main \
+#   PIPER_VOICE_KEYS=en_GB-jenny_dioco-medium,en_GB-northern_english_male-medium \
+#   bash scripts/setup-sherpa-tts-spike.sh
+#
+# After running, rebuild so Gradle picks up the new AAR:
+#   ./gradlew :app:assembleDebug
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SHERPA_VERSION="1.13.0"
+AAR_FILE="sherpa-onnx-${SHERPA_VERSION}.aar"
+AAR_DIR="${REPO_ROOT}/third_party/sherpa-onnx"
+AAR_PATH="${AAR_DIR}/${AAR_FILE}"
+SHERPA_AAR_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v${SHERPA_VERSION}/${AAR_FILE}"
+
+PIPER_BASE_URL="${PIPER_BASE_URL:-https://huggingface.co/rhasspy/piper-voices/resolve/main}"
+PIPER_VOICE_KEYS="${PIPER_VOICE_KEYS:-}"
+ESPEAK_ARCHIVE="espeak-ng-data.tar.bz2"
+ESPEAK_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/${ESPEAK_ARCHIVE}"
+
+ASSETS_DIR="${REPO_ROOT}/core/voice/src/main/assets/sherpa-tts"
+DOWNLOADS_DIR="${ASSETS_DIR}/.downloads"
+ESPEAK_ARCHIVE_PATH="${DOWNLOADS_DIR}/${ESPEAK_ARCHIVE}"
+
+VOICE_SPECS=(
+    "en_GB-jenny_dioco-medium|en/en_GB/jenny_dioco/medium|vits-piper-en_GB-jenny_dioco-medium"
+    "en_GB-southern_english_female-low|en/en_GB/southern_english_female/low|vits-piper-en_GB-southern_english_female-low"
+    "en_GB-northern_english_male-medium|en/en_GB/northern_english_male/medium|vits-piper-en_GB-northern_english_male-medium"
+)
+
+info()  { echo "[sherpa-tts-spike] $*"; }
+warn()  { echo "[sherpa-tts-spike] WARN: $*" >&2; }
+error() { echo "[sherpa-tts-spike] ERROR: $*" >&2; exit 1; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || error "'$1' not found. Please install it and re-run."
+}
+
+download_if_missing() {
+    local url="$1"
+    local dest="$2"
+    local label="$3"
+
+    if [[ -f "${dest}" ]]; then
+        info "${label} already present: ${dest} (skipping download)"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "${dest}")"
+    info "Downloading ${label}..."
+    info "  URL: ${url}"
+    if ! curl --fail --location --progress-bar -o "${dest}" "${url}"; then
+        rm -f "${dest}"
+        return 1
+    fi
+    info "${label} saved to: ${dest}"
+}
+
+should_prepare_voice() {
+    local voice_key="$1"
+    if [[ -z "${PIPER_VOICE_KEYS}" ]]; then
+        return 0
+    fi
+
+    local padded=",${PIPER_VOICE_KEYS},"
+    [[ "${padded}" == *",${voice_key},"* ]]
+}
+
+require_cmd curl
+require_cmd tar
+require_cmd python3
+
+info "Repo root: ${REPO_ROOT}"
+
+mkdir -p "${AAR_DIR}" "${ASSETS_DIR}" "${DOWNLOADS_DIR}"
+
+if [[ -f "${AAR_PATH}" ]]; then
+    info "AAR already present: ${AAR_PATH} (skipping download)"
+else
+    info "Downloading Sherpa-ONNX ${SHERPA_VERSION} AAR..."
+    info "  URL: ${SHERPA_AAR_URL}"
+    if ! curl --fail --location --progress-bar -o "${AAR_PATH}" "${SHERPA_AAR_URL}"; then
+        rm -f "${AAR_PATH}"
+        error "Failed to download AAR from ${SHERPA_AAR_URL}
+  Check the release page: https://github.com/k2-fsa/sherpa-onnx/releases/tag/v${SHERPA_VERSION}
+  If the URL has changed, update SHERPA_AAR_URL in this script."
+    fi
+    info "AAR saved to: ${AAR_PATH}"
+fi
+
+AAR_SIZE=$(wc -c < "${AAR_PATH}" | tr -d '[:space:]')
+info "AAR size: ${AAR_SIZE} bytes"
+if [[ "${AAR_SIZE}" -lt 1000000 ]]; then
+    warn "AAR appears unexpectedly small (${AAR_SIZE} bytes). It may be a redirect/error page."
+    warn "Delete ${AAR_PATH} and re-run if the build fails with class-not-found errors."
+fi
+
+if ! download_if_missing "${ESPEAK_URL}" "${ESPEAK_ARCHIVE_PATH}" "espeak-ng-data archive"; then
+    error "Failed to download espeak-ng-data from ${ESPEAK_URL}"
+fi
+
+READY_VOICES=()
+FAILED_VOICES=()
+
+for spec in "${VOICE_SPECS[@]}"; do
+    IFS="|" read -r voice_key voice_hf_path asset_dir_name <<< "${spec}"
+    if ! should_prepare_voice "${voice_key}"; then
+        continue
+    fi
+
+    raw_model_name="${voice_key}.onnx"
+    raw_json_name="${voice_key}.onnx.json"
+    raw_model_path="${DOWNLOADS_DIR}/${raw_model_name}"
+    raw_json_path="${DOWNLOADS_DIR}/${raw_json_name}"
+    voice_assets_dir="${ASSETS_DIR}/${asset_dir_name}"
+    espeak_dir="${voice_assets_dir}/espeak-ng-data"
+    piper_onnx_url="${PIPER_BASE_URL}/${voice_hf_path}/${raw_model_name}?download=true"
+    piper_json_url="${PIPER_BASE_URL}/${voice_hf_path}/${raw_json_name}?download=true"
+
+    info "Preparing Sherpa Piper voice: ${voice_key}"
+    voice_ready=true
+
+    if ! download_if_missing "${piper_onnx_url}" "${raw_model_path}" "raw Piper ONNX model (${voice_key})"; then
+        warn "Failed to download Piper ONNX model from ${piper_onnx_url}"
+        voice_ready=false
+    fi
+
+    if [[ "${voice_ready}" == true ]] &&
+        ! download_if_missing "${piper_json_url}" "${raw_json_path}" "raw Piper JSON config (${voice_key})"; then
+        warn "Failed to download Piper JSON config from ${piper_json_url}"
+        voice_ready=false
+    fi
+
+    if [[ "${voice_ready}" == true ]]; then
+        rm -rf "${espeak_dir}"
+        mkdir -p "${voice_assets_dir}"
+        info "Extracting espeak-ng-data for ${voice_key}..."
+        tar -xjf "${ESPEAK_ARCHIVE_PATH}" -C "${voice_assets_dir}"
+
+        info "Converting raw Piper voice into Sherpa layout (${voice_key})..."
+        python3 "${REPO_ROOT}/scripts/convert_piper_voice.py" \
+            --voice-key "${voice_key}" \
+            --input-model "${raw_model_path}" \
+            --input-config "${raw_json_path}" \
+            --output-dir "${voice_assets_dir}"
+    fi
+
+    all_ok=true
+    if [[ "${voice_ready}" == true ]]; then
+        for required in model.onnx tokens.txt espeak-ng-data; do
+            if [[ ! -e "${voice_assets_dir}/${required}" ]]; then
+                warn "Expected file/dir missing: ${voice_assets_dir}/${required}"
+                all_ok=false
+            fi
+        done
+    else
+        all_ok=false
+    fi
+
+    if [[ "${all_ok}" == true ]]; then
+        info "✓ ${voice_key} ready at ${voice_assets_dir}"
+        READY_VOICES+=("${voice_key}")
+    else
+        warn "${voice_key} is incomplete. Android TTS will remain available as fallback."
+        FAILED_VOICES+=("${voice_key}")
+    fi
+done
+
+echo ""
+echo "================================================================="
+echo "  Sherpa-ONNX TTS spike setup complete"
+echo "================================================================="
+echo ""
+echo "  AAR: ${AAR_PATH}"
+if [[ "${#READY_VOICES[@]}" -gt 0 ]]; then
+    echo "  Ready voices:"
+    for voice_key in "${READY_VOICES[@]}"; do
+        echo "    - ${voice_key}"
+    done
+else
+    echo "  Ready voices: none"
+fi
+if [[ "${#FAILED_VOICES[@]}" -gt 0 ]]; then
+    echo "  Incomplete voices:"
+    for voice_key in "${FAILED_VOICES[@]}"; do
+        echo "    - ${voice_key}"
+    done
+fi
+echo ""
+echo "  Notes:"
+echo "    - The southern-English public Piper pack currently resolves as low quality, so"
+echo "      this setup prepares en_GB-southern_english_female-low for that option."
+echo "    - Android TTS remains available as the runtime fallback."
+echo ""
+echo "  Next steps:"
+echo "    1. Rebuild the project so Gradle picks up the new AAR:"
+echo "       ./gradlew :app:assembleDebug"
+echo ""
+echo "    2. Install on device and exercise the voice output path."
+echo "       Logcat tag 'KernelAI' shows which backend is selected."
+echo ""
+echo "  To revert to Android TTS only (without touching code):"
+echo "    - Remove or move ${AAR_PATH}"
+echo "    - Rebuild — SherpaOnnxVoiceOutputController will return Unavailable"
+echo "      and FallbackVoiceOutputController will route to Android TTS."
+echo "================================================================="


### PR DESCRIPTION
## Summary
Add a Sherpa-ONNX Piper TTS spike behind the existing voice output seam, with Android TTS fallback and a Voice settings selector for engine and en_GB Piper voice choice.

## Changes
- add `SherpaOnnxVoiceOutputController` and `FallbackVoiceOutputController`
- keep Android TTS as the direct path and runtime fallback when Sherpa is unavailable
- add output engine and Sherpa Piper voice preferences in `core:voice`
- extend Settings -> Voice with output engine selection and en_GB Piper voice selection
- update the local setup script to download a working recommended en_GB Piper pack
- add focused unit coverage for fallback routing and settings view model behavior

## Testing
- `bash scripts/setup-sherpa-tts-spike.sh`
- `./gradlew --no-daemon :core:voice:testDebugUnitTest --tests 'com.kernel.ai.core.voice.FallbackVoiceOutputControllerTest' :feature:settings:testDebugUnitTest --tests 'com.kernel.ai.feature.settings.VoiceViewModelTest'`
- `./gradlew --no-daemon :app:assembleDebug`

## Related issues
Part of #729
Related to #755
Related to #756
