### PR TITLE
feat: start-listening audio cue + slot-fill retry (#791, #790)

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -611,7 +611,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 // MODE_STREAM: stop() is non-blocking — buffered samples continue to drain.
                 // Wait until PLAYSTATE_STOPPED so release() doesn't cut the audio tail,
                 // and SpeakingStopped fires only after audio has actually finished playing.
-                while (track.playState != AudioTrack.PLAYSTATE_STOPPED) {
+                // Also check stopped so a concurrent controller.stop() call breaks out fast.
+                while (!stopped && track.playState != AudioTrack.PLAYSTATE_STOPPED) {
                     Thread.sleep(10)
                 }
             } else {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -606,7 +606,17 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 }
                 offset = end
             }
-            if (!stopped) track.stop() else track.pause()
+            if (!stopped) {
+                track.stop()
+                // MODE_STREAM: stop() is non-blocking — buffered samples continue to drain.
+                // Wait until PLAYSTATE_STOPPED so release() doesn't cut the audio tail,
+                // and SpeakingStopped fires only after audio has actually finished playing.
+                while (track.playState != AudioTrack.PLAYSTATE_STOPPED) {
+                    Thread.sleep(10)
+                }
+            } else {
+                track.pause()
+            }
         } finally {
             track.release()
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
@@ -1,0 +1,13 @@
+package com.kernel.ai.core.voice
+
+/**
+ * Plays a short audio cue to signal that voice capture is ready for speech.
+ *
+ * The cue is played when [VoiceInputEvent.ListeningStarted] fires — i.e. when
+ * `onReadyForSpeech` is received from the recognizer (or the Vosk settle delay
+ * has elapsed). This ensures the user hears the cue only after the microphone
+ * is truly open, not on button-press alone.
+ */
+interface StartListeningCuePlayer {
+    fun playCue()
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
@@ -10,4 +10,16 @@ package com.kernel.ai.core.voice
  */
 interface StartListeningCuePlayer {
     fun playCue()
+
+    /**
+     * Releases any native audio resources held by this player.
+     *
+     * Implementations that hold a [android.media.ToneGenerator] or similar native resource
+     * should free it here. The default no-op keeps existing callers that don't hold native
+     * resources from having to override this method.
+     *
+     * For process-lifetime singletons this is a recovery hook — it is not called automatically
+     * on ViewModel teardown; callers must invoke it explicitly when a bad audio state is detected.
+     */
+    fun release() { /* no-op by default */ }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
@@ -1,0 +1,40 @@
+package com.kernel.ai.core.voice
+
+import android.media.AudioManager
+import android.media.ToneGenerator
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "KernelAI"
+private const val CUE_VOLUME_PERCENT = 60
+private const val CUE_DURATION_MS = 100
+
+/**
+ * Plays a brief, non-jarring beep via [ToneGenerator] when the microphone
+ * becomes ready for speech.
+ *
+ * Uses [ToneGenerator.TONE_PROP_BEEP] on [AudioManager.STREAM_MUSIC] at 60%
+ * volume for a 100 ms duration — a short, clean UI earcon that mirrors the
+ * convention used by [LoopListeningCue].
+ */
+@Singleton
+class ToneStartListeningCuePlayer @Inject constructor() : StartListeningCuePlayer {
+
+    private val toneGenerator by lazy {
+        try {
+            ToneGenerator(AudioManager.STREAM_MUSIC, CUE_VOLUME_PERCENT)
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "ToneStartListeningCuePlayer: failed to create ToneGenerator", e)
+            null
+        }
+    }
+
+    override fun playCue() {
+        try {
+            toneGenerator?.startTone(ToneGenerator.TONE_PROP_BEEP, CUE_DURATION_MS)
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "ToneStartListeningCuePlayer: failed to play cue", e)
+        }
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
@@ -21,20 +21,46 @@ private const val CUE_DURATION_MS = 100
 @Singleton
 class ToneStartListeningCuePlayer @Inject constructor() : StartListeningCuePlayer {
 
-    private val toneGenerator by lazy {
-        try {
-            ToneGenerator(AudioManager.STREAM_MUSIC, CUE_VOLUME_PERCENT)
-        } catch (e: RuntimeException) {
-            Log.w(TAG, "ToneStartListeningCuePlayer: failed to create ToneGenerator", e)
-            null
+    /**
+     * Held for process lifetime as a @Singleton. [release] can be called to free the native
+     * AudioTrack if the audio system enters a bad state — it is not called automatically on
+     * ViewModel teardown because this singleton outlives any single ViewModel.
+     */
+    private var toneGeneratorInstance: ToneGenerator? = null
+    private val toneGenerator: ToneGenerator?
+        get() {
+            if (toneGeneratorInstance == null) {
+                toneGeneratorInstance = try {
+                    ToneGenerator(AudioManager.STREAM_MUSIC, CUE_VOLUME_PERCENT)
+                } catch (e: RuntimeException) {
+                    Log.w(TAG, "ToneStartListeningCuePlayer: failed to create ToneGenerator", e)
+                    null
+                }
+            }
+            return toneGeneratorInstance
         }
-    }
 
     override fun playCue() {
         try {
             toneGenerator?.startTone(ToneGenerator.TONE_PROP_BEEP, CUE_DURATION_MS)
         } catch (e: RuntimeException) {
             Log.w(TAG, "ToneStartListeningCuePlayer: failed to play cue", e)
+        }
+    }
+
+    /**
+     * Releases the native [ToneGenerator] AudioTrack resource and resets the internal reference
+     * so that the next [playCue] call will recreate it.
+     *
+     * Call this when the audio system enters a bad state and needs to be reset.
+     */
+    override fun release() {
+        try {
+            toneGeneratorInstance?.release()
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "ToneStartListeningCuePlayer: failed to release ToneGenerator", e)
+        } finally {
+            toneGeneratorInstance = null
         }
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/di/VoiceModule.kt
@@ -2,6 +2,8 @@ package com.kernel.ai.core.voice.di
 
 import com.kernel.ai.core.voice.FallbackVoiceOutputController
 import com.kernel.ai.core.voice.SelectableVoiceInputController
+import com.kernel.ai.core.voice.StartListeningCuePlayer
+import com.kernel.ai.core.voice.ToneStartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import dagger.Binds
@@ -19,6 +21,12 @@ abstract class VoiceModule {
     abstract fun bindVoiceInputController(
         impl: SelectableVoiceInputController,
     ): VoiceInputController
+
+    @Binds
+    @Singleton
+    abstract fun bindStartListeningCuePlayer(
+        impl: ToneStartListeningCuePlayer,
+    ): StartListeningCuePlayer
 
     /**
      * Binds [FallbackVoiceOutputController] as the active [VoiceOutputController].

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -116,6 +116,7 @@ fun ActionsScreen(
     val voiceCaptureState by viewModel.voiceCaptureState.collectAsStateWithLifecycle()
     val voicePlaybackState by viewModel.voicePlaybackState.collectAsStateWithLifecycle()
     val slotReplyAutoRearmArmed by viewModel.slotReplyAutoRearmArmed.collectAsStateWithLifecycle()
+    val slotPromptPlaybackStarted by viewModel.slotPromptPlaybackStarted.collectAsStateWithLifecycle()
     val currentVoiceCaptureState = voiceCaptureState
     val isCommandVoiceActive = when (currentVoiceCaptureState) {
         is ActionsViewModel.VoiceCaptureState.Preparing -> currentVoiceCaptureState.mode == VoiceCaptureMode.Command
@@ -507,6 +508,7 @@ fun ActionsScreen(
             uiState = uiState,
             voiceCaptureState = voiceCaptureState,
             autoVoiceReplyArmed = slotReplyAutoRearmArmed,
+            slotPromptPlaybackStarted = slotPromptPlaybackStarted,
             onDismiss = { viewModel.cancelSlotFill() },
             onSubmit = { reply -> viewModel.onSlotReply(reply) },
             onVoiceReply = { requestVoiceCapture(VoiceCaptureMode.SlotReply) },
@@ -542,6 +544,7 @@ internal fun PendingSlotBottomSheet(
     uiState: ActionsViewModel.UiState,
     voiceCaptureState: ActionsViewModel.VoiceCaptureState,
     autoVoiceReplyArmed: Boolean,
+    slotPromptPlaybackStarted: Boolean,
     onDismiss: () -> Unit,
     onSubmit: (String) -> Unit,
     onVoiceReply: () -> Unit,
@@ -560,6 +563,7 @@ internal fun PendingSlotBottomSheet(
             uiState = uiState,
             voiceCaptureState = voiceCaptureState,
             autoVoiceReplyArmed = autoVoiceReplyArmed,
+            slotPromptPlaybackStarted = slotPromptPlaybackStarted,
             onDismiss = onDismiss,
             onSubmit = onSubmit,
             onVoiceReply = onVoiceReply,
@@ -576,6 +580,7 @@ private fun SlotFillBottomSheet(
     uiState: ActionsViewModel.UiState,
     voiceCaptureState: ActionsViewModel.VoiceCaptureState,
     autoVoiceReplyArmed: Boolean,
+    slotPromptPlaybackStarted: Boolean,
     onDismiss: () -> Unit,
     onSubmit: (String) -> Unit,
     onVoiceReply: () -> Unit,
@@ -613,18 +618,36 @@ private fun SlotFillBottomSheet(
         )
     }
 
-    LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed, isVoiceReplyActive) {
+    LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed, isVoiceReplyActive, slotPromptPlaybackStarted) {
         if (inputMode != InputMode.Voice || !autoVoiceReplyArmed || isVoiceReplyActive) return@LaunchedEffect
-        val delayMs = estimatedSlotPromptDurationMs(promptMessage)
+        if (!slotPromptPlaybackStarted) {
+            // TTS synthesis guard: audio hasn't started yet. Wait up to 10s for SpeakingStarted.
+            // This coroutine is cancelled and restarted when slotPromptPlaybackStarted → true.
+            Log.d(
+                ACTIONS_SCREEN_TAG,
+                "ActionsScreen: waiting for slot TTS to start prompt=\"$promptMessage\"",
+            )
+            delay(10_000L)
+            if (!isVoiceReplyActive && autoVoiceReplyArmed) {
+                Log.w(
+                    ACTIONS_SCREEN_TAG,
+                    "ActionsScreen: TTS never started — forcing slot voice fallback prompt=\"$promptMessage\"",
+                )
+                onVoiceReply()
+            }
+            return@LaunchedEffect
+        }
+        // Playback safety net: TTS is playing. Primary rearm is SpeakingStopped → 350ms → startVoiceCapture.
+        // This fires only if SpeakingStopped never arrives (TTS failure). Voice-speed-agnostic.
         Log.d(
             ACTIONS_SCREEN_TAG,
-            "ActionsScreen: scheduling slot voice fallback delayMs=$delayMs prompt=\"$promptMessage\"",
+            "ActionsScreen: slot TTS playing — safety net armed prompt=\"$promptMessage\"",
         )
-        delay(delayMs)
+        delay(15_000L)
         if (!isVoiceReplyActive && autoVoiceReplyArmed) {
             Log.w(
                 ACTIONS_SCREEN_TAG,
-                "ActionsScreen: slot voice fallback firing prompt=\"$promptMessage\"",
+                "ActionsScreen: slot voice fallback firing (playback safety net) prompt=\"$promptMessage\"",
             )
             onVoiceReply()
         }
@@ -741,13 +764,6 @@ private fun SlotFillBottomSheet(
             }
         }
     }
-}
-
-private fun estimatedSlotPromptDurationMs(promptMessage: String): Long {
-    val normalizedPrompt = promptMessage.trim()
-    if (normalizedPrompt.isBlank()) return 3_500L
-    val estimatedSpeechMs = normalizedPrompt.length * 50L
-    return (estimatedSpeechMs + 1_500L).coerceIn(3_000L, 6_000L)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -262,7 +262,16 @@ class ActionsViewModel @Inject constructor(
                                             "$commandVoiceRetryCount/$COMMAND_MAX_VOICE_RETRIES",
                                     )
                                     _voiceCaptureState.value = VoiceCaptureState.Idle
-                                    startVoiceCapture(VoiceCaptureMode.Command)
+                                    // Speak reprompt then re-open mic after TTS completes.
+                                    // If spoken responses are off, re-open immediately.
+                                    pendingVoiceSpeechJob = viewModelScope.launch {
+                                        if (spokenResponsesEnabled) {
+                                            voiceOutputController.speak(
+                                                VoiceSpeakRequest("Sorry, I didn't catch that. Please try again.")
+                                            )
+                                        }
+                                        startVoiceCapture(VoiceCaptureMode.Command)
+                                    }
                                 } else {
                                     _voiceCaptureState.value = VoiceCaptureState.Idle
                                     _error.value = event.message

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -13,6 +13,7 @@ import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.toSpokenSummary
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.normalizeSlotReply
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
@@ -41,6 +42,9 @@ private const val SLOT_REPLY_REARM_DELAY_MS = 350L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
+private const val SLOT_REPLY_MAX_VOICE_RETRIES = 2
+private const val COMMAND_MAX_VOICE_RETRIES = 1
+private val VOICE_ESCAPE_PHRASES = setOf("stop", "cancel", "stop that")
 
 /** Input modality for an action. Carried through slot-fill state for voice-readiness (#350/#588). */
 enum class InputMode { Text, Voice }
@@ -65,6 +69,7 @@ class ActionsViewModel @Inject constructor(
     private val voiceInputController: VoiceInputController,
     private val voiceOutputController: VoiceOutputController,
     private val voiceOutputPreferences: VoiceOutputPreferences,
+    private val startListeningCuePlayer: StartListeningCuePlayer,
 ) : ViewModel() {
 
     // ── Action history ──────────────────────────────────────────────────────
@@ -152,6 +157,19 @@ class ActionsViewModel @Inject constructor(
     private var recentVoiceCommandAtMs: Long = 0L
     private var spokenResponsesEnabled = true
 
+    /**
+     * Tracks how many automatic voice retries have been attempted for the current
+     * slot-fill reply session. Reset each time a new slot is primed. Capped at
+     * [SLOT_REPLY_MAX_VOICE_RETRIES] to avoid endless looping.
+     */
+    private var slotReplyVoiceRetryCount = 0
+
+    /**
+     * Tracks automatic voice retries for an idle command capture session.
+     * Capped at [COMMAND_MAX_VOICE_RETRIES] to keep idle retry conservative.
+     */
+    private var commandVoiceRetryCount = 0
+
     init {
         viewModelScope.launch {
             voiceOutputPreferences.spokenResponsesEnabled.collect { enabled ->
@@ -176,6 +194,8 @@ class ActionsViewModel @Inject constructor(
                             ?.transcript
                             .orEmpty()
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, currentTranscript)
+                        // #791: Play the start-listening earcon now that the mic is truly open.
+                        startListeningCuePlayer.playCue()
                     }
                     is VoiceInputEvent.PartialTranscript -> {
                         if (!ownsVoiceCapture(event.mode)) return@collect
@@ -187,14 +207,72 @@ class ActionsViewModel @Inject constructor(
                         _voiceCaptureState.value = VoiceCaptureState.Processing(event.mode, normalizedTranscript)
                         when (event.mode) {
                             VoiceCaptureMode.Command -> executeAction(normalizedTranscript, InputMode.Voice)
-                            VoiceCaptureMode.SlotReply -> onSlotReply(normalizedTranscript)
+                            VoiceCaptureMode.SlotReply -> {
+                                // #790: Recognise escape phrases — abort slot-fill cleanly.
+                                if (isVoiceEscapePhrase(normalizedTranscript)) {
+                                    Log.d(TAG, "ActionsViewModel: escape phrase \"$normalizedTranscript\" — cancelling slot-fill")
+                                    cancelSlotFill()
+                                } else {
+                                    onSlotReply(normalizedTranscript)
+                                }
+                            }
                             VoiceCaptureMode.AlertCommand -> Unit
                         }
                     }
                     is VoiceInputEvent.Error -> {
                         if (!ownsVoiceCapture(event.mode)) return@collect
-                        _voiceCaptureState.value = VoiceCaptureState.Idle
-                        _error.value = event.message
+                        // #790: Auto-retry with reprompt on voice errors during slot-fill or idle command.
+                        when (event.mode) {
+                            VoiceCaptureMode.SlotReply -> {
+                                val pending = _pendingSlot.value
+                                if (pending != null && pending.inputMode == InputMode.Voice &&
+                                    slotReplyVoiceRetryCount < SLOT_REPLY_MAX_VOICE_RETRIES
+                                ) {
+                                    slotReplyVoiceRetryCount++
+                                    Log.d(
+                                        TAG,
+                                        "ActionsViewModel: slot-reply voice error — retry " +
+                                            "$slotReplyVoiceRetryCount/$SLOT_REPLY_MAX_VOICE_RETRIES",
+                                    )
+                                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                                    val prompt = pending.request.promptMessage
+                                    val retryPrompt = "Sorry, I didn't catch that. $prompt"
+                                    // Re-arm so the existing SpeakingStopped handler restarts the mic.
+                                    setSlotReplyAutoRearmArmed(true, "slotReplyVoiceRetry")
+                                    expectedSlotPromptSpeech = retryPrompt
+                                    slotPromptPlaybackStarted = false
+                                    speakForVoice(InputMode.Voice, retryPrompt)
+                                } else {
+                                    // Budget exhausted or no slot active — keep slot visible, let user type.
+                                    Log.d(
+                                        TAG,
+                                        "ActionsViewModel: slot-reply voice error — retry budget exhausted, " +
+                                            "waiting for manual input",
+                                    )
+                                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                                    setSlotReplyAutoRearmArmed(false, "slotReplyVoiceRetryExhausted")
+                                }
+                            }
+                            VoiceCaptureMode.Command -> {
+                                if (commandVoiceRetryCount < COMMAND_MAX_VOICE_RETRIES) {
+                                    commandVoiceRetryCount++
+                                    Log.d(
+                                        TAG,
+                                        "ActionsViewModel: command voice error — retry " +
+                                            "$commandVoiceRetryCount/$COMMAND_MAX_VOICE_RETRIES",
+                                    )
+                                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                                    startVoiceCapture(VoiceCaptureMode.Command)
+                                } else {
+                                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                                    _error.value = event.message
+                                }
+                            }
+                            VoiceCaptureMode.AlertCommand -> {
+                                _voiceCaptureState.value = VoiceCaptureState.Idle
+                                _error.value = event.message
+                            }
+                        }
                     }
                     is VoiceInputEvent.ListeningStopped -> {
                         if (!ownsVoiceCapture(event.mode)) return@collect
@@ -267,6 +345,8 @@ class ActionsViewModel @Inject constructor(
     // ── Public API ──────────────────────────────────────────────────────────
 
     fun startVoiceCommand() {
+        // #790: Reset command retry budget on fresh user-initiated press.
+        commandVoiceRetryCount = 0
         startVoiceCapture(VoiceCaptureMode.Command)
     }
 
@@ -553,6 +633,8 @@ class ActionsViewModel @Inject constructor(
             "ActionsViewModel: primePendingSlot intent=$intentName inputMode=$inputMode " +
                 "missing=${missingSlot.name} delayVoicePrompt=$delayVoicePrompt",
         )
+        // #790: Reset retry budget whenever a fresh slot is primed.
+        slotReplyVoiceRetryCount = 0
         _pendingSlot.value = PendingSlotState(
             request = PendingSlotRequest(
                 intentName = intentName,
@@ -805,6 +887,13 @@ class ActionsViewModel @Inject constructor(
         recentVoiceCommandAtMs = nowMs
         return isDuplicate
     }
+
+    /**
+     * Returns true when [text] is a recognised escape phrase that should abort
+     * an in-progress slot-fill voice session (#790).
+     */
+    private fun isVoiceEscapePhrase(text: String): Boolean =
+        text.trim().lowercase() in VOICE_ESCAPE_PHRASES
 
     private fun toSpokenSummary(text: String): String {
         val normalized = text.lineSequence()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "KernelAI"
-private const val SLOT_REPLY_REARM_DELAY_MS = 350L
+private const val SLOT_REPLY_REARM_DELAY_MS = 700L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -147,8 +147,9 @@ class ActionsViewModel @Inject constructor(
     val voicePlaybackState: StateFlow<VoicePlaybackState> = _voicePlaybackState.asStateFlow()
     private val _slotReplyAutoRearmArmed = MutableStateFlow(false)
     val slotReplyAutoRearmArmed: StateFlow<Boolean> = _slotReplyAutoRearmArmed.asStateFlow()
+    private val _slotPromptPlaybackStarted = MutableStateFlow(false)
+    val slotPromptPlaybackStarted: StateFlow<Boolean> = _slotPromptPlaybackStarted.asStateFlow()
     private var expectedSlotPromptSpeech: String? = null
-    private var slotPromptPlaybackStarted = false
     private var shouldAutoStartVoiceSlotReply = false
     private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
@@ -240,7 +241,7 @@ class ActionsViewModel @Inject constructor(
                                     // Re-arm so the existing SpeakingStopped handler restarts the mic.
                                     setSlotReplyAutoRearmArmed(true, "slotReplyVoiceRetry")
                                     expectedSlotPromptSpeech = retryPrompt
-                                    slotPromptPlaybackStarted = false
+                                    _slotPromptPlaybackStarted.value = false
                                     speakForVoice(InputMode.Voice, retryPrompt)
                                 } else {
                                     // Budget exhausted or no slot active — keep slot visible, let user type.
@@ -311,7 +312,7 @@ class ActionsViewModel @Inject constructor(
                         cancelPendingVoiceSlotReplyRestart()
                         _voicePlaybackState.value = VoicePlaybackState.Speaking(event.text)
                         if (event.text == expectedSlotPromptSpeech) {
-                            slotPromptPlaybackStarted = true
+                            _slotPromptPlaybackStarted.value = true
                             Log.d(TAG, "ActionsViewModel: slot prompt playback started")
                         }
                     }
@@ -321,7 +322,7 @@ class ActionsViewModel @Inject constructor(
                             shouldAutoStartVoiceSlotReply &&
                             _pendingSlot.value?.inputMode == InputMode.Voice &&
                             _voiceCaptureState.value == VoiceCaptureState.Idle &&
-                            slotPromptPlaybackStarted
+                            _slotPromptPlaybackStarted.value
                         ) {
                             setSlotReplyAutoRearmArmed(false, "voiceOutputSpeakingStopped")
                             clearExpectedSlotPromptSpeech()
@@ -666,7 +667,7 @@ class ActionsViewModel @Inject constructor(
         } else {
             null
         }
-        slotPromptPlaybackStarted = false
+        _slotPromptPlaybackStarted.value = false
         if (inputMode == InputMode.Voice) {
             _voiceCaptureState.value = VoiceCaptureState.Idle
         }
@@ -887,7 +888,7 @@ class ActionsViewModel @Inject constructor(
 
     private fun clearExpectedSlotPromptSpeech() {
         expectedSlotPromptSpeech = null
-        slotPromptPlaybackStarted = false
+        _slotPromptPlaybackStarted.value = false
     }
 
     private fun cancelPendingVoiceSpeech() {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val TAG = "KernelAI"
-private const val SLOT_REPLY_REARM_DELAY_MS = 700L
+private const val SLOT_REPLY_REARM_DELAY_MS = 350L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
 private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -352,6 +352,10 @@ class ActionsViewModel @Inject constructor(
 
     fun startVoiceSlotReply() {
         if (_pendingSlot.value == null) return
+        // #825: Reset slot retry budget on manual mic re-tap, mirroring what startVoiceCommand()
+        // does for commandVoiceRetryCount. This ensures the user gets a fresh set of retries
+        // if they tap the mic again after the budget was exhausted.
+        slotReplyVoiceRetryCount = 0
         Log.d(TAG, "ActionsViewModel: startVoiceSlotReply pendingSlot=true")
         setSlotReplyAutoRearmArmed(false, "startVoiceSlotReply")
         clearExpectedSlotPromptSpeech()
@@ -685,6 +689,9 @@ class ActionsViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         // QuickIntentRouter is a @Singleton — no cleanup needed here.
+        // startListeningCuePlayer is also a @Singleton that intentionally outlives this ViewModel
+        // (it is process-scoped). Its release() hook exists for audio-system recovery scenarios
+        // and is NOT called here — doing so would break the shared singleton for other callers.
     }
 
     // ── Private helpers ─────────────────────────────────────────────────────

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -47,6 +48,7 @@ class ActionsViewModelTest {
     private val voiceInputController: VoiceInputController = mockk()
     private val voiceOutputController: VoiceOutputController = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
     private val insertedActions = mutableListOf<QuickActionEntity>()
     private val spokenResponsesEnabled = MutableStateFlow(false)
 
@@ -79,6 +81,7 @@ class ActionsViewModelTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
     }
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1593,4 +1593,96 @@ class ActionsViewModelVoiceTest {
         // Retry should have kicked in (no error shown yet after the fresh press).
         assertEquals(null, viewModel.error.value)
     }
+
+    @Test
+    fun `slot-fill retry budget resets when user manually re-taps mic after exhaustion`() = runTest(dispatcher) {
+        // #825: startVoiceSlotReply() must reset slotReplyVoiceRetryCount so that a user who
+        // manually re-taps the mic after the budget is exhausted gets a fresh set of retries.
+        every { quickIntentRouter.route("send a text to Dave") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "Dave"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text to Dave", InputMode.Voice)
+        advanceUntilIdle()
+
+        // ── Exhaust the retry budget (SLOT_REPLY_MAX_VOICE_RETRIES = 2 retries) ──
+
+        // Initial mic session.
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        // Error 1 → retry 1: reprompt spoken, auto-rearm armed.
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "no speech"))
+        advanceUntilIdle()
+
+        // Simulate TTS completing → auto-rearm restarts mic.
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("Sorry, I didn't catch that. What would you like to say to Dave?"),
+        )
+        runCurrent()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceTimeBy(351L)
+        runCurrent()
+
+        // Error 2 → retry 2: reprompt spoken again, auto-rearm armed.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "no speech"))
+        advanceUntilIdle()
+
+        // Simulate TTS completing → auto-rearm restarts mic.
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("Sorry, I didn't catch that. What would you like to say to Dave?"),
+        )
+        runCurrent()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceTimeBy(351L)
+        runCurrent()
+
+        // Error 3 → budget exhausted: slot visible, voice idle, no further TTS retry.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "no speech"))
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        // Only 2 reprompt speaks during the two auto-retries above.
+        coVerify(exactly = 2) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text.startsWith("Sorry, I didn't catch that.") },
+            )
+        }
+
+        // ── User manually re-taps the mic — budget must reset ──
+
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        // First error of the new session → reprompt should fire (retry budget is fresh).
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "no speech"))
+        advanceUntilIdle()
+
+        // A 3rd reprompt speak confirms the retry path fired (not the exhaustion path).
+        coVerify(atLeast = 3) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> { it.text.startsWith("Sorry, I didn't catch that.") },
+            )
+        }
+        assertNotNull(viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+    }
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.skills.SkillSchema
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.slot.SlotSpec
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
@@ -60,6 +61,7 @@ class ActionsViewModelVoiceTest {
     private val voiceInputController: VoiceInputController = mockk()
     private val voiceOutputController: VoiceOutputController = mockk()
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk()
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
     private val voiceInputEvents = MutableSharedFlow<VoiceInputEvent>()
     private val voiceOutputEvents = MutableSharedFlow<VoiceOutputEvent>()
     private val spokenResponsesEnabled = MutableStateFlow(true)
@@ -90,6 +92,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
     }
 
@@ -180,6 +183,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("at bridge to my last", InputMode.Voice)
@@ -213,6 +217,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("and bred to my last", InputMode.Voice)
@@ -239,6 +244,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("and ice cream to my last", InputMode.Voice)
@@ -265,6 +271,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("create a new lust", InputMode.Voice)
@@ -291,6 +298,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("add a bridge to my list", InputMode.Voice)
@@ -341,6 +349,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -389,6 +398,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -417,6 +427,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -446,6 +457,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -515,6 +527,7 @@ class ActionsViewModelVoiceTest {
             voiceInputController = voiceInputController,
             voiceOutputController = voiceOutputController,
             voiceOutputPreferences = voiceOutputPreferences,
+            startListeningCuePlayer = startListeningCuePlayer,
         )
 
         voiceViewModel.executeAction("send an email", InputMode.Voice)
@@ -1267,5 +1280,317 @@ class ActionsViewModelVoiceTest {
         advanceUntilIdle()
 
         verify { quickIntentRouter.route("set an alarm for 7:30 am") }
+    }
+
+    // ── #791: Start-listening audio cue ──────────────────────────────────────
+
+    @Test
+    fun `ListeningStarted event triggers start-listening cue player`() = runTest(dispatcher) {
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.Command)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.startVoiceCommand()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { startListeningCuePlayer.playCue() }
+    }
+
+    @Test
+    fun `ListeningStarted for unowned mode does not trigger cue player`() = runTest(dispatcher) {
+        // ActionsViewModel is Idle — it owns nothing. An event from an AlertCommand
+        // session started elsewhere should be silently ignored.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand))
+        advanceUntilIdle()
+
+        verify(exactly = 0) { startListeningCuePlayer.playCue() }
+    }
+
+    @Test
+    fun `ListeningStarted for slot reply triggers cue player`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a text to Alice") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "Alice"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text to Alice", InputMode.Voice)
+        advanceUntilIdle()
+
+        // Manually trigger voice slot reply (as the user would press mic)
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        verify(atLeast = 1) { startListeningCuePlayer.playCue() }
+    }
+
+    // ── #790: Slot-fill retry on no-speech + cancel phrase abort ─────────────
+
+    @Test
+    fun `slot-fill voice error retries with reprompt up to 2 times then waits for manual input`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a message to Bob") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "Bob"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a message to Bob", InputMode.Voice)
+        advanceUntilIdle()
+
+        // Put ViewModel into SlotReply capture state so it owns the mode.
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        // First error → retry 1: should speak reprompt and keep slot active.
+        voiceInputEvents.emit(
+            VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "I didn't catch that."),
+        )
+        advanceUntilIdle()
+
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        assertNotNull(viewModel.pendingSlot.value)
+        coVerify(atLeast = 1) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text.startsWith("Sorry, I didn't catch that.")
+                },
+            )
+        }
+
+        // Simulate TTS finishing for retry 1 → mic restarts automatically.
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("Sorry, I didn't catch that. What would you like to say to Bob?"),
+        )
+        runCurrent()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceTimeBy(351L)
+        runCurrent()
+
+        // Second error → retry 2: should speak reprompt again and keep slot active.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+        voiceInputEvents.emit(
+            VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "I didn't catch that."),
+        )
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.pendingSlot.value)
+        coVerify(atLeast = 2) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text.startsWith("Sorry, I didn't catch that.")
+                },
+            )
+        }
+
+        // Simulate TTS finishing for retry 2 → mic restarts.
+        voiceOutputEvents.emit(
+            VoiceOutputEvent.SpeakingStarted("Sorry, I didn't catch that. What would you like to say to Bob?"),
+        )
+        runCurrent()
+        voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
+        advanceTimeBy(351L)
+        runCurrent()
+
+        // Third error → budget exhausted: slot should remain visible but no further TTS retry.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+        voiceInputEvents.emit(
+            VoiceInputEvent.Error(VoiceCaptureMode.SlotReply, "I didn't catch that."),
+        )
+        advanceUntilIdle()
+
+        // Slot is still present (wait for manual input), voice state is idle.
+        assertNotNull(viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        // No further retry speaks should have occurred beyond the 2 retries above.
+        coVerify(exactly = 2) {
+            voiceOutputController.speak(
+                match<VoiceSpeakRequest> {
+                    it.text.startsWith("Sorry, I didn't catch that.")
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `cancel escape phrase during slot-fill aborts slot-fill cleanly`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send a text to Carol") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_sms",
+                    params = mapOf("contact" to "Carol"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "message",
+                    promptTemplate = "What would you like to say to {contact}?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send a text to Carol", InputMode.Voice)
+        advanceUntilIdle()
+        assertNotNull(viewModel.pendingSlot.value)
+
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        // Emit "cancel" as the transcript — should abort the slot-fill.
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "cancel"))
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+    }
+
+    @Test
+    fun `stop phrase during slot-fill aborts slot-fill cleanly`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send an email to Dave") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_email",
+                    params = mapOf("contact" to "Dave"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "to",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send an email to Dave", InputMode.Voice)
+        advanceUntilIdle()
+
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "stop"))
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+    }
+
+    @Test
+    fun `stop that phrase during slot-fill aborts slot-fill cleanly`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("send an email to Eve") } returns
+            QuickIntentRouter.RouteResult.NeedsSlot(
+                intent = QuickIntentRouter.MatchedIntent(
+                    intentName = "send_email",
+                    params = mapOf("contact" to "Eve"),
+                ),
+                missingSlot = SlotSpec(
+                    name = "to",
+                    promptTemplate = "Who would you like to email?",
+                ),
+            )
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.SlotReply)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.executeAction("send an email to Eve", InputMode.Voice)
+        advanceUntilIdle()
+
+        viewModel.startVoiceSlotReply()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+
+        voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "stop that"))
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.pendingSlot.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+    }
+
+    @Test
+    fun `idle command voice error retries once then surfaces error`() = runTest(dispatcher) {
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.Command)
+        } returns VoiceInputStartResult.Started
+
+        viewModel.startVoiceCommand()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+
+        // First error → should auto-retry (1 retry allowed for Command mode).
+        voiceInputEvents.emit(
+            VoiceInputEvent.Error(VoiceCaptureMode.Command, "Didn't hear anything."),
+        )
+        advanceUntilIdle()
+
+        // After retry, the view model is Preparing/Listening again (not showing error).
+        assertEquals(null, viewModel.error.value)
+        // startListening should have been called twice total (original + retry).
+        coVerify(exactly = 2) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+
+        // Second error → budget exhausted, surface the error.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+        voiceInputEvents.emit(
+            VoiceInputEvent.Error(VoiceCaptureMode.Command, "Didn't hear anything."),
+        )
+        advanceUntilIdle()
+
+        assertEquals("Didn't hear anything.", viewModel.error.value)
+        assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
+        // No third startListening call.
+        coVerify(exactly = 2) { voiceInputController.startListening(VoiceCaptureMode.Command) }
+    }
+
+    @Test
+    fun `idle command retry budget resets on fresh startVoiceCommand call`() = runTest(dispatcher) {
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.Command)
+        } returns VoiceInputStartResult.Started
+
+        // First session: exhaust retry budget.
+        viewModel.startVoiceCommand()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.Command, "Error 1"))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.Command, "Error 2"))
+        advanceUntilIdle()
+
+        assertEquals("Error 2", viewModel.error.value)
+
+        // Fresh user-initiated press — retry budget must reset.
+        viewModel.startVoiceCommand()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+        voiceInputEvents.emit(VoiceInputEvent.Error(VoiceCaptureMode.Command, "Error 3"))
+        advanceUntilIdle()
+
+        // Retry should have kicked in (no error shown yet after the fresh press).
+        assertEquals(null, viewModel.error.value)
     }
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -503,7 +503,7 @@ class ActionsViewModelVoiceTest {
         runCurrent()
 
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
-        advanceTimeBy(699)
+        advanceTimeBy(349)
         runCurrent()
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
         advanceTimeBy(1)
@@ -543,7 +543,7 @@ class ActionsViewModelVoiceTest {
         voiceViewModel.onSlotReply("Nick")
         advanceUntilIdle()
 
-        advanceTimeBy(701)
+        advanceTimeBy(351)
         runCurrent()
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
 
@@ -553,7 +553,7 @@ class ActionsViewModelVoiceTest {
         runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()
-        advanceTimeBy(701)
+        advanceTimeBy(351)
         runCurrent()
 
         coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -503,7 +503,7 @@ class ActionsViewModelVoiceTest {
         runCurrent()
 
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
-        advanceTimeBy(349)
+        advanceTimeBy(699)
         runCurrent()
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
         advanceTimeBy(1)
@@ -543,7 +543,7 @@ class ActionsViewModelVoiceTest {
         voiceViewModel.onSlotReply("Nick")
         advanceUntilIdle()
 
-        advanceTimeBy(351)
+        advanceTimeBy(701)
         runCurrent()
         coVerify(exactly = 0) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }
 
@@ -553,7 +553,7 @@ class ActionsViewModelVoiceTest {
         runCurrent()
         voiceOutputEvents.emit(VoiceOutputEvent.SpeakingStopped)
         runCurrent()
-        advanceTimeBy(351)
+        advanceTimeBy(701)
         runCurrent()
 
         coVerify(exactly = 1) { voiceInputController.startListening(VoiceCaptureMode.SlotReply) }


### PR DESCRIPTION
## Summary

Implements two Quick Actions voice UX improvements:

- **#791** — Start-listening audio cue: a short beep plays the instant the mic opens (aligned to `ListeningStarted` event, not button press)
- **#790** — Slot-fill retry on no-speech: up to 2 reprompts on voice error during slot-fill, cancel phrase escape, 1 retry for idle command mode

## Changes

### #791 — Start-listening cue
- `StartListeningCuePlayer` interface + `ToneStartListeningCuePlayer` impl (`ToneGenerator.TONE_PROP_BEEP`, 100ms, `STREAM_MUSIC` at 60% volume)
- Injected into `ActionsViewModel`; `playCue()` called in `ListeningStarted` handler, guarded by `ownsVoiceCapture()`
- Hilt binding in `VoiceModule`

### #790 — Slot-fill retry + cancel escape
- SlotReply errors: up to 2 retries with reprompt `"Sorry, I didn't catch that. <prompt>"`; on exhaustion, slot card stays for manual input
- Command mode errors: 1 retry, then surface error
- Retry budgets reset per slot (`primePendingSlot`) / per press (`startVoiceCommand`)
- Escape phrases `"stop"` / `"cancel"` / `"stop that"` in SlotReply → `cancelSlotFill()` immediately

## Tests

9 new unit tests in `ActionsViewModelVoiceTest`:
- Cue fires on `ListeningStarted` (owned mode only)
- Slot-fill retries ×2 then waits for manual input
- Cancel/stop/stop-that phrases abort slot-fill
- Idle command retries once, resets on fresh press

## Pre-existing failures (not introduced here)
- `ChatViewModelVoiceTest` ×2 and `LatexConversionTest` — confirmed identical on `main` before any changes

## Testing on device
- [ ] Press mic in Quick Actions → short beep plays when recogniser is ready (not on press)
- [ ] Speak nothing during a slot prompt → reprompt plays, up to 2 times, then falls back to text input
- [ ] Say "cancel" or "stop" during slot prompt → flow aborts cleanly

Closes #791
Closes #790
