### PR TITLE
chore: remove stale TODO(#588)

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -122,7 +122,6 @@ class ActionsViewModel @Inject constructor(
     data class PendingSlotState(
         val request: PendingSlotRequest,
         val originalQuery: String,
-        // TODO(#350/#588): use inputMode to adapt SlotFillBottomSheet for voice (mic button, no keyboard)
         val inputMode: InputMode,
     )
 


### PR DESCRIPTION
Removes the stale `TODO(#350/#588)` comment in `ActionsViewModel`. The mic button in `SlotFillBottomSheet` was implemented alongside the broader voice slot-fill work — the TODO was never cleaned up.

Closes #588