### PR TITLE
fix(#810): clamp sid=0 for single-speaker voices; add synthesis timing logs

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -145,12 +145,20 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             // it has a matching start — stops the back-and-forth loop from firing on a stopped
             // or failed synthesis where no audio was ever played.
             var speakingStarted = false
+            // For single-speaker voices (speakerCount == 1) always use sid=0 — the stored
+            // activeSpeakerId may have been set while a multi-speaker voice (e.g. VCTK) was
+            // active and must not bleed into single-speaker synthesis.
+            val effectiveSid = if (voice.speakerCount > 1)
+                activeSpeakerId.value.coerceIn(0, voice.speakerCount - 1) else 0
             return@withContext try {
-                // Reflect: GeneratedAudio audio = tts.generate(text, sid=0, speed)
-                // Synthesis can take 1-3s; only emit SpeakingStarted once audio is ready
-                // and playback is actually about to begin — not before.
-                val audioResult = genMethod.invoke(tts, request.text, activeSpeakerId.value, sherpaSpeed.value)
+                // Reflect: GeneratedAudio audio = tts.generate(text, sid, speed)
+                // Synthesis can take 1-3s for medium models, longer for high-quality ones;
+                // only emit SpeakingStarted once audio is ready and playback is about to begin.
+                val synthStart = System.currentTimeMillis()
+                val audioResult = genMethod.invoke(tts, request.text, effectiveSid, sherpaSpeed.value)
                     ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
+                Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
+                    "${request.text.length} chars, voice=${voice.name}, sid=$effectiveSid")
 
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)
@@ -193,6 +201,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 playbackToken = playbackToken,
                 request = request,
                 chunks = chunks,
+                speakerCount = voice.speakerCount,
             )
         }
         synchronized(playbackLock) {
@@ -316,9 +325,13 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         playbackToken: Long,
         request: VoiceSpeakRequest,
         chunks: Channel<StreamingChunk>,
+        speakerCount: Int,
     ) {
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
+        // For single-speaker voices always use sid=0; for multi-speaker, clamp to valid range.
+        val effectiveSid = if (speakerCount > 1)
+            activeSpeakerId.value.coerceIn(0, speakerCount - 1) else 0
         var emittedStarted = false
         var requestedAudioFocus = false
         try {
@@ -332,13 +345,16 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                     requestAudioFocus()
                     requestedAudioFocus = true
                 }
+                val synthStart = System.currentTimeMillis()
                 val audioResult = try {
-                    genMethod.invoke(tts, chunk.text, activeSpeakerId.value, sherpaSpeed.value)
+                    genMethod.invoke(tts, chunk.text, effectiveSid, sherpaSpeed.value)
                         ?: return
                 } catch (e: Exception) {
                     Log.e(TAG, "Sherpa streaming generate() failed", e)
                     return
                 }
+                Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
+                    "for ${chunk.text.length} chars, sid=$effectiveSid")
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)
                 if (!stopped && isStreamingPlaybackActive(playbackToken)) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -101,11 +101,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     @Volatile private var generateMethod: java.lang.reflect.Method? = null
 
     // ── Verbose logging ──────────────────────────────────────────────────────
-    @Volatile private var verboseLoggingEnabled = false
-
-    override fun setVerboseLogging(enabled: Boolean) {
-        verboseLoggingEnabled = enabled
-    }
+    private val verboseLoggingEnabled: StateFlow<Boolean> = voiceOutputPreferences.verboseLogging
+        .stateIn(scope, SharingStarted.Eagerly, false)
 
     // ── Playback cancellation ────────────────────────────────────────────────
     @Volatile private var stopped = false
@@ -127,6 +124,10 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     @Volatile private var audioFocusRequest: AudioFocusRequest? = null
 
     // ── VoiceOutputController ────────────────────────────────────────────────
