### PR TITLE
feat(#763): add spoken summaries for voice replies

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillResult.kt
@@ -21,17 +21,27 @@ package com.kernel.ai.core.skills
  */
 sealed class SkillResult {
     /** Skill ran successfully. [content] is injected back into the conversation as system context
-     *  so the LLM can produce a natural conversational wrapper around it. */
+     *  so the LLM can produce a natural conversational wrapper around it.
+     *
+     *  [spokenSummary] is an optional concise phrase for TTS — voice surfaces should speak this
+     *  instead of [content] when provided. Use it for skills that return structured data that
+     *  reads awkwardly aloud (e.g. compact units, emojis, multi-line formatting). */
     data class Success(
         val content: String,
         val presentation: ToolPresentation? = null,
+        val spokenSummary: String? = null,
     ) : SkillResult()
     /** Skill ran successfully and [content] should be shown to the user verbatim — the LLM is
      *  bypassed entirely. Use for skills that return structured data (e.g. weather readings,
-     *  sensor values) where LLM rephrasing risks corrupting numbers or units. */
+     *  sensor values) where LLM rephrasing risks corrupting numbers or units.
+     *
+     *  [spokenSummary] is an optional concise phrase for TTS — voice surfaces should speak this
+     *  instead of [content] when provided. Keeps the display text rich while the spoken version
+     *  expands units and drops emojis/formatting that TTS would read literally. */
     data class DirectReply(
         val content: String,
         val presentation: ToolPresentation? = null,
+        val spokenSummary: String? = null,
     ) : SkillResult()
     /** Skill not found in registry. */
     data class UnknownSkill(val skillName: String) : SkillResult()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentationSpokenSummary.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/ToolPresentationSpokenSummary.kt
@@ -1,0 +1,37 @@
+package com.kernel.ai.core.skills
+
+/**
+ * Converts a [ToolPresentation] into a concise, listener-friendly spoken summary for TTS.
+ *
+ * Display text is formatted for on-screen reading: emojis, compact units like `25°C`, multi-line
+ * layout, and terse separators like `H 27°C / L 18°C`. TTS reads all of that literally.
+ *
+ * Fallback order for voice surfaces:
+ * 1. skill-provided `spokenSummary`
+ * 2. [ToolPresentation.toSpokenSummary]
+ * 3. generic display-text truncation in the caller
+ */
+fun ToolPresentation.toSpokenSummary(): String? = when (this) {
+    is ToolPresentation.Weather -> toSpokenSummary()
+    is ToolPresentation.Status,
+    is ToolPresentation.ListPreview,
+    is ToolPresentation.ComputedResult,
+    -> null
+}
+
+fun ToolPresentation.Weather.toSpokenSummary(): String = buildString {
+    val cityName = locationName.substringBefore(",").trim().takeIf { it.isNotBlank() } ?: locationName
+    val expandedTemp = temperatureText.expandTemperatureUnits()
+    append("In $cityName, it's $expandedTemp")
+    if (description.isNotBlank() && description != "Unknown") {
+        append(", $description")
+    }
+    feelsLikeText?.let { feels ->
+        append(", ${feels.expandTemperatureUnits().replaceFirstChar { it.lowercase() }}")
+    }
+    append(".")
+}
+
+internal fun String.expandTemperatureUnits(): String =
+    replace(Regex("""(-?\d+)°C"""), "$1 degrees Celsius")
+        .replace(Regex("""(-?\d+)°F"""), "$1 degrees Fahrenheit")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/GetWeatherSkill.kt
@@ -21,6 +21,7 @@ import okhttp3.Request
 import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.roundToInt
 
 private const val TAG = "KernelAI"
 
@@ -349,6 +350,13 @@ class GetWeatherSkill @Inject constructor(
                 sunText = sunStr,
             )
         }
+        val spokenDays = (0 until len).map { i ->
+            val formattedDate = formatForecastDate(dates.getString(i))
+            val desc = wmoDescription(codes.optInt(i, -1))
+            val high = maxTemps.optDouble(i, Double.NaN)
+            val low = minTemps.optDouble(i, Double.NaN)
+            Triple(formattedDate, desc, Pair(high.takeUnless { it.isNaN() }, low.takeUnless { it.isNaN() }))
+        }
         Log.d(TAG, "GetWeatherSkill: fetched ${len}-day forecast for $locationLabel")
         val firstCode = codes.optInt(0, -1)
         val firstHigh = maxTemps.optDouble(0, Double.NaN)
@@ -399,6 +407,10 @@ class GetWeatherSkill @Inject constructor(
                 airQualityText = null,
                 sunText = sunText,
                 forecast = forecastDays,
+            ),
+            spokenSummary = buildMultiDayForecastSpoken(
+                locationLabel = locationLabel,
+                days = spokenDays,
             ),
         )
     }
@@ -507,6 +519,13 @@ class GetWeatherSkill @Inject constructor(
                 uvText = uvMax?.let { "UV max %.0f (%s)".format(it, uvIndexLabel(it)) },
                 airQualityText = null,
                 sunText = sunText,
+            ),
+            spokenSummary = buildSingleDayForecastSpoken(
+                locationLabel = locationLabel,
+                dayLabel = if (dayIndex == 1) "Tomorrow" else formattedDate,
+                description = desc,
+                high = high,
+                low = low,
             ),
         )
     }
@@ -719,6 +738,14 @@ class GetWeatherSkill @Inject constructor(
                 airQualityText = airQuality?.usAqi?.let { "AQI $it (${aqiLabel(it)})" },
                 sunText = sunText,
             ),
+            spokenSummary = buildCurrentWeatherSpoken(
+                locationLabel = locationLabel,
+                description = description,
+                temp = temp,
+                feelsLike = feelsLike,
+                tempMax = tempMax,
+                tempMin = tempMin,
+            ),
         )
     }
 
@@ -737,6 +764,83 @@ class GetWeatherSkill @Inject constructor(
         aqi <= 200 -> "Unhealthy"
         else -> "Very Unhealthy"
     }
