### PR TITLE
fix(#843): correct aye speech pronunciation

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -149,6 +149,10 @@ private val speechPronunciationRules = listOf(
         pattern = Regex("""\bm(?:ō|o)rena\b""", RegexOption.IGNORE_CASE),
         replacement = "moh-reh-nah",
     ),
+    SpeechPronunciationRule(
+        pattern = Regex("""\baye\b""", RegexOption.IGNORE_CASE),
+        replacement = "ay",
+    ),
 )
 
 private fun findSpeechChunkBoundary(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -151,7 +151,7 @@ private val speechPronunciationRules = listOf(
     ),
     SpeechPronunciationRule(
         pattern = Regex("""\baye\b""", RegexOption.IGNORE_CASE),
-        replacement = "ay",
+        replacement = "A",
     ),
 )
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -150,7 +150,7 @@ private val speechPronunciationRules = listOf(
         replacement = "moh-reh-nah",
     ),
     SpeechPronunciationRule(
-        pattern = Regex("""\baye\b""", RegexOption.IGNORE_CASE),
+        pattern = Regex("""(?<![a-zA-Z-])aye(?![a-zA-Z-])""", RegexOption.IGNORE_CASE),
         replacement = "A",
     ),
 )

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -81,15 +81,15 @@ class ChatTextUtilsTest {
                 normalizeChatTextForSpeech("morena everyone"),
             )
             assertEquals(
-                "Ay, sounds good",
+                "A, sounds good",
                 normalizeChatTextForSpeech("Aye, sounds good"),
             )
             assertEquals(
-                "Maybe ay means yes",
+                "Maybe A means yes",
                 normalizeChatTextForSpeech("Maybe aye means yes"),
             )
             assertEquals(
-                "AY, AY AY CAPTAIN",
+                "A, A A CAPTAIN",
                 normalizeChatTextForSpeech("AYE, AYE AYE CAPTAIN"),
             )
             assertEquals(

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -71,7 +71,7 @@ class ChatTextUtilsTest {
     inner class ChatSpeechNormalizationTests {
 
         @Test
-        fun `applies scoped maori pronunciation overrides for chat speech`() {
+        fun `applies scoped pronunciation overrides for chat speech`() {
             assertEquals(
                 "Keeorah and moh-reh-nah",
                 normalizeChatTextForSpeech("Kia ora and mōrena"),
@@ -79,6 +79,14 @@ class ChatTextUtilsTest {
             assertEquals(
                 "moh-reh-nah everyone",
                 normalizeChatTextForSpeech("morena everyone"),
+            )
+            assertEquals(
+                "Ay, sounds good",
+                normalizeChatTextForSpeech("Aye, sounds good"),
+            )
+            assertEquals(
+                "Maybe ay means yes",
+                normalizeChatTextForSpeech("Maybe aye means yes"),
             )
         }
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -88,6 +88,14 @@ class ChatTextUtilsTest {
                 "Maybe ay means yes",
                 normalizeChatTextForSpeech("Maybe aye means yes"),
             )
+            assertEquals(
+                "AY, AY AY CAPTAIN",
+                normalizeChatTextForSpeech("AYE, AYE AYE CAPTAIN"),
+            )
+            assertEquals(
+                "ayes stay unchanged",
+                normalizeChatTextForSpeech("ayes stay unchanged"),
+            )
         }
 
         @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -80,6 +80,10 @@ class ChatTextUtilsTest {
                 "moh-reh-nah everyone",
                 normalizeChatTextForSpeech("morena everyone"),
             )
+        }
+
+        @Test
+        fun `normalises standalone aye to the spoken letter A`() {
             assertEquals(
                 "A, sounds good",
                 normalizeChatTextForSpeech("Aye, sounds good"),

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -96,6 +96,10 @@ class ChatTextUtilsTest {
                 "ayes stay unchanged",
                 normalizeChatTextForSpeech("ayes stay unchanged"),
             )
+            assertEquals(
+                "aye-aye unchanged",
+                normalizeChatTextForSpeech("aye-aye unchanged"),
+            )
         }
 
         @Test


### PR DESCRIPTION
## Summary
- add a chat speech pronunciation override so standalone `aye` is spoken like the letter `A`
- keep the override scoped so longer words and hyphenated compounds are unchanged
- extend `ChatTextUtilsTest` coverage for the new pronunciation path and edge cases

## Testing
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :feature:chat:testDebugUnitTest --tests "*ChatTextUtilsTest"`

Closes #843