### PR TITLE
feat(#762): expand sherpa voice catalog

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -20,7 +20,7 @@ enum class SherpaPiperVoice(
     ),
     SouthernEnglishFemale(
         displayName = "Southern English Female",
-        description = "Closest publicly available southern-English Piper pack for this spike setup.",
+        description = "Lower-size southern British English female voice.",
         assetDirectoryName = "vits-piper-en_GB-southern_english_female-low",
         downloadKey = "en_GB-southern_english_female-low",
         approxDownloadBytes = 64_000_000L,
@@ -31,6 +31,48 @@ enum class SherpaPiperVoice(
         assetDirectoryName = "vits-piper-en_GB-northern_english_male-medium",
         downloadKey = "en_GB-northern_english_male-medium",
         approxDownloadBytes = 74_000_000L,
+    ),
+    AlanMedium(
+        displayName = "Alan",
+        description = "Balanced British English male voice with a more neutral delivery.",
+        assetDirectoryName = "vits-piper-en_GB-alan-medium",
+        downloadKey = "en_GB-alan-medium",
+        approxDownloadBytes = 67_220_121L,
+    ),
+    CoriHigh(
+        displayName = "Cori",
+        description = "Higher-quality British English female voice with smoother playback.",
+        assetDirectoryName = "vits-piper-en_GB-cori-high",
+        downloadKey = "en_GB-cori-high",
+        approxDownloadBytes = 115_574_061L,
+    ),
+    AmyMedium(
+        displayName = "Amy",
+        description = "Balanced American English female voice for a less region-specific option.",
+        assetDirectoryName = "vits-piper-en_US-amy-medium",
+        downloadKey = "en_US-amy-medium",
+        approxDownloadBytes = 67_223_746L,
+    ),
+    JoeMedium(
+        displayName = "Joe",
+        description = "Balanced American English male voice with a straightforward conversational tone.",
+        assetDirectoryName = "vits-piper-en_US-joe-medium",
+        downloadKey = "en_US-joe-medium",
+        approxDownloadBytes = 67_169_394L,
+    ),
+    LessacHigh(
+        displayName = "Lessac",
+        description = "Higher-quality American English female voice and the most neutral-sounding Sherpa option here.",
+        assetDirectoryName = "vits-piper-en_US-lessac-high",
+        downloadKey = "en_US-lessac-high",
+        approxDownloadBytes = 115_545_841L,
+    ),
+    RyanHigh(
+        displayName = "Ryan",
+        description = "Higher-quality American English male voice with fuller audio output.",
+        assetDirectoryName = "vits-piper-en_US-ryan-high",
+        downloadKey = "en_US-ryan-high",
+        approxDownloadBytes = 115_630_708L,
     ),
     ;
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
@@ -1,0 +1,41 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SherpaPiperVoiceTest {
+
+    @Test
+    fun `unknown stored voice falls back to Jenny`() {
+        assertEquals(SherpaPiperVoice.JennyDioco, SherpaPiperVoice.fromStorage("not-a-real-voice"))
+    }
+
+    @Test
+    fun `catalog includes expanded English voices with unique release identifiers`() {
+        val expectedNewVoices = setOf(
+            SherpaPiperVoice.AlanMedium,
+            SherpaPiperVoice.CoriHigh,
+            SherpaPiperVoice.AmyMedium,
+            SherpaPiperVoice.JoeMedium,
+            SherpaPiperVoice.LessacHigh,
+            SherpaPiperVoice.RyanHigh,
+        )
+
+        assertTrue(SherpaPiperVoice.entries.containsAll(expectedNewVoices))
+        assertEquals(
+            SherpaPiperVoice.entries.size,
+            SherpaPiperVoice.entries.map { it.assetDirectoryName }.toSet().size,
+        )
+        assertEquals(
+            SherpaPiperVoice.entries.size,
+            SherpaPiperVoice.entries.map { it.downloadKey }.toSet().size,
+        )
+        assertTrue(
+            SherpaPiperVoice.entries.all { voice ->
+                voice.approxDownloadBytes > 0 &&
+                    voice.downloadUrl.endsWith("${voice.assetDirectoryName}.tar.bz2")
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Expand the Sherpa Piper voice catalog so the app offers more local voice choices beyond the original narrow `en_GB` set.

## Changes
- add six new downloadable Sherpa voices across `en_GB` and `en_US`
- improve voice descriptions so Settings better communicates accent and quality tradeoffs
- add a focused catalog test to guard release asset names, download keys, and fallback behavior

## Testing
- `./gradlew --no-daemon :core:voice:testDebugUnitTest --tests "com.kernel.ai.core.voice.SherpaPiperVoiceTest" --tests "com.kernel.ai.core.voice.SherpaVoicePackFilesTest" :feature:settings:testDebugUnitTest --tests "com.kernel.ai.feature.settings.VoiceViewModelTest"`
- `./gradlew --no-daemon :app:assembleDebug`

## Related issues
Closes #762
