### PR TITLE
fix(#800): prevent generationMutex deadlock when updateSystemPrompt races with generateOnce

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.sync.Mutex
@@ -172,10 +174,20 @@ class LiteRtInferenceEngine @Inject constructor(
             val config = currentConfig ?: return@withContext
             val backend = _activeBackend.value ?: BackendType.CPU
 
-            safeClose(conversation, "conversation")
-            conversation = eng.createConversation(buildConversationConfig(backend, config))
-            resetConstrainedDecodingFlag()
-            _isGenerating.value = false
+            // Signal any active generation to stop so it releases generationMutex promptly.
+            if (_isGenerating.value) {
+                Log.d(TAG, "resetConversation: signalling cancellation to active generation")
+                conversation?.cancelProcess()
+            }
+
+            // Wait for generationMutex so we don't close the conversation while
+            // generate() or generateOnce() is suspended mid-flight using it.
+            generationMutex.withLock {
+                safeClose(conversation, "conversation")
+                conversation = eng.createConversation(buildConversationConfig(backend, config))
+                resetConstrainedDecodingFlag()
+                _isGenerating.value = false
+            }
         }
     }
 
@@ -186,11 +198,24 @@ class LiteRtInferenceEngine @Inject constructor(
             val backend = _activeBackend.value ?: BackendType.CPU
 
             currentConfig = config.copy(systemPrompt = systemPrompt)
-            safeClose(conversation, "conversation")
-            conversation = eng.createConversation(buildConversationConfig(backend, currentConfig!!))
-            resetConstrainedDecodingFlag()
-            _isGenerating.value = false
-            Log.i(TAG, "System prompt updated and conversation reset")
+
+            // Signal any active generation to stop so it releases generationMutex promptly.
+            if (_isGenerating.value) {
+                Log.d(TAG, "updateSystemPrompt: signalling cancellation to active generation")
+                conversation?.cancelProcess()
+            }
+
+            // Wait for generationMutex so we don't close the conversation while
+            // generate() or generateOnce() is suspended mid-flight using it.
+            // withLock suspends the coroutine (not the dispatcher thread), so the
+            // LlmDispatcher remains available to run the active generation's awaitClose.
+            generationMutex.withLock {
+                safeClose(conversation, "conversation")
+                conversation = eng.createConversation(buildConversationConfig(backend, currentConfig!!))
+                resetConstrainedDecodingFlag()
+                _isGenerating.value = false
+                Log.i(TAG, "System prompt updated and conversation reset")
+            }
         }
     }
 
@@ -312,7 +337,9 @@ class LiteRtInferenceEngine @Inject constructor(
         awaitClose {
             _isGenerating.value = false
             InferenceGenerationService.stop(context)
-            conv.cancelProcess()
+            try { conv.cancelProcess() } catch (e: Exception) {
+                Log.w(TAG, "cancelProcess failed in awaitClose — ignoring", e)
+            }
             generationMutex.unlock()
         }
     }.flowOn(LlmDispatcher)
@@ -368,8 +395,13 @@ class LiteRtInferenceEngine @Inject constructor(
                     }
                 },
             )
-            latch.await()
-            sb.toString()
+            try {
+                withTimeout(30_000) { latch.await() }
+                sb.toString()
+            } catch (e: TimeoutCancellationException) {
+                Log.w(TAG, "generateOnce: timed out after 30s waiting for generation — returning empty")
+                ""
+            }
         } finally {
             generationMutex.unlock()
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1665,6 +1665,7 @@ class ChatViewModel @Inject constructor(
             } while (needsHallucinationRetry)
 
             } catch (e: Exception) {
+                Log.e("KernelAI", "Inference exception in sendMessage — generation failed", e)
                 _voiceMode.value = null
                 pendingVoiceReply = false
                 _voiceCaptureState.value = VoiceCaptureState.Idle


### PR DESCRIPTION
## Summary

Fixes a permanent `generationMutex` deadlock that caused inference to produce zero tokens after startup, showing "Sorry, generation was cancelled." for every user message.

## Root Cause

At startup, 3 `updateSystemPrompt()` calls run on the `LlmDispatcher`. One of them races with `generateOnce()` (episodic distillation). `generateOnce()` acquires `generationMutex` via `tryLock()`, calls `conv.sendMessageAsync()`, then **suspends** on `latch.await()` — releasing the dispatcher thread. `updateSystemPrompt()` runs on the now-free thread and calls `safeClose(conversation)` **without holding the mutex**, destroying the conversation object mid-flight. LiteRT's native runtime silently drops callbacks for a closed conversation → `latch.await()` never completes → `generationMutex` is permanently locked. All subsequent user messages block on `generationMutex.lock()` indefinitely.

Because `generationMutex` lives on the `LiteRtInferenceEngine` singleton, even a full re-init (e.g. after `onTrimMemory`) doesn't release it — every session after the first deadlock also fails.

## Changes

### `LiteRtInferenceEngine.kt`
- **`updateSystemPrompt()`**: signal cancellation if generating, then acquire `generationMutex` via `withLock {}` before `safeClose`/`createConversation`. `withLock` suspends the coroutine (not the thread) so the active generation's `awaitClose` can still run to release the mutex.
- **`resetConversation()`**: same pattern applied for consistency.
- **`generate()` `awaitClose {}`**: wrap `conv.cancelProcess()` in `try/catch` so `generationMutex.unlock()` always runs even if the native cancel throws.
- **`generateOnce()` `latch.await()`**: add `withTimeout(30_000)` guard — a missed callback can no longer permanently lock the mutex; logs a warning and returns `""`.

### `ChatViewModel.kt`
- Add `Log.e` to the inference exception catch block so failures are visible in `adb logcat -s KernelAI` instead of silently showing the fallback message.

## Testing

- [x] `./gradlew :core:inference:testDebugUnitTest` — BUILD SUCCESSFUL (21 tests, 0 failures)
- [x] `./gradlew :feature:chat:testDebugUnitTest` — 295 tests, 3 pre-existing failures (LatexConversionTest nested fractions, 2× ChatViewModelVoiceTest) — no regressions introduced
- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [ ] Device smoke test on S23 Ultra — verify inference works across multiple conversations after startup

## Related issues

Closes #800
