### PR TITLE
chore(#768): stop bundling sherpa assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,5 @@ debug/*.hprof
 # AAR binary
 third_party/sherpa-onnx/
 
-# Piper / Sherpa-ONNX model assets bundled into APK only after running setup.
+# Legacy local Sherpa voice assets (kept ignored if they still exist from old setup flows).
 core/voice/src/main/assets/sherpa-tts/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,8 @@ dependencies {
     //     before assembleDebug so CI APKs always include the Sherpa runtime.
     // Local dev: Run `bash scripts/setup-sherpa-tts-spike.sh` to obtain the AAR, or
     //     leave it absent — SherpaOnnxVoiceOutputController returns Unavailable and
-    //     Android TTS is used as the runtime fallback.
+    //     Android TTS is used as the runtime fallback. Voice packs themselves now
+    //     download on device from Settings -> Voice instead of being bundled into the APK.
     // Absent AAR → SherpaOnnxVoiceOutputController returns Unavailable → Android TTS used.
     val sherpaAar = rootProject.file("third_party/sherpa-onnx/sherpa-onnx-1.13.0.aar")
     if (sherpaAar.exists()) {

--- a/core/voice/build.gradle.kts
+++ b/core/voice/build.gradle.kts
@@ -31,6 +31,10 @@ android {
             all { it.useJUnitPlatform() }
         }
     }
+
+    sourceSets {
+        getByName("main").assets.setSrcDirs(emptyList<String>())
+    }
 }
 
 // ── Sherpa-ONNX spike (reflection-only — no compile-time dependency on Sherpa) ──────

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -18,29 +18,29 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileOutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Spike implementation of [VoiceOutputController] backed by Sherpa-ONNX + locally prepared Piper
+ * Spike implementation of [VoiceOutputController] backed by Sherpa-ONNX + downloaded Piper
  * English voices.
  *
  * **Design goals (spike):**
  * - Zero direct imports from `com.k2fsa.sherpa.onnx.*` — all Sherpa access goes through
  *   Java reflection so this file compiles even when the AAR has not been downloaded yet.
- * - Graceful [VoiceOutputResult.Unavailable] when either the AAR or the model assets are absent.
+ * - Graceful [VoiceOutputResult.Unavailable] when either the AAR or the downloaded voice pack is
+ *   absent.
  * - Streams PCM floats to [AudioTrack] in chunks so the audio focus and stop() interruptibility
  *   work the same way as [AndroidTextToSpeechController].
- * - Extracts `espeak-ng-data` (and the model itself) from APK assets to [Context.getFilesDir]
- *   because Sherpa-ONNX needs real filesystem paths, not `AssetManager` URIs for those files.
  *
  * **Prerequisites (not committed):**
  * Run `scripts/setup-sherpa-tts-spike.sh` to:
  *   1. Download `sherpa-onnx-1.13.0.aar` → `third_party/sherpa-onnx/`
- *   2. Download Piper voice assets → `core/voice/src/main/assets/sherpa-tts/...`
  *
- * When the AAR/assets are absent the class initialises cleanly to [InitState.UNAVAILABLE] and
+ * Voice packs are provisioned on device from Settings → Voice and extracted to [Context.getFilesDir]
+ * because Sherpa-ONNX needs real filesystem paths, not `AssetManager` URIs for those files.
+ *
+ * When the AAR/voice pack are absent the class initialises cleanly to [InitState.UNAVAILABLE] and
  * [FallbackVoiceOutputController] will route to [AndroidTextToSpeechController] instead.
  */
 @Singleton
@@ -155,35 +155,20 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             )
         }
 
-        // 2. Prefer voice pack downloaded to internal storage over APK assets
+        // 2. Use the voice pack downloaded to internal storage.
         val downloadedDir = voice.voiceDir(context)
