### PR TITLE
feat(#817, #812): Semaine speaker selection + streaming per-message TTS

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SemaineSpeakerMetadata.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SemaineSpeakerMetadata.kt
@@ -16,10 +16,7 @@ data class SemaineSpeaker(
 }
 
 /**
- * Bundled metadata for the two exposed female speakers in the `en_GB-semaine-medium` Piper model.
- *
- * The Semaine model has 4 speakers total (sid 0–3). Only the two female speakers are exposed
- * here — the male speakers (sid 1 "Spike" and sid 2 "Obadiah") are intentionally excluded.
+ * Bundled metadata for all 4 speakers in the `en_GB-semaine-medium` Piper model.
  *
  * Sid mapping sourced from the en_GB-semaine-medium.onnx.json speaker_id_map:
  *   0 = prudence, 1 = spike, 2 = obadiah, 3 = poppy
@@ -28,6 +25,8 @@ object SemaineSpeakerMetadata {
 
     val speakers: List<SemaineSpeaker> = listOf(
         SemaineSpeaker(sid = 0, displayName = "Prudence", description = "female, calm"),
+        SemaineSpeaker(sid = 1, displayName = "Spike",    description = "male, neutral"),
+        SemaineSpeaker(sid = 2, displayName = "Obadiah",  description = "male, melancholic"),
         SemaineSpeaker(sid = 3, displayName = "Poppy",    description = "female, upbeat"),
     )
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SemaineSpeakerMetadata.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SemaineSpeakerMetadata.kt
@@ -1,0 +1,40 @@
+package com.kernel.ai.core.voice
+
+/**
+ * Metadata for a single Semaine multi-speaker voice.
+ *
+ * [sid] maps directly to the `sid` parameter in Sherpa-ONNX's `generate(text, sid, speed)`.
+ * [displayName] is the human-readable speaker name (used in the Settings → Voice picker).
+ * [description] is a short description of the speaker's character.
+ */
+data class SemaineSpeaker(
+    val sid: Int,
+    val displayName: String,
+    val description: String,
+) {
+    val displayLabel: String get() = "$displayName — $description"
+}
+
+/**
+ * Bundled metadata for the two exposed female speakers in the `en_GB-semaine-medium` Piper model.
+ *
+ * The Semaine model has 4 speakers total (sid 0–3). Only the two female speakers are exposed
+ * here — the male speakers (sid 1 "Spike" and sid 2 "Obadiah") are intentionally excluded.
+ *
+ * Sid mapping sourced from the en_GB-semaine-medium.onnx.json speaker_id_map:
+ *   0 = prudence, 1 = spike, 2 = obadiah, 3 = poppy
+ */
+object SemaineSpeakerMetadata {
+
+    val speakers: List<SemaineSpeaker> = listOf(
+        SemaineSpeaker(sid = 0, displayName = "Prudence", description = "female, calm"),
+        SemaineSpeaker(sid = 3, displayName = "Poppy",    description = "female, upbeat"),
+    )
+
+    /**
+     * Returns the display label for the given [sid], falling back to "Prudence" (sid=0)
+     * if the sid does not match any exposed speaker.
+     */
+    fun displayLabel(sid: Int): String =
+        speakers.firstOrNull { it.sid == sid }?.displayLabel ?: speakers.first().displayLabel
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -10,6 +10,7 @@ import android.media.PlaybackParams
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -337,34 +338,56 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         val effectiveSid = effectiveSid(speakerCount)
         var emittedStarted = false
         var requestedAudioFocus = false
+
+        // Pipeline: synthesis and playback run as concurrent coroutines connected by a bounded
+        // channel. While chunk N is playing, chunk N+1 is already being synthesised. This
+        // eliminates the per-chunk gap that occurred when synthesis only started after the
+        // previous chunk finished playing (e.g. 6–8 s gaps for LessacHigh).
+        // Capacity of 2 lets synthesis stay at most 2 chunks ahead of playback, capping memory
+        // usage while still guaranteeing the next chunk is ready the moment the current one ends.
+        val audioQueue = Channel<Pair<FloatArray, Int>>(capacity = 2)
         try {
-            for (chunk in chunks) {
-                if (stopped || !isStreamingPlaybackActive(playbackToken)) break
-                if (!emittedStarted) {
-                    _events.emit(VoiceOutputEvent.SpeakingStarted(request.text.ifBlank { chunk.text }))
-                    emittedStarted = true
+            coroutineScope {
+                // ── Synthesis producer ────────────────────────────────────────────────────
+                val synthJob = launch {
+                    try {
+                        for (chunk in chunks) {
+                            if (stopped || !isStreamingPlaybackActive(playbackToken)) break
+                            val synthStart = System.currentTimeMillis()
+                            val audioResult = try {
+                                genMethod.invoke(tts, chunk.text, effectiveSid, sherpaSpeed.value)
+                                    ?: break
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Sherpa streaming generate() failed", e)
+                                break
+                            }
+                            if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
+                                "for ${chunk.text.length} chars, sid=$effectiveSid")
+                            audioQueue.send(Pair(reflectGetSamples(audioResult), reflectGetSampleRate(audioResult)))
+                            if (chunk.isFinal) break
+                        }
+                    } finally {
+                        audioQueue.close()
+                    }
                 }
-                if (!requestedAudioFocus) {
-                    requestAudioFocus()
-                    requestedAudioFocus = true
-                }
-                val synthStart = System.currentTimeMillis()
-                val audioResult = try {
-                    genMethod.invoke(tts, chunk.text, effectiveSid, sherpaSpeed.value)
-                        ?: return
-                } catch (e: Exception) {
-                    Log.e(TAG, "Sherpa streaming generate() failed", e)
-                    return
-                }
-                if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa streaming chunk: ${System.currentTimeMillis() - synthStart}ms " +
-                    "for ${chunk.text.length} chars, sid=$effectiveSid")
-                val samples = reflectGetSamples(audioResult)
-                val sampleRate = reflectGetSampleRate(audioResult)
-                if (!stopped && isStreamingPlaybackActive(playbackToken)) {
-                    playOnAudioTrack(samples, sampleRate)
-                }
-                if (chunk.isFinal) {
-                    break
+
+                // ── Playback consumer ─────────────────────────────────────────────────────
+                launch {
+                    for ((samples, sampleRate) in audioQueue) {
+                        if (stopped || !isStreamingPlaybackActive(playbackToken)) break
+                        if (!emittedStarted) {
+                            _events.emit(VoiceOutputEvent.SpeakingStarted(request.text.ifBlank { "" }))
+                            emittedStarted = true
+                        }
+                        if (!requestedAudioFocus) {
+                            requestAudioFocus()
+                            requestedAudioFocus = true
+                        }
+                        playOnAudioTrack(samples, sampleRate)
+                    }
+                    // Playback finished (or stopped early) — cancel synthesis so it doesn't
+                    // keep producing chunks that will never be consumed.
+                    synthJob.cancel()
                 }
             }
         } finally {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -67,13 +67,13 @@ enum class SherpaPiperVoice(
     ),
     SemaineMedium(
         displayName = "Semaine",
-        description = "Expressive British English voice with multiple emotional styles (neutral, happy, sad, angry, worried). Uses neutral style (sid=0) by default.",
+        description = "Expressive British English multi-speaker voice. Choose between Prudence (calm) and Poppy (upbeat) in Settings → Voice.",
         assetDirectoryName = "vits-piper-en_GB-semaine-medium",
         downloadKey = "en_GB-semaine-medium",
         approxDownloadBytes = 70_000_000L,
-        // speakerCount left at default 1: the shared activeSpeakerId preference is VCTK-specific;
-        // using it for Semaine would bleed VCTK speaker selections into the neutral-only path.
-        // Expose a dedicated Semaine emotional style picker before setting speakerCount = 5 here.
+        // The model has 4 speakers (sid 0–3). Only the two female speakers are exposed in the UI;
+        // speakerCount = 4 so that effectiveSid correctly clamps to 0..3.
+        speakerCount = 4,
     ),
     VctkMedium(
         displayName = "VCTK",

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SemaineSpeakerMetadataTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SemaineSpeakerMetadataTest.kt
@@ -1,0 +1,56 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SemaineSpeakerMetadataTest {
+
+    @Test
+    fun `only female speakers are exposed`() {
+        assertTrue(SemaineSpeakerMetadata.speakers.isNotEmpty())
+        assertTrue(
+            SemaineSpeakerMetadata.speakers.all { it.description.contains("female") },
+            "Expected all exposed Semaine speakers to be female",
+        )
+    }
+
+    @Test
+    fun `Prudence has sid 0 and Poppy has sid 3`() {
+        val prudence = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Prudence" }
+        val poppy = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Poppy" }
+
+        assertEquals(0, prudence?.sid, "Prudence should be sid=0")
+        assertEquals(3, poppy?.sid, "Poppy should be sid=3")
+    }
+
+    @Test
+    fun `male speakers spike and obadiah are not exposed`() {
+        val names = SemaineSpeakerMetadata.speakers.map { it.displayName.lowercase() }
+        assertTrue("spike" !in names, "Spike (male) must not be exposed")
+        assertTrue("obadiah" !in names, "Obadiah (male) must not be exposed")
+    }
+
+    @Test
+    fun `displayLabel returns label for known sids`() {
+        assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(0))
+        assertEquals("Poppy — female, upbeat", SemaineSpeakerMetadata.displayLabel(3))
+    }
+
+    @Test
+    fun `displayLabel falls back to Prudence for unknown sids`() {
+        // A sid that is a valid model sid but not exposed (e.g. Spike = 1)
+        assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(1))
+        // A VCTK-range sid that might bleed through if a user was previously on VCTK
+        assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(50))
+    }
+
+    @Test
+    fun `all speaker sids are within the Semaine model speakerCount`() {
+        val modelSpeakerCount = SherpaPiperVoice.SemaineMedium.speakerCount
+        assertTrue(
+            SemaineSpeakerMetadata.speakers.all { it.sid in 0 until modelSpeakerCount },
+            "All exposed sids must be within 0 until ${modelSpeakerCount}",
+        )
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SemaineSpeakerMetadataTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SemaineSpeakerMetadataTest.kt
@@ -7,41 +7,43 @@ import org.junit.jupiter.api.Test
 class SemaineSpeakerMetadataTest {
 
     @Test
-    fun `only female speakers are exposed`() {
-        assertTrue(SemaineSpeakerMetadata.speakers.isNotEmpty())
-        assertTrue(
-            SemaineSpeakerMetadata.speakers.all { it.description.contains("female") },
-            "Expected all exposed Semaine speakers to be female",
-        )
+    fun `all 4 speakers are exposed`() {
+        assertEquals(4, SemaineSpeakerMetadata.speakers.size, "Expected exactly 4 Semaine speakers")
     }
 
     @Test
-    fun `Prudence has sid 0 and Poppy has sid 3`() {
+    fun `Prudence sid 0 Spike sid 1 Obadiah sid 2 Poppy sid 3`() {
         val prudence = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Prudence" }
-        val poppy = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Poppy" }
+        val spike    = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Spike" }
+        val obadiah  = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Obadiah" }
+        val poppy    = SemaineSpeakerMetadata.speakers.firstOrNull { it.displayName == "Poppy" }
 
         assertEquals(0, prudence?.sid, "Prudence should be sid=0")
-        assertEquals(3, poppy?.sid, "Poppy should be sid=3")
+        assertEquals(1, spike?.sid,    "Spike should be sid=1")
+        assertEquals(2, obadiah?.sid,  "Obadiah should be sid=2")
+        assertEquals(3, poppy?.sid,    "Poppy should be sid=3")
     }
 
     @Test
-    fun `male speakers spike and obadiah are not exposed`() {
-        val names = SemaineSpeakerMetadata.speakers.map { it.displayName.lowercase() }
-        assertTrue("spike" !in names, "Spike (male) must not be exposed")
-        assertTrue("obadiah" !in names, "Obadiah (male) must not be exposed")
+    fun `Spike is male neutral and Obadiah is male melancholic`() {
+        val spike   = SemaineSpeakerMetadata.speakers.first { it.displayName == "Spike" }
+        val obadiah = SemaineSpeakerMetadata.speakers.first { it.displayName == "Obadiah" }
+
+        assertEquals("male, neutral",     spike.description)
+        assertEquals("male, melancholic", obadiah.description)
     }
 
     @Test
-    fun `displayLabel returns label for known sids`() {
-        assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(0))
-        assertEquals("Poppy — female, upbeat", SemaineSpeakerMetadata.displayLabel(3))
+    fun `displayLabel returns label for all known sids`() {
+        assertEquals("Prudence — female, calm",     SemaineSpeakerMetadata.displayLabel(0))
+        assertEquals("Spike — male, neutral",       SemaineSpeakerMetadata.displayLabel(1))
+        assertEquals("Obadiah — male, melancholic", SemaineSpeakerMetadata.displayLabel(2))
+        assertEquals("Poppy — female, upbeat",      SemaineSpeakerMetadata.displayLabel(3))
     }
 
     @Test
     fun `displayLabel falls back to Prudence for unknown sids`() {
-        // A sid that is a valid model sid but not exposed (e.g. Spike = 1)
-        assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(1))
-        // A VCTK-range sid that might bleed through if a user was previously on VCTK
+        // A sid outside the 0-3 range that might bleed through if a user was previously on VCTK
         assertEquals("Prudence — female, calm", SemaineSpeakerMetadata.displayLabel(50))
     }
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
@@ -12,6 +12,11 @@ class SherpaPiperVoiceTest {
     }
 
     @Test
+    fun `SemaineMedium speakerCount is 4 to cover all model sids`() {
+        assertEquals(4, SherpaPiperVoice.SemaineMedium.speakerCount)
+    }
+
+    @Test
     fun `catalog includes expanded English voices with unique release identifiers`() {
         val expectedNewVoices = setOf(
             SherpaPiperVoice.AlanMedium,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -136,11 +136,16 @@ private fun findSpeechChunkBoundary(
         return SpeechChunkBoundary(index = text.length, type = SpeechChunkBoundaryType.FORCED)
     }
 
-    var strongBoundary = -1
+    // Scan forward and return at the FIRST suitable boundary rather than the last.
+    // The previous forEachIndexed approach kept overwriting boundary positions and returned
+    // the last sentence end in the buffer — causing the entire text (e.g. 3000+ chars) to
+    // be returned as one chunk instead of the first sentence (~150 chars).
     var softBoundary = -1
     var whitespaceBoundary = -1
 
-    text.forEachIndexed { index, char ->
+    for (index in text.indices) {
+        val char = text[index]
+
         if (char.isWhitespace()) {
             whitespaceBoundary = index + 1
         }
@@ -148,30 +153,35 @@ private fun findSpeechChunkBoundary(
             '.', '!', '?' -> {
                 val next = text.getOrNull(index + 1)
                 if (next == null || next.isWhitespace() || next == '"' || next == '\'' || next == ')') {
-                    strongBoundary = index + 1
+                    val boundary = index + 1
+                    if (boundary >= minChunkLength) {
+                        return SpeechChunkBoundary(index = boundary, type = SpeechChunkBoundaryType.STRONG)
+                    }
                 }
             }
             '\n' -> {
-                strongBoundary = index + 1
+                val boundary = index + 1
+                if (boundary >= minChunkLength) {
+                    return SpeechChunkBoundary(index = boundary, type = SpeechChunkBoundaryType.STRONG)
+                }
             }
             ',', ';', ':' -> {
                 softBoundary = index + 1
             }
         }
+
+        // Past preferred length: accept the best soft or whitespace boundary we have so far.
+        if (index + 1 >= preferredChunkLength) {
+            if (softBoundary >= minChunkLength) {
+                return SpeechChunkBoundary(index = softBoundary, type = SpeechChunkBoundaryType.SOFT)
+            }
+            if (whitespaceBoundary >= minChunkLength) {
+                return SpeechChunkBoundary(index = whitespaceBoundary, type = SpeechChunkBoundaryType.WHITESPACE)
+            }
+        }
     }
 
-    return when {
-        strongBoundary >= minChunkLength -> {
-            SpeechChunkBoundary(index = strongBoundary, type = SpeechChunkBoundaryType.STRONG)
-        }
-        text.length >= preferredChunkLength && softBoundary >= minChunkLength -> {
-            SpeechChunkBoundary(index = softBoundary, type = SpeechChunkBoundaryType.SOFT)
-        }
-        text.length >= preferredChunkLength && whitespaceBoundary >= minChunkLength -> {
-            SpeechChunkBoundary(index = whitespaceBoundary, type = SpeechChunkBoundaryType.WHITESPACE)
-        }
-        else -> null
-    }
+    return null
 }
 
 private fun applySpeechPronunciationOverrides(text: String): String =

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -171,12 +171,17 @@ private fun findSpeechChunkBoundary(
         }
 
         // Past preferred length: accept the best soft or whitespace boundary we have so far.
+        // Prefer SOFT only if it's at least as recent as the last whitespace; otherwise a stale
+        // early comma would be chosen over a whitespace boundary much closer to preferredChunkLength.
         if (index + 1 >= preferredChunkLength) {
-            if (softBoundary >= minChunkLength) {
+            if (softBoundary >= minChunkLength && softBoundary >= whitespaceBoundary) {
                 return SpeechChunkBoundary(index = softBoundary, type = SpeechChunkBoundaryType.SOFT)
             }
             if (whitespaceBoundary >= minChunkLength) {
                 return SpeechChunkBoundary(index = whitespaceBoundary, type = SpeechChunkBoundaryType.WHITESPACE)
+            }
+            if (softBoundary >= minChunkLength) {
+                return SpeechChunkBoundary(index = softBoundary, type = SpeechChunkBoundaryType.SOFT)
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -59,7 +59,6 @@ import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
 import com.kernel.ai.core.voice.VoiceInputStartResult
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -951,30 +950,23 @@ class ChatViewModel @Inject constructor(
                 )
                 val buffer = StringBuilder(textToSpeak)
                 var finalised = false
-                try {
-                    while (buffer.isNotBlank()) {
-                        val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
-                        val chunk = popNextStreamingSpeechChunk(
-                            buffer = buffer,
-                            minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
-                            preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
-                            force = isShort,
-                        ) ?: break
-                        val isLast = buffer.isBlank()
-                        session.append(chunk, isFinal = isLast)
-                        if (isLast) { finalised = true; break }
-                    }
-                    // Flush any residual text that didn't form a clean chunk boundary.
-                    // Skip if the loop already sent isFinal=true on the last chunk.
-                    if (!finalised) {
-                        val remaining = finalizeChatTextForSpeech(buffer.toString())
-                        session.append(remaining, isFinal = true)
-                    }
-                } catch (e: CancellationException) {
-                    // Ensure the controller's streaming worker is torn down immediately rather
-                    // than blocking indefinitely on channel receive.
-                    voiceOutputController.stop()
-                    throw e
+                while (buffer.isNotBlank()) {
+                    val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
+                    val chunk = popNextStreamingSpeechChunk(
+                        buffer = buffer,
+                        minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                        preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                        force = isShort,
+                    ) ?: break
+                    val isLast = buffer.isBlank()
+                    session.append(chunk, isFinal = isLast)
+                    if (isLast) { finalised = true; break }
+                }
+                // Flush any residual text that didn't form a clean chunk boundary.
+                // Skip if the loop already sent isFinal=true on the last chunk.
+                if (!finalised) {
+                    val remaining = finalizeChatTextForSpeech(buffer.toString())
+                    session.append(remaining, isFinal = true)
                 }
             } finally {
                 if (_speakingMessageId.value == messageId) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -59,6 +59,7 @@ import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
 import com.kernel.ai.core.voice.VoiceInputStartResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -950,23 +951,30 @@ class ChatViewModel @Inject constructor(
                 )
                 val buffer = StringBuilder(textToSpeak)
                 var finalised = false
-                while (buffer.isNotBlank()) {
-                    val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
-                    val chunk = popNextStreamingSpeechChunk(
-                        buffer = buffer,
-                        minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
-                        preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
-                        force = isShort,
-                    ) ?: break
-                    val isLast = buffer.isBlank()
-                    session.append(chunk, isFinal = isLast)
-                    if (isLast) { finalised = true; break }
-                }
-                // Flush any residual text that didn't form a clean chunk boundary.
-                // Skip if the loop already sent isFinal=true on the last chunk.
-                if (!finalised) {
-                    val remaining = finalizeChatTextForSpeech(buffer.toString())
-                    session.append(remaining, isFinal = true)
+                try {
+                    while (buffer.isNotBlank()) {
+                        val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
+                        val chunk = popNextStreamingSpeechChunk(
+                            buffer = buffer,
+                            minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                            preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                            force = isShort,
+                        ) ?: break
+                        val isLast = buffer.isBlank()
+                        session.append(chunk, isFinal = isLast)
+                        if (isLast) { finalised = true; break }
+                    }
+                    // Flush any residual text that didn't form a clean chunk boundary.
+                    // Skip if the loop already sent isFinal=true on the last chunk.
+                    if (!finalised) {
+                        val remaining = finalizeChatTextForSpeech(buffer.toString())
+                        session.append(remaining, isFinal = true)
+                    }
+                } catch (e: CancellationException) {
+                    // Ensure the controller's streaming worker is torn down immediately rather
+                    // than blocking indefinitely on channel receive.
+                    voiceOutputController.stop()
+                    throw e
                 }
             } finally {
                 if (_speakingMessageId.value == messageId) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -942,7 +942,31 @@ class ChatViewModel @Inject constructor(
             val maxSentences = voiceOutputPreferences.maxSpokenSentences.first()
             val textToSpeak = truncateForSpeech(normalizedText, maxSentences)
             try {
-                voiceOutputController.speak(VoiceSpeakRequest(text = textToSpeak))
+                // Use the streaming session path so sentence 1 starts playing while
+                // sentence 2 is being synthesised — critical for long responses with
+                // high-quality voices (e.g. LessacHigh) which synthesise slowly.
+                val session = voiceOutputController.openStreamingSession(
+                    VoiceSpeakRequest(text = textToSpeak),
+                )
+                val buffer = StringBuilder(textToSpeak)
+                while (buffer.isNotBlank()) {
+                    val isShort = buffer.length < CHAT_VOICE_MIN_CHUNK_LENGTH
+                    val chunk = popNextStreamingSpeechChunk(
+                        buffer = buffer,
+                        minChunkLength = CHAT_VOICE_MIN_CHUNK_LENGTH,
+                        preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
+                        force = isShort,
+                    ) ?: break
+                    val isLast = buffer.isBlank()
+                    session.append(chunk, isFinal = isLast)
+                }
+                // Flush any residual text that didn't form a clean chunk boundary
+                val remaining = finalizeChatTextForSpeech(buffer.toString())
+                if (remaining.isNotBlank()) {
+                    session.append(remaining, isFinal = true)
+                } else {
+                    session.append("", isFinal = true)
+                }
             } finally {
                 if (_speakingMessageId.value == messageId) {
                     _speakingMessageId.value = null

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -419,6 +419,13 @@ class ChatViewModel @Inject constructor(
                     VoiceOutputEvent.SpeakingStopped -> {
                         _isSpeakingResponse.value = false
                         _voicePlaybackState.value = VoicePlaybackState.Idle
+                        // Clear per-message speaker icon when streaming playback ends.
+                        // The speakMessageJob finishes as soon as chunks are queued (not when
+                        // audio finishes), so we rely on this event to reset the icon.
+                        if (_speakingMessageId.value != null) {
+                            _speakingMessageId.value = null
+                            speakMessageJob = null
+                        }
                         val shouldHandleCompletion = awaitingVoicePlaybackCompletion
                         awaitingVoicePlaybackCompletion = false
                         if (!shouldHandleCompletion) return@collect
@@ -969,9 +976,9 @@ class ChatViewModel @Inject constructor(
                     session.append(remaining, isFinal = true)
                 }
             } finally {
-                if (_speakingMessageId.value == messageId) {
-                    _speakingMessageId.value = null
-                }
+                // speakingMessageId is cleared by SpeakingStopped event (when audio finishes)
+                // or by stopSpeaking() (when cancelled). Do not clear here — the job ends as
+                // soon as chunks are queued, long before audio playback completes.
             }
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.voice.SemaineSpeakerMetadata
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VctkSpeakerMetadata
 import com.kernel.ai.core.voice.VoiceInputEngine
@@ -435,6 +436,16 @@ private fun VoiceScreenContent(
                         modifier = Modifier.padding(top = 8.dp),
                     )
                 }
+
+                if (uiState.selectedSherpaVoice == SherpaPiperVoice.SemaineMedium &&
+                    uiState.isSelectedSherpaVoiceDownloaded
+                ) {
+                    SemaineSpeakerSelector(
+                        activeSpeakerId = uiState.activeSpeakerId,
+                        onSpeakerSelected = onActiveSpeakerIdChanged,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
             }
 
         }
@@ -498,6 +509,52 @@ private fun VctkSpeakerSelector(
                 modifier = Modifier.fillMaxWidth(),
                 headlineContent = { Text(speaker.speakerCode) },
                 supportingContent = { Text("${speaker.gender} · ${speaker.accent}") },
+                trailingContent = {
+                    RadioButton(
+                        selected = activeSpeakerId == speaker.sid,
+                        onClick = { onSpeakerSelected(speaker.sid) },
+                    )
+                },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+/**
+ * Speaker selector for the `en_GB-semaine-medium` multi-speaker voice.
+ *
+ * Exposes only the two female speakers (Prudence and Poppy). The male speakers
+ * (Spike and Obadiah) are intentionally excluded.
+ */
+@Composable
+private fun SemaineSpeakerSelector(
+    activeSpeakerId: Int,
+    onSpeakerSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Semaine speaker",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+
+        Text(
+            text = "Choose between two female Semaine speakers. Selected: ${SemaineSpeakerMetadata.displayLabel(activeSpeakerId)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+        )
+
+        HorizontalDivider()
+
+        SemaineSpeakerMetadata.speakers.forEach { speaker ->
+            ListItem(
+                modifier = Modifier.fillMaxWidth(),
+                headlineContent = { Text(speaker.displayName) },
+                supportingContent = { Text(speaker.description) },
                 trailingContent = {
                     RadioButton(
                         selected = activeSpeakerId == speaker.sid,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,6 +44,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -415,36 +419,71 @@ private fun VoiceScreenContent(
                     )
                 }
 
+                // Tracks whether the speaker selector is expanded; resets to true on voice change.
+                var speakerSelectorExpanded by rememberSaveable(uiState.selectedSherpaVoice) {
+                    mutableStateOf(true)
+                }
+
                 uiState.sherpaVoices.forEach { voiceRow ->
+                    val isSelected = uiState.selectedSherpaVoice == voiceRow.voice
+                    val isDownloaded = voiceRow.downloadState is VoicePackDownloadState.Downloaded
+                    val isMultiSpeaker = voiceRow.voice == SherpaPiperVoice.VctkMedium ||
+                        voiceRow.voice == SherpaPiperVoice.SemaineMedium
+
                     SherpaVoiceRow(
                         rowState = voiceRow,
-                        isSelected = uiState.selectedSherpaVoice == voiceRow.voice,
+                        isSelected = isSelected,
                         onSelect = { onSherpaVoiceSelected(voiceRow.voice) },
                         onDownload = { onDownloadVoice(voiceRow.voice) },
                         onCancel = { onCancelVoiceDownload(voiceRow.voice) },
                         onDelete = { onDeleteVoice(voiceRow.voice) },
                     )
                     HorizontalDivider()
-                }
 
-                if (uiState.selectedSherpaVoice == SherpaPiperVoice.VctkMedium &&
-                    uiState.isSelectedSherpaVoiceDownloaded
-                ) {
-                    VctkSpeakerSelector(
-                        activeSpeakerId = uiState.activeSpeakerId,
-                        onSpeakerSelected = onActiveSpeakerIdChanged,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-
-                if (uiState.selectedSherpaVoice == SherpaPiperVoice.SemaineMedium &&
-                    uiState.isSelectedSherpaVoiceDownloaded
-                ) {
-                    SemaineSpeakerSelector(
-                        activeSpeakerId = uiState.activeSpeakerId,
-                        onSpeakerSelected = onActiveSpeakerIdChanged,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
+                    if (isSelected && isDownloaded && isMultiSpeaker) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp, vertical = 0.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Speaker",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(start = 8.dp),
+                            )
+                            IconButton(onClick = { speakerSelectorExpanded = !speakerSelectorExpanded }) {
+                                Icon(
+                                    imageVector = if (speakerSelectorExpanded) {
+                                        Icons.Default.ExpandLess
+                                    } else {
+                                        Icons.Default.ExpandMore
+                                    },
+                                    contentDescription = if (speakerSelectorExpanded) {
+                                        "Collapse speaker selector"
+                                    } else {
+                                        "Expand speaker selector"
+                                    },
+                                )
+                            }
+                        }
+                        AnimatedVisibility(visible = speakerSelectorExpanded) {
+                            when (voiceRow.voice) {
+                                SherpaPiperVoice.VctkMedium -> VctkSpeakerSelector(
+                                    activeSpeakerId = uiState.activeSpeakerId,
+                                    onSpeakerSelected = onActiveSpeakerIdChanged,
+                                )
+                                SherpaPiperVoice.SemaineMedium -> SemaineSpeakerSelector(
+                                    activeSpeakerId = uiState.activeSpeakerId,
+                                    onSpeakerSelected = onActiveSpeakerIdChanged,
+                                )
+                                else -> Unit
+                            }
+                        }
+                    }
                 }
             }
 
@@ -524,8 +563,7 @@ private fun VctkSpeakerSelector(
 /**
  * Speaker selector for the `en_GB-semaine-medium` multi-speaker voice.
  *
- * Exposes only the two female speakers (Prudence and Poppy). The male speakers
- * (Spike and Obadiah) are intentionally excluded.
+ * Exposes all 4 speakers: Prudence, Spike, Obadiah, and Poppy.
  */
 @Composable
 private fun SemaineSpeakerSelector(
@@ -542,7 +580,7 @@ private fun SemaineSpeakerSelector(
         )
 
         Text(
-            text = "Choose between two female Semaine speakers. Selected: ${SemaineSpeakerMetadata.displayLabel(activeSpeakerId)}",
+            text = "Semaine has 4 speakers with distinct characters. Selected: ${SemaineSpeakerMetadata.displayLabel(activeSpeakerId)}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -571,6 +571,10 @@ private fun SemaineSpeakerSelector(
     onSpeakerSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Clamp to valid Semaine range so UI stays consistent with effectiveSid() in the controller.
+    // A stale VCTK sid (e.g. 50) would otherwise show no RadioButton selected while TTS plays
+    // sid=3 (Poppy) and the description text names Prudence.
+    val effectiveId = activeSpeakerId.coerceIn(0, SherpaPiperVoice.SemaineMedium.speakerCount - 1)
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = "Semaine speaker",
@@ -580,7 +584,7 @@ private fun SemaineSpeakerSelector(
         )
 
         Text(
-            text = "Semaine has 4 speakers with distinct characters. Selected: ${SemaineSpeakerMetadata.displayLabel(activeSpeakerId)}",
+            text = "Semaine has 4 speakers with distinct characters. Selected: ${SemaineSpeakerMetadata.displayLabel(effectiveId)}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
@@ -595,7 +599,7 @@ private fun SemaineSpeakerSelector(
                 supportingContent = { Text(speaker.description) },
                 trailingContent = {
                     RadioButton(
-                        selected = activeSpeakerId == speaker.sid,
+                        selected = effectiveId == speaker.sid,
                         onClick = { onSpeakerSelected(speaker.sid) },
                     )
                 },


### PR DESCRIPTION
## Summary

Combines two features:

1. **Semaine speaker selection** (#817) — exposes Semaine's two female speakers (Prudence, Poppy) as selectable options in Settings → Voice, consistent with how VCTK speakers work today.
2. **Streaming per-message TTS** (#812) — the per-message speaker button now synthesises sentence-by-sentence so first audio plays while the next sentence is still being generated (critical for large voices like LessacHigh).

PR #812 was folded in here because both branches touched voice infrastructure and merging them avoids a `speakerCount` / `effectiveSid` conflict.

## Changes

### Semaine speaker selection (#817)
- **`SemaineSpeakerMetadata.kt`** (new) — `SemaineSpeaker` data class with Prudence (sid=0) and Poppy (sid=3); male speakers Spike and Obadiah excluded
- **`SherpaPiperVoice.kt`** — `SemaineMedium.speakerCount` corrected from `1` → `4` so `effectiveSid` clamps to the real range `0..3`
- **`VoiceScreen.kt`** — `SemaineSpeakerSelector` composable, mirrors `VctkSpeakerSelector`, appears when Semaine is selected and downloaded
- **`SemaineSpeakerMetadataTest.kt`** (new) — 6 tests: speaker list, sids, male exclusion, displayLabel happy-path and fallback
- **`SherpaPiperVoiceTest.kt`** — assert `SemaineMedium.speakerCount == 4`

### Streaming per-message TTS (#812)
- **`ChatViewModel.speakMessage()`** — replaced `voiceOutputController.speak()` (batch) with `openStreamingSession()` + sentence-chunked feeding via `popNextStreamingSpeechChunk()`; residual text flushed at end
- **Double `isFinal` fix** — added `finalised` flag; residual flush is skipped when the loop already sent `isFinal=true` on the last chunk (eliminates guaranteed double-finalize on normal completion)

## Testing

- [x] `:feature:chat:testDebugUnitTest` — passes (3 pre-existing failures on `main` unrelated: `LatexConversionTest`, 2× `ChatViewModelVoiceTest`)
- [x] `:core:voice:testDebugUnitTest` — all pass (6 new Semaine tests)
- [x] `:feature:settings:testDebugUnitTest` — all pass
- [ ] Manual: select Semaine → Prudence/Poppy picker appears, selection persists
- [ ] Manual: tap speaker on long reply → first sentence starts immediately (no full-synthesis wait)

## Related issues

Closes #817
Closes #812
