### PR TITLE
fix: align MTP docs and init test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Measured on-device from production logs. "tok/s" counts output tokens delivered 
 
 **Multi-Token Prediction (MTP / speculative decoding)**
 
-MTP uses a bundled drafter model to speculatively generate multiple tokens per GPU step. The benefit scales with response length — on long responses (~400+ tokens) we observed a **~2× wall-time speedup**; on short responses the overhead is negligible. Toggle in Settings → Model → E-4B panel.
+MTP speeds up decode by speculatively generating multiple tokens per step. LiteRT-LM recommends it on GPU backends, and Jandal enables it during engine initialisation only when the loaded Gemma 4 model reports support. The toggle is available in Settings → Model for Gemma 4 model cards and requires an app restart. The benefit scales with response length — on long responses (~400+ tokens) we observed a **~2× wall-time speedup**; on short responses the overhead is negligible.
 
 | Response length | MTP off | MTP on | Speedup |
 |----------------|---------|--------|---------|

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -45,6 +45,32 @@ import javax.inject.Singleton
 
 private const val TAG = "LiteRtInferenceEngine"
 
+@OptIn(ExperimentalApi::class)
+internal inline fun <T> withSpeculativeDecodingEnabledForInit(enabled: Boolean, block: () -> T): T {
+    ExperimentalFlags.enableSpeculativeDecoding = enabled
+    return try {
+        block()
+    } finally {
+        ExperimentalFlags.enableSpeculativeDecoding = false
+    }
+}
+
+internal fun resolveSpeculativeDecodingForInit(
+    requested: Boolean,
+    modelPath: String,
+    capabilityProbe: (String) -> Boolean = ::modelSupportsSpeculativeDecoding,
+): Boolean {
+    if (!requested) return false
+    return try {
+        capabilityProbe(modelPath)
+    } catch (_: Exception) {
+        false
+    }
+}
+
+private fun modelSupportsSpeculativeDecoding(modelPath: String): Boolean =
+    Capabilities(modelPath).use { it.hasSpeculativeDecodingSupport() }
+
 /**
  * LiteRT-LM implementation of [InferenceEngine].
  *
@@ -451,26 +477,17 @@ class LiteRtInferenceEngine @Inject constructor(
                 // MTP speculative decoding must be enabled BEFORE Engine.initialize() —
                 // Gallery pattern: the flag is compiled into the engine at init time, not at
                 // createConversation() time. Check Capabilities first to guard unsupported models.
-                var supportsSpeculativeDecoding = false
-                if (config.speculativeDecodingEnabled) {
-                    try {
-                        Capabilities(config.modelPath).use {
-                            supportsSpeculativeDecoding = it.hasSpeculativeDecodingSupport()
-                        }
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Capabilities check failed, assuming no MTP support: ${e.message}")
-                    }
+                val speculativeDecoding = resolveSpeculativeDecodingForInit(
+                    requested = config.speculativeDecodingEnabled,
+                    modelPath = config.modelPath,
+                )
+                Log.d(TAG, "Speculative decoding: requested=${config.speculativeDecodingEnabled} active=$speculativeDecoding")
+                val eng = withSpeculativeDecodingEnabledForInit(speculativeDecoding) {
+                    Engine(engineConfig).also { it.initialize() }
                 }
-                val speculativeDecoding = config.speculativeDecodingEnabled && supportsSpeculativeDecoding
-                ExperimentalFlags.enableSpeculativeDecoding = speculativeDecoding
-                Log.d(TAG, "Speculative decoding: requested=${config.speculativeDecodingEnabled} supported=$supportsSpeculativeDecoding active=$speculativeDecoding")
-                val eng = Engine(engineConfig)
-                eng.initialize()
-                ExperimentalFlags.enableSpeculativeDecoding = false
                 Log.i(TAG, "Backend $backendType initialized successfully")
                 return Pair(eng, backendType)
             } catch (e: Exception) {
-                ExperimentalFlags.enableSpeculativeDecoding = false
                 Log.w(TAG, "Backend $backendType failed: ${e.message}")
                 lastException = e
             }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -59,11 +59,13 @@ internal fun resolveSpeculativeDecodingForInit(
     requested: Boolean,
     modelPath: String,
     capabilityProbe: (String) -> Boolean = ::modelSupportsSpeculativeDecoding,
+    onProbeFailure: (String, Exception) -> Unit = { _, _ -> },
 ): Boolean {
     if (!requested) return false
     return try {
         capabilityProbe(modelPath)
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        onProbeFailure(modelPath, e)
         false
     }
 }
@@ -480,6 +482,9 @@ class LiteRtInferenceEngine @Inject constructor(
                 val speculativeDecoding = resolveSpeculativeDecodingForInit(
                     requested = config.speculativeDecodingEnabled,
                     modelPath = config.modelPath,
+                    onProbeFailure = { modelPath, error ->
+                        Log.w(TAG, "Speculative decoding capability probe failed for $modelPath: ${error.message}")
+                    },
                 )
                 Log.d(TAG, "Speculative decoding: requested=${config.speculativeDecodingEnabled} active=$speculativeDecoding")
                 val eng = withSpeculativeDecodingEnabledForInit(speculativeDecoding) {

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/LiteRtInferenceEngineSpeculativeDecodingTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/LiteRtInferenceEngineSpeculativeDecodingTest.kt
@@ -1,0 +1,81 @@
+package com.kernel.ai.core.inference
+
+import com.google.ai.edge.litertlm.ExperimentalApi
+import com.google.ai.edge.litertlm.ExperimentalFlags
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalApi::class)
+class LiteRtInferenceEngineSpeculativeDecodingTest {
+    @AfterEach
+    fun tearDown() {
+        ExperimentalFlags.enableSpeculativeDecoding = false
+    }
+
+    @Test
+    fun `resolveSpeculativeDecodingForInit returns false without probing when setting disabled`() {
+        var probed = false
+
+        val result = resolveSpeculativeDecodingForInit(
+            requested = false,
+            modelPath = "/tmp/model.litertlm",
+            capabilityProbe = {
+                probed = true
+                true
+            },
+        )
+
+        assertFalse(result)
+        assertFalse(probed)
+    }
+
+    @Test
+    fun `resolveSpeculativeDecodingForInit returns true when requested and supported`() {
+        val result = resolveSpeculativeDecodingForInit(
+            requested = true,
+            modelPath = "/tmp/model.litertlm",
+            capabilityProbe = { true },
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `resolveSpeculativeDecodingForInit returns false when capability probe throws`() {
+        val result = resolveSpeculativeDecodingForInit(
+            requested = true,
+            modelPath = "/tmp/model.litertlm",
+            capabilityProbe = { throw IllegalStateException("boom") },
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `withSpeculativeDecodingEnabledForInit enables flag only during init block`() {
+        assertFalse(ExperimentalFlags.enableSpeculativeDecoding == true)
+
+        withSpeculativeDecodingEnabledForInit(true) {
+            assertTrue(ExperimentalFlags.enableSpeculativeDecoding == true)
+        }
+
+        assertFalse(ExperimentalFlags.enableSpeculativeDecoding == true)
+    }
+
+    @Test
+    fun `withSpeculativeDecodingEnabledForInit resets flag after init failure`() {
+        assertFalse(ExperimentalFlags.enableSpeculativeDecoding == true)
+
+        assertThrows(IllegalStateException::class.java) {
+            withSpeculativeDecodingEnabledForInit(true) {
+                assertTrue(ExperimentalFlags.enableSpeculativeDecoding == true)
+                throw IllegalStateException("init failed")
+            }
+        }
+
+        assertFalse(ExperimentalFlags.enableSpeculativeDecoding == true)
+    }
+}


### PR DESCRIPTION
## Summary
- update the README MTP section so it no longer claims an E-4B-only toggle or repo-managed drafter asset details that are not actually implemented here
- extract small speculative-decoding init helpers in `LiteRtInferenceEngine` so the engine-init flag behavior can be tested directly
- add focused unit coverage proving the MTP flag is only enabled during engine init, resets afterward, and stays off when the setting is disabled or capability probing fails

## Verification
- `./gradlew :core:inference:testDebugUnitTest --tests "*LiteRtInferenceEngineSpeculativeDecodingTest" :core:inference:compileDebugKotlin`

Closes #814
