### PR TITLE
fix: handle important date save phrases

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -183,13 +183,14 @@ class QuickIntentRouter(
     private fun normalizeImportantDateLabel(raw: String): String = raw.trim()
         .replace(Regex("""^(?:my|the)\s+""", RegexOption.IGNORE_CASE), "")
         .replace(Regex("""^(?:an?\s+)?important\s+date(?:\s+for)?\s+""", RegexOption.IGNORE_CASE), "")
+        .replace(Regex("""\s+as\s+(?:an?\s+)?important\s+date$""", RegexOption.IGNORE_CASE), "")
         .trim()
 
     private fun normalizeImportantDateLabelOrNull(raw: String): String? =
         normalizeImportantDateLabel(raw).takeIf { it.isNotBlank() }
 
     private val importantDateValuePattern =
-        "(?:\\d{1,2}(?:st|nd|rd|th)?\\s+[a-zA-Z]+(?:\\s+\\d{4})?|[a-zA-Z]+\\s+\\d{1,2}(?:st|nd|rd|th)?(?:,?\\s+\\d{4})?|\\d{4}-\\d{2}-\\d{2}|\\d{1,2}[/-]\\d{1,2}[/-]\\d{4})"
+        "(?:\\d{1,2}(?:st|nd|rd|th)?(?:\\s+of)?\\s+[a-zA-Z]+(?:\\s+\\d{4})?|[a-zA-Z]+\\s+\\d{1,2}(?:st|nd|rd|th)?(?:,?\\s+\\d{4})?|\\d{4}-\\d{2}-\\d{2}|\\d{1,2}[/-]\\d{1,2}[/-]\\d{4})"
 
     private fun extractImportantDateParams(label: String, date: String): Map<String, String> {
         val params = mutableMapOf<String, String>()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -1994,6 +1994,7 @@ class NativeIntentHandler @Inject constructor(
         val fullDateFormatters = listOf(
             DateTimeFormatter.ISO_LOCAL_DATE,
             DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("d 'of' MMMM yyyy", Locale.ENGLISH),
             DateTimeFormatter.ofPattern("MMMM d yyyy", Locale.ENGLISH),
             DateTimeFormatter.ofPattern("d/M/yyyy"),
             DateTimeFormatter.ofPattern("M/d/yyyy"),
@@ -2010,6 +2011,7 @@ class NativeIntentHandler @Inject constructor(
 
         val partialDateFormatters = listOf(
             DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("d 'of' MMMM", Locale.ENGLISH),
             DateTimeFormatter.ofPattern("MMMM d", Locale.ENGLISH),
         )
         for (formatter in partialDateFormatters) {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
@@ -22,9 +22,15 @@ fun normalizeSlotReply(text: String, slotName: String): String {
 
     return when (slotName.lowercase()) {
         "contact" -> trimmed.replace(Regex("^(?:to|for)\\s+", RegexOption.IGNORE_CASE), "").trim()
+        "date" -> normalizeDateSlotReply(trimmed)
         "list_name" -> normalizeListSlotReply(trimmed)
         else -> trimmed
     }
+}
+
+private fun normalizeDateSlotReply(trimmed: String): String {
+    DATE_SLOT_TRAILING_VALUE.matchEntire(trimmed)?.groupValues?.get(1)?.trim()?.let { return it }
+    return trimmed.replace(Regex("^(?:on|for)\\s+", RegexOption.IGNORE_CASE), "").trim()
 }
 
 private fun normalizeListSlotReply(trimmed: String): String {
@@ -40,3 +46,7 @@ private fun canonicalGenericListAlias(alias: String): String = when (alias) {
     "todo", "to do", "to-do" -> "to-do list"
     else -> alias
 }
+
+private val DATE_SLOT_TRAILING_VALUE = Regex(
+    """(?i).*(?:\b(?:is|on|for)\b)\s+((?:\d{1,2}(?:st|nd|rd|th)?(?:\s+of)?\s+[a-zA-Z]+(?:\s+\d{4})?|[a-zA-Z]+\s+\d{1,2}(?:st|nd|rd|th)?(?:,?\s+\d{4})?|\d{4}-\d{2}-\d{2}|\d{1,2}[/-]\d{1,2}[/-]\d{4}|today|tomorrow|tonight|(?:this|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|week|month|year)|monday|tuesday|wednesday|thursday|friday|saturday|sunday))$""",
+)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2855,6 +2855,8 @@ class QuickIntentRouterTest {
             Arguments.of("my wedding anniversary is 2018-06-22", "wedding anniversary", "2018-06-22"),
             Arguments.of("add important date freya's birthday 22 August", "freya's birthday", "22 August"),
             Arguments.of("add an important date for freya's birthday on 22 August", "freya's birthday", "22 August"),
+            Arguments.of("can you remember that Emily's birthday is 19 November", "Emily's birthday", "19 November"),
+            Arguments.of("add Emily's birthday as an important date on 19th of November", "Emily's birthday", "19th of November"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -891,6 +891,24 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `save important date accepts ordinal of month phrasing`() {
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        coEvery { importantDateRepository.save("Emily's birthday", 11, 19, null) } just Runs
+
+        val result = handler.handle(
+            "save_important_date",
+            mapOf("label" to "Emily's birthday", "date" to "19th of November"),
+        )
+
+        assertTrue(result is SkillResult.DirectReply)
+        assertEquals(
+            "I'll remember Emily's birthday as 19 November.",
+            (result as SkillResult.DirectReply).content,
+        )
+        coVerify(exactly = 1) { importantDateRepository.save("Emily's birthday", 11, 19, null) }
+    }
+
+    @Test
     fun `list important dates returns stored entries`() {
         coEvery { importantDateRepository.getAll() } returns listOf(
             ImportantDateEntity(label = "mum's birthday", normalizedLabel = "mum birthday", month = 3, day = 15),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -260,6 +260,64 @@ class SlotFillerManagerTest {
     }
 
     @Test
+    fun `important date slot fill extracts terminal date from natural sentence reply`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "save_important_date",
+                existingParams = mapOf("label" to "Emily's birthday"),
+                missingSlot = SlotSpec(
+                    name = "date",
+                    promptTemplate = "What date is {label}?",
+                ),
+            ),
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "Can you remember that Emily's birthday is 19 November"),
+        )
+
+        assertFalse(manager.hasPending)
+        assertEquals(
+            mapOf(
+                "label" to "Emily's birthday",
+                "date" to "19 November",
+            ),
+            completed.params,
+        )
+    }
+
+    @Test
+    fun `important date slot fill keeps ordinal of month date replies`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "save_important_date",
+                existingParams = mapOf("label" to "Emily's birthday"),
+                missingSlot = SlotSpec(
+                    name = "date",
+                    promptTemplate = "What date is {label}?",
+                ),
+            ),
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "on 19th of November"),
+        )
+
+        assertFalse(manager.hasPending)
+        assertEquals(
+            mapOf(
+                "label" to "Emily's birthday",
+                "date" to "19th of November",
+            ),
+            completed.params,
+        )
+    }
+
+    @Test
     fun `blank reply cancels and clears pending request`() {
         manager.startSlotFill(
             conversationOne,


### PR DESCRIPTION
## Summary
- accept important-date save phrases that use `19th of November` and strip a trailing `as an important date` suffix from the captured label
- normalize date slot replies so full-sentence answers like `Can you remember that Emily's birthday is 19 November` resolve to the actual date value instead of being passed through verbatim
- add regression coverage for the reported important-dates failures across router, slot-fill, and native parsing paths

## Verification
- `./gradlew :core:skills:testDebugUnitTest --tests "*QuickIntentRouterTest" --tests "*NativeIntentHandlerTest" --tests "*SlotFillerManagerTest" :core:skills:compileDebugKotlin`
