### PR TITLE
fix(#837): pad AudioTrack with hardware-latency silence to prevent TTS tail cutoff

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -607,6 +607,17 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 offset = end
             }
             if (!stopped) {
+                // Write silence padding equal to the hardware output latency before calling
+                // stop(). PLAYSTATE_STOPPED fires when AudioFlinger's mixer buffer is empty,
+                // but the hardware HAL and DSP pipeline (Samsung Adapt Sound / Dolby Atmos)
+                // can hold an additional 100–300 ms of frames that get silently discarded by
+                // track.release(). Padding with silence equal to track.latency pushes the
+                // real speech samples earlier in the playback queue, ensuring they have
+                // cleared the hardware pipeline before PLAYSTATE_STOPPED is reached.
+                val latencyFrames = (sampleRate.toLong() * audioTrackLatencyMs(track).coerceIn(0, 400) / 1000L).toInt()
+                if (latencyFrames > 0 && !stopped) {
+                    track.write(FloatArray(latencyFrames), 0, latencyFrames, AudioTrack.WRITE_BLOCKING)
+                }
                 track.stop()
                 // MODE_STREAM: stop() is non-blocking — buffered samples continue to drain.
                 // Wait until PLAYSTATE_STOPPED so release() doesn't cut the audio tail,
@@ -680,5 +691,16 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
         /** Floats per AudioTrack write chunk (~92 ms at 22050 Hz). */
         const val AUDIO_CHUNK_FLOATS = 2048
+
+        /**
+         * Returns the hardware output latency of [track] in milliseconds via reflection.
+         * `AudioTrack.getLatency()` exists on all API levels but is hidden from the public
+         * SDK surface. We access it reflectively with a safe fallback to 0 if unavailable.
+         */
+        fun audioTrackLatencyMs(track: AudioTrack): Int = try {
+            AudioTrack::class.java.getMethod("getLatency").invoke(track) as? Int ?: 0
+        } catch (_: Exception) {
+            0
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the pre-existing TTS audio tail cutoff where the last ~100–500ms of every Sherpa speech utterance is silently discarded before playback ends. Reproducible on Samsung Galaxy S23 Ultra (One UI 8.0) with audio effects processing enabled.

## Root cause

`PLAYSTATE_STOPPED` is set by Android when AudioFlinger's **mixer buffer** is empty — but the **hardware HAL and DSP pipeline** (Samsung Adapt Sound / Dolby Atmos) still hold additional frames. Calling `track.release()` immediately after the drain loop discards those in-flight frames, clipping the end of speech.

## Fix

Before calling `track.stop()`, write `track.latency` milliseconds of zero-sample silence to the AudioTrack. This shifts real speech samples earlier in the playback queue so they have fully cleared the hardware pipeline by the time `PLAYSTATE_STOPPED` fires. The silence itself is inaudible trailing padding.

`AudioTrack.getLatency()` is a hidden API — accessed via reflection with a safe fallback to 0 if unavailable. Latency is capped at 400 ms to guard against extreme values.

## Changes

- `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt`
  - Write `track.latency` ms of silence to `AudioTrack` before `stop()` in `playOnAudioTrack()`
  - Add `audioTrackLatencyMs(track)` helper in companion object (reflection, safe fallback)

## Testing

- [x] `./gradlew :core:voice:testDebugUnitTest` — BUILD SUCCESSFUL (all tests pass)
- [ ] Manual device test: listen for clean ending on a multi-word response on S23 Ultra

## Notes

- Affects both the non-streaming (`speakForVoice`) and streaming (chat TTS) paths since both call `playOnAudioTrack()`
- The added silence extends each TTS utterance by `track.latency` ms — expected to be 50–200 ms on the S23 Ultra, imperceptible as trailing silence

## Related issues

Closes #837
