### PR TITLE
feat(#757): add custom clock sounds

### DIFF
--- a/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmBroadcastReceiver.kt
@@ -40,18 +40,19 @@ class AlarmBroadcastReceiver : BroadcastReceiver() {
             ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
             -1L,
         ).takeIf { it > 0L }
+        val soundUri = intent.getStringExtra(ClockAlertContract.EXTRA_SOUND_URI)
 
         when (type) {
             ClockEventType.TIMER -> {
                 context.getSystemService(NotificationManager::class.java)
                     .cancel(ClockAlertContract.timerNotificationId(ownerId))
-                triggerAlert(context, ownerId, type, title, label, occurrenceTriggerAtMillis)
+                triggerAlert(context, ownerId, type, title, label, occurrenceTriggerAtMillis, soundUri)
             }
 
             ClockEventType.ALARM -> {
                 context.getSystemService(NotificationManager::class.java)
                     .cancel(ClockAlertContract.preAlarmNotificationId(ownerId))
-                triggerAlert(context, ownerId, type, title, label, occurrenceTriggerAtMillis)
+                triggerAlert(context, ownerId, type, title, label, occurrenceTriggerAtMillis, soundUri)
             }
 
             ClockEventType.PRE_ALARM -> {
@@ -95,6 +96,7 @@ class AlarmBroadcastReceiver : BroadcastReceiver() {
         title: String,
         label: String,
         occurrenceTriggerAtMillis: Long?,
+        soundUri: String?,
     ) {
         ClockAlertService.trigger(
             context,
@@ -104,6 +106,7 @@ class AlarmBroadcastReceiver : BroadcastReceiver() {
                 title = title,
                 label = label,
                 occurrenceTriggerAtMillis = occurrenceTriggerAtMillis,
+                soundUri = soundUri,
             ),
         )
     }

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
@@ -70,6 +70,7 @@ class AlarmManagerClockScheduler @Inject constructor(
                 ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
                 event.occurrenceTriggerAtMillis ?: event.triggerAtMillis,
             )
+            putExtra(ClockAlertContract.EXTRA_SOUND_URI, event.soundUri)
         }
 
     private fun defaultLabel(type: ClockEventType): String =

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertContract.kt
@@ -9,6 +9,7 @@ internal object ClockAlertContract {
     const val EXTRA_EVENT_TYPE = "clock_event_type"
     const val EXTRA_TIMER_ID = "timer_id"
     const val EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS = "occurrence_trigger_at_millis"
+    const val EXTRA_SOUND_URI = "sound_uri"
 
     const val ACTION_TRIGGER_ALERT = "com.kernel.ai.alarm.action.TRIGGER_ALERT"
     const val ACTION_STOP_ALERT = "com.kernel.ai.alarm.action.STOP_ALERT"
@@ -39,4 +40,5 @@ internal data class TriggeredClockAlert(
     val title: String,
     val label: String,
     val occurrenceTriggerAtMillis: Long? = null,
- )
+    val soundUri: String? = null,
+)

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -77,12 +77,15 @@ class ClockAlertService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var voiceEventsJob: Job? = null
     private var voicePreferencesJob: Job? = null
+    private var clockSoundConfigJob: Job? = null
     private var autoStartVoiceJob: Job? = null
     private var ringtone: Ringtone? = null
     private var duckingPlayback = false
     private var isVoiceListening = false
     private var handledVoiceTranscript = false
     private var autoStartAlertVoiceCommandsEnabled = true
+    private var defaultAlarmSoundUri: String? = null
+    private var timerSoundUri: String? = null
     private var voiceStatusMessage: String? = null
 
     override fun onCreate() {
@@ -93,6 +96,12 @@ class ClockAlertService : Service() {
         voicePreferencesJob = serviceScope.launch {
             voiceInputPreferences.autoStartAlertVoiceCommandsEnabled.collectLatest { enabled ->
                 autoStartAlertVoiceCommandsEnabled = enabled
+            }
+        }
+        clockSoundConfigJob = serviceScope.launch {
+            clockRepository.observeClockSoundConfig().collectLatest { config ->
+                defaultAlarmSoundUri = config.defaultAlarmSoundUri
+                timerSoundUri = config.timerSoundUri
             }
         }
     }
@@ -155,6 +164,7 @@ class ClockAlertService : Service() {
         voiceInputController.stopListening()
         voiceEventsJob?.cancel()
         voicePreferencesJob?.cancel()
+        clockSoundConfigJob?.cancel()
         autoStartVoiceJob?.cancel()
         serviceScope.cancel()
         stopPlayback()
@@ -227,17 +237,15 @@ class ClockAlertService : Service() {
     }
 
     private fun startAlertPlayback(ducked: Boolean = false) {
-        if (activeAlerts.isEmpty()) return
+        val alert = currentAlert() ?: return
         stopPlayback()
         if (ducked) {
             defaultVibrator()?.cancel()
         } else {
             startVibration()
         }
-        ringtone = RingtoneManager.getRingtone(
-            this,
-            RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM),
-        )?.apply {
+        val soundUri = resolveAlertSoundUri(alert)
+        ringtone = RingtoneManager.getRingtone(this, soundUri)?.apply {
             audioAttributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_ALARM)
                 .build()
@@ -250,6 +258,15 @@ class ClockAlertService : Service() {
         }
         duckingPlayback = ducked && ringtone != null
     }
+
+    private fun resolveAlertSoundUri(alert: TriggeredClockAlert): Uri =
+        Uri.parse(
+            when (alert.type) {
+                ClockEventType.ALARM -> alert.soundUri ?: defaultAlarmSoundUri
+                ClockEventType.TIMER -> timerSoundUri
+                ClockEventType.PRE_ALARM -> alert.soundUri ?: defaultAlarmSoundUri
+            } ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM).toString(),
+        )
 
     private fun startVibration() {
         defaultVibrator()?.cancel()
@@ -365,6 +382,7 @@ class ClockAlertService : Service() {
                     ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
                     alert.occurrenceTriggerAtMillis ?: -1L,
                 )
+                putExtra(ClockAlertContract.EXTRA_SOUND_URI, alert.soundUri)
             },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
@@ -519,12 +537,14 @@ class ClockAlertService : Service() {
             ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
             -1L,
         ).takeIf { it > 0L }
+        val soundUri = getStringExtra(ClockAlertContract.EXTRA_SOUND_URI)
         return TriggeredClockAlert(
             ownerId = ownerId,
             type = type,
             title = title,
             label = label,
             occurrenceTriggerAtMillis = occurrenceTriggerAtMillis,
+            soundUri = soundUri,
         )
     }
 
@@ -548,6 +568,7 @@ class ClockAlertService : Service() {
                         ClockAlertContract.EXTRA_OCCURRENCE_TRIGGER_AT_MILLIS,
                         alert.occurrenceTriggerAtMillis ?: -1L,
                     )
+                    putExtra(ClockAlertContract.EXTRA_SOUND_URI, alert.soundUri)
                 },
             )
         }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/30.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/30.json
