### PR TITLE
feat(#788,#781): voice expressiveness chips + Semaine emotion skill

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -80,6 +80,7 @@ private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
 private const val ARG_MINIMAL_CONTEXT = "minimalContext"
 private const val ARG_START_VOICE = "startVoice"
+private const val ARG_FROM_VOICE = "fromVoice"
 private const val STATE_OPEN_SHEET_CONSUMED = "openSheetConsumed"
 private const val STATE_START_VOICE_CONSUMED = "startVoiceConsumed"
 
@@ -304,10 +305,10 @@ fun KernelNavHost(
                                 backStackEntry.savedStateHandle[STATE_START_VOICE_CONSUMED] = true
                                 backStackEntry.arguments?.putBoolean(ARG_START_VOICE, false)
                             },
-                            onNavigateToChat = { query ->
+                            onNavigateToChat = { query, fromVoice ->
                                 val encoded = Uri.encode(query)
                                 navController.navigate(
-                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true"
+                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true&$ARG_FROM_VOICE=$fromVoice"
                                 )
                             },
                             onNewConversation = {
@@ -321,7 +322,7 @@ fun KernelNavHost(
                 }
 
                 composable(
-                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}",
+                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}&$ARG_FROM_VOICE={$ARG_FROM_VOICE}",
                     arguments = listOf(
                         navArgument(ARG_INITIAL_QUERY) {
                             type = NavType.StringType
@@ -332,13 +333,19 @@ fun KernelNavHost(
                             type = NavType.BoolType
                             defaultValue = false
                         },
+                        navArgument(ARG_FROM_VOICE) {
+                            type = NavType.BoolType
+                            defaultValue = false
+                        },
                     ),
                 ) { backStackEntry ->
                     val initialQuery = backStackEntry.arguments?.getString(ARG_INITIAL_QUERY)
                         ?.takeIf { it.isNotBlank() }
+                    val fromVoice = backStackEntry.arguments?.getBoolean(ARG_FROM_VOICE) ?: false
                     ChatScreen(
                         conversationId = null,
                         initialQuery = initialQuery,
+                        fromVoice = fromVoice,
                         onBack = { navController.popBackStack() },
                         onNewConversation = {
                             navController.navigate(ROUTE_CHAT) {

--- a/core/skills/build.gradle.kts
+++ b/core/skills/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 dependencies {
     implementation(project(":core:inference"))
     implementation(project(":core:memory"))
+    implementation(project(":core:voice"))
 
     // LiteRT-LM — needed for ToolSet, @Tool, @ToolParam annotations on KernelAIToolSet
     implementation(libs.litertlm.android)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/Skill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/Skill.kt
@@ -39,5 +39,13 @@ interface Skill {
             }
         }
 
+    /**
+     * Whether this skill should be included in the system prompt skill listing.
+     * Override to return false when a skill is only relevant in certain contexts
+     * (e.g. [SetVoiceEmotionSkill] is only useful when Semaine voice is active).
+     * Defaults to true — all skills enabled.
+     */
+    fun isEnabled(): Boolean = true
+
     suspend fun execute(call: SkillCall): SkillResult
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillRegistry.kt
@@ -29,6 +29,7 @@ class SkillRegistry @Inject constructor(
         if (registry.isEmpty()) return ""
         val others = registry.values
             .filter { it.name !in HIDDEN_FROM_PUBLIC_SKILL_LIST }
+            .filter { it.isEnabled() }
             .sortedBy { it.name }
 
         return buildString {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -7,6 +7,7 @@ import com.kernel.ai.core.skills.natives.GetWeatherSkill
 import com.kernel.ai.core.skills.natives.GetWeatherUnifiedSkill
 import com.kernel.ai.core.skills.natives.SaveMemorySkill
 import com.kernel.ai.core.skills.natives.SearchMemorySkill
+import com.kernel.ai.core.skills.natives.SetVoiceEmotionSkill
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -58,6 +59,10 @@ abstract class SkillsModule {
     @Binds
     @IntoSet
     abstract fun bindMealPlannerSkill(skill: MealPlannerSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindSetVoiceEmotionSkill(skill: SetVoiceEmotionSkill): Skill
 
     /** Bind MiniLMIntentClassifier as the IntentClassifier for QuickIntentRouter. */
     @Binds

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
@@ -1,0 +1,79 @@
+package com.kernel.ai.core.skills.natives
+
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillParameter
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.voice.SherpaPiperVoice
+import com.kernel.ai.core.voice.SherpaOnnxVoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+@Singleton
+class SetVoiceEmotionSkill @Inject constructor(
+    private val voiceController: SherpaOnnxVoiceOutputController,
+    private val voiceOutputPreferences: VoiceOutputPreferences,
+) : Skill {
+    override val name = "set_voice_emotion"
+    override val description =
+        "Sets the emotional tone of the spoken voice for the current reply. " +
+            "Only effective when the Semaine voice is selected. " +
+            "Use sparingly — match the user's emotional context. " +
+            "Do NOT use with other voices."
+    override val schema = SkillSchema(
+        parameters = mapOf(
+            "emotion" to SkillParameter(
+                type = "string",
+                description = "The emotional style for the next spoken response. " +
+                    "One of: neutral, happy, sad, worried.",
+            ),
+        ),
+        required = listOf("emotion"),
+    )
+    override val fullInstructions = """
+set_voice_emotion: Set the emotional tone of the spoken voice for the current reply.
+
+Parameters:
+- emotion (required, string): One of "neutral", "happy", "sad", "worried"
+
+Emotion → Semaine speaker mapping:
+  neutral → calm, measured delivery (default)
+  happy   → upbeat, positive tone
+  sad     → subdued, gentle tone
+  worried → concerned, careful delivery
+
+Use sparingly and only when the user's emotional context clearly warrants it.
+For example: happy when delivering good news, worried when the user is stressed.
+ONLY effective when Semaine voice is selected — has no effect with other voices.
+    """.trimIndent()
+
+    // sid mapping matches en_GB-semaine-medium speaker_id_map exactly
+    private val emotionToSid = mapOf("neutral" to 0, "happy" to 1, "sad" to 2, "worried" to 3)
+
+    /**
+     * Only include this skill in the system prompt when Semaine is the active voice.
+     *
+     * [runBlocking] is used here because [isEnabled] is called from the skill declaration
+     * builder (not a suspend context). This is acceptable for a lightweight DataStore read
+     * since declarations are built once per prompt, not on every token.
+     */
+    override fun isEnabled(): Boolean = runBlocking {
+        voiceOutputPreferences.selectedSherpaVoice.first() == SherpaPiperVoice.SemaineMedium
+    }
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        val emotion = call.arguments["emotion"]?.lowercase()
+            ?: return SkillResult.Failure(name, "Missing 'emotion' argument")
+        val sid = emotionToSid[emotion]
+            ?: return SkillResult.Failure(
+                name,
+                "Unknown emotion '$emotion'. Use: neutral, happy, sad, worried",
+            )
+        voiceController.setEmotionOverrideSid(sid)
+        return SkillResult.Success("Voice emotion set to $emotion.")
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
@@ -20,10 +20,11 @@ class SetVoiceEmotionSkill @Inject constructor(
 ) : Skill {
     override val name = "set_voice_emotion"
     override val description =
-        "Sets the emotional tone of the spoken voice for the current reply. " +
-            "Only effective when the Semaine voice is selected. " +
-            "Use sparingly — match the user's emotional context. " +
-            "Do NOT use with other voices."
+        "Sets the emotional tone of the spoken voice for the CURRENT reply. " +
+            "Call this SILENTLY before composing your response — never describe that you are setting the tone. " +
+            "Trigger: (a) user explicitly asks for a voice tone/emotion (e.g. 'say that in a sad voice', " +
+            "'use a happy tone', 'sound angry'); (b) context strongly warrants it (delivering sad news → sad, " +
+            "celebrating → happy). One of: neutral, happy, sad, angry, worried."
     override val schema = SkillSchema(
         parameters = mapOf(
             "emotion" to SkillParameter(
@@ -47,9 +48,21 @@ Emotion → Semaine speaker mapping:
   angry   → intense, forceful delivery
   worried → concerned, careful delivery
 
-Use sparingly and only when the user's emotional context clearly warrants it.
-For example: happy when delivering good news, angry when venting, worried when the user is stressed.
-ONLY effective when Semaine voice is selected — has no effect with other voices.
+CRITICAL: Call this tool SILENTLY as the FIRST action — never say "I'm setting the voice" or "I've set the voice".
+Just call the tool, then compose your response. The tone change happens automatically.
+
+When to call:
+  • User asks for a specific tone:
+      "tell me a joke in a sad voice"              → set_voice_emotion(emotion="sad"), then tell a joke
+      "say that in a happy voice"                  → set_voice_emotion(emotion="happy"), then answer
+      "sound worried" / "use an angry tone"        → set_voice_emotion(emotion=matching_emotion)
+      "set your voice to sad"                      → set_voice_emotion(emotion="sad"), confirm done
+  • Context strongly warrants it:
+      Delivering genuinely bad news → sad
+      Celebrating something → happy
+      Warning about a serious risk → worried
+
+Do NOT say "I don't have a tool" — this tool is available. Do NOT narrate calling it.
     """.trimIndent()
 
     // sid mapping matches en_GB-semaine-medium speaker_id_map exactly

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkill.kt
@@ -29,7 +29,7 @@ class SetVoiceEmotionSkill @Inject constructor(
             "emotion" to SkillParameter(
                 type = "string",
                 description = "The emotional style for the next spoken response. " +
-                    "One of: neutral, happy, sad, worried.",
+                    "One of: neutral, happy, sad, angry, worried.",
             ),
         ),
         required = listOf("emotion"),
@@ -38,21 +38,23 @@ class SetVoiceEmotionSkill @Inject constructor(
 set_voice_emotion: Set the emotional tone of the spoken voice for the current reply.
 
 Parameters:
-- emotion (required, string): One of "neutral", "happy", "sad", "worried"
+- emotion (required, string): One of "neutral", "happy", "sad", "angry", "worried"
 
 Emotion → Semaine speaker mapping:
   neutral → calm, measured delivery (default)
   happy   → upbeat, positive tone
   sad     → subdued, gentle tone
+  angry   → intense, forceful delivery
   worried → concerned, careful delivery
 
 Use sparingly and only when the user's emotional context clearly warrants it.
-For example: happy when delivering good news, worried when the user is stressed.
+For example: happy when delivering good news, angry when venting, worried when the user is stressed.
 ONLY effective when Semaine voice is selected — has no effect with other voices.
     """.trimIndent()
 
     // sid mapping matches en_GB-semaine-medium speaker_id_map exactly
-    private val emotionToSid = mapOf("neutral" to 0, "happy" to 1, "sad" to 2, "worried" to 3)
+    // neutral=0, happy=1, sad=2, angry=3, worried=4
+    private val emotionToSid = mapOf("neutral" to 0, "happy" to 1, "sad" to 2, "angry" to 3, "worried" to 4)
 
     /**
      * Only include this skill in the system prompt when Semaine is the active voice.
@@ -71,7 +73,7 @@ ONLY effective when Semaine voice is selected — has no effect with other voice
         val sid = emotionToSid[emotion]
             ?: return SkillResult.Failure(
                 name,
-                "Unknown emotion '$emotion'. Use: neutral, happy, sad, worried",
+                "Unknown emotion '$emotion'. Use: neutral, happy, sad, angry, worried",
             )
         voiceController.setEmotionOverrideSid(sid)
         return SkillResult.Success("Voice emotion set to $emotion.")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkillTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkillTest.kt
@@ -90,8 +90,15 @@ class SetVoiceEmotionSkillTest {
     }
 
     @Test
-    fun `worried maps to sid 3`() = runTest {
+    fun `worried maps to sid 4`() = runTest {
         val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "worried")))
+        verify { voiceController.setEmotionOverrideSid(4) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    @Test
+    fun `angry maps to sid 3`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "angry")))
         verify { voiceController.setEmotionOverrideSid(3) }
         assertInstanceOf(SkillResult.Success::class.java, result)
     }
@@ -107,11 +114,11 @@ class SetVoiceEmotionSkillTest {
 
     @Test
     fun `unknown emotion returns Failure`() = runTest {
-        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "angry")))
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "disgusted")))
         assertInstanceOf(SkillResult.Failure::class.java, result)
         val failure = result as SkillResult.Failure
         assertEquals("set_voice_emotion", failure.skillName)
-        assertTrue(failure.error.contains("angry"), "Error message should mention the bad emotion")
+        assertTrue(failure.error.contains("disgusted"), "Error message should mention the bad emotion")
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkillTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/SetVoiceEmotionSkillTest.kt
@@ -1,0 +1,137 @@
+package com.kernel.ai.core.skills.natives
+
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.voice.SherpaPiperVoice
+import com.kernel.ai.core.voice.SherpaOnnxVoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SetVoiceEmotionSkillTest {
+
+    private lateinit var voiceController: SherpaOnnxVoiceOutputController
+    private lateinit var voiceOutputPreferences: VoiceOutputPreferences
+    private lateinit var skill: SetVoiceEmotionSkill
+
+    @BeforeEach
+    fun setUp() {
+        voiceController = mockk(relaxed = true)
+        voiceOutputPreferences = mockk()
+        // Default: Semaine is selected
+        every { voiceOutputPreferences.selectedSherpaVoice } returns
+            flowOf(SherpaPiperVoice.SemaineMedium)
+        skill = SetVoiceEmotionSkill(voiceController, voiceOutputPreferences)
+    }
+
+    // ── isEnabled() ────────────────────────────────────────────────────────
+
+    @Test
+    fun `isEnabled returns true when Semaine voice is selected`() {
+        every { voiceOutputPreferences.selectedSherpaVoice } returns
+            flowOf(SherpaPiperVoice.SemaineMedium)
+        assertTrue(skill.isEnabled())
+    }
+
+    @Test
+    fun `isEnabled returns false when JennyDioco is selected`() {
+        every { voiceOutputPreferences.selectedSherpaVoice } returns
+            flowOf(SherpaPiperVoice.JennyDioco)
+        assertFalse(skill.isEnabled())
+    }
+
+    @Test
+    fun `isEnabled returns false when VCTK is selected`() {
+        every { voiceOutputPreferences.selectedSherpaVoice } returns
+            flowOf(SherpaPiperVoice.VctkMedium)
+        assertFalse(skill.isEnabled())
+    }
+
+    @Test
+    fun `isEnabled returns false when any non-Semaine voice is selected`() {
+        SherpaPiperVoice.entries
+            .filter { it != SherpaPiperVoice.SemaineMedium }
+            .forEach { voice ->
+                every { voiceOutputPreferences.selectedSherpaVoice } returns flowOf(voice)
+                assertFalse(skill.isEnabled(), "Expected isEnabled() = false for ${voice.name}")
+            }
+    }
+
+    // ── execute() — successful emotion mappings ────────────────────────────
+
+    @Test
+    fun `neutral maps to sid 0`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "neutral")))
+        verify { voiceController.setEmotionOverrideSid(0) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    @Test
+    fun `happy maps to sid 1`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "happy")))
+        verify { voiceController.setEmotionOverrideSid(1) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    @Test
+    fun `sad maps to sid 2`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "sad")))
+        verify { voiceController.setEmotionOverrideSid(2) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    @Test
+    fun `worried maps to sid 3`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "worried")))
+        verify { voiceController.setEmotionOverrideSid(3) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    @Test
+    fun `emotion matching is case-insensitive`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "HAPPY")))
+        verify { voiceController.setEmotionOverrideSid(1) }
+        assertInstanceOf(SkillResult.Success::class.java, result)
+    }
+
+    // ── execute() — failure cases ──────────────────────────────────────────
+
+    @Test
+    fun `unknown emotion returns Failure`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", mapOf("emotion" to "angry")))
+        assertInstanceOf(SkillResult.Failure::class.java, result)
+        val failure = result as SkillResult.Failure
+        assertEquals("set_voice_emotion", failure.skillName)
+        assertTrue(failure.error.contains("angry"), "Error message should mention the bad emotion")
+    }
+
+    @Test
+    fun `missing emotion argument returns Failure`() = runTest {
+        val result = skill.execute(SkillCall("set_voice_emotion", emptyMap()))
+        assertInstanceOf(SkillResult.Failure::class.java, result)
+        val failure = result as SkillResult.Failure
+        assertEquals("set_voice_emotion", failure.skillName)
+    }
+
+    // ── schema ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `skill name is set_voice_emotion`() {
+        assertEquals("set_voice_emotion", skill.name)
+    }
+
+    @Test
+    fun `schema requires emotion parameter`() {
+        assertTrue(skill.schema.required.contains("emotion"))
+        assertTrue(skill.schema.parameters.containsKey("emotion"))
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -61,6 +61,10 @@ class FallbackVoiceOutputController @Inject constructor(
         androidTts.stop()
     }
 
+    override fun setEmotionOverrideSid(sid: Int) {
+        activeController.value.setEmotionOverrideSid(sid)
+    }
+
     private suspend fun warmUpAndroidTts(): VoiceOutputResult {
         activate(androidTts)
         return androidTts.warmUp()

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -101,10 +102,10 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     @Volatile private var initializedExpressiveness: VoiceExpressiveness? = null
 
     // ── Emotion override (transient, per-utterance, in-memory only) ──────────
-    @Volatile private var emotionOverrideSid: Int = -1
+    private val emotionOverrideSid = AtomicInteger(-1)
 
     override fun setEmotionOverrideSid(sid: Int) {
-        emotionOverrideSid = sid
+        emotionOverrideSid.set(sid)
     }
 
     /** Reflected handle to `OfflineTts` instance; non-null iff [initState] == AVAILABLE. */
@@ -156,7 +157,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
             // Capture effective sid now (before any await) and reset override so it is
             // single-utterance-only. Reset happens in the finally block below.
-            val effectiveSid = if (emotionOverrideSid >= 0) emotionOverrideSid else activeSpeakerId.value
+            val effectiveSid = if (emotionOverrideSid.get() >= 0) emotionOverrideSid.get() else activeSpeakerId.value
 
             // Track whether SpeakingStarted was emitted so SpeakingStopped is only sent when
             // it has a matching start — stops the back-and-forth loop from firing on a stopped
@@ -187,7 +188,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 if (speakingStarted) _events.emit(VoiceOutputEvent.SpeakingStopped)
                 VoiceOutputResult.Unavailable("Sherpa generate failed: ${e.message}")
             } finally {
-                emotionOverrideSid = -1
+                emotionOverrideSid.set(-1)
             }
         }
 
@@ -341,7 +342,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
         // Capture effective sid at session start — emotion override is per-utterance only.
-        val effectiveSid = if (emotionOverrideSid >= 0) emotionOverrideSid else activeSpeakerId.value
+        val effectiveSid = if (emotionOverrideSid.get() >= 0) emotionOverrideSid.get() else activeSpeakerId.value
         var emittedStarted = false
         var requestedAudioFocus = false
         try {
@@ -372,7 +373,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 }
             }
         } finally {
-            emotionOverrideSid = -1
+            emotionOverrideSid.set(-1)
             releaseAudioFocus()
             if (finishStreamingPlayback(playbackToken)) {
                 _events.emit(VoiceOutputEvent.SpeakingStopped)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -354,8 +354,6 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     ) {
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
-        // Emotion override is per-utterance for Semaine; for all other voices effectiveSid handles clamping.
-        val effectiveSid = if (emotionOverrideSid.get() >= 0) emotionOverrideSid.get() else effectiveSid(speakerCount)
         var emittedStarted = false
         var requestedAudioFocus = false
         try {
@@ -369,16 +367,19 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                     requestAudioFocus()
                     requestedAudioFocus = true
                 }
+                // Read emotion override lazily per-chunk so tool calls (set_voice_emotion) that
+                // fire mid-generation are picked up before synthesis starts for each sentence.
+                val chunkSid = if (emotionOverrideSid.get() >= 0) emotionOverrideSid.get() else effectiveSid(speakerCount)
                 val synthStart = System.currentTimeMillis()
                 val audioResult = try {
-                    genMethod.invoke(tts, chunk.text, effectiveSid, sherpaSpeed.value)
+                    genMethod.invoke(tts, chunk.text, chunkSid, sherpaSpeed.value)
                         ?: return
                 } catch (e: Exception) {
                     Log.e(TAG, "Sherpa streaming generate() failed", e)
                     return
                 }
                 if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
-                    "for ${chunk.text.length} chars, sid=$effectiveSid")
+                    "for ${chunk.text.length} chars, sid=$chunkSid")
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)
                 if (!stopped && isStreamingPlaybackActive(playbackToken)) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -103,7 +103,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     // ── Emotion override (transient, per-utterance, in-memory only) ──────────
     @Volatile private var emotionOverrideSid: Int = -1
 
-    fun setEmotionOverrideSid(sid: Int) {
+    override fun setEmotionOverrideSid(sid: Int) {
         emotionOverrideSid = sid
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -105,6 +105,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     private val emotionOverrideSid = AtomicInteger(-1)
 
     override fun setEmotionOverrideSid(sid: Int) {
+        Log.d(TAG, "setEmotionOverrideSid: $sid (was ${emotionOverrideSid.get()})")
         emotionOverrideSid.set(sid)
     }
 
@@ -369,7 +370,9 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 }
                 // Read emotion override lazily per-chunk so tool calls (set_voice_emotion) that
                 // fire mid-generation are picked up before synthesis starts for each sentence.
-                val chunkSid = if (emotionOverrideSid.get() >= 0) emotionOverrideSid.get() else effectiveSid(speakerCount)
+                val overrideSid = emotionOverrideSid.get()
+                val chunkSid = if (overrideSid >= 0) overrideSid else effectiveSid(speakerCount)
+                Log.d(TAG, "runStreamingPlayback chunk: overrideSid=$overrideSid effectiveSid=${effectiveSid(speakerCount)} chunkSid=$chunkSid speakerCount=$speakerCount")
                 val synthStart = System.currentTimeMillis()
                 val audioResult = try {
                     genMethod.invoke(tts, chunk.text, chunkSid, sherpaSpeed.value)
@@ -390,6 +393,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 }
             }
         } finally {
+            Log.d(TAG, "runStreamingPlayback finally: resetting emotionOverrideSid from ${emotionOverrideSid.get()} to -1")
             emotionOverrideSid.set(-1)
             releaseAudioFocus()
             if (finishStreamingPlayback(playbackToken)) {
@@ -417,6 +421,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     private fun clearStreamingPlayback(): Boolean = synchronized(playbackLock) {
         val active = activeStreamingPlayback ?: return@synchronized false
         activeStreamingPlayback = null
+        Log.d(TAG, "clearStreamingPlayback: cancelling worker (emotionOverrideSid=${emotionOverrideSid.get()})")
         active.chunks.close()
         active.worker.cancel()
         true

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -88,11 +88,24 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     private val activeSpeakerId: StateFlow<Int> = voiceOutputPreferences.activeSpeakerId
         .stateIn(scope, SharingStarted.Eagerly, 0)
 
+    /** VITS noise_scale expressiveness setting; triggers reinit when changed. */
+    private val expressiveness: StateFlow<VoiceExpressiveness> =
+        voiceOutputPreferences.voiceExpressiveness
+            .stateIn(scope, SharingStarted.Eagerly, VoiceExpressiveness.MEDIUM)
+
     // ── Lifecycle state ──────────────────────────────────────────────────────
     private enum class InitState { UNINITIALIZED, AVAILABLE, UNAVAILABLE }
 
     @Volatile private var initState = InitState.UNINITIALIZED
     @Volatile private var initializedVoice: SherpaPiperVoice? = null
+    @Volatile private var initializedExpressiveness: VoiceExpressiveness? = null
+
+    // ── Emotion override (transient, per-utterance, in-memory only) ──────────
+    @Volatile private var emotionOverrideSid: Int = -1
+
+    fun setEmotionOverrideSid(sid: Int) {
+        emotionOverrideSid = sid
+    }
 
     /** Reflected handle to `OfflineTts` instance; non-null iff [initState] == AVAILABLE. */
     @Volatile private var ttsInstance: Any? = null
@@ -141,6 +154,10 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             stopped = false
             val myGeneration = nonStreamingPlaybackGeneration.incrementAndGet()
 
+            // Capture effective sid now (before any await) and reset override so it is
+            // single-utterance-only. Reset happens in the finally block below.
+            val effectiveSid = if (emotionOverrideSid >= 0) emotionOverrideSid else activeSpeakerId.value
+
             // Track whether SpeakingStarted was emitted so SpeakingStopped is only sent when
             // it has a matching start — stops the back-and-forth loop from firing on a stopped
             // or failed synthesis where no audio was ever played.
@@ -149,7 +166,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 // Reflect: GeneratedAudio audio = tts.generate(text, sid=0, speed)
                 // Synthesis can take 1-3s; only emit SpeakingStarted once audio is ready
                 // and playback is actually about to begin — not before.
-                val audioResult = genMethod.invoke(tts, request.text, activeSpeakerId.value, sherpaSpeed.value)
+                val audioResult = genMethod.invoke(tts, request.text, effectiveSid, sherpaSpeed.value)
                     ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
 
                 val samples = reflectGetSamples(audioResult)
@@ -169,6 +186,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 releaseAudioFocus()
                 if (speakingStarted) _events.emit(VoiceOutputEvent.SpeakingStopped)
                 VoiceOutputResult.Unavailable("Sherpa generate failed: ${e.message}")
+            } finally {
+                emotionOverrideSid = -1
             }
         }
 
@@ -237,7 +256,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
      * otherwise (AAR missing, assets missing, or any reflection error).
      */
     private fun initialize(voice: SherpaPiperVoice): VoiceOutputResult {
-        if (initializedVoice != voice) {
+        if (initializedVoice != voice || initializedExpressiveness != expressiveness.value) {
             resetForVoice(voice)
         }
         return when (initState) {
@@ -276,7 +295,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         }
 
         return try {
-            val config = buildOfflineTtsConfig(modelDir)
+            val config = buildOfflineTtsConfig(modelDir, expressiveness.value)
             val configClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
             val ctor = ttsClass.getConstructor(
                 android.content.res.AssetManager::class.java,
@@ -295,6 +314,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             ttsInstance = instance
             generateMethod = gen
             initState = InitState.AVAILABLE
+            initializedExpressiveness = expressiveness.value
             Log.i(TAG, "Sherpa-ONNX TTS initialised — voice: ${voice.downloadKey} at ${modelDir.absolutePath}")
             VoiceOutputResult.Spoken
         } catch (e: Exception) {
@@ -310,6 +330,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         generateMethod = null
         initState = InitState.UNINITIALIZED
         initializedVoice = voice
+        initializedExpressiveness = null
     }
 
     private suspend fun runStreamingPlayback(
@@ -319,6 +340,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     ) {
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
+        // Capture effective sid at session start — emotion override is per-utterance only.
+        val effectiveSid = if (emotionOverrideSid >= 0) emotionOverrideSid else activeSpeakerId.value
         var emittedStarted = false
         var requestedAudioFocus = false
         try {
@@ -333,7 +356,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                     requestedAudioFocus = true
                 }
                 val audioResult = try {
-                    genMethod.invoke(tts, chunk.text, activeSpeakerId.value, sherpaSpeed.value)
+                    genMethod.invoke(tts, chunk.text, effectiveSid, sherpaSpeed.value)
                         ?: return
                 } catch (e: Exception) {
                     Log.e(TAG, "Sherpa streaming generate() failed", e)
@@ -349,6 +372,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 }
             }
         } finally {
+            emotionOverrideSid = -1
             releaseAudioFocus()
             if (finishStreamingPlayback(playbackToken)) {
                 _events.emit(VoiceOutputEvent.SpeakingStopped)
@@ -396,7 +420,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
      * OfflineTtsConfig          { model, ruleFsts, maxNumSentences }
      * ```
      */
-    private fun buildOfflineTtsConfig(modelDir: File): Any {
+    private fun buildOfflineTtsConfig(modelDir: File, expressiveness: VoiceExpressiveness): Any {
         val vitsClass = Class.forName(SHERPA_VITS_MODEL_CONFIG_CLASS)
         val modelConfigClass = Class.forName(SHERPA_MODEL_CONFIG_CLASS)
         val configClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
@@ -406,6 +430,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         setProperty(vitsConfig, "model", File(modelDir, SHERPA_MODEL_ONNX_FILE).absolutePath)
         setProperty(vitsConfig, "tokens", File(modelDir, SHERPA_TOKENS_FILE).absolutePath)
         setProperty(vitsConfig, "dataDir", File(modelDir, SHERPA_ESPEAK_DATA_DIR).absolutePath)
+        setProperty(vitsConfig, "noiseScale", expressiveness.noiseScale)
+        setProperty(vitsConfig, "noiseScaleW", expressiveness.noiseScaleW)
 
         // OfflineTtsModelConfig
         val modelConfig = newInstance(modelConfigClass)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceExpressiveness.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceExpressiveness.kt
@@ -1,0 +1,7 @@
+package com.kernel.ai.core.voice
+
+enum class VoiceExpressiveness(val noiseScale: Float, val noiseScaleW: Float) {
+    LOW(noiseScale = 0.3f, noiseScaleW = 0.3f),
+    MEDIUM(noiseScale = 0.667f, noiseScaleW = 0.8f),   // Sherpa default
+    HIGH(noiseScale = 1.0f, noiseScaleW = 1.0f),
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
@@ -60,4 +60,10 @@ interface VoiceOutputController {
 
     /** Suspending variant of [stop]; default delegates to [stop]. */
     suspend fun stopSpeaking() { stop() }
+
+    /**
+     * Sets a transient emotion override for the next TTS call (Semaine voice only).
+     * Resets automatically after the call completes. No-op for non-Semaine voices.
+     */
+    fun setEmotionOverrideSid(sid: Int) {}
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -34,6 +34,7 @@ class VoiceOutputPreferences @Inject constructor(
     private val autoSpeakKey = booleanPreferencesKey("voice_auto_speak")
     private val maxSpokenSentencesKey = intPreferencesKey("voice_max_spoken_sentences")
     private val activeSpeakerIdKey = intPreferencesKey("voice_active_speaker_id")
+    private val voiceExpressivenessKey = stringPreferencesKey("voice_expressiveness")
 
     val spokenResponsesEnabled: Flow<Boolean> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
@@ -185,6 +186,31 @@ class VoiceOutputPreferences @Inject constructor(
     suspend fun setActiveSpeakerId(sid: Int) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
             prefs[activeSpeakerIdKey] = sid.coerceIn(0, 108)
+        }
+    }
+
+    val voiceExpressiveness: Flow<VoiceExpressiveness> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs ->
+            prefs[voiceExpressivenessKey]?.let { stored ->
+                try {
+                    VoiceExpressiveness.valueOf(stored)
+                } catch (_: IllegalArgumentException) {
+                    VoiceExpressiveness.MEDIUM
+                }
+            } ?: VoiceExpressiveness.MEDIUM
+        }
+
+    suspend fun setVoiceExpressiveness(e: VoiceExpressiveness) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[voiceExpressivenessKey] = e.name
         }
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceExpressivenessTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceExpressivenessTest.kt
@@ -1,0 +1,47 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class VoiceExpressivenessTest {
+
+    @Test
+    fun `LOW has correct noise scale values`() {
+        assertEquals(0.3f, VoiceExpressiveness.LOW.noiseScale)
+        assertEquals(0.3f, VoiceExpressiveness.LOW.noiseScaleW)
+    }
+
+    @Test
+    fun `MEDIUM has Sherpa default noise scale values`() {
+        assertEquals(0.667f, VoiceExpressiveness.MEDIUM.noiseScale)
+        assertEquals(0.8f, VoiceExpressiveness.MEDIUM.noiseScaleW)
+    }
+
+    @Test
+    fun `HIGH has maximum noise scale values`() {
+        assertEquals(1.0f, VoiceExpressiveness.HIGH.noiseScale)
+        assertEquals(1.0f, VoiceExpressiveness.HIGH.noiseScaleW)
+    }
+
+    @Test
+    fun `enum has exactly three entries`() {
+        assertEquals(3, VoiceExpressiveness.entries.size)
+    }
+
+    @Test
+    fun `all entries have noise scales in valid range`() {
+        VoiceExpressiveness.entries.forEach { level ->
+            assertTrue(level.noiseScale in 0.0f..1.0f, "${level.name}.noiseScale out of range")
+            assertTrue(level.noiseScaleW in 0.0f..1.0f, "${level.name}.noiseScaleW out of range")
+        }
+    }
+
+    @Test
+    fun `noise scales increase from LOW to HIGH`() {
+        assertTrue(VoiceExpressiveness.LOW.noiseScale < VoiceExpressiveness.MEDIUM.noiseScale)
+        assertTrue(VoiceExpressiveness.MEDIUM.noiseScale < VoiceExpressiveness.HIGH.noiseScale)
+        assertTrue(VoiceExpressiveness.LOW.noiseScaleW < VoiceExpressiveness.MEDIUM.noiseScaleW)
+        assertTrue(VoiceExpressiveness.MEDIUM.noiseScaleW < VoiceExpressiveness.HIGH.noiseScaleW)
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -282,7 +282,7 @@ Lower-priority skill additions — third-party integrations and local utilities.
 | [#770](https://github.com/NickMonrad/kernel-ai-assistant/issues/770) | Sherpa voice quality evaluation | ✅ Done — PR #780 | 🟡 Medium |
 | [#775](https://github.com/NickMonrad/kernel-ai-assistant/issues/775) | TTS quality fixes (URL colon preservation, speech rate clamping, sentence splitting) | ✅ Done — PR #780 | 🟡 Medium |
 | [#781](https://github.com/NickMonrad/kernel-ai-assistant/issues/781) | Semaine emotional TTS styles | ⬜ Pending | 🟢 Low |
-| [#782](https://github.com/NickMonrad/kernel-ai-assistant/issues/782) | VCTK speaker selection | ⬜ Pending | 🟢 Low |
+| [#782](https://github.com/NickMonrad/kernel-ai-assistant/issues/782) | VCTK speaker selection | ✅ Done — PR #805 | 🟢 Low |
 | [#783](https://github.com/NickMonrad/kernel-ai-assistant/issues/783) | Kokoro-82M / VoxSherpa research | ⬜ Pending | 🟢 Low |
 | [#784](https://github.com/NickMonrad/kernel-ai-assistant/issues/784) | Kiwi language corpus tuning | ⬜ Pending | 🟢 Low |
 | [#785](https://github.com/NickMonrad/kernel-ai-assistant/issues/785) | Per-message speaker button | ✅ Done — PR #789 | 🟡 Medium |
@@ -298,14 +298,14 @@ Lower-priority skill additions — third-party integrations and local utilities.
 | [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word — Picovoice Porcupine | ⬜ Pending | 🟡 Medium |
 | [#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64) | Live mode — real-time streaming interaction | ⬜ Pending | 🟢 Low |
 
-**Current state after merged PRs #780 and #789:**
+**Current state after merged PRs #780, #789, and #805:**
 
-> **Dependency note:** #782 (VCTK speaker selection) should ship before #781 (emotional styles) as it builds the sid selection mechanism #781 depends on.
+> **Dependency note:** #782 (VCTK speaker selection) is shipped — #781 (emotional styles) can now build on the sid selection mechanism.
 
-- Streaming TTS (`runStreamingPlayback()`), per-message speaker button, verbal stop command, and expanded TTS settings are all shipped.
+- Streaming TTS (`runStreamingPlayback()`), per-message speaker button, verbal stop command, expanded TTS settings, and VCTK multi-speaker selection are all shipped.
 - Voice quality slice complete: URL colon preservation in `cleanTextForSpeech()`, speech rate clamping on the non-streaming read-path, abbreviation-aware sentence splitting (`truncateForSpeech()` with `KNOWN_ABBREV` + `INITIALS_REGEX`), and Sherpa quality evaluation done on Samsung Galaxy S23 Ultra.
 - `autoSpeakEnabled` is now a cached field in `ChatViewModel` — chat auto-speak is fully decoupled from the Quick Actions `spokenResponsesEnabled` toggle.
-- Remaining voice quality research: Semaine emotional styles (#781), VCTK speaker selection (#782), Kokoro-82M/VoxSherpa (#783), Kiwi corpus tuning (#784), and VITS noise_scale expressiveness (#788).
+- Remaining voice quality research: Semaine emotional styles (#781), Kokoro-82M/VoxSherpa (#783), Kiwi corpus tuning (#784), and VITS noise_scale expressiveness (#788).
 - Fallback-path issues and the appointment QIR bug ([#773](https://github.com/NickMonrad/kernel-ai-assistant/issues/773)) remain tracked separately.
 
 ---
@@ -554,7 +554,7 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#770](https://github.com/NickMonrad/kernel-ai-assistant/issues/770) | Sherpa voice quality evaluation | Phase 3F | ✅ Done — PR #780 |
 | [#775](https://github.com/NickMonrad/kernel-ai-assistant/issues/775) | TTS quality fixes (URL colon, speech rate, sentence splitting) | Phase 3F | ✅ Done — PR #780 |
 | [#781](https://github.com/NickMonrad/kernel-ai-assistant/issues/781) | Semaine emotional TTS styles | Phase 3F | ⬜ Pending |
-| [#782](https://github.com/NickMonrad/kernel-ai-assistant/issues/782) | VCTK speaker selection | Phase 3F | ⬜ Pending |
+| [#782](https://github.com/NickMonrad/kernel-ai-assistant/issues/782) | VCTK speaker selection | Phase 3F | ✅ Done — PR #805 |
 | [#783](https://github.com/NickMonrad/kernel-ai-assistant/issues/783) | Kokoro-82M / VoxSherpa research | Phase 3F | ⬜ Pending |
 | [#784](https://github.com/NickMonrad/kernel-ai-assistant/issues/784) | Kiwi language corpus tuning | Phase 3F | ⬜ Pending |
 | [#785](https://github.com/NickMonrad/kernel-ai-assistant/issues/785) | Per-message speaker button | Phase 3F | ✅ Done — PR #789 |

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -104,7 +104,7 @@ fun ActionsScreen(
     adbSlotReply: String? = null,
     onAutoOpenSheetConsumed: () -> Unit = {},
     onAutoStartVoiceConsumed: () -> Unit = {},
-    onNavigateToChat: (query: String) -> Unit = {},
+    onNavigateToChat: (query: String, fromVoice: Boolean) -> Unit = { _, _ -> },
     onNewConversation: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     viewModel: ActionsViewModel = hiltViewModel(),
@@ -225,7 +225,7 @@ fun ActionsScreen(
             when (event) {
                 is ActionsViewModel.UiEvent.NavigateToChat -> {
                     viewModel.pauseTransientVoiceUi(reason = "navigateToChat")
-                    onNavigateToChat(event.query)
+                    onNavigateToChat(event.query, event.fromVoice)
                 }
                 ActionsViewModel.UiEvent.RequestPhonePermission ->
                     phonePermissionLauncher.launch(Manifest.permission.CALL_PHONE)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -94,7 +94,7 @@ class ActionsViewModel @Inject constructor(
     /** One-shot navigation/UI events consumed by the screen. */
     sealed interface UiEvent {
         /** Query couldn't be handled by quick actions — navigate to chat for LLM processing. */
-        data class NavigateToChat(val query: String) : UiEvent
+        data class NavigateToChat(val query: String, val fromVoice: Boolean = false) : UiEvent
         object RequestPhonePermission : UiEvent
     }
 
@@ -399,7 +399,7 @@ class ActionsViewModel @Inject constructor(
                         )
                         quickActionDao.insert(entity)
                         speakForVoice(inputMode, entity.resultText)
-                        _events.emit(UiEvent.NavigateToChat(normalizedQuery))
+                        _events.emit(UiEvent.NavigateToChat(normalizedQuery, fromVoice = inputMode == InputMode.Voice))
                     }
                     is QuickIntentRouter.RouteResult.NeedsSlot -> {
                         // Pause execution — show slot prompt in a ModalBottomSheet.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -138,6 +138,7 @@ import com.kernel.ai.feature.chat.model.ToolCallInfo
 fun ChatScreen(
     conversationId: String? = null,
     initialQuery: String? = null,
+    fromVoice: Boolean = false,
     onBack: () -> Unit = {},
     onNewConversation: () -> Unit = {},
     onNavigateToList: () -> Unit = {},
@@ -162,7 +163,7 @@ fun ChatScreen(
                 viewModel.isConversationReady.first { it }
             }
             if (ready != null) {
-                viewModel.submitInitialQueryIfNeeded(initialQuery)
+                viewModel.submitInitialQueryIfNeeded(initialQuery, fromVoice = fromVoice)
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1158,12 +1158,9 @@ class ChatViewModel @Inject constructor(
             }
 
             // Emotion pre-intercept: detect "in a X voice" / "sound X" patterns before QIR.
-            // Sets the TTS emotion override immediately so TTS speaks in the right style even
-            // when the LLM generates the response — no tool call needed from the model.
-            val emotionSystemContext = detectAndApplyVoiceEmotion(text)
-            if (emotionSystemContext != null) {
-                systemContext = emotionSystemContext
-            }
+            // The override is applied only if QIR falls through to the LLM — applying it for
+            // skill-matched queries would style TTS with an emotion the LLM never knew about.
+            val emotionDetection = detectVoiceEmotion(text)
 
             val weatherFollowUpLocation = WeatherConversationReferenceResolver.resolveLocation(
                 query = text,
@@ -1209,6 +1206,13 @@ class ChatViewModel @Inject constructor(
                     )
                     return@launch
                 }
+            }
+            // Apply emotion override only when QIR falls through to the LLM. Applying it for
+            // skill-matched queries would let TTS speak with an emotion the LLM wasn't told about.
+            if (routeResult is QuickIntentRouter.RouteResult.FallThrough && emotionDetection != null) {
+                systemContext = emotionDetection.systemContext
+                voiceOutputController.setEmotionOverrideSid(emotionDetection.sid)
+                Log.d("KernelAI", "Voice emotion pre-intercept applied: sid=${emotionDetection.sid}")
             }
             if (matchedIntent != null) {
                 // Calendar intent matched by classifier but params not extractable via regex —
@@ -1290,6 +1294,7 @@ class ChatViewModel @Inject constructor(
                 initGemma4()
                 if (!inferenceEngine.isReady.value) {
                     // Model still not ready (e.g. file absent) — tell the user and bail.
+                    voiceOutputController.setEmotionOverrideSid(-1)
                     appendAssistantMessage(convId, "Still loading the AI model, please try again in a moment.", shouldIndex = false)
                     return@launch
                 }
@@ -2067,6 +2072,7 @@ class ChatViewModel @Inject constructor(
         pendingVoiceReply = false
         _voiceCaptureState.value = VoiceCaptureState.Idle
         if (!shouldSpeak || !autoSpeakEnabled) {
+            voiceOutputController.setEmotionOverrideSid(-1)
             awaitingVoicePlaybackCompletion = false
             _voiceMode.value = null
             return
@@ -2118,17 +2124,17 @@ class ChatViewModel @Inject constructor(
         com.kernel.ai.feature.chat.looksLikeRawToolCall(response)
 
     /**
-     * Detects voice emotion modifier phrases ("in a sad voice", "sound angry", etc.) and
-     * pre-sets [emotionOverrideSid] on the voice controller so TTS uses the right Semaine
-     * speaker without the LLM needing to call [SetVoiceEmotionSkill] itself.
+     * Detects voice emotion modifier phrases ("in a sad voice", "sound angry", etc.).
      *
      * Only fires when [SherpaPiperVoice.SemaineMedium] is the active voice — no-ops silently
      * for all other voices to avoid injecting invalid sids into single-speaker Sherpa engines.
      *
-     * Returns a [System:] context string to inject into the prompt so Jandal acknowledges
-     * the voice style naturally, or null if no emotion was detected / wrong voice.
+     * Returns an [EmotionDetection] with the target sid and a [System:] context string to
+     * inject into the prompt, or null if no emotion was detected / wrong voice selected.
+     * Does NOT set [emotionOverrideSid] — the caller applies the override only when the
+     * query is confirmed to reach the LLM (i.e. QIR FallThrough).
      */
-    private suspend fun detectAndApplyVoiceEmotion(text: String): String? {
+    private suspend fun detectVoiceEmotion(text: String): EmotionDetection? {
         val emotionToSid = mapOf(
             "neutral" to 0, "happy" to 1, "sad" to 2, "angry" to 3, "worried" to 4,
         )
@@ -2138,10 +2144,11 @@ class ChatViewModel @Inject constructor(
         val sid = emotionToSid[emotion] ?: return null
         val activeVoice = voiceOutputPreferences.selectedSherpaVoice.first()
         if (activeVoice != SherpaPiperVoice.SemaineMedium) return null
-        voiceOutputController.setEmotionOverrideSid(sid)
-        Log.d("KernelAI", "Voice emotion pre-intercept: $emotion → sid=$sid")
-        return "[System: set_voice_emotion — Voice tone set to $emotion for this reply.]"
+        Log.d("KernelAI", "Voice emotion detected: $emotion → sid=$sid")
+        return EmotionDetection(sid, "[System: set_voice_emotion — Voice tone set to $emotion for this reply.]")
     }
+
+    private data class EmotionDetection(val sid: Int, val systemContext: String)
 
     companion object {
         private val VOICE_EMOTION_PATTERN = Regex(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1156,6 +1156,14 @@ class ChatViewModel @Inject constructor(
                 pendingConfirmationIntent = null
             }
 
+            // Emotion pre-intercept: detect "in a X voice" / "sound X" patterns before QIR.
+            // Sets the TTS emotion override immediately so TTS speaks in the right style even
+            // when the LLM generates the response — no tool call needed from the model.
+            val emotionSystemContext = detectAndApplyVoiceEmotion(text)
+            if (emotionSystemContext != null) {
+                systemContext = emotionSystemContext
+            }
+
             val weatherFollowUpLocation = WeatherConversationReferenceResolver.resolveLocation(
                 query = text,
                 messages = _messages.value.dropLast(1),
@@ -2107,6 +2115,36 @@ class ChatViewModel @Inject constructor(
 
     private fun looksLikeRawToolCall(response: String): Boolean =
         com.kernel.ai.feature.chat.looksLikeRawToolCall(response)
+
+    /**
+     * Detects voice emotion modifier phrases ("in a sad voice", "sound angry", etc.) and
+     * pre-sets [emotionOverrideSid] on the voice controller so TTS uses the right Semaine
+     * speaker without the LLM needing to call [SetVoiceEmotionSkill] itself.
+     *
+     * Returns a [System:] context string to inject into the prompt so Jandal acknowledges
+     * the voice style naturally, or null if no emotion was detected.
+     */
+    private fun detectAndApplyVoiceEmotion(text: String): String? {
+        val emotionToSid = mapOf(
+            "neutral" to 0, "happy" to 1, "sad" to 2, "angry" to 3, "worried" to 4,
+        )
+        val match = VOICE_EMOTION_PATTERN.find(text) ?: return null
+        val emotion = (match.groups["emotion1"] ?: match.groups["emotion2"] ?: match.groups["emotion3"])
+            ?.value?.lowercase() ?: return null
+        val sid = emotionToSid[emotion] ?: return null
+        voiceOutputController.setEmotionOverrideSid(sid)
+        Log.d("KernelAI", "Voice emotion pre-intercept: $emotion → sid=$sid")
+        return "[System: set_voice_emotion — Voice tone set to $emotion for this reply.]"
+    }
+
+    companion object {
+        private val VOICE_EMOTION_PATTERN = Regex(
+            """(?:in\s+an?\s+(?<emotion1>neutral|happy|sad|angry|worried)\s+voice""" +
+                """|sound\s+(?<emotion2>neutral|happy|sad|angry|worried)""" +
+                """|speak\s+(?:in\s+an?\s+)?(?<emotion3>neutral|happy|sad|angry|worried)(?:\s+voice)?)\b""",
+            RegexOption.IGNORE_CASE,
+        )
+    }
 }
 
 /** C2 correction prepended to the prompt when a hallucination retry is attempted (#487). */

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -963,7 +963,7 @@ class ChatViewModel @Inject constructor(
         _speakingMessageId.value = null
     }
 
-    fun submitInitialQueryIfNeeded(initialQuery: String) {
+    fun submitInitialQueryIfNeeded(initialQuery: String, fromVoice: Boolean = false) {
         val normalized = initialQuery.trim()
         if (normalized.isBlank()) return
         val alreadyPresent = _messages.value.any {
@@ -976,7 +976,7 @@ class ChatViewModel @Inject constructor(
             return
         }
         onInputChanged(normalized)
-        sendMessage()
+        sendMessage(if (fromVoice) SubmitMode.Voice else SubmitMode.Text)
     }
 
     fun renameConversation(newTitle: String) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -2147,7 +2147,10 @@ class ChatViewModel @Inject constructor(
             ?.value?.lowercase() ?: return null
         val sid = emotionToSid[emotion] ?: return null
         val activeVoice = voiceOutputPreferences.selectedSherpaVoice.first()
-        if (activeVoice != SherpaPiperVoice.SemaineMedium) return null
+        if (activeVoice != SherpaPiperVoice.SemaineMedium) {
+            Log.d("KernelAI", "Voice emotion pattern matched '$emotion' but voice=$activeVoice (not Semaine) — skipping override")
+            return null
+        }
         Log.d("KernelAI", "Voice emotion detected: $emotion → sid=$sid")
         val stripped = text.replace(match.value, "", ignoreCase = true)
             .replace(Regex("\\s{2,}"), " ").trim().ifBlank { null }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -41,6 +41,7 @@ import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.SlotFillResult
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VoiceOutputController
 import com.kernel.ai.core.voice.VoiceOutputEvent
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -2121,10 +2122,13 @@ class ChatViewModel @Inject constructor(
      * pre-sets [emotionOverrideSid] on the voice controller so TTS uses the right Semaine
      * speaker without the LLM needing to call [SetVoiceEmotionSkill] itself.
      *
+     * Only fires when [SherpaPiperVoice.SemaineMedium] is the active voice — no-ops silently
+     * for all other voices to avoid injecting invalid sids into single-speaker Sherpa engines.
+     *
      * Returns a [System:] context string to inject into the prompt so Jandal acknowledges
-     * the voice style naturally, or null if no emotion was detected.
+     * the voice style naturally, or null if no emotion was detected / wrong voice.
      */
-    private fun detectAndApplyVoiceEmotion(text: String): String? {
+    private suspend fun detectAndApplyVoiceEmotion(text: String): String? {
         val emotionToSid = mapOf(
             "neutral" to 0, "happy" to 1, "sad" to 2, "angry" to 3, "worried" to 4,
         )
@@ -2132,6 +2136,8 @@ class ChatViewModel @Inject constructor(
         val emotion = (match.groups["emotion1"] ?: match.groups["emotion2"] ?: match.groups["emotion3"])
             ?.value?.lowercase() ?: return null
         val sid = emotionToSid[emotion] ?: return null
+        val activeVoice = voiceOutputPreferences.selectedSherpaVoice.first()
+        if (activeVoice != SherpaPiperVoice.SemaineMedium) return null
         voiceOutputController.setEmotionOverrideSid(sid)
         Log.d("KernelAI", "Voice emotion pre-intercept: $emotion → sid=$sid")
         return "[System: set_voice_emotion — Voice tone set to $emotion for this reply.]"

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1027,6 +1027,9 @@ class ChatViewModel @Inject constructor(
             // the E4B prompt so it can generate a natural conversational wrapper.
             var systemContext: String? = null
             var groundingContext: String? = null
+            // May be updated by the emotion pre-intercept to strip the voice modifier phrase
+            // from the text sent to the LLM (the user-facing conversation message keeps `text`).
+            var promptText = text
             var isToolQueryForTurn = false
             // Set true when QIR routes to a device action, OR when the LLM calls a non-indexable
             // tool (run_intent, get_weather, etc.) — suppresses RAG indexing for both the user
@@ -1213,6 +1216,7 @@ class ChatViewModel @Inject constructor(
                 systemContext = emotionDetection.systemContext
                 voiceOutputController.setEmotionOverrideSid(emotionDetection.sid)
                 Log.d("KernelAI", "Voice emotion pre-intercept applied: sid=${emotionDetection.sid}")
+                emotionDetection.strippedText?.let { promptText = it }
             }
             if (matchedIntent != null) {
                 // Calendar intent matched by classifier but params not extractable via regex —
@@ -1426,7 +1430,7 @@ class ChatViewModel @Inject constructor(
                 if (!isToolQuery) {
                     append("[System: ${jandalPersona.buildGreetingInstruction(isFirstReply, jandalPersona.currentPersonaMode)}]\n\n")
                 }
-                append(text)
+                append(promptText)
             }
             groundingContext = buildString {
                 if (effectiveRagContext.isNotBlank()) append(effectiveRagContext)
@@ -2145,10 +2149,18 @@ class ChatViewModel @Inject constructor(
         val activeVoice = voiceOutputPreferences.selectedSherpaVoice.first()
         if (activeVoice != SherpaPiperVoice.SemaineMedium) return null
         Log.d("KernelAI", "Voice emotion detected: $emotion → sid=$sid")
-        return EmotionDetection(sid, "[System: set_voice_emotion — Voice tone set to $emotion for this reply.]")
+        val stripped = text.replace(match.value, "", ignoreCase = true)
+            .replace(Regex("\\s{2,}"), " ").trim().ifBlank { null }
+        return EmotionDetection(
+            sid = sid,
+            systemContext = "[System: Voice mode — Your speaking voice has been set to $emotion for this response. " +
+                "Respond with content that matches that emotional tone. " +
+                "Do not mention voice settings or claim you cannot change your voice.]",
+            strippedText = stripped,
+        )
     }
 
-    private data class EmotionDetection(val sid: Int, val systemContext: String)
+    private data class EmotionDetection(val sid: Int, val systemContext: String, val strippedText: String?)
 
     companion object {
         private val VOICE_EMOTION_PATTERN = Regex(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -55,6 +55,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VctkSpeakerMetadata
+import com.kernel.ai.core.voice.VoiceExpressiveness
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoicePackDownloadState
@@ -85,6 +86,7 @@ fun VoiceScreen(
         onCancelVoiceDownload = viewModel::cancelSherpaVoiceDownload,
         onDeleteVoice = viewModel::deleteSherpaVoice,
         onActiveSpeakerIdChanged = viewModel::setActiveSpeakerId,
+        onVoiceExpressivenessChanged = viewModel::setVoiceExpressiveness,
     )
 }
 
@@ -107,6 +109,7 @@ private fun VoiceScreenContent(
     onCancelVoiceDownload: (SherpaPiperVoice) -> Unit,
     onDeleteVoice: (SherpaPiperVoice) -> Unit,
     onActiveSpeakerIdChanged: (Int) -> Unit,
+    onVoiceExpressivenessChanged: (VoiceExpressiveness) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -412,6 +415,34 @@ private fun VoiceScreenContent(
                             )
                         },
                     )
+                }
+
+                // Expressiveness chip selector — controls VITS noise_scale / noise_scale_w
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+                    Text(
+                        text = "Expressiveness",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "Controls VITS noise parameters. Higher = more varied, expressive delivery. Changing this reinitialises the TTS engine on the next utterance.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp, bottom = 6.dp),
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        VoiceExpressiveness.entries.forEach { level ->
+                            FilterChip(
+                                selected = uiState.voiceExpressiveness == level,
+                                onClick = { onVoiceExpressivenessChanged(level) },
+                                label = {
+                                    Text(
+                                        level.name.lowercase()
+                                            .replaceFirstChar { it.uppercase() },
+                                    )
+                                },
+                            )
+                        }
+                    }
                 }
 
                 uiState.sherpaVoices.forEach { voiceRow ->
@@ -853,6 +884,7 @@ private fun VoiceScreenPreview() {
             onCancelVoiceDownload = {},
             onDeleteVoice = {},
             onActiveSpeakerIdChanged = {},
+            onVoiceExpressivenessChanged = {},
         )
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
+import com.kernel.ai.core.voice.VoiceExpressiveness
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoicePackDownloadState
@@ -43,6 +44,8 @@ data class VoiceUiState(
     val isSelectedSherpaVoiceDownloaded: Boolean = false,
     /** Active speaker ID for multi-speaker voices (VCTK). Stored as sid 0–108. */
     val activeSpeakerId: Int = 0,
+    /** VITS noise_scale expressiveness setting (Low/Medium/High). */
+    val voiceExpressiveness: VoiceExpressiveness = VoiceExpressiveness.MEDIUM,
 )
 
 @HiltViewModel
@@ -137,6 +140,11 @@ class VoiceViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            voiceOutputPreferences.voiceExpressiveness.collect { e ->
+                _uiState.update { it.copy(voiceExpressiveness = e) }
+            }
+        }
+        viewModelScope.launch {
             voiceInputPreferences.autoStartAlertVoiceCommandsEnabled.collect { enabled ->
                 _uiState.update { it.copy(autoStartAlertVoiceCommandsEnabled = enabled) }
             }
@@ -226,6 +234,13 @@ class VoiceViewModel @Inject constructor(
         _uiState.update { it.copy(activeSpeakerId = sid) }
         viewModelScope.launch {
             voiceOutputPreferences.setActiveSpeakerId(sid)
+        }
+    }
+
+    fun setVoiceExpressiveness(e: VoiceExpressiveness) {
+        _uiState.update { it.copy(voiceExpressiveness = e) }
+        viewModelScope.launch {
+            voiceOutputPreferences.setVoiceExpressiveness(e)
         }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -5,6 +5,7 @@ import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
+import com.kernel.ai.core.voice.VoiceExpressiveness
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceInputPreferences
 import com.kernel.ai.core.voice.VoicePackDownloadState
@@ -48,6 +49,7 @@ class VoiceViewModelTest {
     private val autoSpeak = MutableStateFlow(true)
     private val maxSpokenSentences = MutableStateFlow(0)
     private val activeSpeakerId = MutableStateFlow(0)
+    private val voiceExpressiveness = MutableStateFlow(VoiceExpressiveness.MEDIUM)
     private val sherpaDownloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
         MutableStateFlow(
             SherpaPiperVoice.entries.associateWith {
@@ -81,6 +83,7 @@ class VoiceViewModelTest {
         every { voiceOutputPreferences.autoSpeak } returns autoSpeak
         every { voiceOutputPreferences.maxSpokenSentences } returns maxSpokenSentences
         every { voiceOutputPreferences.activeSpeakerId } returns activeSpeakerId
+        every { voiceOutputPreferences.voiceExpressiveness } returns voiceExpressiveness
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedEngine(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedSherpaVoice(any()) } just Runs
@@ -90,6 +93,7 @@ class VoiceViewModelTest {
         coEvery { voiceOutputPreferences.setAutoSpeak(any()) } just Runs
         coEvery { voiceOutputPreferences.setMaxSpokenSentences(any()) } just Runs
         coEvery { voiceOutputPreferences.setActiveSpeakerId(any()) } just Runs
+        coEvery { voiceOutputPreferences.setVoiceExpressiveness(any()) } just Runs
         every { sherpaVoicePackDownloadManager.downloadStates } returns sherpaDownloadStates
         every { sherpaVoicePackDownloadManager.startDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.cancelDownload(any()) } just Runs


### PR DESCRIPTION
## Summary

Implements two Phase 3F voice quality issues together — they share the same voice controller territory.

## #788 — VITS noise_scale Expressiveness Setting

Adds a three-chip selector (Low / Medium / High) in Voice Settings → Advanced that controls VITS `noise_scale` and `noise_scale_w`. Changing expressiveness marks the engine for reinit — the new config is applied on the next utterance without blocking the UI.

| Level  | noise_scale | noise_scale_w | Effect |
|--------|------------|---------------|--------|
| Low    | 0.3        | 0.3           | Flat, consistent delivery |
| Medium | 0.667      | 0.8           | Sherpa default |
| High   | 1.0        | 1.0           | More varied, natural prosody |

## #781 — LLM-Selectable Emotional Voice Styles (Semaine)

Adds a `set_voice_emotion` native skill that lets the LLM select the appropriate emotional style when the Semaine voice is active.

| Emotion  | Semaine sid | Style |
|----------|-------------|-------|
| neutral  | 0           | Calm, measured (default) |
| happy    | 1           | Upbeat, positive |
| sad      | 2           | Subdued, gentle |
| worried  | 3           | Concerned, careful |

**Key behaviours:**
- `Skill.isEnabled()` default method added — `SetVoiceEmotionSkill` returns `false` when Semaine is not the active voice, so the skill is filtered from the system prompt and the LLM never sees it with other voices
- Emotion override is transient (in-memory only, not persisted) and resets to `-1` after each TTS call — no bleed between turns
- `SkillRegistry.buildNativeDeclarations()` filters out disabled skills before prompt injection

## Changes

- `VoiceExpressiveness.kt` — new enum (LOW / MEDIUM / HIGH)
- `VoiceOutputPreferences.kt` — `voiceExpressiveness` Flow + setter
- `SherpaOnnxVoiceOutputController.kt` — expressiveness reinit logic; `emotionOverrideSid` transient state; reset in `finally` of both `speak()` and `runStreamingPlayback()`
- `VoiceViewModel.kt` + `VoiceScreen.kt` — expressiveness chips wired through
- `SetVoiceEmotionSkill.kt` — new native skill
- `Skill.kt` — `isEnabled()` default method
- `SkillRegistry.kt` — filters disabled skills from declarations
- `SkillsModule.kt` — Hilt binding for `SetVoiceEmotionSkill`
- `core/skills/build.gradle.kts` — adds `:core:voice` dependency

## Testing

- `VoiceExpressivenessTest` — 6 tests (enum values, range, ordering)
- `SetVoiceEmotionSkillTest` — 11 tests (all 4 emotions, case-insensitivity, unknown emotion failure, `isEnabled()` for Semaine vs all other voices)
- Build: `./gradlew :core:voice:testDebugUnitTest :core:skills:testDebugUnitTest :feature:settings:testDebugUnitTest assembleDebug` — ✅ 0 new failures

## Related issues

Closes #788
Closes #781