+
+    internal fun locationForSpeech(locationLabel: String?): String =
+        locationLabel?.substringBefore(",")?.trim()?.takeIf { it.isNotBlank() } ?: "your location"
+
+    internal fun buildCurrentWeatherSpoken(
+        locationLabel: String?,
+        description: String,
+        temp: Double,
+        feelsLike: Double,
+        tempMax: Double?,
+        tempMin: Double?,
+    ): String {
+        val place = locationForSpeech(locationLabel)
+        val headline = buildList {
+            if (!temp.isNaN()) add("it's ${temp.toRoundedDegreesText()}")
+            if (description.isNotBlank() && description != "Unknown") add(description.lowercase())
+            if (!feelsLike.isNaN()) add("feeling like ${feelsLike.toRoundedDegreesText()}")
+        }
+        val highLow = buildList {
+            tempMax?.let { add("high is ${it.toRoundedDegreesText()}") }
+            tempMin?.let { add("low is ${it.toRoundedDegreesText()}") }
+        }
+        return buildString {
+            append(
+                if (headline.isNotEmpty()) {
+                    "In $place, ${headline.joinToString(", ")}."
+                } else {
+                    "Here's the weather for $place."
+                },
+            )
+            if (highLow.isNotEmpty()) append(" Today's ${highLow.joinToString(", ")}.")
+        }
+    }
+
+    internal fun buildMultiDayForecastSpoken(
+        locationLabel: String?,
+        days: List<Triple<String, String, Pair<Double?, Double?>>>,
+    ): String {
+        val place = locationForSpeech(locationLabel)
+        val daySlice = days.take(3)
+        return buildString {
+            append("$place ${daySlice.size}-day forecast.")
+            for ((date, description, temps) in daySlice) {
+                val (high, low) = temps
+                val parts = buildList {
+                    if (description.isNotBlank() && description != "Unknown") add(description.lowercase())
+                    if (high != null && !high.isNaN()) add("high ${high.toRoundedDegreesText()}")
+                    if (low != null && !low.isNaN()) add("low ${low.toRoundedDegreesText()}")
+                }
+                append(" $date")
+                if (parts.isNotEmpty()) append(": ${parts.joinToString(", ")}")
+                append(".")
+            }
+        }
+    }
+
+    internal fun buildSingleDayForecastSpoken(
+        locationLabel: String?,
+        dayLabel: String,
+        description: String,
+        high: Double,
+        low: Double,
+    ): String {
+        val place = locationForSpeech(locationLabel)
+        val parts = buildList {
+            if (description.isNotBlank() && description != "Unknown") add(description.lowercase())
+            if (!high.isNaN()) add("high ${high.toRoundedDegreesText()}")
+            if (!low.isNaN()) add("low ${low.toRoundedDegreesText()}")
+        }
+        return buildString {
+            append("$dayLabel in $place")
+            if (parts.isNotEmpty()) append(": ${parts.joinToString(", ")}")
+            append(".")
+        }
+    }
+
+    private fun Double.toRoundedDegreesText(): String = "${roundToInt()} degrees"
 
     // ── WMO code → description / emoji ───────────────────────────────────────
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationSpokenSummaryTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/ToolPresentationSpokenSummaryTest.kt
@@ -1,0 +1,176 @@
+package com.kernel.ai.core.skills
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ToolPresentationSpokenSummaryTest {
+    private fun weather(
+        locationName: String = "Wellington",
+        temperatureText: String = "25°C",
+        feelsLikeText: String? = "Feels like 23°C",
+        description: String = "Partly cloudy",
+        emoji: String = "⛅",
+        highLowText: String? = "H 27°C / L 18°C",
+    ): ToolPresentation.Weather = ToolPresentation.Weather(
+        locationName = locationName,
+        temperatureText = temperatureText,
+        feelsLikeText = feelsLikeText,
+        description = description,
+        emoji = emoji,
+        highLowText = highLowText,
+        humidityText = "Humidity 60%",
+        windText = "NW 15 km/h",
+        precipText = "20%",
+        airQualityText = null,
+    )
+
+    @Test
+    fun `toSpokenSummary returns non-null for Weather presentation`() {
+        val presentation: ToolPresentation = weather()
+        assertNotNull(presentation.toSpokenSummary())
+    }
+
+    @Test
+    fun `toSpokenSummary returns null for Status presentation`() {
+        val presentation: ToolPresentation = ToolPresentation.Status(icon = "✓", title = "Done")
+        assertNull(presentation.toSpokenSummary())
+    }
+
+    @Test
+    fun `toSpokenSummary returns null for ListPreview presentation`() {
+        val presentation: ToolPresentation =
+            ToolPresentation.ListPreview(title = "My list", items = listOf("A", "B"), totalCount = 2)
+        assertNull(presentation.toSpokenSummary())
+    }
+
+    @Test
+    fun `toSpokenSummary returns null for ComputedResult presentation`() {
+        val presentation: ToolPresentation =
+            ToolPresentation.ComputedResult(primaryText = "42", contextText = "Meaning of life")
+        assertNull(presentation.toSpokenSummary())
+    }
+
+    @Test
+    fun `weather spoken summary contains location name`() {
+        val spoken = weather(locationName = "Wellington").toSpokenSummary()
+        assertTrue(spoken.contains("Wellington"))
+    }
+
+    @Test
+    fun `weather spoken summary strips country code from location`() {
+        val spoken = weather(locationName = "Brisbane, AU").toSpokenSummary()
+        assertTrue(spoken.contains("Brisbane"))
+        assertFalse(spoken.contains(", AU"))
+    }
+
+    @Test
+    fun `weather spoken summary expands temperature to degrees Celsius`() {
+        val spoken = weather(temperatureText = "25°C").toSpokenSummary()
+        assertTrue(spoken.contains("25 degrees Celsius"))
+        assertFalse(spoken.contains("25°C"))
+    }
+
+    @Test
+    fun `weather spoken summary contains description in original case`() {
+        val spoken = weather(description = "Partly cloudy").toSpokenSummary()
+        assertTrue(spoken.contains("Partly cloudy"))
+    }
+
+    @Test
+    fun `weather spoken summary includes feels-like temperature when present`() {
+        val spoken = weather(feelsLikeText = "Feels like 23°C").toSpokenSummary()
+        assertTrue(spoken.contains("23 degrees Celsius"))
+        assertFalse(spoken.contains("23°C"))
+    }
+
+    @Test
+    fun `weather spoken summary omits feels-like when null`() {
+        val spoken = weather(feelsLikeText = null).toSpokenSummary()
+        assertFalse(spoken.contains("feels"))
+    }
+
+    @Test
+    fun `weather spoken summary does not contain high-low display text`() {
+        val spoken = weather(highLowText = "H 27°C / L 18°C").toSpokenSummary()
+        assertFalse(spoken.contains("H 27°C"))
+        assertFalse(spoken.contains("/ L"))
+    }
+
+    @Test
+    fun `weather spoken summary does not contain emoji`() {
+        val spoken = weather(emoji = "⛅").toSpokenSummary()
+        assertFalse(spoken.contains("⛅"))
+    }
+
+    @Test
+    fun `weather spoken summary does not contain degree symbol`() {
+        val spoken = weather().toSpokenSummary()
+        assertFalse(spoken.contains("°"))
+    }
+
+    @Test
+    fun `weather spoken summary differs from raw display text`() {
+        val displayText = "Wellington forecast: 25°C, feels like 23°C. H 27°C / L 18°C. Wind NW 15 km/h."
+        val spoken = weather().toSpokenSummary()
+        assertTrue(spoken != displayText)
+    }
+
+    @Test
+    fun `weather spoken summary omits Unknown description`() {
+        val spoken = weather(description = "Unknown").toSpokenSummary()
+        assertFalse(spoken.contains("Unknown"))
+        assertFalse(spoken.contains("unknown"))
+    }
+
+    @Test
+    fun `weather spoken summary handles negative temperature`() {
+        val spoken = weather(
+            temperatureText = "-3°C",
+            feelsLikeText = "Feels like -6°C",
+        ).toSpokenSummary()
+        assertTrue(spoken.contains("-3 degrees Celsius"))
+        assertTrue(spoken.contains("-6 degrees Celsius"))
+    }
+
+    @Test
+    fun `weather spoken summary handles Fahrenheit temperature`() {
+        val spoken = weather(
+            temperatureText = "77°F",
+            feelsLikeText = "Feels like 74°F",
+        ).toSpokenSummary()
+        assertTrue(spoken.contains("77 degrees Fahrenheit"))
+        assertFalse(spoken.contains("77°F"))
+    }
+
+    @Test
+    fun `expandTemperatureUnits expands Celsius`() {
+        assertEquals("25 degrees Celsius", "25°C".expandTemperatureUnits())
+    }
+
+    @Test
+    fun `expandTemperatureUnits expands Fahrenheit`() {
+        assertEquals("77 degrees Fahrenheit", "77°F".expandTemperatureUnits())
+    }
+
+    @Test
+    fun `expandTemperatureUnits expands negative Celsius`() {
+        assertEquals("-3 degrees Celsius", "-3°C".expandTemperatureUnits())
+    }
+
+    @Test
+    fun `expandTemperatureUnits expands both units in same string`() {
+        val result = "Feels like 23°C or 73°F".expandTemperatureUnits()
+        assertTrue(result.contains("23 degrees Celsius"))
+        assertTrue(result.contains("73 degrees Fahrenheit"))
+    }
+
+    @Test
+    fun `expandTemperatureUnits passes through strings without units`() {
+        val noUnit = "This has no temperature notation."
+        assertEquals(noUnit, noUnit.expandTemperatureUnits())
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/GetWeatherSpokenSummaryTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/GetWeatherSpokenSummaryTest.kt
@@ -1,0 +1,189 @@
+package com.kernel.ai.core.skills.natives
+
+import io.mockk.mockk
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GetWeatherSpokenSummaryTest {
+    private val skill = GetWeatherSkill(
+        context = mockk(relaxed = true),
+        httpClient = mockk<OkHttpClient>(),
+    )
+
+    @Test
+    fun `locationForSpeech strips country code from reverse-geocoded label`() {
+        assertEquals("Brisbane", skill.locationForSpeech("Brisbane, AU"))
+    }
+
+    @Test
+    fun `locationForSpeech returns bare city name unchanged`() {
+        assertEquals("Auckland", skill.locationForSpeech("Auckland"))
+    }
+
+    @Test
+    fun `locationForSpeech returns placeholder for null`() {
+        assertEquals("your location", skill.locationForSpeech(null))
+    }
+
+    @Test
+    fun `locationForSpeech returns placeholder for blank`() {
+        assertEquals("your location", skill.locationForSpeech("   "))
+    }
+
+    @Test
+    fun `locationForSpeech handles multi-part label by taking only first segment`() {
+        assertEquals("Murrumba Downs", skill.locationForSpeech("Murrumba Downs, QLD, AU"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken produces natural current-conditions sentence`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Brisbane, AU",
+            description = "Partly cloudy",
+            temp = 25.0,
+            feelsLike = 24.0,
+            tempMax = 28.0,
+            tempMin = 18.0,
+        )
+        assertEquals(
+            "In Brisbane, it's 25 degrees, partly cloudy, feeling like 24 degrees. Today's high is 28 degrees, low is 18 degrees.",
+            spoken,
+        )
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken omits feels-like when NaN`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Sydney",
+            description = "Clear sky",
+            temp = 22.0,
+            feelsLike = Double.NaN,
+            tempMax = 24.0,
+            tempMin = 16.0,
+        )
+        assertFalse(spoken.contains("feeling"))
+        assertTrue(spoken.contains("22 degrees"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken omits high-low when both null`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Melbourne",
+            description = "Rain",
+            temp = 18.0,
+            feelsLike = 16.0,
+            tempMax = null,
+            tempMin = null,
+        )
+        assertFalse(spoken.contains("high"))
+        assertFalse(spoken.contains("low"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken omits high when only min available`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Canberra",
+            description = "Fog",
+            temp = 10.0,
+            feelsLike = 9.0,
+            tempMax = null,
+            tempMin = 6.0,
+        )
+        assertFalse(spoken.contains("high"))
+        assertTrue(spoken.contains("low is 6 degrees"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken skips unknown description`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "GPS location",
+            description = "Unknown",
+            temp = 20.0,
+            feelsLike = 19.0,
+            tempMax = 22.0,
+            tempMin = 14.0,
+        )
+        assertFalse(spoken.contains("unknown"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken rounds temperature to nearest integer`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Perth",
+            description = "Clear sky",
+            temp = 25.6,
+            feelsLike = 24.3,
+            tempMax = 28.9,
+            tempMin = 18.1,
+        )
+        assertTrue(spoken.contains("26 degrees"))
+        assertTrue(spoken.contains("24 degrees"))
+        assertTrue(spoken.contains("29 degrees"))
+        assertTrue(spoken.contains("18 degrees"))
+    }
+
+    @Test
+    fun `buildCurrentWeatherSpoken does not contain degree symbol`() {
+        val spoken = skill.buildCurrentWeatherSpoken(
+            locationLabel = "Darwin",
+            description = "Overcast",
+            temp = 31.0,
+            feelsLike = 35.0,
+            tempMax = 33.0,
+            tempMin = 25.0,
+        )
+        assertFalse(spoken.contains("°"))
+    }
+
+    @Test
+    fun `buildMultiDayForecastSpoken produces natural forecast sentence`() {
+        val days = listOf(
+            Triple("Mon 2 Jun", "Partly cloudy", Pair(25.0, 18.0)),
+            Triple("Tue 3 Jun", "Rain", Pair(22.0, 15.0)),
+        )
+        val spoken = skill.buildMultiDayForecastSpoken("Brisbane, AU", days)
+        assertEquals(
+            "Brisbane 2-day forecast. Mon 2 Jun: partly cloudy, high 25 degrees, low 18 degrees. Tue 3 Jun: rain, high 22 degrees, low 15 degrees.",
+            spoken,
+        )
+    }
+
+    @Test
+    fun `buildMultiDayForecastSpoken caps output at 3 days`() {
+        val days = (1..7).map { i ->
+            Triple("Day $i", "Clear sky", Pair(25.0, 18.0))
+        }
+        val spoken = skill.buildMultiDayForecastSpoken("Sydney", days)
+        assertTrue(spoken.contains("3-day forecast"))
+        assertFalse(spoken.contains("Day 4"))
+    }
+
+    @Test
+    fun `buildMultiDayForecastSpoken handles null high or low gracefully`() {
+        val days = listOf(
+            Triple("Mon", "Clear sky", Pair(null as Double?, null as Double?)),
+        )
+        val spoken = skill.buildMultiDayForecastSpoken("Hobart", days)
+        assertFalse(spoken.contains("high"))
+        assertFalse(spoken.contains("low"))
+        assertTrue(spoken.contains("clear sky"))
+    }
+
+    @Test
+    fun `buildSingleDayForecastSpoken produces natural tomorrow sentence`() {
+        val spoken = skill.buildSingleDayForecastSpoken(
+            locationLabel = "Brisbane, AU",
+            dayLabel = "Tomorrow",
+            description = "Rain",
+            high = 22.0,
+            low = 15.0,
+        )
+        assertEquals(
+            "Tomorrow in Brisbane: rain, high 22 degrees, low 15 degrees.",
+            spoken,
+        )
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.text.input.ImeAction
 import com.kernel.ai.core.memory.entity.QuickActionEntity
 import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.voice.VoiceCaptureMode
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -108,6 +109,7 @@ fun ActionsScreen(
     val pendingSlot by viewModel.pendingSlot.collectAsStateWithLifecycle()
     val voiceCaptureState by viewModel.voiceCaptureState.collectAsStateWithLifecycle()
     val voicePlaybackState by viewModel.voicePlaybackState.collectAsStateWithLifecycle()
+    val slotReplyAutoRearmArmed by viewModel.slotReplyAutoRearmArmed.collectAsStateWithLifecycle()
     val currentVoiceCaptureState = voiceCaptureState
     val isCommandVoiceActive = when (currentVoiceCaptureState) {
         is ActionsViewModel.VoiceCaptureState.Preparing -> currentVoiceCaptureState.mode == VoiceCaptureMode.Command
@@ -484,6 +486,7 @@ fun ActionsScreen(
             inputMode = slot.inputMode,
             uiState = uiState,
             voiceCaptureState = voiceCaptureState,
+            autoVoiceReplyArmed = slotReplyAutoRearmArmed,
             onDismiss = { viewModel.cancelSlotFill() },
             onSubmit = { reply -> viewModel.onSlotReply(reply) },
             onVoiceReply = { requestVoiceCapture(VoiceCaptureMode.SlotReply) },
@@ -519,6 +522,7 @@ private fun SlotFillBottomSheet(
     inputMode: InputMode,
     uiState: ActionsViewModel.UiState,
     voiceCaptureState: ActionsViewModel.VoiceCaptureState,
+    autoVoiceReplyArmed: Boolean,
     onDismiss: () -> Unit,
     onSubmit: (String) -> Unit,
     onVoiceReply: () -> Unit,
@@ -536,6 +540,14 @@ private fun SlotFillBottomSheet(
         ActionsViewModel.VoiceCaptureState.Idle -> null
     }
     val isVoiceReplyActive = slotReplyCaptureState != null
+
+    LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed, isVoiceReplyActive) {
+        if (inputMode != InputMode.Voice || !autoVoiceReplyArmed || isVoiceReplyActive) return@LaunchedEffect
+        delay(estimatedSlotPromptDurationMs(promptMessage))
+        if (!isVoiceReplyActive && autoVoiceReplyArmed) {
+            onVoiceReply()
+        }
+    }
 
     fun submit() {
         val text = inputText.trim()
@@ -645,6 +657,13 @@ private fun SlotFillBottomSheet(
             }
         }
     }
+}
+
+private fun estimatedSlotPromptDurationMs(promptMessage: String): Long {
+    val normalizedPrompt = promptMessage.trim()
+    if (normalizedPrompt.isBlank()) return 3_500L
+    val estimatedSpeechMs = normalizedPrompt.length * 50L
+    return (estimatedSpeechMs + 1_500L).coerceIn(3_000L, 6_000L)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -554,6 +554,17 @@ private fun SlotFillBottomSheet(
         ActionsViewModel.VoiceCaptureState.Idle -> null
     }
     val isVoiceReplyActive = slotReplyCaptureState != null
+    val loopListeningCueState = when (slotReplyCaptureState) {
+        is ActionsViewModel.VoiceCaptureState.Preparing -> LoopListeningCueState.Preparing
+        is ActionsViewModel.VoiceCaptureState.Listening -> LoopListeningCueState.Listening
+        is ActionsViewModel.VoiceCaptureState.Processing -> LoopListeningCueState.Processing
+        ActionsViewModel.VoiceCaptureState.Idle, null -> LoopListeningCueState.Idle
+    }
+
+    LoopListeningCueEffect(
+        loopActive = inputMode == InputMode.Voice,
+        captureState = loopListeningCueState,
+    )
 
     LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed) {
         Log.d(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.feature.chat
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -89,6 +90,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+private const val ACTIONS_SCREEN_TAG = "KernelAI"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActionsScreen(
@@ -135,6 +138,7 @@ fun ActionsScreen(
     ) { granted ->
         val mode = pendingPermissionMode
         pendingPermissionMode = null
+        Log.d(ACTIONS_SCREEN_TAG, "ActionsScreen: microphone permission result granted=$granted mode=$mode")
         if (!granted) {
             viewModel.onMicrophonePermissionDenied()
             return@rememberLauncherForActivityResult
@@ -161,6 +165,10 @@ fun ActionsScreen(
             context,
             Manifest.permission.RECORD_AUDIO,
         ) == PackageManager.PERMISSION_GRANTED
+        Log.d(
+            ACTIONS_SCREEN_TAG,
+            "ActionsScreen: requestVoiceCapture mode=$mode alreadyGranted=$alreadyGranted",
+        )
         if (alreadyGranted) {
             when (mode) {
                 VoiceCaptureMode.Command -> viewModel.startVoiceCommand()
@@ -541,10 +549,27 @@ private fun SlotFillBottomSheet(
     }
     val isVoiceReplyActive = slotReplyCaptureState != null
 
+    LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed) {
+        Log.d(
+            ACTIONS_SCREEN_TAG,
+            "ActionsScreen: SlotFillBottomSheet shown inputMode=$inputMode autoVoiceReplyArmed=$autoVoiceReplyArmed " +
+                "prompt=\"$promptMessage\"",
+        )
+    }
+
     LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed, isVoiceReplyActive) {
         if (inputMode != InputMode.Voice || !autoVoiceReplyArmed || isVoiceReplyActive) return@LaunchedEffect
-        delay(estimatedSlotPromptDurationMs(promptMessage))
+        val delayMs = estimatedSlotPromptDurationMs(promptMessage)
+        Log.d(
+            ACTIONS_SCREEN_TAG,
+            "ActionsScreen: scheduling slot voice fallback delayMs=$delayMs prompt=\"$promptMessage\"",
+        )
+        delay(delayMs)
         if (!isVoiceReplyActive && autoVoiceReplyArmed) {
+            Log.w(
+                ACTIONS_SCREEN_TAG,
+                "ActionsScreen: slot voice fallback firing prompt=\"$promptMessage\"",
+            )
             onVoiceReply()
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -217,7 +217,7 @@ fun ActionsScreen(
         viewModel.events.collect { event ->
             when (event) {
                 is ActionsViewModel.UiEvent.NavigateToChat -> {
-                    viewModel.pauseTransientVoiceUi()
+                    viewModel.pauseTransientVoiceUi(reason = "navigateToChat")
                     onNavigateToChat(event.query)
                 }
                 ActionsViewModel.UiEvent.RequestPhonePermission ->
@@ -229,7 +229,13 @@ fun ActionsScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
-                viewModel.pauseTransientVoiceUi()
+                Log.d(
+                    ACTIONS_SCREEN_TAG,
+                    "ActionsScreen: lifecycle ON_STOP pendingSlot=${pendingSlot != null} " +
+                        "showBottomSheet=$showBottomSheet voiceCaptureState=$voiceCaptureState " +
+                        "voicePlaybackState=$voicePlaybackState",
+                )
+                viewModel.pauseTransientVoiceUi(reason = "lifecycleOnStop")
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -515,6 +515,11 @@ class ActionsViewModel @Inject constructor(
         inputMode: InputMode,
         delayVoicePrompt: Boolean = false,
     ) {
+        Log.d(
+            TAG,
+            "ActionsViewModel: primePendingSlot intent=$intentName inputMode=$inputMode " +
+                "missing=${missingSlot.name} delayVoicePrompt=$delayVoicePrompt",
+        )
         _pendingSlot.value = PendingSlotState(
             request = PendingSlotRequest(
                 intentName = intentName,
@@ -528,6 +533,11 @@ class ActionsViewModel @Inject constructor(
         if (inputMode == InputMode.Voice) {
             _voiceCaptureState.value = VoiceCaptureState.Idle
         }
+        Log.d(
+            TAG,
+            "ActionsViewModel: slot prompt=\"${_pendingSlot.value?.request?.promptMessage}\" " +
+                "autoRearm=$shouldAutoStartVoiceSlotReply spokenResponsesEnabled=$spokenResponsesEnabled",
+        )
         speakForVoice(
             inputMode,
             _pendingSlot.value?.request?.promptMessage.orEmpty(),
@@ -673,6 +683,11 @@ class ActionsViewModel @Inject constructor(
         mode: VoiceCaptureMode,
         interruptPlayback: Boolean = true,
     ) {
+        Log.d(
+            TAG,
+            "ActionsViewModel: startVoiceCapture mode=$mode interruptPlayback=$interruptPlayback " +
+                "pendingSlot=${_pendingSlot.value != null}",
+        )
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
         _error.value = null
@@ -683,11 +698,13 @@ class ActionsViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = voiceInputController.startListening(mode)) {
                 is VoiceInputStartResult.Started -> {
+                    Log.d(TAG, "ActionsViewModel: voiceInputController.startListening started mode=$mode")
                     if (_voiceCaptureState.value is VoiceCaptureState.Preparing) {
                         _voiceCaptureState.value = VoiceCaptureState.Listening(mode)
                     }
                 }
                 is VoiceInputStartResult.Unavailable -> {
+                    Log.w(TAG, "ActionsViewModel: voiceInputController.startListening unavailable mode=$mode message=${result.message}")
                     _voiceCaptureState.value = VoiceCaptureState.Idle
                     _error.value = result.message
                 }
@@ -723,6 +740,7 @@ class ActionsViewModel @Inject constructor(
     }
 
     private fun setSlotReplyAutoRearmArmed(armed: Boolean) {
+        Log.d(TAG, "ActionsViewModel: setSlotReplyAutoRearmArmed armed=$armed")
         shouldAutoStartVoiceSlotReply = armed
         _slotReplyAutoRearmArmed.value = armed
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -158,7 +158,7 @@ class ActionsViewModel @Inject constructor(
                 if (enabled) {
                     voiceOutputController.warmUp()
                 } else {
-                    setSlotReplyAutoRearmArmed(false)
+                    setSlotReplyAutoRearmArmed(false, "spokenResponsesDisabled")
                     cancelPendingVoiceSlotReplyRestart()
                     cancelPendingVoiceSpeech()
                     voiceOutputController.stop()
@@ -235,7 +235,7 @@ class ActionsViewModel @Inject constructor(
                             _voiceCaptureState.value == VoiceCaptureState.Idle &&
                             slotPromptPlaybackStarted
                         ) {
-                            setSlotReplyAutoRearmArmed(false)
+                            setSlotReplyAutoRearmArmed(false, "voiceOutputSpeakingStopped")
                             clearExpectedSlotPromptSpeech()
                             cancelPendingVoiceSlotReplyRestart()
                             pendingVoiceSlotReplyRestartJob = viewModelScope.launch {
@@ -271,7 +271,8 @@ class ActionsViewModel @Inject constructor(
 
     fun startVoiceSlotReply() {
         if (_pendingSlot.value == null) return
-        setSlotReplyAutoRearmArmed(false)
+        Log.d(TAG, "ActionsViewModel: startVoiceSlotReply pendingSlot=true")
+        setSlotReplyAutoRearmArmed(false, "startVoiceSlotReply")
         clearExpectedSlotPromptSpeech()
         startVoiceCapture(VoiceCaptureMode.SlotReply)
     }
@@ -281,8 +282,9 @@ class ActionsViewModel @Inject constructor(
         _voiceCaptureState.value = VoiceCaptureState.Idle
     }
 
-    fun stopVoiceOutput() {
-        setSlotReplyAutoRearmArmed(false)
+    fun stopVoiceOutput(reason: String = "manual") {
+        Log.d(TAG, "ActionsViewModel: stopVoiceOutput reason=$reason")
+        setSlotReplyAutoRearmArmed(false, "stopVoiceOutput:$reason")
         clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
@@ -290,8 +292,13 @@ class ActionsViewModel @Inject constructor(
         _voicePlaybackState.value = VoicePlaybackState.Idle
     }
 
-    fun pauseTransientVoiceUi() {
-        setSlotReplyAutoRearmArmed(false)
+    fun pauseTransientVoiceUi(reason: String = "unspecified") {
+        Log.d(
+            TAG,
+            "ActionsViewModel: pauseTransientVoiceUi reason=$reason pendingSlot=${_pendingSlot.value != null} " +
+                "voiceCaptureState=${_voiceCaptureState.value} voicePlaybackState=${_voicePlaybackState.value}",
+        )
+        setSlotReplyAutoRearmArmed(false, "pauseTransientVoiceUi:$reason")
         clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
@@ -311,7 +318,7 @@ class ActionsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = UiState.Executing
             try {
-                setSlotReplyAutoRearmArmed(false)
+                setSlotReplyAutoRearmArmed(false, "onPhonePermissionGranted")
                 clearExpectedSlotPromptSpeech()
                 voiceOutputController.stop()
                 val result = executeIntent(
@@ -370,7 +377,7 @@ class ActionsViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                setSlotReplyAutoRearmArmed(false)
+                setSlotReplyAutoRearmArmed(false, "executeAction")
                 clearExpectedSlotPromptSpeech()
                 voiceOutputController.stop()
                 _uiState.value = UiState.Executing
@@ -448,7 +455,7 @@ class ActionsViewModel @Inject constructor(
     fun onSlotReply(text: String) {
         cancelPendingVoiceSpeech()
         val pending = _pendingSlot.value ?: return
-        setSlotReplyAutoRearmArmed(false)
+        setSlotReplyAutoRearmArmed(false, "onSlotReply")
         clearExpectedSlotPromptSpeech()
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
             normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
@@ -519,7 +526,7 @@ class ActionsViewModel @Inject constructor(
 
     /** Silently dismiss the slot-fill sheet with no log entry. */
     fun cancelSlotFill() {
-        setSlotReplyAutoRearmArmed(false)
+        setSlotReplyAutoRearmArmed(false, "cancelSlotFill")
         clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
@@ -550,7 +557,10 @@ class ActionsViewModel @Inject constructor(
             originalQuery = originalQuery,
             inputMode = inputMode,
         )
-        setSlotReplyAutoRearmArmed(inputMode == InputMode.Voice && spokenResponsesEnabled)
+        setSlotReplyAutoRearmArmed(
+            inputMode == InputMode.Voice && spokenResponsesEnabled,
+            "primePendingSlot",
+        )
         expectedSlotPromptSpeech = if (inputMode == InputMode.Voice && spokenResponsesEnabled) {
             _pendingSlot.value?.request?.promptMessage.orEmpty()
         } else {
@@ -766,8 +776,8 @@ class ActionsViewModel @Inject constructor(
         pendingVoiceSlotReplyRestartJob = null
     }
 
-    private fun setSlotReplyAutoRearmArmed(armed: Boolean) {
-        Log.d(TAG, "ActionsViewModel: setSlotReplyAutoRearmArmed armed=$armed")
+    private fun setSlotReplyAutoRearmArmed(armed: Boolean, reason: String) {
+        Log.d(TAG, "ActionsViewModel: setSlotReplyAutoRearmArmed armed=$armed reason=$reason")
         shouldAutoStartVoiceSlotReply = armed
         _slotReplyAutoRearmArmed.value = armed
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -10,6 +10,7 @@ import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.ToolPresentationJson
+import com.kernel.ai.core.skills.toSpokenSummary
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.normalizeSlotReply
 import com.kernel.ai.core.voice.VoiceCaptureMode
@@ -101,6 +102,11 @@ class ActionsViewModel @Inject constructor(
         val intentName: String,
         val params: Map<String, String>,
         val inputMode: InputMode,
+    )
+
+    private data class ExecutedAction(
+        val entity: QuickActionEntity,
+        val spokenSummary: String?,
     )
 
     /**
@@ -288,14 +294,18 @@ class ActionsViewModel @Inject constructor(
             try {
                 shouldAutoStartVoiceSlotReply = false
                 voiceOutputController.stop()
-                val entity = executeIntent(
+                val result = executeIntent(
                     query = pending.query,
                     intentName = pending.intentName,
                     params = pending.params,
                     inputMode = pending.inputMode,
                 )
-                quickActionDao.insert(entity)
-                speakForVoice(pending.inputMode, entity.resultText)
+                quickActionDao.insert(result.entity)
+                speakForVoice(
+                    pending.inputMode,
+                    result.entity.resultText,
+                    spokenOverride = result.spokenSummary,
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onPhonePermissionGranted failed — ${e.message}", e)
                 _error.value = e.message ?: "Unknown error"
@@ -371,24 +381,24 @@ class ActionsViewModel @Inject constructor(
                         )
                     }
                     is QuickIntentRouter.RouteResult.RegexMatch -> {
-                        val entity = executeIntent(
+                        val result = executeIntent(
                             query = normalizedQuery,
                             intentName = routeResult.intent.intentName,
                             params = routeResult.intent.params,
                             inputMode = inputMode,
                         )
-                        quickActionDao.insert(entity)
-                        speakForVoice(inputMode, entity.resultText)
+                        quickActionDao.insert(result.entity)
+                        speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary)
                     }
                     is QuickIntentRouter.RouteResult.ClassifierMatch -> {
-                        val entity = executeIntent(
+                        val result = executeIntent(
                             query = normalizedQuery,
                             intentName = routeResult.intent.intentName,
                             params = routeResult.intent.params,
                             inputMode = inputMode,
                         )
-                        quickActionDao.insert(entity)
-                        speakForVoice(inputMode, entity.resultText)
+                        quickActionDao.insert(result.entity)
+                        speakForVoice(inputMode, result.entity.resultText, spokenOverride = result.spokenSummary)
                     }
                 }
             } catch (e: Exception) {
@@ -451,17 +461,18 @@ class ActionsViewModel @Inject constructor(
             _uiState.value = UiState.Executing
             try {
                 voiceOutputController.stop()
-                val entity = executeIntent(
+                val result = executeIntent(
                     query = pending.originalQuery,
                     intentName = pending.request.intentName,
                     params = mergedParams,
                     inputMode = pending.inputMode,
                 )
-                quickActionDao.insert(entity)
+                quickActionDao.insert(result.entity)
                 speakForVoice(
                     pending.inputMode,
-                    entity.resultText,
+                    result.entity.resultText,
                     delayMs = if (pending.inputMode == InputMode.Voice) VOICE_REPLY_TTS_DELAY_MS else 0L,
+                    spokenOverride = result.spokenSummary,
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "ActionsViewModel: onSlotReply failed — ${e.message}", e)
@@ -552,7 +563,7 @@ class ActionsViewModel @Inject constructor(
         intentName: String,
         params: Map<String, String>,
         inputMode: InputMode,
-    ): QuickActionEntity {
+    ): ExecutedAction {
         val directSkill = skillRegistry.get(intentName)
         val (skill, callParams) = when {
             directSkill != null -> directSkill to params
@@ -569,16 +580,28 @@ class ActionsViewModel @Inject constructor(
                 )
                 _events.emit(UiEvent.RequestPhonePermission)
             }
-            buildEntityFromSkillResult(query, intentName, skillResult)
+            ExecutedAction(
+                entity = buildEntityFromSkillResult(query, intentName, skillResult),
+                spokenSummary = spokenSummaryFrom(skillResult),
+            )
         } else {
             Log.w(TAG, "ActionsViewModel: intent '$intentName' has no registered skill")
-            QuickActionEntity(
-                userQuery = query,
-                skillName = intentName,
-                resultText = "Action recognised but not yet implemented.",
-                isSuccess = false,
+            ExecutedAction(
+                entity = QuickActionEntity(
+                    userQuery = query,
+                    skillName = intentName,
+                    resultText = "Action recognised but not yet implemented.",
+                    isSuccess = false,
+                ),
+                spokenSummary = null,
             )
         }
+    }
+
+    private fun spokenSummaryFrom(result: SkillResult): String? = when (result) {
+        is SkillResult.DirectReply -> result.spokenSummary ?: result.presentation?.toSpokenSummary()
+        is SkillResult.Success -> result.spokenSummary ?: result.presentation?.toSpokenSummary()
+        else -> null
     }
 
     private fun buildEntityFromSkillResult(
@@ -674,10 +697,11 @@ class ActionsViewModel @Inject constructor(
         inputMode: InputMode,
         text: String,
         delayMs: Long = 0L,
+        spokenOverride: String? = null,
     ) {
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
-        val summary = toSpokenSummary(text)
+        val summary = spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text)
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -37,6 +37,7 @@ import javax.inject.Inject
 
 private const val TAG = "KernelAI"
 private const val SLOT_REPLY_REARM_DELAY_MS = 350L
+private const val SLOT_REPLY_REARM_FALLBACK_DELAY_MS = 3_000L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
@@ -141,6 +142,7 @@ class ActionsViewModel @Inject constructor(
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
     private var shouldAutoStartVoiceSlotReply = false
     private var pendingVoiceSlotReplyRestartJob: Job? = null
+    private var pendingVoiceSlotReplyFallbackJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
     private var recentVoiceCommand: String? = null
@@ -218,6 +220,13 @@ class ActionsViewModel @Inject constructor(
                     is VoiceOutputEvent.SpeakingStarted -> {
                         cancelPendingVoiceSlotReplyRestart()
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
+                        if (
+                            shouldAutoStartVoiceSlotReply &&
+                            _pendingSlot.value?.inputMode == InputMode.Voice &&
+                            _voiceCaptureState.value == VoiceCaptureState.Idle
+                        ) {
+                            scheduleVoiceSlotReplyFallback()
+                        }
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
                         _voicePlaybackState.value = VoicePlaybackState.Idle
@@ -228,6 +237,7 @@ class ActionsViewModel @Inject constructor(
                         ) {
                             shouldAutoStartVoiceSlotReply = false
                             cancelPendingVoiceSlotReplyRestart()
+                            cancelPendingVoiceSlotReplyFallback()
                             pendingVoiceSlotReplyRestartJob = viewModelScope.launch {
                                 delay(SLOT_REPLY_REARM_DELAY_MS)
                                 if (
@@ -267,6 +277,7 @@ class ActionsViewModel @Inject constructor(
     fun stopVoiceOutput() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         voiceOutputController.stop()
         _voicePlaybackState.value = VoicePlaybackState.Idle
@@ -275,6 +286,7 @@ class ActionsViewModel @Inject constructor(
     fun pauseTransientVoiceUi() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         voiceInputController.stopListening()
         _voiceCaptureState.value = VoiceCaptureState.Idle
@@ -499,6 +511,7 @@ class ActionsViewModel @Inject constructor(
     fun cancelSlotFill() {
         shouldAutoStartVoiceSlotReply = false
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         _pendingSlot.value = null
         stopVoiceCapture()
@@ -672,6 +685,7 @@ class ActionsViewModel @Inject constructor(
         interruptPlayback: Boolean = true,
     ) {
         cancelPendingVoiceSlotReplyRestart()
+        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         _error.value = null
         if (interruptPlayback) {
@@ -718,6 +732,31 @@ class ActionsViewModel @Inject constructor(
     private fun cancelPendingVoiceSlotReplyRestart() {
         pendingVoiceSlotReplyRestartJob?.cancel()
         pendingVoiceSlotReplyRestartJob = null
+    }
+
+    private fun cancelPendingVoiceSlotReplyFallback() {
+        pendingVoiceSlotReplyFallbackJob?.cancel()
+        pendingVoiceSlotReplyFallbackJob = null
+    }
+
+    private fun scheduleVoiceSlotReplyFallback() {
+        cancelPendingVoiceSlotReplyFallback()
+        pendingVoiceSlotReplyFallbackJob = viewModelScope.launch {
+            delay(SLOT_REPLY_REARM_FALLBACK_DELAY_MS)
+            if (
+                _pendingSlot.value?.inputMode == InputMode.Voice &&
+                _voiceCaptureState.value == VoiceCaptureState.Idle
+            ) {
+                shouldAutoStartVoiceSlotReply = false
+                cancelPendingVoiceSlotReplyRestart()
+                _voicePlaybackState.value = VoicePlaybackState.Idle
+                voiceOutputController.stop()
+                startVoiceCapture(
+                    mode = VoiceCaptureMode.SlotReply,
+                    interruptPlayback = false,
+                )
+            }
+        }
     }
 
     private fun cancelPendingVoiceSpeech() {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -37,7 +37,6 @@ import javax.inject.Inject
 
 private const val TAG = "KernelAI"
 private const val SLOT_REPLY_REARM_DELAY_MS = 350L
-private const val SLOT_REPLY_REARM_FALLBACK_DELAY_MS = 3_000L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
@@ -140,9 +139,10 @@ class ActionsViewModel @Inject constructor(
 
     private val _voicePlaybackState = MutableStateFlow<VoicePlaybackState>(VoicePlaybackState.Idle)
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
+    private val _slotReplyAutoRearmArmed = MutableStateFlow(false)
+    val slotReplyAutoRearmArmed: StateFlow<Boolean> = _slotReplyAutoRearmArmed.asStateFlow()
     private var shouldAutoStartVoiceSlotReply = false
     private var pendingVoiceSlotReplyRestartJob: Job? = null
-    private var pendingVoiceSlotReplyFallbackJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
     private var recentVoiceCommand: String? = null
@@ -156,7 +156,7 @@ class ActionsViewModel @Inject constructor(
                 if (enabled) {
                     voiceOutputController.warmUp()
                 } else {
-                    shouldAutoStartVoiceSlotReply = false
+                    setSlotReplyAutoRearmArmed(false)
                     cancelPendingVoiceSlotReplyRestart()
                     cancelPendingVoiceSpeech()
                     voiceOutputController.stop()
@@ -220,13 +220,6 @@ class ActionsViewModel @Inject constructor(
                     is VoiceOutputEvent.SpeakingStarted -> {
                         cancelPendingVoiceSlotReplyRestart()
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
-                        if (
-                            shouldAutoStartVoiceSlotReply &&
-                            _pendingSlot.value?.inputMode == InputMode.Voice &&
-                            _voiceCaptureState.value == VoiceCaptureState.Idle
-                        ) {
-                            scheduleVoiceSlotReplyFallback()
-                        }
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
                         _voicePlaybackState.value = VoicePlaybackState.Idle
@@ -235,9 +228,8 @@ class ActionsViewModel @Inject constructor(
                             _pendingSlot.value?.inputMode == InputMode.Voice &&
                             _voiceCaptureState.value == VoiceCaptureState.Idle
                         ) {
-                            shouldAutoStartVoiceSlotReply = false
+                            setSlotReplyAutoRearmArmed(false)
                             cancelPendingVoiceSlotReplyRestart()
-                            cancelPendingVoiceSlotReplyFallback()
                             pendingVoiceSlotReplyRestartJob = viewModelScope.launch {
                                 delay(SLOT_REPLY_REARM_DELAY_MS)
                                 if (
@@ -265,7 +257,7 @@ class ActionsViewModel @Inject constructor(
 
     fun startVoiceSlotReply() {
         if (_pendingSlot.value == null) return
-        shouldAutoStartVoiceSlotReply = false
+        setSlotReplyAutoRearmArmed(false)
         startVoiceCapture(VoiceCaptureMode.SlotReply)
     }
 
@@ -275,18 +267,16 @@ class ActionsViewModel @Inject constructor(
     }
 
     fun stopVoiceOutput() {
-        shouldAutoStartVoiceSlotReply = false
+        setSlotReplyAutoRearmArmed(false)
         cancelPendingVoiceSlotReplyRestart()
-        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         voiceOutputController.stop()
         _voicePlaybackState.value = VoicePlaybackState.Idle
     }
 
     fun pauseTransientVoiceUi() {
-        shouldAutoStartVoiceSlotReply = false
+        setSlotReplyAutoRearmArmed(false)
         cancelPendingVoiceSlotReplyRestart()
-        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         voiceInputController.stopListening()
         _voiceCaptureState.value = VoiceCaptureState.Idle
@@ -304,7 +294,7 @@ class ActionsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = UiState.Executing
             try {
-                shouldAutoStartVoiceSlotReply = false
+                setSlotReplyAutoRearmArmed(false)
                 voiceOutputController.stop()
                 val result = executeIntent(
                     query = pending.query,
@@ -362,7 +352,7 @@ class ActionsViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                shouldAutoStartVoiceSlotReply = false
+                setSlotReplyAutoRearmArmed(false)
                 voiceOutputController.stop()
                 _uiState.value = UiState.Executing
 
@@ -439,7 +429,7 @@ class ActionsViewModel @Inject constructor(
     fun onSlotReply(text: String) {
         cancelPendingVoiceSpeech()
         val pending = _pendingSlot.value ?: return
-        shouldAutoStartVoiceSlotReply = false
+        setSlotReplyAutoRearmArmed(false)
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
             normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
         } else {
@@ -509,9 +499,8 @@ class ActionsViewModel @Inject constructor(
 
     /** Silently dismiss the slot-fill sheet with no log entry. */
     fun cancelSlotFill() {
-        shouldAutoStartVoiceSlotReply = false
+        setSlotReplyAutoRearmArmed(false)
         cancelPendingVoiceSlotReplyRestart()
-        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         _pendingSlot.value = null
         stopVoiceCapture()
@@ -535,7 +524,7 @@ class ActionsViewModel @Inject constructor(
             originalQuery = originalQuery,
             inputMode = inputMode,
         )
-        shouldAutoStartVoiceSlotReply = inputMode == InputMode.Voice
+        setSlotReplyAutoRearmArmed(inputMode == InputMode.Voice && spokenResponsesEnabled)
         if (inputMode == InputMode.Voice) {
             _voiceCaptureState.value = VoiceCaptureState.Idle
         }
@@ -685,7 +674,6 @@ class ActionsViewModel @Inject constructor(
         interruptPlayback: Boolean = true,
     ) {
         cancelPendingVoiceSlotReplyRestart()
-        cancelPendingVoiceSlotReplyFallback()
         cancelPendingVoiceSpeech()
         _error.value = null
         if (interruptPlayback) {
@@ -734,29 +722,9 @@ class ActionsViewModel @Inject constructor(
         pendingVoiceSlotReplyRestartJob = null
     }
 
-    private fun cancelPendingVoiceSlotReplyFallback() {
-        pendingVoiceSlotReplyFallbackJob?.cancel()
-        pendingVoiceSlotReplyFallbackJob = null
-    }
-
-    private fun scheduleVoiceSlotReplyFallback() {
-        cancelPendingVoiceSlotReplyFallback()
-        pendingVoiceSlotReplyFallbackJob = viewModelScope.launch {
-            delay(SLOT_REPLY_REARM_FALLBACK_DELAY_MS)
-            if (
-                _pendingSlot.value?.inputMode == InputMode.Voice &&
-                _voiceCaptureState.value == VoiceCaptureState.Idle
-            ) {
-                shouldAutoStartVoiceSlotReply = false
-                cancelPendingVoiceSlotReplyRestart()
-                _voicePlaybackState.value = VoicePlaybackState.Idle
-                voiceOutputController.stop()
-                startVoiceCapture(
-                    mode = VoiceCaptureMode.SlotReply,
-                    interruptPlayback = false,
-                )
-            }
-        }
+    private fun setSlotReplyAutoRearmArmed(armed: Boolean) {
+        shouldAutoStartVoiceSlotReply = armed
+        _slotReplyAutoRearmArmed.value = armed
     }
 
     private fun cancelPendingVoiceSpeech() {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -141,6 +141,8 @@ class ActionsViewModel @Inject constructor(
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
     private val _slotReplyAutoRearmArmed = MutableStateFlow(false)
     val slotReplyAutoRearmArmed: StateFlow<Boolean> = _slotReplyAutoRearmArmed.asStateFlow()
+    private var expectedSlotPromptSpeech: String? = null
+    private var slotPromptPlaybackStarted = false
     private var shouldAutoStartVoiceSlotReply = false
     private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
@@ -220,15 +222,21 @@ class ActionsViewModel @Inject constructor(
                     is VoiceOutputEvent.SpeakingStarted -> {
                         cancelPendingVoiceSlotReplyRestart()
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
+                        if (event.text == expectedSlotPromptSpeech) {
+                            slotPromptPlaybackStarted = true
+                            Log.d(TAG, "ActionsViewModel: slot prompt playback started")
+                        }
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
                         _voicePlaybackState.value = VoicePlaybackState.Idle
                         if (
                             shouldAutoStartVoiceSlotReply &&
                             _pendingSlot.value?.inputMode == InputMode.Voice &&
-                            _voiceCaptureState.value == VoiceCaptureState.Idle
+                            _voiceCaptureState.value == VoiceCaptureState.Idle &&
+                            slotPromptPlaybackStarted
                         ) {
                             setSlotReplyAutoRearmArmed(false)
+                            clearExpectedSlotPromptSpeech()
                             cancelPendingVoiceSlotReplyRestart()
                             pendingVoiceSlotReplyRestartJob = viewModelScope.launch {
                                 delay(SLOT_REPLY_REARM_DELAY_MS)
@@ -242,6 +250,12 @@ class ActionsViewModel @Inject constructor(
                                     )
                                 }
                             }
+                        } else if (
+                            shouldAutoStartVoiceSlotReply &&
+                            _pendingSlot.value?.inputMode == InputMode.Voice &&
+                            _voiceCaptureState.value == VoiceCaptureState.Idle
+                        ) {
+                            Log.d(TAG, "ActionsViewModel: ignoring stale SpeakingStopped before slot prompt playback starts")
                         }
                     }
                 }
@@ -258,6 +272,7 @@ class ActionsViewModel @Inject constructor(
     fun startVoiceSlotReply() {
         if (_pendingSlot.value == null) return
         setSlotReplyAutoRearmArmed(false)
+        clearExpectedSlotPromptSpeech()
         startVoiceCapture(VoiceCaptureMode.SlotReply)
     }
 
@@ -268,6 +283,7 @@ class ActionsViewModel @Inject constructor(
 
     fun stopVoiceOutput() {
         setSlotReplyAutoRearmArmed(false)
+        clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
         voiceOutputController.stop()
@@ -276,6 +292,7 @@ class ActionsViewModel @Inject constructor(
 
     fun pauseTransientVoiceUi() {
         setSlotReplyAutoRearmArmed(false)
+        clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
         voiceInputController.stopListening()
@@ -295,6 +312,7 @@ class ActionsViewModel @Inject constructor(
             _uiState.value = UiState.Executing
             try {
                 setSlotReplyAutoRearmArmed(false)
+                clearExpectedSlotPromptSpeech()
                 voiceOutputController.stop()
                 val result = executeIntent(
                     query = pending.query,
@@ -353,6 +371,7 @@ class ActionsViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 setSlotReplyAutoRearmArmed(false)
+                clearExpectedSlotPromptSpeech()
                 voiceOutputController.stop()
                 _uiState.value = UiState.Executing
 
@@ -430,6 +449,7 @@ class ActionsViewModel @Inject constructor(
         cancelPendingVoiceSpeech()
         val pending = _pendingSlot.value ?: return
         setSlotReplyAutoRearmArmed(false)
+        clearExpectedSlotPromptSpeech()
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
             normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
         } else {
@@ -500,6 +520,7 @@ class ActionsViewModel @Inject constructor(
     /** Silently dismiss the slot-fill sheet with no log entry. */
     fun cancelSlotFill() {
         setSlotReplyAutoRearmArmed(false)
+        clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()
         _pendingSlot.value = null
@@ -530,6 +551,12 @@ class ActionsViewModel @Inject constructor(
             inputMode = inputMode,
         )
         setSlotReplyAutoRearmArmed(inputMode == InputMode.Voice && spokenResponsesEnabled)
+        expectedSlotPromptSpeech = if (inputMode == InputMode.Voice && spokenResponsesEnabled) {
+            _pendingSlot.value?.request?.promptMessage.orEmpty()
+        } else {
+            null
+        }
+        slotPromptPlaybackStarted = false
         if (inputMode == InputMode.Voice) {
             _voiceCaptureState.value = VoiceCaptureState.Idle
         }
@@ -743,6 +770,11 @@ class ActionsViewModel @Inject constructor(
         Log.d(TAG, "ActionsViewModel: setSlotReplyAutoRearmArmed armed=$armed")
         shouldAutoStartVoiceSlotReply = armed
         _slotReplyAutoRearmArmed.value = armed
+    }
+
+    private fun clearExpectedSlotPromptSpeech() {
+        expectedSlotPromptSpeech = null
+        slotPromptPlaybackStarted = false
     }
 
     private fun cancelPendingVoiceSpeech() {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -1,7 +1,5 @@
 package com.kernel.ai.feature.chat
 
-import android.media.AudioManager
-import android.media.ToneGenerator
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -232,14 +230,19 @@ private fun ChatContent(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
-    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 65) }
-    var lastVoiceCaptureState by remember { mutableStateOf<ChatViewModel.VoiceCaptureState>(ChatViewModel.VoiceCaptureState.Idle) }
     val view = androidx.compose.ui.platform.LocalView.current
     val keepScreenAwake = voiceMode == ChatViewModel.VoiceMode.BackAndForth
-
-    DisposableEffect(Unit) {
-        onDispose { loopListeningCue.release() }
+    val loopListeningCueState = when (voiceCaptureState) {
+        ChatViewModel.VoiceCaptureState.Idle -> LoopListeningCueState.Idle
+        is ChatViewModel.VoiceCaptureState.Preparing -> LoopListeningCueState.Preparing
+        is ChatViewModel.VoiceCaptureState.Listening -> LoopListeningCueState.Listening
+        is ChatViewModel.VoiceCaptureState.Processing -> LoopListeningCueState.Processing
     }
+
+    LoopListeningCueEffect(
+        loopActive = voiceMode == ChatViewModel.VoiceMode.BackAndForth,
+        captureState = loopListeningCueState,
+    )
 
     DisposableEffect(view, keepScreenAwake) {
         val previousKeepScreenOn = view.keepScreenOn
@@ -247,18 +250,6 @@ private fun ChatContent(
         onDispose {
             view.keepScreenOn = previousKeepScreenOn
         }
-    }
-
-    LaunchedEffect(voiceCaptureState, voiceMode) {
-        val startedLoopListening =
-            voiceMode == ChatViewModel.VoiceMode.BackAndForth &&
-                voiceCaptureState is ChatViewModel.VoiceCaptureState.Preparing &&
-                lastVoiceCaptureState !is ChatViewModel.VoiceCaptureState.Preparing &&
-                lastVoiceCaptureState !is ChatViewModel.VoiceCaptureState.Listening
-        if (startedLoopListening) {
-            loopListeningCue.startTone(ToneGenerator.TONE_PROP_BEEP2, 120)
-        }
-        lastVoiceCaptureState = voiceCaptureState
     }
 
     // Auto-scroll when a new message is appended, but only if the user is already

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoopListeningCue.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoopListeningCue.kt
@@ -1,0 +1,42 @@
+package com.kernel.ai.feature.chat
+
+import android.media.AudioManager
+import android.media.ToneGenerator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+internal enum class LoopListeningCueState { Idle, Preparing, Listening, Processing }
+
+internal fun shouldPlayLoopListeningCue(
+    loopActive: Boolean,
+    currentState: LoopListeningCueState,
+    previousState: LoopListeningCueState,
+): Boolean = loopActive &&
+    currentState == LoopListeningCueState.Preparing &&
+    previousState != LoopListeningCueState.Preparing &&
+    previousState != LoopListeningCueState.Listening
+
+@Composable
+internal fun LoopListeningCueEffect(
+    loopActive: Boolean,
+    captureState: LoopListeningCueState,
+) {
+    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 65) }
+    var previousState by remember { mutableStateOf(LoopListeningCueState.Idle) }
+
+    DisposableEffect(Unit) {
+        onDispose { loopListeningCue.release() }
+    }
+
+    LaunchedEffect(loopActive, captureState) {
+        if (shouldPlayLoopListeningCue(loopActive, captureState, previousState)) {
+            loopListeningCue.startTone(ToneGenerator.TONE_PROP_BEEP2, 120)
+        }
+        previousState = captureState
+    }
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -482,6 +482,10 @@ class ActionsViewModelVoiceTest {
 
         viewModel.executeAction("send a text message to my wife", InputMode.Voice)
         advanceUntilIdle()
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"),
+        )
+        runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()
 
@@ -513,6 +517,10 @@ class ActionsViewModelVoiceTest {
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
         advanceUntilIdle()
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("Who would you like to email?"),
+        )
+        runCurrent()
 
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()
@@ -524,6 +532,10 @@ class ActionsViewModelVoiceTest {
         runCurrent()
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
 
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("What's the subject of your email to Nick?"),
+        )
+        runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()
         advanceTimeBy(351)
@@ -553,6 +565,10 @@ class ActionsViewModelVoiceTest {
         advanceUntilIdle()
 
         viewModel.pauseTransientVoiceUi()
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"),
+        )
+        runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         advanceTimeBy(351)
         runCurrent()
@@ -829,6 +845,10 @@ class ActionsViewModelVoiceTest {
         advanceUntilIdle()
 
         spokenResponsesEnabled.value = false
+        runCurrent()
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"),
+        )
         runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -8,6 +8,8 @@ import com.kernel.ai.core.skills.Skill
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.skills.ToolPresentation
+import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.slot.SlotSpec
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
@@ -616,6 +618,147 @@ class ActionsViewModelVoiceTest {
                 }
             )
         }
+    }
+
+    @Test
+    fun `voice weather direct reply speaks listener friendly summary and preserves visible result`() = runTest(dispatcher) {
+        val weatherSkill = mockk<Skill>()
+        val displayText =
+            "Wellington forecast: 25°C, feels like 23°C. H 27°C / L 18°C. Wind NW 15 km/h."
+        val presentation = ToolPresentation.Weather(
+            locationName = "Wellington",
+            temperatureText = "25°C",
+            feelsLikeText = "Feels like 23°C",
+            description = "Partly cloudy",
+            emoji = "⛅",
+            highLowText = "H 27°C / L 18°C",
+            humidityText = "Humidity 60%",
+            windText = "NW 15 km/h",
+            precipText = "20%",
+            airQualityText = null,
+        )
+
+        every { quickIntentRouter.route("what's the weather in Wellington") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "get_weather",
+                    params = mapOf("location" to "Wellington"),
+                ),
+            )
+        every { skillRegistry.get("get_weather") } returns weatherSkill
+        every { weatherSkill.name } returns "get_weather"
+        every { weatherSkill.description } returns "Get weather"
+        every { weatherSkill.schema } returns SkillSchema()
+        coEvery { weatherSkill.execute(any()) } returns SkillResult.DirectReply(
+            content = displayText,
+            presentation = presentation,
+        )
+
+        viewModel.executeAction("what's the weather in Wellington", InputMode.Voice)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            quickActionDao.insert(
+                match {
+                    it.userQuery == "what's the weather in Wellington" &&
+                        it.skillName == "get_weather" &&
+                        it.resultText == displayText &&
+                        it.presentationJson == ToolPresentationJson.toJsonString(presentation) &&
+                        it.isSuccess
+                },
+            )
+        }
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text != displayText &&
+                        it.text.contains("Wellington") &&
+                        it.text.contains("Partly cloudy") &&
+                        it.text.contains("25 degrees Celsius") &&
+                        !it.text.contains("25°C") &&
+                        !it.text.contains("H 27°C / L 18°C")
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `voice mode falls back to visible direct reply when no spoken summary is available`() = runTest(dispatcher) {
+        val directSkill = mockk<Skill>()
+        val displayText = "Created checklist Weekend errands."
+
+        every { quickIntentRouter.route("create checklist weekend errands") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "create_list",
+                    params = mapOf("list_name" to "Weekend errands"),
+                ),
+            )
+        every { skillRegistry.get("create_list") } returns directSkill
+        every { directSkill.name } returns "create_list"
+        every { directSkill.description } returns "Create list"
+        every { directSkill.schema } returns SkillSchema()
+        coEvery { directSkill.execute(any()) } returns SkillResult.DirectReply(displayText)
+
+        viewModel.executeAction("create checklist weekend errands", InputMode.Voice)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text == displayText },
+            )
+        }
+    }
+
+    @Test
+    fun `typed weather direct reply keeps display result silent`() = runTest(dispatcher) {
+        val weatherSkill = mockk<Skill>()
+        val displayText =
+            "Wellington forecast: 25°C, feels like 23°C. H 27°C / L 18°C. Wind NW 15 km/h."
+        val presentation = ToolPresentation.Weather(
+            locationName = "Wellington",
+            temperatureText = "25°C",
+            feelsLikeText = "Feels like 23°C",
+            description = "Partly cloudy",
+            emoji = "⛅",
+            highLowText = "H 27°C / L 18°C",
+            humidityText = "Humidity 60%",
+            windText = "NW 15 km/h",
+            precipText = "20%",
+            airQualityText = null,
+        )
+
+        every { quickIntentRouter.route("what's the weather in Wellington") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "get_weather",
+                    params = mapOf("location" to "Wellington"),
+                ),
+            )
+        every { skillRegistry.get("get_weather") } returns weatherSkill
+        every { weatherSkill.name } returns "get_weather"
+        every { weatherSkill.description } returns "Get weather"
+        every { weatherSkill.schema } returns SkillSchema()
+        coEvery { weatherSkill.execute(any()) } returns SkillResult.DirectReply(
+            content = displayText,
+            presentation = presentation,
+        )
+
+        viewModel.executeAction("what's the weather in Wellington", InputMode.Text)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            quickActionDao.insert(
+                match {
+                    it.userQuery == "what's the weather in Wellington" &&
+                        it.skillName == "get_weather" &&
+                        it.resultText == displayText &&
+                        it.presentationJson == ToolPresentationJson.toJsonString(presentation) &&
+                        it.isSuccess
+                },
+            )
+        }
+        coVerify(exactly = 0) { voiceOutputController.speak(any()) }
     }
 
     @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -496,39 +496,6 @@ class ActionsViewModelVoiceTest {
         verify(exactly = 1) { voiceOutputController.stop() }
     }
 
-    @Test
-    fun `voice mode fallback auto starts slot reply capture when prompt stop event is missed`() = runTest(dispatcher) {
-        every { quickIntentRouter.route("send a text message to my wife") } returns
-            QuickIntentRouter.RouteResult.NeedsSlot(
-                intent = QuickIntentRouter.MatchedIntent(
-                    intentName = "send_sms",
-                    params = mapOf("contact" to "my wife"),
-                ),
-                missingSlot = SlotSpec(
-                    name = "message",
-                    promptTemplate = "What would you like to say to {contact}?",
-                ),
-            )
-        coEvery {
-            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
-
-        viewModel.executeAction("send a text message to my wife", InputMode.Voice)
-        advanceUntilIdle()
-        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"))
-        runCurrent()
-
-        advanceTimeBy(2_999)
-        runCurrent()
-        coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
-
-        advanceTimeBy(1)
-        runCurrent()
-
-        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
-    }
-
-    @Test
     fun `stale slot reply auto restart is cancelled when a newer follow up prompt starts`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         coEvery {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -500,6 +500,7 @@ class ActionsViewModelVoiceTest {
         verify(exactly = 1) { voiceOutputController.stop() }
     }
 
+    @Test
     fun `stale slot reply auto restart is cancelled when a newer follow up prompt starts`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         coEvery {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -497,6 +497,38 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice mode fallback auto starts slot reply capture when prompt stop event is missed`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a text message to my wife") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "my wife"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text message to my wife", InputMode.Voice)
+        advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"))
+        runCurrent()
+
+        advanceTimeBy(2_999)
+        runCurrent()
+        coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
+
+        advanceTimeBy(1)
+        runCurrent()
+
+        coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
+    }
+
+    @Test
     fun `stale slot reply auto restart is cancelled when a newer follow up prompt starts`() = runTest(dispatcher) {
         val router = QuickIntentRouter()
         coEvery {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/LoopListeningCueTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/LoopListeningCueTest.kt
@@ -1,0 +1,48 @@
+package com.kernel.ai.feature.chat
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LoopListeningCueTest {
+
+    @Test
+    fun `plays cue when loop enters preparing from idle`() {
+        assertTrue(
+            shouldPlayLoopListeningCue(
+                loopActive = true,
+                currentState = LoopListeningCueState.Preparing,
+                previousState = LoopListeningCueState.Idle,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not play cue when loop is inactive`() {
+        assertFalse(
+            shouldPlayLoopListeningCue(
+                loopActive = false,
+                currentState = LoopListeningCueState.Preparing,
+                previousState = LoopListeningCueState.Idle,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not replay cue while listen startup is already in progress`() {
+        assertFalse(
+            shouldPlayLoopListeningCue(
+                loopActive = true,
+                currentState = LoopListeningCueState.Preparing,
+                previousState = LoopListeningCueState.Preparing,
+            ),
+        )
+        assertFalse(
+            shouldPlayLoopListeningCue(
+                loopActive = true,
+                currentState = LoopListeningCueState.Preparing,
+                previousState = LoopListeningCueState.Listening,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Add voice-friendly spoken summaries so spoken quick-action replies sound natural without changing the visible result text.

## Changes
- add optional `spokenSummary` support to `SkillResult`
- add a `ToolPresentation.toSpokenSummary()` seam for presentation-driven TTS fallbacks
- generate natural spoken weather summaries for current conditions and forecasts
- teach `ActionsViewModel` to prefer spoken summaries for voice replies while preserving existing text-mode behavior
- add focused unit coverage for the new spoken-summary helpers and weather voice flow

## Testing
- [x] `./gradlew :core:skills:testDebugUnitTest --tests '*ToolPresentationSpokenSummaryTest' --tests '*GetWeatherSpokenSummaryTest'`
- [x] `./gradlew :feature:chat:testDebugUnitTest --tests '*ActionsViewModelVoiceTest'`
- [x] `./gradlew :app:assembleDebug`

## Related issues
Closes #763