@@ -1,0 +1,1037 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 30,
+    "identityHash": "c041a1995d5e7ddaeb302b433a7d7155",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c041a1995d5e7ddaeb302b433a7d7155')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -57,7 +57,7 @@ import java.time.ZoneId
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 29,
+    version = 30,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -385,6 +385,13 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_28_29 = object : Migration(28, 29) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN snoozed_until_ms INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Adds sound_uri to scheduled_alarms for custom alarm sounds (#757). */
+        val MIGRATION_29_30 = object : Migration(29, 30) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN sound_uri TEXT DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -85,6 +85,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_26_27,
                     KernelDatabase.MIGRATION_27_28,
                     KernelDatabase.MIGRATION_28_29,
+                    KernelDatabase.MIGRATION_29_30,
                 )
                 .build()
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -29,6 +29,12 @@ data class AlarmDraft(
     val minute: Int,
     val repeatRule: AlarmRepeatRule,
     val timeZoneId: String,
+    val soundUri: String? = null,
+)
+
+data class ClockSoundConfig(
+    val defaultAlarmSoundUri: String? = null,
+    val timerSoundUri: String? = null,
 )
 
 data class ClockAlarm(
@@ -41,7 +47,8 @@ data class ClockAlarm(
     val repeatRule: AlarmRepeatRule,
     val timeZoneId: String,
     val triggerAtMillis: Long,
- ) {
+    val soundUri: String? = null,
+) {
     val nextTriggerAtMillis: Long get() = triggerAtMillis
 }
 
@@ -114,7 +121,8 @@ data class ClockScheduledEvent(
     val durationMs: Long? = null,
     val startedAtMillis: Long? = null,
     val occurrenceTriggerAtMillis: Long? = null,
- )
+    val soundUri: String? = null,
+)
 
 data class ClockPlatformState(
     val canScheduleExactAlarms: Boolean,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -10,6 +10,7 @@ interface ClockRepository {
     fun observeRecentCompletedTimers(): Flow<List<ClockTimer>>
     fun observeStopwatch(): Flow<ClockStopwatch>
     fun observeWorldClocks(): Flow<List<WorldClock>>
+    fun observeClockSoundConfig(): Flow<ClockSoundConfig>
 
     suspend fun startStopwatch(
         nowWallClockMillis: Long = System.currentTimeMillis(),
@@ -48,6 +49,7 @@ interface ClockRepository {
     suspend fun cancelAlarmsByLabel(label: String): Int
     suspend fun skipAlarmOccurrence(alarmId: String, occurrenceTriggerAtMillis: Long): Boolean
     suspend fun snoozeAlarm(alarmId: String, snoozedUntilMillis: Long): Boolean
+    suspend fun setDefaultAlarmSoundUri(soundUri: String?)
 
     suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
     suspend fun cancelTimer(timerId: String)
@@ -63,4 +65,5 @@ interface ClockRepository {
     suspend fun cancelTimersMatching(name: String?, durationMs: Long?): Int
     suspend fun getAllTimers(): List<ClockTimer>
     suspend fun restoreScheduledEntries(nowMillis: Long = System.currentTimeMillis()): ClockRestoreReport
+    suspend fun setTimerSoundUri(soundUri: String?)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -31,7 +31,8 @@ class ClockRepositoryImpl @Inject constructor(
     private val worldClockDao: WorldClockDao,
     private val stopwatchDao: StopwatchDao,
     private val scheduler: ClockScheduler,
- ) : ClockRepository {
+    private val clockSoundPreferences: ClockSoundPreferences,
+) : ClockRepository {
     override fun observeManageableAlarms(): Flow<List<ClockAlarm>> =
         scheduledAlarmDao.observeAllAlarmSchedules().map { schedules ->
             schedules.mapNotNull { it.toClockAlarm() }
@@ -73,6 +74,9 @@ class ClockRepositoryImpl @Inject constructor(
         worldClockDao.observeAll().map { clocks ->
             clocks.map { it.toWorldClock() }
         }
+
+    override fun observeClockSoundConfig(): Flow<ClockSoundConfig> =
+        clockSoundPreferences.soundConfig
 
 
     override suspend fun startStopwatch(
@@ -226,6 +230,7 @@ class ClockRepositoryImpl @Inject constructor(
             repeatDaysMask = draft.repeatDaysMask(),
             oneOffDateEpochDay = draft.oneOffDateEpochDay(),
             timeZoneId = draft.timeZoneId,
+            soundUri = draft.soundUri,
         ).withDefaultOwnerId()
         scheduleAlarmEvents(entity, now)
         return try {
@@ -253,6 +258,7 @@ class ClockRepositoryImpl @Inject constructor(
             repeatDaysMask = draft.repeatDaysMask(),
             oneOffDateEpochDay = draft.oneOffDateEpochDay(),
             timeZoneId = draft.timeZoneId,
+            soundUri = draft.soundUri,
             snoozedUntilMs = null,
         )
         cancelAlarmEvents(existing, now)
@@ -382,6 +388,10 @@ class ClockRepositoryImpl @Inject constructor(
         }
     }
 
+
+    override suspend fun setDefaultAlarmSoundUri(soundUri: String?) {
+        clockSoundPreferences.setDefaultAlarmSoundUri(soundUri)
+    }
 
     override suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer? {
         if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
@@ -575,6 +585,10 @@ class ClockRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun setTimerSoundUri(soundUri: String?) {
+        clockSoundPreferences.setTimerSoundUri(soundUri)
+    }
+
     private fun scheduleAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long) {
         entity.toPrimaryAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
         entity.toSnoozeScheduledEvent(nowMillis)?.let(scheduler::schedule)
@@ -631,6 +645,7 @@ private fun StopwatchLapEntity.toStopwatchLap(): StopwatchLap =
         createdAtMillis = createdAt,
     )
 
+
 private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm? {
     if (entryType != ClockEventType.ALARM.name) return null
     val zoneId = ZoneId.of(timeZoneId ?: ZoneId.systemDefault().id)
@@ -646,6 +661,7 @@ private fun ScheduledAlarmEntity.toClockAlarm(): ClockAlarm? {
         repeatRule = repeatRule,
         timeZoneId = zoneId.id,
         triggerAtMillis = snoozedUntilMs ?: triggerAtMillis,
+        soundUri = soundUri,
     )
 }
 
@@ -673,6 +689,7 @@ private fun ScheduledAlarmEntity.toScheduledEvent(): ClockScheduledEvent =
         durationMs = durationMs,
         startedAtMillis = startedAtMs,
         occurrenceTriggerAtMillis = triggerAtMillis,
+        soundUri = soundUri,
     )
 
 private fun ScheduledAlarmEntity.toPrimaryAlarmScheduledEvent(nowMillis: Long): ClockScheduledEvent? {
@@ -688,6 +705,7 @@ private fun ScheduledAlarmEntity.toPrimaryAlarmCancellationEvent(): ClockSchedul
         triggerAtMillis = triggerAtMillis,
         label = label,
         occurrenceTriggerAtMillis = triggerAtMillis,
+        soundUri = soundUri,
     )
 
 private fun ScheduledAlarmEntity.toSnoozeScheduledEvent(nowMillis: Long): ClockScheduledEvent? {
@@ -700,6 +718,7 @@ private fun ScheduledAlarmEntity.toSnoozeScheduledEvent(nowMillis: Long): ClockS
         triggerAtMillis = snoozeAt,
         label = label,
         occurrenceTriggerAtMillis = snoozeAt,
+        soundUri = soundUri,
     )
 }
 
@@ -713,6 +732,7 @@ private fun ScheduledAlarmEntity.toSnoozeCancellationEvent(): ClockScheduledEven
         triggerAtMillis = snoozeAt,
         label = label,
         occurrenceTriggerAtMillis = snoozeAt,
+        soundUri = soundUri,
     )
 }
 
@@ -727,6 +747,7 @@ private fun ScheduledAlarmEntity.toPreAlarmScheduledEvent(nowMillis: Long): Cloc
         triggerAtMillis = preAlarmTrigger,
         label = label,
         occurrenceTriggerAtMillis = triggerAtMillis,
+        soundUri = soundUri,
     )
 }
 
@@ -738,6 +759,7 @@ private fun ScheduledAlarmEntity.toPreAlarmCancellationEvent(): ClockScheduledEv
         triggerAtMillis = triggerAtMillis,
         label = label,
         occurrenceTriggerAtMillis = triggerAtMillis,
+        soundUri = soundUri,
     )
 
 private fun ScheduledAlarmEntity.isRepeatingAlarm(): Boolean =
@@ -753,6 +775,7 @@ private fun ScheduledAlarmEntity.toAlarmDraft(): AlarmDraft? {
         minute = alarmMinute ?: trigger.minute,
         repeatRule = toAlarmRepeatRule(trigger),
         timeZoneId = zoneId,
+        soundUri = soundUri,
     )
 }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockSoundPreferences.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockSoundPreferences.kt
@@ -1,0 +1,56 @@
+package com.kernel.ai.core.memory.clock
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+private const val TAG = "ClockSoundPrefs"
+private val Context.clockSoundPrefsDataStore by preferencesDataStore(name = "clock_sound_preferences")
+
+@Singleton
+class ClockSoundPreferences @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val defaultAlarmSoundUriKey = stringPreferencesKey("default_alarm_sound_uri")
+    private val timerSoundUriKey = stringPreferencesKey("timer_sound_uri")
+
+    val soundConfig: Flow<ClockSoundConfig> = context.clockSoundPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading clock sound preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs ->
+            ClockSoundConfig(
+                defaultAlarmSoundUri = prefs[defaultAlarmSoundUriKey],
+                timerSoundUri = prefs[timerSoundUriKey],
+            )
+        }
+
+    suspend fun setDefaultAlarmSoundUri(soundUri: String?) {
+        context.clockSoundPrefsDataStore.edit { prefs ->
+            if (soundUri.isNullOrBlank()) prefs.remove(defaultAlarmSoundUriKey)
+            else prefs[defaultAlarmSoundUriKey] = soundUri
+        }
+    }
+
+    suspend fun setTimerSoundUri(soundUri: String?) {
+        context.clockSoundPrefsDataStore.edit { prefs ->
+            if (soundUri.isNullOrBlank()) prefs.remove(timerSoundUriKey)
+            else prefs[timerSoundUriKey] = soundUri
+        }
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ScheduledAlarmEntity.kt
@@ -22,6 +22,7 @@ data class ScheduledAlarmEntity(
     @ColumnInfo(name = "repeat_days_mask") val repeatDaysMask: Int? = null,
     @ColumnInfo(name = "one_off_date_epoch_day") val oneOffDateEpochDay: Long? = null,
     @ColumnInfo(name = "time_zone_id") val timeZoneId: String? = null,
+    @ColumnInfo(name = "sound_uri") val soundUri: String? = null,
     @ColumnInfo(name = "snoozed_until_ms") val snoozedUntilMs: Long? = null,
     @ColumnInfo(name = "completed_at_ms") val completedAtMs: Long? = null,
 )

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -35,12 +35,19 @@ class ClockRepositoryImplTest {
     private val scheduler = mockk<ClockScheduler>(relaxed = true)
     private val stopwatchDao = mockk<StopwatchDao>()
     private val worldClockDao = mockk<WorldClockDao>()
+    private val clockSoundPreferences = mockk<ClockSoundPreferences>()
 
     private lateinit var repository: ClockRepositoryImpl
 
     @BeforeEach
     fun setUp() {
-        repository = ClockRepositoryImpl(scheduledAlarmDao, worldClockDao, stopwatchDao, scheduler)
+        repository = ClockRepositoryImpl(
+            scheduledAlarmDao,
+            worldClockDao,
+            stopwatchDao,
+            scheduler,
+            clockSoundPreferences,
+        )
         every {
             scheduler.getPlatformState()
         } returns ClockPlatformState(
@@ -48,6 +55,7 @@ class ClockRepositoryImplTest {
             notificationsEnabled = true,
             canUseFullScreenIntent = false,
         )
+        every { clockSoundPreferences.soundConfig } returns flowOf(ClockSoundConfig())
     }
 
     @Test
@@ -90,6 +98,50 @@ class ClockRepositoryImplTest {
         assertEquals(AlarmRepeatRule.Daily, result?.repeatRule)
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM }) }
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM }) }
+    }
+
+    @Test
+    fun `createAlarm stores custom sound uri and schedules it`() = runTest {
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+        val draft = dailyDraft(label = "Gym", hour = 8, minute = 0)
+            .copy(soundUri = "content://media/internal/audio/media/7")
+
+        val result = repository.createAlarm(draft)
+
+        assertEquals("content://media/internal/audio/media/7", result?.soundUri)
+        coVerify(exactly = 1) {
+            scheduledAlarmDao.insert(match { it.soundUri == "content://media/internal/audio/media/7" })
+        }
+        verify(exactly = 1) {
+            scheduler.schedule(
+                match {
+                    it.type == ClockEventType.ALARM &&
+                        it.soundUri == "content://media/internal/audio/media/7"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `setDefaultAlarmSoundUri delegates to preferences`() = runTest {
+        coEvery { clockSoundPreferences.setDefaultAlarmSoundUri("content://media/internal/audio/media/9") } just Runs
+
+        repository.setDefaultAlarmSoundUri("content://media/internal/audio/media/9")
+
+        coVerify(exactly = 1) {
+            clockSoundPreferences.setDefaultAlarmSoundUri("content://media/internal/audio/media/9")
+        }
+    }
+
+    @Test
+    fun `setTimerSoundUri delegates to preferences`() = runTest {
+        coEvery { clockSoundPreferences.setTimerSoundUri("content://media/internal/audio/media/11") } just Runs
+
+        repository.setTimerSoundUri("content://media/internal/audio/media/11")
+
+        coVerify(exactly = 1) {
+            clockSoundPreferences.setTimerSoundUri("content://media/internal/audio/media/11")
+        }
     }
 
     @Test

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -1,7 +1,12 @@
 package com.kernel.ai.feature.settings
 
+import android.content.Intent
+import android.media.RingtoneManager
+import android.net.Uri
 import android.os.SystemClock
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -63,6 +68,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -98,6 +104,7 @@ fun SidePanelScreen(
     val recentCompletedTimers by viewModel.recentCompletedTimers.collectAsStateWithLifecycle()
     val stopwatch by viewModel.stopwatch.collectAsStateWithLifecycle()
     val worldClocks by viewModel.worldClocks.collectAsStateWithLifecycle()
+    val clockSoundConfig by viewModel.clockSoundConfig.collectAsStateWithLifecycle()
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedIds by viewModel.selectedIds.collectAsStateWithLifecycle()
@@ -220,6 +227,8 @@ fun SidePanelScreen(
                     nowMs = nowMs,
                     inSelectionMode = isInSelectionMode,
                     selectedIds = selectedIds,
+                    timerSoundUri = clockSoundConfig.timerSoundUri,
+                    onTimerSoundSelected = viewModel::setTimerSoundUri,
                     onCreateCustomTimer = { showCreateTimerDialog = true },
                     onPresetTimer = { durationMs ->
                         viewModel.scheduleTimer(durationMs, null) { success ->
@@ -246,6 +255,8 @@ fun SidePanelScreen(
                     alarms = alarms,
                     inSelectionMode = isInSelectionMode,
                     selectedIds = selectedIds,
+                    defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
+                    onDefaultAlarmSoundSelected = viewModel::setDefaultAlarmSoundUri,
                     onNewAlarm = { showCreateAlarmDialog = true },
                     onAlarmTap = { alarm ->
                         if (isInSelectionMode) viewModel.toggleSelection(alarm.id) else editingAlarm = alarm
@@ -421,6 +432,7 @@ fun SidePanelScreen(
     if (showCreateAlarmDialog) {
         AlarmCreateEditDialog(
             existingAlarm = null,
+            defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.scheduleAlarm(draft) { result ->
                     when (result) {
@@ -439,6 +451,7 @@ fun SidePanelScreen(
     editingAlarm?.let { alarm ->
         AlarmCreateEditDialog(
             existingAlarm = alarm,
+            defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.editAlarm(alarm, draft) { result ->
                     when (result) {
@@ -605,6 +618,80 @@ private fun SectionHeader(
     }
 }
 
+private fun defaultClockSoundUri(): Uri =
+    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+
+private fun normalizePickedClockSoundUri(uri: Uri?): String? =
+    uri?.toString()?.takeUnless { it == defaultClockSoundUri().toString() }
+
+private fun clockSoundLabel(context: android.content.Context, soundUri: String?): String =
+    if (soundUri == null) {
+        "System default"
+    } else {
+        runCatching { RingtoneManager.getRingtone(context, Uri.parse(soundUri))?.getTitle(context) }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: "Custom sound"
+    }
+
+private fun createClockSoundPickerIntent(currentSoundUri: String?): Intent =
+    Intent(RingtoneManager.ACTION_RINGTONE_PICKER).apply {
+        putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALARM)
+        putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true)
+        putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, false)
+        putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, defaultClockSoundUri())
+        putExtra(
+            RingtoneManager.EXTRA_RINGTONE_EXISTING_URI,
+            currentSoundUri?.let(Uri::parse) ?: defaultClockSoundUri(),
+        )
+    }
+
+@Composable
+private fun ClockSoundSettingCard(
+    title: String,
+    currentSoundUri: String?,
+    onSoundSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val soundLabel = remember(currentSoundUri) { clockSoundLabel(context, currentSoundUri) }
+    val pickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        @Suppress("DEPRECATION")
+        val pickedUri = result.data?.getParcelableExtra<Uri>(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
+        onSoundSelected(normalizePickedClockSoundUri(pickedUri))
+    }
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = soundLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(
+                    onClick = { pickerLauncher.launch(createClockSoundPickerIntent(currentSoundUri)) },
+                    modifier = Modifier.weight(1f),
+                ) { Text("Choose sound") }
+                if (currentSoundUri != null) {
+                    TextButton(
+                        onClick = { onSoundSelected(null) },
+                        modifier = Modifier.weight(1f),
+                    ) { Text("System default") }
+                }
+            }
+        }
+    }
+}
+
+
 @Composable
 private fun TimerDashboard(
     timers: List<ClockTimer>,
@@ -612,6 +699,8 @@ private fun TimerDashboard(
     nowMs: Long,
     inSelectionMode: Boolean,
     selectedIds: Set<String>,
+    timerSoundUri: String?,
+    onTimerSoundSelected: (String?) -> Unit,
     onCreateCustomTimer: () -> Unit,
     onPresetTimer: (Long) -> Unit,
     onTimerTap: (ClockTimer) -> Unit,
@@ -620,13 +709,15 @@ private fun TimerDashboard(
     onRestartTimer: (ClockTimer) -> Unit,
     onDeleteCompletedTimer: (ClockTimer) -> Unit,
     onClearCompletedTimers: () -> Unit,
- ) {
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
         item {
             TimerQuickStartCard(
+                timerSoundUri = timerSoundUri,
+                onTimerSoundSelected = onTimerSoundSelected,
                 onCreateCustomTimer = onCreateCustomTimer,
                 onPresetTimer = onPresetTimer,
             )
@@ -682,9 +773,11 @@ private fun TimerDashboard(
 
 @Composable
 private fun TimerQuickStartCard(
+    timerSoundUri: String?,
+    onTimerSoundSelected: (String?) -> Unit,
     onCreateCustomTimer: () -> Unit,
     onPresetTimer: (Long) -> Unit,
- ) {
+) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -699,6 +792,11 @@ private fun TimerQuickStartCard(
                 text = "Start a timer fast, keep multiple timers running, and revisit finished timers without retyping durations.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            ClockSoundSettingCard(
+                title = "Timer sound",
+                currentSoundUri = timerSoundUri,
+                onSoundSelected = onTimerSoundSelected,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 TIMER_PRESETS.take(2).forEach { preset ->
@@ -1066,15 +1164,23 @@ private fun AlarmDashboard(
     alarms: List<ClockAlarm>,
     inSelectionMode: Boolean,
     selectedIds: Set<String>,
+    defaultAlarmSoundUri: String?,
+    onDefaultAlarmSoundSelected: (String?) -> Unit,
     onNewAlarm: () -> Unit,
     onAlarmTap: (ClockAlarm) -> Unit,
     onAlarmLongPress: (ClockAlarm) -> Unit,
     onDismissAlarm: (ClockAlarm) -> Unit,
     onToggleAlarm: (ClockAlarm) -> Unit,
- ) {
+) {
     if (alarms.isEmpty()) {
         Column(modifier = Modifier.fillMaxWidth()) {
             SectionHeader(title = "Alarms")
+            ClockSoundSettingCard(
+                title = "Default alarm sound",
+                currentSoundUri = defaultAlarmSoundUri,
+                onSoundSelected = onDefaultAlarmSoundSelected,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
             EmptyStateCard(
                 title = "No active alarms",
                 body = "Create one-time or repeating alarms here. Repeating alarms get a Skip today reminder 30 minutes before they ring.",
@@ -1090,6 +1196,14 @@ private fun AlarmDashboard(
             SectionHeader(
                 title = "Alarms",
                 supportingText = alarms.firstOrNull()?.let { "Next: ${formatClockTime(it.triggerAtMillis)}" } ?: "",
+            )
+        }
+        item {
+            ClockSoundSettingCard(
+                title = "Default alarm sound",
+                currentSoundUri = defaultAlarmSoundUri,
+                onSoundSelected = onDefaultAlarmSoundSelected,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
         }
         items(alarms, key = { it.id }) { alarm ->
@@ -1474,9 +1588,10 @@ private val AlarmWeekdays = listOf(
 @Composable
 private fun AlarmCreateEditDialog(
     existingAlarm: ClockAlarm?,
+    defaultAlarmSoundUri: String?,
     onConfirm: (AlarmDraft) -> Unit,
     onDismiss: () -> Unit,
- ) {
+) {
     val zoneId = remember(existingAlarm) { ZoneId.of(existingAlarm?.timeZoneId ?: ZoneId.systemDefault().id) }
     val defaultTrigger = remember(existingAlarm, zoneId) {
         if (existingAlarm != null) {
@@ -1488,6 +1603,7 @@ private fun AlarmCreateEditDialog(
     val defaultZdt = defaultTrigger.atZone(zoneId)
     val existingRepeatRule = existingAlarm?.repeatRule
     var label by remember { mutableStateOf(existingAlarm?.label ?: "") }
+    var customSoundUri by remember(existingAlarm) { mutableStateOf(existingAlarm?.soundUri) }
     var step by remember { mutableStateOf(AlarmEditorStep.TIME) }
     var repeatSelection by remember(existingRepeatRule) { mutableStateOf(existingRepeatRule.toSelection()) }
     var repeatDaysMask by remember(existingRepeatRule) {
@@ -1519,6 +1635,7 @@ private fun AlarmCreateEditDialog(
         repeatDaysMask,
         selectedDateEpochDay,
         zoneId.id,
+        customSoundUri,
     ) {
         buildAlarmDraft(
             label = label,
@@ -1528,6 +1645,7 @@ private fun AlarmCreateEditDialog(
             repeatDaysMask = repeatDaysMask,
             oneOffDateEpochDay = selectedDateEpochDay,
             timeZoneId = zoneId.id,
+            soundUri = customSoundUri,
         )
     }
 
@@ -1641,6 +1759,16 @@ private fun AlarmCreateEditDialog(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
+                        ClockSoundSettingCard(
+                            title = if (customSoundUri == null) "Alarm sound (default)" else "Alarm sound override",
+                            currentSoundUri = customSoundUri ?: defaultAlarmSoundUri,
+                            onSoundSelected = { pickedUri -> customSoundUri = pickedUri },
+                        )
+                        if (customSoundUri != null) {
+                            TextButton(onClick = { customSoundUri = null }) {
+                                Text("Use default alarm sound")
+                            }
+                        }
                         OutlinedTextField(
                             value = label,
                             onValueChange = { label = it },
@@ -1703,7 +1831,8 @@ private fun buildAlarmDraft(
     repeatDaysMask: Int,
     oneOffDateEpochDay: Long?,
     timeZoneId: String,
- ): AlarmDraft? {
+    soundUri: String?,
+): AlarmDraft? {
     val repeatRule = when (repeatSelection) {
         AlarmRepeatSelection.ONE_OFF -> {
             val epochDay = oneOffDateEpochDay ?: return null
@@ -1721,6 +1850,7 @@ private fun buildAlarmDraft(
         minute = minute,
         repeatRule = repeatRule,
         timeZoneId = timeZoneId,
+        soundUri = soundUri,
     )
 }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -6,6 +6,7 @@ import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockSoundConfig
 import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.ClockTimer
 import com.kernel.ai.core.memory.clock.WorldClock
@@ -56,6 +57,10 @@ class SidePanelViewModel @Inject constructor(
     val worldClocks: StateFlow<List<WorldClock>> =
         clockRepository.observeWorldClocks()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val clockSoundConfig: StateFlow<ClockSoundConfig> =
+        clockRepository.observeClockSoundConfig()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ClockSoundConfig())
 
     private val _selectedTab = MutableStateFlow(ClockSurfaceTab.TIMERS)
     val selectedTab: StateFlow<ClockSurfaceTab> = _selectedTab.asStateFlow()
@@ -222,6 +227,18 @@ class SidePanelViewModel @Inject constructor(
     fun scheduleTimer(durationMs: Long, label: String?, onResult: (Boolean) -> Unit = {}) {
         viewModelScope.launch {
             onResult(tryScheduleTimer(durationMs, label))
+        }
+    }
+
+    fun setDefaultAlarmSoundUri(soundUri: String?) {
+        viewModelScope.launch {
+            clockRepository.setDefaultAlarmSoundUri(soundUri)
+        }
+    }
+
+    fun setTimerSoundUri(soundUri: String?) {
+        viewModelScope.launch {
+            clockRepository.setTimerSoundUri(soundUri)
         }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.feature.settings
 
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.ClockSoundConfig
 import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.ClockTimer
 import com.kernel.ai.core.memory.clock.StopwatchStatus
@@ -36,6 +37,7 @@ class SidePanelViewModelTest {
         every { clockRepository.observeActiveTimers() } returns emptyFlow()
         every { clockRepository.observeRecentCompletedTimers() } returns emptyFlow()
         every { clockRepository.observeWorldClocks() } returns emptyFlow()
+        every { clockRepository.observeClockSoundConfig() } returns kotlinx.coroutines.flow.flowOf(ClockSoundConfig())
         every { clockRepository.observeStopwatch() } returns kotlinx.coroutines.flow.flowOf(
             ClockStopwatch(
                 id = "primary",


### PR DESCRIPTION
## Summary
- add ClockSoundPreferences-backed default alarm and shared timer sounds plus per-alarm sound overrides
- wire chosen sound URIs through the clock repository, scheduler extras, and ClockAlertService playback resolution
- add ringtone picker controls for timer sound, default alarm sound, and per-alarm overrides in the Clock surface

## Testing
- ./gradlew :core:memory:testDebugUnitTest --tests "*ClockRepositoryImplTest" :feature:settings:testDebugUnitTest --tests "*SidePanelViewModelTest" :app:testDebugUnitTest --tests "*ClockAlertPlaybackTest" :core:memory:compileDebugKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin

Closes #757
