### PR TITLE
fix(#841): guard against blank response when LiteRT produces 0 tokens

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1560,6 +1560,9 @@ class ChatViewModel @Inject constructor(
                                 if (!blankResponseRetryAttempted) {
                                     blankResponseRetryAttempted = true
                                     Log.w("KernelAI", "blank_response_guard: 0 tokens — retrying without RAG context")
+                                    // Null out grounding context so correctGroundedFacts does not
+                                    // mutate the retry response using stale RAG-injected data.
+                                    groundingContext = null
                                     currentPrompt = buildString {
                                         if (systemContext != null) append("$systemContext\n\n")
                                         append("[System: ${jandalPersona.buildGreetingInstruction(false, jandalPersona.currentPersonaMode)}]\n\n")
@@ -1582,8 +1585,16 @@ class ChatViewModel @Inject constructor(
                                         }
                                     }
                                     conversationRepository.addMessage(convId, "assistant", fallback, thinking)
+                                    // Index the user message so this exchange isn't silently orphaned
+                                    // from semantic search — only the fallback assistant text is skipped.
+                                    if (savedUserMsgId.isNotBlank()) {
+                                        ragRepository.indexMessage(savedUserMsgId, convId, text)
+                                    }
                                     finalizeVoicePlaybackForResponse(fallback)
-                                    // Skip RAG indexing — fallback text is noise
+                                    // Clear streaming tracking — mirrors the normal Complete path.
+                                    activeStreamingMsgId = null
+                                    activeStreamingContent = StringBuilder()
+                                    activeStreamingThinking = StringBuilder()
                                 }
                                 return@collect
                             }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1510,6 +1510,7 @@ class ChatViewModel @Inject constructor(
                 kernelAIToolSet.resetTurnState()
                 hallucinationRetryAttempted = false
                 var rawToolCallRetryAttempted = false
+                var blankResponseRetryAttempted = false
                 var currentPrompt = prompt
                 var needsHallucinationRetry: Boolean
 
@@ -1550,21 +1551,40 @@ class ChatViewModel @Inject constructor(
                             }
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
 
-                            // Guard: LiteRT occasionally produces 0 tokens (TTFT=-1ms) when
-                            // the GPU KV-cache enters a corrupted state. LiteRT self-heals by
-                            // resetting the session, but without this guard the UI shows a blank
-                            // assistant bubble and an empty string gets indexed into RAG (#841).
+                            // Guard: LiteRT occasionally produces 0 tokens (TTFT=-1ms) when the model
+                            // generates an immediate EOS — often triggered by an unusual RAG injection
+                            // creating a token pattern where EOS is most likely. LiteRT then
+                            // self-heals by resetting the session (#841).
+                            // Retry once without RAG context (stripped prompt) before showing fallback.
                             if (fullContent.isBlank()) {
-                                Log.w("KernelAI", "blank_response_guard: LiteRT produced 0 tokens — showing fallback")
-                                val fallback = "I lost my train of thought there — could you say that again?"
-                                _messages.update { msgs ->
-                                    msgs.map {
-                                        if (it.id == assistantMsgId) it.copy(content = fallback, isStreaming = false) else it
+                                if (!blankResponseRetryAttempted) {
+                                    blankResponseRetryAttempted = true
+                                    Log.w("KernelAI", "blank_response_guard: 0 tokens — retrying without RAG context")
+                                    currentPrompt = buildString {
+                                        if (systemContext != null) append("$systemContext\n\n")
+                                        append("[System: ${jandalPersona.buildGreetingInstruction(false, jandalPersona.currentPersonaMode)}]\n\n")
+                                        append(text)
                                     }
+                                    accumulatedContent = StringBuilder()
+                                    accumulatedThinking = StringBuilder()
+                                    activeStreamingContent = accumulatedContent
+                                    activeStreamingThinking = accumulatedThinking
+                                    _messages.update { msgs ->
+                                        msgs.map { if (it.id == assistantMsgId) it.copy(content = "", isStreaming = true) else it }
+                                    }
+                                    needsHallucinationRetry = true
+                                } else {
+                                    Log.w("KernelAI", "blank_response_guard: retry also produced 0 tokens — showing fallback")
+                                    val fallback = "I lost my train of thought there — could you say that again?"
+                                    _messages.update { msgs ->
+                                        msgs.map {
+                                            if (it.id == assistantMsgId) it.copy(content = fallback, isStreaming = false) else it
+                                        }
+                                    }
+                                    conversationRepository.addMessage(convId, "assistant", fallback, thinking)
+                                    finalizeVoicePlaybackForResponse(fallback)
+                                    // Skip RAG indexing — fallback text is noise
                                 }
-                                conversationRepository.addMessage(convId, "assistant", fallback, thinking)
-                                finalizeVoicePlaybackForResponse(fallback)
-                                // Skip RAG indexing — fallback text is noise
                                 return@collect
                             }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1550,6 +1550,24 @@ class ChatViewModel @Inject constructor(
                             }
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
 
+                            // Guard: LiteRT occasionally produces 0 tokens (TTFT=-1ms) when
+                            // the GPU KV-cache enters a corrupted state. LiteRT self-heals by
+                            // resetting the session, but without this guard the UI shows a blank
+                            // assistant bubble and an empty string gets indexed into RAG (#841).
+                            if (fullContent.isBlank()) {
+                                Log.w("KernelAI", "blank_response_guard: LiteRT produced 0 tokens — showing fallback")
+                                val fallback = "I lost my train of thought there — could you say that again?"
+                                _messages.update { msgs ->
+                                    msgs.map {
+                                        if (it.id == assistantMsgId) it.copy(content = fallback, isStreaming = false) else it
+                                    }
+                                }
+                                conversationRepository.addMessage(convId, "assistant", fallback, thinking)
+                                finalizeVoicePlaybackForResponse(fallback)
+                                // Skip RAG indexing — fallback text is noise
+                                return@collect
+                            }
+
                             // With native SDK tool calling, tool execution happens
                             // transparently during generate() — the SDK calls our @Tool
                             // methods and feeds results back to the model. Check if any

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -413,4 +413,110 @@ class ChatViewModelInitTest {
             systemPrompts.joinToString(separator = "\n---\n"),
         )
     }
+
+    @Test
+    fun `blank response retries without RAG context on first zero-token generation`() = runTest(dispatcher) {
+        val prompts = mutableListOf<String>()
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        // First call: 0 tokens (blank). Second call (retry): normal response.
+        every { inferenceEngine.generate(capture(prompts)) } returnsMany listOf(
+            flowOf(GenerationResult.Complete(durationMs = 1L)),
+            flowOf(GenerationResult.Token("Got it."), GenerationResult.Complete(durationMs = 1L)),
+        )
+        coEvery { ragRepository.getRelevantContext(any(), any(), any()) } returns "RAG memory context"
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg-id", "assistant-msg-id")
+        every { quickIntentRouter.route(any()) } returns QuickIntentRouter.RouteResult.FallThrough(input = "hello")
+
+        val viewModel = ChatViewModel(
+            savedStateHandle = SavedStateHandle(),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+        advanceUntilIdle()
+
+        viewModel.onInputChanged("hello")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        // First prompt included RAG context; retry prompt must not.
+        assertTrue(prompts.size == 2, "Expected 2 generate() calls, got ${prompts.size}")
+        assertTrue(prompts[0].contains("RAG memory context"), "First prompt should contain RAG context")
+        assertTrue(!prompts[1].contains("RAG memory context"), "Retry prompt must not contain RAG context")
+
+        // Final assistant message saved to DB must be the retry response (not a blank or fallback).
+        coVerify(atLeast = 1) { conversationRepository.addMessage(any(), eq("assistant"), eq("Got it."), any(), any()) }
+    }
+
+    @Test
+    fun `blank response shows fallback when retry also produces zero tokens`() = runTest(dispatcher) {
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        // Both calls produce 0 tokens.
+        every { inferenceEngine.generate(any()) } returns
+            flowOf(GenerationResult.Complete(durationMs = 1L))
+        coEvery { ragRepository.getRelevantContext(any(), any(), any()) } returns "RAG memory context"
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg-id", "assistant-fallback-id")
+        every { quickIntentRouter.route(any()) } returns QuickIntentRouter.RouteResult.FallThrough(input = "hello")
+
+        val viewModel = ChatViewModel(
+            savedStateHandle = SavedStateHandle(),
+            inferenceEngine = inferenceEngine,
+            downloadManager = downloadManager,
+            conversationRepository = conversationRepository,
+            ragRepository = ragRepository,
+            userProfileRepository = userProfileRepository,
+            memoryRepository = memoryRepository,
+            episodicDistillationUseCase = episodicDistillationUseCase,
+            modelSettingsRepository = modelSettingsRepository,
+            skillRegistry = skillRegistry,
+            skillExecutor = skillExecutor,
+            quickIntentRouter = quickIntentRouter,
+            slotFillerManager = slotFillerManager,
+            kernelAIToolSet = kernelAIToolSet,
+            toolProvider = toolProvider,
+            embeddingEngine = embeddingEngine,
+            voiceInputController = voiceInputController,
+            voiceOutputController = voiceOutputController,
+            voiceOutputPreferences = voiceOutputPreferences,
+            jandalPersona = jandalPersona,
+            nzTruthSeedingService = nzTruthSeedingService,
+            verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        )
+        advanceUntilIdle()
+
+        viewModel.onInputChanged("hello")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        // Fallback message must be persisted to DB.
+        coVerify(atLeast = 1) {
+            conversationRepository.addMessage(
+                any(), eq("assistant"), match { it.contains("lost my train of thought") }, any(), any(),
+            )
+        }
+        // User message must be indexed into RAG even when fallback fires.
+        coVerify(atLeast = 1) { ragRepository.indexMessage("user-msg-id", any(), "hello") }
+        // Fallback text must not be indexed.
+        coVerify(exactly = 0) { ragRepository.indexMessage("assistant-fallback-id", any(), any()) }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a guard in `GenerationResult.Complete` for when LiteRT's GPU decode produces zero tokens (`TTFT=-1ms, tokens=0`). Without this guard the UI shows a blank `Jandal:` bubble and an empty string gets indexed into RAG.

## Changes

- `ChatViewModel.kt`: early-return guard after `fullContent.isBlank()` check — logs a warning, displays a friendly fallback, persists it to conversation history, triggers voice playback, skips RAG indexing

## Root Cause

LiteRT's GPU decode occasionally enters a corrupted KV-cache state (observed on S23 Ultra after ~10+ turns with Wikipedia tool calls). LiteRT self-heals by resetting the model session automatically, but `fullContent.isBlank()` had no handling in `ChatViewModel`.

## Before / After

**Before:** Blank `Jandal:` bubble, empty string in RAG, no voice feedback  
**After:** `"I lost my train of thought there — could you say that again?"` — persisted, spoken in voice mode, not indexed

## Testing

- [ ] Unit tests pass (only pre-existing `LatexConversionTest` failure)
- [ ] Long conversation test on S23 Ultra — verify fallback message appears if 0-token generation occurs; normal responses unaffected

Closes #841