-        val modelDir: File = when {
-            voice.isDownloaded(context) -> {
-                Log.i(TAG, "Using downloaded voice pack at ${downloadedDir.absolutePath}")
-                downloadedDir
-            }
-            else -> {
-                // 3. Fall back to APK assets (local dev path — assets are gitignored)
-                val assetsSubdir = voice.assetsSubdirectory
-                val assetsPresent = runCatching {
-                    context.assets.list(assetsSubdir)?.isNotEmpty() == true
-                }.getOrDefault(false)
-
-                if (!assetsPresent) {
-                    Log.i(TAG, "Voice pack not downloaded and not in APK assets: $assetsSubdir. " +
-                        "Use Settings → Voice to download the voice pack.")
-                    initState = InitState.UNAVAILABLE
-                    return VoiceOutputResult.Unavailable(
-                        "Voice pack not yet downloaded for ${voice.displayName}. " +
-                            "Tap Download in Settings → Voice."
-                    )
-                }
-
-                // Extract assets to filesystem so Sherpa gets real paths
-                val extractedDir = File(context.filesDir, assetsSubdir)
-                extractAssetsIfNeeded(assetsSubdir, extractedDir)
-                extractedDir
-            }
+        val modelDir: File = if (voice.isDownloaded(context)) {
+            Log.i(TAG, "Using downloaded voice pack at ${downloadedDir.absolutePath}")
+            downloadedDir
+        } else {
+            Log.i(
+                TAG,
+                "Voice pack not downloaded for ${voice.displayName}. Use Settings → Voice to download it.",
+            )
+            initState = InitState.UNAVAILABLE
+            return VoiceOutputResult.Unavailable(
+                "Voice pack not yet downloaded for ${voice.displayName}. Tap Download in Settings → Voice.",
+            )
         }
 
         return try {
@@ -337,39 +322,6 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             audio.javaClass.getDeclaredField("sampleRate")
                 .also { it.isAccessible = true }
                 .getInt(audio)
-        }
-    }
-
-    // ── Asset extraction ─────────────────────────────────────────────────────
-
-    /**
-     * Copies the Piper model directory from APK assets to [destDir] on the real filesystem.
-     * Skips individual files that already exist so subsequent launches are fast.
-     * espeak-ng-data/ is recursed because Sherpa requires it as a real directory tree.
-     */
-    private fun extractAssetsIfNeeded(assetSubdir: String, destDir: File) {
-        destDir.mkdirs()
-        extractAssetsRecursive(assetSubdir, destDir)
-    }
-
-    private fun extractAssetsRecursive(assetPath: String, destDir: File) {
-        val children = context.assets.list(assetPath) ?: return
-        destDir.mkdirs()
-        for (child in children) {
-            val childAssetPath = "$assetPath/$child"
-            val childDest = File(destDir, child)
-            val isDir = context.assets.list(childAssetPath)?.isNotEmpty() == true
-            if (isDir) {
-                extractAssetsRecursive(childAssetPath, childDest)
-            } else if (!childDest.exists()) {
-                copyAsset(childAssetPath, childDest)
-            }
-        }
-    }
-
-    private fun copyAsset(assetPath: String, destFile: File) {
-        context.assets.open(assetPath).use { inp ->
-            FileOutputStream(destFile).use { out -> inp.copyTo(out) }
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -80,10 +80,6 @@ enum class SherpaPiperVoice(
     val downloadUrl: String
         get() = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/$assetDirectoryName.tar.bz2"
 
-    /** Legacy asset sub-path (used if the voice is still bundled as an APK asset). */
-    val assetsSubdirectory: String
-        get() = "sherpa-tts/$assetDirectoryName"
-
     /** Returns the directory where this voice pack is extracted on internal storage. */
     fun voiceDir(context: Context): File =
         File(context.filesDir, "sherpa-tts/$assetDirectoryName")

--- a/scripts/setup-sherpa-tts-spike.sh
+++ b/scripts/setup-sherpa-tts-spike.sh
@@ -2,19 +2,12 @@
 # =============================================================================
 # scripts/setup-sherpa-tts-spike.sh
 #
-# Downloads the Sherpa-ONNX AAR and prepares a small locally converted en_GB
-# Piper voice pack so the Sherpa TTS spike can be compiled and exercised.
+# Downloads the Sherpa-ONNX AAR needed for the Sherpa TTS spike.
 #
 # NOTHING downloaded here is committed to git — see .gitignore patterns:
 #   third_party/sherpa-onnx/
-#   core/voice/src/main/assets/sherpa-tts/
 #
 # Usage (run from repo root):
-#   bash scripts/setup-sherpa-tts-spike.sh
-#
-# Optional overrides:
-#   PIPER_BASE_URL=https://huggingface.co/rhasspy/piper-voices/resolve/main \
-#   PIPER_VOICE_KEYS=en_GB-jenny_dioco-medium,en_GB-northern_english_male-medium \
 #   bash scripts/setup-sherpa-tts-spike.sh
 #
 # After running, rebuild so Gradle picks up the new AAR:
@@ -29,21 +22,6 @@ AAR_FILE="sherpa-onnx-${SHERPA_VERSION}.aar"
 AAR_DIR="${REPO_ROOT}/third_party/sherpa-onnx"
 AAR_PATH="${AAR_DIR}/${AAR_FILE}"
 SHERPA_AAR_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v${SHERPA_VERSION}/${AAR_FILE}"
-
-PIPER_BASE_URL="${PIPER_BASE_URL:-https://huggingface.co/rhasspy/piper-voices/resolve/main}"
-PIPER_VOICE_KEYS="${PIPER_VOICE_KEYS:-}"
-ESPEAK_ARCHIVE="espeak-ng-data.tar.bz2"
-ESPEAK_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/${ESPEAK_ARCHIVE}"
-
-ASSETS_DIR="${REPO_ROOT}/core/voice/src/main/assets/sherpa-tts"
-DOWNLOADS_DIR="${ASSETS_DIR}/.downloads"
-ESPEAK_ARCHIVE_PATH="${DOWNLOADS_DIR}/${ESPEAK_ARCHIVE}"
-
-VOICE_SPECS=(
-    "en_GB-jenny_dioco-medium|en/en_GB/jenny_dioco/medium|vits-piper-en_GB-jenny_dioco-medium"
-    "en_GB-southern_english_female-low|en/en_GB/southern_english_female/low|vits-piper-en_GB-southern_english_female-low"
-    "en_GB-northern_english_male-medium|en/en_GB/northern_english_male/medium|vits-piper-en_GB-northern_english_male-medium"
-)
 
 info()  { echo "[sherpa-tts-spike] $*"; }
 warn()  { echo "[sherpa-tts-spike] WARN: $*" >&2; }
@@ -73,23 +51,11 @@ download_if_missing() {
     info "${label} saved to: ${dest}"
 }
 
-should_prepare_voice() {
-    local voice_key="$1"
-    if [[ -z "${PIPER_VOICE_KEYS}" ]]; then
-        return 0
-    fi
-
-    local padded=",${PIPER_VOICE_KEYS},"
-    [[ "${padded}" == *",${voice_key},"* ]]
-}
-
 require_cmd curl
-require_cmd tar
-require_cmd python3
 
 info "Repo root: ${REPO_ROOT}"
 
-mkdir -p "${AAR_DIR}" "${ASSETS_DIR}" "${DOWNLOADS_DIR}"
+mkdir -p "${AAR_DIR}"
 
 if [[ -f "${AAR_PATH}" ]]; then
     info "AAR already present: ${AAR_PATH} (skipping download)"
@@ -112,108 +78,23 @@ if [[ "${AAR_SIZE}" -lt 1000000 ]]; then
     warn "Delete ${AAR_PATH} and re-run if the build fails with class-not-found errors."
 fi
 
-if ! download_if_missing "${ESPEAK_URL}" "${ESPEAK_ARCHIVE_PATH}" "espeak-ng-data archive"; then
-    error "Failed to download espeak-ng-data from ${ESPEAK_URL}"
-fi
-
-READY_VOICES=()
-FAILED_VOICES=()
-
-for spec in "${VOICE_SPECS[@]}"; do
-    IFS="|" read -r voice_key voice_hf_path asset_dir_name <<< "${spec}"
-    if ! should_prepare_voice "${voice_key}"; then
-        continue
-    fi
-
-    raw_model_name="${voice_key}.onnx"
-    raw_json_name="${voice_key}.onnx.json"
-    raw_model_path="${DOWNLOADS_DIR}/${raw_model_name}"
-    raw_json_path="${DOWNLOADS_DIR}/${raw_json_name}"
-    voice_assets_dir="${ASSETS_DIR}/${asset_dir_name}"
-    espeak_dir="${voice_assets_dir}/espeak-ng-data"
-    piper_onnx_url="${PIPER_BASE_URL}/${voice_hf_path}/${raw_model_name}?download=true"
-    piper_json_url="${PIPER_BASE_URL}/${voice_hf_path}/${raw_json_name}?download=true"
-
-    info "Preparing Sherpa Piper voice: ${voice_key}"
-    voice_ready=true
-
-    if ! download_if_missing "${piper_onnx_url}" "${raw_model_path}" "raw Piper ONNX model (${voice_key})"; then
-        warn "Failed to download Piper ONNX model from ${piper_onnx_url}"
-        voice_ready=false
-    fi
-
-    if [[ "${voice_ready}" == true ]] &&
-        ! download_if_missing "${piper_json_url}" "${raw_json_path}" "raw Piper JSON config (${voice_key})"; then
-        warn "Failed to download Piper JSON config from ${piper_json_url}"
-        voice_ready=false
-    fi
-
-    if [[ "${voice_ready}" == true ]]; then
-        rm -rf "${espeak_dir}"
-        mkdir -p "${voice_assets_dir}"
-        info "Extracting espeak-ng-data for ${voice_key}..."
-        tar -xjf "${ESPEAK_ARCHIVE_PATH}" -C "${voice_assets_dir}"
-
-        info "Converting raw Piper voice into Sherpa layout (${voice_key})..."
-        python3 "${REPO_ROOT}/scripts/convert_piper_voice.py" \
-            --voice-key "${voice_key}" \
-            --input-model "${raw_model_path}" \
-            --input-config "${raw_json_path}" \
-            --output-dir "${voice_assets_dir}"
-    fi
-
-    all_ok=true
-    if [[ "${voice_ready}" == true ]]; then
-        for required in model.onnx tokens.txt espeak-ng-data; do
-            if [[ ! -e "${voice_assets_dir}/${required}" ]]; then
-                warn "Expected file/dir missing: ${voice_assets_dir}/${required}"
-                all_ok=false
-            fi
-        done
-    else
-        all_ok=false
-    fi
-
-    if [[ "${all_ok}" == true ]]; then
-        info "✓ ${voice_key} ready at ${voice_assets_dir}"
-        READY_VOICES+=("${voice_key}")
-    else
-        warn "${voice_key} is incomplete. Android TTS will remain available as fallback."
-        FAILED_VOICES+=("${voice_key}")
-    fi
-done
-
 echo ""
 echo "================================================================="
-echo "  Sherpa-ONNX TTS spike setup complete"
+  echo "  Sherpa-ONNX TTS spike setup complete"
 echo "================================================================="
 echo ""
 echo "  AAR: ${AAR_PATH}"
-if [[ "${#READY_VOICES[@]}" -gt 0 ]]; then
-    echo "  Ready voices:"
-    for voice_key in "${READY_VOICES[@]}"; do
-        echo "    - ${voice_key}"
-    done
-else
-    echo "  Ready voices: none"
-fi
-if [[ "${#FAILED_VOICES[@]}" -gt 0 ]]; then
-    echo "  Incomplete voices:"
-    for voice_key in "${FAILED_VOICES[@]}"; do
-        echo "    - ${voice_key}"
-    done
-fi
 echo ""
 echo "  Notes:"
-echo "    - The southern-English public Piper pack currently resolves as low quality, so"
-echo "      this setup prepares en_GB-southern_english_female-low for that option."
+echo "    - Voice packs are now downloaded on device from Settings -> Voice."
+echo "    - The build no longer bundles local sherpa-tts assets into the APK."
 echo "    - Android TTS remains available as the runtime fallback."
 echo ""
 echo "  Next steps:"
 echo "    1. Rebuild the project so Gradle picks up the new AAR:"
 echo "       ./gradlew :app:assembleDebug"
 echo ""
-echo "    2. Install on device and exercise the voice output path."
+echo "    2. Install on device, open Settings -> Voice, and download a Sherpa voice pack."
 echo "       Logcat tag 'KernelAI' shows which backend is selected."
 echo ""
 echo "  To revert to Android TTS only (without touching code):"


### PR DESCRIPTION
## Summary
Stop bundling legacy Sherpa voice assets into the APK now that Sherpa voices are download-only.

## Changes
- remove the Sherpa runtime fallback that loaded voices from APK assets
- configure `core:voice` to package no module assets, so stray local `sherpa-tts` folders cannot bloat the APK
- simplify the local Sherpa setup script so it only downloads the runtime AAR
- update comments to reflect that Sherpa voices are provisioned on device from Settings -> Voice

## Testing
- `./gradlew --no-daemon :core:voice:testDebugUnitTest`
- `./gradlew --no-daemon :app:assembleDebug`
- built with a synthetic local `core/voice/src/main/assets/sherpa-tts/test-pack/marker.txt` and confirmed the APK contained no `sherpa-tts` assets

## Related issues
Closes #768
