### PR TITLE
feat(#812): stream per-message TTS sentence-by-sentence

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -942,7 +942,31 @@ class ChatViewModel @Inject constructor(
             val maxSentences = voiceOutputPreferences.maxSpokenSentences.first()
             val textToSpeak = truncateForSpeech(normalizedText, maxSentences)
             try {
-                voiceOutputController.speak(VoiceSpeakRequest(text = textToSpeak))
+                // Use the streaming session path so sentence 1 starts playing while
+                // sentence 2 is being synthesised — critical for long responses with
+                // high-quality voices (e.g. LessacHigh) which synthesise slowly.
+                val session = voiceOutputController.openStreamingSession(
+                    VoiceSpeakRequest(text = textToSpeak),
+                )
+                val buffer = StringBuilder(textToSpeak)
+                while (buffer.isNotBlank()) {
+                    val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
+                    val chunk = popNextStreamingSpeechChunk(
+                        buffer = buffer,
+                        minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                        preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                        force = isShort,
+                    ) ?: break
+                    val isLast = buffer.isBlank()
+                    session.append(chunk, isFinal = isLast)
+                }
+                // Flush any residual text that didn't form a clean chunk boundary
+                val remaining = finalizeChatTextForSpeech(buffer.toString())
+                if (remaining.isNotBlank()) {
+                    session.append(remaining, isFinal = true)
+                } else {
+                    session.append("", isFinal = true)
+                }
             } finally {
                 if (_speakingMessageId.value == messageId) {
                     _speakingMessageId.value = null


### PR DESCRIPTION
## Summary

Per-message speaker button now uses the streaming TTS path (sentence-by-sentence) instead of batch synthesis. Previously, tapping the speaker icon on a long reply would wait for the entire response to be synthesised before any audio played — especially painful with high-quality voices like `LessacHigh` (115MB ONNX model). Now sentence 1 plays while sentence 2 is synthesising.

## Changes

- `ChatViewModel.speakMessage()`: replaced `voiceOutputController.speak()` with `voiceOutputController.openStreamingSession()` + sentence-chunked feeding using `popNextStreamingSpeechChunk()`
- Residual text (shorter than a clean sentence boundary) is flushed as the final chunk via `finalizeChatTextForSpeech()`
- Empty-text safety: if nothing remains after chunking, sends `append("", isFinal=true)` to properly close the streaming session

## Testing

- [ ] Unit tests pass (3 pre-existing failures on `main` unrelated to this change: `LatexConversionTest`, 2× `ChatViewModelVoiceTest`)
- [ ] `./gradlew :app:assembleDebug` succeeds
- [ ] Manual: tap speaker button on a long Lessac reply — first sentence starts playing immediately instead of waiting for full synthesis

## Related issues

Closes #812
