### PR TITLE
feat(#828): normalise first-person pronouns in TTS spoken summaries

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -294,11 +294,12 @@ Lower-priority skill additions — third-party integrations and local utilities.
 | [#788](https://github.com/NickMonrad/kernel-ai-assistant/issues/788) | VITS noise_scale expressiveness tuning | ⬜ Pending | 🟢 Low |
 | [#729](https://github.com/NickMonrad/kernel-ai-assistant/issues/729) | Better local TTS engine for conversational voice | ✅ Done — PR #804 | 🟡 Medium |
 | [#756](https://github.com/NickMonrad/kernel-ai-assistant/issues/756) | Research: evaluate custom Piper voice training | ⬜ Pending | 🟢 Low |
-| [#790](https://github.com/NickMonrad/kernel-ai-assistant/issues/790) | Voice slot-fill retry on no-speech + cancel phrases | ⬜ Pending | 🟡 Medium |
-| [#791](https://github.com/NickMonrad/kernel-ai-assistant/issues/791) | Start-listening audio cue for Quick Actions voice capture | ⬜ Pending | 🟢 Low |
+| [#790](https://github.com/NickMonrad/kernel-ai-assistant/issues/790) | Voice slot-fill retry on no-speech + cancel phrases | ✅ Done — PR #825 | 🟡 Medium |
+| [#791](https://github.com/NickMonrad/kernel-ai-assistant/issues/791) | Start-listening audio cue for Quick Actions voice capture | ✅ Done — PR #825 | 🟢 Low |
 | [#823](https://github.com/NickMonrad/kernel-ai-assistant/issues/823) | Voice memo / note-taking native skill | ⬜ Pending | 🟡 Medium |
 | [#675](https://github.com/NickMonrad/kernel-ai-assistant/issues/675) | Comprehensive Quick Actions + weather voice QA matrix | 🔴 Closed — superseded by #824 | 🟡 Medium |
 | [#824](https://github.com/NickMonrad/kernel-ai-assistant/issues/824) | QA gate: Phase 3F real-device voice validation (current stack) | ⬜ Pending | 🟡 Medium |
+| [#828](https://github.com/NickMonrad/kernel-ai-assistant/issues/828) | TTS pronoun normalisation (my/I → your/you) | ⬜ Pending | 🟢 Low |
 | [#588](https://github.com/NickMonrad/kernel-ai-assistant/issues/588) | VoiceSession architecture for slot-fill + follow-on assistant mode | ⬜ Pending | 🟡 Medium |
 | [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | ⬜ Pending | 🟡 Medium |
 | [#659](https://github.com/NickMonrad/kernel-ai-assistant/issues/659) | Translator skill with multilingual TTS | ⬜ Pending | 🟡 Medium |
@@ -578,10 +579,11 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#756](https://github.com/NickMonrad/kernel-ai-assistant/issues/756) | Research: evaluate custom Piper voice training | Phase 3F | ⬜ Pending |
 | [#783](https://github.com/NickMonrad/kernel-ai-assistant/issues/783) | Kokoro-82M / VoxSherpa + expressiveness research | Phase 3F | ⬜ Pending |
 | [#784](https://github.com/NickMonrad/kernel-ai-assistant/issues/784) | Kiwi language corpus tuning | Phase 3F | ⬜ Pending |
-| [#790](https://github.com/NickMonrad/kernel-ai-assistant/issues/790) | Voice slot-fill retry on no-speech + cancel phrases | Phase 3F | ⬜ Pending |
-| [#791](https://github.com/NickMonrad/kernel-ai-assistant/issues/791) | Start-listening audio cue for Quick Actions voice capture | Phase 3F | ⬜ Pending |
+| [#790](https://github.com/NickMonrad/kernel-ai-assistant/issues/790) | Voice slot-fill retry on no-speech + cancel phrases | Phase 3F | ✅ Done — PR #825 |
+| [#791](https://github.com/NickMonrad/kernel-ai-assistant/issues/791) | Start-listening audio cue for Quick Actions voice capture | Phase 3F | ✅ Done — PR #825 |
 | [#823](https://github.com/NickMonrad/kernel-ai-assistant/issues/823) | Voice memo / note-taking native skill | Phase 3F | ⬜ Pending |
 | [#824](https://github.com/NickMonrad/kernel-ai-assistant/issues/824) | QA gate: Phase 3F real-device voice validation (current stack) | Phase 3F | ⬜ Pending |
+| [#828](https://github.com/NickMonrad/kernel-ai-assistant/issues/828) | TTS pronoun normalisation (my/I → your/you) | Phase 3F | ⬜ Pending |
 | [#821](https://github.com/NickMonrad/kernel-ai-assistant/issues/821) | Sherpa-ONNX / Sherpa-ncnn STT + VAD evaluation | Phase 3F | ⬜ Pending |
 | [#675](https://github.com/NickMonrad/kernel-ai-assistant/issues/675) | Comprehensive Quick Actions + weather voice QA matrix | Phase 3F | 🔴 Closed |
 | [#588](https://github.com/NickMonrad/kernel-ai-assistant/issues/588) | VoiceSession architecture for slot-fill + follow-on assistant mode | Phase 3F | ⬜ Pending |

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -861,7 +861,7 @@ class ActionsViewModel @Inject constructor(
     ) {
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
-        val summary = spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text)
+        val summary = normalisePronounsForTts(spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text))
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -108,6 +108,38 @@ private data class SpeechPronunciationRule(
     val replacement: String,
 )
 
+// Contractions first — must precede bare \bI\b to avoid partial substitution.
+private val PRONOUN_LITERAL_RULES: List<Pair<Regex, String>> = listOf(
+    Regex("""\bI'm\b""") to "you're",
+    Regex("""\bI've\b""") to "you've",
+    Regex("""\bI'll\b""") to "you'll",
+    Regex("""\bI'd\b""") to "you'd",
+    Regex("""\bI\b""") to "you",
+    Regex("""\bme\b""") to "you",
+)
+
+// Case-preserving rules: "My" → "Your", "MY" → "YOUR", "my" → "your".
+private val PRONOUN_CASE_PRESERVING_RULES: List<Pair<Regex, String>> = listOf(
+    Regex("""\bmy\b""", RegexOption.IGNORE_CASE) to "your",
+    Regex("""\bmine\b""", RegexOption.IGNORE_CASE) to "yours",
+    Regex("""\bmyself\b""", RegexOption.IGNORE_CASE) to "yourself",
+)
+
+/**
+ * Converts first-person pronouns to second-person so echoed user phrases sound natural
+ * when spoken back by TTS (e.g. "my wife" → "your wife", "I" → "you").
+ *
+ * Apply only to the TTS path — never to displayed text.
+ */
+internal fun normalisePronounsForTts(text: String): String {
+    val afterLiteral = PRONOUN_LITERAL_RULES.fold(text) { current, (pattern, replacement) ->
+        pattern.replace(current, replacement)
+    }
+    return PRONOUN_CASE_PRESERVING_RULES.fold(afterLiteral) { current, (pattern, replacement) ->
+        pattern.replace(current) { match -> matchCase(match.value, replacement) }
+    }
+}
+
 private val speechPronunciationRules = listOf(
     SpeechPronunciationRule(
         pattern = Regex("""\bkia\s+ora\b""", RegexOption.IGNORE_CASE),

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -553,4 +553,92 @@ class ChatTextUtilsTest {
             assertEquals("Dr. Smith explained the plan.", result.trimEnd())
         }
     }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // NORMALISE PRONOUNS FOR TTS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("normalisePronounsForTts")
+    inner class NormalisePronounsForTtsTests {
+
+        @Test
+        fun `my is replaced with your`() {
+            assertEquals("Sending a message to your wife", normalisePronounsForTts("Sending a message to my wife"))
+        }
+
+        @Test
+        fun `My is replaced with Your preserving case`() {
+            assertEquals("Your wife", normalisePronounsForTts("My wife"))
+        }
+
+        @Test
+        fun `MY is replaced with YOUR preserving caps`() {
+            assertEquals("YOUR WIFE", normalisePronounsForTts("MY WIFE"))
+        }
+
+        @Test
+        fun `mine is replaced with yours`() {
+            assertEquals("That is yours", normalisePronounsForTts("That is mine"))
+        }
+
+        @Test
+        fun `myself is replaced with yourself`() {
+            assertEquals("Did you hurt yourself", normalisePronounsForTts("Did I hurt myself"))
+        }
+
+        @Test
+        fun `bare I is replaced with you`() {
+            assertEquals("What would you like to say", normalisePronounsForTts("What would I like to say"))
+        }
+
+        @Test
+        fun `I'm is replaced with you're`() {
+            assertEquals("you're going to love this", normalisePronounsForTts("I'm going to love this"))
+        }
+
+        @Test
+        fun `I've is replaced with you've`() {
+            assertEquals("you've done well", normalisePronounsForTts("I've done well"))
+        }
+
+        @Test
+        fun `I'll is replaced with you'll`() {
+            assertEquals("you'll get a confirmation", normalisePronounsForTts("I'll get a confirmation"))
+        }
+
+        @Test
+        fun `I'd is replaced with you'd`() {
+            assertEquals("you'd prefer that", normalisePronounsForTts("I'd prefer that"))
+        }
+
+        @Test
+        fun `me as object is replaced with you`() {
+            assertEquals("What would you like to say to you", normalisePronounsForTts("What would you like to say to me"))
+        }
+
+        @Test
+        fun `word boundaries prevent partial word replacement`() {
+            // "my" inside "Myra" must not be touched
+            assertEquals("Emailing Myra", normalisePronounsForTts("Emailing Myra"))
+            // "me" inside "email" must not be touched
+            assertEquals("sending email", normalisePronounsForTts("sending email"))
+            // "mine" inside "minefield" must not be touched
+            assertEquals("a minefield of options", normalisePronounsForTts("a minefield of options"))
+        }
+
+        @Test
+        fun `multiple pronouns in one string are all replaced`() {
+            assertEquals(
+                "What would you like to say to your mum",
+                normalisePronounsForTts("What would I like to say to my mum"),
+            )
+        }
+
+        @Test
+        fun `text with no pronouns is unchanged`() {
+            val text = "Sending a message to Sarah"
+            assertEquals(text, normalisePronounsForTts(text))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Normalises first-person pronouns to second-person in the TTS spoken summary path so echoed user phrases sound natural when spoken back. For example, "sending a message to my wife" is now spoken as "sending a message to your wife".

## Changes

- **`ChatTextUtils.kt`** — adds `normalisePronounsForTts()`:
  - Contractions handled first (`I'm → you're`, `I've → you've`, `I'll → you'll`, `I'd → you'd`) to prevent partial substitution of bare `I`
  - Bare `I → you`, `me → you`
  - Case-preserving rules via `matchCase()`: `my → your`, `mine → yours`, `myself → yourself` (handles `My`, `MY`, `my` correctly)
  - Word boundaries (`\b`) throughout — `Myra`, `email`, `minefield` are unchanged
- **`ActionsViewModel.kt`** — applies `normalisePronounsForTts()` in `speakForVoice()` only (not in `normalizeChatTextForSpeech()` which handles AI-generated responses)
- **`ChatTextUtilsTest.kt`** — 14 new tests covering all rules, case preservation, word boundaries, and multi-pronoun strings

## Testing

- [x] 14 new unit tests pass (`NormalisePronounsForTtsTests`)
- [x] Full `ChatTextUtilsTest` suite passes
- [ ] Manual device test — "send an email to my mum" should be spoken as "sending an email to your mum"

## Related issues

Closes #828
