### PR TITLE
fix(#766): clarify voice settings selection

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -218,11 +218,33 @@ private fun VoiceScreenContent(
                 HorizontalDivider()
             }
 
+            Text(
+                text = "Choose one spoken output engine. Android TTS and Sherpa Piper are alternative playback paths, so only the selected engine will speak.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
             if (uiState.selectedOutputEngine == VoiceOutputEngine.SherpaExperimental) {
                 Text(
                     text = "Sherpa Piper voice",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+
+                val sherpaHelpText = when {
+                    !uiState.hasDownloadedSherpaVoice ->
+                        "Download a Sherpa voice pack below before Sherpa Piper can speak."
+                    !uiState.isSelectedSherpaVoiceDownloaded ->
+                        "Your saved Sherpa voice is not downloaded on this device. Download it again or choose another installed voice below."
+                    else ->
+                        "Only downloaded voices can be selected. Android TTS is disabled while Sherpa Piper is selected above."
+                }
+                Text(
+                    text = sherpaHelpText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
@@ -258,6 +280,7 @@ private fun SherpaVoiceRow(
 ) {
     val voice = rowState.voice
     val state = rowState.downloadState
+    val isDownloaded = state is VoicePackDownloadState.Downloaded
 
     ListItem(
         modifier = modifier.fillMaxWidth(),
@@ -274,6 +297,17 @@ private fun SherpaVoiceRow(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (!isDownloaded) {
+                    Text(
+                        text = when (state) {
+                            is VoicePackDownloadState.Downloading -> "Selectable after download completes"
+                            is VoicePackDownloadState.Error -> "Retry download before selecting this voice"
+                            else -> "Download to make this voice selectable"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 when (state) {
                     is VoicePackDownloadState.Downloading -> {
                         Spacer(modifier = Modifier.height(4.dp))
@@ -324,17 +358,11 @@ private fun SherpaVoiceRow(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        // Allow selecting AND deleting when downloaded
                         RadioButton(selected = isSelected, onClick = onSelect)
                         TextButton(onClick = onDelete) {
                             Text("Delete", color = MaterialTheme.colorScheme.error)
                         }
                     }
-                }
-                // Show radio button to select voice when downloaded; also allow selection intent
-                // when not yet downloaded (selection happens, but Sherpa won't activate until ready)
-                if (state !is VoicePackDownloadState.Downloaded) {
-                    RadioButton(selected = isSelected, onClick = onSelect)
                 }
             }
         },
@@ -389,6 +417,8 @@ private fun VoiceScreenPreview() {
             uiState = VoiceUiState(
                 selectedOutputEngine = VoiceOutputEngine.SherpaExperimental,
                 selectedSherpaVoice = SherpaPiperVoice.NorthernEnglishMale,
+                hasDownloadedSherpaVoice = true,
+                isSelectedSherpaVoiceDownloaded = false,
                 sherpaVoices = listOf(
                     SherpaVoiceRowUiState(
                         voice = SherpaPiperVoice.JennyDioco,
@@ -416,4 +446,3 @@ private fun VoiceScreenPreview() {
         )
     }
 }
-

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -203,11 +203,40 @@ private fun VoiceScreenContent(
             )
             HorizontalDivider()
 
+            Text(
+                text = "Spoken output engine",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
+            VoiceOutputSelectionCard(
+                selectedEngine = uiState.selectedOutputEngine,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+
             VoiceOutputEngine.entries.forEach { engine ->
                 ListItem(
                     modifier = Modifier.fillMaxWidth(),
                     headlineContent = { Text(engine.displayName) },
-                    supportingContent = { Text(engine.description) },
+                    supportingContent = {
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(engine.description)
+                            Text(
+                                text = if (uiState.selectedOutputEngine == engine) {
+                                    "Currently active"
+                                } else {
+                                    "Inactive"
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (uiState.selectedOutputEngine == engine) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            )
+                        }
+                    },
                     trailingContent = {
                         RadioButton(
                             selected = uiState.selectedOutputEngine == engine,
@@ -241,10 +270,9 @@ private fun VoiceScreenContent(
                     else ->
                         "Only downloaded voices can be selected. Android TTS is disabled while Sherpa Piper is selected above."
                 }
-                Text(
-                    text = sherpaHelpText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                VoiceInfoCard(
+                    title = "Sherpa Piper is active",
+                    message = sherpaHelpText,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
@@ -284,7 +312,27 @@ private fun SherpaVoiceRow(
 
     ListItem(
         modifier = modifier.fillMaxWidth(),
-        headlineContent = { Text(voice.displayName) },
+        headlineContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(voice.displayName)
+                Text(
+                    text = when {
+                        isDownloaded && isSelected -> "Selected voice"
+                        isDownloaded -> "Downloaded and ready"
+                        state is VoicePackDownloadState.Downloading -> "Downloading"
+                        state is VoicePackDownloadState.Error -> "Download failed"
+                        else -> "Not downloaded"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = when {
+                        isDownloaded && isSelected -> MaterialTheme.colorScheme.primary
+                        isDownloaded -> Color(0xFF2E7D32)
+                        state is VoicePackDownloadState.Error -> MaterialTheme.colorScheme.error
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+        },
         supportingContent = {
             Column {
                 Text(
@@ -400,6 +448,57 @@ private fun VoiceWarningCard(
             )
         }
     }
+}
+
+@Composable
+private fun VoiceInfoCard(
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceOutputSelectionCard(
+    selectedEngine: VoiceOutputEngine,
+    modifier: Modifier = Modifier,
+) {
+    val message = when (selectedEngine) {
+        VoiceOutputEngine.AndroidTts ->
+            "Android TTS is currently the only engine that will speak. Sherpa voices below stay inactive until you switch engines."
+        VoiceOutputEngine.SherpaExperimental ->
+            "Sherpa Piper is currently the only engine that will speak. Android TTS is inactive until you switch back."
+    }
+
+    VoiceInfoCard(
+        title = "Active engine: ${selectedEngine.displayName}",
+        message = message,
+        modifier = modifier,
+    )
 }
 
 private fun formatBytes(bytes: Long): String = when {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -34,6 +34,8 @@ data class VoiceUiState(
     val autoStartAlertVoiceCommandsEnabled: Boolean = true,
     val androidNativeAvailabilityMessage: String? = null,
     val androidNativeLanguageSummary: String? = null,
+    val hasDownloadedSherpaVoice: Boolean = false,
+    val isSelectedSherpaVoiceDownloaded: Boolean = false,
 )
 
 @HiltViewModel
@@ -80,13 +82,19 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             sherpaVoicePackDownloadManager.downloadStates.collect { states ->
                 _uiState.update {
+                    val sherpaRows = SherpaPiperVoice.entries.map { voice ->
+                        SherpaVoiceRowUiState(
+                            voice = voice,
+                            downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
+                        )
+                    }
                     it.copy(
-                        sherpaVoices = SherpaPiperVoice.entries.map { voice ->
-                            SherpaVoiceRowUiState(
-                                voice = voice,
-                                downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
-                            )
+                        sherpaVoices = sherpaRows,
+                        hasDownloadedSherpaVoice = sherpaRows.any { row ->
+                            row.downloadState is VoicePackDownloadState.Downloaded
                         },
+                        isSelectedSherpaVoiceDownloaded =
+                            states[it.selectedSherpaVoice] is VoicePackDownloadState.Downloaded,
                     )
                 }
             }
@@ -120,6 +128,10 @@ class VoiceViewModel @Inject constructor(
     }
 
     fun setSherpaVoice(voice: SherpaPiperVoice) {
+        val row = _uiState.value.sherpaVoices.firstOrNull { it.voice == voice }
+        if (row?.downloadState !is VoicePackDownloadState.Downloaded) {
+            return
+        }
         _uiState.update { it.copy(selectedSherpaVoice = voice) }
         viewModelScope.launch {
             voiceOutputPreferences.setSelectedSherpaVoice(voice)

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -276,6 +276,11 @@ class VoiceViewModelTest {
 
     @Test
     fun `setSherpaVoice updates ui state immediately`() = runTest {
+        sherpaDownloadStates.value = mapOf(
+            SherpaPiperVoice.NorthernEnglishMale to VoicePackDownloadState.Downloaded("/voices/northern"),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
         viewModel.setSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -284,6 +289,31 @@ class VoiceViewModelTest {
             viewModel.uiState.value.selectedSherpaVoice,
         )
         coVerify { voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.NorthernEnglishMale) }
+    }
+
+    @Test
+    fun `setSherpaVoice ignores undownloaded voices`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.setSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(SherpaPiperVoice.JennyDioco, viewModel.uiState.value.selectedSherpaVoice)
+        coVerify(exactly = 0) {
+            voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
+        }
+    }
+
+    @Test
+    fun `Sherpa download flags reflect available and selected voices`() = runTest {
+        sherpaDownloadStates.value = mapOf(
+            SherpaPiperVoice.JennyDioco to VoicePackDownloadState.Downloaded("/voices/jenny"),
+            SherpaPiperVoice.AlanMedium to VoicePackDownloadState.Downloaded("/voices/alan"),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.hasDownloadedSherpaVoice)
+        assertTrue(viewModel.uiState.value.isSelectedSherpaVoiceDownloaded)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Clarify the Voice settings screen so Android TTS vs Sherpa Piper is easier to understand and undownloaded Sherpa voices are no longer selectable.

## Changes
- add clearer helper copy explaining that Android TTS and Sherpa Piper are mutually exclusive spoken-output engines
- show Sherpa-specific guidance when no voice is downloaded or when the saved Sherpa voice is unavailable on the device
- block selection of undownloaded Sherpa voices in both the UI and the view-model
- add focused tests for downloaded-voice gating and Sherpa availability flags

## Testing
- `./gradlew --no-daemon :feature:settings:testDebugUnitTest --tests "com.kernel.ai.feature.settings.VoiceViewModelTest"`
- `./gradlew --no-daemon :app:assembleDebug`

## Related issues
Closes #766
