### PR TITLE
fix(#758): recover split-minute alarm transcripts

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2877,6 +2877,18 @@ class QuickIntentRouter(
         private fun normalizeCompactAlarmText(raw: String): String {
             var normalized = raw
             normalized = Regex(
+                """\b(\d{1,2}):(\d):(\d{2})\s*(am|pm|a\.m\.|p\.m\.)(?=\s|$)""",
+                RegexOption.IGNORE_CASE,
+            ).replace(normalized) { match ->
+                val hour = match.groupValues[1].toIntOrNull() ?: return@replace match.value
+                val minutePrefix = match.groupValues[2].toIntOrNull() ?: return@replace match.value
+                val trailingTens = match.groupValues[3].toIntOrNull() ?: return@replace match.value
+                val meridiem = match.groupValues[4].lowercase()
+                val minute = minutePrefix + trailingTens
+                if (hour !in 1..12 || trailingTens % 10 != 0 || minute !in 0..59) return@replace match.value
+                "$hour:${minute.toString().padStart(2, '0')} $meridiem"
+            }
+            normalized = Regex(
                 """\b(\d{1,2})\s+(\d{2})\b""",
                 RegexOption.IGNORE_CASE,
             ).replace(normalized) { match ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2099,6 +2099,18 @@ class NativeIntentHandler @Inject constructor(
     }
 
     private fun recoverMalformedTime(input: String): String {
+        val splitMinute = Regex("""^(\d{1,2}):(\d):(\d{2})(\s*(?:am|pm|AM|PM|a\.m\.|p\.m\.))?$""")
+        splitMinute.matchEntire(input)?.let { match ->
+            val hour = match.groupValues[1].toIntOrNull() ?: return@let
+            val minutePrefix = match.groupValues[2].toIntOrNull() ?: return@let
+            val trailingTens = match.groupValues[3].toIntOrNull() ?: return@let
+            val minute = minutePrefix + trailingTens
+            val meridiem = match.groupValues[4]
+            if (hour in 1..12 && trailingTens % 10 == 0 && minute in 0..59) {
+                return "$hour:${minute.toString().padStart(2, '0')}$meridiem"
+            }
+        }
+
         val flattenedThirty = Regex("""^(3[1-9]|4[0-2]):00(\s*(?:am|pm|AM|PM))?$""")
         flattenedThirty.matchEntire(input)?.let { match ->
             val rawHour = match.groupValues[1].toIntOrNull() ?: return@let

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -313,6 +313,17 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `should recover split minute alarm times`() {
+            val result = regexOnlyRouter.route("set an alarm for 8:6:30 p.m.")
+            assertRegexMatch(result, "set_alarm", "set an alarm for 8:6:30 p.m.")
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("20", intent.params["hours"])
+            assertEquals("36", intent.params["minutes"])
+            assertEquals("20:36", intent.params["time"])
+        }
+
+        @Test
         fun `should match alarm phrases with day before preposition`() {
             val result = regexOnlyRouter.route("set an alarm tomorrow for 7:30 a.m. called rugby")
             assertRegexMatch(result, "set_alarm", "set an alarm tomorrow for 7:30 a.m. called rugby")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -140,6 +140,19 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `resolveTime recovers split minute voice transcript format`() {
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "resolveTime",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "8:6:30 p.m.") as LocalTime?
+
+        assertNotNull(resolved)
+        assertEquals(LocalTime.of(20, 36), resolved)
+    }
+
+    @Test
     fun `resolveTime recovers flattened seven oclock format`() {
         val method = NativeIntentHandler::class.java.getDeclaredMethod(
             "resolveTime",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -1079,7 +1079,7 @@ class ActionsViewModel @Inject constructor(
             RegexOption.IGNORE_CASE,
         )
         val FLATTENED_BARE_THIRTY_TIME = Regex(
-            """\b(3[1-9]|4\d|5[0-3])\b""",
+            """(?<![:\d])(3[1-9]|4\d|5[0-3])(?![:\d])""",
             RegexOption.IGNORE_CASE,
         )
         val TO_THIRTY_TIME = Regex(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1213,6 +1213,29 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `voice command preserves already colonized alarm times`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("set an alarm for 8:36 p.m.") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "set an alarm for 8:36 p.m.")
+        every { quickIntentRouter.route("set an alarm for 7:47 p.m.") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "set an alarm for 7:47 p.m.")
+        every { quickIntentRouter.route("set an alarm for 3:43 p.m.") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "set an alarm for 3:43 p.m.")
+        every { quickIntentRouter.route("set an alarm for 15:47") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "set an alarm for 15:47")
+
+        viewModel.executeAction("set an alarm for 8:36 p.m.", InputMode.Voice)
+        viewModel.executeAction("set an alarm for 7:47 p.m.", InputMode.Voice)
+        viewModel.executeAction("set an alarm for 3:43 p.m.", InputMode.Voice)
+        viewModel.executeAction("set an alarm for 15:47", InputMode.Voice)
+        advanceUntilIdle()
+
+        verify { quickIntentRouter.route("set an alarm for 8:36 p.m.") }
+        verify { quickIntentRouter.route("set an alarm for 7:47 p.m.") }
+        verify { quickIntentRouter.route("set an alarm for 3:43 p.m.") }
+        verify { quickIntentRouter.route("set an alarm for 15:47") }
+    }
+
+    @Test
     fun `voice command normalizes mixed digit and spoken alarm time`() = runTest(dispatcher) {
         every { quickIntentRouter.route("set an alarm for 6:30 am") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "set an alarm for 6:30 am")


### PR DESCRIPTION
## Summary
- recover malformed split-minute alarm transcripts like `8:6:30 p.m.` before regex routing falls back to `8:00`
- teach `NativeIntentHandler.resolveTime()` the same recovery so direct/native alarm handling stays consistent
- stop voice alarm normalization from corrupting already-colonized times like `8:36 p.m.` and `7:47 p.m.` into malformed `:30` forms
- add regressions for the reported `836pm`, `747 pm`, and `343 pm` failure paths

## Testing
- ./gradlew :feature:chat:testDebugUnitTest --tests "*ActionsViewModelVoiceTest" :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest"

## Manual testing
- Install the PR build on device.
- Trigger voice input and say: `set an alarm for 836pm`.
- Confirm the created alarm is scheduled for `8:36 PM`, not `8:00 AM`.
- Trigger voice input and say: `set an alarm for 747 pm` and `set an alarm for 343 pm`.
- Confirm those alarms are scheduled for `7:47 PM` and `3:43 PM`, not malformed `7:17 AM` / `3:13 AM` results.
- Sanity-check an existing compact format such as `set an alarm for 7:30am` still creates `7:30 AM`.

Closes #758
