### PR TITLE
fix(#832): preserve voice-speak expectation through Actions→Chat fallthrough

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -79,6 +79,7 @@ private const val ARG_LIST_NAME = "listName"
 private const val ARG_CONVERSATION_ID = "conversationId"
 private const val ARG_INITIAL_QUERY = "initialQuery"
 private const val ARG_MINIMAL_CONTEXT = "minimalContext"
+private const val ARG_SPEAK_RESPONSE = "speakResponse"
 private const val ARG_START_VOICE = "startVoice"
 private const val STATE_OPEN_SHEET_CONSUMED = "openSheetConsumed"
 private const val STATE_START_VOICE_CONSUMED = "startVoiceConsumed"
@@ -304,10 +305,10 @@ fun KernelNavHost(
                                 backStackEntry.savedStateHandle[STATE_START_VOICE_CONSUMED] = true
                                 backStackEntry.arguments?.putBoolean(ARG_START_VOICE, false)
                             },
-                            onNavigateToChat = { query ->
+                            onNavigateToChat = { query, speakResponse ->
                                 val encoded = Uri.encode(query)
                                 navController.navigate(
-                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true"
+                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true&$ARG_SPEAK_RESPONSE=$speakResponse"
                                 )
                             },
                             onNewConversation = {
@@ -321,7 +322,7 @@ fun KernelNavHost(
                 }
 
                 composable(
-                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}",
+                    route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}&$ARG_SPEAK_RESPONSE={$ARG_SPEAK_RESPONSE}",
                     arguments = listOf(
                         navArgument(ARG_INITIAL_QUERY) {
                             type = NavType.StringType
@@ -332,13 +333,19 @@ fun KernelNavHost(
                             type = NavType.BoolType
                             defaultValue = false
                         },
+                        navArgument(ARG_SPEAK_RESPONSE) {
+                            type = NavType.BoolType
+                            defaultValue = false
+                        },
                     ),
                 ) { backStackEntry ->
                     val initialQuery = backStackEntry.arguments?.getString(ARG_INITIAL_QUERY)
                         ?.takeIf { it.isNotBlank() }
+                    val speakResponse = backStackEntry.arguments?.getBoolean(ARG_SPEAK_RESPONSE) ?: false
                     ChatScreen(
                         conversationId = null,
                         initialQuery = initialQuery,
+                        speakInitialResponse = speakResponse,
                         onBack = { navController.popBackStack() },
                         onNewConversation = {
                             navController.navigate(ROUTE_CHAT) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -104,7 +104,7 @@ fun ActionsScreen(
     adbSlotReply: String? = null,
     onAutoOpenSheetConsumed: () -> Unit = {},
     onAutoStartVoiceConsumed: () -> Unit = {},
-    onNavigateToChat: (query: String) -> Unit = {},
+    onNavigateToChat: (query: String, speakResponse: Boolean) -> Unit = { _, _ -> },
     onNewConversation: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     viewModel: ActionsViewModel = hiltViewModel(),
@@ -226,7 +226,7 @@ fun ActionsScreen(
             when (event) {
                 is ActionsViewModel.UiEvent.NavigateToChat -> {
                     viewModel.pauseTransientVoiceUi(reason = "navigateToChat")
-                    onNavigateToChat(event.query)
+                    onNavigateToChat(event.query, event.speakResponse)
                 }
                 ActionsViewModel.UiEvent.RequestPhonePermission ->
                     phonePermissionLauncher.launch(Manifest.permission.CALL_PHONE)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -99,7 +99,7 @@ class ActionsViewModel @Inject constructor(
     /** One-shot navigation/UI events consumed by the screen. */
     sealed interface UiEvent {
         /** Query couldn't be handled by quick actions — navigate to chat for LLM processing. */
-        data class NavigateToChat(val query: String) : UiEvent
+        data class NavigateToChat(val query: String, val speakResponse: Boolean) : UiEvent
         object RequestPhonePermission : UiEvent
     }
 
@@ -493,7 +493,7 @@ class ActionsViewModel @Inject constructor(
                         )
                         quickActionDao.insert(entity)
                         speakForVoice(inputMode, entity.resultText)
-                        _events.emit(UiEvent.NavigateToChat(normalizedQuery))
+                        _events.emit(UiEvent.NavigateToChat(normalizedQuery, speakResponse = inputMode == InputMode.Voice))
                     }
                     is QuickIntentRouter.RouteResult.NeedsSlot -> {
                         // Pause execution — show slot prompt in a ModalBottomSheet.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -138,6 +138,7 @@ import com.kernel.ai.feature.chat.model.ToolCallInfo
 fun ChatScreen(
     conversationId: String? = null,
     initialQuery: String? = null,
+    speakInitialResponse: Boolean = false,
     onBack: () -> Unit = {},
     onNewConversation: () -> Unit = {},
     onNavigateToList: () -> Unit = {},
@@ -162,7 +163,7 @@ fun ChatScreen(
                 viewModel.isConversationReady.first { it }
             }
             if (ready != null) {
-                viewModel.submitInitialQueryIfNeeded(initialQuery)
+                viewModel.submitInitialQueryIfNeeded(initialQuery, speakResponse = speakInitialResponse)
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -994,7 +994,7 @@ class ChatViewModel @Inject constructor(
         _speakingMessageId.value = null
     }
 
-    fun submitInitialQueryIfNeeded(initialQuery: String) {
+    fun submitInitialQueryIfNeeded(initialQuery: String, speakResponse: Boolean = false) {
         val normalized = initialQuery.trim()
         if (normalized.isBlank()) return
         val alreadyPresent = _messages.value.any {
@@ -1007,7 +1007,7 @@ class ChatViewModel @Inject constructor(
             return
         }
         onInputChanged(normalized)
-        sendMessage()
+        sendMessage(if (speakResponse) SubmitMode.Voice else SubmitMode.Text)
     }
 
     fun renameConversation(newTitle: String) {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1685,4 +1685,42 @@ class ActionsViewModelVoiceTest {
         assertNotNull(viewModel.pendingSlot.value)
         assertEquals(ActionsViewModel.VoiceCaptureState.Idle, viewModel.voiceCaptureState.value)
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // #832 — voice fallthrough NavigateToChat speakResponse handoff
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `voice fallthrough emits NavigateToChat with speakResponse true`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("convert 100 aud to nzd") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "convert 100 aud to nzd")
+
+        val events = mutableListOf<ActionsViewModel.UiEvent>()
+        val job = launch { viewModel.events.collect { events.add(it) } }
+
+        viewModel.executeAction("convert 100 aud to nzd", InputMode.Voice)
+        advanceUntilIdle()
+        job.cancel()
+
+        val nav = events.filterIsInstance<ActionsViewModel.UiEvent.NavigateToChat>().first()
+        assertEquals("convert 100 aud to nzd", nav.query)
+        assertEquals(true, nav.speakResponse)
+    }
+
+    @Test
+    fun `text fallthrough emits NavigateToChat with speakResponse false`() = runTest(dispatcher) {
+        every { quickIntentRouter.route("convert 100 aud to nzd") } returns
+            QuickIntentRouter.RouteResult.FallThrough(input = "convert 100 aud to nzd")
+
+        val events = mutableListOf<ActionsViewModel.UiEvent>()
+        val job = launch { viewModel.events.collect { events.add(it) } }
+
+        viewModel.executeAction("convert 100 aud to nzd", InputMode.Text)
+        advanceUntilIdle()
+        job.cancel()
+
+        val nav = events.filterIsInstance<ActionsViewModel.UiEvent.NavigateToChat>().first()
+        assertEquals("convert 100 aud to nzd", nav.query)
+        assertEquals(false, nav.speakResponse)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a gap where voice-initiated Quick Actions fallthrough to LLM chat did not speak the assistant reply. The issue was at the handoff: `NavigateToChat` carried the query but no signal that the reply should be spoken, so `ChatViewModel` submitted it as a typed message (`pendingVoiceReply = false`).

## Root cause

`ChatViewModel.submitInitialQueryIfNeeded()` always called `sendMessage(SubmitMode.Text)`, meaning `pendingVoiceReply` was never set — the TTS streaming session was never opened for the reply.

## Fix

A `speakResponse: Boolean` flag is threaded from the `ActionsViewModel` event through the nav route into `ChatScreen` → `ChatViewModel`. When `speakResponse=true`, `submitInitialQueryIfNeeded` calls `sendMessage(SubmitMode.Voice)`, which sets `pendingVoiceReply = true` and opens the TTS session before inference begins.

## Changes

- **`ActionsViewModel`** — `NavigateToChat` data class gains `speakResponse: Boolean`; set to `inputMode == InputMode.Voice` at the emit site
- **`ActionsScreen`** — `onNavigateToChat` callback signature updated to `(String, Boolean)`
- **`KernelNavHost`** — `ARG_SPEAK_RESPONSE` added to the chat optional-arg route; extracted from back-stack and passed to `ChatScreen.speakInitialResponse`
- **`ChatScreen`** — new `speakInitialResponse: Boolean = false` parameter threaded to `submitInitialQueryIfNeeded`
- **`ChatViewModel`** — `submitInitialQueryIfNeeded` accepts `speakResponse: Boolean = false`; uses `SubmitMode.Voice` when true
- **`ActionsViewModelVoiceTest`** — 2 regression tests: voice FT → `speakResponse=true`, text FT → `speakResponse=false`

## Acceptance criteria verified

- [x] Voice fallthrough: `speakResponse = true` propagated through the chain
- [x] Text fallthrough: `speakResponse = false` (silent)
- [x] `autoSpeakEnabled` / `suppressVoiceOutputForCurrentResponse` guards still apply — no bypass of existing TTS settings
- [x] Build passes, no new test failures (3 pre-existing failures unchanged)

## Testing

Manual test: say *"Convert 100 Australian dollars to New Zealand dollars"* in Quick Actions voice mode → navigates to chat → reply is spoken.

## Related issues

Closes #832
