### PR TITLE
feat: integrate calendar birthdays into important date lookup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <!-- Contact lookup for SMS, email, and call by name -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!-- Calendar lookup for synced contact birthdays -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
     <!-- Microphone access for offline Quick Actions voice input -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Required to read/write the Do Not Disturb (interruption filter) policy -->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -1,0 +1,132 @@
+package com.kernel.ai.core.skills.natives
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.CalendarContract
+import com.kernel.ai.core.memory.ImportantDateRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CalendarBirthdayLookup @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    data class BirthdayEntry(
+        val label: String,
+        val normalizedLabel: String,
+        val month: Int,
+        val day: Int,
+    )
+
+    @Volatile
+    private var cachedBirthdays: List<BirthdayEntry>? = null
+
+    fun hasPermission(): Boolean =
+        context.checkSelfPermission(Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED
+
+    fun findBirthday(label: String): BirthdayEntry? {
+        if (!hasPermission()) return null
+        val normalizedQuery = normalizeBirthdayLookupLabel(label)
+        if (normalizedQuery.isBlank()) return null
+        val birthdays = loadBirthdays()
+        birthdays.firstOrNull { it.normalizedLabel == normalizedQuery }?.let { return it }
+
+        val queryTokens = normalizedQuery.split(" ").filter { it.isNotBlank() }.toSet()
+        if (queryTokens.isEmpty()) return null
+        val partialMatches = birthdays.filter { entry ->
+            val entryTokens = entry.normalizedLabel.split(" ").filter { it.isNotBlank() }.toSet()
+            entryTokens.containsAll(queryTokens)
+        }
+        return partialMatches.singleOrNull()
+    }
+
+    fun invalidateCache() {
+        cachedBirthdays = null
+    }
+
+    private fun loadBirthdays(): List<BirthdayEntry> {
+        cachedBirthdays?.let { return it }
+        return synchronized(this) {
+            cachedBirthdays ?: queryBirthdays().also { cachedBirthdays = it }
+        }
+    }
+
+    private fun queryBirthdays(): List<BirthdayEntry> {
+        val projection = arrayOf(
+            CalendarContract.Events.TITLE,
+            CalendarContract.Events.DTSTART,
+            CalendarContract.Events.ALL_DAY,
+            CalendarContract.Events.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Events.ACCOUNT_TYPE,
+        )
+        val selection = "${CalendarContract.Events.DELETED} = 0 AND ${CalendarContract.Events.TITLE} IS NOT NULL"
+        val results = linkedMapOf<String, BirthdayEntry>()
+
+        context.contentResolver.query(
+            CalendarContract.Events.CONTENT_URI,
+            projection,
+            selection,
+            null,
+            null,
+        )?.use { cursor ->
+            val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.TITLE)
+            val dtStartIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.DTSTART)
+            val allDayIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.ALL_DAY)
+            val displayNameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.CALENDAR_DISPLAY_NAME)
+            val accountTypeIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.ACCOUNT_TYPE)
+
+            while (cursor.moveToNext()) {
+                val title = cursor.getString(titleIndex) ?: continue
+                val calendarDisplayName = cursor.getString(displayNameIndex).orEmpty()
+                val accountType = cursor.getString(accountTypeIndex).orEmpty()
+                if (!looksLikeBirthdaySource(calendarDisplayName, accountType, title)) continue
+
+                val normalizedTitle = normalizeBirthdayTitle(title) ?: continue
+                val startMillis = cursor.getLong(dtStartIndex)
+                val isAllDay = cursor.getInt(allDayIndex) != 0
+                val date = toLocalDate(startMillis, isAllDay)
+                results.putIfAbsent(
+                    normalizedTitle,
+                    BirthdayEntry(
+                        label = normalizedTitle,
+                        normalizedLabel = normalizeBirthdayLookupLabel(normalizedTitle),
+                        month = date.monthValue,
+                        day = date.dayOfMonth,
+                    ),
+                )
+            }
+        }
+        return results.values.toList()
+    }
+
+    private fun looksLikeBirthdaySource(calendarDisplayName: String, accountType: String, title: String): Boolean {
+        val displayNameLower = calendarDisplayName.lowercase(Locale.ENGLISH)
+        val titleLower = title.lowercase(Locale.ENGLISH)
+        return displayNameLower.contains("birthday") ||
+            titleLower.contains("birthday") ||
+            (accountType == "com.google" && titleLower.contains("birthday"))
+    }
+
+    private fun normalizeBirthdayTitle(raw: String): String? {
+        val trimmed = raw.trim()
+        val birthdaySuffix = Regex("""(?i)^(.+?)'?s\s+birthday$|^birthday\s*:?\s+(.+)$|^(.+?)\s+birthday$""")
+        val match = birthdaySuffix.matchEntire(trimmed) ?: return null
+        val label = match.groupValues.drop(1).firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+        return label.takeIf { it.isNotBlank() }
+    }
+
+    private fun normalizeBirthdayLookupLabel(raw: String): String = ImportantDateRepository.normalizeLabel(
+        raw.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
+    )
+
+    private fun toLocalDate(startMillis: Long, isAllDay: Boolean): LocalDate {
+        val zone = if (isAllDay) ZoneId.of("UTC") else ZoneId.systemDefault()
+        return Instant.ofEpochMilli(startMillis).atZone(zone).toLocalDate()
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -125,6 +125,7 @@ class NativeIntentHandler @Inject constructor(
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
     private val importantDateRepository: ImportantDateRepository,
+    private val calendarBirthdayLookup: CalendarBirthdayLookup,
     private val memoryRepository: MemoryRepository,
     private val embeddingEngine: EmbeddingEngine,
 ) {
@@ -1893,7 +1894,14 @@ class NativeIntentHandler @Inject constructor(
         val fromDate = params["from_date"]?.takeIf { it.isNotBlank() }
             ?.let { parseDateString(it) } ?: today
         val targetDate = parseDateString(targetStr)
-            ?: return SkillResult.Failure("get_date_diff", "Could not parse date: \"$targetStr\"")
+            ?: return SkillResult.Failure(
+                "get_date_diff",
+                if (targetStr.contains("birthday", ignoreCase = true) && !calendarBirthdayLookup.hasPermission()) {
+                    "Could not parse date: \"$targetStr\". If this is a synced contact birthday, enable Calendar access in Settings first."
+                } else {
+                    "Could not parse date: \"$targetStr\""
+                },
+            )
 
         val days = ChronoUnit.DAYS.between(fromDate, targetDate)
         val absDays = Math.abs(days)
@@ -2020,6 +2028,11 @@ class NativeIntentHandler @Inject constructor(
 
         runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
             return resolveRecurringDate(stored.month, stored.day, today)
+        }
+        if (s.contains("birthday", ignoreCase = true)) {
+            calendarBirthdayLookup.findBirthday(s)?.let { birthday ->
+                return resolveRecurringDate(birthday.month, birthday.day, today)
+            }
         }
 
         fun nextOccurrence(month: Int, day: Int): LocalDate {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -1,0 +1,113 @@
+package com.kernel.ai.core.skills.natives
+
+import android.Manifest
+import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.provider.CalendarContract
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+class CalendarBirthdayLookupTest {
+    @Test
+    fun `findBirthday normalizes birthday titles and caches query results`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Jane Smith's Birthday",
+            dtStart = LocalDate.of(2020, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val first = lookup.findBirthday("Jane's birthday")
+        val second = lookup.findBirthday("Jane's birthday")
+
+        assertNotNull(first)
+        assertEquals(4, first?.month)
+        assertEquals(5, first?.day)
+        assertEquals("Jane Smith", first?.label)
+        assertEquals(first, second)
+        verify(exactly = 1) {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `findBirthday returns null without calendar permission`() {
+        val context = mockk<Context>(relaxed = true)
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_DENIED
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        assertNull(lookup.findBirthday("Jane's birthday"))
+        verify(exactly = 0) { context.contentResolver }
+    }
+
+    private fun birthdayCursor(
+        title: String,
+        dtStart: Long,
+        isAllDay: Boolean,
+        calendarDisplayName: String,
+        accountType: String,
+    ): Cursor {
+        val cursor = mockk<Cursor>()
+        val columns = mapOf(
+            CalendarContract.Events.TITLE to 0,
+            CalendarContract.Events.DTSTART to 1,
+            CalendarContract.Events.ALL_DAY to 2,
+            CalendarContract.Events.CALENDAR_DISPLAY_NAME to 3,
+            CalendarContract.Events.ACCOUNT_TYPE to 4,
+        )
+        var moved = false
+
+        every { cursor.getColumnIndexOrThrow(any()) } answers {
+            columns[firstArg<String>()] ?: error("Unknown column ${firstArg<String>()}")
+        }
+        every { cursor.moveToNext() } answers {
+            if (moved) {
+                false
+            } else {
+                moved = true
+                true
+            }
+        }
+        every { cursor.getString(0) } returns title
+        every { cursor.getLong(1) } returns dtStart
+        every { cursor.getInt(2) } returns if (isAllDay) 1 else 0
+        every { cursor.getString(3) } returns calendarDisplayName
+        every { cursor.getString(4) } returns accountType
+        every { cursor.close() } just runs
+        return cursor
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -49,6 +49,7 @@ class NativeIntentHandlerTest {
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
     private val importantDateRepository = mockk<ImportantDateRepository>(relaxed = true)
+    private val calendarBirthdayLookup = mockk<CalendarBirthdayLookup>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>(relaxed = true)
     private val clockAlertController = mockk<ClockAlertController>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
@@ -61,6 +62,7 @@ class NativeIntentHandlerTest {
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
         importantDateRepository = importantDateRepository,
+        calendarBirthdayLookup = calendarBirthdayLookup,
         memoryRepository = mockk<MemoryRepository>(relaxed = true),
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
     )
@@ -935,6 +937,55 @@ class NativeIntentHandlerTest {
 
         assertEquals(expected, resolved)
     }
+
+    @Test
+    fun `parseDateString resolves calendar birthdays when taught date missing`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 4, 5).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 4, 5)
+        }
+        coEvery { importantDateRepository.findByLabel("jane's birthday") } returns null
+        every { calendarBirthdayLookup.findBirthday("jane's birthday") } returns CalendarBirthdayLookup.BirthdayEntry(
+            label = "Jane Smith",
+            normalizedLabel = "jane smith",
+            month = 4,
+            day = 5,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "jane's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+    }
+
+    @Test
+    fun `parseDateString prefers taught dates over calendar birthdays`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 3, 15).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 3, 15)
+        }
+        coEvery { importantDateRepository.findByLabel("mum's birthday") } returns ImportantDateEntity(
+            label = "mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "mum's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+        verify(exactly = 0) { calendarBirthdayLookup.findBirthday(any()) }
+    }
+
 
     private data class PhoneRow(
         val contactId: String,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -1,5 +1,11 @@
 package com.kernel.ai.feature.settings
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,6 +26,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,14 +44,21 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 
 /** Amber / HuggingFace brand colour — same as in OnboardingScreen. */
 private val HfOrange = Color(0xFFFF9D00)
@@ -64,7 +78,28 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val uriHandler = LocalUriHandler.current
-
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    var hasCalendarPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    var showCalendarPermissionRationale by remember { mutableStateOf(false) }
+    val calendarPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        hasCalendarPermission = granted
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                if (granted) {
+                    "Calendar birthday access enabled."
+                } else {
+                    "Calendar birthday access denied. You can enable it later from Settings."
+                },
+            )
+        }
+    }
     LaunchedEffect(Unit) {
         viewModel.saveError.collect { message ->
             snackbarHostState.showSnackbar(message)
@@ -204,6 +239,44 @@ fun SettingsScreen(
             )
             HorizontalDivider()
 
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        val activity = context.findActivity()
+                        if (hasCalendarPermission) {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar("Calendar birthday access is already enabled.")
+                            }
+                        } else if (activity != null &&
+                            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_CALENDAR)
+                        ) {
+                            showCalendarPermissionRationale = true
+                        } else {
+                            calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                        }
+                    },
+                headlineContent = { Text("Calendar birthdays") },
+                supportingContent = {
+                    Text(
+                        if (hasCalendarPermission) {
+                            "Use synced contact birthdays in date queries"
+                        } else {
+                            "Optional — enable synced contact birthdays for important date lookups"
+                        },
+                    )
+                },
+                leadingContent = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
+                trailingContent = {
+                    Text(
+                        if (hasCalendarPermission) "Allowed" else "Off",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+            HorizontalDivider()
+
             // ── App ───────────────────────────────────────────────────────────
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -224,6 +297,32 @@ fun SettingsScreen(
             )
             HorizontalDivider()
         }
+    }
+    if (showCalendarPermissionRationale) {
+        AlertDialog(
+            onDismissRequest = { showCalendarPermissionRationale = false },
+            title = { Text("Allow calendar birthday access?") },
+            text = {
+                Text(
+                    "This lets Kernel AI read synced birthday calendar events so queries like 'how many days until Jane's birthday' work without teaching the date manually.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCalendarPermissionRationale = false
+                        calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                    },
+                ) {
+                    Text("Continue")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCalendarPermissionRationale = false }) {
+                    Text("Not now")
+                }
+            },
+        )
     }
 }
 
