### PR TITLE
feat: land important dates end-to-end

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <!-- Contact lookup for SMS, email, and call by name -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!-- Calendar lookup for synced contact birthdays -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
     <!-- Microphone access for offline Quick Actions voice input -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Required to read/write the Do Not Disturb (interruption filter) policy -->

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Settings
@@ -152,6 +153,20 @@ fun KernelNavHost(
                     onClick = {
                         coroutineScope.launch { drawerState.close() }
                         navController.navigate(ROUTE_SIDE_PANEL) {
+                            popUpTo(ROUTE_LIST) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                )
+                NavigationDrawerItem(
+                    label = { Text("Important dates") },
+                    icon = { Icon(Icons.Default.Event, contentDescription = null) },
+                    selected = currentBaseRoute == ROUTE_IMPORTANT_DATES,
+                    onClick = {
+                        coroutineScope.launch { drawerState.close() }
+                        navController.navigate(ROUTE_IMPORTANT_DATES) {
                             popUpTo(ROUTE_LIST) { saveState = true }
                             launchSingleTop = true
                             restoreState = true
@@ -369,9 +384,6 @@ fun KernelNavHost(
                         },
                         onNavigateToMemory = {
                             navController.navigate(ROUTE_MEMORY)
-                        },
-                        onNavigateToImportantDates = {
-                            navController.navigate(ROUTE_IMPORTANT_DATES)
                         },
                         onNavigateToVoice = {
                             navController.navigate(ROUTE_VOICE)

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -42,6 +42,7 @@ import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.ContactAliasesScreen
+import com.kernel.ai.feature.settings.ImportantDatesScreen
 import com.kernel.ai.feature.settings.ListItemsScreen
 import com.kernel.ai.feature.settings.ListsScreen
 import com.kernel.ai.feature.settings.MemoryScreen
@@ -62,6 +63,7 @@ private const val ROUTE_CHAT = "chat"
 private const val ROUTE_SETTINGS = "settings"
 private const val ROUTE_USER_PROFILE = "settings/user_profile"
 private const val ROUTE_MEMORY = "settings/memory"
+private const val ROUTE_IMPORTANT_DATES = "settings/important_dates"
 private const val ROUTE_VOICE = "settings/voice"
 private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management?scrollTo={scrollTo}"
@@ -368,6 +370,9 @@ fun KernelNavHost(
                         onNavigateToMemory = {
                             navController.navigate(ROUTE_MEMORY)
                         },
+                        onNavigateToImportantDates = {
+                            navController.navigate(ROUTE_IMPORTANT_DATES)
+                        },
                         onNavigateToVoice = {
                             navController.navigate(ROUTE_VOICE)
                         },
@@ -392,6 +397,12 @@ fun KernelNavHost(
 
                 composable(ROUTE_MEMORY) {
                     MemoryScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable(ROUTE_IMPORTANT_DATES) {
+                    ImportantDatesScreen(
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/31.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/31.json
@@ -1,0 +1,1101 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "2d09e7fa77b39591233b88f45a5ba082",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listName` TEXT NOT NULL, `item` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "listName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2d09e7fa77b39591233b88f45a5ba082')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
@@ -1,0 +1,51 @@
+package com.kernel.ai.core.memory
+
+import com.kernel.ai.core.memory.dao.ImportantDateDao
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ImportantDateRepository @Inject constructor(
+    private val dao: ImportantDateDao,
+) {
+    fun observeAll(): Flow<List<ImportantDateEntity>> = dao.observeAll()
+
+    suspend fun getAll(): List<ImportantDateEntity> = dao.getAll()
+
+    suspend fun findByLabel(label: String): ImportantDateEntity? =
+        dao.findByNormalizedLabel(normalizeLabel(label))
+
+    suspend fun save(
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+    ) {
+        val trimmedLabel = label.trim()
+        dao.insert(
+            ImportantDateEntity(
+                label = trimmedLabel,
+                normalizedLabel = normalizeLabel(trimmedLabel),
+                month = month,
+                day = day,
+                year = year,
+            ),
+        )
+    }
+
+    suspend fun deleteByLabel(label: String): Int = dao.deleteByNormalizedLabel(normalizeLabel(label))
+
+    companion object {
+        fun normalizeLabel(raw: String): String = raw
+            .trim()
+            .lowercase()
+            .removePrefix("my ")
+            .removePrefix("the ")
+            .replace(Regex("""\b([\p{L}\d]+)'s\b"""), "$1")
+            .replace("'", "")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.kernel.ai.core.memory.dao.ContactAliasDao
+import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -21,6 +22,7 @@ import com.kernel.ai.core.memory.dao.StopwatchDao
 import com.kernel.ai.core.memory.dao.WorldClockDao
 import com.kernel.ai.core.memory.dao.UserProfileDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.KiwiMemoryEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
@@ -54,10 +56,11 @@ import java.time.ZoneId
         StopwatchStateEntity::class,
         StopwatchLapEntity::class,
         ContactAliasEntity::class,
+        ImportantDateEntity::class,
         ListItemEntity::class,
         ListNameEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -76,6 +79,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun worldClockDao(): WorldClockDao
     abstract fun stopwatchDao(): StopwatchDao
     abstract fun contactAliasDao(): ContactAliasDao
+    abstract fun importantDateDao(): ImportantDateDao
     abstract fun listItemDao(): ListItemDao
     abstract fun listNameDao(): ListNameDao
     abstract fun kiwiMemoryDao(): KiwiMemoryDao
@@ -392,6 +396,28 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_29_30 = object : Migration(29, 30) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE scheduled_alarms ADD COLUMN sound_uri TEXT DEFAULT NULL")
+            }
+        }
+
+        /** Creates important_dates table for taught recurring personal dates (#632). */
+        val MIGRATION_30_31 = object : Migration(30, 31) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `important_dates` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `label` TEXT NOT NULL,
+                        `normalized_label` TEXT NOT NULL,
+                        `month` INTEGER NOT NULL,
+                        `day` INTEGER NOT NULL,
+                        `year` INTEGER DEFAULT NULL,
+                        `created_at` INTEGER NOT NULL
+                    )
+                    """.trimIndent(),
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `important_dates` (`normalized_label`)"
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.memory
 import android.content.Context
 import androidx.room.Room
 import com.kernel.ai.core.memory.dao.ContactAliasDao
+import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -86,6 +87,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_27_28,
                     KernelDatabase.MIGRATION_28_29,
                     KernelDatabase.MIGRATION_29_30,
+                    KernelDatabase.MIGRATION_30_31,
                 )
                 .build()
 
@@ -125,6 +127,9 @@ abstract class MemoryModule {
 
         @Provides
         fun provideContactAliasDao(db: KernelDatabase): ContactAliasDao = db.contactAliasDao()
+
+        @Provides
+        fun provideImportantDateDao(db: KernelDatabase): ImportantDateDao = db.importantDateDao()
 
         @Provides
         fun provideListItemDao(db: KernelDatabase): ListItemDao = db.listItemDao()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ImportantDateDao {
+    @Query("SELECT * FROM important_dates ORDER BY label COLLATE NOCASE ASC")
+    fun observeAll(): Flow<List<ImportantDateEntity>>
+
+    @Query("SELECT * FROM important_dates ORDER BY label COLLATE NOCASE ASC")
+    suspend fun getAll(): List<ImportantDateEntity>
+
+    @Query("SELECT * FROM important_dates WHERE normalized_label = :normalizedLabel LIMIT 1")
+    suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(date: ImportantDateEntity)
+
+    @Query("DELETE FROM important_dates WHERE normalized_label = :normalizedLabel")
+    suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
@@ -1,0 +1,20 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "important_dates",
+    indices = [Index(value = ["normalized_label"], unique = true)],
+)
+data class ImportantDateEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val label: String,
+    @ColumnInfo(name = "normalized_label") val normalizedLabel: String,
+    val month: Int,
+    val day: Int,
+    val year: Int? = null,
+    @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis(),
+)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
@@ -1,0 +1,62 @@
+package com.kernel.ai.core.memory
+
+import com.kernel.ai.core.memory.dao.ImportantDateDao
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ImportantDateRepositoryTest {
+    @Test
+    fun `normalizeLabel strips possessives and leading articles`() {
+        assertEquals("mum birthday", ImportantDateRepository.normalizeLabel("my mum's birthday"))
+        assertEquals("parents anniversary", ImportantDateRepository.normalizeLabel("the parents' anniversary"))
+    }
+
+    @Test
+    fun `save find and delete round trip through dao`() = runTest {
+        val dao = FakeImportantDateDao()
+        val repository = ImportantDateRepository(dao)
+
+        repository.save(label = "My Mum's birthday", month = 3, day = 15, year = null)
+        repository.save(label = "Our anniversary", month = 6, day = 22, year = 2018)
+
+        val birthday = repository.findByLabel("mum's birthday")
+        val anniversary = repository.findByLabel("our anniversary")
+
+        requireNotNull(birthday)
+        requireNotNull(anniversary)
+        assertEquals("My Mum's birthday", birthday.label)
+        assertEquals("mum birthday", birthday.normalizedLabel)
+        assertEquals(3, birthday.month)
+        assertEquals(15, birthday.day)
+        assertNull(birthday.year)
+        assertEquals(2018, anniversary.year)
+
+        assertEquals(2, repository.getAll().size)
+        assertEquals(1, repository.deleteByLabel("mum's birthday"))
+        assertNull(repository.findByLabel("my mum's birthday"))
+        assertEquals(1, repository.getAll().size)
+    }
+
+    private class FakeImportantDateDao : ImportantDateDao {
+        private val rows = linkedMapOf<String, ImportantDateEntity>()
+        private var nextId = 1L
+
+        override fun observeAll(): Flow<List<ImportantDateEntity>> = flowOf(rows.values.toList())
+
+        override suspend fun getAll(): List<ImportantDateEntity> = rows.values.toList()
+
+        override suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity? = rows[normalizedLabel]
+
+        override suspend fun insert(date: ImportantDateEntity) {
+            rows[date.normalizedLabel] = date.copy(id = nextId++)
+        }
+
+        override suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int =
+            if (rows.remove(normalizedLabel) != null) 1 else 0
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -182,6 +182,7 @@ class QuickIntentRouter(
 
     private fun normalizeImportantDateLabel(raw: String): String = raw.trim()
         .replace(Regex("""^(?:my|the)\s+""", RegexOption.IGNORE_CASE), "")
+        .replace(Regex("""^(?:an?\s+)?important\s+date(?:\s+for)?\s+""", RegexOption.IGNORE_CASE), "")
         .trim()
 
     private fun normalizeImportantDateLabelOrNull(raw: String): String? =
@@ -2462,7 +2463,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_important_date",
             regex = Regex(
-                """^(?:remember|save|store|note|don't\s+forget)(?:\s+that)?\s+(.+?)\s+(?:is|as)\s+($importantDateValuePattern)$""",
+                """^(?:remember|save|store|note|don't\s+forget|add|create)(?:\s+that)?\s+(?:(?:an?\s+)?important\s+date(?:\s+for)?\s+)?(.+?)\s+(?:is|as|on)\s+($importantDateValuePattern)$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -2490,7 +2491,21 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_important_date",
             regex = Regex(
-                """^(?:remember|save|store)(?:\s+that)?\s+(.+?\b(?:birthday|anniversary)\b.*)$""",
+                """^(?:add|create)(?:\s+an?)?\s+important\s+date(?:\s+for)?\s+(.+?)\s+($importantDateValuePattern)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                extractImportantDateParams(
+                    label = match.groupValues[1],
+                    date = match.groupValues[2],
+                )
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^(?:remember|save|store|add|create)(?:\s+that)?\s+(?:(?:an?\s+)?important\s+date(?:\s+for)?\s+)?(.+?\b(?:birthday|anniversary)\b.*)$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2285,7 +2285,7 @@ class QuickIntentRouter(
                 """(?:how\s+(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?(?:until|till|to|before))\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim(), "direction" to "until") }
         ),
         // "how many days since March 1" / "how long since Easter"
         IntentPattern(
@@ -2294,7 +2294,7 @@ class QuickIntentRouter(
                 """(?:how\s+(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?since)\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim(), "direction" to "since") }
         ),
         // "days until Christmas" / "weeks until New Year"
         IntentPattern(
@@ -2303,7 +2303,7 @@ class QuickIntentRouter(
                 """(?:days?|weeks?)\s+(?:until|till|to)\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim(), "direction" to "until") }
         ),
         // "what day of the week is 22 August" / "what day is Christmas"  (not "what day is X this year")
         IntentPattern(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -133,6 +133,22 @@ class QuickIntentRouter(
                 promptTemplate = "What would you like to call the list?",
             ),
         ),
+        "save_important_date" to mapOf(
+            "label" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "label",
+                promptTemplate = "What important date should I save?",
+            ),
+            "date" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "date",
+                promptTemplate = "What date is {label}?",
+            ),
+        ),
+        "remove_important_date" to mapOf(
+            "label" to com.kernel.ai.core.skills.slot.SlotSpec(
+                name = "label",
+                promptTemplate = "Which important date should I remove?",
+            ),
+        ),
         "save_memory" to mapOf(
             "content" to com.kernel.ai.core.skills.slot.SlotSpec(
                 name = "content",
@@ -163,6 +179,23 @@ class QuickIntentRouter(
     private fun normalizeOptionalItem(raw: String): String? = raw.trim()
         .takeIf { it.isNotBlank() }
         ?.takeUnless { it.lowercase() in placeholderItems }
+
+    private fun normalizeImportantDateLabel(raw: String): String = raw.trim()
+        .replace(Regex("""^(?:my|the)\s+""", RegexOption.IGNORE_CASE), "")
+        .trim()
+
+    private fun normalizeImportantDateLabelOrNull(raw: String): String? =
+        normalizeImportantDateLabel(raw).takeIf { it.isNotBlank() }
+
+    private val importantDateValuePattern =
+        "(?:\\d{1,2}(?:st|nd|rd|th)?\\s+[a-zA-Z]+(?:\\s+\\d{4})?|[a-zA-Z]+\\s+\\d{1,2}(?:st|nd|rd|th)?(?:,?\\s+\\d{4})?|\\d{4}-\\d{2}-\\d{2}|\\d{1,2}[/-]\\d{1,2}[/-]\\d{4})"
+
+    private fun extractImportantDateParams(label: String, date: String): Map<String, String> {
+        val params = mutableMapOf<String, String>()
+        normalizeImportantDateLabelOrNull(label)?.let { params["label"] = it }
+        date.trim().takeIf { it.isNotBlank() }?.let { params["date"] = it }
+        return params
+    }
 
 
 
@@ -2416,6 +2449,76 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("list_name" to match.groupValues[1].trim()) },
             requiredSlots = slotContract("create_list"),
+        ),
+        // ── Important Dates ──
+        IntentPattern(
+            intentName = "list_important_dates",
+            regex = Regex(
+                """^(?:list|show(?:\s+me)?|what(?:'s|\s+are))\s+(?:my\s+)?important dates$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^(?:remember|save|store|note|don't\s+forget)(?:\s+that)?\s+(.+?)\s+(?:is|as)\s+($importantDateValuePattern)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                extractImportantDateParams(
+                    label = match.groupValues[1],
+                    date = match.groupValues[2],
+                )
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^my\s+(.+?)\s+is\s+($importantDateValuePattern)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                extractImportantDateParams(
+                    label = match.groupValues[1],
+                    date = match.groupValues[2],
+                )
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "save_important_date",
+            regex = Regex(
+                """^(?:remember|save|store)(?:\s+that)?\s+(.+?\b(?:birthday|anniversary)\b.*)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("save_important_date"),
+        ),
+        IntentPattern(
+            intentName = "remove_important_date",
+            regex = Regex(
+                """^(?:remove|delete|forget)\s+(.+?)\s+from\s+(?:my\s+)?important dates$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("remove_important_date"),
+        ),
+        IntentPattern(
+            intentName = "remove_important_date",
+            regex = Regex(
+                """^(?:remove|delete|forget)\s+(.+?\b(?:birthday|anniversary)\b.*)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                normalizeImportantDateLabelOrNull(match.groupValues[1])?.let { mapOf("label" to it) } ?: emptyMap()
+            },
+            requiredSlots = slotContract("remove_important_date"),
         ),
         // "remove milk from my shopping list" / "take eggs off the grocery list"
         IntentPattern(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -46,6 +46,9 @@ class RunIntentSkill @Inject constructor(
                     "set_alarm",
                     "set_timer",
                     "create_calendar_event",
+                    "save_important_date",
+                    "list_important_dates",
+                    "remove_important_date",
                     // System toggles
                     "toggle_dnd_on",
                     "toggle_dnd_off",
@@ -96,6 +99,9 @@ class RunIntentSkill @Inject constructor(
         "Calendar event (explicit date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Lunch\",\"date\":\"2026-04-15\",\"time\":\"12:30\"}')",
         "Calendar event (relative date) → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Cancel MightyApe\",\"date\":\"next thursday\",\"time\":\"16:00\"}')",
         "Calendar with attendees → runIntent(intentName=\"create_calendar_event\", parameters='{\"title\":\"Dinner\",\"date\":\"friday\",\"time\":\"19:00\",\"attendees\":\"Sarah,John\"}')",
+        "Save important date → runIntent(intentName=\"save_important_date\", parameters='{\"label\":\"mum's birthday\",\"date\":\"15 March\"}')",
+        "List important dates → runIntent(intentName=\"list_important_dates\", parameters='{}')",
+        "Remove important date → runIntent(intentName=\"remove_important_date\", parameters='{\"label\":\"mum's birthday\"}')",
         // System toggles
         "Turn on DND → runIntent(intentName=\"toggle_dnd_on\", parameters=\"{}\")",
         "Enable Wi-Fi → runIntent(intentName=\"toggle_wifi\", parameters='{\"state\":\"on\"}')",
@@ -137,6 +143,9 @@ class RunIntentSkill @Inject constructor(
         appendLine("  set_alarm — params: time (\"10pm\", \"9:30am\"), day (optional: \"tomorrow\", \"monday\"), label (optional)")
         appendLine("  set_timer — params: duration_seconds (\"180\" for 3 min), label (optional)")
         appendLine("  create_calendar_event — params: title, date (pass relative terms as-is: \"tomorrow\", \"next thursday\", \"this friday\"; or YYYY-MM-DD for explicit dates), time (HH:MM), duration_minutes (optional), description (optional), attendees (optional, comma-separated contact names)")
+        appendLine("  save_important_date — params: label, date (e.g. \"15 March\" or \"22 June 2018\")")
+        appendLine("  list_important_dates — no params")
+        appendLine("  remove_important_date — params: label")
         appendLine()
         appendLine("SYSTEM TOGGLES:")
         appendLine("  toggle_dnd_on, toggle_dnd_off — No params")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -46,6 +46,11 @@ class CalendarBirthdayLookup @Inject constructor(
         return partialMatches.singleOrNull()
     }
 
+    fun getAllBirthdays(): List<BirthdayEntry> {
+        if (!hasPermission()) return emptyList()
+        return loadBirthdays()
+    }
+
     fun invalidateCache() {
         cachedBirthdays = null
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -41,7 +41,7 @@ class CalendarBirthdayLookup @Inject constructor(
         if (queryTokens.isEmpty()) return null
         val partialMatches = birthdays.filter { entry ->
             val entryTokens = entry.normalizedLabel.split(" ").filter { it.isNotBlank() }.toSet()
-            entryTokens.containsAll(queryTokens)
+            entryTokens.containsAll(queryTokens) || queryTokens.containsAll(entryTokens)
         }
         return partialMatches.singleOrNull()
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -1,0 +1,132 @@
+package com.kernel.ai.core.skills.natives
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.CalendarContract
+import com.kernel.ai.core.memory.ImportantDateRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CalendarBirthdayLookup @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    data class BirthdayEntry(
+        val label: String,
+        val normalizedLabel: String,
+        val month: Int,
+        val day: Int,
+    )
+
+    @Volatile
+    private var cachedBirthdays: List<BirthdayEntry>? = null
+
+    fun hasPermission(): Boolean =
+        context.checkSelfPermission(Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED
+
+    fun findBirthday(label: String): BirthdayEntry? {
+        if (!hasPermission()) return null
+        val normalizedQuery = normalizeBirthdayLookupLabel(label)
+        if (normalizedQuery.isBlank()) return null
+        val birthdays = loadBirthdays()
+        birthdays.firstOrNull { it.normalizedLabel == normalizedQuery }?.let { return it }
+
+        val queryTokens = normalizedQuery.split(" ").filter { it.isNotBlank() }.toSet()
+        if (queryTokens.isEmpty()) return null
+        val partialMatches = birthdays.filter { entry ->
+            val entryTokens = entry.normalizedLabel.split(" ").filter { it.isNotBlank() }.toSet()
+            entryTokens.containsAll(queryTokens)
+        }
+        return partialMatches.singleOrNull()
+    }
+
+    fun invalidateCache() {
+        cachedBirthdays = null
+    }
+
+    private fun loadBirthdays(): List<BirthdayEntry> {
+        cachedBirthdays?.let { return it }
+        return synchronized(this) {
+            cachedBirthdays ?: queryBirthdays().also { cachedBirthdays = it }
+        }
+    }
+
+    private fun queryBirthdays(): List<BirthdayEntry> {
+        val projection = arrayOf(
+            CalendarContract.Events.TITLE,
+            CalendarContract.Events.DTSTART,
+            CalendarContract.Events.ALL_DAY,
+            CalendarContract.Events.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Events.ACCOUNT_TYPE,
+        )
+        val selection = "${CalendarContract.Events.DELETED} = 0 AND ${CalendarContract.Events.TITLE} IS NOT NULL"
+        val results = linkedMapOf<String, BirthdayEntry>()
+
+        context.contentResolver.query(
+            CalendarContract.Events.CONTENT_URI,
+            projection,
+            selection,
+            null,
+            null,
+        )?.use { cursor ->
+            val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.TITLE)
+            val dtStartIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.DTSTART)
+            val allDayIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.ALL_DAY)
+            val displayNameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.CALENDAR_DISPLAY_NAME)
+            val accountTypeIndex = cursor.getColumnIndexOrThrow(CalendarContract.Events.ACCOUNT_TYPE)
+
+            while (cursor.moveToNext()) {
+                val title = cursor.getString(titleIndex) ?: continue
+                val calendarDisplayName = cursor.getString(displayNameIndex).orEmpty()
+                val accountType = cursor.getString(accountTypeIndex).orEmpty()
+                if (!looksLikeBirthdaySource(calendarDisplayName, accountType, title)) continue
+
+                val normalizedTitle = normalizeBirthdayTitle(title) ?: continue
+                val startMillis = cursor.getLong(dtStartIndex)
+                val isAllDay = cursor.getInt(allDayIndex) != 0
+                val date = toLocalDate(startMillis, isAllDay)
+                results.putIfAbsent(
+                    normalizedTitle,
+                    BirthdayEntry(
+                        label = normalizedTitle,
+                        normalizedLabel = normalizeBirthdayLookupLabel(normalizedTitle),
+                        month = date.monthValue,
+                        day = date.dayOfMonth,
+                    ),
+                )
+            }
+        }
+        return results.values.toList()
+    }
+
+    private fun looksLikeBirthdaySource(calendarDisplayName: String, accountType: String, title: String): Boolean {
+        val displayNameLower = calendarDisplayName.lowercase(Locale.ENGLISH)
+        val titleLower = title.lowercase(Locale.ENGLISH)
+        return displayNameLower.contains("birthday") ||
+            titleLower.contains("birthday") ||
+            (accountType == "com.google" && titleLower.contains("birthday"))
+    }
+
+    private fun normalizeBirthdayTitle(raw: String): String? {
+        val trimmed = raw.trim()
+        val birthdaySuffix = Regex("""(?i)^(.+?)'?s\s+birthday$|^birthday\s*:?\s+(.+)$|^(.+?)\s+birthday$""")
+        val match = birthdaySuffix.matchEntire(trimmed) ?: return null
+        val label = match.groupValues.drop(1).firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+        return label.takeIf { it.isNotBlank() }
+    }
+
+    private fun normalizeBirthdayLookupLabel(raw: String): String = ImportantDateRepository.normalizeLabel(
+        raw.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
+    )
+
+    private fun toLocalDate(startMillis: Long, isAllDay: Boolean): LocalDate {
+        val zone = if (isAllDay) ZoneId.of("UTC") else ZoneId.systemDefault()
+        return Instant.ofEpochMilli(startMillis).atZone(zone).toLocalDate()
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -37,12 +37,7 @@ class CalendarBirthdayLookup @Inject constructor(
         val birthdays = loadBirthdays()
         birthdays.firstOrNull { it.normalizedLabel == normalizedQuery }?.let { return it }
 
-        val queryTokens = normalizedQuery.split(" ").filter { it.isNotBlank() }.toSet()
-        if (queryTokens.isEmpty()) return null
-        val partialMatches = birthdays.filter { entry ->
-            val entryTokens = entry.normalizedLabel.split(" ").filter { it.isNotBlank() }.toSet()
-            entryTokens.containsAll(queryTokens) || queryTokens.containsAll(entryTokens)
-        }
+        val partialMatches = birthdays.filter { labelsPotentiallyMatch(it.label, label) }
         return partialMatches.singleOrNull()
     }
 
@@ -126,9 +121,40 @@ class CalendarBirthdayLookup @Inject constructor(
         return label.takeIf { it.isNotBlank() }
     }
 
-    private fun normalizeBirthdayLookupLabel(raw: String): String = ImportantDateRepository.normalizeLabel(
-        raw.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
-    )
+    companion object {
+        fun labelsPotentiallyMatch(left: String, right: String): Boolean {
+            val leftTokens = matchTokens(left)
+            val rightTokens = matchTokens(right)
+            if (leftTokens.isEmpty() || rightTokens.isEmpty()) return false
+            return containsAllEquivalent(leftTokens, rightTokens) || containsAllEquivalent(rightTokens, leftTokens)
+        }
+
+        private fun containsAllEquivalent(container: List<String>, query: List<String>): Boolean =
+            query.all { queryToken -> container.any { containerToken -> tokensEquivalent(containerToken, queryToken) } }
+
+        private fun tokensEquivalent(left: String, right: String): Boolean {
+            if (left == right) return true
+            return tokenVariants(left).intersect(tokenVariants(right)).isNotEmpty()
+        }
+
+        private fun tokenVariants(token: String): Set<String> {
+            val trimmed = token.trim().lowercase(Locale.ENGLISH)
+            if (trimmed.isBlank()) return emptySet()
+
+            val variants = linkedSetOf(trimmed)
+            if (trimmed.endsWith("s") && trimmed.length > 3) {
+                variants += trimmed.dropLast(1)
+            }
+            return variants
+        }
+
+        private fun matchTokens(raw: String): List<String> =
+            normalizeBirthdayLookupLabel(raw).split(" ").filter { it.isNotBlank() }
+
+        private fun normalizeBirthdayLookupLabel(raw: String): String = ImportantDateRepository.normalizeLabel(
+            raw.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
+        )
+    }
 
     private fun toLocalDate(startMillis: Long, isAllDay: Boolean): LocalDate {
         val zone = if (isAllDay) ZoneId.of("UTC") else ZoneId.systemDefault()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2033,6 +2033,17 @@ class NativeIntentHandler @Inject constructor(
             calendarBirthdayLookup.findBirthday(s)?.let { birthday ->
                 return resolveRecurringDate(birthday.month, birthday.day, today)
             }
+
+            val aliasBirthdayLabel = ImportantDateRepository.normalizeLabel(
+                s.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
+            )
+            if (aliasBirthdayLabel.isNotBlank()) {
+                runBlocking { contactAliasRepository.getByAlias(aliasBirthdayLabel) }?.let { alias ->
+                    calendarBirthdayLookup.findBirthday(alias.displayName)?.let { birthday ->
+                        return resolveRecurringDate(birthday.month, birthday.day, today)
+                    }
+                }
+            }
         }
 
         fun nextOccurrence(month: Int, day: Int): LocalDate {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -125,6 +125,7 @@ class NativeIntentHandler @Inject constructor(
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
     private val importantDateRepository: ImportantDateRepository,
+    private val calendarBirthdayLookup: CalendarBirthdayLookup,
     private val memoryRepository: MemoryRepository,
     private val embeddingEngine: EmbeddingEngine,
 ) {
@@ -1893,7 +1894,14 @@ class NativeIntentHandler @Inject constructor(
         val fromDate = params["from_date"]?.takeIf { it.isNotBlank() }
             ?.let { parseDateString(it) } ?: today
         val targetDate = parseDateString(targetStr)
-            ?: return SkillResult.Failure("get_date_diff", "Could not parse date: \"$targetStr\"")
+            ?: return SkillResult.Failure(
+                "get_date_diff",
+                if (targetStr.contains("birthday", ignoreCase = true) && !calendarBirthdayLookup.hasPermission()) {
+                    "Could not parse date: \"$targetStr\". If this is a synced contact birthday, enable Calendar access in Settings first."
+                } else {
+                    "Could not parse date: \"$targetStr\""
+                },
+            )
 
         val days = ChronoUnit.DAYS.between(fromDate, targetDate)
         val absDays = Math.abs(days)
@@ -2020,6 +2028,11 @@ class NativeIntentHandler @Inject constructor(
 
         runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
             return resolveRecurringDate(stored.month, stored.day, today)
+        }
+        if (s.contains("birthday", ignoreCase = true)) {
+            calendarBirthdayLookup.findBirthday(s)?.let { birthday ->
+                return resolveRecurringDate(birthday.month, birthday.day, today)
+            }
         }
 
         fun nextOccurrence(month: Int, day: Int): LocalDate {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import android.view.KeyEvent
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.WorldClockCatalog
@@ -109,6 +110,9 @@ interface ClockAlertController {
  *   get_weather             — Opens Google search for weather (params: location?)
  *   get_system_info         — Returns storage and RAM info — returns DirectReply
  *   get_date_diff           — Native date arithmetic: days/weeks until or since a date (params: target_date, from_date?) — returns DirectReply
+ *   save_important_date     — Stores a taught recurring personal date (params: label, date) — returns DirectReply
+ *   list_important_dates    — Lists taught recurring personal dates — returns DirectReply
+ *   remove_important_date   — Deletes a taught recurring personal date (params: label) — returns DirectReply
  *   save_memory             — Saves content to long-term core memory (params: content)
  *   set_brightness          — Sets screen brightness (params: value?, direction?, is_percent?)
  */
@@ -120,6 +124,7 @@ class NativeIntentHandler @Inject constructor(
     private val listItemDao: ListItemDao,
     private val listNameDao: ListNameDao,
     private val contactAliasRepository: ContactAliasRepository,
+    private val importantDateRepository: ImportantDateRepository,
     private val memoryRepository: MemoryRepository,
     private val embeddingEngine: EmbeddingEngine,
 ) {
@@ -188,6 +193,9 @@ class NativeIntentHandler @Inject constructor(
                 "get_weather" -> getWeather(params)
                 "get_date_diff" -> getDateDiff(params)
                 "get_system_info" -> getSystemInfo()
+                "save_important_date" -> saveImportantDate(params)
+                "list_important_dates" -> listImportantDates()
+                "remove_important_date" -> removeImportantDate(params)
                 "save_memory" -> saveMemory(params)
                 "set_brightness" -> setBrightness(params)
                 else -> SkillResult.Failure("run_intent", "Unknown intent: $intentName")
@@ -242,7 +250,8 @@ class NativeIntentHandler @Inject constructor(
             "add_to_list", "bulk_add_to_list", "create_list", "get_list_items", "remove_from_list",
             "smart_home_on", "smart_home_off",
             "get_weather", "get_date_diff", "get_system_info",
-            "save_memory",
+            "save_important_date", "list_important_dates", "remove_important_date",
+            "save_memory", 
         )
 
         private val GENERIC_MEDIA_QUERY_KEYS = setOf(
@@ -1815,6 +1824,66 @@ class NativeIntentHandler @Inject constructor(
         }
     }
 
+    // ── Important Dates ─────────────────────────────────────────────────────────
+
+    private data class ParsedImportantDateInput(
+        val month: Int,
+        val day: Int,
+        val year: Int?,
+    )
+
+    private fun saveImportantDate(params: Map<String, String>): SkillResult {
+        val label = params["label"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("save_important_date", "No label specified")
+        val rawDate = params["date"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("save_important_date", "No date specified")
+        val parsed = parseImportantDateInput(rawDate)
+            ?: return SkillResult.Failure(
+                "save_important_date",
+                "Could not parse date '$rawDate' — use a date like '15 March' or '22 June 2018'.",
+            )
+
+        runBlocking {
+            importantDateRepository.save(
+                label = label,
+                month = parsed.month,
+                day = parsed.day,
+                year = parsed.year,
+            )
+        }
+
+        return SkillResult.DirectReply(
+            "I'll remember ${label.trim()} as ${formatImportantDate(parsed.month, parsed.day, parsed.year)}.",
+        )
+    }
+
+    private fun listImportantDates(): SkillResult {
+        val today = LocalDate.now()
+        val dates = runBlocking { importantDateRepository.getAll() }
+        if (dates.isEmpty()) {
+            return SkillResult.DirectReply("You haven't taught me any important dates yet.")
+        }
+
+        val lines = dates
+            .sortedBy { resolveRecurringDate(it.month, it.day, today) }
+            .map { "• ${it.label} — ${formatImportantDate(it.month, it.day, it.year)}" }
+
+        return SkillResult.DirectReply(
+            "Important dates:\n" + lines.joinToString("\n"),
+        )
+    }
+
+    private fun removeImportantDate(params: Map<String, String>): SkillResult {
+        val label = params["label"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("remove_important_date", "No label specified")
+        val deleted = runBlocking { importantDateRepository.deleteByLabel(label) }
+        return if (deleted > 0) {
+            SkillResult.DirectReply("Removed important date ${label.trim()}.")
+        } else {
+            SkillResult.DirectReply("I couldn't find an important date named ${label.trim()}.")
+        }
+    }
+
     // ── Date Diff ─────────────────────────────────────────────────────────────
 
     private fun getDateDiff(params: Map<String, String>): SkillResult {
@@ -1894,8 +1963,54 @@ class NativeIntentHandler @Inject constructor(
         emptyMessage = emptyMessage,
     )
 
+    private fun resolveRecurringDate(month: Int, day: Int, today: LocalDate): LocalDate {
+        val candidate = LocalDate.of(today.year, month, day)
+        return if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+    }
+
+    private fun formatImportantDate(month: Int, day: Int, year: Int?): String {
+        val date = LocalDate.of(year ?: 2000, month, day)
+        val pattern = if (year != null) "d MMMM yyyy" else "d MMMM"
+        return date.format(DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH))
+    }
+
+    private fun parseImportantDateInput(input: String): ParsedImportantDateInput? {
+        val sanitized = input.trim()
+            .replace(Regex("""\b(\d{1,2})(st|nd|rd|th)\b""", RegexOption.IGNORE_CASE), "$1")
+            .replace(",", "")
+        val fullDateFormatters = listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("MMMM d yyyy", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("d/M/yyyy"),
+            DateTimeFormatter.ofPattern("M/d/yyyy"),
+            DateTimeFormatter.ofPattern("d-M-yyyy"),
+            DateTimeFormatter.ofPattern("M-d-yyyy"),
+        )
+        for (formatter in fullDateFormatters) {
+            try {
+                val date = LocalDate.parse(sanitized, formatter)
+                return ParsedImportantDateInput(date.monthValue, date.dayOfMonth, date.year)
+            } catch (_: Exception) {
+            }
+        }
+
+        val partialDateFormatters = listOf(
+            DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("MMMM d", Locale.ENGLISH),
+        )
+        for (formatter in partialDateFormatters) {
+            try {
+                val monthDay = MonthDay.parse(sanitized, formatter)
+                return ParsedImportantDateInput(monthDay.monthValue, monthDay.dayOfMonth, null)
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
     /**
-     * Parses a date string in various natural formats, including named NZ/common holidays.
+     * Parses a date string in various natural formats, including taught important dates and named NZ/common holidays.
      * For dates without a year, picks the next upcoming occurrence.
      */
     private fun parseDateString(input: String): LocalDate? {
@@ -1903,12 +2018,14 @@ class NativeIntentHandler @Inject constructor(
         val today = LocalDate.now()
         val year = today.year
 
-        // Named holidays — next upcoming occurrence
+        runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
+            return resolveRecurringDate(stored.month, stored.day, today)
+        }
+
         fun nextOccurrence(month: Int, day: Int): LocalDate {
             val candidate = LocalDate.of(year, month, day)
             return if (!candidate.isBefore(today)) candidate else LocalDate.of(year + 1, month, day)
         }
-        // Nth weekday helper: e.g. nthWeekday(2, DayOfWeek.SUNDAY, Month.MAY, year) = 2nd Sunday in May
         fun nthWeekday(n: Int, dow: java.time.DayOfWeek, month: java.time.Month, y: Int): LocalDate {
             val first = LocalDate.of(y, month, 1)
             val firstMatch = first.with(java.time.temporal.TemporalAdjusters.nextOrSame(dow))
@@ -1928,11 +2045,9 @@ class NativeIntentHandler @Inject constructor(
             "waitangi day", "waitangi" -> return nextOccurrence(2, 6)
             "anzac day", "anzac" -> return nextOccurrence(4, 25)
             "valentines day", "valentine's day", "valentines" -> return nextOccurrence(2, 14)
-            // Floating holidays (NZ): Mother's Day = 2nd Sunday May, Father's Day = 1st Sunday September
             "mothers day", "mother's day", "mothers" -> return nextFloating(java.time.Month.MAY, 2)
             "fathers day", "father's day", "fathers" -> return nextFloating(java.time.Month.SEPTEMBER, 1)
             "easter" -> {
-                // Computus (anonymous Gregorian algorithm)
                 fun easterDate(y: Int): LocalDate {
                     val a = y % 19; val b = y / 100; val c = y % 100
                     val d = b / 4; val e = b % 4; val f = (b + 8) / 25
@@ -1948,32 +2063,12 @@ class NativeIntentHandler @Inject constructor(
             }
         }
 
-        // Explicit date formats (ordered most-to-least specific)
-        val formatters = listOf(
-            DateTimeFormatter.ISO_LOCAL_DATE,                              // 2026-08-22
-            DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),   // 22 August 2026
-            DateTimeFormatter.ofPattern("MMMM d yyyy", Locale.ENGLISH),   // August 22 2026
-            DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH),  // August 22, 2026
-            DateTimeFormatter.ofPattern("d/MM/yyyy"),                      // 22/08/2026
-            DateTimeFormatter.ofPattern("MM/dd/yyyy"),                     // 08/22/2026
-            DateTimeFormatter.ofPattern("d-MM-yyyy"),                      // 22-08-2026
-        )
-        for (fmt in formatters) {
-            try { return LocalDate.parse(s, fmt) } catch (_: Exception) {}
-        }
-
-        // Partial dates without year — pick next upcoming occurrence
-        val partialFormatters = listOf(
-            DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH),  // 22 August
-            DateTimeFormatter.ofPattern("MMMM d", Locale.ENGLISH),  // August 22
-            DateTimeFormatter.ofPattern("MMMM", Locale.ENGLISH),    // August (1st of that month)
-        )
-        for (fmt in partialFormatters) {
-            try {
-                val md = MonthDay.parse(s, fmt)
-                val candidate = md.atYear(year)
-                return if (!candidate.isBefore(today)) candidate else md.atYear(year + 1)
-            } catch (_: Exception) {}
+        parseImportantDateInput(s)?.let { parsed ->
+            return if (parsed.year != null) {
+                LocalDate.of(parsed.year, parsed.month, parsed.day)
+            } else {
+                resolveRecurringDate(parsed.month, parsed.day, today)
+            }
         }
         return null
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1891,13 +1891,14 @@ class NativeIntentHandler @Inject constructor(
         val targetStr = params["target_date"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure("get_date_diff", "No target_date provided")
         val today = LocalDate.now()
+        val preferPast = params["direction"] == "since"
         val fromDate = params["from_date"]?.takeIf { it.isNotBlank() }
             ?.let { parseDateString(it) } ?: today
-        val targetDate = parseDateString(targetStr)
+        val targetDate = parseDateString(targetStr, preferPast = preferPast)
             ?: return SkillResult.Failure(
                 "get_date_diff",
                 if (targetStr.contains("birthday", ignoreCase = true) && !calendarBirthdayLookup.hasPermission()) {
-                    "Could not parse date: \"$targetStr\". If this is a synced contact birthday, enable Calendar access in Settings first."
+                    "Could not parse date: \"$targetStr\". If this is a synced contact birthday, enable Calendar birthdays in Important dates first."
                 } else {
                     "Could not parse date: \"$targetStr\""
                 },
@@ -1971,9 +1972,13 @@ class NativeIntentHandler @Inject constructor(
         emptyMessage = emptyMessage,
     )
 
-    private fun resolveRecurringDate(month: Int, day: Int, today: LocalDate): LocalDate {
+    private fun resolveRecurringDate(month: Int, day: Int, today: LocalDate, preferPast: Boolean = false): LocalDate {
         val candidate = LocalDate.of(today.year, month, day)
-        return if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+        return if (preferPast) {
+            if (!candidate.isAfter(today)) candidate else LocalDate.of(today.year - 1, month, day)
+        } else {
+            if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+        }
     }
 
     private fun formatImportantDate(month: Int, day: Int, year: Int?): String {
@@ -2019,19 +2024,21 @@ class NativeIntentHandler @Inject constructor(
 
     /**
      * Parses a date string in various natural formats, including taught important dates and named NZ/common holidays.
-     * For dates without a year, picks the next upcoming occurrence.
+     * For dates without a year, resolves either the next or most recent occurrence depending on `preferPast`.
      */
-    private fun parseDateString(input: String): LocalDate? {
+    private fun parseDateString(input: String): LocalDate? = parseDateString(input, preferPast = false)
+
+    private fun parseDateString(input: String, preferPast: Boolean): LocalDate? {
         val s = input.trim()
         val today = LocalDate.now()
         val year = today.year
 
         runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
-            return resolveRecurringDate(stored.month, stored.day, today)
+            return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
         }
         if (s.contains("birthday", ignoreCase = true)) {
             calendarBirthdayLookup.findBirthday(s)?.let { birthday ->
-                return resolveRecurringDate(birthday.month, birthday.day, today)
+                return resolveRecurringDate(birthday.month, birthday.day, today, preferPast = preferPast)
             }
 
             val aliasBirthdayLabel = ImportantDateRepository.normalizeLabel(
@@ -2040,58 +2047,72 @@ class NativeIntentHandler @Inject constructor(
             if (aliasBirthdayLabel.isNotBlank()) {
                 runBlocking { contactAliasRepository.getByAlias(aliasBirthdayLabel) }?.let { alias ->
                     calendarBirthdayLookup.findBirthday(alias.displayName)?.let { birthday ->
-                        return resolveRecurringDate(birthday.month, birthday.day, today)
+                        return resolveRecurringDate(birthday.month, birthday.day, today, preferPast = preferPast)
                     }
                 }
             }
         }
 
-        fun nextOccurrence(month: Int, day: Int): LocalDate {
-            val candidate = LocalDate.of(year, month, day)
-            return if (!candidate.isBefore(today)) candidate else LocalDate.of(year + 1, month, day)
-        }
+        fun resolveFixedDate(month: Int, day: Int): LocalDate =
+            resolveRecurringDate(month, day, today, preferPast = preferPast)
+
         fun nthWeekday(n: Int, dow: java.time.DayOfWeek, month: java.time.Month, y: Int): LocalDate {
             val first = LocalDate.of(y, month, 1)
             val firstMatch = first.with(java.time.temporal.TemporalAdjusters.nextOrSame(dow))
             return firstMatch.plusWeeks((n - 1).toLong())
         }
-        fun nextFloating(month: java.time.Month, nthSunday: Int): LocalDate {
+
+        fun resolveFloating(month: java.time.Month, nthSunday: Int): LocalDate {
             val candidate = nthWeekday(nthSunday, java.time.DayOfWeek.SUNDAY, month, year)
-            return if (!candidate.isBefore(today)) candidate else nthWeekday(nthSunday, java.time.DayOfWeek.SUNDAY, month, year + 1)
-        }
-        when (s.lowercase().replace(Regex("[''`]"), "").trim()) {
-            "christmas", "christmas day", "xmas" -> return nextOccurrence(12, 25)
-            "new years day", "new years", "new year", "new year's day", "new year day" ->
-                return LocalDate.of(year + 1, 1, 1).let {
-                    if (!LocalDate.of(year, 1, 1).isBefore(today)) LocalDate.of(year, 1, 1) else it
-                }
-            "halloween" -> return nextOccurrence(10, 31)
-            "waitangi day", "waitangi" -> return nextOccurrence(2, 6)
-            "anzac day", "anzac" -> return nextOccurrence(4, 25)
-            "valentines day", "valentine's day", "valentines" -> return nextOccurrence(2, 14)
-            "mothers day", "mother's day", "mothers" -> return nextFloating(java.time.Month.MAY, 2)
-            "fathers day", "father's day", "fathers" -> return nextFloating(java.time.Month.SEPTEMBER, 1)
-            "easter" -> {
-                fun easterDate(y: Int): LocalDate {
-                    val a = y % 19; val b = y / 100; val c = y % 100
-                    val d = b / 4; val e = b % 4; val f = (b + 8) / 25
-                    val g = (b - f + 1) / 3; val h = (19 * a + b - d - g + 15) % 30
-                    val i = c / 4; val k = c % 4; val l = (32 + 2 * e + 2 * i - h - k) % 7
-                    val m = (a + 11 * h + 22 * l) / 451
-                    val month = (h + l - 7 * m + 114) / 31
-                    val day = ((h + l - 7 * m + 114) % 31) + 1
-                    return LocalDate.of(y, month, day)
-                }
-                val thisYearEaster = easterDate(year)
-                return if (!thisYearEaster.isBefore(today)) thisYearEaster else easterDate(year + 1)
+            return if (preferPast) {
+                if (!candidate.isAfter(today)) candidate else nthWeekday(nthSunday, java.time.DayOfWeek.SUNDAY, month, year - 1)
+            } else {
+                if (!candidate.isBefore(today)) candidate else nthWeekday(nthSunday, java.time.DayOfWeek.SUNDAY, month, year + 1)
             }
+        }
+
+        fun resolveEaster(): LocalDate {
+            fun easterDate(y: Int): LocalDate {
+                val a = y % 19; val b = y / 100; val c = y % 100
+                val d = b / 4; val e = b % 4; val f = (b + 8) / 25
+                val g = (b - f + 1) / 3; val h = (19 * a + b - d - g + 15) % 30
+                val i = c / 4; val k = c % 4; val l = (32 + 2 * e + 2 * i - h - k) % 7
+                val m = (a + 11 * h + 22 * l) / 451
+                val month = (h + l - 7 * m + 114) / 31
+                val day = ((h + l - 7 * m + 114) % 31) + 1
+                return LocalDate.of(y, month, day)
+            }
+
+            val candidate = easterDate(year)
+            return if (preferPast) {
+                if (!candidate.isAfter(today)) candidate else easterDate(year - 1)
+            } else {
+                if (!candidate.isBefore(today)) candidate else easterDate(year + 1)
+            }
+        }
+
+        when (s.lowercase().replace(Regex("[''`]"), "").trim()) {
+            "christmas", "christmas day", "xmas" -> return resolveFixedDate(12, 25)
+            "new years day", "new years", "new year", "new year's day", "new year day" ->
+                return if (preferPast) {
+                    if (!LocalDate.of(year, 1, 1).isAfter(today)) LocalDate.of(year, 1, 1) else LocalDate.of(year - 1, 1, 1)
+                } else {
+                    if (!LocalDate.of(year, 1, 1).isBefore(today)) LocalDate.of(year, 1, 1) else LocalDate.of(year + 1, 1, 1)
+                }
+            "halloween" -> return resolveFixedDate(10, 31)
+            "waitangi day", "waitangi" -> return resolveFixedDate(2, 6)
+            "anzac day", "anzac" -> return resolveFixedDate(4, 25)
+            "valentines day", "valentine's day", "valentines" -> return resolveFixedDate(2, 14)
+            "mothers day", "mother's day", "mothers" -> return resolveFloating(java.time.Month.MAY, 2)
+            "fathers day", "father's day", "fathers" -> return resolveFloating(java.time.Month.SEPTEMBER, 1)
+            "easter" -> return resolveEaster()
         }
 
         parseImportantDateInput(s)?.let { parsed ->
             return if (parsed.year != null) {
                 LocalDate.of(parsed.year, parsed.month, parsed.day)
             } else {
-                resolveRecurringDate(parsed.month, parsed.day, today)
+                resolveRecurringDate(parsed.month, parsed.day, today, preferPast = preferPast)
             }
         }
         return null

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2853,12 +2853,15 @@ class QuickIntentRouterTest {
             Arguments.of("save our anniversary as 22 June 2018", "our anniversary", "22 June 2018"),
             Arguments.of("don't forget that dad's birthday is March 3", "dad's birthday", "March 3"),
             Arguments.of("my wedding anniversary is 2018-06-22", "wedding anniversary", "2018-06-22"),
+            Arguments.of("add important date freya's birthday 22 August", "freya's birthday", "22 August"),
+            Arguments.of("add an important date for freya's birthday on 22 August", "freya's birthday", "22 August"),
         )
 
         @JvmStatic
         fun importantDateSaveNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("remember my mum's birthday", "mum's birthday"),
             Arguments.of("save our anniversary", "our anniversary"),
+            Arguments.of("add important date freya's birthday", "freya's birthday"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -738,6 +738,26 @@ class QuickIntentRouterTest {
             assertEquals("London", intent.params["location"])
         }
 
+    @Test
+    fun `date diff until phrases tag direction as until`() {
+        val result = regexOnlyRouter.route("how long until Christmas")
+        assertRegexMatch(result, "get_date_diff", "how long until Christmas")
+
+        val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("until", intent.params["direction"])
+        assertEquals("Christmas", intent.params["target_date"])
+    }
+
+    @Test
+    fun `date diff since phrases tag direction as since`() {
+        val result = regexOnlyRouter.route("how long since Easter")
+        assertRegexMatch(result, "get_date_diff", "how long since Easter")
+
+        val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("since", intent.params["direction"])
+        assertEquals("Easter", intent.params["target_date"])
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // E4B FALLTHROUGH — these should NEVER match Tier 2
     // ═══════════════════════════════════════════════════════════════════════════

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1535,6 +1535,56 @@ class QuickIntentRouterTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // IMPORTANT DATES TESTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Important Dates")
+    inner class ImportantDates {
+
+        @ParameterizedTest(name = "Save important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateSaveRegexPhrases")
+        fun `should match save important date phrases with extracted params`(
+            input: String,
+            expectedLabel: String,
+            expectedDate: String,
+        ) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "save_important_date", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedLabel, intent.params["label"], "label for '$input'")
+            assertEquals(expectedDate, intent.params["date"], "date for '$input'")
+        }
+
+        @ParameterizedTest(name = "NeedsSlot save important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateSaveNeedsSlotPhrases")
+        fun `should return NeedsSlot for important date phrases missing date`(input: String, expectedLabel: String) {
+            val result = regexOnlyRouter.route(input)
+            val needsSlot = assertInstanceOf(QuickIntentRouter.RouteResult.NeedsSlot::class.java, result)
+
+            assertEquals("save_important_date", needsSlot.intent.intentName)
+            assertEquals("date", needsSlot.missingSlot.name)
+            assertEquals(expectedLabel, needsSlot.intent.params["label"])
+        }
+
+        @Test
+        fun `should match list important dates phrase`() {
+            assertRegexMatch(regexOnlyRouter.route("list my important dates"), "list_important_dates", "list my important dates")
+        }
+
+        @ParameterizedTest(name = "Remove important date: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#importantDateRemoveRegexPhrases")
+        fun `should match remove important date phrases`(input: String, expectedLabel: String) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "remove_important_date", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedLabel, intent.params["label"], "label for '$input'")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // SAVE MEMORY TESTS
     // ═══════════════════════════════════════════════════════════════════════════
 
@@ -1727,6 +1777,10 @@ class QuickIntentRouterTest {
         addCases(weatherUvRegexPhrases(), "get_weather", "Weather UV (regex)")
         addCases(weatherAqiRegexPhrases(), "get_weather", "Weather AQI (regex)")
         addCases(weatherSunriseRegexPhrases(), "get_weather", "Weather Sunrise/Sunset (regex)")
+        addCases(importantDateSaveRegexPhrases(), "save_important_date", "Important Dates Save (regex)")
+        addCases(importantDateSaveNeedsSlotPhrases(), "save_important_date", "Important Dates Save (needs slot)")
+        addCases(importantDateRemoveRegexPhrases(), "remove_important_date", "Important Dates Remove (regex)")
+        addCases(listImportantDatesRegexPhrases(), "list_important_dates", "Important Dates List (regex)")
         addCases(saveMemoryRegexPhrases(), "save_memory", "Save Memory (regex)")
         addCases(saveMemoryNeedsSlotPhrases(), "save_memory", "Save Memory (needs slot)")
         addCases(brightnessRegexPhrases(), "set_brightness", "Brightness (regex)")
@@ -2762,16 +2816,42 @@ class QuickIntentRouterTest {
             Arguments.of("save to memory: important note", "important note"),
             Arguments.of("can you save to memory that my dog is named Xena", "my dog is named Xena"),
             Arguments.of("note that the gate code is 4567", "the gate code is 4567"),
-            Arguments.of("don't forget that mum's birthday is March 3", "mum's birthday is March 3"),
             Arguments.of("store that my doctor is Dr Smith", "my doctor is Dr Smith"),
         )
-
         @JvmStatic
         fun saveMemoryNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("remember something"),
             Arguments.of("save something to memory"),
             Arguments.of("make a note"),
             Arguments.of("take a note"),
+        )
+
+
+        @JvmStatic
+        fun importantDateSaveRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remember my mum's birthday is 15 March", "mum's birthday", "15 March"),
+            Arguments.of("save our anniversary as 22 June 2018", "our anniversary", "22 June 2018"),
+            Arguments.of("don't forget that dad's birthday is March 3", "dad's birthday", "March 3"),
+            Arguments.of("my wedding anniversary is 2018-06-22", "wedding anniversary", "2018-06-22"),
+        )
+
+        @JvmStatic
+        fun importantDateSaveNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remember my mum's birthday", "mum's birthday"),
+            Arguments.of("save our anniversary", "our anniversary"),
+        )
+
+        @JvmStatic
+        fun listImportantDatesRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("list my important dates"),
+            Arguments.of("show me important dates"),
+        )
+
+        @JvmStatic
+        fun importantDateRemoveRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("remove mum's birthday", "mum's birthday"),
+            Arguments.of("forget our anniversary", "our anniversary"),
+            Arguments.of("delete dad's birthday from my important dates", "dad's birthday"),
         )
 
         // ── Brightness ───────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -1,0 +1,113 @@
+package com.kernel.ai.core.skills.natives
+
+import android.Manifest
+import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.provider.CalendarContract
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+class CalendarBirthdayLookupTest {
+    @Test
+    fun `findBirthday normalizes birthday titles and caches query results`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Jane Smith's Birthday",
+            dtStart = LocalDate.of(2020, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val first = lookup.findBirthday("Jane's birthday")
+        val second = lookup.findBirthday("Jane's birthday")
+
+        assertNotNull(first)
+        assertEquals(4, first?.month)
+        assertEquals(5, first?.day)
+        assertEquals("Jane Smith", first?.label)
+        assertEquals(first, second)
+        verify(exactly = 1) {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `findBirthday returns null without calendar permission`() {
+        val context = mockk<Context>(relaxed = true)
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_DENIED
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        assertNull(lookup.findBirthday("Jane's birthday"))
+        verify(exactly = 0) { context.contentResolver }
+    }
+
+    private fun birthdayCursor(
+        title: String,
+        dtStart: Long,
+        isAllDay: Boolean,
+        calendarDisplayName: String,
+        accountType: String,
+    ): Cursor {
+        val cursor = mockk<Cursor>()
+        val columns = mapOf(
+            CalendarContract.Events.TITLE to 0,
+            CalendarContract.Events.DTSTART to 1,
+            CalendarContract.Events.ALL_DAY to 2,
+            CalendarContract.Events.CALENDAR_DISPLAY_NAME to 3,
+            CalendarContract.Events.ACCOUNT_TYPE to 4,
+        )
+        var moved = false
+
+        every { cursor.getColumnIndexOrThrow(any()) } answers {
+            columns[firstArg<String>()] ?: error("Unknown column ${firstArg<String>()}")
+        }
+        every { cursor.moveToNext() } answers {
+            if (moved) {
+                false
+            } else {
+                moved = true
+                true
+            }
+        }
+        every { cursor.getString(0) } returns title
+        every { cursor.getLong(1) } returns dtStart
+        every { cursor.getInt(2) } returns if (isAllDay) 1 else 0
+        every { cursor.getString(3) } returns calendarDisplayName
+        every { cursor.getString(4) } returns accountType
+        every { cursor.close() } just runs
+        return cursor
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -97,6 +97,39 @@ class CalendarBirthdayLookupTest {
     }
 
     @Test
+    fun `findBirthday matches a taught birthday phrased without an apostrophe`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Lachlan Birthday",
+            dtStart = LocalDate.of(2020, 8, 22).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val birthday = lookup.findBirthday("Lachlans birthday")
+
+        assertNotNull(birthday)
+        assertEquals("Lachlan", birthday?.label)
+        assertEquals(8, birthday?.month)
+        assertEquals(22, birthday?.day)
+    }
+
+    @Test
     fun `findBirthday returns null without calendar permission`() {
         val context = mockk<Context>(relaxed = true)
         every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_DENIED

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -64,6 +64,39 @@ class CalendarBirthdayLookupTest {
     }
 
     @Test
+    fun `findBirthday matches a shorter synced birthday label from a mapped full contact name`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Alice Birthday",
+            dtStart = LocalDate.of(2020, 4, 5).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(
+                CalendarContract.Events.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val birthday = lookup.findBirthday("Alice Smith's birthday")
+
+        assertNotNull(birthday)
+        assertEquals("Alice", birthday?.label)
+        assertEquals(4, birthday?.month)
+        assertEquals(5, birthday?.day)
+    }
+
+    @Test
     fun `findBirthday returns null without calendar permission`() {
         val context = mockk<Context>(relaxed = true)
         every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_DENIED

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.flow.flowOf
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
@@ -1017,6 +1019,31 @@ class NativeIntentHandlerTest {
 
         assertEquals(expected, resolved)
         verify(exactly = 0) { calendarBirthdayLookup.findBirthday(any()) }
+    }
+
+    @Test
+    fun `get_date_diff since uses the most recent recurring important date`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 3, 1).let {
+            if (!it.isAfter(today)) it else LocalDate.of(today.year - 1, 3, 1)
+        }
+        coEvery { importantDateRepository.findByLabel("my wedding anniversary") } returns ImportantDateEntity(
+            label = "my wedding anniversary",
+            normalizedLabel = "wedding anniversary",
+            month = 3,
+            day = 1,
+            year = 2018,
+        )
+
+        val result = handler.handle(
+            "get_date_diff",
+            mapOf("target_date" to "my wedding anniversary", "direction" to "since"),
+        )
+
+        assertTrue(result is SkillResult.DirectReply)
+        val content = (result as SkillResult.DirectReply).content
+        assertTrue(content.contains("ago"), content)
+        assertTrue(content.contains(expected.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy", Locale.ENGLISH))), content)
     }
 
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -12,6 +12,7 @@ import android.provider.ContactsContract
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.ContactAliasRepository
+import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.clock.ClockStopwatch
@@ -20,6 +21,7 @@ import com.kernel.ai.core.memory.clock.StopwatchStatus
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ContactAliasEntity
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.skills.SkillResult
@@ -46,11 +48,11 @@ class NativeIntentHandlerTest {
     private val context = mockk<Context>(relaxed = true)
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
+    private val importantDateRepository = mockk<ImportantDateRepository>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>(relaxed = true)
     private val clockAlertController = mockk<ClockAlertController>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
     private val listNameDao = mockk<ListNameDao>(relaxed = true)
-
     private val handler = NativeIntentHandler(
         context = context,
         clockRepository = clockRepository,
@@ -58,6 +60,7 @@ class NativeIntentHandlerTest {
         listItemDao = listItemDao,
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
+        importantDateRepository = importantDateRepository,
         memoryRepository = mockk<MemoryRepository>(relaxed = true),
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
     )
@@ -863,6 +866,74 @@ class NativeIntentHandlerTest {
         assertEquals(true, spaced)
         assertEquals(true, compact)
         assertEquals(false, contact)
+    }
+
+    @Test
+    fun `save important date stores parsed recurring date`() {
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        coEvery { importantDateRepository.save("mum's birthday", 3, 15, null) } just Runs
+
+        val result = handler.handle(
+            "save_important_date",
+            mapOf("label" to "mum's birthday", "date" to "15 March"),
+        )
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertEquals(
+            "I'll remember mum's birthday as 15 March.",
+            (result as SkillResult.DirectReply).content,
+        )
+        coVerify(exactly = 1) { importantDateRepository.save("mum's birthday", 3, 15, null) }
+    }
+
+    @Test
+    fun `list important dates returns stored entries`() {
+        coEvery { importantDateRepository.getAll() } returns listOf(
+            ImportantDateEntity(label = "mum's birthday", normalizedLabel = "mum birthday", month = 3, day = 15),
+            ImportantDateEntity(label = "our anniversary", normalizedLabel = "our anniversary", month = 6, day = 22, year = 2018),
+        )
+
+        val result = handler.handle("list_important_dates", emptyMap())
+
+        assertTrue(result is SkillResult.DirectReply)
+        val reply = (result as SkillResult.DirectReply).content
+        assertTrue(reply.contains("Important dates:"))
+        assertTrue(reply.contains("mum's birthday — 15 March"))
+        assertTrue(reply.contains("our anniversary — 22 June 2018"))
+    }
+
+    @Test
+    fun `remove important date deletes by label`() {
+        coEvery { importantDateRepository.deleteByLabel("mum's birthday") } returns 1
+
+        val result = handler.handle("remove_important_date", mapOf("label" to "mum's birthday"))
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertEquals("Removed important date mum's birthday.", (result as SkillResult.DirectReply).content)
+        coVerify(exactly = 1) { importantDateRepository.deleteByLabel("mum's birthday") }
+    }
+
+    @Test
+    fun `parseDateString resolves taught important dates before holiday lookup`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 3, 15).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 3, 15)
+        }
+        coEvery { importantDateRepository.findByLabel("mum's birthday") } returns ImportantDateEntity(
+            label = "mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "mum's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
     }
 
     private data class PhoneRow(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -963,6 +963,39 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `parseDateString resolves mapped birthday aliases through contact names`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 4, 5).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 4, 5)
+        }
+        coEvery { importantDateRepository.findByLabel("my wife's birthday") } returns null
+        every { calendarBirthdayLookup.findBirthday("my wife's birthday") } returns null
+        coEvery { contactAliasRepository.getByAlias("wife") } returns ContactAliasEntity(
+            alias = "wife",
+            displayName = "Alice Smith",
+            contactId = "42",
+            phoneNumber = "021111222",
+        )
+        every { calendarBirthdayLookup.findBirthday("Alice Smith") } returns CalendarBirthdayLookup.BirthdayEntry(
+            label = "Alice Smith",
+            normalizedLabel = "alice smith",
+            month = 4,
+            day = 5,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "my wife's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+        coVerify(exactly = 1) { contactAliasRepository.getByAlias("wife") }
+        verify(exactly = 1) { calendarBirthdayLookup.findBirthday("Alice Smith") }
+    }
+
+    @Test
     fun `parseDateString prefers taught dates over calendar birthdays`() {
         val today = LocalDate.now()
         val expected = LocalDate.of(today.year, 3, 15).let {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -49,6 +49,7 @@ class NativeIntentHandlerTest {
     private val contentResolver = mockk<ContentResolver>(relaxed = true)
     private val contactAliasRepository = mockk<ContactAliasRepository>(relaxed = true)
     private val importantDateRepository = mockk<ImportantDateRepository>(relaxed = true)
+    private val calendarBirthdayLookup = mockk<CalendarBirthdayLookup>(relaxed = true)
     private val clockRepository = mockk<ClockRepository>(relaxed = true)
     private val clockAlertController = mockk<ClockAlertController>(relaxed = true)
     private val listItemDao = mockk<ListItemDao>(relaxed = true)
@@ -61,6 +62,7 @@ class NativeIntentHandlerTest {
         listNameDao = listNameDao,
         contactAliasRepository = contactAliasRepository,
         importantDateRepository = importantDateRepository,
+        calendarBirthdayLookup = calendarBirthdayLookup,
         memoryRepository = mockk<MemoryRepository>(relaxed = true),
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
     )
@@ -935,6 +937,55 @@ class NativeIntentHandlerTest {
 
         assertEquals(expected, resolved)
     }
+
+    @Test
+    fun `parseDateString resolves calendar birthdays when taught date missing`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 4, 5).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 4, 5)
+        }
+        coEvery { importantDateRepository.findByLabel("jane's birthday") } returns null
+        every { calendarBirthdayLookup.findBirthday("jane's birthday") } returns CalendarBirthdayLookup.BirthdayEntry(
+            label = "Jane Smith",
+            normalizedLabel = "jane smith",
+            month = 4,
+            day = 5,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "jane's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+    }
+
+    @Test
+    fun `parseDateString prefers taught dates over calendar birthdays`() {
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 3, 15).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 3, 15)
+        }
+        coEvery { importantDateRepository.findByLabel("mum's birthday") } returns ImportantDateEntity(
+            label = "mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "mum's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+        verify(exactly = 0) { calendarBirthdayLookup.findBirthday(any()) }
+    }
+
 
     private data class PhoneRow(
         val contactId: String,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -1,5 +1,14 @@
 package com.kernel.ai.feature.settings
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -12,6 +21,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -35,11 +45,13 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,10 +59,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.time.Instant
 import java.time.LocalDate
@@ -66,16 +82,47 @@ fun ImportantDatesScreen(
     viewModel: ImportantDatesViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     var editingDate by remember { mutableStateOf<ImportantDateListItem?>(null) }
     var pendingDelete by remember { mutableStateOf<ImportantDateListItem?>(null) }
     var createRequested by remember { mutableStateOf(false) }
+    var showCalendarPermissionRationale by remember { mutableStateOf(false) }
+    var showCalendarPermissionSettingsHint by remember { mutableStateOf(false) }
+    val calendarPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        viewModel.refreshCalendarBirthdays()
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                if (granted) {
+                    "Calendar birthdays enabled."
+                } else {
+                    "Calendar birthdays stay off. You can enable them here later."
+                },
+            )
+        }
+    }
+    val visibleSyncedBirthdayCount = remember(uiState.upcomingDates, uiState.laterDates) {
+        (uiState.upcomingDates + uiState.laterDates).count { it.source == ImportantDateSource.CALENDAR }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.messages.collect { message ->
             snackbarHostState.showSnackbar(message)
         }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshCalendarBirthdays()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Scaffold(
@@ -102,27 +149,34 @@ fun ImportantDatesScreen(
                 .padding(innerPadding),
             contentPadding = PaddingValues(bottom = 88.dp),
         ) {
-            if (!uiState.calendarPermissionGranted) {
-                item {
-                    ListItem(
-                        headlineContent = { Text("Calendar birthdays are off") },
-                        supportingContent = {
-                            Text("Enable Calendar birthdays in Settings to show synced birthdays here. Taught dates still work without it.")
-                        },
-                        leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
-                    )
-                    HorizontalDivider()
-                }
-            }
-
-            if (uiState.isRefreshingCalendarBirthdays) {
-                item {
-                    ListItem(
-                        headlineContent = { Text("Refreshing synced birthdays…") },
-                        supportingContent = { Text("Pulling the latest read-only birthdays from Android Calendar.") },
-                    )
-                    HorizontalDivider()
-                }
+            item {
+                CalendarBirthdayAccessRow(
+                    enabled = uiState.calendarPermissionGranted,
+                    syncedBirthdayCount = visibleSyncedBirthdayCount,
+                    isRefreshing = uiState.isRefreshingCalendarBirthdays,
+                    onToggle = { enabled ->
+                        if (enabled) {
+                            if (uiState.calendarPermissionGranted) {
+                                viewModel.refreshCalendarBirthdays()
+                                coroutineScope.launch {
+                                    snackbarHostState.showSnackbar("Calendar birthdays refreshed.")
+                                }
+                            } else {
+                                val activity = context.findActivity()
+                                if (activity != null &&
+                                    ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_CALENDAR)
+                                ) {
+                                    showCalendarPermissionRationale = true
+                                } else {
+                                    calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                                }
+                            }
+                        } else if (uiState.calendarPermissionGranted) {
+                            showCalendarPermissionSettingsHint = true
+                        }
+                    },
+                )
+                HorizontalDivider()
             }
 
             if (!uiState.hasAnyDates) {
@@ -230,8 +284,105 @@ fun ImportantDatesScreen(
             },
         )
     }
+
+    if (showCalendarPermissionRationale) {
+        AlertDialog(
+            onDismissRequest = { showCalendarPermissionRationale = false },
+            title = { Text("Allow calendar birthdays?") },
+            text = {
+                Text(
+                    "This reads Android Calendar birthday calendars and birthday-style events like 'Jane's Birthday'. Matching taught dates still take precedence.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCalendarPermissionRationale = false
+                        calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                    },
+                ) {
+                    Text("Continue")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCalendarPermissionRationale = false }) {
+                    Text("Not now")
+                }
+            },
+        )
+    }
+
+    if (showCalendarPermissionSettingsHint) {
+        AlertDialog(
+            onDismissRequest = { showCalendarPermissionSettingsHint = false },
+            title = { Text("Turn off calendar birthdays?") },
+            text = {
+                Text(
+                    "Android does not let the app revoke Calendar access directly. Open App info to turn this off in system permissions.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCalendarPermissionSettingsHint = false
+                        context.openAppPermissionSettings()
+                    },
+                ) {
+                    Text("Open settings")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCalendarPermissionSettingsHint = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
 }
 
+@Composable
+private fun CalendarBirthdayAccessRow(
+    enabled: Boolean,
+    syncedBirthdayCount: Int,
+    isRefreshing: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle(!enabled) },
+        headlineContent = { Text("Calendar birthdays") },
+        supportingContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    if (enabled) {
+                        "Reads Android Calendar birthday calendars and birthday-style events such as 'Jane's Birthday'."
+                    } else {
+                        "Optional — include read-only birthdays from Android Calendar alongside taught dates."
+                    },
+                )
+                Text(
+                    when {
+                        isRefreshing -> "Refreshing synced birthdays…"
+                        !enabled -> "Turn this on here when you want birthday lookups without teaching each date manually."
+                        syncedBirthdayCount == 0 -> "No synced birthdays are visible yet. Matching taught dates still override synced entries."
+                        syncedBirthdayCount == 1 -> "Showing 1 synced birthday. Matching taught dates override synced entries."
+                        else -> "Showing $syncedBirthdayCount synced birthdays. Matching taught dates override synced entries."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
+        trailingContent = {
+            Switch(
+                checked = enabled,
+                onCheckedChange = onToggle,
+            )
+        },
+    )
+}
 @Composable
 private fun ImportantDatesSectionHeader(title: String) {
     Text(
@@ -252,7 +403,7 @@ private fun EmptyImportantDatesState(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = "Tap + to add one here, or teach Jandal by saying something like 'remember mum's birthday is 15 March'.",
+            text = "Tap + to add one here, teach Jandal with something like 'remember mum's birthday is 15 March', or turn on Calendar birthdays above for read-only synced birthdays.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -462,3 +613,17 @@ private fun formatStoredDate(month: Int, day: Int, year: Int?): String {
 
 private fun formatNextOccurrence(date: LocalDate): String =
     "Next: ${date.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))}"
+
+private fun Context.openAppPermissionSettings() {
+    val intent = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.fromParts("package", packageName, null),
+    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    startActivity(intent)
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -1,0 +1,464 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportantDatesScreen(
+    onBack: () -> Unit,
+    viewModel: ImportantDatesViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    var editingDate by remember { mutableStateOf<ImportantDateListItem?>(null) }
+    var pendingDelete by remember { mutableStateOf<ImportantDateListItem?>(null) }
+    var createRequested by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.messages.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Important dates") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { createRequested = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add important date")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(bottom = 88.dp),
+        ) {
+            if (!uiState.calendarPermissionGranted) {
+                item {
+                    ListItem(
+                        headlineContent = { Text("Calendar birthdays are off") },
+                        supportingContent = {
+                            Text("Enable Calendar birthdays in Settings to show synced birthdays here. Taught dates still work without it.")
+                        },
+                        leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            if (uiState.isRefreshingCalendarBirthdays) {
+                item {
+                    ListItem(
+                        headlineContent = { Text("Refreshing synced birthdays…") },
+                        supportingContent = { Text("Pulling the latest read-only birthdays from Android Calendar.") },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            if (!uiState.hasAnyDates) {
+                item {
+                    EmptyImportantDatesState(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    )
+                }
+            } else {
+                if (uiState.upcomingDates.isNotEmpty()) {
+                    item {
+                        ImportantDatesSectionHeader("Upcoming (next 90 days)")
+                    }
+                    items(uiState.upcomingDates, key = { it.stableKey }) { item ->
+                        ImportantDateRow(
+                            item = item,
+                            onEdit = { editingDate = item },
+                            onDelete = { pendingDelete = item },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+
+                if (uiState.laterDates.isNotEmpty()) {
+                    item {
+                        ImportantDatesSectionHeader(
+                            if (uiState.upcomingDates.isEmpty()) "All dates" else "Later",
+                        )
+                    }
+                    items(uiState.laterDates, key = { it.stableKey }) { item ->
+                        ImportantDateRow(
+                            item = item,
+                            onEdit = { editingDate = item },
+                            onDelete = { pendingDelete = item },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+
+    if (createRequested) {
+        ImportantDateEditorSheet(
+            existingItem = null,
+            onDismiss = { createRequested = false },
+            onSave = { label, month, day, year ->
+                coroutineScope.launch {
+                    val saved = viewModel.saveTaughtDate(
+                        existingLabel = null,
+                        label = label,
+                        month = month,
+                        day = day,
+                        year = year,
+                    )
+                    if (saved) createRequested = false
+                }
+            },
+        )
+    }
+
+    editingDate?.let { item ->
+        ImportantDateEditorSheet(
+            existingItem = item,
+            onDismiss = { editingDate = null },
+            onSave = { label, month, day, year ->
+                coroutineScope.launch {
+                    val saved = viewModel.saveTaughtDate(
+                        existingLabel = item.label,
+                        label = label,
+                        month = month,
+                        day = day,
+                        year = year,
+                    )
+                    if (saved) editingDate = null
+                }
+            },
+        )
+    }
+
+    pendingDelete?.let { item ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            icon = { Icon(Icons.Default.Delete, contentDescription = null) },
+            title = { Text("Delete ${item.label}?") },
+            text = { Text("This only removes the taught date. Synced calendar birthdays stay read-only.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            viewModel.deleteTaughtDate(item.label)
+                            pendingDelete = null
+                        }
+                    },
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ImportantDatesSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun EmptyImportantDatesState(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "No important dates yet.",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Tap + to add one here, or teach Jandal by saying something like 'remember mum's birthday is 15 March'.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ImportantDateRow(
+    item: ImportantDateListItem,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dateSummary = formatStoredDate(item.month, item.day, item.year)
+    val nextSummary = formatNextOccurrence(item.nextOccurrence)
+
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !item.isReadOnly, onClick = onEdit),
+        headlineContent = { Text(item.label) },
+        supportingContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(dateSummary)
+                Text(
+                    if (item.isReadOnly) {
+                        "$nextSummary · Synced from Calendar"
+                    } else {
+                        "$nextSummary · Taught by you"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        leadingContent = {
+            Icon(Icons.Default.Event, contentDescription = null)
+        },
+        trailingContent = {
+            if (item.isReadOnly) {
+                Text(
+                    text = "Read-only",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    IconButton(onClick = onEdit) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit ${item.label}")
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(Icons.Default.Delete, contentDescription = "Delete ${item.label}")
+                    }
+                }
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImportantDateEditorSheet(
+    existingItem: ImportantDateListItem?,
+    onDismiss: () -> Unit,
+    onSave: (label: String, month: Int, day: Int, year: Int?) -> Unit,
+) {
+    val today = LocalDate.now()
+    var label by remember(existingItem) { mutableStateOf(existingItem?.label ?: "") }
+    var selectedDate by remember(existingItem) {
+        mutableStateOf(
+            LocalDate.of(
+                existingItem?.year ?: today.year,
+                existingItem?.month ?: today.monthValue,
+                existingItem?.day ?: today.dayOfMonth,
+            ),
+        )
+    }
+    var yearText by remember(existingItem) { mutableStateOf(existingItem?.year?.toString().orEmpty()) }
+    var localError by remember(existingItem) { mutableStateOf<String?>(null) }
+    var showDatePicker by remember(existingItem) { mutableStateOf(false) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = if (existingItem == null) "Add important date" else "Edit important date",
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                text = "Month and day are required. Leave year blank to repeat every year.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = label,
+                onValueChange = {
+                    label = it
+                    localError = null
+                },
+                label = { Text("Label") },
+                placeholder = { Text("e.g. Mum's birthday") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedButton(
+                onClick = { showDatePicker = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Date: ${formatStoredDate(selectedDate.monthValue, selectedDate.dayOfMonth, null)}")
+            }
+            OutlinedTextField(
+                value = yearText,
+                onValueChange = {
+                    yearText = it.filter(Char::isDigit).take(4)
+                    localError = null
+                },
+                label = { Text("Year (optional)") },
+                placeholder = { Text("Leave blank for recurring dates") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            localError?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        val parsedYear = when {
+                            yearText.isBlank() -> null
+                            yearText.length != 4 -> {
+                                localError = "Year must be four digits or left blank."
+                                return@Button
+                            }
+                            else -> yearText.toIntOrNull()?.also {
+                                if (it < 1) {
+                                    localError = "Year must be a valid positive number."
+                                    return@Button
+                                }
+                            } ?: run {
+                                localError = "Year must be a valid number."
+                                return@Button
+                            }
+                        }
+                        onSave(label, selectedDate.monthValue, selectedDate.dayOfMonth, parsedYear)
+                    },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(if (existingItem == null) "Add" else "Save")
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val selectedMillis = datePickerState.selectedDateMillis ?: return@TextButton
+                        selectedDate = Instant.ofEpochMilli(selectedMillis)
+                            .atZone(ZoneId.of("UTC"))
+                            .toLocalDate()
+                        showDatePicker = false
+                    },
+                ) {
+                    Text("Use date")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text("Cancel")
+                }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+private fun formatStoredDate(month: Int, day: Int, year: Int?): String {
+    val date = LocalDate.of(year ?: 2000, month, day)
+    val pattern = if (year == null) "d MMMM" else "d MMMM yyyy"
+    return date.format(DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH))
+}
+
+private fun formatNextOccurrence(date: LocalDate): String =
+    "Next: ${date.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))}"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
@@ -152,8 +152,12 @@ class ImportantDatesViewModel @Inject constructor(
             isRefreshing: Boolean,
             today: LocalDate,
         ): ImportantDatesUiState {
-            val taughtLabels = taughtDates.map { it.normalizedLabel }.toSet()
-            val merged = (taughtDates + calendarBirthdays.filter { it.normalizedLabel !in taughtLabels })
+            val merged = (taughtDates + calendarBirthdays.filter { calendarBirthday ->
+                taughtDates.none { taughtDate ->
+                    taughtDate.normalizedLabel == calendarBirthday.normalizedLabel ||
+                        CalendarBirthdayLookup.labelsPotentiallyMatch(taughtDate.label, calendarBirthday.label)
+                }
+            })
                 .sortedWith(
                     compareBy<ImportantDateListItem> { it.nextOccurrence }
                         .thenBy { it.label.lowercase() },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
@@ -1,0 +1,197 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.ImportantDateRepository
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.skills.natives.CalendarBirthdayLookup
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class ImportantDateSource {
+    TAUGHT,
+    CALENDAR,
+}
+
+data class ImportantDateListItem(
+    val label: String,
+    val normalizedLabel: String,
+    val month: Int,
+    val day: Int,
+    val year: Int?,
+    val source: ImportantDateSource,
+    val nextOccurrence: LocalDate,
+) {
+    val stableKey: String = "${source.name}:$normalizedLabel"
+    val isReadOnly: Boolean = source == ImportantDateSource.CALENDAR
+}
+
+data class ImportantDatesUiState(
+    val upcomingDates: List<ImportantDateListItem> = emptyList(),
+    val laterDates: List<ImportantDateListItem> = emptyList(),
+    val calendarPermissionGranted: Boolean = false,
+    val isRefreshingCalendarBirthdays: Boolean = false,
+) {
+    val hasAnyDates: Boolean = upcomingDates.isNotEmpty() || laterDates.isNotEmpty()
+}
+
+@HiltViewModel
+class ImportantDatesViewModel @Inject constructor(
+    private val repository: ImportantDateRepository,
+    private val calendarBirthdayLookup: CalendarBirthdayLookup,
+) : ViewModel() {
+    private val calendarBirthdays = MutableStateFlow<List<ImportantDateListItem>>(emptyList())
+    private val calendarPermissionGranted = MutableStateFlow(calendarBirthdayLookup.hasPermission())
+    private val isRefreshingCalendarBirthdays = MutableStateFlow(false)
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    val messages = _messages.asSharedFlow()
+
+    val uiState: StateFlow<ImportantDatesUiState> = combine(
+        repository.observeAll().map { dates ->
+            dates.map { it.toUiItem() }
+        },
+        calendarBirthdays,
+        calendarPermissionGranted,
+        isRefreshingCalendarBirthdays,
+    ) { taughtDates, syncedBirthdays, hasCalendarPermission, isRefreshing ->
+        buildUiState(
+            taughtDates = taughtDates,
+            calendarBirthdays = syncedBirthdays,
+            hasCalendarPermission = hasCalendarPermission,
+            isRefreshing = isRefreshing,
+            today = LocalDate.now(),
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ImportantDatesUiState(
+            calendarPermissionGranted = calendarBirthdayLookup.hasPermission(),
+        ),
+    )
+
+    init {
+        refreshCalendarBirthdays()
+    }
+
+    fun refreshCalendarBirthdays() {
+        viewModelScope.launch {
+            isRefreshingCalendarBirthdays.value = true
+            val granted = calendarBirthdayLookup.hasPermission()
+            calendarPermissionGranted.value = granted
+            calendarBirthdays.value = if (granted) {
+                calendarBirthdayLookup.invalidateCache()
+                calendarBirthdayLookup.getAllBirthdays().map { it.toUiItem() }
+            } else {
+                emptyList()
+            }
+            isRefreshingCalendarBirthdays.value = false
+        }
+    }
+
+    suspend fun saveTaughtDate(
+        existingLabel: String?,
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+    ): Boolean {
+        val trimmedLabel = label.trim()
+        if (trimmedLabel.isBlank()) {
+            _messages.emit("Label is required.")
+            return false
+        }
+        if (month !in 1..12 || day !in 1..31) {
+            _messages.emit("Pick a valid month and day.")
+            return false
+        }
+
+        val normalizedLabel = ImportantDateRepository.normalizeLabel(trimmedLabel)
+        val originalNormalizedLabel = existingLabel?.let(ImportantDateRepository::normalizeLabel)
+        val existing = repository.findByLabel(trimmedLabel)
+        if (existing != null && existing.normalizedLabel != originalNormalizedLabel) {
+            _messages.emit("An important date named $trimmedLabel already exists.")
+            return false
+        }
+
+        if (existingLabel != null && originalNormalizedLabel != normalizedLabel) {
+            repository.deleteByLabel(existingLabel)
+        }
+        repository.save(trimmedLabel, month, day, year)
+        _messages.emit(if (existingLabel == null) "Saved $trimmedLabel." else "Updated $trimmedLabel.")
+        return true
+    }
+
+    suspend fun deleteTaughtDate(label: String): Boolean {
+        val deleted = repository.deleteByLabel(label)
+        _messages.emit(
+            if (deleted > 0) {
+                "Removed $label."
+            } else {
+                "I couldn't find $label anymore."
+            },
+        )
+        return deleted > 0
+    }
+
+    companion object {
+        internal fun buildUiState(
+            taughtDates: List<ImportantDateListItem>,
+            calendarBirthdays: List<ImportantDateListItem>,
+            hasCalendarPermission: Boolean,
+            isRefreshing: Boolean,
+            today: LocalDate,
+        ): ImportantDatesUiState {
+            val taughtLabels = taughtDates.map { it.normalizedLabel }.toSet()
+            val merged = (taughtDates + calendarBirthdays.filter { it.normalizedLabel !in taughtLabels })
+                .sortedWith(
+                    compareBy<ImportantDateListItem> { it.nextOccurrence }
+                        .thenBy { it.label.lowercase() },
+                )
+            val upcomingCutoff = today.plusDays(90)
+            return ImportantDatesUiState(
+                upcomingDates = merged.filter { !it.nextOccurrence.isAfter(upcomingCutoff) },
+                laterDates = merged.filter { it.nextOccurrence.isAfter(upcomingCutoff) },
+                calendarPermissionGranted = hasCalendarPermission,
+                isRefreshingCalendarBirthdays = isRefreshing,
+            )
+        }
+
+        internal fun ImportantDateEntity.toUiItem(today: LocalDate = LocalDate.now()): ImportantDateListItem =
+            ImportantDateListItem(
+                label = label,
+                normalizedLabel = normalizedLabel,
+                month = month,
+                day = day,
+                year = year,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = nextOccurrence(month, day, today),
+            )
+
+        internal fun CalendarBirthdayLookup.BirthdayEntry.toUiItem(today: LocalDate = LocalDate.now()): ImportantDateListItem =
+            ImportantDateListItem(
+                label = label,
+                normalizedLabel = normalizedLabel,
+                month = month,
+                day = day,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = nextOccurrence(month, day, today),
+            )
+
+        internal fun nextOccurrence(month: Int, day: Int, today: LocalDate): LocalDate {
+            val candidate = LocalDate.of(today.year, month, day)
+            return if (!candidate.isBefore(today)) candidate else LocalDate.of(today.year + 1, month, day)
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -1,11 +1,5 @@
 package com.kernel.ai.feature.settings
 
-import android.Manifest
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,12 +16,10 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,21 +37,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.launch
 
 /** Amber / HuggingFace brand colour — same as in OnboardingScreen. */
 private val HfOrange = Color(0xFFFF9D00)
@@ -70,7 +55,6 @@ fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
-    onNavigateToImportantDates: () -> Unit = {},
     onNavigateToVoice: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
     onNavigateToModelManagement: (preferred: Boolean) -> Unit = {},
@@ -80,28 +64,6 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val uriHandler = LocalUriHandler.current
-    val context = LocalContext.current
-    val coroutineScope = rememberCoroutineScope()
-    var hasCalendarPermission by remember {
-        mutableStateOf(
-            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) == android.content.pm.PackageManager.PERMISSION_GRANTED,
-        )
-    }
-    var showCalendarPermissionRationale by remember { mutableStateOf(false) }
-    val calendarPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { granted ->
-        hasCalendarPermission = granted
-        coroutineScope.launch {
-            snackbarHostState.showSnackbar(
-                if (granted) {
-                    "Calendar birthday access enabled."
-                } else {
-                    "Calendar birthday access denied. You can enable it later from Settings."
-                },
-            )
-        }
-    }
     LaunchedEffect(Unit) {
         viewModel.saveError.collect { message ->
             snackbarHostState.showSnackbar(message)
@@ -233,17 +195,6 @@ fun SettingsScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onNavigateToImportantDates() },
-                headlineContent = { Text("Important dates") },
-                supportingContent = { Text("Browse and edit taught dates") },
-                leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
-                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
-            )
-            HorizontalDivider()
-
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
                     .clickable { onNavigateToVoice() },
                 headlineContent = { Text("Voice") },
                 supportingContent = { Text("Speech and spoken response settings") },
@@ -252,43 +203,6 @@ fun SettingsScreen(
             )
             HorizontalDivider()
 
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        val activity = context.findActivity()
-                        if (hasCalendarPermission) {
-                            coroutineScope.launch {
-                                snackbarHostState.showSnackbar("Calendar birthday access is already enabled.")
-                            }
-                        } else if (activity != null &&
-                            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_CALENDAR)
-                        ) {
-                            showCalendarPermissionRationale = true
-                        } else {
-                            calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
-                        }
-                    },
-                headlineContent = { Text("Calendar birthdays") },
-                supportingContent = {
-                    Text(
-                        if (hasCalendarPermission) {
-                            "Use synced contact birthdays in date queries"
-                        } else {
-                            "Optional — enable synced contact birthdays for important date lookups"
-                        },
-                    )
-                },
-                leadingContent = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
-                trailingContent = {
-                    Text(
-                        if (hasCalendarPermission) "Allowed" else "Off",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-            )
-            HorizontalDivider()
 
             // ── App ───────────────────────────────────────────────────────────
             Spacer(modifier = Modifier.height(4.dp))
@@ -310,32 +224,6 @@ fun SettingsScreen(
             )
             HorizontalDivider()
         }
-    }
-    if (showCalendarPermissionRationale) {
-        AlertDialog(
-            onDismissRequest = { showCalendarPermissionRationale = false },
-            title = { Text("Allow calendar birthday access?") },
-            text = {
-                Text(
-                    "This lets Kernel AI read synced birthday calendar events so queries like 'how many days until Jane's birthday' work without teaching the date manually.",
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showCalendarPermissionRationale = false
-                        calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
-                    },
-                ) {
-                    Text("Continue")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showCalendarPermissionRationale = false }) {
-                    Text("Not now")
-                }
-            },
-        )
     }
 }
 
@@ -468,8 +356,3 @@ private fun HuggingFaceAccountRowNotSignedInPreview() {
 }
 
 
-private tailrec fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
-}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
@@ -69,6 +70,7 @@ fun SettingsScreen(
     onBack: () -> Unit = {},
     onNavigateToUserProfile: () -> Unit = {},
     onNavigateToMemory: () -> Unit = {},
+    onNavigateToImportantDates: () -> Unit = {},
     onNavigateToVoice: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
     onNavigateToModelManagement: (preferred: Boolean) -> Unit = {},
@@ -224,6 +226,17 @@ fun SettingsScreen(
                 headlineContent = { Text("Memory") },
                 supportingContent = { Text("Manage stored memories") },
                 leadingContent = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToImportantDates() },
+                headlineContent = { Text("Important dates") },
+                supportingContent = { Text("Browse and edit taught dates") },
+                leadingContent = { Icon(Icons.Default.Event, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -1,5 +1,11 @@
 package com.kernel.ai.feature.settings
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,6 +26,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,14 +44,21 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 
 /** Amber / HuggingFace brand colour — same as in OnboardingScreen. */
 private val HfOrange = Color(0xFFFF9D00)
@@ -64,7 +78,28 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val uriHandler = LocalUriHandler.current
-
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    var hasCalendarPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    var showCalendarPermissionRationale by remember { mutableStateOf(false) }
+    val calendarPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        hasCalendarPermission = granted
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                if (granted) {
+                    "Calendar birthday access enabled."
+                } else {
+                    "Calendar birthday access denied. You can enable it later from Settings."
+                },
+            )
+        }
+    }
     LaunchedEffect(Unit) {
         viewModel.saveError.collect { message ->
             snackbarHostState.showSnackbar(message)
@@ -204,6 +239,44 @@ fun SettingsScreen(
             )
             HorizontalDivider()
 
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        val activity = context.findActivity()
+                        if (hasCalendarPermission) {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar("Calendar birthday access is already enabled.")
+                            }
+                        } else if (activity != null &&
+                            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_CALENDAR)
+                        ) {
+                            showCalendarPermissionRationale = true
+                        } else {
+                            calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                        }
+                    },
+                headlineContent = { Text("Calendar birthdays") },
+                supportingContent = {
+                    Text(
+                        if (hasCalendarPermission) {
+                            "Use synced contact birthdays in date queries"
+                        } else {
+                            "Optional — enable synced contact birthdays for important date lookups"
+                        },
+                    )
+                },
+                leadingContent = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
+                trailingContent = {
+                    Text(
+                        if (hasCalendarPermission) "Allowed" else "Off",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+            HorizontalDivider()
+
             // ── App ───────────────────────────────────────────────────────────
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -224,6 +297,32 @@ fun SettingsScreen(
             )
             HorizontalDivider()
         }
+    }
+    if (showCalendarPermissionRationale) {
+        AlertDialog(
+            onDismissRequest = { showCalendarPermissionRationale = false },
+            title = { Text("Allow calendar birthday access?") },
+            text = {
+                Text(
+                    "This lets Kernel AI read synced birthday calendar events so queries like 'how many days until Jane's birthday' work without teaching the date manually.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCalendarPermissionRationale = false
+                        calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+                    },
+                ) {
+                    Text("Continue")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCalendarPermissionRationale = false }) {
+                    Text("Not now")
+                }
+            },
+        )
     }
 }
 
@@ -355,3 +454,9 @@ private fun HuggingFaceAccountRowNotSignedInPreview() {
     }
 }
 
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
@@ -124,6 +124,43 @@ class ImportantDatesViewModelTest {
     }
 
     @Test
+    fun `buildUiState hides calendar birthdays when taught label differs only by missing apostrophe`() {
+        val today = LocalDate.of(2026, 1, 10)
+        val taught = listOf(
+            ImportantDateListItem(
+                label = "Lachlans birthday",
+                normalizedLabel = "lachlans birthday",
+                month = 8,
+                day = 22,
+                year = null,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = LocalDate.of(2026, 8, 22),
+            ),
+        )
+        val synced = listOf(
+            ImportantDateListItem(
+                label = "Lachlan",
+                normalizedLabel = "lachlan",
+                month = 8,
+                day = 22,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = LocalDate.of(2026, 8, 22),
+            ),
+        )
+
+        val state = ImportantDatesViewModel.buildUiState(
+            taughtDates = taught,
+            calendarBirthdays = synced,
+            hasCalendarPermission = true,
+            isRefreshing = false,
+            today = today,
+        )
+
+        assertEquals(listOf("Lachlans birthday"), state.laterDates.map { it.label })
+    }
+
+    @Test
     fun `saveTaughtDate renames existing entry without keeping the old label`() = runTest {
         val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
         advanceUntilIdle()

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
@@ -1,0 +1,169 @@
+package com.kernel.ai.feature.settings
+
+import com.kernel.ai.core.memory.ImportantDateRepository
+import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.skills.natives.CalendarBirthdayLookup
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportantDatesViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: ImportantDateRepository = mockk()
+    private val calendarBirthdayLookup: CalendarBirthdayLookup = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        every { repository.observeAll() } returns flowOf(emptyList())
+        every { calendarBirthdayLookup.hasPermission() } returns false
+        every { calendarBirthdayLookup.getAllBirthdays() } returns emptyList()
+        every { calendarBirthdayLookup.invalidateCache() } returns Unit
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refreshCalendarBirthdays loads read only birthdays when permission is granted`() = runTest {
+        every { calendarBirthdayLookup.hasPermission() } returns true
+        every { calendarBirthdayLookup.getAllBirthdays() } returns listOf(
+            CalendarBirthdayLookup.BirthdayEntry(
+                label = "Jane Smith",
+                normalizedLabel = "jane smith",
+                month = 4,
+                day = 5,
+            ),
+        )
+
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        val collectionJob = launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.calendarPermissionGranted)
+        val allDates = viewModel.uiState.value.upcomingDates + viewModel.uiState.value.laterDates
+        assertEquals(listOf("Jane Smith"), allDates.map { it.label })
+        assertTrue(allDates.all { it.isReadOnly })
+        collectionJob.cancel()
+    }
+
+    @Test
+    fun `buildUiState hides calendar duplicates behind taught dates and groups later dates`() {
+        val today = LocalDate.of(2026, 1, 10)
+        val taught = listOf(
+            ImportantDateListItem(
+                label = "Mum's birthday",
+                normalizedLabel = "mum birthday",
+                month = 1,
+                day = 12,
+                year = null,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = LocalDate.of(2026, 1, 12),
+            ),
+        )
+        val synced = listOf(
+            ImportantDateListItem(
+                label = "Mum",
+                normalizedLabel = "mum birthday",
+                month = 1,
+                day = 12,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = LocalDate.of(2026, 1, 12),
+            ),
+            ImportantDateListItem(
+                label = "Dad",
+                normalizedLabel = "dad",
+                month = 2,
+                day = 1,
+                year = null,
+                source = ImportantDateSource.CALENDAR,
+                nextOccurrence = LocalDate.of(2026, 2, 1),
+            ),
+            ImportantDateListItem(
+                label = "Our anniversary",
+                normalizedLabel = "our anniversary",
+                month = 7,
+                day = 1,
+                year = 2018,
+                source = ImportantDateSource.TAUGHT,
+                nextOccurrence = LocalDate.of(2026, 7, 1),
+            ),
+        )
+
+        val state = ImportantDatesViewModel.buildUiState(
+            taughtDates = taught,
+            calendarBirthdays = synced,
+            hasCalendarPermission = true,
+            isRefreshing = false,
+            today = today,
+        )
+
+        assertEquals(listOf("Mum's birthday", "Dad"), state.upcomingDates.map { it.label })
+        assertEquals(listOf("Our anniversary"), state.laterDates.map { it.label })
+    }
+
+    @Test
+    fun `saveTaughtDate renames existing entry without keeping the old label`() = runTest {
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        advanceUntilIdle()
+        coEvery { repository.findByLabel("Parents anniversary") } returns null
+        coEvery { repository.deleteByLabel("Our anniversary") } returns 1
+        coEvery { repository.save("Parents anniversary", 6, 22, 2018) } returns Unit
+
+        val saved = viewModel.saveTaughtDate(
+            existingLabel = "Our anniversary",
+            label = "Parents anniversary",
+            month = 6,
+            day = 22,
+            year = 2018,
+        )
+
+        assertTrue(saved)
+        coVerify(exactly = 1) { repository.deleteByLabel("Our anniversary") }
+        coVerify(exactly = 1) { repository.save("Parents anniversary", 6, 22, 2018) }
+    }
+
+    @Test
+    fun `saveTaughtDate rejects conflicting rename`() = runTest {
+        val viewModel = ImportantDatesViewModel(repository, calendarBirthdayLookup)
+        advanceUntilIdle()
+        coEvery { repository.findByLabel("Mum's birthday") } returns ImportantDateEntity(
+            label = "Mum's birthday",
+            normalizedLabel = "mum birthday",
+            month = 3,
+            day = 15,
+        )
+
+        val saved = viewModel.saveTaughtDate(
+            existingLabel = "Dad's birthday",
+            label = "Mum's birthday",
+            month = 3,
+            day = 15,
+            year = null,
+        )
+
+        assertFalse(saved)
+        coVerify(exactly = 0) { repository.save(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- add Room-backed taught important dates storage, natural-language save/list/remove intents, and taught-date resolution in native date parsing
- integrate synced Android Calendar birthdays behind `READ_CALENDAR`, surfaced directly inside the Important dates screen instead of a separate Settings row
- move Important dates to the top-level drawer alongside peer management surfaces like People & Contacts, with add/edit/delete for taught dates and read-only synced birthday visibility
- resolve mapped contact birthday queries and make `since` phrasing use the most recent recurring occurrence instead of a future one

## Verification
- `./gradlew :core:memory:testDebugUnitTest --tests "*ImportantDateRepositoryTest" :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" --tests "*CalendarBirthdayLookupTest" :feature:settings:testDebugUnitTest --tests "*ImportantDatesViewModelTest" :core:memory:compileDebugKotlin :core:skills:compileDebugKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin`
- `./gradlew :feature:settings:testDebugUnitTest --tests "*ImportantDatesViewModelTest" :feature:settings:compileDebugKotlin :app:compileDebugKotlin`
- `./gradlew :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" --tests "*CalendarBirthdayLookupTest" :core:skills:compileDebugKotlin :app:compileDebugKotlin`

## Notes
- consolidates and supersedes #793, #794, and #796 so on-device QA can happen against one branch instead of three stacked branches
- taught dates take precedence over synced calendar birthdays when the normalized label overlaps
- synced birthdays come from Android Calendar events that look birthday-related: birthday calendars and birthday-style titles such as `Jane's Birthday`
- recurring `since` queries now resolve against the most recent occurrence; `until` queries still resolve against the next occurrence

## Device test matrix
### Navigation and layout
- [ ] Open the app drawer and verify `Important dates` is a top-level item near `People & Contacts`, not buried inside `Settings`.
- [ ] Open `Settings` and verify the old `Important dates` and `Calendar birthdays` rows are no longer shown there.

### Taught dates backend / conversational flow
- [ ] Open `Important dates`, add `Mum's birthday` on `15 March`, and confirm it appears in the list.
- [ ] Say `what are my important dates` and confirm the saved label/date appears.
- [ ] Say `how many days until mum's birthday` and confirm the reply resolves from the saved date.
- [ ] Say `how long since my wedding anniversary` and confirm it reports the most recent anniversary as an `ago` result, not a future date.
- [ ] Force close and reopen the app, then ask `how many days until mum's birthday` again to confirm persistence.
- [ ] Say `remove mum's birthday from my important dates` and confirm the assistant reports removal.
- [ ] Say `what are my important dates` again and verify the removed date is gone.

### Calendar birthday integration
- [ ] Open `Important dates` and verify the `Calendar birthdays` control explains that it reads birthday calendars and birthday-style titles.
- [ ] With Calendar permission not yet granted, verify the toggle is off.
- [ ] Turn on `Calendar birthdays`, grant permission, and verify synced birthdays can appear as read-only rows.
- [ ] Ask a synced birthday query such as `when is my wife's birthday` and confirm it resolves from the mapped People & Contacts alias plus calendar data.
- [ ] Turn the toggle off and verify the screen sends you to Android app permissions to disable Calendar access.
- [ ] After revoking Calendar permission, return to the app and ask the same birthday query again.
- [ ] Confirm the failure copy points back to the in-app control: `If this is a synced contact birthday, enable Calendar birthdays in Important dates first.`

### Important dates screen behavior
- [ ] Open `Important dates` when no dates are saved and verify the empty state explains manual add, AI teaching, and the in-screen calendar toggle.
- [ ] Tap `+`, add a recurring date such as `Mum's birthday` on `15 March` with the year left blank, and confirm it appears in the list.
- [ ] Tap that row, edit the label/date/year, save, and confirm the list updates instead of keeping both old and new labels.
- [ ] Delete a taught date from the screen and confirm it disappears.
- [ ] With Calendar birthdays enabled, confirm synced birthdays appear as read-only and cannot be edited or deleted.
- [ ] If a taught date and a synced birthday refer to the same normalized label, confirm only the taught date is shown.

Closes #632
Closes #633
Closes #634
