### PR TITLE
fix(#760): duck alert audio during voice capture

### DIFF
--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -11,6 +11,7 @@ import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
 import android.media.Ringtone
 import android.media.RingtoneManager
+import android.net.Uri
 import android.os.IBinder
 import android.os.VibrationEffect
 import android.os.Vibrator
@@ -38,12 +39,27 @@ import kotlinx.coroutines.launch
 private const val ALARM_SNOOZE_MS = 10 * 60 * 1_000L
 private const val ALERT_ADD_MINUTE_MS = 60_000L
 private const val AUTO_START_VOICE_DELAY_MS = 2_000L
+private const val ALERT_PLAYBACK_FULL_VOLUME = 1.0f
+private const val ALERT_PLAYBACK_DUCKED_VOLUME = 0.2f
 internal fun shouldAutoStartAlertVoiceControl(
     enabled: Boolean,
     type: ClockEventType,
 ): Boolean = enabled && type != ClockEventType.PRE_ALARM
 
+internal fun shouldDuckAlertPlayback(activeAlertsSize: Int): Boolean = activeAlertsSize > 0
 
+internal fun shouldRestoreDuckedPlayback(
+    duckingPlayback: Boolean,
+    activeAlertsSize: Int,
+): Boolean = duckingPlayback && activeAlertsSize > 0
+
+internal fun applyAlertPlaybackVolume(ringtone: Ringtone, volume: Float) {
+    ringtone.setVolume(volume)
+}
+
+internal fun alertPendingIntentIdentity(action: String, alert: TriggeredClockAlert): String =
+    "kernel-ai://clock-alert/${action}|${alert.type.name.lowercase()}|${alert.ownerId}|" +
+        (alert.occurrenceTriggerAtMillis?.toString() ?: "none")
 
 @AndroidEntryPoint
 class ClockAlertService : Service() {
@@ -63,6 +79,7 @@ class ClockAlertService : Service() {
     private var voicePreferencesJob: Job? = null
     private var autoStartVoiceJob: Job? = null
     private var ringtone: Ringtone? = null
+    private var duckingPlayback = false
     private var isVoiceListening = false
     private var handledVoiceTranscript = false
     private var autoStartAlertVoiceCommandsEnabled = true
@@ -209,10 +226,14 @@ class ClockAlertService : Service() {
         )
     }
 
-    private fun startAlertPlayback() {
-        if (isVoiceListening || activeAlerts.isEmpty()) return
+    private fun startAlertPlayback(ducked: Boolean = false) {
+        if (activeAlerts.isEmpty()) return
         stopPlayback()
-        startVibration()
+        if (ducked) {
+            defaultVibrator()?.cancel()
+        } else {
+            startVibration()
+        }
         ringtone = RingtoneManager.getRingtone(
             this,
             RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM),
@@ -221,8 +242,13 @@ class ClockAlertService : Service() {
                 .setUsage(AudioAttributes.USAGE_ALARM)
                 .build()
             isLooping = true
+            applyAlertPlaybackVolume(
+                this,
+                if (ducked) ALERT_PLAYBACK_DUCKED_VOLUME else ALERT_PLAYBACK_FULL_VOLUME,
+            )
             play()
         }
+        duckingPlayback = ducked && ringtone != null
     }
 
     private fun startVibration() {
@@ -277,8 +303,24 @@ class ClockAlertService : Service() {
     private fun stopPlayback() {
         ringtone?.stop()
         ringtone = null
+        duckingPlayback = false
         defaultVibrator()?.cancel()
     }
+
+    private fun duckPlaybackForVoiceControl() {
+        if (shouldDuckAlertPlayback(activeAlerts.size)) {
+            startAlertPlayback(ducked = true)
+        }
+    }
+
+    private fun restorePlaybackAfterVoiceCapture() {
+        if (shouldRestoreDuckedPlayback(duckingPlayback, activeAlerts.size)) {
+            startAlertPlayback()
+        } else if (activeAlerts.isNotEmpty() && ringtone?.isPlaying != true) {
+            startAlertPlayback()
+        }
+    }
+
 
     private fun defaultVibrator(): Vibrator? = vibratorManager.defaultVibrator
 
@@ -311,9 +353,10 @@ class ClockAlertService : Service() {
     private fun buildServicePendingIntent(action: String, alert: TriggeredClockAlert): PendingIntent =
         PendingIntent.getService(
             this,
-            31 * action.hashCode() + alert.ownerId.hashCode(),
+            0,
             Intent(this, ClockAlertService::class.java).apply {
                 this.action = action
+                data = Uri.parse(alertPendingIntentIdentity(action, alert))
                 putExtra(ClockAlertContract.EXTRA_OWNER_ID, alert.ownerId)
                 putExtra(ClockAlertContract.EXTRA_LABEL, alert.label)
                 putExtra(ClockAlertContract.EXTRA_TITLE, alert.title)
@@ -360,7 +403,7 @@ class ClockAlertService : Service() {
         isVoiceListening = true
         handledVoiceTranscript = false
         voiceStatusMessage = if (autoStarted) "Listening for alert commands…" else alertVoiceListeningPrompt(alert.type)
-        stopPlayback()
+        duckPlaybackForVoiceControl()
         refreshForeground()
         serviceScope.launch {
             when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
@@ -461,7 +504,7 @@ class ClockAlertService : Service() {
             stopAlertSession()
         } else {
             refreshForeground()
-            startAlertPlayback()
+            restorePlaybackAfterVoiceCapture()
         }
     }
 

--- a/app/src/test/java/com/kernel/ai/alarm/ClockAlertPlaybackTest.kt
+++ b/app/src/test/java/com/kernel/ai/alarm/ClockAlertPlaybackTest.kt
@@ -1,0 +1,59 @@
+package com.kernel.ai.alarm
+
+import android.media.Ringtone
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class ClockAlertPlaybackTest {
+    @Test
+    fun `shouldDuckAlertPlayback returns true only when alerts are active`() {
+        assertEquals(true, shouldDuckAlertPlayback(1))
+        assertEquals(true, shouldDuckAlertPlayback(2))
+        assertEquals(false, shouldDuckAlertPlayback(0))
+    }
+
+    @Test
+    fun `shouldRestoreDuckedPlayback returns true only for active ducked playback`() {
+        assertEquals(true, shouldRestoreDuckedPlayback(true, 1))
+        assertEquals(false, shouldRestoreDuckedPlayback(false, 1))
+        assertEquals(false, shouldRestoreDuckedPlayback(true, 0))
+    }
+
+    @Test
+    fun `applyAlertPlaybackVolume forwards the requested volume to ringtone`() {
+        val ringtone = mockk<Ringtone>(relaxed = true)
+
+        applyAlertPlaybackVolume(ringtone, 0.2f)
+
+        verify(exactly = 1) { ringtone.setVolume(0.2f) }
+    }
+
+    @Test
+    fun `alertPendingIntentIdentity distinguishes action owner and occurrence`() {
+        val first = TriggeredClockAlert(
+            ownerId = "alarm-1",
+            type = com.kernel.ai.core.memory.clock.ClockEventType.ALARM,
+            title = "Alarm",
+            label = "Weekday",
+            occurrenceTriggerAtMillis = 1000L,
+        )
+        val secondOccurrence = first.copy(occurrenceTriggerAtMillis = 2000L)
+        val secondOwner = first.copy(ownerId = "alarm-2")
+
+        assertNotEquals(
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_STOP_ALERT, first),
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_SNOOZE_ALERT, first),
+        )
+        assertNotEquals(
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_STOP_ALERT, first),
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_STOP_ALERT, secondOccurrence),
+        )
+        assertNotEquals(
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_STOP_ALERT, first),
+            alertPendingIntentIdentity(ClockAlertContract.ACTION_STOP_ALERT, secondOwner),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- keep alert audio audible during alert-time voice capture by restarting playback in a ducked mode
- restore full-volume playback with a fresh ringtone instance when voice capture ends without a successful command
- harden `ClockAlertService` notification actions by using explicit PendingIntent identity instead of collision-prone request code hashing

## Testing
- ./gradlew :app:testDebugUnitTest --tests "*ClockAlertPlaybackTest" --tests "*ClockAlertVoiceCommandTest" :app:compileDebugKotlin

Closes #760
