### PR TITLE
feat(chat): stream spoken chat responses

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidTextToSpeechController.kt
@@ -1,37 +1,51 @@
 package com.kernel.ai.core.voice
 
+import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
-import android.content.Context
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
-import java.util.Locale
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private const val TAG = "AndroidTtsController"
+private const val TAG = "KernelAI"
 
 @Singleton
 class AndroidTextToSpeechController @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : VoiceOutputController {
 
+    private data class ActivePlayback(
+        val token: Long,
+        val utteranceIds: MutableSet<String> = mutableSetOf(),
+        var firstChunkText: String? = null,
+        var finalChunkQueued: Boolean = false,
+    )
+
+    private data class ActiveUtterance(
+        val playbackToken: Long,
+        val text: String,
+    )
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val _events = MutableSharedFlow<VoiceOutputEvent>(extraBufferCapacity = 8)
     override val events: Flow<VoiceOutputEvent> = _events.asSharedFlow()
+    private val playbackLock = Any()
+    private val activeUtterances = mutableMapOf<String, ActiveUtterance>()
     private val audioManager by lazy {
         context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     }
@@ -43,10 +57,10 @@ class AndroidTextToSpeechController @Inject constructor(
     private var initDeferred: CompletableDeferred<Int>? = null
 
     @Volatile
-    private var activeUtteranceId: String? = null
+    private var nextPlaybackToken: Long = 0L
 
     @Volatile
-    private var activeUtteranceText: String? = null
+    private var activePlayback: ActivePlayback? = null
 
     @Volatile
     private var audioFocusRequest: AudioFocusRequest? = null
@@ -60,11 +74,100 @@ class AndroidTextToSpeechController @Inject constructor(
     }
 
     override suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult {
+        val text = request.text.trim()
+        if (text.isBlank()) return VoiceOutputResult.Spoken
+        val playbackToken = nextPlaybackToken()
+        synchronized(playbackLock) {
+            activePlayback = ActivePlayback(token = playbackToken)
+        }
+        return enqueuePlaybackChunk(
+            playbackToken = playbackToken,
+            text = text,
+            locale = request.locale,
+            utteranceId = request.utteranceId,
+            queueMode = TextToSpeech.QUEUE_FLUSH,
+            isFinal = true,
+        )
+    }
+
+    override suspend fun openStreamingSession(
+        request: VoiceSpeakRequest,
+    ): VoiceOutputStreamingSession {
+        val playbackToken = nextPlaybackToken()
+        return object : VoiceOutputStreamingSession {
+            private var hasQueuedChunk = false
+            private var isClosed = false
+
+            override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult {
+                if (isClosed) return VoiceOutputResult.Spoken
+
+                val normalized = text.trim()
+                if (normalized.isBlank()) {
+                    if (isFinal) {
+                        isClosed = true
+                        synchronized(playbackLock) {
+                            activePlayback
+                                ?.takeIf { it.token == playbackToken }
+                                ?.finalChunkQueued = true
+                        }
+                        completePlaybackIfDrained(playbackToken)
+                    }
+                    return VoiceOutputResult.Spoken
+                }
+
+                synchronized(playbackLock) {
+                    val playback = activePlayback
+                    if (playback?.token != playbackToken) {
+                        activePlayback = ActivePlayback(token = playbackToken)
+                    }
+                }
+                val result = enqueuePlaybackChunk(
+                    playbackToken = playbackToken,
+                    text = normalized,
+                    locale = request.locale,
+                    utteranceId = null,
+                    queueMode = if (hasQueuedChunk) TextToSpeech.QUEUE_ADD else TextToSpeech.QUEUE_FLUSH,
+                    isFinal = isFinal,
+                )
+                if (result is VoiceOutputResult.Spoken) {
+                    hasQueuedChunk = true
+                    if (isFinal) {
+                        isClosed = true
+                    }
+                }
+                return result
+            }
+        }
+    }
+
+    override fun stop() {
+        scope.launch {
+            val hadActivePlayback = synchronized(playbackLock) {
+                val hadPlayback = activePlayback != null || activeUtterances.isNotEmpty()
+                activePlayback = null
+                activeUtterances.clear()
+                hadPlayback
+            }
+            textToSpeech?.stop()
+            releaseAudioFocus()
+            if (hadActivePlayback) {
+                _events.emit(VoiceOutputEvent.SpeakingStopped)
+            }
+        }
+    }
+
+    private suspend fun enqueuePlaybackChunk(
+        playbackToken: Long,
+        text: String,
+        locale: Locale,
+        utteranceId: String?,
+        queueMode: Int,
+        isFinal: Boolean,
+    ): VoiceOutputResult {
         val engine = ensureReady() ?: return VoiceOutputResult.Unavailable(
             "Text-to-speech is unavailable on this device."
         )
 
-        val locale = request.locale
         val availability = engine.isLanguageAvailable(locale)
         if (availability < TextToSpeech.LANG_AVAILABLE) {
             return VoiceOutputResult.Unavailable(
@@ -74,35 +177,40 @@ class AndroidTextToSpeechController @Inject constructor(
 
         engine.language = locale
         requestAudioFocus()
-        val utteranceId = request.utteranceId ?: "kernel-voice-${System.nanoTime()}"
-        activeUtteranceId = utteranceId
-        activeUtteranceText = request.text
+        val resolvedUtteranceId = utteranceId ?: "kernel-voice-${System.nanoTime()}"
+        synchronized(playbackLock) {
+            val playback = activePlayback?.takeIf { it.token == playbackToken }
+                ?: ActivePlayback(token = playbackToken).also { activePlayback = it }
+            playback.utteranceIds += resolvedUtteranceId
+            if (playback.firstChunkText == null) {
+                playback.firstChunkText = text
+            }
+            if (isFinal) {
+                playback.finalChunkQueued = true
+            }
+            activeUtterances[resolvedUtteranceId] = ActiveUtterance(
+                playbackToken = playbackToken,
+                text = text,
+            )
+        }
         val result = engine.speak(
-            request.text,
-            TextToSpeech.QUEUE_FLUSH,
+            text,
+            queueMode,
             Bundle(),
-            utteranceId,
+            resolvedUtteranceId,
         )
         return if (result == TextToSpeech.ERROR) {
-            activeUtteranceId = null
-            activeUtteranceText = null
-            releaseAudioFocus()
+            synchronized(playbackLock) {
+                activeUtterances.remove(resolvedUtteranceId)
+                activePlayback
+                    ?.takeIf { it.token == playbackToken }
+                    ?.utteranceIds
+                    ?.remove(resolvedUtteranceId)
+            }
+            completePlaybackIfDrained(playbackToken)
             VoiceOutputResult.Unavailable("Text-to-speech failed to start.")
         } else {
             VoiceOutputResult.Spoken
-        }
-    }
-
-    override fun stop() {
-        scope.launch {
-            val hadActiveUtterance = activeUtteranceId != null || activeUtteranceText != null
-            textToSpeech?.stop()
-            activeUtteranceId = null
-            activeUtteranceText = null
-            releaseAudioFocus()
-            if (hadActiveUtterance) {
-                _events.emit(VoiceOutputEvent.SpeakingStopped)
-            }
         }
     }
 
@@ -129,28 +237,33 @@ class AndroidTextToSpeechController @Inject constructor(
         engine.setOnUtteranceProgressListener(
             object : UtteranceProgressListener() {
                 override fun onStart(utteranceId: String?) {
-                    if (utteranceId == activeUtteranceId) {
-                        activeUtteranceText?.let { text ->
-                            _events.tryEmit(VoiceOutputEvent.SpeakingStarted(text))
-                        }
+                    val speakingText = synchronized(playbackLock) {
+                        val resolvedUtteranceId = utteranceId ?: return@synchronized null
+                        val meta = activeUtterances[resolvedUtteranceId] ?: return@synchronized null
+                        val playback = activePlayback?.takeIf { it.token == meta.playbackToken }
+                            ?: return@synchronized null
+                        playback.firstChunkText ?: meta.text
+                    }
+                    speakingText?.let { text ->
+                        _events.tryEmit(VoiceOutputEvent.SpeakingStarted(text))
                     }
                 }
 
                 override fun onDone(utteranceId: String?) {
-                    clearActiveUtterance(utteranceId)
+                    onUtteranceFinished(utteranceId)
                 }
 
                 @Deprecated("Deprecated in Java")
                 override fun onError(utteranceId: String?) {
-                    clearActiveUtterance(utteranceId)
+                    onUtteranceFinished(utteranceId)
                 }
 
                 override fun onError(utteranceId: String?, errorCode: Int) {
-                    clearActiveUtterance(utteranceId)
+                    onUtteranceFinished(utteranceId)
                 }
 
                 override fun onStop(utteranceId: String?, interrupted: Boolean) {
-                    clearActiveUtterance(utteranceId)
+                    onUtteranceFinished(utteranceId)
                 }
             }
         )
@@ -163,7 +276,7 @@ class AndroidTextToSpeechController @Inject constructor(
         return if (status == TextToSpeech.SUCCESS) {
             textToSpeech
         } else {
-            Log.w(TAG, "TextToSpeech init failed with status=$status")
+            Log.w(TAG, "AndroidTextToSpeechController: init failed with status=$status")
             textToSpeech?.shutdown()
             textToSpeech = null
             initDeferred = null
@@ -171,15 +284,41 @@ class AndroidTextToSpeechController @Inject constructor(
         }
     }
 
-    private fun clearActiveUtterance(utteranceId: String?) {
-        if (utteranceId != activeUtteranceId) return
-        activeUtteranceId = null
-        activeUtteranceText = null
-        releaseAudioFocus()
-        _events.tryEmit(VoiceOutputEvent.SpeakingStopped)
+    private fun onUtteranceFinished(utteranceId: String?) {
+        val playbackToken = synchronized(playbackLock) {
+            val resolvedUtteranceId = utteranceId ?: return@synchronized null
+            val meta = activeUtterances.remove(resolvedUtteranceId) ?: return@synchronized null
+            activePlayback
+                ?.takeIf { it.token == meta.playbackToken }
+                ?.utteranceIds
+                ?.remove(resolvedUtteranceId)
+            meta.playbackToken
+        } ?: return
+        completePlaybackIfDrained(playbackToken)
+    }
+
+    private fun completePlaybackIfDrained(playbackToken: Long) {
+        val shouldEmitStopped = synchronized(playbackLock) {
+            val playback = activePlayback?.takeIf { it.token == playbackToken } ?: return@synchronized false
+            if (!playback.finalChunkQueued || playback.utteranceIds.isNotEmpty()) {
+                return@synchronized false
+            }
+            activePlayback = null
+            true
+        }
+        if (shouldEmitStopped) {
+            releaseAudioFocus()
+            _events.tryEmit(VoiceOutputEvent.SpeakingStopped)
+        }
+    }
+
+    private fun nextPlaybackToken(): Long = synchronized(playbackLock) {
+        nextPlaybackToken += 1L
+        nextPlaybackToken
     }
 
     private fun requestAudioFocus() {
+        if (audioFocusRequest != null) return
         val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
             .setAudioAttributes(
                 AudioAttributes.Builder()
@@ -194,7 +333,7 @@ class AndroidTextToSpeechController @Inject constructor(
         audioFocusRequest = request
         val result = audioManager.requestAudioFocus(request)
         if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            Log.w(TAG, "TextToSpeech audio focus request not granted: $result")
+            Log.w(TAG, "AndroidTextToSpeechController: audio focus request not granted: $result")
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -46,6 +46,16 @@ class FallbackVoiceOutputController @Inject constructor(
             VoiceOutputEngine.SherpaExperimental -> speakWithSherpaFallback(request)
         }
 
+    override suspend fun openStreamingSession(request: VoiceSpeakRequest): VoiceOutputStreamingSession =
+        when (voiceOutputPreferences.selectedEngine.first()) {
+            VoiceOutputEngine.AndroidTts -> {
+                activate(androidTts)
+                androidTts.openStreamingSession(request)
+            }
+
+            VoiceOutputEngine.SherpaExperimental -> openSherpaStreamingSessionOrFallback(request)
+        }
+
     override fun stop() {
         sherpa.stop()
         androidTts.stop()
@@ -97,6 +107,31 @@ class FallbackVoiceOutputController @Inject constructor(
             return androidWarmUpResult
         }
         return androidTts.speak(request)
+    }
+
+    private suspend fun openSherpaStreamingSessionOrFallback(
+        request: VoiceSpeakRequest,
+    ): VoiceOutputStreamingSession {
+        val warmUpResult = sherpa.warmUp()
+        if (warmUpResult !is VoiceOutputResult.Unavailable) {
+            activate(sherpa)
+            return sherpa.openStreamingSession(request)
+        }
+
+        Log.i(
+            TAG,
+            "Sherpa-ONNX TTS unavailable (${warmUpResult.message}); routing streaming session to Android TTS fallback.",
+        )
+        activate(androidTts)
+        val androidWarmUpResult = androidTts.warmUp()
+        return if (androidWarmUpResult is VoiceOutputResult.Unavailable) {
+            object : VoiceOutputStreamingSession {
+                override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult =
+                    androidWarmUpResult
+            }
+        } else {
+            androidTts.openStreamingSession(request)
+        }
     }
 
     private fun activate(controller: VoiceOutputController) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -8,8 +8,10 @@ import android.media.AudioFocusRequest
 import android.media.AudioTrack
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -48,6 +50,16 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     @ApplicationContext private val context: Context,
     private val voiceOutputPreferences: VoiceOutputPreferences,
 ) : VoiceOutputController {
+    private data class ActiveStreamingPlayback(
+        val token: Long,
+        val chunks: Channel<StreamingChunk>,
+        val worker: Job,
+    )
+
+    private data class StreamingChunk(
+        val text: String,
+        val isFinal: Boolean,
+    )
 
     // ── Coroutine scope on IO — never Main ──────────────────────────────────
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -69,6 +81,9 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
     // ── Playback cancellation ────────────────────────────────────────────────
     @Volatile private var stopped = false
+    @Volatile private var nextPlaybackToken = 0L
+    @Volatile private var activeStreamingPlayback: ActiveStreamingPlayback? = null
+    private val playbackLock = Any()
 
     // ── AudioFocus ───────────────────────────────────────────────────────────
     private val audioManager by lazy {
@@ -93,6 +108,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             val genMethod = generateMethod
                 ?: return@withContext VoiceOutputResult.Unavailable("Sherpa generate() not found.")
 
+            stopped = true
+            clearStreamingPlayback()
             stopped = false
             requestAudioFocus()
             _events.emit(VoiceOutputEvent.SpeakingStarted(request.text))
@@ -119,10 +136,64 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             }
         }
 
+    override suspend fun openStreamingSession(
+        request: VoiceSpeakRequest,
+    ): VoiceOutputStreamingSession = withContext(Dispatchers.IO) {
+        val voice = voiceOutputPreferences.selectedSherpaVoice.first()
+        val initResult = initialize(voice)
+        if (initResult is VoiceOutputResult.Unavailable) {
+            return@withContext object : VoiceOutputStreamingSession {
+                override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult = initResult
+            }
+        }
+
+        val playbackToken = allocatePlaybackToken()
+        stopped = true
+        clearStreamingPlayback()
+        stopped = false
+        val chunks = Channel<StreamingChunk>(Channel.UNLIMITED)
+        val worker = scope.launch {
+            runStreamingPlayback(
+                playbackToken = playbackToken,
+                request = request,
+                chunks = chunks,
+            )
+        }
+        synchronized(playbackLock) {
+            activeStreamingPlayback = ActiveStreamingPlayback(
+                token = playbackToken,
+                chunks = chunks,
+                worker = worker,
+            )
+        }
+
+        return@withContext object : VoiceOutputStreamingSession {
+            private var closed = false
+
+            override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult {
+                if (closed) return VoiceOutputResult.Spoken
+                val normalized = text.trim()
+                if (normalized.isNotBlank()) {
+                    chunks.send(StreamingChunk(text = normalized, isFinal = isFinal))
+                } else if (isFinal) {
+                    chunks.close()
+                }
+                if (isFinal) {
+                    closed = true
+                    chunks.close()
+                }
+                return VoiceOutputResult.Spoken
+            }
+        }
+    }
+
     override fun stop() {
         stopped = true
         releaseAudioFocus()
-        scope.launch { _events.emit(VoiceOutputEvent.SpeakingStopped) }
+        val shouldEmitStopped = clearStreamingPlayback()
+        if (shouldEmitStopped) {
+            scope.launch { _events.emit(VoiceOutputEvent.SpeakingStopped) }
+        }
     }
 
     // ── Initialisation ───────────────────────────────────────────────────────
@@ -201,10 +272,77 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     }
 
     private fun resetForVoice(voice: SherpaPiperVoice) {
+        clearStreamingPlayback()
         ttsInstance = null
         generateMethod = null
         initState = InitState.UNINITIALIZED
         initializedVoice = voice
+    }
+
+    private suspend fun runStreamingPlayback(
+        playbackToken: Long,
+        request: VoiceSpeakRequest,
+        chunks: Channel<StreamingChunk>,
+    ) {
+        val tts = ttsInstance ?: return
+        val genMethod = generateMethod ?: return
+        var emittedStarted = false
+        var spokeAnyChunk = false
+        requestAudioFocus()
+        try {
+            for (chunk in chunks) {
+                if (stopped || !isStreamingPlaybackActive(playbackToken)) break
+                if (!emittedStarted) {
+                    _events.emit(VoiceOutputEvent.SpeakingStarted(request.text.ifBlank { chunk.text }))
+                    emittedStarted = true
+                }
+                val audioResult = try {
+                    genMethod.invoke(tts, chunk.text, 0, 1.0f)
+                        ?: return
+                } catch (e: Exception) {
+                    Log.e(TAG, "Sherpa streaming generate() failed", e)
+                    return
+                }
+                val samples = reflectGetSamples(audioResult)
+                val sampleRate = reflectGetSampleRate(audioResult)
+                if (!stopped && isStreamingPlaybackActive(playbackToken)) {
+                    playOnAudioTrack(samples, sampleRate)
+                    spokeAnyChunk = true
+                }
+                if (chunk.isFinal) {
+                    break
+                }
+            }
+        } finally {
+            releaseAudioFocus()
+            if (finishStreamingPlayback(playbackToken) && (emittedStarted || spokeAnyChunk)) {
+                _events.emit(VoiceOutputEvent.SpeakingStopped)
+            }
+        }
+    }
+
+    private fun allocatePlaybackToken(): Long = synchronized(playbackLock) {
+        nextPlaybackToken += 1L
+        nextPlaybackToken
+    }
+
+    private fun isStreamingPlaybackActive(playbackToken: Long): Boolean = synchronized(playbackLock) {
+        activeStreamingPlayback?.token == playbackToken
+    }
+
+    private fun finishStreamingPlayback(playbackToken: Long): Boolean = synchronized(playbackLock) {
+        val active = activeStreamingPlayback ?: return@synchronized false
+        if (active.token != playbackToken) return@synchronized false
+        activeStreamingPlayback = null
+        true
+    }
+
+    private fun clearStreamingPlayback(): Boolean = synchronized(playbackLock) {
+        val active = activeStreamingPlayback ?: return@synchronized false
+        activeStreamingPlayback = null
+        active.chunks.close()
+        active.worker.cancel()
+        true
     }
 
     // ── Config construction via reflection ───────────────────────────────────

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -190,10 +190,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     override fun stop() {
         stopped = true
         releaseAudioFocus()
-        val shouldEmitStopped = clearStreamingPlayback()
-        if (shouldEmitStopped) {
-            scope.launch { _events.emit(VoiceOutputEvent.SpeakingStopped) }
-        }
+        clearStreamingPlayback()
     }
 
     // ── Initialisation ───────────────────────────────────────────────────────
@@ -287,14 +284,17 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
         var emittedStarted = false
-        var spokeAnyChunk = false
-        requestAudioFocus()
+        var requestedAudioFocus = false
         try {
             for (chunk in chunks) {
                 if (stopped || !isStreamingPlaybackActive(playbackToken)) break
                 if (!emittedStarted) {
                     _events.emit(VoiceOutputEvent.SpeakingStarted(request.text.ifBlank { chunk.text }))
                     emittedStarted = true
+                }
+                if (!requestedAudioFocus) {
+                    requestAudioFocus()
+                    requestedAudioFocus = true
                 }
                 val audioResult = try {
                     genMethod.invoke(tts, chunk.text, 0, 1.0f)
@@ -307,7 +307,6 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 val sampleRate = reflectGetSampleRate(audioResult)
                 if (!stopped && isStreamingPlaybackActive(playbackToken)) {
                     playOnAudioTrack(samples, sampleRate)
-                    spokeAnyChunk = true
                 }
                 if (chunk.isFinal) {
                     break
@@ -315,7 +314,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             }
         } finally {
             releaseAudioFocus()
-            if (finishStreamingPlayback(playbackToken) && (emittedStarted || spokeAnyChunk)) {
+            if (finishStreamingPlayback(playbackToken)) {
                 _events.emit(VoiceOutputEvent.SpeakingStopped)
             }
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
@@ -10,6 +10,10 @@ data class VoiceSpeakRequest(
     val utteranceId: String? = null,
 )
 
+interface VoiceOutputStreamingSession {
+    suspend fun append(text: String, isFinal: Boolean = false): VoiceOutputResult
+}
+
 sealed interface VoiceOutputResult {
     object Spoken : VoiceOutputResult
     data class Unavailable(val message: String) : VoiceOutputResult
@@ -20,12 +24,37 @@ sealed interface VoiceOutputEvent {
     object SpeakingStopped : VoiceOutputEvent
 }
 
+private class BufferedVoiceOutputStreamingSession(
+    private val controller: VoiceOutputController,
+    private val request: VoiceSpeakRequest,
+) : VoiceOutputStreamingSession {
+    private val buffer = StringBuilder()
+    private var isClosed = false
+
+    override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult {
+        if (isClosed) return VoiceOutputResult.Spoken
+        if (text.isNotBlank()) {
+            buffer.append(text)
+        }
+        if (!isFinal) return VoiceOutputResult.Spoken
+
+        isClosed = true
+        val finalText = buffer.toString().trim()
+        if (finalText.isBlank()) return VoiceOutputResult.Spoken
+        return controller.speak(request.copy(text = finalText))
+    }
+}
+
 interface VoiceOutputController {
     val events: Flow<VoiceOutputEvent> get() = emptyFlow()
 
     suspend fun warmUp(): VoiceOutputResult = VoiceOutputResult.Spoken
 
     suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult
+
+    suspend fun openStreamingSession(
+        request: VoiceSpeakRequest = VoiceSpeakRequest(text = ""),
+    ): VoiceOutputStreamingSession = BufferedVoiceOutputStreamingSession(this, request)
 
     fun stop()
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/FallbackVoiceOutputControllerTest.kt
@@ -179,6 +179,42 @@ class FallbackVoiceOutputControllerTest {
     }
 
     @Test
+    fun `openStreamingSession routes to Sherpa when Sherpa is selected and available`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+            val request = VoiceSpeakRequest("Kia ora")
+            val session = mockk<VoiceOutputStreamingSession>()
+            coEvery { sherpa.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { sherpa.openStreamingSession(request) } returns session
+
+            val controller = buildController()
+            val result = controller.openStreamingSession(request)
+
+            assertEquals(session, result)
+            coVerify(exactly = 1) { sherpa.openStreamingSession(request) }
+            coVerify(exactly = 0) { androidTts.openStreamingSession(any()) }
+        }
+
+    @Test
+    fun `openStreamingSession falls back to Android TTS when Sherpa is unavailable`() =
+        runTest(dispatcher) {
+            selectedEngine.value = VoiceOutputEngine.SherpaExperimental
+            val request = VoiceSpeakRequest("Fallback stream")
+            val session = mockk<VoiceOutputStreamingSession>()
+            coEvery { sherpa.warmUp() } returns VoiceOutputResult.Unavailable("no AAR")
+            coEvery { androidTts.warmUp() } returns VoiceOutputResult.Spoken
+            coEvery { androidTts.openStreamingSession(request) } returns session
+
+            val controller = buildController()
+            val result = controller.openStreamingSession(request)
+
+            assertEquals(session, result)
+            coVerify(exactly = 1) { sherpa.warmUp() }
+            coVerify(exactly = 1) { androidTts.warmUp() }
+            coVerify(exactly = 1) { androidTts.openStreamingSession(request) }
+        }
+
+    @Test
     fun `stop stops both controllers defensively`() = runTest(dispatcher) {
         every { sherpa.stop() } just runs
         every { androidTts.stop() } just runs

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -173,6 +173,7 @@ fun ChatScreen(
                 onInputChanged = viewModel::onInputChanged,
                 onSend = viewModel::sendMessage,
                 onCancel = viewModel::cancelGeneration,
+                onStopVoicePlayback = viewModel::stopVoicePlayback,
                 onBack = onBack,
                 onNewConversation = {
                     viewModel.startNewConversation()
@@ -213,6 +214,7 @@ private fun ChatContent(
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
+    onStopVoicePlayback: () -> Unit,
     onBack: () -> Unit,
     onNewConversation: () -> Unit,
     onRenameConversation: (String) -> Unit,
@@ -288,6 +290,11 @@ private fun ChatContent(
                     }
                 },
                 actions = {
+                    AnimatedVisibility(visible = state.isSpeakingResponse) {
+                        IconButton(onClick = onStopVoicePlayback) {
+                            Icon(Icons.Default.Close, contentDescription = "Stop voice playback")
+                        }
+                    }
                     IconButton(onClick = onCopyAll) {
                         Icon(Icons.Default.ContentCopy, contentDescription = "Copy conversation")
                     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -7,6 +7,73 @@ package com.kernel.ai.feature.chat
 internal fun stripMarkdownForClipboard(text: String): String =
     stripMarkdown(convertLatexToUnicode(text))
 
+internal fun normalizeChatTextForSpeech(text: String): String =
+    stripMarkdownForClipboard(text)
+        .replace(Regex("""\s+"""), " ")
+        .trim()
+
+internal fun popNextStreamingSpeechChunk(
+    buffer: StringBuilder,
+    minChunkLength: Int = 72,
+    preferredChunkLength: Int = 180,
+    force: Boolean = false,
+): String? {
+    if (buffer.isEmpty()) return null
+    val raw = buffer.toString()
+    val boundary = findSpeechChunkBoundary(
+        text = raw,
+        minChunkLength = minChunkLength,
+        preferredChunkLength = preferredChunkLength,
+        force = force,
+    )
+    if (boundary <= 0) return null
+
+    val chunk = raw.substring(0, boundary)
+    buffer.delete(0, boundary)
+    return normalizeChatTextForSpeech(chunk).takeIf { it.isNotBlank() }
+}
+
+private fun findSpeechChunkBoundary(
+    text: String,
+    minChunkLength: Int,
+    preferredChunkLength: Int,
+    force: Boolean,
+): Int {
+    if (text.isBlank()) return if (force) text.length else -1
+    if (force) return text.length
+
+    var strongBoundary = -1
+    var softBoundary = -1
+    var whitespaceBoundary = -1
+
+    text.forEachIndexed { index, char ->
+        if (char.isWhitespace()) {
+            whitespaceBoundary = index + 1
+        }
+        when (char) {
+            '.', '!', '?' -> {
+                val next = text.getOrNull(index + 1)
+                if (next == null || next.isWhitespace() || next == '"' || next == '\'' || next == ')') {
+                    strongBoundary = index + 1
+                }
+            }
+            '\n' -> {
+                strongBoundary = index + 1
+            }
+            ',', ';', ':' -> {
+                softBoundary = index + 1
+            }
+        }
+    }
+
+    return when {
+        strongBoundary >= minChunkLength -> strongBoundary
+        text.length >= preferredChunkLength && softBoundary >= minChunkLength -> softBoundary
+        text.length >= preferredChunkLength && whitespaceBoundary >= minChunkLength -> whitespaceBoundary
+        else -> -1
+    }
+}
+
 /**
  * Strips common Markdown syntax from text for plain-text clipboard output.
  */

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -405,6 +405,7 @@ class ChatViewModel @Inject constructor(
                         val shouldHandleCompletion = awaitingVoicePlaybackCompletion
                         awaitingVoicePlaybackCompletion = false
                         if (!shouldHandleCompletion) return@collect
+                        _voiceCaptureState.value = VoiceCaptureState.Idle
                         if (_voiceMode.value == VoiceMode.BackAndForth) {
                             rearmVoiceInput()
                         } else {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1837,7 +1837,11 @@ class ChatViewModel @Inject constructor(
         activeVoiceStreamingBuffer = StringBuilder()
         activeVoiceStreamingSession = null
         isVoiceStreamingEnabledForTurn = streamingEnabled
-        if (!spokenResponsesEnabled || suppressVoiceOutputForCurrentResponse) return
+        val shouldSpeak = pendingVoiceReply
+        pendingVoiceReply = false
+        awaitingVoicePlaybackCompletion = false
+        if (!shouldSpeak || !spokenResponsesEnabled || suppressVoiceOutputForCurrentResponse) return
+        awaitingVoicePlaybackCompletion = true
         activeVoiceStreamingSession = voiceOutputController.openStreamingSession(
             VoiceSpeakRequest(text = "", locale = Locale.getDefault()),
         )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -41,6 +41,12 @@ import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.SlotFillResult
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputEvent
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.VoiceOutputResult
+import com.kernel.ai.core.voice.VoiceOutputStreamingSession
+import com.kernel.ai.core.voice.VoiceSpeakRequest
 import com.google.ai.edge.litertlm.ToolProvider
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
@@ -52,11 +58,6 @@ import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
 import com.kernel.ai.core.voice.VoiceInputStartResult
-import com.kernel.ai.core.voice.VoiceOutputController
-import com.kernel.ai.core.voice.VoiceOutputEvent
-import com.kernel.ai.core.voice.VoiceOutputPreferences
-import com.kernel.ai.core.voice.VoiceOutputResult
-import com.kernel.ai.core.voice.VoiceSpeakRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -83,6 +84,10 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
+
+private const val TAG = "KernelAI"
+private const val CHAT_VOICE_MIN_CHUNK_LENGTH = 72
+private const val CHAT_VOICE_PREFERRED_CHUNK_LENGTH = 180
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
@@ -167,6 +172,12 @@ class ChatViewModel @Inject constructor(
     private var activeStreamingMsgId: String? = null
     private var activeStreamingContent = StringBuilder()
     private var activeStreamingThinking = StringBuilder()
+    private var activeVoiceStreamingSession: VoiceOutputStreamingSession? = null
+    private var activeVoiceStreamingBuffer = StringBuilder()
+    private var isVoiceStreamingEnabledForTurn = false
+    private var suppressVoiceOutputForCurrentResponse = false
+    private var spokenResponsesEnabled = true
+    private val _isSpeakingResponse = MutableStateFlow(false)
 
     /**
      * When true, the next [sendMessage] will re-inject conversation history into the
@@ -206,7 +217,6 @@ class ChatViewModel @Inject constructor(
     private val _voicePlaybackState = MutableStateFlow<VoicePlaybackState>(VoicePlaybackState.Idle)
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
 
-    private var spokenResponsesEnabled = true
     private var pendingVoiceReply = false
     private var awaitingVoicePlaybackCompletion = false
 
@@ -240,6 +250,7 @@ class ChatViewModel @Inject constructor(
         val inputText: String,
         val error: String?,
         val conversationTitle: String?,
+        val isSpeakingResponse: Boolean,
     )
 
     private val engineState = combine(
@@ -256,7 +267,10 @@ class ChatViewModel @Inject constructor(
         _inputText,
         _error,
         _conversationTitle,
-    ) { messages, inputText, error, title -> InputState(messages, inputText, error, title) }
+        _isSpeakingResponse,
+    ) { messages, inputText, error, title, isSpeakingResponse ->
+        InputState(messages, inputText, error, title, isSpeakingResponse)
+    }
 
     val uiState: StateFlow<ChatUiState> = combine(
         engineState,
@@ -292,6 +306,7 @@ class ChatViewModel @Inject constructor(
                 conversationTitle = input.conversationTitle,
                 messages = input.messages,
                 isGenerating = engine.isGenerating,
+                isSpeakingResponse = input.isSpeakingResponse,
                 inputText = input.inputText,
                 error = input.error,
                 isLoadingModel = engine.isLoadingModel,
@@ -318,8 +333,9 @@ class ChatViewModel @Inject constructor(
                     awaitingVoicePlaybackCompletion = false
                     pendingVoiceReply = false
                     _voiceMode.value = null
+                    _voiceCaptureState.value = VoiceCaptureState.Idle
                     _voicePlaybackState.value = VoicePlaybackState.Idle
-                    voiceOutputController.stop()
+                    stopVoicePlayback()
                 }
             }
         }
@@ -354,8 +370,6 @@ class ChatViewModel @Inject constructor(
                         when (val currentState = _voiceCaptureState.value) {
                             is VoiceCaptureState.Listening -> {
                                 if (currentState.transcript.isBlank()) {
-                                    // Blank transcript — conservatively stop the loop even in
-                                    // back-and-forth mode rather than spinning indefinitely.
                                     _voiceMode.value = null
                                     _voiceCaptureState.value = VoiceCaptureState.Idle
                                 } else {
@@ -376,6 +390,7 @@ class ChatViewModel @Inject constructor(
             voiceOutputController.events.collect { event ->
                 when (event) {
                     is VoiceOutputEvent.SpeakingStarted -> {
+                        _isSpeakingResponse.value = true
                         if (
                             _voiceCaptureState.value !is VoiceCaptureState.Preparing &&
                             _voiceCaptureState.value !is VoiceCaptureState.Listening
@@ -385,6 +400,7 @@ class ChatViewModel @Inject constructor(
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
                     }
                     VoiceOutputEvent.SpeakingStopped -> {
+                        _isSpeakingResponse.value = false
                         _voicePlaybackState.value = VoicePlaybackState.Idle
                         val shouldHandleCompletion = awaitingVoicePlaybackCompletion
                         awaitingVoicePlaybackCompletion = false
@@ -911,6 +927,8 @@ class ChatViewModel @Inject constructor(
             return
         }
 
+        stopVoicePlayback()
+        suppressVoiceOutputForCurrentResponse = false
         _inputText.value = ""
         val convId = conversationId ?: return
         pendingVoiceReply = submitMode == SubmitMode.Voice
@@ -1325,6 +1343,11 @@ class ChatViewModel @Inject constructor(
                     append(systemContext)
                 }
             }.ifBlank { null }
+            prepareVoicePlaybackForTurn(
+                streamingEnabled = spokenResponsesEnabled &&
+                    !isToolQueryForTurn &&
+                    !_correctGroundedFactsEnabled.value,
+            )
 
             } finally {
                 // Reset the loading spinner on every exit path from the pre-inference block —
@@ -1346,6 +1369,7 @@ class ChatViewModel @Inject constructor(
                     when (result) {
                         is GenerationResult.Token -> {
                             accumulatedContent.append(result.text)
+                            streamVoiceToken(result.text)
                             _messages.update { msgs ->
                                 msgs.map { msg ->
                                     if (msg.id == assistantMsgId) {
@@ -1438,7 +1462,7 @@ class ChatViewModel @Inject constructor(
                                     contextWindowManager.estimateTokens(resultContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
                                 turnsSinceReset++
-                                speakAssistantReplyIfNeeded(resultContent)
+                                finalizeVoicePlaybackForResponse(resultContent)
                                 // Do NOT set needsHistoryReplay here — KV cache remains valid after
                                 // native tool calls and forcing a replay drops prior turns from the
                                 // tight history budget, causing context amnesia (#446).
@@ -1528,7 +1552,7 @@ class ChatViewModel @Inject constructor(
                                     contextWindowManager.estimateTokens(displayContent) +
                                     contextWindowManager.estimateTokens(thinking ?: "")
                                 turnsSinceReset++
-                                speakAssistantReplyIfNeeded(displayContent)
+                                finalizeVoicePlaybackForResponse(displayContent)
                             }
 
                             // Clear streaming tracking now that the message is fully persisted.
@@ -1556,6 +1580,7 @@ class ChatViewModel @Inject constructor(
                             _voiceMode.value = null
                             pendingVoiceReply = false
                             _voiceCaptureState.value = VoiceCaptureState.Idle
+                            stopVoicePlayback()
                             _messages.update { msgs ->
                                 msgs.map { msg ->
                                     if (msg.id == assistantMsgId) {
@@ -1576,6 +1601,7 @@ class ChatViewModel @Inject constructor(
                 _voiceMode.value = null
                 pendingVoiceReply = false
                 _voiceCaptureState.value = VoiceCaptureState.Idle
+                stopVoicePlayback()
                 _messages.update { msgs ->
                     msgs.map { msg ->
                         if (msg.id == assistantMsgId) {
@@ -1599,6 +1625,7 @@ class ChatViewModel @Inject constructor(
         _voiceMode.value = null
         pendingVoiceReply = false
         _voiceCaptureState.value = VoiceCaptureState.Idle
+        stopVoicePlayback()
         inferenceEngine.cancelGeneration()
         val partialContent = activeStreamingContent.toString()
         val partialThinking = activeStreamingThinking.toString().takeIf { it.isNotBlank() }
@@ -1634,6 +1661,17 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    fun stopVoicePlayback() {
+        awaitingVoicePlaybackCompletion = false
+        pendingVoiceReply = false
+        suppressVoiceOutputForCurrentResponse = true
+        isVoiceStreamingEnabledForTurn = false
+        activeVoiceStreamingBuffer = StringBuilder()
+        activeVoiceStreamingSession = null
+        voiceOutputController.stop()
+        _isSpeakingResponse.value = false
+    }
+
     fun getConversationAsText(): String {
         val messages = _messages.value
         return messages.joinToString("\n") { msg ->
@@ -1643,6 +1681,7 @@ class ChatViewModel @Inject constructor(
     }
 
     fun startNewConversation() {
+        stopVoicePlayback()
         viewModelScope.launch {
             awaitingVoicePlaybackCompletion = false
             _voiceMode.value = null
@@ -1794,6 +1833,82 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    private suspend fun prepareVoicePlaybackForTurn(streamingEnabled: Boolean) {
+        activeVoiceStreamingBuffer = StringBuilder()
+        activeVoiceStreamingSession = null
+        isVoiceStreamingEnabledForTurn = streamingEnabled
+        if (!spokenResponsesEnabled || suppressVoiceOutputForCurrentResponse) return
+        activeVoiceStreamingSession = voiceOutputController.openStreamingSession(
+            VoiceSpeakRequest(text = "", locale = Locale.getDefault()),
+        )
+    }
+
+    private suspend fun streamVoiceToken(token: String) {
+        if (!spokenResponsesEnabled || suppressVoiceOutputForCurrentResponse || !isVoiceStreamingEnabledForTurn) {
+            return
+        }
+        activeVoiceStreamingBuffer.append(token)
+        drainVoiceStreamingBuffer(force = false)
+    }
+
+    private suspend fun drainVoiceStreamingBuffer(force: Boolean) {
+        val session = activeVoiceStreamingSession ?: return
+        while (true) {
+            val chunk = popNextStreamingSpeechChunk(
+                buffer = activeVoiceStreamingBuffer,
+                minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                force = force,
+            ) ?: break
+            speakVoiceChunk(session, chunk, isFinal = false)
+        }
+    }
+
+    private suspend fun finalizeVoicePlaybackForResponse(finalContent: String) {
+        if (!spokenResponsesEnabled || suppressVoiceOutputForCurrentResponse) {
+            stopVoicePlayback()
+            return
+        }
+        val session = activeVoiceStreamingSession ?: return
+        val finalChunk = if (isVoiceStreamingEnabledForTurn) {
+            val bufferedChunks = mutableListOf<String>()
+            while (true) {
+                val chunk = popNextStreamingSpeechChunk(
+                    buffer = activeVoiceStreamingBuffer,
+                    minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                    preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                    force = true,
+                ) ?: break
+                bufferedChunks += chunk
+            }
+            bufferedChunks.joinToString(" ").trim()
+        } else {
+            normalizeChatTextForSpeech(finalContent)
+        }
+        val result = session.append(finalChunk, isFinal = true)
+        handleVoiceOutputResult(result)
+        activeVoiceStreamingSession = null
+        activeVoiceStreamingBuffer = StringBuilder()
+        isVoiceStreamingEnabledForTurn = false
+    }
+
+    private suspend fun speakVoiceChunk(
+        session: VoiceOutputStreamingSession,
+        chunk: String,
+        isFinal: Boolean,
+    ) {
+        if (chunk.isBlank()) return
+        val result = session.append(chunk, isFinal = isFinal)
+        handleVoiceOutputResult(result)
+    }
+
+    private fun handleVoiceOutputResult(result: VoiceOutputResult) {
+        if (result is VoiceOutputResult.Unavailable) {
+            _error.value = result.message
+            stopVoicePlayback()
+        }
+    }
+
 
 
     override fun onCleared() {
@@ -1803,6 +1918,7 @@ class ChatViewModel @Inject constructor(
         pendingVoiceReply = false
         voiceInputController.stopListening()
         voiceOutputController.stop()
+        stopVoicePlayback()
         // Flush any in-progress streamed content to Room before the ViewModel is destroyed.
         // runBlocking is acceptable here — called once on ViewModel teardown,
         // Room insert is fast (<10ms), main thread briefly blocked on nav back.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -11,6 +11,7 @@ sealed interface ChatUiState {
         val conversationTitle: String?,
         val messages: List<ChatMessage>,
         val isGenerating: Boolean,
+        val isSpeakingResponse: Boolean,
         val inputText: String,
         val error: String?,
         val isLoadingModel: Boolean = false,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -600,6 +600,69 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice playback state follows voice output events`() = runTest(dispatcher) {
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Streaming reply chunk"))
+        advanceUntilIdle()
+
+        assertEquals(
+            ActionsViewModel.VoicePlaybackState.Speaking("Streaming reply chunk"),
+            viewModel.voicePlaybackState.value,
+        )
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceUntilIdle()
+
+        assertEquals(
+            ActionsViewModel.VoicePlaybackState.Idle,
+            viewModel.voicePlaybackState.value,
+        )
+    }
+
+    @Test
+    fun `stopVoiceOutput interrupts prompt playback and keeps microphone closed`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a text message to my wife") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "my wife"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text message to my wife", InputMode.Voice)
+        advanceUntilIdle()
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("What would you like to say to my wife?"),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            ActionsViewModel.VoicePlaybackState.Speaking("What would you like to say to my wife?"),
+            viewModel.voicePlaybackState.value,
+        )
+
+        viewModel.stopVoiceOutput()
+
+        assertEquals(
+            ActionsViewModel.VoicePlaybackState.Idle,
+            viewModel.voicePlaybackState.value,
+        )
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceTimeBy(351)
+        runCurrent()
+
+        coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
+        verify(atLeast = 1) { voiceOutputController.stop() }
+    }
+
+    @Test
     fun `listening stopped preserves transcript while processing`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
@@ -722,6 +785,52 @@ class ActionsViewModelVoiceTest {
         coVerify(exactly = 1) {
             voiceOutputController.speak(
                 match<VoiceSpeakRequest> { it.text == displayText },
+            )
+        }
+    }
+
+    @Test
+    fun `voice direct reply prefers explicit spoken summary over presentation fallback`() = runTest(dispatcher) {
+        val weatherSkill = mockk<Skill>()
+        val displayText =
+            "Wellington forecast: 25°C, feels like 23°C. H 27°C / L 18°C. Wind NW 15 km/h."
+        val spokenSummary = "In Wellington, it's 25 degrees, partly cloudy."
+        val presentation = ToolPresentation.Weather(
+            locationName = "Wellington",
+            temperatureText = "25°C",
+            feelsLikeText = "Feels like 23°C",
+            description = "Partly cloudy",
+            emoji = "⛅",
+            highLowText = "H 27°C / L 18°C",
+            humidityText = "Humidity 60%",
+            windText = "NW 15 km/h",
+            precipText = "20%",
+            airQualityText = null,
+        )
+
+        every { quickIntentRouter.route("what's the weather in Wellington") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "get_weather",
+                    params = mapOf("location" to "Wellington"),
+                ),
+            )
+        every { skillRegistry.get("get_weather") } returns weatherSkill
+        every { weatherSkill.name } returns "get_weather"
+        every { weatherSkill.description } returns "Get weather"
+        every { weatherSkill.schema } returns SkillSchema()
+        coEvery { weatherSkill.execute(any()) } returns SkillResult.DirectReply(
+            content = displayText,
+            presentation = presentation,
+            spokenSummary = spokenSummary,
+        )
+
+        viewModel.executeAction("what's the weather in Wellington", InputMode.Voice)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text == spokenSummary },
             )
         }
     }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -337,6 +337,26 @@ class ChatViewModelVoiceTest {
     }
 
     @Test
+    fun `back-and-forth voice re-arms when playback completes without speaking started`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("Hello silent loop") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "Hello silent loop")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.startBackAndForthVoiceInput()
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello silent loop"))
+        advanceUntilIdle()
+
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceUntilIdle()
+
+        assertEquals("You: Hello silent loop\nJandal: Hi back", viewModel.getConversationAsText())
+        assertEquals(ChatViewModel.VoiceCaptureState.Listening(), viewModel.voiceCaptureState.value)
+        coVerify(exactly = 2) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+    }
+
+    @Test
     fun `stopVoiceOutput prevents speaking stopped from restarting back-and-forth capture`() = runTest(dispatcher) {
         every { quickIntentRouter.route("Stop speaking") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "Stop speaking")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -38,6 +38,7 @@ import com.kernel.ai.core.voice.VoiceOutputEvent
 import com.kernel.ai.core.voice.VoiceOutputPreferences
 import com.kernel.ai.core.voice.VoiceOutputResult
 import com.kernel.ai.core.voice.VoiceSpeakRequest
+import com.kernel.ai.core.voice.VoiceOutputStreamingSession
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -86,6 +87,7 @@ class ChatViewModelVoiceTest {
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
     private val voiceInputController: VoiceInputController = mockk(relaxed = true)
     private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceStreamingSession: VoiceOutputStreamingSession = mockk(relaxed = true)
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
     private val jandalPersona: JandalPersona = mockk(relaxed = true)
     private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
@@ -94,6 +96,7 @@ class ChatViewModelVoiceTest {
     private val voiceInputEvents = MutableSharedFlow<VoiceInputEvent>()
     private val voiceOutputEvents = MutableSharedFlow<VoiceOutputEvent>()
     private val spokenResponsesEnabled = MutableStateFlow(true)
+    private val streamedChunks = mutableListOf<Pair<String, Boolean>>()
 
     @BeforeEach
     fun setUp() {
@@ -133,6 +136,12 @@ class ChatViewModelVoiceTest {
         every { voiceInputController.stopListening() } just runs
         every { voiceOutputController.events } returns voiceOutputEvents
         coEvery { voiceOutputController.warmUp() } returns VoiceOutputResult.Spoken
+        streamedChunks.clear()
+        coEvery { voiceOutputController.openStreamingSession(any()) } returns voiceStreamingSession
+        coEvery { voiceStreamingSession.append(any(), any()) } coAnswers {
+            streamedChunks += firstArg<String>() to secondArg<Boolean>()
+            VoiceOutputResult.Spoken
+        }
         coEvery { voiceOutputController.speak(any()) } returns VoiceOutputResult.Spoken
         every { voiceOutputController.stop() } just runs
         every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
@@ -184,14 +193,15 @@ class ChatViewModelVoiceTest {
         viewModel.startVoiceInput()
         voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello there"))
         advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+        advanceUntilIdle()
 
         assertEquals("You: Hello there\nJandal: Hi back", viewModel.getConversationAsText())
         assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
         coVerify {
-            voiceOutputController.speak(
-                match<VoiceSpeakRequest> { it.text == "Hi back" }
-            )
+            voiceOutputController.openStreamingSession(any())
         }
+        assertEquals(listOf("Hi back" to true), streamedChunks)
     }
 
     @Test
@@ -308,12 +318,12 @@ class ChatViewModelVoiceTest {
         viewModel.startBackAndForthVoiceInput()
         voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "Hello loop"))
         advanceUntilIdle()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
+        advanceUntilIdle()
 
         assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
         coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
 
-        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
-        advanceUntilIdle()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         advanceUntilIdle()
 
@@ -321,8 +331,9 @@ class ChatViewModelVoiceTest {
         assertEquals(ChatViewModel.VoiceCaptureState.Listening(), viewModel.voiceCaptureState.value)
         coVerify(exactly = 2) { voiceInputController.startListening(VoiceCaptureMode.Command) }
         coVerify(exactly = 1) {
-            voiceOutputController.speak(match<VoiceSpeakRequest> { it.text == "Hi back" })
+            voiceOutputController.openStreamingSession(any())
         }
+        assertEquals(listOf("Hi back" to true), streamedChunks)
     }
 
     @Test
@@ -330,7 +341,7 @@ class ChatViewModelVoiceTest {
         every { quickIntentRouter.route("Stop speaking") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "Stop speaking")
         val speakGate = CompletableDeferred<Unit>()
-        coEvery { voiceOutputController.speak(any()) } coAnswers {
+        coEvery { voiceStreamingSession.append(any(), any()) } coAnswers {
             voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
             speakGate.await()
             VoiceOutputResult.Spoken
@@ -350,7 +361,7 @@ class ChatViewModelVoiceTest {
 
         assertEquals(ChatViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
         coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.Command) }
-        verify(exactly = 1) { voiceOutputController.stop() }
+        verify(atLeast = 1) { voiceOutputController.stop() }
     }
 
     @Test
@@ -358,7 +369,7 @@ class ChatViewModelVoiceTest {
         every { quickIntentRouter.route("Stop listening") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "Stop listening")
         val speakGate = CompletableDeferred<Unit>()
-        coEvery { voiceOutputController.speak(any()) } coAnswers {
+        coEvery { voiceStreamingSession.append(any(), any()) } coAnswers {
             voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStarted("Hi back"))
             speakGate.await()
             VoiceOutputResult.Spoken


### PR DESCRIPTION
## Summary
Add incremental spoken playback for chat so voice responses can begin before the full reply has finished generating.

## Changes
- add a streaming TTS session seam to `VoiceOutputController`
- queue incremental Android TTS chunks during chat generation
- wire `ChatViewModel` to stream speakable chat chunks and finalize playback cleanly
- add chat stop-playback UI state/wiring
- update focused chat voice tests

## Testing
- [x] `./gradlew :feature:chat:testDebugUnitTest --tests 'com.kernel.ai.feature.chat.ChatViewModelInitTest' --tests 'com.kernel.ai.feature.chat.ActionsViewModelVoiceTest' --tests 'com.kernel.ai.core.skills.ToolPresentationSpokenSummaryTest' --tests 'com.kernel.ai.core.skills.natives.GetWeatherSpokenSummaryTest' :app:assembleDebug`

## Related issues
- Follow-up voice feature: incremental / streaming TTS in chat