@@ -355,3 +454,9 @@ private fun HuggingFaceAccountRowNotSignedInPreview() {
     }
 }
 
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}


### PR DESCRIPTION
## Summary
- add cached CalendarContract birthday lookup and feed it into native date parsing after taught dates
- add READ_CALENDAR support with a Settings rationale/request flow for birthday lookup access
- cover calendar birthday lookup and taught-date precedence in native tests

## Verification
- `./gradlew :core:skills:testDebugUnitTest --tests "*CalendarBirthdayLookupTest" --tests "*NativeIntentHandlerTest" :core:skills:compileDebugKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin`

## Notes
- stacked on #793 because #633 depends on #632

## Device test matrix
- [ ] Stack smoke test: save one taught date and confirm `what are my important dates` still works on this branch.
- [ ] Open `Settings` and verify a `Calendar birthdays` row is present.
- [ ] With Calendar permission not yet granted, verify the row shows `Off`.
- [ ] Tap `Calendar birthdays`, grant permission, and verify the row updates to `Allowed`.
- [ ] Ask a synced birthday query such as `how many days until Jane's birthday` and confirm it resolves from calendar data.
- [ ] Revoke Calendar permission in Android system settings, return to the app, and ask the same birthday query again.
- [ ] Confirm the failure copy points back to Settings for Calendar access: `If this is a synced contact birthday, enable Calendar access in Settings first.`

Closes #633