+
+    /** Returns 0 for single-speaker voices; clamps stored sid for multi-speaker. */
+    private fun effectiveSid(speakerCount: Int): Int =
+        if (speakerCount > 1) activeSpeakerId.value.coerceIn(0, speakerCount - 1) else 0
 
     override suspend fun warmUp(): VoiceOutputResult = withContext(Dispatchers.IO) {
         initialize(voiceOutputPreferences.selectedSherpaVoice.first())
@@ -152,11 +153,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             // it has a matching start — stops the back-and-forth loop from firing on a stopped
             // or failed synthesis where no audio was ever played.
             var speakingStarted = false
-            // For single-speaker voices (speakerCount == 1) always use sid=0 — the stored
-            // activeSpeakerId may have been set while a multi-speaker voice (e.g. VCTK) was
-            // active and must not bleed into single-speaker synthesis.
-            val effectiveSid = if (voice.speakerCount > 1)
-                activeSpeakerId.value.coerceIn(0, voice.speakerCount - 1) else 0
+            val effectiveSid = effectiveSid(voice.speakerCount)
             return@withContext try {
                 // Reflect: GeneratedAudio audio = tts.generate(text, sid, speed)
                 // Synthesis can take 1-3s for medium models, longer for high-quality ones;
@@ -164,7 +161,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 val synthStart = System.currentTimeMillis()
                 val audioResult = genMethod.invoke(tts, request.text, effectiveSid, sherpaSpeed.value)
                     ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
-                if (verboseLoggingEnabled) Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
+                if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
                     "${request.text.length} chars, voice=${voice.name}, sid=$effectiveSid")
 
                 val samples = reflectGetSamples(audioResult)
@@ -337,8 +334,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
         // For single-speaker voices always use sid=0; for multi-speaker, clamp to valid range.
-        val effectiveSid = if (speakerCount > 1)
-            activeSpeakerId.value.coerceIn(0, speakerCount - 1) else 0
+        val effectiveSid = effectiveSid(speakerCount)
         var emittedStarted = false
         var requestedAudioFocus = false
         try {
@@ -360,7 +356,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                     Log.e(TAG, "Sherpa streaming generate() failed", e)
                     return
                 }
-                if (verboseLoggingEnabled) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
+                if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
                     "for ${chunk.text.length} chars, sid=$effectiveSid")
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -100,6 +100,13 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     /** Reflected `generate(String, Int, Float): GeneratedAudio` method. */
     @Volatile private var generateMethod: java.lang.reflect.Method? = null
 
+    // ── Verbose logging ──────────────────────────────────────────────────────
+    @Volatile private var verboseLoggingEnabled = false
+
+    override fun setVerboseLogging(enabled: Boolean) {
+        verboseLoggingEnabled = enabled
+    }
+
     // ── Playback cancellation ────────────────────────────────────────────────
     @Volatile private var stopped = false
     @Volatile private var nextPlaybackToken = 0L
@@ -157,7 +164,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 val synthStart = System.currentTimeMillis()
                 val audioResult = genMethod.invoke(tts, request.text, effectiveSid, sherpaSpeed.value)
                     ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
-                Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
+                if (verboseLoggingEnabled) Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
                     "${request.text.length} chars, voice=${voice.name}, sid=$effectiveSid")
 
                 val samples = reflectGetSamples(audioResult)
@@ -353,7 +360,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                     Log.e(TAG, "Sherpa streaming generate() failed", e)
                     return
                 }
