### PR TITLE
fix(#839): keep chat awake during load and generation

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -133,6 +133,22 @@ import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.feature.chat.model.ChatUiState.ModelDownloadProgress
 import com.kernel.ai.feature.chat.model.ToolCallInfo
 
+internal fun shouldKeepChatScreenAwake(
+    uiState: ChatUiState,
+    voiceCaptureState: ChatViewModel.VoiceCaptureState,
+    voicePlaybackState: ChatViewModel.VoicePlaybackState,
+    voiceMode: ChatViewModel.VoiceMode?,
+): Boolean = when (uiState) {
+    ChatUiState.Loading -> true
+    is ChatUiState.ModelsNotReady -> false
+    is ChatUiState.Ready ->
+        uiState.isLoadingModel ||
+            uiState.isGenerating ||
+            voiceMode == ChatViewModel.VoiceMode.BackAndForth ||
+            voiceCaptureState != ChatViewModel.VoiceCaptureState.Idle ||
+            voicePlaybackState != ChatViewModel.VoicePlaybackState.Idle
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
@@ -151,6 +167,21 @@ fun ChatScreen(
     val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val view = androidx.compose.ui.platform.LocalView.current
+    val keepScreenAwake = shouldKeepChatScreenAwake(
+        uiState = uiState,
+        voiceCaptureState = voiceCaptureState,
+        voicePlaybackState = voicePlaybackState,
+        voiceMode = voiceMode,
+    )
+
+    DisposableEffect(view, keepScreenAwake) {
+        val previousKeepScreenOn = view.keepScreenOn
+        view.keepScreenOn = keepScreenAwake || previousKeepScreenOn
+        onDispose {
+            view.keepScreenOn = previousKeepScreenOn
+        }
+    }
 
     // Auto-send the initial query from Actions tab (runs once per navigation).
     // We only wait for conversation initialisation, NOT for the LLM to be ready.
@@ -294,8 +325,6 @@ private fun ChatContent(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
-    val view = androidx.compose.ui.platform.LocalView.current
-    val keepScreenAwake = voiceMode == ChatViewModel.VoiceMode.BackAndForth
     val loopListeningCueState = when (voiceCaptureState) {
         ChatViewModel.VoiceCaptureState.Idle -> LoopListeningCueState.Idle
         is ChatViewModel.VoiceCaptureState.Preparing -> LoopListeningCueState.Preparing
@@ -307,14 +336,6 @@ private fun ChatContent(
         loopActive = voiceMode == ChatViewModel.VoiceMode.BackAndForth,
         captureState = loopListeningCueState,
     )
-
-    DisposableEffect(view, keepScreenAwake) {
-        val previousKeepScreenOn = view.keepScreenOn
-        view.keepScreenOn = keepScreenAwake || previousKeepScreenOn
-        onDispose {
-            view.keepScreenOn = previousKeepScreenOn
-        }
-    }
 
     // Auto-scroll when a new message is appended, but only if the user is already
     // near the bottom (within 2 items). If they've scrolled up to read history,
@@ -407,7 +428,7 @@ private fun ChatContent(
                                     )
                                     Spacer(Modifier.width(8.dp))
                                     Text(
-                                        text = "Loading model…",
+                                        text = "Loading model… keeping this screen awake.",
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
@@ -1065,6 +1086,13 @@ private fun LoadingContent() {
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 8.dp),
+            )
+            Text(
+                text = "Still loading the on-device model. This can take a while after sleep or switching apps, so keep this screen open.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp),
             )
         }
         }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -2043,7 +2043,10 @@ class ChatViewModel @Inject constructor(
             stopVoicePlayback()
             return
         }
-        val session = activeVoiceStreamingSession ?: return
+        val session = activeVoiceStreamingSession ?: run {
+            activeVoiceGroundingContext = null
+            return
+        }
         val finalChunk = if (isVoiceStreamingEnabledForTurn) {
             val bufferedChunks = mutableListOf<String>()
             while (true) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -181,6 +181,7 @@ class ChatViewModel @Inject constructor(
     private var activeVoiceStreamingSession: VoiceOutputStreamingSession? = null
     private var activeVoiceStreamingBuffer = StringBuilder()
     private var isVoiceStreamingEnabledForTurn = false
+    private var activeVoiceGroundingContext: String? = null
     private var suppressVoiceOutputForCurrentResponse = false
     private var spokenResponsesEnabled = true
     private var autoSpeakEnabled = true
@@ -1495,9 +1496,8 @@ class ChatViewModel @Inject constructor(
                 }
             }.ifBlank { null }
             prepareVoicePlaybackForTurn(
-                streamingEnabled = autoSpeakEnabled &&
-                    !isToolQueryForTurn &&
-                    !_correctGroundedFactsEnabled.value,
+                streamingEnabled = autoSpeakEnabled && !isToolQueryForTurn,
+                groundingContext = groundingContext,
             )
 
             } finally {
@@ -1822,6 +1822,7 @@ class ChatViewModel @Inject constructor(
         isVoiceStreamingEnabledForTurn = false
         activeVoiceStreamingBuffer = StringBuilder()
         activeVoiceStreamingSession = null
+        activeVoiceGroundingContext = null
         voiceOutputController.stop()
         _isSpeakingResponse.value = false
     }
@@ -1989,9 +1990,13 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private suspend fun prepareVoicePlaybackForTurn(streamingEnabled: Boolean) {
+    private suspend fun prepareVoicePlaybackForTurn(
+        streamingEnabled: Boolean,
+        groundingContext: String?,
+    ) {
         activeVoiceStreamingBuffer = StringBuilder()
         activeVoiceStreamingSession = null
+        activeVoiceGroundingContext = groundingContext
         isVoiceStreamingEnabledForTurn = streamingEnabled
         val shouldSpeak = pendingVoiceReply
         pendingVoiceReply = false
@@ -2021,7 +2026,15 @@ class ChatViewModel @Inject constructor(
                 preferredChunkLength = CHAT_VOICE_PREFERRED_CHUNK_LENGTH,
                 force = force,
             ) ?: break
-            speakVoiceChunk(session, chunk, isFinal = false)
+            speakVoiceChunk(
+                session = session,
+                chunk = maybeCorrectStreamingSpeechChunk(
+                    chunk = chunk,
+                    groundingContext = activeVoiceGroundingContext,
+                    correctionEnabled = _correctGroundedFactsEnabled.value,
+                ),
+                isFinal = false,
+            )
         }
     }
 
@@ -2042,7 +2055,11 @@ class ChatViewModel @Inject constructor(
                 ) ?: break
                 bufferedChunks += chunk
             }
-            finalizeChatTextForSpeech(bufferedChunks.joinToString(" ").trim())
+            maybeCorrectStreamingSpeechChunk(
+                chunk = finalizeChatTextForSpeech(bufferedChunks.joinToString(" ").trim()),
+                groundingContext = activeVoiceGroundingContext,
+                correctionEnabled = _correctGroundedFactsEnabled.value,
+            )
         } else {
             finalizeChatTextForSpeech(finalContent)
         }
@@ -2050,6 +2067,7 @@ class ChatViewModel @Inject constructor(
         handleVoiceOutputResult(result)
         activeVoiceStreamingSession = null
         activeVoiceStreamingBuffer = StringBuilder()
+        activeVoiceGroundingContext = null
         isVoiceStreamingEnabledForTurn = false
     }
 
@@ -2232,6 +2250,16 @@ private fun shouldIndexToolCallResult(skillName: String): Boolean = when (skillN
  *
  * Broader paraphrasing is left untouched so analytical answers still read naturally.
  */
+internal fun maybeCorrectStreamingSpeechChunk(
+    chunk: String,
+    groundingContext: String?,
+    correctionEnabled: Boolean,
+): String = if (correctionEnabled) {
+    correctGroundedFacts(chunk, groundingContext)
+} else {
+    chunk
+}
+
 internal fun correctGroundedFacts(response: String, groundingContext: String?): String {
     if (groundingContext.isNullOrBlank()) return response
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatScreenKeepAwakeTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatScreenKeepAwakeTest.kt
@@ -1,0 +1,107 @@
+package com.kernel.ai.feature.chat
+
+import com.kernel.ai.feature.chat.model.ChatUiState
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ChatScreenKeepAwakeTest {
+    @Test
+    fun `keeps screen awake while initial chat loading is in progress`() {
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = ChatUiState.Loading,
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `keeps screen awake while model is loading inside ready chat state`() {
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(isLoadingModel = true),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `keeps screen awake while response is generating or speaking`() {
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(isGenerating = true),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = null,
+            ),
+        )
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Speaking("Reply"),
+                voiceMode = ChatViewModel.VoiceMode.OneShot,
+            ),
+        )
+    }
+
+    @Test
+    fun `keeps screen awake during one shot voice capture and back and forth mode`() {
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Listening("hello"),
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = ChatViewModel.VoiceMode.OneShot,
+            ),
+        )
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = ChatViewModel.VoiceMode.BackAndForth,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not keep screen awake when chat is idle`() {
+        assertFalse(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = null,
+            ),
+        )
+        assertFalse(
+            shouldKeepChatScreenAwake(
+                uiState = ChatUiState.ModelsNotReady(isDownloading = true),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Idle,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = null,
+            ),
+        )
+    }
+
+    private fun readyState(
+        isGenerating: Boolean = false,
+        isLoadingModel: Boolean = false,
+    ) = ChatUiState.Ready(
+        conversationId = "conv-1",
+        conversationTitle = null,
+        messages = emptyList(),
+        isGenerating = isGenerating,
+        isSpeakingResponse = false,
+        inputText = "",
+        error = null,
+        isLoadingModel = isLoadingModel,
+        showThinkingProcess = true,
+    )
+}

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -187,6 +187,30 @@ class ChatTextUtilsTest {
 
             assertEquals("Keeorah everyone.", chunk)
         }
+
+        @Test
+        fun `streaming correction repairs grounded percentage chunks when enabled`() {
+            assertEquals(
+                "Battery is at 92%.",
+                maybeCorrectStreamingSpeechChunk(
+                    chunk = "Battery is at 9%.",
+                    groundingContext = "[System: Battery is at 92%]",
+                    correctionEnabled = true,
+                ),
+            )
+        }
+
+        @Test
+        fun `streaming correction leaves chunk unchanged when disabled`() {
+            assertEquals(
+                "Battery is at 9%.",
+                maybeCorrectStreamingSpeechChunk(
+                    chunk = "Battery is at 9%.",
+                    groundingContext = "[System: Battery is at 92%]",
+                    correctionEnabled = false,
+                ),
+            )
+        }
     }
 
     // ═════════════════════════════════════════════════════════════════════════

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -211,6 +211,18 @@ class ChatTextUtilsTest {
                 ),
             )
         }
+
+        @Test
+        fun `streaming correction leaves chunk unchanged when grounding context is absent`() {
+            assertEquals(
+                "Battery is at 9%.",
+                maybeCorrectStreamingSpeechChunk(
+                    chunk = "Battery is at 9%.",
+                    groundingContext = null,
+                    correctionEnabled = true,
+                ),
+            )
+        }
     }
 
     // ═════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- keep the chat screen awake during initial loading, in-chat model loading, response generation, voice capture, and voice playback
- make long waits more truthful with loading copy that explains sleep/app-switch reloads can take a while
- restore streaming chat auto-speak even when grounded-facts repair is enabled by applying the same narrow numeric/year correction to streamed chunks
- add regression coverage for the keep-awake policy and grounded streaming correction paths

## Testing
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :feature:chat:testDebugUnitTest --tests "*ChatTextUtilsTest" --tests "*ChatViewModelVoiceTest" --tests "*ChatScreenKeepAwakeTest"`

Closes #839