### PR TITLE
feat: add important dates settings screen

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -42,6 +42,7 @@ import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.ContactAliasesScreen
+import com.kernel.ai.feature.settings.ImportantDatesScreen
 import com.kernel.ai.feature.settings.ListItemsScreen
 import com.kernel.ai.feature.settings.ListsScreen
 import com.kernel.ai.feature.settings.MemoryScreen
@@ -62,6 +63,7 @@ private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
 private const val ROUTE_MEMORY = "settings/memory"
+private const val ROUTE_IMPORTANT_DATES = "settings/important_dates"
 private const val ROUTE_VOICE = "settings/voice"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management?scrollTo={scrollTo}"
@@ -368,6 +370,9 @@ fun KernelNavHost(
                         onNavigateToMemory = {
                             navController.navigate(ROUTE_MEMORY)
                         },
+                        onNavigateToImportantDates = {
+                            navController.navigate(ROUTE_IMPORTANT_DATES)
+                        },
                         onNavigateToVoice = {
                             navController.navigate(ROUTE_VOICE)
                         },
@@ -392,6 +397,12 @@ fun KernelNavHost(
 
                 composable(ROUTE_MEMORY) {
                     MemoryScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable(ROUTE_IMPORTANT_DATES) {
+                    ImportantDatesScreen(
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -46,6 +46,11 @@ class CalendarBirthdayLookup @Inject constructor(
         return partialMatches.singleOrNull()
     }
 
+    fun getAllBirthdays(): List<BirthdayEntry> {
+        if (!hasPermission()) return emptyList()
+        return loadBirthdays()
+    }
+
     fun invalidateCache() {
         cachedBirthdays = null
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -1,0 +1,464 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportantDatesScreen(
+    onBack: () -> Unit,
+    viewModel: ImportantDatesViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    var editingDate by remember { mutableStateOf<ImportantDateListItem?>(null) }
+    var pendingDelete by remember { mutableStateOf<ImportantDateListItem?>(null) }
+    var createRequested by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.messages.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Important dates") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { createRequested = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add important date")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(bottom = 88.dp),
+        ) {
+            if (!uiState.calendarPermissionGranted) {
+                item {
+                    ListItem(
+                        headlineContent = { Text("Calendar birthdays are off") },
+                        supportingContent = {
+                            Text("Enable Calendar birthdays in Settings to show synced birthdays here. Taught dates still work without it.")
+                        },
+                        leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            if (uiState.isRefreshingCalendarBirthdays) {
+                item {
+                    ListItem(
+                        headlineContent = { Text("Refreshing synced birthdays…") },
+                        supportingContent = { Text("Pulling the latest read-only birthdays from Android Calendar.") },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            if (!uiState.hasAnyDates) {
+                item {
+                    EmptyImportantDatesState(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    )
+                }
+            } else {
+                if (uiState.upcomingDates.isNotEmpty()) {
+                    item {
+                        ImportantDatesSectionHeader("Upcoming (next 90 days)")
+                    }
+                    items(uiState.upcomingDates, key = { it.stableKey }) { item ->
+                        ImportantDateRow(
+                            item = item,
+                            onEdit = { editingDate = item },
+                            onDelete = { pendingDelete = item },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+
+                if (uiState.laterDates.isNotEmpty()) {
+                    item {
+                        ImportantDatesSectionHeader(
+                            if (uiState.upcomingDates.isEmpty()) "All dates" else "Later",
+                        )
+                    }
+                    items(uiState.laterDates, key = { it.stableKey }) { item ->
+                        ImportantDateRow(
+                            item = item,
+                            onEdit = { editingDate = item },
+                            onDelete = { pendingDelete = item },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+
+    if (createRequested) {
+        ImportantDateEditorSheet(
+            existingItem = null,
+            onDismiss = { createRequested = false },
+            onSave = { label, month, day, year ->
+                coroutineScope.launch {
+                    val saved = viewModel.saveTaughtDate(
+                        existingLabel = null,
+                        label = label,
+                        month = month,
+                        day = day,
+                        year = year,
+                    )
+                    if (saved) createRequested = false
+                }
+            },
+        )
+    }
+
+    editingDate?.let { item ->
+        ImportantDateEditorSheet(
+            existingItem = item,
+            onDismiss = { editingDate = null },
+            onSave = { label, month, day, year ->
+                coroutineScope.launch {
+                    val saved = viewModel.saveTaughtDate(
+                        existingLabel = item.label,
+                        label = label,
+                        month = month,
+                        day = day,
+                        year = year,
+                    )
+                    if (saved) editingDate = null
+                }
+            },
+        )
+    }
+
+    pendingDelete?.let { item ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            icon = { Icon(Icons.Default.Delete, contentDescription = null) },
+            title = { Text("Delete ${item.label}?") },
+            text = { Text("This only removes the taught date. Synced calendar birthdays stay read-only.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            viewModel.deleteTaughtDate(item.label)
+                            pendingDelete = null
+                        }
+                    },
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ImportantDatesSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun EmptyImportantDatesState(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "No important dates yet.",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Tap + to add one here, or teach Jandal by saying something like 'remember mum's birthday is 15 March'.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ImportantDateRow(
+    item: ImportantDateListItem,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dateSummary = formatStoredDate(item.month, item.day, item.year)
+    val nextSummary = formatNextOccurrence(item.nextOccurrence)
+
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !item.isReadOnly, onClick = onEdit),
+        headlineContent = { Text(item.label) },
+        supportingContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(dateSummary)
+                Text(
+                    if (item.isReadOnly) {
+                        "$nextSummary · Synced from Calendar"
+                    } else {
+                        "$nextSummary · Taught by you"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        leadingContent = {
+            Icon(Icons.Default.Event, contentDescription = null)
+        },
+        trailingContent = {
+            if (item.isReadOnly) {
+                Text(
+                    text = "Read-only",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    IconButton(onClick = onEdit) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit ${item.label}")
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(Icons.Default.Delete, contentDescription = "Delete ${item.label}")
+                    }
+                }
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImportantDateEditorSheet(
+    existingItem: ImportantDateListItem?,
+    onDismiss: () -> Unit,
+    onSave: (label: String, month: Int, day: Int, year: Int?) -> Unit,
+) {
+    val today = LocalDate.now()
+    var label by remember(existingItem) { mutableStateOf(existingItem?.label ?: "") }
+    var selectedDate by remember(existingItem) {
+        mutableStateOf(
+            LocalDate.of(
+                existingItem?.year ?: today.year,
+                existingItem?.month ?: today.monthValue,
+                existingItem?.day ?: today.dayOfMonth,
+            ),
+        )
+    }
+    var yearText by remember(existingItem) { mutableStateOf(existingItem?.year?.toString().orEmpty()) }
+    var localError by remember(existingItem) { mutableStateOf<String?>(null) }
+    var showDatePicker by remember(existingItem) { mutableStateOf(false) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = if (existingItem == null) "Add important date" else "Edit important date",
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                text = "Month and day are required. Leave year blank to repeat every year.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = label,
+                onValueChange = {
+                    label = it
+                    localError = null
+                },
+                label = { Text("Label") },
+                placeholder = { Text("e.g. Mum's birthday") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedButton(
+                onClick = { showDatePicker = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Date: ${formatStoredDate(selectedDate.monthValue, selectedDate.dayOfMonth, null)}")
+            }
+            OutlinedTextField(
+                value = yearText,
+                onValueChange = {
+                    yearText = it.filter(Char::isDigit).take(4)
+                    localError = null
+                },
+                label = { Text("Year (optional)") },
+                placeholder = { Text("Leave blank for recurring dates") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            localError?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        val parsedYear = when {
+                            yearText.isBlank() -> null
+                            yearText.length != 4 -> {
+                                localError = "Year must be four digits or left blank."
+                                return@Button
+                            }
+                            else -> yearText.toIntOrNull()?.also {
+                                if (it < 1) {
+                                    localError = "Year must be a valid positive number."
+                                    return@Button
+                                }
+                            } ?: run {
+                                localError = "Year must be a valid number."
+                                return@Button
+                            }
+                        }
+                        onSave(label, selectedDate.monthValue, selectedDate.dayOfMonth, parsedYear)
+                    },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(if (existingItem == null) "Add" else "Save")
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val selectedMillis = datePickerState.selectedDateMillis ?: return@TextButton
+                        selectedDate = Instant.ofEpochMilli(selectedMillis)
+                            .atZone(ZoneId.of("UTC"))
+                            .toLocalDate()
+                        showDatePicker = false
+                    },
+                ) {
+                    Text("Use date")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text("Cancel")
+                }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+private fun formatStoredDate(month: Int, day: Int, year: Int?): String {
+    val date = LocalDate.of(year ?: 2000, month, day)
+    val pattern = if (year == null) "d MMMM" else "d MMMM yyyy"
+    return date.format(DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH))
+}
+
+private fun formatNextOccurrence(date: LocalDate): String =
+    "Next: ${date.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))}"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
@@ -1,0 +1,197 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.ImportantDateRepository
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.skills.natives.CalendarBirthdayLookup
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class ImportantDateSource {
+    TAUGHT,
+    CALENDAR,
+}
+
+data class ImportantDateListItem(
+    val label: String,
+    val normalizedLabel: String,
+    val month: Int,
+    val day: Int,
+    val year: Int?,
+    val source: ImportantDateSource,
+    val nextOccurrence: LocalDate,
+) {
+    val stableKey: String = "${source.name}:$normalizedLabel"
+    val isReadOnly: Boolean = source == ImportantDateSource.CALENDAR
+}
+
+data class ImportantDatesUiState(
+    val upcomingDates: List<ImportantDateListItem> = emptyList(),
+    val laterDates: List<ImportantDateListItem> = emptyList(),
+    val calendarPermissionGranted: Boolean = false,
+    val isRefreshingCalendarBirthdays: Boolean = false,
+) {
+    val hasAnyDates: Boolean = upcomingDates.isNotEmpty() || laterDates.isNotEmpty()
+}
+
+@HiltViewModel
+class ImportantDatesViewModel @Inject constructor(
+    private val repository: ImportantDateRepository,
+    private val calendarBirthdayLookup: CalendarBirthdayLookup,
+) : ViewModel() {
+    private val calendarBirthdays = MutableStateFlow<List<ImportantDateListItem>>(emptyList())
+    private val calendarPermissionGranted = MutableStateFlow(calendarBirthdayLookup.hasPermission())
+    private val isRefreshingCalendarBirthdays = MutableStateFlow(false)
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    val messages = _messages.asSharedFlow()
+
+    val uiState: StateFlow<ImportantDatesUiState> = combine(
+        repository.observeAll().map { dates ->
+            dates.map { it.toUiItem() }
+        },
+        calendarBirthdays,
+        calendarPermissionGranted,
+        isRefreshingCalendarBirthdays,
+    ) { taughtDates, syncedBirthdays, hasCalendarPermission, isRefreshing ->
+        buildUiState(
+            taughtDates = taughtDates,
+            calendarBirthdays = syncedBirthdays,
+            hasCalendarPermission = hasCalendarPermission,
+            isRefreshing = isRefreshing,
+            today = LocalDate.now(),
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ImportantDatesUiState(
+            calendarPermissionGranted = calendarBirthdayLookup.hasPermission(),
+        ),
+    )
+
+    init {
+        refreshCalendarBirthdays()
+    }
+
+    fun refreshCalendarBirthdays() {
+        viewModelScope.launch {
+            isRefreshingCalendarBirthdays.value = true
+            val granted = calendarBirthdayLookup.hasPermission()
+            calendarPermissionGranted.value = granted
+            calendarBirthdays.value = if (granted) {
+                calendarBirthdayLookup.invalidateCache()
+                calendarBirthdayLookup.getAllBirthdays().map { it.toUiItem() }
+            } else {
+                emptyList()
+            }
+            isRefreshingCalendarBirthdays.value = false
+        }
+    }
+
+    suspend fun saveTaughtDate(
+        existingLabel: String?,
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+    ): Boolean {
+        val trimmedLabel = label.trim()
+        if (trimmedLabel.isBlank()) {
+            _messages.emit("Label is required.")
+            return false
+        }
+        if (month !in 1..12 || day !in 1..31) {
+            _messages.emit("Pick a valid month and day.")
+            return false
+        }
+
+        val normalizedLabel = ImportantDateRepository.normalizeLabel(trimmedLabel)
+        val originalNormalizedLabel = existingLabel?.let(ImportantDateRepository::normalizeLabel)
+        val existing = repository.findByLabel(trimmedLabel)
+        if (existing != null && existing.normalizedLabel != originalNormalizedLabel) {
+            _messages.emit("An important date named $trimmedLabel already exists.")
+            return false
+        }
+
+        if (existingLabel != null && originalNormalizedLabel != normalizedLabel) {
+            repository.deleteByLabel(existingLabel)
+        }
+        repository.save(trimmedLabel, month, day, year)
+        _messages.emit(if (existingLabel == null) "Saved $trimmedLabel." else "Updated $trimmedLabel.")
+        return true
+    }
+
+    suspend fun deleteTaughtDate(label: String): Boolean {
+        val deleted = repository.deleteByLabel(label)
+        _messages.emit(
+            if (deleted > 0) {
+                "Removed $label."
+            } else {
+                "I couldn't find $label anymore."
+            },
+        )
+        return deleted > 0
+    }
+
+    companion object {
+        internal fun buildUiState(
+            taughtDates: List<ImportantDateListItem>,
+            calendarBirthdays: List<ImportantDateListItem>,
+            hasCalendarPermission: Boolean,
+            isRefreshing: Boolean,
+            today: LocalDate,
+        ): ImportantDatesUiState {
+            val taughtLabels = taughtDates.map { it.normalizedLabel }.toSet()
+            val merged = (taughtDates + calendarBirthdays.filter { it.normalizedLabel !in taughtLabels })
+                .sortedWith(
+                    compareBy<ImportantDateListItem> { it.nextOccurrence }
+                        .thenBy { it.label.lowercase() },
+                )
+            val upcomingCutoff = today.plusDays(90)
+            return ImportantDatesUiState(
+                upcomingDates = merged.filter { !it.nextOccurrence.isAfter(upcomingCutoff) },
+                laterDates = merged.filter { it.nextOccurrence.isAfter(upcomingCutoff) },
+                calendarPermissionGranted = hasCalendarPermission,
+                isRefreshingCalendarBirthdays = isRefreshing,
+            )
+        }
+
+        internal fun ImportantDateEntity.toUiItem(today: LocalDate = LocalDate.now()): ImportantDateListItem =
+            ImportantDateListItem(
+                label = label,
+                normalizedLabel = normalizedLabel,
+                month = month,
+                day = day,
+                year = year,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = nextOccurrence(month, day, today),
+            )
+
+        internal fun CalendarBirthdayLookup.BirthdayEntry.toUiItem(today: LocalDate = LocalDate.now()): ImportantDateListItem =
+            ImportantDateListItem(
+                label = label,
+                normalizedLabel = normalizedLabel,
+                month = month,
+                day = day,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = nextOccurrence(month, day, today),
+            )
+
+        internal fun nextOccurrence(month: Int, day: Int, today: LocalDate): LocalDate {
+            val candidate = LocalDate.of(today.year, month, day)
+            return if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
@@ -69,6 +70,7 @@ fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
+    onNavigateToImportantDates: () -> Unit = {},
     onNavigateToVoice: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
     onNavigateToModelManagement: (preferred: Boolean) -> Unit = {},
@@ -224,6 +226,17 @@ fun SettingsScreen(
                 headlineContent = { Text("Memory") },
                 supportingContent = { Text("Manage stored memories") },
                 leadingContent = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToImportantDates() },
+                headlineContent = { Text("Important dates") },
+                supportingContent = { Text("Browse and edit taught dates") },
+                leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
@@ -1,0 +1,169 @@
+package com.kernel.ai.feature.settings
+
+import com.kernel.ai.core.memory.ImportantDateRepository
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.skills.natives.CalendarBirthdayLookup
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportantDatesViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: ImportantDateRepository = mockk()
+    private val calendarBirthdayLookup: CalendarBirthdayLookup = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { repository.observeAll() } returns flowOf(emptyList())
+        every { calendarBirthdayLookup.hasPermission() } returns false
+        every { calendarBirthdayLookup.getAllBirthdays() } returns emptyList()
+        every { calendarBirthdayLookup.invalidateCache() } returns Unit
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refreshCalendarBirthdays loads read only birthdays when permission is granted`() = runTest {
+        every { calendarBirthdayLookup.hasPermission() } returns true
+        every { calendarBirthdayLookup.getAllBirthdays() } returns listOf(
+            CalendarBirthdayLookup.BirthdayEntry(
+                label = "Jane Smith",
+                normalizedLabel = "jane smith",
+                month = 4,
+                day = 5,
+            ),
+        )
+
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        val collectionJob = launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.calendarPermissionGranted)
+        val allDates = viewModel.uiState.value.upcomingDates + viewModel.uiState.value.laterDates
+        assertEquals(listOf("Jane Smith"), allDates.map { it.label })
+        assertTrue(allDates.all { it.isReadOnly })
+        collectionJob.cancel()
+    }
+
+    @Test
+    fun `buildUiState hides calendar duplicates behind taught dates and groups later dates`() {
+        val today = LocalDate.of(2026, 1, 10)
+        val taught = listOf(
+            ImportantDateListItem(
+                label = "Mum's birthday",
+                normalizedLabel = "mum birthday",
+                month = 1,
+                day = 12,
+                year = null,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = LocalDate.of(2026, 1, 12),
+            ),
+        )
+        val synced = listOf(
+            ImportantDateListItem(
+                label = "Mum",
+                normalizedLabel = "mum birthday",
+                month = 1,
+                day = 12,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = LocalDate.of(2026, 1, 12),
+            ),
+            ImportantDateListItem(
+                label = "Dad",
+                normalizedLabel = "dad",
+                month = 2,
+                day = 1,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = LocalDate.of(2026, 2, 1),
+            ),
+            ImportantDateListItem(
+                label = "Our anniversary",
+                normalizedLabel = "our anniversary",
+                month = 7,
+                day = 1,
+                year = 2018,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = LocalDate.of(2026, 7, 1),
+            ),
+        )
+
+        val state = ImportantDatesViewModel.buildUiState(
+            taughtDates = taught,
+            calendarBirthdays = synced,
+            hasCalendarPermission = true,
+            isRefreshing = false,
+            today = today,
+        )
+
+        assertEquals(listOf("Mum's birthday", "Dad"), state.upcomingDates.map { it.label })
+        assertEquals(listOf("Our anniversary"), state.laterDates.map { it.label })
+    }
+
+    @Test
+    fun `saveTaughtDate renames existing entry without keeping the old label`() = runTest {
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        advanceUntilIdle()
+        coEvery { repository.findByLabel("Parents anniversary") } returns null
+        coEvery { repository.deleteByLabel("Our anniversary") } returns 1
+        coEvery { repository.save("Parents anniversary", 6, 22, 2018) } returns Unit
+
+        val saved = viewModel.saveTaughtDate(
+            existingLabel = "Our anniversary",
+            label = "Parents anniversary",
+            month = 6,
+            day = 22,
+            year = 2018,
+        )
+
+        assertTrue(saved)
+        coVerify(exactly = 1) { repository.deleteByLabel("Our anniversary") }
+        coVerify(exactly = 1) { repository.save("Parents anniversary", 6, 22, 2018) }
+    }
+
+    @Test
+    fun `saveTaughtDate rejects conflicting rename`() = runTest {
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        advanceUntilIdle()
+        coEvery { repository.findByLabel("Mum's birthday") } returns ImportantDateEntity(
+            label = "Mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val saved = viewModel.saveTaughtDate(
+            existingLabel = "Dad's birthday",
+            label = "Mum's birthday",
+            month = 3,
+            day = 15,
+            year = null,
+        )
+
+        assertFalse(saved)
+        coVerify(exactly = 0) { repository.save(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- add a first-class Settings screen for important dates with add, edit, and delete flows for taught dates
- surface synced calendar birthdays as read-only entries and hide calendar duplicates when a taught date takes precedence
- wire Settings navigation to the new screen and cover the view-model merge/sort/edit behavior with tests

## Verification
- `./gradlew :feature:settings:testDebugUnitTest --tests "*ImportantDatesViewModelTest" :feature:settings:compileDebugKotlin :app:compileDebugKotlin`
- `./gradlew :core:skills:testDebugUnitTest --tests "*CalendarBirthdayLookupTest"`

## Notes
- stacked on #794 because the screen shows read-only calendar birthdays from #633 when Calendar access is enabled

## Device test matrix
- [ ] Open `Settings` and verify a new `Important dates` row is present under Personal.
- [ ] Open `Important dates` and verify the empty state explains both manual add and AI teaching when no dates are saved.
- [ ] Tap `+`, add a recurring date such as `Mum's birthday` on `15 March` with the year left blank, and confirm it appears in the list.
- [ ] Tap that row, edit the label/date/year, save, and confirm the list updates instead of keeping both old and new labels.
- [ ] Delete a taught date from the screen and confirm it disappears.
- [ ] With Calendar birthdays enabled, confirm synced birthdays appear with the calendar icon/read-only copy and cannot be edited or deleted.
- [ ] If a taught date and a synced birthday refer to the same normalized label, confirm only the taught date is shown.

Closes #634