### PR TITLE
test: cover remaining keep-awake capture states

### DIFF
--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatScreenKeepAwakeTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatScreenKeepAwakeTest.kt
@@ -51,11 +51,27 @@ class ChatScreenKeepAwakeTest {
     }
 
     @Test
-    fun `keeps screen awake during one shot voice capture and back and forth mode`() {
+    fun `keeps screen awake during one shot voice capture states and back and forth mode`() {
         assertTrue(
             shouldKeepChatScreenAwake(
                 uiState = readyState(),
                 voiceCaptureState = ChatViewModel.VoiceCaptureState.Listening("hello"),
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = ChatViewModel.VoiceMode.OneShot,
+            ),
+        )
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Preparing,
+                voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
+                voiceMode = ChatViewModel.VoiceMode.OneShot,
+            ),
+        )
+        assertTrue(
+            shouldKeepChatScreenAwake(
+                uiState = readyState(),
+                voiceCaptureState = ChatViewModel.VoiceCaptureState.Processing("hello"),
                 voicePlaybackState = ChatViewModel.VoicePlaybackState.Idle,
                 voiceMode = ChatViewModel.VoiceMode.OneShot,
             ),


### PR DESCRIPTION
## Summary
- add `ChatScreenKeepAwakeTest` coverage for `VoiceCaptureState.Preparing`
- add `ChatScreenKeepAwakeTest` coverage for `VoiceCaptureState.Processing`
- close the small keep-awake test gap noted during PR #840 review

## Testing
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :feature:chat:testDebugUnitTest --tests "*ChatScreenKeepAwakeTest"`

Manual device testing not required because this PR only adds unit-test coverage.