### PR TITLE
feat: teach recurring important dates

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/31.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/31.json
@@ -1,0 +1,1101 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "2d09e7fa77b39591233b88f45a5ba082",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2d09e7fa77b39591233b88f45a5ba082')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
@@ -1,0 +1,51 @@
+package com.kernel.ai.core.memory
+
+import com.kernel.ai.core.memory.dao.ImportantDateDao
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ImportantDateRepository @Inject constructor(
+    private val dao: ImportantDateDao,
+) {
+    fun observeAll(): Flow<List<ImportantDateEntity>> = dao.observeAll()
+
+    suspend fun getAll(): List<ImportantDateEntity> = dao.getAll()
+
+    suspend fun findByLabel(label: String): ImportantDateEntity? =
+        dao.findByNormalizedLabel(normalizeLabel(label))
+
+    suspend fun save(
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+    ) {
+        val trimmedLabel = label.trim()
+        dao.insert(
+            ImportantDateEntity(
+                label = trimmedLabel,
+                normalizedLabel = normalizeLabel(trimmedLabel),
+                month = month,
+                day = day,
+                year = year,
+            ),
+        )
+    }
+
+    suspend fun deleteByLabel(label: String): Int = dao.deleteByNormalizedLabel(normalizeLabel(label))
+
+    companion object {
+        fun normalizeLabel(raw: String): String = raw
+            .trim()
+            .lowercase()
+            .removePrefix("my ")
+            .removePrefix("the ")
+            .replace(Regex("""\b([\p{L}\d]+)'s\b"""), "$1")
+            .replace("'", "")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.kernel.ai.core.memory.dao.ContactAliasDao
+import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -21,6 +22,7 @@ import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.KiwiMemoryEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
@@ -54,10 +56,11 @@ import java.time.ZoneId
         StopwatchStateEntity::class,
         StopwatchLapEntity::class,
         ContactAliasEntity::class,
+        ImportantDateEntity::class,
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -76,6 +79,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun worldClockDao(): WorldClockDao
     abstract fun stopwatchDao(): StopwatchDao
     abstract fun contactAliasDao(): ContactAliasDao
+    abstract fun importantDateDao(): ImportantDateDao
     abstract fun listItemDao(): ListItemDao
     abstract fun listNameDao(): ListNameDao
     abstract fun kiwiMemoryDao(): KiwiMemoryDao
@@ -392,6 +396,28 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_29_30 = object : Migration(29, 30) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN sound_uri TEXT DEFAULT NULL")
+            }
+        }
+
+        /** Creates important_dates table for taught recurring personal dates (#632). */
+        val MIGRATION_30_31 = object : Migration(30, 31) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `important_dates` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `label` TEXT NOT NULL,
+                        `normalized_label` TEXT NOT NULL,
+                        `month` INTEGER NOT NULL,
+                        `day` INTEGER NOT NULL,
+                        `year` INTEGER DEFAULT NULL,
+                        `created_at` INTEGER NOT NULL
+                    )
+                    """.trimIndent(),
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `important_dates` (`normalized_label`)"
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.memory
 import android.content.Context
 import androidx.room.Room
 import com.kernel.ai.core.memory.dao.ContactAliasDao
+import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -86,6 +87,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_27_28,
                     KernelDatabase.MIGRATION_28_29,
                     KernelDatabase.MIGRATION_29_30,
+                    KernelDatabase.MIGRATION_30_31,
                 )
                 .build()
 
@@ -125,6 +127,9 @@ abstract class MemoryModule {
 
         @Provides
         fun provideContactAliasDao(db: KernelDatabase): ContactAliasDao = db.contactAliasDao()
+
+        @Provides
+        fun provideImportantDateDao(db: KernelDatabase): ImportantDateDao = db.importantDateDao()
 
         @Provides
         fun provideListItemDao(db: KernelDatabase): ListItemDao = db.listItemDao()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ImportantDateDao {
+    @Query("SELECT * FROM important_dates ORDER BY label COLLATE NOCASE ASC")
+    fun observeAll(): Flow<List<ImportantDateEntity>>
+
+    @Query("SELECT * FROM important_dates ORDER BY label COLLATE NOCASE ASC")
+    suspend fun getAll(): List<ImportantDateEntity>
+
+    @Query("SELECT * FROM important_dates WHERE normalized_label = :normalizedLabel LIMIT 1")
+    suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(date: ImportantDateEntity)
+
+    @Query("DELETE FROM important_dates WHERE normalized_label = :normalizedLabel")
+    suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
@@ -1,0 +1,20 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "important_dates",
+    indices = [Index(value = ["normalized_label"], unique = true)],
+)
+data class ImportantDateEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val label: String,
+    @ColumnInfo(name = "normalized_label") val normalizedLabel: String,
+    val month: Int,
+    val day: Int,
+    val year: Int? = null,
+    @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis(),
+)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
@@ -1,0 +1,62 @@
+package com.kernel.ai.core.memory
+
+import com.kernel.ai.core.memory.dao.ImportantDateDao
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ImportantDateRepositoryTest {
+    @Test
+    fun `normalizeLabel strips possessives and leading articles`() {
+        assertEquals("mum birthday", ImportantDateRepository.normalizeLabel("my mum's birthday"))
+        assertEquals("parents anniversary", ImportantDateRepository.normalizeLabel("the parents' anniversary"))
+    }
+
+    @Test
+    fun `save find and delete round trip through dao`() = runTest {
+        val dao = FakeImportantDateDao()
+        val repository = ImportantDateRepository(dao)
+
+        repository.save(label = "My Mum's birthday", month = 3, day = 15, year = null)
+        repository.save(label = "Our anniversary", month = 6, day = 22, year = 2018)
+
+        val birthday = repository.findByLabel("mum's birthday")
+        val anniversary = repository.findByLabel("our anniversary")
+
+        requireNotNull(birthday)
+        requireNotNull(anniversary)
+        assertEquals("My Mum's birthday", birthday.label)
+        assertEquals("mum birthday", birthday.normalizedLabel)
+        assertEquals(3, birthday.month)
+        assertEquals(15, birthday.day)
+        assertNull(birthday.year)
+        assertEquals(2018, anniversary.year)
+
+        assertEquals(2, repository.getAll().size)
+        assertEquals(1, repository.deleteByLabel("mum's birthday"))
+        assertNull(repository.findByLabel("my mum's birthday"))
+        assertEquals(1, repository.getAll().size)
+    }
+
+    private class FakeImportantDateDao : ImportantDateDao {
+        private val rows = linkedMapOf<String, ImportantDateEntity>()
+        private var nextId = 1L
+
+        override fun observeAll(): Flow<List<ImportantDateEntity>> = flowOf(rows.values.toList())
+
+        override suspend fun getAll(): List<ImportantDateEntity> = rows.values.toList()
+
+        override suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity? = rows[normalizedLabel]
+
+        override suspend fun insert(date: ImportantDateEntity) {
+            rows[date.normalizedLabel] = date.copy(id = nextId++)
+        }
+
+        override suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int =
+            if (rows.remove(normalizedLabel) != null) 1 else 0
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -133,6 +133,22 @@ class QuickIntentRouter(
                 promptTemplate = "What would you like to call the list?",
             ),
         ),
+        "save_important_date" to mapOf(
+            "label" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "label",
+                promptTemplate = "What important date should I save?",
+            ),
+            "date" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "date",
+                promptTemplate = "What date is {label}?",
+            ),
+        ),
+        "remove_important_date" to mapOf(
+            "label" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "label",
+                promptTemplate = "Which important date should I remove?",
+            ),
+        ),
         "save_memory" to mapOf(
             "content" to com.kernel.ai.core.skills.slot.SlotSpec(
                 name = "content",
@@ -163,6 +179,23 @@ class QuickIntentRouter(
     private fun normalizeOptionalItem(raw: String): String? = raw.trim()
         .takeIf { it.isNotBlank() }
         ?.takeUnless { it.lowercase() in placeholderItems }
+
+    private fun normalizeImportantDateLabel(raw: String): String = raw.trim()
+        .replace(Regex("""^(?:my|the)\s+""", RegexOption.IGNORE_CASE), "")
+        .trim()
+
+    private fun normalizeImportantDateLabelOrNull(raw: String): String? =
+        normalizeImportantDateLabel(raw).takeIf { it.isNotBlank() }
+
+    private val importantDateValuePattern =
+        "(?:\\d{1,2}(?:st|nd|rd|th)?\\s+[a-zA-Z]+(?:\\s+\\d{4})?|[a-zA-Z]+\\s+\\d{1,2}(?:st|nd|rd|th)?(?:,?\\s+\\d{4})?|\\d{4}-\\d{2}-\\d{2}|\\d{1,2}[/-]\\d{1,2}[/-]\\d{4})"
+
+    private fun extractImportantDateParams(label: String, date: String): Map<String, String> {
+        val params = mutableMapOf<String, String>()
+        normalizeImportantDateLabelOrNull(label)?.let { params["label"] = it }
+        date.trim().takeIf { it.isNotBlank() }?.let { params["date"] = it }
+        return params
+    }
 
 
 
@@ -2416,6 +2449,76 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
             requiredSlots = slotContract("create_list"),
+        ),
+        // ── Important Dates ──
+        IntentPattern(
+            intentName = "list_important_dates",
+            regex = Regex(
+                """^(?:list|show(?:\s+me)?|what(?:'s|\s+are))\s+(?:my\s+)?important dates$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^(?:remember|save|store|note|don't\s+forget)(?:\s+that)?\s+(.+?)\s+(?:is|as)\s+($importantDateValuePattern)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                extractImportantDateParams(
+                    label = match.groupValues[1],
+                    date = match.groupValues[2],
+                )
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^my\s+(.+?)\s+is\s+($importantDateValuePattern)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                extractImportantDateParams(
+                    label = match.groupValues[1],
+                    date = match.groupValues[2],
+                )
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^(?:remember|save|store)(?:\s+that)?\s+(.+?\b(?:birthday|anniversary)\b.*)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "remove_important_date",
+            regex = Regex(
+                """^(?:remove|delete|forget)\s+(.+?)\s+from\s+(?:my\s+)?important dates$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("remove_important_date"),
+        ),
+        IntentPattern(
+            intentName = "remove_important_date",
+            regex = Regex(
+                """^(?:remove|delete|forget)\s+(.+?\b(?:birthday|anniversary)\b.*)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("remove_important_date"),
         ),
         // "remove milk from my shopping list" / "take eggs off the grocery list"
         IntentPattern(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -46,6 +46,9 @@ class RunIntentSkill @Inject constructor(
                     "set_alarm",
                     "set_timer",
                     "create_calendar_event",
+                    "save_important_date",
+                    "list_important_dates",
+                    "remove_important_date",
                     // System toggles
                     "toggle_dnd_on",
                     "toggle_dnd_off",
@@ -96,6 +99,9 @@ class RunIntentSkill @Inject constructor(
         "Calendar event (explicit date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Lunch\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}')",
         "Calendar event (relative date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Cancel MightyApe\",\"date\":\"next thursday\",\"time\":\"16:00\"}')",
         "Calendar with attendees → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Dinner\",\"date\":\"friday\",\"time\":\"19:00\",\"attendees\":\"Sarah,John\"}')",
+        "Save important date → runIntent(intentName=\"save_important_date\", parameters='{\"label\":\"mum's birthday\",\"date\":\"15 March\"}')",
+        "List important dates → runIntent(intentName=\"list_important_dates\", parameters='{}')",
+        "Remove important date → runIntent(intentName=\"remove_important_date\", parameters='{\"label\":\"mum's birthday\"}')",
         // System toggles
         "Turn on DND → runIntent(intentName=\"toggle_dnd_on\", parameters=\"{}\")",
         "Enable Wi-Fi → runIntent(intentName=\"toggle_wifi\", parameters='{\"state\":\"on\"}')",
@@ -137,6 +143,9 @@ class RunIntentSkill @Inject constructor(
         appendLine("  set_alarm — params: time (\"10pm\", \"9:30am\"), day (optional: \"tomorrow\", \"monday\"), label (optional)")
         appendLine("  set_timer — params: duration_seconds (\"180\" for 3 min), label (optional)")
         appendLine("  create_calendar_event — params: title, date (pass relative terms as-is: \"tomorrow\", \"next thursday\", \"this friday\"; or YYYY-MM-DD for explicit dates), time (HH:MM), duration_minutes (optional), description (optional), attendees (optional, comma-separated contact names)")
+        appendLine("  save_important_date — params: label, date (e.g. \"15 March\" or \"22 June 2018\")")
+        appendLine("  list_important_dates — no params")
+        appendLine("  remove_important_date — params: label")
         appendLine()
         appendLine("SYSTEM TOGGLES:")
         appendLine("  toggle_dnd_on, toggle_dnd_off — No params")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import android.view.KeyEvent
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.WorldClockCatalog
@@ -109,6 +110,9 @@ interface ClockAlertController {
  *   get_weather             — Opens Google search for weather (params: location?)
  *   get_system_info         — Returns storage and RAM info — returns DirectReply
  *   get_date_diff           — Native date arithmetic: days/weeks until or since a date (params: target_date, from_date?) — returns DirectReply
+ *   save_important_date     — Stores a taught recurring personal date (params: label, date) — returns DirectReply
+ *   list_important_dates    — Lists taught recurring personal dates — returns DirectReply
+ *   remove_important_date   — Deletes a taught recurring personal date (params: label) — returns DirectReply
  *   save_memory             — Saves content to long-term core memory (params: content)
  *   set_brightness          — Sets screen brightness (params: value?, direction?, is_percent?)
  */
@@ -120,6 +124,7 @@ class NativeIntentHandler @Inject constructor(
     private val listItemDao: ListItemDao,
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
+    private val importantDateRepository: ImportantDateRepository,
     private val memoryRepository: MemoryRepository,
     private val embeddingEngine: EmbeddingEngine,
 ) {
@@ -188,6 +193,9 @@ class NativeIntentHandler @Inject constructor(
                 "get_weather" -> getWeather(params)
                 "get_date_diff" -> getDateDiff(params)
                 "get_system_info" -> getSystemInfo()
+                "save_important_date" -> saveImportantDate(params)
+                "list_important_dates" -> listImportantDates()
+                "remove_important_date" -> removeImportantDate(params)
                 "save_memory" -> saveMemory(params)
                 "set_brightness" -> setBrightness(params)
                 else -> SkillResult.Failure("run_intent", "Unknown intent: $intentName")
@@ -242,7 +250,8 @@ class NativeIntentHandler @Inject constructor(
             "add_to_list", "bulk_add_to_list", "create_list", "get_list_items", "remove_from_list",
             "smart_home_on", "smart_home_off",
             "get_weather", "get_date_diff", "get_system_info",
-            "save_memory",
+            "save_important_date", "list_important_dates", "remove_important_date",
+            "save_memory", 
         )
 
         private val GENERIC_MEDIA_QUERY_KEYS = setOf(
@@ -1815,6 +1824,66 @@ class NativeIntentHandler @Inject constructor(
         }
     }
 
+    // ── Important Dates ─────────────────────────────────────────────────────────
+
+    private data class ParsedImportantDateInput(
+        val month: Int,
+        val day: Int,
+        val year: Int?,
+    )
+
+    private fun saveImportantDate(params: Map<String, String>): SkillResult {
+        val label = params["label"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("save_important_date", "No label specified")
+        val rawDate = params["date"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("save_important_date", "No date specified")
+        val parsed = parseImportantDateInput(rawDate)
+            ?: return SkillResult.Failure(
+                "save_important_date",
+                "Could not parse date '$rawDate' — use a date like '15 March' or '22 June 2018'.",
+            )
+
+        runBlocking {
+            importantDateRepository.save(
+                label = label,
+                month = parsed.month,
+                day = parsed.day,
+                year = parsed.year,
+            )
+        }
+
+        return SkillResult.DirectReply(
+            "I'll remember ${label.trim()} as ${formatImportantDate(parsed.month, parsed.day, parsed.year)}.",
+        )
+    }
+
+    private fun listImportantDates(): SkillResult {
+        val today = LocalDate.now()
+        val dates = runBlocking { importantDateRepository.getAll() }
+        if (dates.isEmpty()) {
+            return SkillResult.DirectReply("You haven't taught me any important dates yet.")
+        }
+
+        val lines = dates
+            .sortedBy { resolveRecurringDate(it.month, it.day, today) }
+            .map { "• ${it.label} — ${formatImportantDate(it.month, it.day, it.year)}" }
+
+        return SkillResult.DirectReply(
+            "Important dates:\n" + lines.joinToString("\n"),
+        )
+    }
+
+    private fun removeImportantDate(params: Map<String, String>): SkillResult {
+        val label = params["label"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("remove_important_date", "No label specified")
+        val deleted = runBlocking { importantDateRepository.deleteByLabel(label) }
+        return if (deleted > 0) {
+            SkillResult.DirectReply("Removed important date ${label.trim()}.")
+        } else {
+            SkillResult.DirectReply("I couldn't find an important date named ${label.trim()}.")
+        }
+    }
+
     // ── Date Diff ─────────────────────────────────────────────────────────────
 
     private fun getDateDiff(params: Map<String, String>): SkillResult {
@@ -1894,8 +1963,54 @@ class NativeIntentHandler @Inject constructor(
         emptyMessage = emptyMessage,
     )
 
+    private fun resolveRecurringDate(month: Int, day: Int, today: LocalDate): LocalDate {
+        val candidate = LocalDate.of(today.year, month, day)
+        return if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+    }
+
+    private fun formatImportantDate(month: Int, day: Int, year: Int?): String {
+        val date = LocalDate.of(year ?: 2000, month, day)
+        val pattern = if (year != null) "d MMMM yyyy" else "d MMMM"
+        return date.format(DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH))
+    }
+
+    private fun parseImportantDateInput(input: String): ParsedImportantDateInput? {
+        val sanitized = input.trim()
+            .replace(Regex("""\b(\d{1,2})(st|nd|rd|th)\b""", RegexOption.IGNORE_CASE), "$1")
+            .replace(",", "")
+        val fullDateFormatters = listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("MMMM d yyyy", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("d/M/yyyy"),
+            DateTimeFormatter.ofPattern("M/d/yyyy"),
+            DateTimeFormatter.ofPattern("d-M-yyyy"),
+            DateTimeFormatter.ofPattern("M-d-yyyy"),
+        )
+        for (formatter in fullDateFormatters) {
+            try {
+                val date = LocalDate.parse(sanitized, formatter)
+                return ParsedImportantDateInput(date.monthValue, date.dayOfMonth, date.year)
+            } catch (_: Exception) {
+            }
+        }
+
+        val partialDateFormatters = listOf(
+            DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("MMMM d", Locale.ENGLISH),
+        )
+        for (formatter in partialDateFormatters) {
+            try {
+                val monthDay = MonthDay.parse(sanitized, formatter)
+                return ParsedImportantDateInput(monthDay.monthValue, monthDay.dayOfMonth, null)
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
     /**
-     * Parses a date string in various natural formats, including named NZ/common holidays.
+     * Parses a date string in various natural formats, including taught important dates and named NZ/common holidays.
      * For dates without a year, picks the next upcoming occurrence.
      */
     private fun parseDateString(input: String): LocalDate? {
@@ -1903,12 +2018,14 @@ class NativeIntentHandler @Inject constructor(
         val today = LocalDate.now()
         val year = today.year
 
-        // Named holidays — next upcoming occurrence
+        runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
+            return resolveRecurringDate(stored.month, stored.day, today)
+        }
+
         fun nextOccurrence(month: Int, day: Int): LocalDate {
             val candidate = LocalDate.of(year, month, day)
             return if (!candidate.isBefore(today)) candidate else LocalDate.of(year + 1, month, day)
         }
-        // Nth weekday helper: e.g. nthWeekday(2, DayOfWeek.SUNDAY, Month.MAY, year) = 2nd Sunday in May
         fun nthWeekday(n: Int, dow: java.time.DayOfWeek, month: java.time.Month, y: Int): LocalDate {
             val first = LocalDate.of(y, month, 1)
             val firstMatch = first.with(java.time.temporal.TemporalAdjusters.nextOrSame(dow))
@@ -1928,11 +2045,9 @@ class NativeIntentHandler @Inject constructor(
             "waitangi day", "waitangi" -> return nextOccurrence(2, 6)
             "anzac day", "anzac" -> return nextOccurrence(4, 25)
             "valentines day", "valentine's day", "valentines" -> return nextOccurrence(2, 14)
-            // Floating holidays (NZ): Mother's Day = 2nd Sunday May, Father's Day = 1st Sunday September
             "mothers day", "mother's day", "mothers" -> return nextFloating(java.time.Month.MAY, 2)
             "fathers day", "father's day", "fathers" -> return nextFloating(java.time.Month.SEPTEMBER, 1)
             "easter" -> {
-                // Computus (anonymous Gregorian algorithm)
                 fun easterDate(y: Int): LocalDate {
                     val a = y % 19; val b = y / 100; val c = y % 100
                     val d = b / 4; val e = b % 4; val f = (b + 8) / 25
@@ -1948,32 +2063,12 @@ class NativeIntentHandler @Inject constructor(
             }
         }
 
-        // Explicit date formats (ordered most-to-least specific)
-        val formatters = listOf(
-            DateTimeFormatter.ISO_LOCAL_DATE,                              // 2026-08-22
-            DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),   // 22 August 2026
-            DateTimeFormatter.ofPattern("MMMM d yyyy", Locale.ENGLISH),   // August 22 2026
-            DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH),  // August 22, 2026
-            DateTimeFormatter.ofPattern("d/MM/yyyy"),                      // 22/08/2026
-            DateTimeFormatter.ofPattern("MM/dd/yyyy"),                     // 08/22/2026
-            DateTimeFormatter.ofPattern("d-MM-yyyy"),                      // 22-08-2026
-        )
-        for (fmt in formatters) {
-            try { return LocalDate.parse(s, fmt) } catch (_: Exception) {}
-        }
-
-        // Partial dates without year — pick next upcoming occurrence
-        val partialFormatters = listOf(
-            DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH),  // 22 August
-            DateTimeFormatter.ofPattern("MMMM d", Locale.ENGLISH),  // August 22
-            DateTimeFormatter.ofPattern("MMMM", Locale.ENGLISH),    // August (1st of that month)
-        )
-        for (fmt in partialFormatters) {
-            try {
-                val md = MonthDay.parse(s, fmt)
-                val candidate = md.atYear(year)
-                return if (!candidate.isBefore(today)) candidate else md.atYear(year + 1)
-            } catch (_: Exception) {}
+        parseImportantDateInput(s)?.let { parsed ->
+            return if (parsed.year != null) {
+                LocalDate.of(parsed.year, parsed.month, parsed.day)
+            } else {
+                resolveRecurringDate(parsed.month, parsed.day, today)
+            }
         }
         return null
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1535,6 +1535,56 @@ class QuickIntentRouterTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // IMPORTANT DATES TESTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Important Dates")
+    inner class ImportantDates {
+
+        @ParameterizedTest(name = "Save important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateSaveRegexPhrases")
+        fun `should match save important date phrases with extracted params`(
+            input: String,
+            expectedLabel: String,
+            expectedDate: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "save_important_date", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedLabel, intent.params["label"], "label for '$input'")
+            assertEquals(expectedDate, intent.params["date"], "date for '$input'")
+        }
+
+        @ParameterizedTest(name = "NeedsSlot save important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateSaveNeedsSlotPhrases")
+        fun `should return NeedsSlot for important date phrases missing date`(input: String, expectedLabel: String) {
+            val result = regexOnlyRouter.route(input)
+            val needsSlot = assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result)
+
+            assertEquals("save_important_date", needsSlot.intent.intentName)
+            assertEquals("date", needsSlot.missingSlot.name)
+            assertEquals(expectedLabel, needsSlot.intent.params["label"])
+        }
+
+        @Test
+        fun `should match list important dates phrase`() {
+            assertRegexMatch(regexOnlyRouter.route("list my important dates"), "list_important_dates", "list my important dates")
+        }
+
+        @ParameterizedTest(name = "Remove important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateRemoveRegexPhrases")
+        fun `should match remove important date phrases`(input: String, expectedLabel: String) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "remove_important_date", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedLabel, intent.params["label"], "label for '$input'")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // SAVE MEMORY TESTS
     // ═══════════════════════════════════════════════════════════════════════════
 
@@ -1727,6 +1777,10 @@ class QuickIntentRouterTest {
         addCases(weatherUvRegexPhrases(), "get_weather", "Weather UV (regex)")
         addCases(weatherAqiRegexPhrases(), "get_weather", "Weather AQI (regex)")
         addCases(weatherSunriseRegexPhrases(), "get_weather", "Weather Sunrise/Sunset (regex)")
+        addCases(importantDateSaveRegexPhrases(), "save_important_date", "Important Dates Save (regex)")
+        addCases(importantDateSaveNeedsSlotPhrases(), "save_important_date", "Important Dates Save (needs slot)")
+        addCases(importantDateRemoveRegexPhrases(), "remove_important_date", "Important Dates Remove (regex)")
+        addCases(listImportantDatesRegexPhrases(), "list_important_dates", "Important Dates List (regex)")
         addCases(saveMemoryRegexPhrases(), "save_memory", "Save Memory (regex)")
         addCases(saveMemoryNeedsSlotPhrases(), "save_memory", "Save Memory (needs slot)")
         addCases(brightnessRegexPhrases(), "set_brightness", "Brightness (regex)")
@@ -2762,16 +2816,42 @@ class QuickIntentRouterTest {
             Arguments.of("save to memory: important note", "important note"),
             Arguments.of("can you save to memory that my dog is named Xena", "my dog is named Xena"),
             Arguments.of("note that the gate code is 4567", "the gate code is 4567"),
-            Arguments.of("don't forget that mum's birthday is March 3", "mum's birthday is March 3"),
             Arguments.of("store that my doctor is Dr Smith", "my doctor is Dr Smith"),
         )
-
         @JvmStatic
         fun saveMemoryNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("remember something"),
             Arguments.of("save something to memory"),
             Arguments.of("make a note"),
             Arguments.of("take a note"),
+        )
+
+
+        @JvmStatic
+        fun importantDateSaveRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remember my mum's birthday is 15 March", "mum's birthday", "15 March"),
+            Arguments.of("save our anniversary as 22 June 2018", "our anniversary", "22 June 2018"),
+            Arguments.of("don't forget that dad's birthday is March 3", "dad's birthday", "March 3"),
+            Arguments.of("my wedding anniversary is 2018-06-22", "wedding anniversary", "2018-06-22"),
+        )
+
+        @JvmStatic
+        fun importantDateSaveNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remember my mum's birthday", "mum's birthday"),
+            Arguments.of("save our anniversary", "our anniversary"),
+        )
+
+        @JvmStatic
+        fun listImportantDatesRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("list my important dates"),
+            Arguments.of("show me important dates"),
+        )
+
+        @JvmStatic
+        fun importantDateRemoveRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remove mum's birthday", "mum's birthday"),
+            Arguments.of("forget our anniversary", "our anniversary"),
+            Arguments.of("delete dad's birthday from my important dates", "dad's birthday"),
         )
 
         // ── Brightness ───────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -12,6 +12,7 @@ import android.provider.ContactsContract
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockStopwatch
@@ -20,6 +21,7 @@ import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
@@ -46,11 +48,11 @@ class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
+    private val importantDateRepository = mockk<ImportantDateRepository>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>(relaxed = true)
     private val clockAlertController = mockk<ClockAlertController>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
     private val listNameDao = mockk<ListNameDao>(relaxed = true)
-
     private val handler = NativeIntentHandler(
         context = context,
         clockRepository = clockRepository,
@@ -58,6 +60,7 @@ class NativeIntentHandlerTest {
         listItemDao = listItemDao,
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
+        importantDateRepository = importantDateRepository,
         memoryRepository = mockk<MemoryRepository>(relaxed = true),
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
     )
@@ -863,6 +866,74 @@ class NativeIntentHandlerTest {
         assertEquals(true, spaced)
         assertEquals(true, compact)
         assertEquals(false, contact)
+    }
+
+    @Test
+    fun `save important date stores parsed recurring date`() {
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        coEvery { importantDateRepository.save("mum's birthday", 3, 15, null) } just Runs
+
+        val result = handler.handle(
+            "save_important_date",
+            mapOf("label" to "mum's birthday", "date" to "15 March"),
+        )
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertEquals(
+            "I'll remember mum's birthday as 15 March.",
+            (result as SkillResult.DirectReply).content,
+        )
+        coVerify(exactly = 1) { importantDateRepository.save("mum's birthday", 3, 15, null) }
+    }
+
+    @Test
+    fun `list important dates returns stored entries`() {
+        coEvery { importantDateRepository.getAll() } returns listOf(
+            ImportantDateEntity(label = "mum's birthday", normalizedLabel = "mum birthday", month = 3, day = 15),
+            ImportantDateEntity(label = "our anniversary", normalizedLabel = "our anniversary", month = 6, day = 22, year = 2018),
+        )
+
+        val result = handler.handle("list_important_dates", emptyMap())
+
+        assertTrue(result is SkillResult.DirectReply)
+        val reply = (result as SkillResult.DirectReply).content
+        assertTrue(reply.contains("Important dates:"))
+        assertTrue(reply.contains("mum's birthday — 15 March"))
+        assertTrue(reply.contains("our anniversary — 22 June 2018"))
+    }
+
+    @Test
+    fun `remove important date deletes by label`() {
+        coEvery { importantDateRepository.deleteByLabel("mum's birthday") } returns 1
+
+        val result = handler.handle("remove_important_date", mapOf("label" to "mum's birthday"))
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertEquals("Removed important date mum's birthday.", (result as SkillResult.DirectReply).content)
+        coVerify(exactly = 1) { importantDateRepository.deleteByLabel("mum's birthday") }
+    }
+
+    @Test
+    fun `parseDateString resolves taught important dates before holiday lookup`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 3, 15).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 3, 15)
+        }
+        coEvery { importantDateRepository.findByLabel("mum's birthday") } returns ImportantDateEntity(
+            label = "mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "mum's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
     }
 
     private data class PhoneRow(


### PR DESCRIPTION
## Summary
- add Room-backed taught important dates storage with normalization and migration
- expose save/list/remove important date intents through QIR and NativeIntentHandler
- resolve taught dates during native date-diff parsing before holiday lookup

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ImportantDateRepositoryTest" :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" :core:memory:compileDebugKotlin :core:skills:compileDebugKotlin`

## Device test matrix
- [ ] Teach a recurring date: say `remember mum's birthday is 15 March` and confirm the assistant reports success.
- [ ] List saved dates: say `what are my important dates` and confirm the saved label/date appears.
- [ ] Resolve a taught date in date math: say `how many days until mum's birthday` and confirm the reply uses the saved date rather than failing to parse.
- [ ] Remove a taught date: say `remove mum's birthday from my important dates` and confirm the assistant reports removal.
- [ ] Confirm removal stuck: say `what are my important dates` again and verify the removed date is gone.
- [ ] Persistence smoke test: save an important date again, fully restart the app, then ask `how many days until mum's birthday` and confirm the saved date still resolves.

Closes #632
