### PR TITLE
docs: update roadmap after important dates merge

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -206,12 +206,12 @@ Active follow-on model/runtime investigations now live under
 | [#258](https://github.com/NickMonrad/kernel-ai-assistant/issues/258) | Maps & location — navigate, open, nearby search | ⬜ Pending | 🟡 Medium |
 | [#327](https://github.com/NickMonrad/kernel-ai-assistant/issues/327) | Full date-specific alarms via `AlarmManager.setExact()` | ⬜ Pending | 🟢 Low |
 | [#407](https://github.com/NickMonrad/kernel-ai-assistant/issues/407) | WebSearchSkill — LLM tool calling via Brave/Tavily API | ⬜ Pending | 🟡 Medium |
-| [#631](https://github.com/NickMonrad/kernel-ai-assistant/issues/631) | Important dates — taught dates + calendar birthday integration | ⬜ Pending | 🟡 Medium |
+| [#631](https://github.com/NickMonrad/kernel-ai-assistant/issues/631) | Important dates — taught dates + calendar birthday integration | ✅ Done — PR #797 | 🟡 Medium |
 | [#638](https://github.com/NickMonrad/kernel-ai-assistant/issues/638) | Messaging-app intents (WhatsApp, Signal, Telegram, etc.) | ⬜ Pending | 🟡 Medium |
 | [#658](https://github.com/NickMonrad/kernel-ai-assistant/issues/658) | Deterministic arithmetic / calculator tool | ⬜ Pending | 🔴 High |
 | [#662](https://github.com/NickMonrad/kernel-ai-assistant/issues/662) | Lists management upgrades (rename, pin, sort, edit items, favorites, due dates) | ⬜ Pending | 🟡 Medium |
 | [#676](https://github.com/NickMonrad/kernel-ai-assistant/issues/676) | Native unit conversion tool | ⬜ Pending | 🟡 Medium |
-| [#677](https://github.com/NickMonrad/kernel-ai-assistant/issues/677) | World clock and timezone lookup | ⬜ Pending | 🟢 Low |
+| [#677](https://github.com/NickMonrad/kernel-ai-assistant/issues/677) | World clock and timezone lookup | ✅ Done — PR #743 | 🟢 Low |
 | [#697](https://github.com/NickMonrad/kernel-ai-assistant/issues/697) | Multi-day weather forecast card in chat | ✅ Done — PR #710 | 🟡 Medium |
 
 **Already completed skills:**


### PR DESCRIPTION
## Summary
- mark `#631` as done after merged PR #797
- mark `#677` as done after merged PR #743

## Notes
- issue `#631` has been closed separately now that the merged replacement PR landed and passed on-device validation
- stacked PRs `#793`, `#794`, and `#796` were already closed as superseded by `#797`
