### PR TITLE
feat: add deterministic arithmetic intent

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2325,6 +2325,26 @@ class QuickIntentRouter(
             paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim()) },
         ),
 
+        // ── Calculator ──
+        // Symbolic expressions and helper functions: "245 * 17", "what is round(sqrt(25^2), 2)"
+        IntentPattern(
+            intentName = "calculate_arithmetic",
+            regex = Regex(
+                """^(?:(?:what(?:'s|\s+is)|calculate|compute|evaluate)\s+)?((?=.*(?:[+*/^%()]|\b(?:sqrt|abs|floor|ceil|round)\b))(?:(?:sqrt|abs|floor|ceil|round)|[-+*/%^().,\d\s])+)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("expression" to match.groupValues[1].trim()) },
+        ),
+        // Worded calculator phrases: "what is 18.5 percent of 240", "12 divided by 3", "5 plus 7"
+        IntentPattern(
+            intentName = "calculate_arithmetic",
+            regex = Regex(
+                """^(?:(?:what(?:'s|\s+is)|calculate|compute|evaluate)\s+)?((?:-?\d+(?:\.\d+)?\s*(?:%|percent)\s+of\s+-?\d+(?:\.\d+)?|-?\d+(?:\.\d+)?(?:\s+(?:plus|minus|times|multiplied\s+by|divided\s+by|over|mod(?:ulo)?|to\s+the\s+power\s+of|raised\s+to)\s+-?\d+(?:\.\d+)?)+))$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("expression" to match.groupValues[1].trim()) },
+        ),
+
         // ── Lists ──
         // "add milk to my list" / "put eggs on the list" (item present, list missing) → ask which list
         IntentPattern(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -102,6 +102,8 @@ class RunIntentSkill @Inject constructor(
         "Save important date → runIntent(intentName=\"save_important_date\", parameters='{\"label\":\"mum's birthday\",\"date\":\"15 March\"}')",
         "List important dates → runIntent(intentName=\"list_important_dates\", parameters='{}')",
         "Remove important date → runIntent(intentName=\"remove_important_date\", parameters='{\"label\":\"mum's birthday\"}')",
+        "Calculator → runIntent(intentName=\"calculate_arithmetic\", parameters='{\"expression\":\"18.5% of 240\"}')",
+        "Math helpers → runIntent(intentName=\"calculate_arithmetic\", parameters='{\"expression\":\"round(sqrt((25^2)) + abs(-2.6) + (10 % 3), 2)\"}')",
         // System toggles
         "Turn on DND → runIntent(intentName=\"toggle_dnd_on\", parameters=\"{}\")",
         "Enable Wi-Fi → runIntent(intentName=\"toggle_wifi\", parameters='{\"state\":\"on\"}')",
@@ -146,6 +148,9 @@ class RunIntentSkill @Inject constructor(
         appendLine("  save_important_date — params: label, date (e.g. \"15 March\" or \"22 June 2018\")")
         appendLine("  list_important_dates — no params")
         appendLine("  remove_important_date — params: label")
+        appendLine()
+        appendLine("CALCULATOR:")
+        appendLine("  calculate_arithmetic — params: expression (calculator expression or simple arithmetic phrase)")
         appendLine()
         appendLine("SYSTEM TOGGLES:")
         appendLine("  toggle_dnd_on, toggle_dnd_off — No params")
@@ -206,6 +211,11 @@ class RunIntentSkill @Inject constructor(
         appendLine()
         appendLine("Volume rule: 'set volume to 50%', 'volume 7' → runIntent with intentName=set_volume.")
         appendLine("If user says percentage (0-100), set is_percent=\"true\". If 1-10, set is_percent=\"false\".")
+        appendLine()
+        appendLine("Calculator rule: for arithmetic or calculator-style questions, ALWAYS call")
+        appendLine("runIntent with intentName=calculate_arithmetic instead of doing the math yourself.")
+        appendLine("Pass the math in expression exactly as symbols when already present (e.g. '245 * 17'),")
+        appendLine("or as a simple phrase the evaluator understands (e.g. '18.5% of 240').")
         appendLine()
         appendLine("Media rule: For music playback, use play_media with query (song name) and artist.")
         appendLine("For albums, use play_media_album. For playlists, use play_media_playlist.")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/ArithmeticExpressionEvaluator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/ArithmeticExpressionEvaluator.kt
@@ -1,0 +1,297 @@
+package com.kernel.ai.core.skills.natives
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+import java.util.Locale
+
+internal object ArithmeticExpressionEvaluator {
+    private const val MAX_INPUT_LENGTH = 256
+    private const val APPROXIMATE_SCALE = 16
+    private const val MAX_ROUND_SCALE = 16
+    private const val MAX_EXPONENT = 1000
+    private val SQRT_CONTEXT = MathContext.DECIMAL128
+
+    data class Result(
+        val value: BigDecimal,
+        val isApproximate: Boolean,
+    )
+
+    fun evaluate(rawInput: String): Result {
+        val normalized = normalizeInput(rawInput)
+        require(normalized.isNotBlank()) { "No expression provided" }
+        require(normalized.length <= MAX_INPUT_LENGTH) { "Expression is too long" }
+
+        val parser = Parser(normalized)
+        val value = parser.parseExpression()
+        parser.skipWhitespace()
+        require(parser.isAtEnd()) { "Unexpected token near '${parser.remainingInput()}'" }
+
+        return Result(value.number.normalizeForOutput(), isApproximate = !value.exact)
+    }
+
+    private fun normalizeInput(rawInput: String): String {
+        var normalized = rawInput.trim()
+            .replace(Regex("""[?!.]+$"""), "")
+            .replace('×', '*')
+            .replace('÷', '/')
+            .trim()
+
+        normalized = normalized.replace(
+            Regex("""^(?:what(?:'s|\s+is)|calculate|compute|evaluate)\s+""", RegexOption.IGNORE_CASE),
+            "",
+        )
+
+        normalized = Regex(
+            """(-?\d+(?:\.\d+)?)\s*(?:%|percent)\s+of\s+(-?\d+(?:\.\d+)?)""",
+            RegexOption.IGNORE_CASE,
+        ).replace(normalized) { match ->
+            "(${match.groupValues[1]} / 100) * ${match.groupValues[2]}"
+        }
+
+        normalized = normalized
+            .replace(Regex("""\bto\s+the\s+power\s+of\b""", RegexOption.IGNORE_CASE), "^")
+            .replace(Regex("""\braised\s+to\b""", RegexOption.IGNORE_CASE), "^")
+            .replace(Regex("""\bmultiplied\s+by\b""", RegexOption.IGNORE_CASE), "*")
+            .replace(Regex("""\bdivided\s+by\b""", RegexOption.IGNORE_CASE), "/")
+            .replace(Regex("""\bmodulo\b|\bmod\b""", RegexOption.IGNORE_CASE), "%")
+            .replace(Regex("""\bplus\b""", RegexOption.IGNORE_CASE), "+")
+            .replace(Regex("""\bminus\b""", RegexOption.IGNORE_CASE), "-")
+            .replace(Regex("""\btimes\b""", RegexOption.IGNORE_CASE), "*")
+            .replace(Regex("""\bover\b""", RegexOption.IGNORE_CASE), "/")
+
+        normalized = Regex("""(-?\d+(?:\.\d+)?)%(?!\s*\d)""").replace(normalized) { match ->
+            "(${match.groupValues[1]} / 100)"
+        }
+
+        return normalized.replace(Regex("""\s+"""), " ").trim()
+    }
+
+    private data class EvaluatedNumber(
+        val number: BigDecimal,
+        val exact: Boolean,
+    )
+
+    private class Parser(private val input: String) {
+        private var index: Int = 0
+
+        fun parseExpression(): EvaluatedNumber = parseAdditive()
+
+        fun skipWhitespace() {
+            while (!isAtEnd() && input[index].isWhitespace()) index += 1
+        }
+
+        fun isAtEnd(): Boolean = index >= input.length
+
+        fun remainingInput(): String = input.substring(index).take(16)
+
+        private fun parseAdditive(): EvaluatedNumber {
+            var value = parseMultiplicative()
+            while (true) {
+                skipWhitespace()
+                value = when {
+                    consume('+') -> combine(value, parseMultiplicative()) { left, right ->
+                        EvaluatedNumber(left.number.add(right.number), left.exact && right.exact)
+                    }
+                    consume('-') -> combine(value, parseMultiplicative()) { left, right ->
+                        EvaluatedNumber(left.number.subtract(right.number), left.exact && right.exact)
+                    }
+                    else -> return value
+                }
+            }
+        }
+
+        private fun parseMultiplicative(): EvaluatedNumber {
+            var value = parsePower()
+            while (true) {
+                skipWhitespace()
+                value = when {
+                    consume('*') -> combine(value, parsePower()) { left, right ->
+                        EvaluatedNumber(left.number.multiply(right.number), left.exact && right.exact)
+                    }
+                    consume('/') -> divide(value, parsePower())
+                    consume('%') -> remainder(value, parsePower())
+                    else -> return value
+                }
+            }
+        }
+
+        private fun parsePower(): EvaluatedNumber {
+            var value = parseUnary()
+            skipWhitespace()
+            if (consume('^')) {
+                value = power(value, parsePower())
+            }
+            return value
+        }
+
+        private fun parseUnary(): EvaluatedNumber {
+            skipWhitespace()
+            return when {
+                consume('+') -> parseUnary()
+                consume('-') -> {
+                    val nested = parseUnary()
+                    EvaluatedNumber(nested.number.negate(), nested.exact)
+                }
+                else -> parsePrimary()
+            }
+        }
+
+        private fun parsePrimary(): EvaluatedNumber {
+            skipWhitespace()
+            require(!isAtEnd()) { "Unexpected end of expression" }
+
+            return when {
+                consume('(') -> {
+                    val value = parseExpression()
+                    skipWhitespace()
+                    require(consume(')')) { "Missing closing ')'" }
+                    value
+                }
+                currentChar().isDigit() || currentChar() == '.' -> parseNumber()
+                currentChar().isLetter() -> parseFunctionCall()
+                else -> throw IllegalArgumentException("Unexpected token '${currentChar()}'")
+            }
+        }
+
+        private fun parseNumber(): EvaluatedNumber {
+            val start = index
+            var seenDot = false
+            while (!isAtEnd()) {
+                val c = input[index]
+                when {
+                    c.isDigit() -> index += 1
+                    c == '.' && !seenDot -> {
+                        seenDot = true
+                        index += 1
+                    }
+                    else -> break
+                }
+            }
+            val token = input.substring(start, index)
+            require(token.any(Char::isDigit)) { "Invalid number '$token'" }
+            return EvaluatedNumber(BigDecimal(token), exact = true)
+        }
+
+        private fun parseFunctionCall(): EvaluatedNumber {
+            val name = parseIdentifier().lowercase(Locale.ENGLISH)
+            skipWhitespace()
+            require(consume('(')) { "Expected '(' after $name" }
+
+            val arguments = mutableListOf<EvaluatedNumber>()
+            skipWhitespace()
+            if (!consume(')')) {
+                do {
+                    arguments += parseExpression()
+                    skipWhitespace()
+                } while (consume(','))
+                require(consume(')')) { "Missing closing ')' after $name arguments" }
+            }
+
+            return applyFunction(name, arguments)
+        }
+
+        private fun applyFunction(name: String, arguments: List<EvaluatedNumber>): EvaluatedNumber = when (name) {
+            "abs" -> {
+                require(arguments.size == 1) { "abs() takes exactly 1 argument" }
+                EvaluatedNumber(arguments[0].number.abs(), arguments[0].exact)
+            }
+            "floor" -> {
+                require(arguments.size == 1) { "floor() takes exactly 1 argument" }
+                EvaluatedNumber(arguments[0].number.setScale(0, RoundingMode.FLOOR), arguments[0].exact)
+            }
+            "ceil" -> {
+                require(arguments.size == 1) { "ceil() takes exactly 1 argument" }
+                EvaluatedNumber(arguments[0].number.setScale(0, RoundingMode.CEILING), arguments[0].exact)
+            }
+            "round" -> round(arguments)
+            "sqrt" -> sqrt(arguments)
+            else -> throw IllegalArgumentException("Unsupported function '$name'")
+        }
+
+        private fun round(arguments: List<EvaluatedNumber>): EvaluatedNumber {
+            require(arguments.size in 1..2) { "round() takes 1 or 2 arguments" }
+            val scale = if (arguments.size == 2) {
+                try {
+                    arguments[1].number.intValueExact()
+                } catch (_: ArithmeticException) {
+                    throw IllegalArgumentException("round() scale must be a whole number")
+                }
+            } else {
+                0
+            }
+            require(scale in 0..MAX_ROUND_SCALE) { "round() scale must be between 0 and $MAX_ROUND_SCALE" }
+            return EvaluatedNumber(arguments[0].number.setScale(scale, RoundingMode.HALF_UP), arguments.all { it.exact })
+        }
+
+        private fun sqrt(arguments: List<EvaluatedNumber>): EvaluatedNumber {
+            require(arguments.size == 1) { "sqrt() takes exactly 1 argument" }
+            val value = arguments[0].number
+            require(value.signum() >= 0) { "sqrt() is undefined for negative numbers" }
+            val result = value.sqrt(SQRT_CONTEXT)
+            val exact = arguments[0].exact && result.multiply(result).compareTo(value) == 0
+            return EvaluatedNumber(result, exact)
+        }
+
+        private fun power(left: EvaluatedNumber, right: EvaluatedNumber): EvaluatedNumber {
+            val exponent = try {
+                right.number.intValueExact()
+            } catch (_: ArithmeticException) {
+                throw IllegalArgumentException("Exponent must be a whole number")
+            }
+            require(kotlin.math.abs(exponent) <= MAX_EXPONENT) { "Exponent is too large" }
+
+            return if (exponent >= 0) {
+                EvaluatedNumber(left.number.pow(exponent), left.exact && right.exact)
+            } else {
+                divide(
+                    EvaluatedNumber(BigDecimal.ONE, exact = true),
+                    EvaluatedNumber(left.number.pow(-exponent), exact = left.exact && right.exact),
+                )
+            }
+        }
+
+        private fun divide(left: EvaluatedNumber, right: EvaluatedNumber): EvaluatedNumber {
+            require(right.number.compareTo(BigDecimal.ZERO) != 0) { "Division by zero is undefined" }
+            return try {
+                EvaluatedNumber(left.number.divide(right.number), left.exact && right.exact)
+            } catch (_: ArithmeticException) {
+                EvaluatedNumber(
+                    left.number.divide(right.number, APPROXIMATE_SCALE, RoundingMode.HALF_UP),
+                    exact = false,
+                )
+            }
+        }
+
+        private fun remainder(left: EvaluatedNumber, right: EvaluatedNumber): EvaluatedNumber {
+            require(right.number.compareTo(BigDecimal.ZERO) != 0) { "Modulo by zero is undefined" }
+            return EvaluatedNumber(left.number.remainder(right.number), left.exact && right.exact)
+        }
+
+        private fun parseIdentifier(): String {
+            val start = index
+            while (!isAtEnd() && input[index].isLetter()) index += 1
+            return input.substring(start, index)
+        }
+
+        private fun currentChar(): Char = input[index]
+
+        private fun consume(expected: Char): Boolean {
+            skipWhitespace()
+            if (!isAtEnd() && input[index] == expected) {
+                index += 1
+                return true
+            }
+            return false
+        }
+
+        private inline fun combine(
+            left: EvaluatedNumber,
+            right: EvaluatedNumber,
+            op: (EvaluatedNumber, EvaluatedNumber) -> EvaluatedNumber,
+        ): EvaluatedNumber = op(left, right)
+    }
+
+    private fun BigDecimal.normalizeForOutput(): BigDecimal =
+        if (compareTo(BigDecimal.ZERO) == 0) BigDecimal.ZERO else stripTrailingZeros()
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -110,6 +110,7 @@ interface ClockAlertController {
  *   get_weather             — Opens Google search for weather (params: location?)
  *   get_system_info         — Returns storage and RAM info — returns DirectReply
  *   get_date_diff           — Native date arithmetic: days/weeks until or since a date (params: target_date, from_date?) — returns DirectReply
+ *   calculate_arithmetic    — Deterministic arithmetic/calculator evaluator (params: expression) — returns DirectReply
  *   save_important_date     — Stores a taught recurring personal date (params: label, date) — returns DirectReply
  *   list_important_dates    — Lists taught recurring personal dates — returns DirectReply
  *   remove_important_date   — Deletes a taught recurring personal date (params: label) — returns DirectReply
@@ -193,6 +194,7 @@ class NativeIntentHandler @Inject constructor(
                 "smart_home_off" -> handleSmartHome(params["device"] ?: "device", false)
                 "get_weather" -> getWeather(params)
                 "get_date_diff" -> getDateDiff(params)
+                "calculate_arithmetic" -> calculateArithmetic(params)
                 "get_system_info" -> getSystemInfo()
                 "save_important_date" -> saveImportantDate(params)
                 "list_important_dates" -> listImportantDates()
@@ -250,7 +252,7 @@ class NativeIntentHandler @Inject constructor(
             "open_app", "navigate_to", "find_nearby",
             "add_to_list", "bulk_add_to_list", "create_list", "get_list_items", "remove_from_list",
             "smart_home_on", "smart_home_off",
-            "get_weather", "get_date_diff", "get_system_info",
+            "get_weather", "get_date_diff", "get_system_info", "calculate_arithmetic",
             "save_important_date", "list_important_dates", "remove_important_date",
             "save_memory", 
         )
@@ -1959,6 +1961,23 @@ class NativeIntentHandler @Inject constructor(
                 breakdownText = breakdownText,
             ),
         )
+    }
+
+    private fun calculateArithmetic(params: Map<String, String>): SkillResult {
+        val expression = params["expression"]?.trim()?.takeIf { it.isNotBlank() }
+            ?: return SkillResult.Failure("calculate_arithmetic", "No expression provided")
+
+        return try {
+            val result = ArithmeticExpressionEvaluator.evaluate(expression)
+            val content = if (result.isApproximate) {
+                "The result is approximately ${result.value.toPlainString()}."
+            } else {
+                "The result is ${result.value.toPlainString()}."
+            }
+            SkillResult.DirectReply(content)
+        } catch (e: IllegalArgumentException) {
+            SkillResult.Failure("calculate_arithmetic", e.message ?: "Could not evaluate expression")
+        }
     }
 
     private fun buildListPreview(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -758,6 +758,20 @@ class QuickIntentRouterTest {
         assertEquals("Easter", intent.params["target_date"])
     }
 
+    @Nested
+    @DisplayName("Calculator")
+    inner class Calculator {
+        @ParameterizedTest(name = "Regex: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#calculatorRegexPhrases")
+        fun `should match calculator phrases with expression param`(input: String, expectedExpression: String) {
+            val result = regexOnlyRouter.route(input)
+            assertRegexMatch(result, "calculate_arithmetic", input)
+
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals(expectedExpression, intent.params["expression"])
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // E4B FALLTHROUGH — these should NEVER match Tier 2
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1740,6 +1754,7 @@ class QuickIntentRouterTest {
         addCases(batteryRegexPhrases(), "get_battery", "Battery (regex)")
         addCases(batteryClassifierPhrases(), "get_battery", "Battery (classifier)")
         addCases(dateDiffRegexPhrases(), "get_date_diff", "Date Diff (regex)")
+        addCases(calculatorRegexPhrases(), "calculate_arithmetic", "Calculator (regex)")
         addCases(timeRegexPhrases(), "get_time", "Time (regex)")
         addCases(timeClassifierPhrases(), "get_time", "Time (classifier)")
         addCases(volumeRegexPhrases(), "set_volume", "Volume (regex)")
@@ -2132,6 +2147,14 @@ class QuickIntentRouterTest {
             Arguments.of("when is Easter"),
             Arguments.of("how many days until 2026-08-22"),
             Arguments.of("how long until August 22 2026"),
+        )
+
+        @JvmStatic
+        fun calculatorRegexPhrases(): Stream<Arguments> = Stream.of(
+            Arguments.of("245 * 17", "245 * 17"),
+            Arguments.of("what is 18.5% of 240", "18.5% of 240"),
+            Arguments.of("12 divided by 3", "12 divided by 3"),
+            Arguments.of("calculate round(sqrt((25^2)) + abs(-2.6) + (10 % 3), 2)", "round(sqrt((25^2)) + abs(-2.6) + (10 % 3), 2)"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/ArithmeticExpressionEvaluatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/ArithmeticExpressionEvaluatorTest.kt
@@ -1,0 +1,67 @@
+package com.kernel.ai.core.skills.natives
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ArithmeticExpressionEvaluatorTest {
+    @Test
+    fun `evaluate respects operator precedence`() {
+        val result = ArithmeticExpressionEvaluator.evaluate("2 + 3 * 4")
+
+        assertEquals("14", result.value.toPlainString())
+        assertFalse(result.isApproximate)
+    }
+
+    @Test
+    fun `evaluate normalizes percent of phrases`() {
+        val result = ArithmeticExpressionEvaluator.evaluate("what is 18.5% of 240")
+
+        assertEquals("44.4", result.value.toPlainString())
+        assertFalse(result.isApproximate)
+    }
+
+    @Test
+    fun `evaluate supports helper functions and modulo`() {
+        val result = ArithmeticExpressionEvaluator.evaluate("round(sqrt((25^2)) + abs(-2.6) + (10 % 3), 2)")
+
+        assertEquals("28.6", result.value.toPlainString())
+        assertFalse(result.isApproximate)
+    }
+
+    @Test
+    fun `evaluate marks non terminating division as approximate`() {
+        val result = ArithmeticExpressionEvaluator.evaluate("1 / 3")
+
+        assertEquals("0.3333333333333333", result.value.toPlainString())
+        assertTrue(result.isApproximate)
+    }
+
+    @Test
+    fun `evaluate supports apostrophe free percentage suffixes`() {
+        val result = ArithmeticExpressionEvaluator.evaluate("200 * 10%")
+
+        assertEquals("20", result.value.toPlainString())
+        assertFalse(result.isApproximate)
+    }
+
+    @Test
+    fun `evaluate rejects malformed expressions cleanly`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            ArithmeticExpressionEvaluator.evaluate("2 + )")
+        }
+
+        assertTrue(error.message!!.contains("Unexpected token") || error.message!!.contains("Missing"))
+    }
+
+    @Test
+    fun `evaluate rejects division by zero`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            ArithmeticExpressionEvaluator.evaluate("10 / 0")
+        }
+
+        assertEquals("Division by zero is undefined", error.message)
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1046,6 +1046,29 @@ class NativeIntentHandlerTest {
         assertTrue(content.contains(expected.format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy", Locale.ENGLISH))), content)
     }
 
+    @Test
+    fun `calculate_arithmetic returns deterministic direct reply`() {
+        val result = handler.handle(
+            "calculate_arithmetic",
+            mapOf("expression" to "18.5% of 240"),
+        )
+
+        assertEquals(SkillResult.DirectReply("The result is 44.4."), result)
+    }
+
+    @Test
+    fun `calculate_arithmetic reports malformed expressions cleanly`() {
+        val result = handler.handle(
+            "calculate_arithmetic",
+            mapOf("expression" to "2 + )"),
+        )
+
+        assertEquals(
+            SkillResult.Failure("calculate_arithmetic", "Unexpected token ')'"),
+            result,
+        )
+    }
+
 
     private data class PhoneRow(
         val contactId: String,


### PR DESCRIPTION
## Summary
- add a BigDecimal-backed native arithmetic evaluator with operator precedence, unary minus, parentheses, `%`, `^`, and helper functions `sqrt`, `abs`, `floor`, `ceil`, and `round`
- add a new `calculate_arithmetic` native intent, quick-intent regex coverage for obvious calculator queries, and RunIntentSkill instructions so arithmetic routes to the tool instead of being done in-model
- report approximate results truthfully for non-terminating decimal operations like `1 / 3`, and fail cleanly for malformed expressions or divide-by-zero

## Verification
- `./gradlew :core:skills:testDebugUnitTest --tests "*ArithmeticExpressionEvaluatorTest" --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" :core:skills:compileDebugKotlin :app:compileDebugKotlin`

## Device test matrix
- [ ] Ask `what is 245 * 17` and confirm the app answers with the exact deterministic result instead of a model-generated guess.
- [ ] Ask `what is 18.5% of 240` and confirm it routes through the arithmetic intent and returns `44.4`.
- [ ] Ask `12 divided by 3` and confirm the result is `4`.
- [ ] Ask a helper-function expression such as `calculate round(sqrt((25^2)) + abs(-2.6) + (10 % 3), 2)` and confirm the result is `28.6`.
- [ ] Ask `what is 1 / 3` and confirm the reply is marked approximate rather than presented as exact.
- [ ] Ask a malformed query like `calculate 2 + )` and confirm the failure is clean and non-crashing.
- [ ] Ask `what is 10 / 0` and confirm the failure says division by zero is undefined.

Closes #658