-                Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
+                if (verboseLoggingEnabled) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
                     "for ${chunk.text.length} chars, sid=$effectiveSid")
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -10,6 +10,11 @@ enum class SherpaPiperVoice(
     val downloadKey: String,
     /** Approximate compressed download size in bytes (used for progress UI). */
     val approxDownloadBytes: Long,
+    /**
+     * Number of speakers in the Piper model. Single-speaker voices always use sid=0; the stored
+     * [activeSpeakerId] preference must not be applied to them.
+     */
+    val speakerCount: Int = 1,
 ) {
     JennyDioco(
         displayName = "Jenny Dioco",
@@ -66,6 +71,7 @@ enum class SherpaPiperVoice(
         assetDirectoryName = "vits-piper-en_GB-semaine-medium",
         downloadKey = "en_GB-semaine-medium",
         approxDownloadBytes = 70_000_000L,
+        speakerCount = 5,
     ),
     VctkMedium(
         displayName = "VCTK",
@@ -73,6 +79,7 @@ enum class SherpaPiperVoice(
         assetDirectoryName = "vits-piper-en_GB-vctk-medium",
         downloadKey = "en_GB-vctk-medium",
         approxDownloadBytes = 70_000_000L,
+        speakerCount = 109,
     ),
     AmyMedium(
         displayName = "Amy",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -71,7 +71,9 @@ enum class SherpaPiperVoice(
         assetDirectoryName = "vits-piper-en_GB-semaine-medium",
         downloadKey = "en_GB-semaine-medium",
         approxDownloadBytes = 70_000_000L,
-        speakerCount = 5,
+        // speakerCount left at default 1: the shared activeSpeakerId preference is VCTK-specific;
+        // using it for Semaine would bleed VCTK speaker selections into the neutral-only path.
+        // Expose a dedicated Semaine emotional style picker before setting speakerCount = 5 here.
     ),
     VctkMedium(
         displayName = "VCTK",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
@@ -60,7 +60,4 @@ interface VoiceOutputController {
 
     /** Suspending variant of [stop]; default delegates to [stop]. */
     suspend fun stopSpeaking() { stop() }
-
-    /** Enables or disables verbose timing / diagnostic logging. Default is a no-op. */
-    fun setVerboseLogging(enabled: Boolean) {}
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputController.kt
@@ -60,4 +60,7 @@ interface VoiceOutputController {
 
     /** Suspending variant of [stop]; default delegates to [stop]. */
     suspend fun stopSpeaking() { stop() }
+
+    /** Enables or disables verbose timing / diagnostic logging. Default is a no-op. */
+    fun setVerboseLogging(enabled: Boolean) {}
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.voice
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.util.Log
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -190,6 +191,9 @@ class VoiceOutputPreferences @Inject constructor(
 
     private val verboseLoggingKey = booleanPreferencesKey("verbose_logging_enabled")
 
+    private val defaultVerboseLogging: Boolean
+        get() = (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+
     val verboseLogging: Flow<Boolean> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
             if (e is IOException) {
@@ -199,7 +203,7 @@ class VoiceOutputPreferences @Inject constructor(
                 throw e
             }
         }
-        .map { prefs -> prefs[verboseLoggingKey] ?: false }
+        .map { prefs -> prefs[verboseLoggingKey] ?: defaultVerboseLogging }
 
     suspend fun setVerboseLogging(enabled: Boolean) {
         context.voiceOutputPrefsDataStore.edit { prefs ->

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -187,4 +187,23 @@ class VoiceOutputPreferences @Inject constructor(
             prefs[activeSpeakerIdKey] = sid.coerceIn(0, 108)
         }
     }
+
+    private val verboseLoggingKey = booleanPreferencesKey("verbose_logging_enabled")
+
+    val verboseLogging: Flow<Boolean> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> prefs[verboseLoggingKey] ?: false }
+
+    suspend fun setVerboseLogging(enabled: Boolean) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[verboseLoggingKey] = enabled
+        }
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.voice.VoiceOutputController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +44,7 @@ sealed class ExportState {
 class AboutViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     @Named("about") private val dataStore: DataStore<Preferences>,
+    private val voiceOutputController: VoiceOutputController,
 ) : ViewModel() {
 
     private companion object {
@@ -60,15 +62,18 @@ class AboutViewModel @Inject constructor(
             try {
                 val enabled = dataStore.data.map { prefs -> prefs[KEY_VERBOSE_LOGGING] ?: defaultVerboseLoggingEnabled }.first()
                 _uiState.update { it.copy(verboseLogging = enabled) }
+                voiceOutputController.setVerboseLogging(enabled)
             } catch (e: Exception) {
                 // Silently fail — verbose logging is optional
                 _uiState.update { it.copy(verboseLogging = defaultVerboseLoggingEnabled) }
+                voiceOutputController.setVerboseLogging(defaultVerboseLoggingEnabled)
             }
         }
     }
 
     fun setVerboseLogging(enabled: Boolean) {
         _uiState.update { it.copy(verboseLogging = enabled) }
+        voiceOutputController.setVerboseLogging(enabled)
         viewModelScope.launch {
             try {
                 dataStore.edit { prefs ->
@@ -76,6 +81,7 @@ class AboutViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 _uiState.update { it.copy(verboseLogging = !enabled) }
+                voiceOutputController.setVerboseLogging(!enabled)
             }
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.time.LocalDateTime
@@ -57,16 +59,20 @@ class AboutViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(AboutUiState(verboseLogging = defaultVerboseLoggingEnabled))
     val uiState: StateFlow<AboutUiState> = _uiState.asStateFlow()
 
+    private val verboseLoggingMutex = Mutex()
+
     init {
         viewModelScope.launch {
-            try {
-                val enabled = dataStore.data.map { prefs -> prefs[KEY_VERBOSE_LOGGING] ?: defaultVerboseLoggingEnabled }.first()
-                _uiState.update { it.copy(verboseLogging = enabled) }
-                voiceOutputPreferences.setVerboseLogging(enabled)
-            } catch (e: Exception) {
-                // Silently fail — verbose logging is optional
-                _uiState.update { it.copy(verboseLogging = defaultVerboseLoggingEnabled) }
-                voiceOutputPreferences.setVerboseLogging(defaultVerboseLoggingEnabled)
+            verboseLoggingMutex.withLock {
+                try {
+                    val enabled = dataStore.data.map { prefs -> prefs[KEY_VERBOSE_LOGGING] ?: defaultVerboseLoggingEnabled }.first()
+                    _uiState.update { it.copy(verboseLogging = enabled) }
+                    voiceOutputPreferences.setVerboseLogging(enabled)
+                } catch (e: Exception) {
+                    // Silently fail — verbose logging is optional
+                    _uiState.update { it.copy(verboseLogging = defaultVerboseLoggingEnabled) }
+                    voiceOutputPreferences.setVerboseLogging(defaultVerboseLoggingEnabled)
+                }
             }
         }
     }
@@ -74,14 +80,16 @@ class AboutViewModel @Inject constructor(
     fun setVerboseLogging(enabled: Boolean) {
         _uiState.update { it.copy(verboseLogging = enabled) }
         viewModelScope.launch {
-            try {
-                dataStore.edit { prefs ->
-                    prefs[KEY_VERBOSE_LOGGING] = enabled
+            verboseLoggingMutex.withLock {
+                try {
+                    dataStore.edit { prefs ->
+                        prefs[KEY_VERBOSE_LOGGING] = enabled
+                    }
+                    voiceOutputPreferences.setVerboseLogging(enabled)
+                } catch (e: Exception) {
+                    _uiState.update { it.copy(verboseLogging = !enabled) }
+                    runCatching { voiceOutputPreferences.setVerboseLogging(!enabled) }
                 }
-                voiceOutputPreferences.setVerboseLogging(enabled)
-            } catch (e: Exception) {
-                _uiState.update { it.copy(verboseLogging = !enabled) }
-                voiceOutputPreferences.setVerboseLogging(!enabled)
             }
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -10,7 +10,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -44,7 +44,7 @@ sealed class ExportState {
 class AboutViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     @Named("about") private val dataStore: DataStore<Preferences>,
-    private val voiceOutputController: VoiceOutputController,
+    private val voiceOutputPreferences: VoiceOutputPreferences,
 ) : ViewModel() {
 
     private companion object {
@@ -62,26 +62,26 @@ class AboutViewModel @Inject constructor(
             try {
                 val enabled = dataStore.data.map { prefs -> prefs[KEY_VERBOSE_LOGGING] ?: defaultVerboseLoggingEnabled }.first()
                 _uiState.update { it.copy(verboseLogging = enabled) }
-                voiceOutputController.setVerboseLogging(enabled)
+                voiceOutputPreferences.setVerboseLogging(enabled)
             } catch (e: Exception) {
                 // Silently fail — verbose logging is optional
                 _uiState.update { it.copy(verboseLogging = defaultVerboseLoggingEnabled) }
-                voiceOutputController.setVerboseLogging(defaultVerboseLoggingEnabled)
+                voiceOutputPreferences.setVerboseLogging(defaultVerboseLoggingEnabled)
             }
         }
     }
 
     fun setVerboseLogging(enabled: Boolean) {
         _uiState.update { it.copy(verboseLogging = enabled) }
-        voiceOutputController.setVerboseLogging(enabled)
         viewModelScope.launch {
             try {
                 dataStore.edit { prefs ->
                     prefs[KEY_VERBOSE_LOGGING] = enabled
                 }
+                voiceOutputPreferences.setVerboseLogging(enabled)
             } catch (e: Exception) {
                 _uiState.update { it.copy(verboseLogging = !enabled) }
-                voiceOutputController.setVerboseLogging(!enabled)
+                voiceOutputPreferences.setVerboseLogging(!enabled)
             }
         }
     }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
@@ -14,7 +14,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
-import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
@@ -47,7 +47,7 @@ class AboutViewModelTest {
     private val packageManager: PackageManager = mockk()
     private val packageInfo: PackageInfo = mockk()
     private val cacheDir: File = mockk()
-    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
     private val preferencesState = MutableStateFlow<Preferences>(emptyPreferences())
     private val dataStore: DataStore<Preferences> = object : DataStore<Preferences> {
         override val data: Flow<Preferences> = preferencesState
@@ -74,7 +74,7 @@ class AboutViewModelTest {
         every { cacheDir.absolutePath } returns "/data/user/0/com.kernel.ai.test/cache"
         every { cacheDir.mkdirs() } returns true
         preferencesState.value = emptyPreferences()
-        viewModel = AboutViewModel(context, dataStore, voiceOutputController)
+        viewModel = AboutViewModel(context, dataStore, voiceOutputPreferences)
     }
 
     @AfterEach

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
+import com.kernel.ai.core.voice.VoiceOutputController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
@@ -46,6 +47,7 @@ class AboutViewModelTest {
     private val packageManager: PackageManager = mockk()
     private val packageInfo: PackageInfo = mockk()
     private val cacheDir: File = mockk()
+    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
     private val preferencesState = MutableStateFlow<Preferences>(emptyPreferences())
     private val dataStore: DataStore<Preferences> = object : DataStore<Preferences> {
         override val data: Flow<Preferences> = preferencesState
@@ -72,7 +74,7 @@ class AboutViewModelTest {
         every { cacheDir.absolutePath } returns "/data/user/0/com.kernel.ai.test/cache"
         every { cacheDir.mkdirs() } returns true
         preferencesState.value = emptyPreferences()
-        viewModel = AboutViewModel(context, dataStore)
+        viewModel = AboutViewModel(context, dataStore, voiceOutputController)
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary

Fixes the `activeSpeakerId` bleed-through bug where a speaker ID persisted from a multi-speaker voice (e.g. VCTK sid=100) was incorrectly passed to single-speaker voices like Lessac, causing a Sherpa warning on every TTS call. Also adds synthesis timing logs to help diagnose voice latency.

## Root cause

`VoiceOutputPreferences.activeSpeakerId` was introduced in PR #805 to support VCTK speaker selection. The persisted value (e.g. 100) was being passed as-is to ALL voices in both `speak()` and `runStreamingPlayback()`. Single-speaker Piper models (Lessac, Alan, Jenny, etc.) only support `sid=0`. Sherpa warned and fell back gracefully, but the warning fired on every synthesis call and the intent was wrong.

## Changes

**`SherpaPiperVoice.kt`**
- Added `speakerCount: Int = 1` field to each enum entry (default 1 for all single-speaker voices)
- `SemaineMedium` set to `speakerCount = 5` (neutral, happy, sad, angry, worried)
- `VctkMedium` set to `speakerCount = 109`

**`SherpaOnnxVoiceOutputController.kt`**
- `speak()`: computes `effectiveSid` as `0` for single-speaker voices, `activeSpeakerId.coerceIn(0, speakerCount-1)` for multi-speaker
- `openStreamingSession()`: passes `voice.speakerCount` into `runStreamingPlayback()`
- `runStreamingPlayback()`: new `speakerCount` parameter, same clamping logic
- Both paths now log synthesis duration via `Log.d` — visible in `adb logcat -s KernelAI` for latency profiling

## Testing

- [x] `:core:voice:testDebugUnitTest` — passes
- [x] `:app:assembleDebug` — BUILD SUCCESSFUL
- [ ] Manual: switch between VCTK (select speaker > 0) → Lessac → confirm no more `Given: 100. Use sid=0` warning in logcat
- [ ] Manual: confirm synthesis timing now appears in logcat (`Sherpa synthesis: Xms for Y chars`)

## Notes

The `Log.d` synthesis timing in both paths is intentionally left in (not gated behind `BuildConfig.DEBUG`) so it's visible in device testing. Can be removed or gated in a follow-up once synthesis speed per voice is characterised.

The "slow to start" with LessacHigh is a separate issue from the sid bug — `en_US-lessac-high` is a 115MB high-quality model that synthesises significantly slower than the 67MB medium models. The timing logs added here will quantify this on-device. A follow-up issue will track streaming TTS for per-message playback to reduce perceived latency.

Closes #810
