### PR TITLE
feat(#783): add Kokoro-82M TTS engine behind VoiceOutputEngine.KokoroExperimental

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/FallbackVoiceOutputController.kt
@@ -33,7 +33,8 @@ class FallbackVoiceOutputController @Inject constructor(
 
     override suspend fun warmUp(): VoiceOutputResult = when (voiceOutputPreferences.selectedEngine.first()) {
         VoiceOutputEngine.AndroidTts -> warmUpAndroidTts()
-        VoiceOutputEngine.SherpaExperimental -> warmUpSherpaOrFallback()
+        VoiceOutputEngine.SherpaExperimental,
+        VoiceOutputEngine.KokoroExperimental -> warmUpSherpaOrFallback()
     }
 
     override suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult =
@@ -43,7 +44,8 @@ class FallbackVoiceOutputController @Inject constructor(
                 androidTts.speak(request)
             }
 
-            VoiceOutputEngine.SherpaExperimental -> speakWithSherpaFallback(request)
+            VoiceOutputEngine.SherpaExperimental,
+            VoiceOutputEngine.KokoroExperimental -> speakWithSherpaFallback(request)
         }
 
     override suspend fun openStreamingSession(request: VoiceSpeakRequest): VoiceOutputStreamingSession =
@@ -53,7 +55,8 @@ class FallbackVoiceOutputController @Inject constructor(
                 androidTts.openStreamingSession(request)
             }
 
-            VoiceOutputEngine.SherpaExperimental -> openSherpaStreamingSessionOrFallback(request)
+            VoiceOutputEngine.SherpaExperimental,
+            VoiceOutputEngine.KokoroExperimental -> openSherpaStreamingSessionOrFallback(request)
         }
 
     override fun stop() {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
@@ -1,0 +1,54 @@
+package com.kernel.ai.core.voice
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Enum of available Kokoro-based Sherpa-ONNX TTS models.
+ *
+ * Kokoro uses [com.k2fsa.sherpa.onnx.OfflineTtsKokoroModelConfig] (accessed via reflection in
+ * [SherpaOnnxVoiceOutputController]) rather than the Piper VITS config.  Sample rate is read
+ * dynamically from [com.k2fsa.sherpa.onnx.GeneratedAudio] at runtime so 24 kHz just works.
+ *
+ * Voice packs are downloaded on-device from Settings → Voice and extracted to
+ * [Context.filesDir]/sherpa-tts/<assetDirectoryName>/.
+ */
+enum class SherpaKokoroVoice(
+    val displayName: String,
+    val description: String,
+    val assetDirectoryName: String,
+    val downloadKey: String,
+    /** Approximate total download size in bytes (model + voices.bin + lexicons). */
+    val approxDownloadBytes: Long,
+    val speakerCount: Int,
+    /** BCP-47 language tag passed to Sherpa's Kokoro config. */
+    val lang: String,
+) {
+    KokoroMultiLangInt8(
+        displayName = "Kokoro (Experimental)",
+        description = "Studio-grade 82M parameter multilingual TTS. ~82MB model. Requires download.",
+        assetDirectoryName = "kokoro-int8-multi-lang-v1_1",
+        downloadKey = "kokoro-int8-multi-lang-v1_1",
+        approxDownloadBytes = 130_000_000L,  // rough estimate incl voices.bin + lexicons
+        speakerCount = 103,
+        lang = "en",
+    ),
+    ;
+
+    /** URL to the Sherpa-ONNX Kokoro model tarball on GitHub releases. */
+    val downloadUrl: String
+        get() = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/$assetDirectoryName.tar.bz2"
+
+    /** Returns the directory where this voice pack is extracted on internal storage. */
+    fun voiceDir(context: Context): File =
+        File(context.filesDir, "sherpa-tts/$assetDirectoryName")
+
+    /** Returns true when the voice pack is fully extracted and validated. */
+    fun isDownloaded(context: Context): Boolean =
+        hasRequiredKokoroVoicePackFiles(voiceDir(context))
+
+    companion object {
+        fun fromStorage(value: String?): SherpaKokoroVoice =
+            entries.firstOrNull { it.name == value } ?: KokoroMultiLangInt8
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
@@ -23,6 +23,11 @@ enum class SherpaKokoroVoice(
     val speakerCount: Int,
     /** BCP-47 language tag passed to Sherpa's Kokoro config. */
     val lang: String,
+    /**
+     * Ordered list of speaker names, indexed by sid (0-based).
+     * For `kokoro-int8-multi-lang-v1_1` this is the 103-entry v1.1 speaker map.
+     */
+    val speakerNames: List<String>,
 ) {
     KokoroMultiLangInt8(
         displayName = "Kokoro (Experimental)",
@@ -32,8 +37,116 @@ enum class SherpaKokoroVoice(
         approxDownloadBytes = 130_000_000L,  // rough estimate incl voices.bin + lexicons
         speakerCount = 103,
         lang = "en",
+        speakerNames = listOf(
+            /* 0  */ "af_maple",
+            /* 1  */ "af_sol",
+            /* 2  */ "bf_vale",
+            /* 3  */ "zf_001",
+            /* 4  */ "zf_002",
+            /* 5  */ "zf_003",
+            /* 6  */ "zf_004",
+            /* 7  */ "zf_005",
+            /* 8  */ "zf_006",
+            /* 9  */ "zf_007",
+            /* 10 */ "zf_008",
+            /* 11 */ "zf_017",
+            /* 12 */ "zf_018",
+            /* 13 */ "zf_019",
+            /* 14 */ "zf_021",
+            /* 15 */ "zf_022",
+            /* 16 */ "zf_023",
+            /* 17 */ "zf_024",
+            /* 18 */ "zf_026",
+            /* 19 */ "zf_027",
+            /* 20 */ "zf_028",
+            /* 21 */ "zf_032",
+            /* 22 */ "zf_036",
+            /* 23 */ "zf_038",
+            /* 24 */ "zf_039",
+            /* 25 */ "zf_040",
+            /* 26 */ "zf_042",
+            /* 27 */ "zf_043",
+            /* 28 */ "zf_044",
+            /* 29 */ "zf_046",
+            /* 30 */ "zf_047",
+            /* 31 */ "zf_048",
+            /* 32 */ "zf_049",
+            /* 33 */ "zf_051",
+            /* 34 */ "zf_059",
+            /* 35 */ "zf_060",
+            /* 36 */ "zf_067",
+            /* 37 */ "zf_070",
+            /* 38 */ "zf_071",
+            /* 39 */ "zf_072",
+            /* 40 */ "zf_073",
+            /* 41 */ "zf_074",
+            /* 42 */ "zf_075",
+            /* 43 */ "zf_076",
+            /* 44 */ "zf_077",
+            /* 45 */ "zf_078",
+            /* 46 */ "zf_079",
+            /* 47 */ "zf_083",
+            /* 48 */ "zf_084",
+            /* 49 */ "zf_085",
+            /* 50 */ "zf_086",
+            /* 51 */ "zf_087",
+            /* 52 */ "zf_088",
+            /* 53 */ "zf_090",
+            /* 54 */ "zf_092",
+            /* 55 */ "zf_093",
+            /* 56 */ "zf_094",
+            /* 57 */ "zf_099",
+            /* 58 */ "zm_009",
+            /* 59 */ "zm_010",
+            /* 60 */ "zm_011",
+            /* 61 */ "zm_012",
+            /* 62 */ "zm_013",
+            /* 63 */ "zm_014",
+            /* 64 */ "zm_015",
+            /* 65 */ "zm_016",
+            /* 66 */ "zm_020",
+            /* 67 */ "zm_025",
+            /* 68 */ "zm_029",
+            /* 69 */ "zm_030",
+            /* 70 */ "zm_031",
+            /* 71 */ "zm_033",
+            /* 72 */ "zm_034",
+            /* 73 */ "zm_035",
+            /* 74 */ "zm_037",
+            /* 75 */ "zm_041",
+            /* 76 */ "zm_045",
+            /* 77 */ "zm_050",
+            /* 78 */ "zm_052",
+            /* 79 */ "zm_053",
+            /* 80 */ "zm_054",
+            /* 81 */ "zm_055",
+            /* 82 */ "zm_056",
+            /* 83 */ "zm_057",
+            /* 84 */ "zm_058",
+            /* 85 */ "zm_061",
+            /* 86 */ "zm_062",
+            /* 87 */ "zm_063",
+            /* 88 */ "zm_064",
+            /* 89 */ "zm_065",
+            /* 90 */ "zm_066",
+            /* 91 */ "zm_068",
+            /* 92 */ "zm_069",
+            /* 93 */ "zm_080",
+            /* 94 */ "zm_081",
+            /* 95 */ "zm_082",
+            /* 96 */ "zm_089",
+            /* 97 */ "zm_091",
+            /* 98 */ "zm_095",
+            /* 99 */ "zm_096",
+            /* 100 */ "zm_097",
+            /* 101 */ "zm_098",
+            /* 102 */ "zm_100",
+        ),
     ),
     ;
+
+    /** Returns the display name for [sid], or "Speaker N" if out of range. */
+    fun speakerNameForSid(sid: Int): String = speakerNames.getOrElse(sid) { "Speaker $sid" }
 
     /** URL to the Sherpa-ONNX Kokoro model tarball on GitHub releases. */
     val downloadUrl: String
@@ -52,3 +165,21 @@ enum class SherpaKokoroVoice(
             entries.firstOrNull { it.name == value } ?: KokoroMultiLangInt8
     }
 }
+
+/**
+ * Logical groupings of Kokoro speakers for the `kokoro-int8-multi-lang-v1_1` voice pack.
+ *
+ * Each group maps to a contiguous sid range. The prefix convention is:
+ * - `af` = American female, `bf` = British female, `zf` = Chinese female, `zm` = Chinese male.
+ */
+enum class KokoroSpeakerGroup(val label: String, val sidRange: IntRange) {
+    AmericanFemale("American female", 0..1),
+    BritishFemale("British female", 2..2),
+    ChineseFemale("Chinese female", 3..57),
+    ChineseMale("Chinese male", 58..102),
+}
+
+/** Returns the [KokoroSpeakerGroup] that contains [sid], defaulting to [KokoroSpeakerGroup.AmericanFemale]. */
+fun SherpaKokoroVoice.speakerGroupForSid(sid: Int): KokoroSpeakerGroup =
+    KokoroSpeakerGroup.entries.firstOrNull { sid in it.sidRange }
+        ?: KokoroSpeakerGroup.AmericanFemale

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt
@@ -31,116 +31,71 @@ enum class SherpaKokoroVoice(
 ) {
     KokoroMultiLangInt8(
         displayName = "Kokoro (Experimental)",
-        description = "Studio-grade 82M parameter multilingual TTS. ~82MB model. Requires download.",
-        assetDirectoryName = "kokoro-int8-multi-lang-v1_1",
-        downloadKey = "kokoro-int8-multi-lang-v1_1",
+        description = "Studio-grade 82M parameter multilingual TTS. 20 English + 33 multilingual voices. ~130MB. Requires download.",
+        assetDirectoryName = "kokoro-int8-multi-lang-v1_0",
+        downloadKey = "kokoro-int8-multi-lang-v1_0",
         approxDownloadBytes = 130_000_000L,  // rough estimate incl voices.bin + lexicons
-        speakerCount = 103,
+        speakerCount = 53,
         lang = "en",
         speakerNames = listOf(
-            /* 0  */ "af_maple",
-            /* 1  */ "af_sol",
-            /* 2  */ "bf_vale",
-            /* 3  */ "zf_001",
-            /* 4  */ "zf_002",
-            /* 5  */ "zf_003",
-            /* 6  */ "zf_004",
-            /* 7  */ "zf_005",
-            /* 8  */ "zf_006",
-            /* 9  */ "zf_007",
-            /* 10 */ "zf_008",
-            /* 11 */ "zf_017",
-            /* 12 */ "zf_018",
-            /* 13 */ "zf_019",
-            /* 14 */ "zf_021",
-            /* 15 */ "zf_022",
-            /* 16 */ "zf_023",
-            /* 17 */ "zf_024",
-            /* 18 */ "zf_026",
-            /* 19 */ "zf_027",
-            /* 20 */ "zf_028",
-            /* 21 */ "zf_032",
-            /* 22 */ "zf_036",
-            /* 23 */ "zf_038",
-            /* 24 */ "zf_039",
-            /* 25 */ "zf_040",
-            /* 26 */ "zf_042",
-            /* 27 */ "zf_043",
-            /* 28 */ "zf_044",
-            /* 29 */ "zf_046",
-            /* 30 */ "zf_047",
-            /* 31 */ "zf_048",
-            /* 32 */ "zf_049",
-            /* 33 */ "zf_051",
-            /* 34 */ "zf_059",
-            /* 35 */ "zf_060",
-            /* 36 */ "zf_067",
-            /* 37 */ "zf_070",
-            /* 38 */ "zf_071",
-            /* 39 */ "zf_072",
-            /* 40 */ "zf_073",
-            /* 41 */ "zf_074",
-            /* 42 */ "zf_075",
-            /* 43 */ "zf_076",
-            /* 44 */ "zf_077",
-            /* 45 */ "zf_078",
-            /* 46 */ "zf_079",
-            /* 47 */ "zf_083",
-            /* 48 */ "zf_084",
-            /* 49 */ "zf_085",
-            /* 50 */ "zf_086",
-            /* 51 */ "zf_087",
-            /* 52 */ "zf_088",
-            /* 53 */ "zf_090",
-            /* 54 */ "zf_092",
-            /* 55 */ "zf_093",
-            /* 56 */ "zf_094",
-            /* 57 */ "zf_099",
-            /* 58 */ "zm_009",
-            /* 59 */ "zm_010",
-            /* 60 */ "zm_011",
-            /* 61 */ "zm_012",
-            /* 62 */ "zm_013",
-            /* 63 */ "zm_014",
-            /* 64 */ "zm_015",
-            /* 65 */ "zm_016",
-            /* 66 */ "zm_020",
-            /* 67 */ "zm_025",
-            /* 68 */ "zm_029",
-            /* 69 */ "zm_030",
-            /* 70 */ "zm_031",
-            /* 71 */ "zm_033",
-            /* 72 */ "zm_034",
-            /* 73 */ "zm_035",
-            /* 74 */ "zm_037",
-            /* 75 */ "zm_041",
-            /* 76 */ "zm_045",
-            /* 77 */ "zm_050",
-            /* 78 */ "zm_052",
-            /* 79 */ "zm_053",
-            /* 80 */ "zm_054",
-            /* 81 */ "zm_055",
-            /* 82 */ "zm_056",
-            /* 83 */ "zm_057",
-            /* 84 */ "zm_058",
-            /* 85 */ "zm_061",
-            /* 86 */ "zm_062",
-            /* 87 */ "zm_063",
-            /* 88 */ "zm_064",
-            /* 89 */ "zm_065",
-            /* 90 */ "zm_066",
-            /* 91 */ "zm_068",
-            /* 92 */ "zm_069",
-            /* 93 */ "zm_080",
-            /* 94 */ "zm_081",
-            /* 95 */ "zm_082",
-            /* 96 */ "zm_089",
-            /* 97 */ "zm_091",
-            /* 98 */ "zm_095",
-            /* 99 */ "zm_096",
-            /* 100 */ "zm_097",
-            /* 101 */ "zm_098",
-            /* 102 */ "zm_100",
+            // American Female (sids 0–10)
+            /* 0  */ "af_alloy",
+            /* 1  */ "af_aoede",
+            /* 2  */ "af_bella",
+            /* 3  */ "af_heart",
+            /* 4  */ "af_jessica",
+            /* 5  */ "af_kore",
+            /* 6  */ "af_nicole",
+            /* 7  */ "af_nova",
+            /* 8  */ "af_river",
+            /* 9  */ "af_sarah",
+            /* 10 */ "af_sky",
+            // American Male (sids 11–19)
+            /* 11 */ "am_adam",
+            /* 12 */ "am_echo",
+            /* 13 */ "am_eric",
+            /* 14 */ "am_fenrir",
+            /* 15 */ "am_liam",
+            /* 16 */ "am_michael",
+            /* 17 */ "am_onyx",
+            /* 18 */ "am_puck",
+            /* 19 */ "am_santa",
+            // British Female (sids 20–23)
+            /* 20 */ "bf_alice",
+            /* 21 */ "bf_emma",
+            /* 22 */ "bf_isabella",
+            /* 23 */ "bf_lily",
+            // British Male (sids 24–27)
+            /* 24 */ "bm_daniel",
+            /* 25 */ "bm_fable",
+            /* 26 */ "bm_george",
+            /* 27 */ "bm_lewis",
+            // Multilingual (sids 28–52)
+            /* 28 */ "ef_dora",       // Spanish Female
+            /* 29 */ "em_alex",       // Spanish Male
+            /* 30 */ "ff_siwis",      // French Female
+            /* 31 */ "hf_alpha",      // Hindi Female
+            /* 32 */ "hf_beta",       // Hindi Female
+            /* 33 */ "hm_omega",      // Hindi Male
+            /* 34 */ "hm_psi",        // Hindi Male
+            /* 35 */ "if_sara",       // Italian Female
+            /* 36 */ "im_nicola",     // Italian Male
+            /* 37 */ "jf_alpha",      // Japanese Female
+            /* 38 */ "jf_gongitsune", // Japanese Female
+            /* 39 */ "jf_nezumi",     // Japanese Female
+            /* 40 */ "jf_tebukuro",   // Japanese Female
+            /* 41 */ "jm_kumo",       // Japanese Male
+            /* 42 */ "pf_dora",       // Portuguese Female
+            /* 43 */ "pm_alex",       // Portuguese Male
+            /* 44 */ "pm_santa",      // Portuguese Male
+            /* 45 */ "zf_xiaobei",    // Chinese Female
+            /* 46 */ "zf_xiaoni",     // Chinese Female
+            /* 47 */ "zf_xiaoxiao",   // Chinese Female
+            /* 48 */ "zf_xiaoyi",     // Chinese Female
+            /* 49 */ "zm_yunjian",    // Chinese Male
+            /* 50 */ "zm_yunxi",      // Chinese Male
+            /* 51 */ "zm_yunxia",     // Chinese Male
+            /* 52 */ "zm_yunyang",    // Chinese Male
         ),
     ),
     ;
@@ -167,16 +122,19 @@ enum class SherpaKokoroVoice(
 }
 
 /**
- * Logical groupings of Kokoro speakers for the `kokoro-int8-multi-lang-v1_1` voice pack.
+ * Logical groupings of Kokoro speakers for the `kokoro-int8-multi-lang-v1_0` voice pack.
  *
- * Each group maps to a contiguous sid range. The prefix convention is:
- * - `af` = American female, `bf` = British female, `zf` = Chinese female, `zm` = Chinese male.
+ * Each group maps to a contiguous sid range. Prefix conventions:
+ * - `af`/`am` = American female/male, `bf`/`bm` = British female/male
+ * - `ef`/`em` = Spanish, `ff` = French, `hf`/`hm` = Hindi, `if`/`im` = Italian
+ * - `jf`/`jm` = Japanese, `pf`/`pm` = Portuguese, `zf`/`zm` = Chinese
  */
 enum class KokoroSpeakerGroup(val label: String, val sidRange: IntRange) {
-    AmericanFemale("American female", 0..1),
-    BritishFemale("British female", 2..2),
-    ChineseFemale("Chinese female", 3..57),
-    ChineseMale("Chinese male", 58..102),
+    AmericanFemale("American female", 0..10),
+    AmericanMale("American male", 11..19),
+    BritishFemale("British female", 20..23),
+    BritishMale("British male", 24..27),
+    Multilingual("Multilingual", 28..52),
 }
 
 /** Returns the [KokoroSpeakerGroup] that contains [sid], defaulting to [KokoroSpeakerGroup.AmericanFemale]. */

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -769,7 +769,12 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 )
                 .newInstance(null, config)
             ttsInstance = instance
-            generateMethod = ttsClass.getMethod("generate", String::class.java, Int::class.java, Float::class.java)
+            generateMethod = ttsClass.getDeclaredMethod(
+                "generate",
+                String::class.java,
+                Int::class.javaPrimitiveType,
+                Float::class.javaPrimitiveType,
+            )
             initState = InitState.AVAILABLE
             Log.i(TAG, "Kokoro TTS initialised: ${voice.displayName}")
             VoiceOutputResult.Spoken
@@ -805,11 +810,16 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
         // Build OfflineTtsModelConfig and inject Kokoro config
         val modelConfig = modelConfigClass.getDeclaredConstructor().newInstance()
+        // setProperty() swallows its own exceptions (Log.w only), so use explicit reflection here
+        // to ensure a real failure propagates up and returns UNAVAILABLE rather than corrupt state.
         try {
-            setProperty(modelConfig, "kokoro", kokoroConfig)
-        } catch (_: Exception) {
-            // Some builds use setKokoro() method instead of a field
-            modelConfigClass.getMethod("setKokoro", kokoroConfigClass).invoke(modelConfig, kokoroConfig)
+            val setter = modelConfigClass.getDeclaredMethod("setKokoro", kokoroConfigClass)
+            setter.isAccessible = true
+            setter.invoke(modelConfig, kokoroConfig)
+        } catch (_: NoSuchMethodException) {
+            val field = modelConfigClass.getDeclaredField("kokoro")
+            field.isAccessible = true
+            field.set(modelConfig, kokoroConfig)
         }
         setProperty(modelConfig, "numThreads", 4)
         setProperty(modelConfig, "debug", false)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -782,39 +782,39 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         val modelConfigClass = Class.forName(SHERPA_MODEL_CONFIG_CLASS)
         val ttsConfigClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
 
-        // Build OfflineTtsKokoroModelConfig
+        // Build OfflineTtsKokoroModelConfig — use setProperty() which calls getDeclaredField() +
+        // setAccessible(true), since all fields in the Sherpa AAR are private Kotlin backing fields.
         val kokoroConfig = kokoroConfigClass.getDeclaredConstructor().newInstance()
-        kokoroConfigClass.getField("model").set(kokoroConfig, File(modelDir, "model.onnx").absolutePath)
-        kokoroConfigClass.getField("voices").set(kokoroConfig, File(modelDir, SHERPA_KOKORO_VOICES_FILE).absolutePath)
-        kokoroConfigClass.getField("tokens").set(kokoroConfig, File(modelDir, "tokens.txt").absolutePath)
-        kokoroConfigClass.getField("dataDir").set(kokoroConfig, File(modelDir, "espeak-ng-data").absolutePath)
-        // lang hint — Kokoro accepts "en-us" style; default empty string is also fine for the
-        // multi-lingual model, but an explicit hint improves G2P quality.
-        try { kokoroConfigClass.getField("lang").set(kokoroConfig, "") } catch (_: NoSuchFieldException) { /* optional */ }
-        // lexicon: join any present lexicon files with a comma
+        setProperty(kokoroConfig, "model", File(modelDir, "model.onnx").absolutePath)
+        setProperty(kokoroConfig, "voices", File(modelDir, SHERPA_KOKORO_VOICES_FILE).absolutePath)
+        setProperty(kokoroConfig, "tokens", File(modelDir, "tokens.txt").absolutePath)
+        setProperty(kokoroConfig, "dataDir", File(modelDir, "espeak-ng-data").absolutePath)
+        // lang hint — empty string is fine for the multi-lingual model (optional field)
+        setProperty(kokoroConfig, "lang", "")
+        // lexicon: join any present lexicon files with a comma (optional field)
         val lexiconFiles = listOf("lexicon-us-en.txt", "lexicon-gb-en.txt")
             .map { File(modelDir, it) }
             .filter { it.exists() }
             .joinToString(",") { it.absolutePath }
         if (lexiconFiles.isNotEmpty()) {
-            try { kokoroConfigClass.getField("lexicon").set(kokoroConfig, lexiconFiles) } catch (_: NoSuchFieldException) { /* optional */ }
+            setProperty(kokoroConfig, "lexicon", lexiconFiles)
         }
 
         // Build OfflineTtsModelConfig and inject Kokoro config
         val modelConfig = modelConfigClass.getDeclaredConstructor().newInstance()
         try {
-            modelConfigClass.getField("kokoro").set(modelConfig, kokoroConfig)
-        } catch (_: NoSuchFieldException) {
-            // Some builds use setKokoro()
+            setProperty(modelConfig, "kokoro", kokoroConfig)
+        } catch (_: Exception) {
+            // Some builds use setKokoro() method instead of a field
             modelConfigClass.getMethod("setKokoro", kokoroConfigClass).invoke(modelConfig, kokoroConfig)
         }
-        modelConfigClass.getField("numThreads").set(modelConfig, 4)
-        modelConfigClass.getField("debug").set(modelConfig, false)
+        setProperty(modelConfig, "numThreads", 4)
+        setProperty(modelConfig, "debug", false)
 
         // Build OfflineTtsConfig
         val ttsConfig = ttsConfigClass.getDeclaredConstructor().newInstance()
-        ttsConfigClass.getField("model").set(ttsConfig, modelConfig)
-        ttsConfigClass.getField("maxNumSentences").set(ttsConfig, 1)
+        setProperty(ttsConfig, "model", modelConfig)
+        setProperty(ttsConfig, "maxNumSentences", 1)
         return ttsConfig
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -797,8 +797,11 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         setProperty(kokoroConfig, "voices", File(modelDir, SHERPA_KOKORO_VOICES_FILE).absolutePath)
         setProperty(kokoroConfig, "tokens", File(modelDir, "tokens.txt").absolutePath)
         setProperty(kokoroConfig, "dataDir", File(modelDir, "espeak-ng-data").absolutePath)
-        // lang hint — empty string is fine for the multi-lingual model (optional field)
-        setProperty(kokoroConfig, "lang", "")
+        // Set "en-us" so espeak-ng uses English text normalisation rules: sentence-ending
+        // periods become pauses rather than being vocalised as "dot". This is safe even with
+        // multilingual speakers (sid 28-52) because synthesis language is driven by the
+        // speaker ID, not lang; lang only controls the G2P text-normalisation pipeline.
+        setProperty(kokoroConfig, "lang", "en-us")
         // lexicon: join any present lexicon files with a comma (optional field)
         val lexiconFiles = listOf("lexicon-us-en.txt", "lexicon-gb-en.txt")
             .map { File(modelDir, it) }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -89,11 +89,16 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     private val activeSpeakerId: StateFlow<Int> = voiceOutputPreferences.activeSpeakerId
         .stateIn(scope, SharingStarted.Eagerly, 0)
 
+    /** Active speaker ID for Kokoro multi-speaker voice (sid 0–102). Default 0. */
+    private val kokoroActiveSpeakerId: StateFlow<Int> = voiceOutputPreferences.kokoroActiveSpeakerId
+        .stateIn(scope, SharingStarted.Eagerly, 0)
+
     // ── Lifecycle state ──────────────────────────────────────────────────────
     private enum class InitState { UNINITIALIZED, AVAILABLE, UNAVAILABLE }
 
     @Volatile private var initState = InitState.UNINITIALIZED
     @Volatile private var initializedVoice: SherpaPiperVoice? = null
+    @Volatile private var initializedKokoroVoice: SherpaKokoroVoice? = null
 
     /** Reflected handle to `OfflineTts` instance; non-null iff [initState] == AVAILABLE. */
     @Volatile private var ttsInstance: Any? = null
@@ -126,18 +131,36 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
 
     // ── VoiceOutputController ────────────────────────────────────────────────
 
-    /** Returns 0 for single-speaker voices; clamps stored sid for multi-speaker. */
-    private fun effectiveSid(speakerCount: Int): Int =
-        if (speakerCount > 1) activeSpeakerId.value.coerceIn(0, speakerCount - 1) else 0
+    /** Returns 0 for single-speaker voices; clamps [sid] to valid range for multi-speaker. */
+    private fun effectiveSid(speakerCount: Int, sid: Int): Int =
+        if (speakerCount > 1) sid.coerceIn(0, speakerCount - 1) else 0
 
     override suspend fun warmUp(): VoiceOutputResult = withContext(Dispatchers.IO) {
-        initialize(voiceOutputPreferences.selectedSherpaVoice.first())
+        if (voiceOutputPreferences.selectedEngine.first() == VoiceOutputEngine.KokoroExperimental) {
+            initKokoro(voiceOutputPreferences.selectedKokoroVoice.first())
+        } else {
+            initialize(voiceOutputPreferences.selectedSherpaVoice.first())
+        }
     }
 
     override suspend fun speak(request: VoiceSpeakRequest): VoiceOutputResult =
         withContext(Dispatchers.IO) {
-            val voice = voiceOutputPreferences.selectedSherpaVoice.first()
-            val initResult = initialize(voice)
+            val isKokoro =
+                voiceOutputPreferences.selectedEngine.first() == VoiceOutputEngine.KokoroExperimental
+            val initResult: VoiceOutputResult
+            val speakerCount: Int
+            val voiceSid: Int
+            if (isKokoro) {
+                val voice = voiceOutputPreferences.selectedKokoroVoice.first()
+                initResult = initKokoro(voice)
+                speakerCount = voice.speakerCount
+                voiceSid = kokoroActiveSpeakerId.value
+            } else {
+                val voice = voiceOutputPreferences.selectedSherpaVoice.first()
+                initResult = initialize(voice)
+                speakerCount = voice.speakerCount
+                voiceSid = activeSpeakerId.value
+            }
             if (initResult is VoiceOutputResult.Unavailable) return@withContext initResult
 
             val tts = ttsInstance
@@ -154,7 +177,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             // it has a matching start — stops the back-and-forth loop from firing on a stopped
             // or failed synthesis where no audio was ever played.
             var speakingStarted = false
-            val effectiveSid = effectiveSid(voice.speakerCount)
+            val effectiveSid = effectiveSid(speakerCount, voiceSid)
             return@withContext try {
                 // Reflect: GeneratedAudio audio = tts.generate(text, sid, speed)
                 // Synthesis can take 1-3s for medium models, longer for high-quality ones;
@@ -162,8 +185,11 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 val synthStart = System.currentTimeMillis()
                 val audioResult = genMethod.invoke(tts, request.text, effectiveSid, sherpaSpeed.value)
                     ?: return@withContext VoiceOutputResult.Unavailable("Sherpa returned null audio.")
-                if (verboseLoggingEnabled.value) Log.d(TAG, "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
-                    "${request.text.length} chars, voice=${voice.name}, sid=$effectiveSid")
+                if (verboseLoggingEnabled.value) Log.d(
+                    TAG,
+                    "Sherpa synthesis: ${System.currentTimeMillis() - synthStart}ms for " +
+                        "${request.text.length} chars, sid=$effectiveSid",
+                )
 
                 val samples = reflectGetSamples(audioResult)
                 val sampleRate = reflectGetSampleRate(audioResult)
@@ -188,8 +214,22 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
     override suspend fun openStreamingSession(
         request: VoiceSpeakRequest,
     ): VoiceOutputStreamingSession = withContext(Dispatchers.IO) {
-        val voice = voiceOutputPreferences.selectedSherpaVoice.first()
-        val initResult = initialize(voice)
+        val isKokoro =
+            voiceOutputPreferences.selectedEngine.first() == VoiceOutputEngine.KokoroExperimental
+        val initResult: VoiceOutputResult
+        val speakerCount: Int
+        val activeSid: Int
+        if (isKokoro) {
+            val voice = voiceOutputPreferences.selectedKokoroVoice.first()
+            initResult = initKokoro(voice)
+            speakerCount = voice.speakerCount
+            activeSid = kokoroActiveSpeakerId.value
+        } else {
+            val voice = voiceOutputPreferences.selectedSherpaVoice.first()
+            initResult = initialize(voice)
+            speakerCount = voice.speakerCount
+            activeSid = activeSpeakerId.value
+        }
         if (initResult is VoiceOutputResult.Unavailable) {
             return@withContext object : VoiceOutputStreamingSession {
                 override suspend fun append(text: String, isFinal: Boolean): VoiceOutputResult = initResult
@@ -206,7 +246,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
                 playbackToken = playbackToken,
                 request = request,
                 chunks = chunks,
-                speakerCount = voice.speakerCount,
+                speakerCount = speakerCount,
+                activeSid = activeSid,
             )
         }
         synchronized(playbackLock) {
@@ -251,7 +292,8 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
      * otherwise (AAR missing, assets missing, or any reflection error).
      */
     private fun initialize(voice: SherpaPiperVoice): VoiceOutputResult {
-        if (initializedVoice != voice) {
+        // If Kokoro was loaded, force a reset before switching to Piper.
+        if (initializedKokoroVoice != null || initializedVoice != voice) {
             resetForVoice(voice)
         }
         return when (initState) {
@@ -324,6 +366,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         generateMethod = null
         initState = InitState.UNINITIALIZED
         initializedVoice = voice
+        initializedKokoroVoice = null
     }
 
     private suspend fun runStreamingPlayback(
@@ -331,11 +374,12 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         request: VoiceSpeakRequest,
         chunks: Channel<StreamingChunk>,
         speakerCount: Int,
+        activeSid: Int,
     ) {
         val tts = ttsInstance ?: return
         val genMethod = generateMethod ?: return
         // For single-speaker voices always use sid=0; for multi-speaker, clamp to valid range.
-        val effectiveSid = effectiveSid(speakerCount)
+        val effectiveSid = effectiveSid(speakerCount, activeSid)
         var emittedStarted = false
         var requestedAudioFocus = false
 
@@ -678,6 +722,105 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         }
     }
 
+    fun markKokoroVoiceAvailable(voice: SherpaKokoroVoice) {
+        if (initState == InitState.UNAVAILABLE && (initializedKokoroVoice == voice || initializedKokoroVoice == null)) {
+            Log.i(TAG, "Kokoro voice pack available for ${voice.displayName} — resetting init state for retry.")
+            resetForKokoroVoice(voice)
+        }
+    }
+
+    // ── Kokoro init ──────────────────────────────────────────────────────────
+
+    private fun initKokoro(voice: SherpaKokoroVoice): VoiceOutputResult {
+        // If Piper was loaded, or a different Kokoro voice, force a reset.
+        if (initializedVoice != null || initializedKokoroVoice != voice) {
+            resetForKokoroVoice(voice)
+        }
+        return when (initState) {
+            InitState.AVAILABLE -> VoiceOutputResult.Spoken
+            InitState.UNAVAILABLE -> VoiceOutputResult.Unavailable(unavailableMessageKokoro(voice))
+            InitState.UNINITIALIZED -> doInitializeKokoro(voice)
+        }
+    }
+
+    private fun resetForKokoroVoice(voice: SherpaKokoroVoice) {
+        clearStreamingPlayback()
+        ttsInstance = null
+        generateMethod = null
+        initState = InitState.UNINITIALIZED
+        initializedVoice = null
+        initializedKokoroVoice = voice
+    }
+
+    private fun doInitializeKokoro(voice: SherpaKokoroVoice): VoiceOutputResult {
+        val modelDir = voice.voiceDir(context)
+        if (!hasRequiredKokoroVoicePackFiles(modelDir)) {
+            Log.w(TAG, "Kokoro voice pack not downloaded: ${voice.displayName}")
+            initState = InitState.UNAVAILABLE
+            return VoiceOutputResult.Unavailable(unavailableMessageKokoro(voice))
+        }
+        return try {
+            val config = buildOfflineTtsKokoroConfig(modelDir, voice)
+            val ttsClass = Class.forName(SHERPA_OFFLINE_TTS_CLASS)
+            val instance = ttsClass
+                .getConstructor(Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS))
+                .newInstance(config)
+            ttsInstance = instance
+            generateMethod = ttsClass.getMethod("generate", String::class.java, Int::class.java, Float::class.java)
+            initState = InitState.AVAILABLE
+            Log.i(TAG, "Kokoro TTS initialised: ${voice.displayName}")
+            VoiceOutputResult.Spoken
+        } catch (e: Exception) {
+            Log.e(TAG, "Kokoro TTS init failed", e)
+            initState = InitState.UNAVAILABLE
+            VoiceOutputResult.Unavailable("Kokoro init failed: ${e.message}")
+        }
+    }
+
+    private fun buildOfflineTtsKokoroConfig(modelDir: File, voice: SherpaKokoroVoice): Any {
+        val kokoroConfigClass = Class.forName(SHERPA_KOKORO_MODEL_CONFIG_CLASS)
+        val modelConfigClass = Class.forName(SHERPA_MODEL_CONFIG_CLASS)
+        val ttsConfigClass = Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS)
+
+        // Build OfflineTtsKokoroModelConfig
+        val kokoroConfig = kokoroConfigClass.getDeclaredConstructor().newInstance()
+        kokoroConfigClass.getField("model").set(kokoroConfig, File(modelDir, "model.onnx").absolutePath)
+        kokoroConfigClass.getField("voices").set(kokoroConfig, File(modelDir, SHERPA_KOKORO_VOICES_FILE).absolutePath)
+        kokoroConfigClass.getField("tokens").set(kokoroConfig, File(modelDir, "tokens.txt").absolutePath)
+        kokoroConfigClass.getField("dataDir").set(kokoroConfig, File(modelDir, "espeak-ng-data").absolutePath)
+        // lang hint — Kokoro accepts "en-us" style; default empty string is also fine for the
+        // multi-lingual model, but an explicit hint improves G2P quality.
+        try { kokoroConfigClass.getField("lang").set(kokoroConfig, "") } catch (_: NoSuchFieldException) { /* optional */ }
+        // lexicon: join any present lexicon files with a comma
+        val lexiconFiles = listOf("lexicon-us-en.txt", "lexicon-gb-en.txt")
+            .map { File(modelDir, it) }
+            .filter { it.exists() }
+            .joinToString(",") { it.absolutePath }
+        if (lexiconFiles.isNotEmpty()) {
+            try { kokoroConfigClass.getField("lexicon").set(kokoroConfig, lexiconFiles) } catch (_: NoSuchFieldException) { /* optional */ }
+        }
+
+        // Build OfflineTtsModelConfig and inject Kokoro config
+        val modelConfig = modelConfigClass.getDeclaredConstructor().newInstance()
+        try {
+            modelConfigClass.getField("kokoro").set(modelConfig, kokoroConfig)
+        } catch (_: NoSuchFieldException) {
+            // Some builds use setKokoro()
+            modelConfigClass.getMethod("setKokoro", kokoroConfigClass).invoke(modelConfig, kokoroConfig)
+        }
+        modelConfigClass.getField("numThreads").set(modelConfig, 4)
+        modelConfigClass.getField("debug").set(modelConfig, false)
+
+        // Build OfflineTtsConfig
+        val ttsConfig = ttsConfigClass.getDeclaredConstructor().newInstance()
+        ttsConfigClass.getField("model").set(ttsConfig, modelConfig)
+        ttsConfigClass.getField("maxNumSentences").set(ttsConfig, 1)
+        return ttsConfig
+    }
+
+    private fun unavailableMessageKokoro(voice: SherpaKokoroVoice): String =
+        "Kokoro voice '${voice.displayName}' is not available. Please download the voice pack in Settings."
+
     // ── Constants ────────────────────────────────────────────────────────────
 
     private companion object {
@@ -688,6 +831,7 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
         const val SHERPA_OFFLINE_TTS_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsConfig"
         const val SHERPA_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsModelConfig"
         const val SHERPA_VITS_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsVitsModelConfig"
+        const val SHERPA_KOKORO_MODEL_CONFIG_CLASS = "$SHERPA_PKG.OfflineTtsKokoroModelConfig"
 
         /** Floats per AudioTrack write chunk (~92 ms at 22050 Hz). */
         const val AUDIO_CHUNK_FLOATS = 2048

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceOutputController.kt
@@ -763,8 +763,11 @@ class SherpaOnnxVoiceOutputController @Inject constructor(
             val config = buildOfflineTtsKokoroConfig(modelDir, voice)
             val ttsClass = Class.forName(SHERPA_OFFLINE_TTS_CLASS)
             val instance = ttsClass
-                .getConstructor(Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS))
-                .newInstance(config)
+                .getConstructor(
+                    android.content.res.AssetManager::class.java,
+                    Class.forName(SHERPA_OFFLINE_TTS_CONFIG_CLASS),
+                )
+                .newInstance(null, config)
             ttsInstance = instance
             generateMethod = ttsClass.getMethod("generate", String::class.java, Int::class.java, Float::class.java)
             initState = InitState.AVAILABLE

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
@@ -44,6 +44,7 @@ class SherpaVoicePackDownloadManager @Inject constructor(
     private val workManager = WorkManager.getInstance(context)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val observerJobs = ConcurrentHashMap<SherpaPiperVoice, Job>()
+    private val observerJobsKokoro = ConcurrentHashMap<SherpaKokoroVoice, Job>()
 
     private val _downloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
         MutableStateFlow(
@@ -59,9 +60,24 @@ class SherpaVoicePackDownloadManager @Inject constructor(
     val downloadStates: StateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
         _downloadStates.asStateFlow()
 
+    private val _kokoroDownloadStates: MutableStateFlow<Map<SherpaKokoroVoice, VoicePackDownloadState>> =
+        MutableStateFlow(
+            SherpaKokoroVoice.entries.associateWith { voice ->
+                if (voice.isDownloaded(context)) {
+                    VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                } else {
+                    VoicePackDownloadState.NotDownloaded
+                }
+            }
+        )
+
+    val kokoroDownloadStates: StateFlow<Map<SherpaKokoroVoice, VoicePackDownloadState>> =
+        _kokoroDownloadStates.asStateFlow()
+
     init {
         // Resume observing any in-progress workers from a previous process lifecycle
         SherpaPiperVoice.entries.forEach { voice -> ensureObserving(voice) }
+        SherpaKokoroVoice.entries.forEach { voice -> ensureObservingKokoro(voice) }
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -153,16 +169,94 @@ class SherpaVoicePackDownloadManager @Inject constructor(
         updateState(voice, newState)
     }
 
+    // ── Kokoro public API ─────────────────────────────────────────────────────
+
+    fun startKokoroDownload(voice: SherpaKokoroVoice, force: Boolean = false) {
+        if (!force && voice.isDownloaded(context)) {
+            updateKokoroState(voice, VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath))
+            return
+        }
+
+        Log.i(TAG, "Enqueuing Kokoro voice pack download: ${voice.displayName}")
+
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val existingInfos = workManager.getWorkInfosForUniqueWork(voice.kokoroWorkerTag).get()
+                val policy = when {
+                    force -> ExistingWorkPolicy.REPLACE
+                    existingInfos.any { it.state == WorkInfo.State.RUNNING } -> ExistingWorkPolicy.KEEP
+                    else -> ExistingWorkPolicy.REPLACE
+                }
+
+                if (policy == ExistingWorkPolicy.REPLACE) {
+                    updateKokoroState(voice, VoicePackDownloadState.Downloading())
+                }
+
+                val request = OneTimeWorkRequestBuilder<VoicePackDownloadWorker>()
+                    .setInputData(
+                        Data.Builder()
+                            .putString(KEY_VOICE_NAME, voice.name)
+                            .putString(KEY_VOICE_DISPLAY_NAME, voice.displayName)
+                            .putString(KEY_VOICE_DOWNLOAD_URL, voice.downloadUrl)
+                            .putLong(KEY_VOICE_TOTAL_BYTES, voice.approxDownloadBytes)
+                            .build()
+                    )
+                    .addTag(voice.kokoroWorkerTag)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .setConstraints(
+                        Constraints.Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build()
+                    )
+                    .build()
+
+                workManager.enqueueUniqueWork(voice.kokoroWorkerTag, policy, request)
+            }
+        }
+
+        ensureObservingKokoro(voice)
+    }
+
+    fun cancelKokoroDownload(voice: SherpaKokoroVoice) {
+        workManager.cancelUniqueWork(voice.kokoroWorkerTag)
+        updateKokoroState(voice, VoicePackDownloadState.NotDownloaded)
+        Log.i(TAG, "Cancelled Kokoro voice pack download: ${voice.displayName}")
+    }
+
+    fun deleteKokoroVoice(voice: SherpaKokoroVoice) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val dir = voice.voiceDir(context)
+                if (dir.exists()) {
+                    dir.deleteRecursively()
+                    Log.i(TAG, "Deleted Kokoro voice pack: ${dir.absolutePath}")
+                }
+            }
+            updateKokoroState(voice, VoicePackDownloadState.NotDownloaded)
+        }
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     private fun updateState(voice: SherpaPiperVoice, state: VoicePackDownloadState) {
         _downloadStates.value = _downloadStates.value.toMutableMap().apply { put(voice, state) }
     }
 
+    private fun updateKokoroState(voice: SherpaKokoroVoice, state: VoicePackDownloadState) {
+        _kokoroDownloadStates.value = _kokoroDownloadStates.value.toMutableMap().apply { put(voice, state) }
+    }
+
     private fun ensureObserving(voice: SherpaPiperVoice) {
         observerJobs.compute(voice) { _, existing ->
             if (existing?.isActive == true) existing
             else scope.launch { observeWorkInfo(voice) }
+        }
+    }
+
+    private fun ensureObservingKokoro(voice: SherpaKokoroVoice) {
+        observerJobsKokoro.compute(voice) { _, existing ->
+            if (existing?.isActive == true) existing
+            else scope.launch { observeKokoroWorkInfo(voice) }
         }
     }
 
@@ -231,8 +325,73 @@ class SherpaVoicePackDownloadManager @Inject constructor(
                 updateState(voice, newState)
             }
     }
+
+    private suspend fun observeKokoroWorkInfo(voice: SherpaKokoroVoice) {
+        workManager
+            .getWorkInfosByTagFlow(voice.kokoroWorkerTag)
+            .collect { infoList ->
+                val info = infoList.firstOrNull() ?: return@collect
+                val newState: VoicePackDownloadState = when (info.state) {
+                    WorkInfo.State.RUNNING, WorkInfo.State.ENQUEUED -> {
+                        if (voice.isDownloaded(context)) {
+                            workManager.cancelUniqueWork(voice.kokoroWorkerTag)
+                            return@collect
+                        }
+                        val progress = info.progress
+                        val totalBytes = voice.approxDownloadBytes
+                        val downloadedBytes = progress.getLong(KEY_VOICE_PROGRESS_BYTES, 0L)
+                        val bps = progress.getLong(KEY_VOICE_DOWNLOAD_RATE, 0L)
+                        val remainingMs = progress.getLong(KEY_VOICE_REMAINING_MS, 0L)
+                        val fraction = if (totalBytes > 0) {
+                            (downloadedBytes.toFloat() / totalBytes).coerceIn(0f, 1f) * 0.9f
+                        } else 0f
+                        VoicePackDownloadState.Downloading(
+                            progress = fraction,
+                            downloadedBytes = downloadedBytes,
+                            bytesPerSecond = bps,
+                            remainingMs = remainingMs,
+                        )
+                    }
+
+                    WorkInfo.State.SUCCEEDED -> {
+                        val dir = withContext(Dispatchers.IO) { voice.voiceDir(context) }
+                        Log.i(TAG, "Kokoro voice pack download succeeded: ${dir.absolutePath}")
+                        sherpaController.markKokoroVoiceAvailable(voice)
+                        VoicePackDownloadState.Downloaded(dir.absolutePath)
+                    }
+
+                    WorkInfo.State.FAILED -> {
+                        val isPresent = withContext(Dispatchers.IO) { voice.isDownloaded(context) }
+                        if (isPresent) {
+                            Log.i(TAG, "Kokoro worker failed but pack present — treating as Downloaded: ${voice.displayName}")
+                            sherpaController.markKokoroVoiceAvailable(voice)
+                            VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                        } else {
+                            val msg = info.outputData.getString(KEY_VOICE_ERROR_MESSAGE) ?: "Download failed"
+                            Log.w(TAG, "Kokoro voice pack download failed for ${voice.displayName}: $msg")
+                            VoicePackDownloadState.Error(msg)
+                        }
+                    }
+
+                    WorkInfo.State.CANCELLED -> {
+                        val isPresent = withContext(Dispatchers.IO) { voice.isDownloaded(context) }
+                        if (isPresent) {
+                            VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath)
+                        } else {
+                            VoicePackDownloadState.NotDownloaded
+                        }
+                    }
+
+                    else -> return@collect
+                }
+                updateKokoroState(voice, newState)
+            }
+    }
 }
 
-/** Unique WorkManager work name for this voice. */
+/** Unique WorkManager work name for this Piper voice. */
 private val SherpaPiperVoice.workerTag: String get() = "voice_pack_${name.lowercase()}"
+
+/** Unique WorkManager work name for this Kokoro voice. Uses a distinct prefix to avoid collisions with Piper. */
+private val SherpaKokoroVoice.kokoroWorkerTag: String get() = "kokoro_voice_pack_${name.lowercase()}"
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackFiles.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackFiles.kt
@@ -7,10 +7,24 @@ internal const val SHERPA_MODEL_JSON_FILE = "model.onnx.json"
 internal const val SHERPA_TOKENS_FILE = "tokens.txt"
 internal const val SHERPA_ESPEAK_DATA_DIR = "espeak-ng-data"
 
+/** voices.bin required by the Kokoro model (speaker embeddings). */
+internal const val SHERPA_KOKORO_VOICES_FILE = "voices.bin"
+
 internal fun hasRequiredSherpaVoicePackFiles(dir: File): Boolean =
     dir.isDirectory &&
         File(dir, SHERPA_MODEL_ONNX_FILE).isFile &&
         File(dir, SHERPA_TOKENS_FILE).isFile &&
+        File(dir, SHERPA_ESPEAK_DATA_DIR).isDirectory
+
+/**
+ * Validates that the extracted Kokoro voice pack directory contains all required files:
+ * `model.onnx`, `tokens.txt`, `voices.bin`, and the `espeak-ng-data` directory.
+ */
+internal fun hasRequiredKokoroVoicePackFiles(dir: File): Boolean =
+    dir.isDirectory &&
+        File(dir, SHERPA_MODEL_ONNX_FILE).isFile &&
+        File(dir, SHERPA_TOKENS_FILE).isFile &&
+        File(dir, SHERPA_KOKORO_VOICES_FILE).isFile &&
         File(dir, SHERPA_ESPEAK_DATA_DIR).isDirectory
 
 internal fun normalizeExtractedSherpaVoicePack(dir: File) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputEngine.kt
@@ -12,6 +12,10 @@ enum class VoiceOutputEngine(
         displayName = "Sherpa Piper (Experimental)",
         description = "Uses locally prepared Sherpa-ONNX Piper voices and falls back to Android TTS if setup is missing or playback fails.",
     ),
+    KokoroExperimental(
+        displayName = "Kokoro (Experimental)",
+        description = "Studio-grade Kokoro-82M TTS. Requires a ~130MB download. Falls back to Android TTS if unavailable.",
+    ),
     ;
 
     companion object {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -208,7 +208,7 @@ class VoiceOutputPreferences @Inject constructor(
         }
     }
 
-    /** Active Kokoro speaker ID (sid 0–102 matching the 103-speaker model). Default 0. */
+    /** Active Kokoro speaker ID (sid 0–52 for the current 53-speaker v1.0 multilingual pack). Default 0. */
     val kokoroActiveSpeakerId: Flow<Int> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
             if (e is IOException) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -218,11 +218,11 @@ class VoiceOutputPreferences @Inject constructor(
                 throw e
             }
         }
-        .map { prefs -> (prefs[kokoroActiveSpeakerIdKey] ?: 0).coerceIn(0, 102) }
+        .map { prefs -> (prefs[kokoroActiveSpeakerIdKey] ?: 0).coerceIn(0, 52) }
 
     suspend fun setKokoroActiveSpeakerId(sid: Int) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
-            prefs[kokoroActiveSpeakerIdKey] = sid.coerceIn(0, 102)
+            prefs[kokoroActiveSpeakerIdKey] = sid.coerceIn(0, 52)
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -29,12 +29,14 @@ class VoiceOutputPreferences @Inject constructor(
         booleanPreferencesKey("quick_actions_spoken_responses_enabled")
     private val selectedEngineKey = stringPreferencesKey("selected_voice_output_engine")
     private val selectedSherpaVoiceKey = stringPreferencesKey("selected_sherpa_piper_voice")
+    private val selectedKokoroVoiceKey = stringPreferencesKey("selected_sherpa_kokoro_voice")
     private val sherpaSpeedKey = floatPreferencesKey("sherpa_speed")
     private val voicePitchKey = floatPreferencesKey("voice_pitch")
     private val voiceGainKey = floatPreferencesKey("voice_gain")
     private val autoSpeakKey = booleanPreferencesKey("voice_auto_speak")
     private val maxSpokenSentencesKey = intPreferencesKey("voice_max_spoken_sentences")
     private val activeSpeakerIdKey = intPreferencesKey("voice_active_speaker_id")
+    private val kokoroActiveSpeakerIdKey = intPreferencesKey("kokoro_active_speaker_id")
 
     val spokenResponsesEnabled: Flow<Boolean> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
@@ -69,6 +71,17 @@ class VoiceOutputPreferences @Inject constructor(
         }
         .map { prefs -> SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey]) }
 
+    val selectedKokoroVoice: Flow<SherpaKokoroVoice> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> SherpaKokoroVoice.fromStorage(prefs[selectedKokoroVoiceKey]) }
+
     val sherpaSpeed: Flow<Float> = context.voiceOutputPrefsDataStore.data
         .catch { e ->
             if (e is IOException) {
@@ -95,6 +108,12 @@ class VoiceOutputPreferences @Inject constructor(
     suspend fun setSelectedSherpaVoice(voice: SherpaPiperVoice) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
             prefs[selectedSherpaVoiceKey] = voice.name
+        }
+    }
+
+    suspend fun setSelectedKokoroVoice(voice: SherpaKokoroVoice) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[selectedKokoroVoiceKey] = voice.name
         }
     }
 
@@ -186,6 +205,24 @@ class VoiceOutputPreferences @Inject constructor(
     suspend fun setActiveSpeakerId(sid: Int) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
             prefs[activeSpeakerIdKey] = sid.coerceIn(0, 108)
+        }
+    }
+
+    /** Active Kokoro speaker ID (sid 0–102 matching the 103-speaker model). Default 0. */
+    val kokoroActiveSpeakerId: Flow<Int> = context.voiceOutputPrefsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading voice output preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs -> (prefs[kokoroActiveSpeakerIdKey] ?: 0).coerceIn(0, 102) }
+
+    suspend fun setKokoroActiveSpeakerId(sid: Int) {
+        context.voiceOutputPrefsDataStore.edit { prefs ->
+            prefs[kokoroActiveSpeakerIdKey] = sid.coerceIn(0, 102)
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -117,7 +117,9 @@ class VoicePackDownloadWorker(
 
             // Phase 2: Extract (90–100%)
             trySetForeground(buildForegroundInfo(displayName, 90))
-            extractTarBz2(tmpFile, destDir, normalizePiperPack = kokoroVoice == null)
+            // normalizeVoicePack renames variant model files (e.g. model.int8.onnx → model.onnx)
+            // and is safe for all packs; always enable it.
+            extractTarBz2(tmpFile, destDir, normalizePiperPack = true)
             tmpFile.delete()
 
             if (!validationFn(destDir)) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -90,7 +90,14 @@ class VoicePackDownloadWorker(
             validationFn = ::hasRequiredSherpaVoicePackFiles
         }
         val cacheDir = File(applicationContext.cacheDir, "sherpa-pack").also { it.mkdirs() }
-        val tmpFile = File(cacheDir, "$voiceName.tar.bz2$TMP_SUFFIX")
+        // Use destDir.name (pack version-specific) so a different pack version never resumes
+        // from a stale partial file left by a previous version (e.g. v1.1 → v1.0 migration).
+        val tmpFile = File(cacheDir, "${destDir.name}.tar.bz2$TMP_SUFFIX")
+        // One-time migration: remove any stale temp file that used the old enum-name key.
+        File(cacheDir, "$voiceName.tar.bz2$TMP_SUFFIX").takeIf { it.exists() }?.let {
+            Log.i(TAG, "Removing stale temp file with old naming: ${it.name}")
+            it.delete()
+        }
 
         trySetForeground(buildForegroundInfo(displayName, 0))
 
@@ -114,7 +121,10 @@ class VoicePackDownloadWorker(
             tmpFile.delete()
 
             if (!validationFn(destDir)) {
-                Log.e(TAG, "Extraction appeared to succeed but required files are missing for $voiceName")
+                val contents = destDir.listFiles()
+                    ?.joinToString { f -> "${f.name}(${if (f.isDirectory) "dir" else "${f.length()}b"})" }
+                    ?: "(empty or missing)"
+                Log.e(TAG, "Extraction appeared to succeed but required files are missing for $voiceName. Extracted: $contents")
                 return@withContext Result.failure(errorData("Extraction incomplete — required files missing"))
             }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -73,10 +73,22 @@ class VoicePackDownloadWorker(
             ?: return@withContext Result.failure(errorData("Missing download URL"))
         val totalBytes = inputData.getLong(KEY_VOICE_TOTAL_BYTES, 0L)
 
-        val voice = SherpaPiperVoice.entries.firstOrNull { it.name == voiceName }
-            ?: return@withContext Result.failure(errorData("Unknown voice: $voiceName"))
+        val piperVoice = SherpaPiperVoice.entries.firstOrNull { it.name == voiceName }
+        val kokoroVoice = if (piperVoice == null) SherpaKokoroVoice.entries.firstOrNull { it.name == voiceName } else null
 
-        val destDir = voice.voiceDir(applicationContext)
+        if (piperVoice == null && kokoroVoice == null) {
+            return@withContext Result.failure(errorData("Unknown voice: $voiceName"))
+        }
+
+        val destDir: File
+        val validationFn: (File) -> Boolean
+        if (kokoroVoice != null) {
+            destDir = kokoroVoice.voiceDir(applicationContext)
+            validationFn = ::hasRequiredKokoroVoicePackFiles
+        } else {
+            destDir = piperVoice!!.voiceDir(applicationContext)
+            validationFn = ::hasRequiredSherpaVoicePackFiles
+        }
         val cacheDir = File(applicationContext.cacheDir, "sherpa-pack").also { it.mkdirs() }
         val tmpFile = File(cacheDir, "$voiceName.tar.bz2$TMP_SUFFIX")
 
@@ -101,7 +113,7 @@ class VoicePackDownloadWorker(
             extractTarBz2(tmpFile, destDir)
             tmpFile.delete()
 
-            if (!hasRequiredSherpaVoicePackFiles(destDir)) {
+            if (!validationFn(destDir)) {
                 Log.e(TAG, "Extraction appeared to succeed but required files are missing for $voiceName")
                 return@withContext Result.failure(errorData("Extraction incomplete — required files missing"))
             }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -110,7 +110,7 @@ class VoicePackDownloadWorker(
 
             // Phase 2: Extract (90–100%)
             trySetForeground(buildForegroundInfo(displayName, 90))
-            extractTarBz2(tmpFile, destDir)
+            extractTarBz2(tmpFile, destDir, normalizePiperPack = kokoroVoice == null)
             tmpFile.delete()
 
             if (!validationFn(destDir)) {
@@ -213,7 +213,7 @@ class VoicePackDownloadWorker(
      * We strip this single top-level component so the contents land directly in [destDir]:
      *   `vits-piper-en_GB-jenny_dioco-medium/model.onnx` → `destDir/model.onnx`
      */
-    private fun extractTarBz2(tarBz2: File, destDir: File) {
+    private fun extractTarBz2(tarBz2: File, destDir: File, normalizePiperPack: Boolean = true) {
         if (destDir.exists()) {
             destDir.deleteRecursively()
         }
@@ -250,7 +250,7 @@ class VoicePackDownloadWorker(
                 }
             }
         }
-        normalizeExtractedSherpaVoicePack(destDir)
+        if (normalizePiperPack) normalizeExtractedSherpaVoicePack(destDir)
     }
 
     // ── Foreground / notification ─────────────────────────────────────────────

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoicePackDownloadWorker.kt
@@ -251,6 +251,13 @@ class VoicePackDownloadWorker(
                         val relativePath = strippedParts.joinToString(File.separator)
 
                         val outFile = File(destDir, relativePath)
+                        // Guard against path-traversal sequences (e.g. "../../etc/passwd")
+                        val destCanonical = destDir.canonicalPath + File.separator
+                        if (!outFile.canonicalPath.startsWith(destCanonical)) {
+                            Log.w(TAG, "Skipping unsafe tar entry: ${entry.name}")
+                            entry = tar.nextEntry
+                            continue
+                        }
                         if (entry.isDirectory) {
                             outFile.mkdirs()
                         } else {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -59,7 +59,9 @@ internal fun normalizeChatTextForSpeech(text: String): String =
         .replace(Regex("""\s*(?:\r?\n){2,}\s*"""), ". ")
         .replace(Regex("""\s*\r?\n\s*"""), ". ")
         .replace(Regex("""\s+"""), " ")
+        .replace(Regex("""\.\s+\."""), ".")   // collapse ". ." artifacts from compound transforms
         .let(::applySpeechPronunciationOverrides)
+        .trimStart('.')   // strip leading period artifacts (read by espeak as "dot")
         .trim()
 
 internal fun finalizeChatTextForSpeech(text: String): String =

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -50,16 +50,18 @@ internal fun truncateForSpeech(text: String, maxSentences: Int): String {
 
 internal fun normalizeChatTextForSpeech(text: String): String =
     stripMarkdownForClipboard(text)
+        .replace(Regex("""(?m)^\s*[-*_]{1,3}\s*$"""), "")  // thematic break / standalone dividers (***, ---, *, lone *)
         .replace(Regex("""\r?\n\s*\d+\.\s+"""), ". ")   // numbered list item boundary → sentence break
         .replace(Regex("""(?m)^\s*\d+\.\s+"""), "")      // strip leading numbered marker at start
-        .replace(Regex("""(?m)^\s*[-*•]\s+"""), "")      // strip bullet markers at line start
+        .replace(Regex("""(?m)^\s*[-*•]\s*"""), "")       // strip bullet markers at line start (lone * has no trailing ws)
         .replace(Regex("""[•‣◦∙⋅·]\s*"""), "")           // strip any remaining inline bullet chars
         .replace(Regex("""(?<!\d):(?!\d)(?!//)\s*"""), ". ")   // non-numeric colons → sentence break (preserves ://)
         .replace(Regex("""[—–]\s*"""), ", ")              // em/en dashes → natural comma pause
         .replace(Regex("""\s*(?:\r?\n){2,}\s*"""), ". ")
         .replace(Regex("""\s*\r?\n\s*"""), ". ")
         .replace(Regex("""\s+"""), " ")
-        .replace(Regex("""\.\s+\."""), ".")   // collapse ". ." artifacts from compound transforms
+        .replace(Regex("""\.{2,}"""), ".")    // collapse consecutive dots (.., ...) from compound transforms
+        .replace(Regex("""\.\s+\."""), ".")   // collapse ". ." spaced artifacts from compound transforms
         .let(::applySpeechPronunciationOverrides)
         .trimStart('.')   // strip leading period artifacts (read by espeak as "dot")
         .trim()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -52,7 +52,8 @@ internal fun normalizeChatTextForSpeech(text: String): String =
     stripMarkdownForClipboard(text)
         .replace(Regex("""\r?\n\s*\d+\.\s+"""), ". ")   // numbered list item boundary → sentence break
         .replace(Regex("""(?m)^\s*\d+\.\s+"""), "")      // strip leading numbered marker at start
-        .replace(Regex("""(?m)^\s*[-*•]\s+"""), "")      // strip bullet markers
+        .replace(Regex("""(?m)^\s*[-*•]\s+"""), "")      // strip bullet markers at line start
+        .replace(Regex("""[•‣◦∙⋅·]\s*"""), "")           // strip any remaining inline bullet chars
         .replace(Regex("""(?<!\d):(?!\d)(?!//)\s*"""), ". ")   // non-numeric colons → sentence break (preserves ://)
         .replace(Regex("""[—–]\s*"""), ", ")              // em/en dashes → natural comma pause
         .replace(Regex("""\s*(?:\r?\n){2,}\s*"""), ". ")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -119,6 +119,25 @@ class ChatTextUtilsTest {
         }
 
         @Test
+        fun `strips inline unicode bullet characters that would be vocalised as dot`() {
+            // • not at line start (e.g. single-line bullet run)
+            assertEquals(
+                "apples bread oranges",
+                normalizeChatTextForSpeech("apples • bread • oranges"),
+            )
+            // Triangular bullet
+            assertEquals(
+                "item one. item two",
+                normalizeChatTextForSpeech("item one\n‣ item two"),
+            )
+            // White bullet ◦
+            assertEquals(
+                "first. second",
+                normalizeChatTextForSpeech("first\n◦ second"),
+            )
+        }
+
+        @Test
         fun `converts numbered list items into sentence-break pauses`() {
             assertEquals(
                 "Maintain a schedule. Create a routine. Optimise your environment",

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -163,6 +163,35 @@ class ChatTextUtilsTest {
         }
 
         @Test
+        fun `standalone asterisk divider is stripped and not vocalised as dot`() {
+            // LLM outputs *** as a thematic break; stripMarkdown reduces *** → * (italic middle char);
+            // the lone * must then be silently removed rather than passed to espeak as "dot".
+            assertEquals("", normalizeChatTextForSpeech("***"))
+            assertEquals("", normalizeChatTextForSpeech("*"))
+            assertEquals("", normalizeChatTextForSpeech("---"))
+        }
+
+        @Test
+        fun `standalone asterisk divider between sections is stripped`() {
+            // Full essay pattern: paragraph, blank line, ***, blank line, next section.
+            val input = "Comparing big cats is fascinating.\n\n***\n\nThe Big Cat Family Tree"
+            val result = normalizeChatTextForSpeech(input)
+            assertFalse(result.contains("*"), "Asterisk divider must not appear in speech text, got: $result")
+            assertTrue(result.contains("Comparing big cats is fascinating"), "Preceding text must be preserved")
+            assertTrue(result.contains("The Big Cat Family Tree"), "Following text must be preserved")
+        }
+
+        @Test
+        fun `numbered section header after sentence does not produce double dot`() {
+            // "habitat.\n\n1. Tigers" — sentence ends with period, then numbered header follows;
+            // compound transform must not yield ".." which espeak reads as "dot Tigers".
+            val result = normalizeChatTextForSpeech("Their habitat.\n\n1. Tigers vs. Lions")
+            assertFalse(result.contains(".."), "Double period must be collapsed, got: $result")
+            assertFalse(result.startsWith("dot", ignoreCase = true), "Must not start with 'dot', got: $result")
+            assertTrue(result.contains("Tigers vs. Lions"), "Section content must be preserved, got: $result")
+        }
+
+        @Test
         fun `leading period at start of normalised text is stripped`() {
             // Chunk starting with ". Tigers" (period injected by compound transforms) must not
             // be read by espeak-ng as "dot Tigers".

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -154,6 +154,25 @@ class ChatTextUtilsTest {
         }
 
         @Test
+        fun `colons followed by numbered list do not produce double dot artifact`() {
+            // "big cats:\n1. Tigers" → colon→". " and \n1.→". " both fire; must dedup to single "."
+            assertEquals(
+                "big cats. Tigers",
+                normalizeChatTextForSpeech("big cats:\n1. Tigers"),
+            )
+        }
+
+        @Test
+        fun `leading period at start of normalised text is stripped`() {
+            // Chunk starting with ". Tigers" (period injected by compound transforms) must not
+            // be read by espeak-ng as "dot Tigers".
+            assertEquals(
+                "Tigers",
+                normalizeChatTextForSpeech(". Tigers"),
+            )
+        }
+
+        @Test
         fun `converts non-numeric colons into sentence-break pauses`() {
             assertEquals(
                 "Bedtime Routine. Predictability is key",

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -67,7 +67,6 @@ import com.kernel.ai.core.voice.VctkSpeakerMetadata
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoicePackDownloadState
-import com.kernel.ai.core.voice.speakerGroupForSid
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -930,36 +929,23 @@ private fun KokoroSpeakerSelector(
 ) {
     val effectiveId = activeSpeakerId.coerceIn(0, voice.speakerCount - 1)
 
-    // Tabs: English (3 speakers), Chinese Female (55 speakers), Chinese Male (45 speakers)
-    data class TabSpec(val group: KokoroSpeakerGroup, val label: String)
-    val tabs = listOf(
-        TabSpec(KokoroSpeakerGroup.AmericanFemale, "English (3)"),
-        TabSpec(KokoroSpeakerGroup.ChineseFemale, "Chinese F (55)"),
-        TabSpec(KokoroSpeakerGroup.ChineseMale, "Chinese M (45)"),
-    )
+    // Three tabs: American English (sids 0–19), British English (20–27), Other (28–52)
+    val americanRange = KokoroSpeakerGroup.AmericanFemale.sidRange.first..KokoroSpeakerGroup.AmericanMale.sidRange.last
+    val britishRange  = KokoroSpeakerGroup.BritishFemale.sidRange.first..KokoroSpeakerGroup.BritishMale.sidRange.last
+    val otherRange    = KokoroSpeakerGroup.Multilingual.sidRange
 
-    // Determine the initial tab from the active speaker's group.
-    // BritishFemale (sid 2) maps to the English tab since it is included in the English tab range.
-    fun groupToTabIndex(group: KokoroSpeakerGroup): Int = when (group) {
-        KokoroSpeakerGroup.AmericanFemale, KokoroSpeakerGroup.BritishFemale -> 0
-        KokoroSpeakerGroup.ChineseFemale -> 1
-        KokoroSpeakerGroup.ChineseMale -> 2
+    fun sidToTabIndex(sid: Int): Int = when {
+        sid in americanRange -> 0
+        sid in britishRange  -> 1
+        else                 -> 2
     }
 
-    val initialTabIndex = groupToTabIndex(voice.speakerGroupForSid(effectiveId))
+    val initialTabIndex = sidToTabIndex(effectiveId)
     var selectedTabIndex by rememberSaveable(effectiveId) { mutableIntStateOf(initialTabIndex) }
 
-    // Chinese-Female slider local state (within-group index 0–54 → sids 3–57)
-    val chineseFemaleRange = KokoroSpeakerGroup.ChineseFemale.sidRange
-    val initialCfIndex = if (effectiveId in chineseFemaleRange)
-        effectiveId - chineseFemaleRange.first else 0
-    var cfSliderValue by remember(effectiveId) { mutableIntStateOf(initialCfIndex) }
-
-    // Chinese-Male slider local state (within-group index 0–44 → sids 58–102)
-    val chineseMaleRange = KokoroSpeakerGroup.ChineseMale.sidRange
-    val initialCmIndex = if (effectiveId in chineseMaleRange)
-        effectiveId - chineseMaleRange.first else 0
-    var cmSliderValue by remember(effectiveId) { mutableIntStateOf(initialCmIndex) }
+    // Slider state for the Other tab (25 speakers, 0-based index within the range)
+    val initialOtherIndex = if (effectiveId in otherRange) effectiveId - otherRange.first else 0
+    var otherSliderValue by remember(effectiveId) { mutableIntStateOf(initialOtherIndex) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
@@ -976,71 +962,52 @@ private fun KokoroSpeakerSelector(
         )
 
         TabRow(selectedTabIndex = selectedTabIndex) {
-            tabs.forEachIndexed { index, tab ->
-                Tab(
-                    selected = selectedTabIndex == index,
-                    onClick = { selectedTabIndex = index },
-                    text = { Text(tab.label) },
-                )
-            }
+            Tab(selected = selectedTabIndex == 0, onClick = { selectedTabIndex = 0 }, text = { Text("🇺🇸 American") })
+            Tab(selected = selectedTabIndex == 1, onClick = { selectedTabIndex = 1 }, text = { Text("🇬🇧 British") })
+            Tab(selected = selectedTabIndex == 2, onClick = { selectedTabIndex = 2 }, text = { Text("🌍 Other") })
         }
 
         when (selectedTabIndex) {
-            // English tab: named radio buttons for sids 0 (af_maple), 1 (af_sol), 2 (bf_vale)
-            0 -> {
-                data class EnglishSpeaker(val sid: Int, val subtitle: String)
-                val englishSpeakers = listOf(
-                    EnglishSpeaker(0, "American female"),
-                    EnglishSpeaker(1, "American female"),
-                    EnglishSpeaker(2, "British female"),
+            // American tab: 20 named speakers (sids 0–19)
+            0 -> americanRange.forEach { sid ->
+                val name = voice.speakerNameForSid(sid)
+                val subtitle = if (name.startsWith("af_")) "American Female" else "American Male"
+                ListItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    headlineContent = { Text(name) },
+                    supportingContent = { Text(subtitle) },
+                    trailingContent = {
+                        RadioButton(
+                            selected = effectiveId == sid,
+                            onClick = { onSpeakerSelected(sid) },
+                        )
+                    },
                 )
-                englishSpeakers.forEach { speaker ->
-                    ListItem(
-                        modifier = Modifier.fillMaxWidth(),
-                        headlineContent = { Text(voice.speakerNameForSid(speaker.sid)) },
-                        supportingContent = { Text(speaker.subtitle) },
-                        trailingContent = {
-                            RadioButton(
-                                selected = effectiveId == speaker.sid,
-                                onClick = { onSpeakerSelected(speaker.sid) },
-                            )
-                        },
-                    )
-                    HorizontalDivider()
-                }
+                HorizontalDivider()
             }
 
-            // Chinese Female tab: slider over sids 3–57
-            1 -> {
-                val steps = chineseFemaleRange.last - chineseFemaleRange.first  // 54 steps → 55 values
-                val currentSid = chineseFemaleRange.first + cfSliderValue
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                ) {
-                    Text(
-                        text = voice.speakerNameForSid(currentSid),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(bottom = 4.dp),
-                    )
-                    Slider(
-                        value = cfSliderValue.toFloat(),
-                        onValueChange = { cfSliderValue = it.roundToInt() },
-                        onValueChangeFinished = {
-                            onSpeakerSelected(chineseFemaleRange.first + cfSliderValue)
-                        },
-                        valueRange = 0f..steps.toFloat(),
-                        steps = steps - 1,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+            // British tab: 8 named speakers (sids 20–27)
+            1 -> britishRange.forEach { sid ->
+                val name = voice.speakerNameForSid(sid)
+                val subtitle = if (name.startsWith("bf_")) "British Female" else "British Male"
+                ListItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    headlineContent = { Text(name) },
+                    supportingContent = { Text(subtitle) },
+                    trailingContent = {
+                        RadioButton(
+                            selected = effectiveId == sid,
+                            onClick = { onSpeakerSelected(sid) },
+                        )
+                    },
+                )
+                HorizontalDivider()
             }
 
-            // Chinese Male tab: slider over sids 58–102
+            // Other tab: slider over 25 multilingual speakers (sids 28–52)
             else -> {
-                val steps = chineseMaleRange.last - chineseMaleRange.first  // 44 steps → 45 values
-                val currentSid = chineseMaleRange.first + cmSliderValue
+                val steps = otherRange.last - otherRange.first  // 24 steps → 25 values
+                val currentSid = otherRange.first + otherSliderValue
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1052,10 +1019,10 @@ private fun KokoroSpeakerSelector(
                         modifier = Modifier.padding(bottom = 4.dp),
                     )
                     Slider(
-                        value = cmSliderValue.toFloat(),
-                        onValueChange = { cmSliderValue = it.roundToInt() },
+                        value = otherSliderValue.toFloat(),
+                        onValueChange = { otherSliderValue = it.roundToInt() },
                         onValueChangeFinished = {
-                            onSpeakerSelected(chineseMaleRange.first + cmSliderValue)
+                            onSpeakerSelected(otherRange.first + otherSliderValue)
                         },
                         valueRange = 0f..steps.toFloat(),
                         steps = steps - 1,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.voice.SemaineSpeakerMetadata
+import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.VctkSpeakerMetadata
 import com.kernel.ai.core.voice.VoiceInputEngine
@@ -90,6 +91,11 @@ fun VoiceScreen(
         onCancelVoiceDownload = viewModel::cancelSherpaVoiceDownload,
         onDeleteVoice = viewModel::deleteSherpaVoice,
         onActiveSpeakerIdChanged = viewModel::setActiveSpeakerId,
+        onKokoroVoiceSelected = viewModel::setKokoroVoice,
+        onDownloadKokoroVoice = viewModel::downloadKokoroVoice,
+        onCancelKokoroVoiceDownload = viewModel::cancelKokoroVoiceDownload,
+        onDeleteKokoroVoice = viewModel::deleteKokoroVoice,
+        onKokoroActiveSpeakerIdChanged = viewModel::setKokoroActiveSpeakerId,
     )
 }
 
@@ -112,6 +118,11 @@ private fun VoiceScreenContent(
     onCancelVoiceDownload: (SherpaPiperVoice) -> Unit,
     onDeleteVoice: (SherpaPiperVoice) -> Unit,
     onActiveSpeakerIdChanged: (Int) -> Unit,
+    onKokoroVoiceSelected: (SherpaKokoroVoice) -> Unit,
+    onDownloadKokoroVoice: (SherpaKokoroVoice) -> Unit,
+    onCancelKokoroVoiceDownload: (SherpaKokoroVoice) -> Unit,
+    onDeleteKokoroVoice: (SherpaKokoroVoice) -> Unit,
+    onKokoroActiveSpeakerIdChanged: (Int) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -487,6 +498,49 @@ private fun VoiceScreenContent(
                 }
             }
 
+            if (uiState.selectedOutputEngine == VoiceOutputEngine.KokoroExperimental) {
+                Text(
+                    text = "Kokoro voice",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+
+                val kokoroHelpText = if (!uiState.isSelectedKokoroVoiceDownloaded) {
+                    "Download the Kokoro voice pack below before Kokoro can speak."
+                } else {
+                    "Kokoro (Experimental) is active. Android TTS is inactive while Kokoro is selected."
+                }
+                VoiceInfoCard(
+                    title = "Kokoro (Experimental) is active",
+                    message = kokoroHelpText,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+
+                uiState.kokoroVoices.forEach { voiceRow ->
+                    val isSelected = uiState.selectedKokoroVoice == voiceRow.voice
+                    val isDownloaded = voiceRow.downloadState is VoicePackDownloadState.Downloaded
+
+                    KokoroVoiceRow(
+                        rowState = voiceRow,
+                        isSelected = isSelected,
+                        onSelect = { onKokoroVoiceSelected(voiceRow.voice) },
+                        onDownload = { onDownloadKokoroVoice(voiceRow.voice) },
+                        onCancel = { onCancelKokoroVoiceDownload(voiceRow.voice) },
+                        onDelete = { onDeleteKokoroVoice(voiceRow.voice) },
+                    )
+                    HorizontalDivider()
+
+                    if (isSelected && isDownloaded && voiceRow.voice.speakerCount > 1) {
+                        KokoroSpeakerSelector(
+                            voice = voiceRow.voice,
+                            activeSpeakerId = uiState.kokoroActiveSpeakerId,
+                            onSpeakerSelected = onKokoroActiveSpeakerIdChanged,
+                        )
+                    }
+                }
+            }
+
         }
     }
 }
@@ -734,6 +788,168 @@ private fun SherpaVoiceRow(
     )
 }
 
+/**
+ * A single Kokoro voice row with download/cancel/delete controls and progress indicator.
+ * Mirrors [SherpaVoiceRow] for visual consistency.
+ */
+@Composable
+private fun KokoroVoiceRow(
+    rowState: KokoroVoiceRowUiState,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+    onDownload: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val voice = rowState.voice
+    val state = rowState.downloadState
+    val isDownloaded = state is VoicePackDownloadState.Downloaded
+
+    ListItem(
+        modifier = modifier.fillMaxWidth(),
+        headlineContent = {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(voice.displayName)
+                Text(
+                    text = when {
+                        isDownloaded && isSelected -> "Selected voice"
+                        isDownloaded -> "Downloaded and ready"
+                        state is VoicePackDownloadState.Downloading -> "Downloading"
+                        state is VoicePackDownloadState.Error -> "Download failed"
+                        else -> "Not downloaded"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = when {
+                        isDownloaded && isSelected -> MaterialTheme.colorScheme.primary
+                        isDownloaded -> Color(0xFF2E7D32)
+                        state is VoicePackDownloadState.Error -> MaterialTheme.colorScheme.error
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+        },
+        supportingContent = {
+            Column {
+                Text(
+                    text = voice.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = formatBytes(voice.approxDownloadBytes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (!isDownloaded) {
+                    Text(
+                        text = when (state) {
+                            is VoicePackDownloadState.Downloading -> "Selectable after download completes"
+                            is VoicePackDownloadState.Error -> "Retry download before selecting this voice"
+                            else -> "Download to make this voice selectable"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                when (state) {
+                    is VoicePackDownloadState.Downloading -> {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        LinearProgressIndicator(
+                            progress = { state.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        val pct = (state.progress * 100).toInt()
+                        val mbps = state.bytesPerSecond / 1_000_000.0
+                        val etaSec = state.remainingMs / 1000
+                        Text(
+                            text = buildString {
+                                if (pct >= 90) append("Extracting…")
+                                else {
+                                    append("$pct%")
+                                    if (state.bytesPerSecond > 0) append(" · ${"%.1f".format(mbps)} MB/s")
+                                    if (etaSec > 0) append(" · ${etaSec}s remaining")
+                                }
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    is VoicePackDownloadState.Error -> {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    else -> Unit
+                }
+            }
+        },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                when (state) {
+                    is VoicePackDownloadState.NotDownloaded, is VoicePackDownloadState.Error -> {
+                        TextButton(onClick = onDownload) { Text("Download") }
+                    }
+                    is VoicePackDownloadState.Downloading -> {
+                        TextButton(onClick = onCancel) { Text("Cancel") }
+                    }
+                    is VoicePackDownloadState.Downloaded -> {
+                        Icon(
+                            Icons.Default.CheckCircle,
+                            contentDescription = "Downloaded",
+                            tint = Color(0xFF4CAF50),
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        RadioButton(selected = isSelected, onClick = onSelect)
+                        TextButton(onClick = onDelete) {
+                            Text("Delete", color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/**
+ * Speaker selector for Kokoro multi-speaker model (103 speakers, sid 0–102).
+ * Shows a numeric input and slider since there are no labelled speaker names in the model card.
+ */
+@Composable
+private fun KokoroSpeakerSelector(
+    voice: SherpaKokoroVoice,
+    activeSpeakerId: Int,
+    onSpeakerSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val effectiveId = activeSpeakerId.coerceIn(0, voice.speakerCount - 1)
+    var sliderValue by remember(effectiveId) { mutableIntStateOf(effectiveId) }
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
+        Text(
+            text = "Kokoro speaker",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+        Text(
+            text = "Speaker $effectiveId of ${voice.speakerCount - 1}. Slide to preview different voices.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+        Slider(
+            value = sliderValue.toFloat(),
+            onValueChange = { sliderValue = it.toInt() },
+            onValueChangeFinished = { onSpeakerSelected(sliderValue) },
+            valueRange = 0f..(voice.speakerCount - 1).toFloat(),
+            steps = voice.speakerCount - 2,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
 @Composable
 private fun VoiceWarningCard(
     message: String,
@@ -809,6 +1025,8 @@ private fun VoiceOutputSelectionCard(
             "Android TTS is currently the only engine that will speak. Sherpa voices below stay inactive until you switch engines."
         VoiceOutputEngine.SherpaExperimental ->
             "Sherpa Piper is currently the only engine that will speak. Android TTS is inactive until you switch back."
+        VoiceOutputEngine.KokoroExperimental ->
+            "Kokoro (Experimental) is currently the only engine that will speak. Android TTS is inactive until you switch back."
     }
 
     VoiceInfoCard(
@@ -952,6 +1170,11 @@ private fun VoiceScreenPreview() {
             onCancelVoiceDownload = {},
             onDeleteVoice = {},
             onActiveSpeakerIdChanged = {},
+            onKokoroVoiceSelected = {},
+            onDownloadKokoroVoice = {},
+            onCancelKokoroVoiceDownload = {},
+            onDeleteKokoroVoice = {},
+            onKokoroActiveSpeakerIdChanged = {},
         )
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -520,6 +520,54 @@ private fun VoiceScreenContent(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                 )
 
+                // Speech rate slider — shared with Piper; 0.5–1.5 in steps of 0.05
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    SliderRow(
+                        label = "Speech rate",
+                        valueLabel = "%.2fx".format(uiState.sherpaSpeed),
+                        value = uiState.sherpaSpeed,
+                        valueRange = 0.5f..1.5f,
+                        steps = 19,
+                        onValueChangeFinished = { newVal ->
+                            onSherpaSpeedChanged(
+                                (newVal * 20).roundToInt() / 20f
+                            )
+                        },
+                    )
+                }
+
+                // Pitch slider — shared with Piper; 0.5–2.0 in steps of 0.05
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+                    SliderRow(
+                        label = "Pitch",
+                        valueLabel = "%.2fx".format(uiState.sherpaPitch),
+                        value = uiState.sherpaPitch,
+                        valueRange = 0.5f..2.0f,
+                        steps = 29,
+                        onValueChangeFinished = { newVal ->
+                            onSherpaPitchChanged(
+                                (newVal * 20).roundToInt() / 20f
+                            )
+                        },
+                    )
+                }
+
+                // Volume boost slider — shared with Piper; 0.5–3.0 in steps of 0.25
+                Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+                    SliderRow(
+                        label = "Volume boost",
+                        valueLabel = "%.2fx".format(uiState.sherpaGain),
+                        value = uiState.sherpaGain,
+                        valueRange = 0.5f..3.0f,
+                        steps = 9,
+                        onValueChangeFinished = { newVal ->
+                            onSherpaGainChanged(
+                                (newVal * 4).roundToInt() / 4f
+                            )
+                        },
+                    )
+                }
+
                 uiState.kokoroVoices.forEach { voiceRow ->
                     val isSelected = uiState.selectedKokoroVoice == voiceRow.voice
                     val isDownloaded = voiceRow.downloadState is VoicePackDownloadState.Downloaded

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -57,6 +59,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.voice.KokoroSpeakerGroup
 import com.kernel.ai.core.voice.SemaineSpeakerMetadata
 import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.SherpaPiperVoice
@@ -64,6 +67,7 @@ import com.kernel.ai.core.voice.VctkSpeakerMetadata
 import com.kernel.ai.core.voice.VoiceInputEngine
 import com.kernel.ai.core.voice.VoiceOutputEngine
 import com.kernel.ai.core.voice.VoicePackDownloadState
+import com.kernel.ai.core.voice.speakerGroupForSid
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -925,28 +929,141 @@ private fun KokoroSpeakerSelector(
     modifier: Modifier = Modifier,
 ) {
     val effectiveId = activeSpeakerId.coerceIn(0, voice.speakerCount - 1)
-    var sliderValue by remember(effectiveId) { mutableIntStateOf(effectiveId) }
-    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
+
+    // Tabs: English (3 speakers), Chinese Female (55 speakers), Chinese Male (45 speakers)
+    data class TabSpec(val group: KokoroSpeakerGroup, val label: String)
+    val tabs = listOf(
+        TabSpec(KokoroSpeakerGroup.AmericanFemale, "English (3)"),
+        TabSpec(KokoroSpeakerGroup.ChineseFemale, "Chinese F (55)"),
+        TabSpec(KokoroSpeakerGroup.ChineseMale, "Chinese M (45)"),
+    )
+
+    // Determine the initial tab from the active speaker's group.
+    // BritishFemale (sid 2) maps to the English tab since it is included in the English tab range.
+    fun groupToTabIndex(group: KokoroSpeakerGroup): Int = when (group) {
+        KokoroSpeakerGroup.AmericanFemale, KokoroSpeakerGroup.BritishFemale -> 0
+        KokoroSpeakerGroup.ChineseFemale -> 1
+        KokoroSpeakerGroup.ChineseMale -> 2
+    }
+
+    val initialTabIndex = groupToTabIndex(voice.speakerGroupForSid(effectiveId))
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(initialTabIndex) }
+
+    // Chinese-Female slider local state (within-group index 0–54 → sids 3–57)
+    val chineseFemaleRange = KokoroSpeakerGroup.ChineseFemale.sidRange
+    val initialCfIndex = if (effectiveId in chineseFemaleRange)
+        effectiveId - chineseFemaleRange.first else 0
+    var cfSliderValue by remember { mutableIntStateOf(initialCfIndex) }
+
+    // Chinese-Male slider local state (within-group index 0–44 → sids 58–102)
+    val chineseMaleRange = KokoroSpeakerGroup.ChineseMale.sidRange
+    val initialCmIndex = if (effectiveId in chineseMaleRange)
+        effectiveId - chineseMaleRange.first else 0
+    var cmSliderValue by remember { mutableIntStateOf(initialCmIndex) }
+
+    Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = "Kokoro speaker",
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(vertical = 4.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         )
         Text(
-            text = "Speaker $effectiveId of ${voice.speakerCount - 1}. Slide to preview different voices.",
+            text = "Selected: ${voice.speakerNameForSid(effectiveId)}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 4.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
         )
-        Slider(
-            value = sliderValue.toFloat(),
-            onValueChange = { sliderValue = it.toInt() },
-            onValueChangeFinished = { onSpeakerSelected(sliderValue) },
-            valueRange = 0f..(voice.speakerCount - 1).toFloat(),
-            steps = voice.speakerCount - 2,
-            modifier = Modifier.fillMaxWidth(),
-        )
+
+        TabRow(selectedTabIndex = selectedTabIndex) {
+            tabs.forEachIndexed { index, tab ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = { Text(tab.label) },
+                )
+            }
+        }
+
+        when (selectedTabIndex) {
+            // English tab: named radio buttons for sids 0 (af_maple), 1 (af_sol), 2 (bf_vale)
+            0 -> {
+                data class EnglishSpeaker(val sid: Int, val subtitle: String)
+                val englishSpeakers = listOf(
+                    EnglishSpeaker(0, "American female"),
+                    EnglishSpeaker(1, "American female"),
+                    EnglishSpeaker(2, "British female"),
+                )
+                englishSpeakers.forEach { speaker ->
+                    ListItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        headlineContent = { Text(voice.speakerNameForSid(speaker.sid)) },
+                        supportingContent = { Text(speaker.subtitle) },
+                        trailingContent = {
+                            RadioButton(
+                                selected = effectiveId == speaker.sid,
+                                onClick = { onSpeakerSelected(speaker.sid) },
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            // Chinese Female tab: slider over sids 3–57
+            1 -> {
+                val steps = chineseFemaleRange.last - chineseFemaleRange.first  // 54 steps → 55 values
+                val currentSid = chineseFemaleRange.first + cfSliderValue
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = voice.speakerNameForSid(currentSid),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                    Slider(
+                        value = cfSliderValue.toFloat(),
+                        onValueChange = { cfSliderValue = it.roundToInt() },
+                        onValueChangeFinished = {
+                            onSpeakerSelected(chineseFemaleRange.first + cfSliderValue)
+                        },
+                        valueRange = 0f..steps.toFloat(),
+                        steps = steps - 1,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            // Chinese Male tab: slider over sids 58–102
+            else -> {
+                val steps = chineseMaleRange.last - chineseMaleRange.first  // 44 steps → 45 values
+                val currentSid = chineseMaleRange.first + cmSliderValue
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = voice.speakerNameForSid(currentSid),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                    Slider(
+                        value = cmSliderValue.toFloat(),
+                        onValueChange = { cmSliderValue = it.roundToInt() },
+                        onValueChangeFinished = {
+                            onSpeakerSelected(chineseMaleRange.first + cmSliderValue)
+                        },
+                        valueRange = 0f..steps.toFloat(),
+                        steps = steps - 1,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -947,19 +947,19 @@ private fun KokoroSpeakerSelector(
     }
 
     val initialTabIndex = groupToTabIndex(voice.speakerGroupForSid(effectiveId))
-    var selectedTabIndex by rememberSaveable { mutableIntStateOf(initialTabIndex) }
+    var selectedTabIndex by rememberSaveable(effectiveId) { mutableIntStateOf(initialTabIndex) }
 
     // Chinese-Female slider local state (within-group index 0–54 → sids 3–57)
     val chineseFemaleRange = KokoroSpeakerGroup.ChineseFemale.sidRange
     val initialCfIndex = if (effectiveId in chineseFemaleRange)
         effectiveId - chineseFemaleRange.first else 0
-    var cfSliderValue by remember { mutableIntStateOf(initialCfIndex) }
+    var cfSliderValue by remember(effectiveId) { mutableIntStateOf(initialCfIndex) }
 
     // Chinese-Male slider local state (within-group index 0–44 → sids 58–102)
     val chineseMaleRange = KokoroSpeakerGroup.ChineseMale.sidRange
     val initialCmIndex = if (effectiveId in chineseMaleRange)
         effectiveId - chineseMaleRange.first else 0
-    var cmSliderValue by remember { mutableIntStateOf(initialCmIndex) }
+    var cmSliderValue by remember(effectiveId) { mutableIntStateOf(initialCmIndex) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Text(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
 import com.kernel.ai.core.voice.VoiceInputEngine
@@ -20,6 +21,11 @@ import javax.inject.Inject
 
 data class SherpaVoiceRowUiState(
     val voice: SherpaPiperVoice,
+    val downloadState: VoicePackDownloadState = VoicePackDownloadState.NotDownloaded,
+)
+
+data class KokoroVoiceRowUiState(
+    val voice: SherpaKokoroVoice,
     val downloadState: VoicePackDownloadState = VoicePackDownloadState.NotDownloaded,
 )
 
@@ -43,6 +49,13 @@ data class VoiceUiState(
     val isSelectedSherpaVoiceDownloaded: Boolean = false,
     /** Active speaker ID for multi-speaker voices (VCTK). Stored as sid 0–108. */
     val activeSpeakerId: Int = 0,
+    // ── Kokoro ────────────────────────────────────────────────────────────────
+    val kokoroVoices: List<KokoroVoiceRowUiState> = SherpaKokoroVoice.entries.map { voice ->
+        KokoroVoiceRowUiState(voice = voice)
+    },
+    val selectedKokoroVoice: SherpaKokoroVoice = SherpaKokoroVoice.KokoroMultiLangInt8,
+    val kokoroActiveSpeakerId: Int = 0,
+    val isSelectedKokoroVoiceDownloaded: Boolean = false,
 )
 
 @HiltViewModel
@@ -134,6 +147,40 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             voiceOutputPreferences.activeSpeakerId.collect { sid ->
                 _uiState.update { it.copy(activeSpeakerId = sid) }
+            }
+        }
+        viewModelScope.launch {
+            voiceOutputPreferences.selectedKokoroVoice.collect { voice ->
+                _uiState.update { state ->
+                    state.copy(
+                        selectedKokoroVoice = voice,
+                        isSelectedKokoroVoiceDownloaded =
+                            state.kokoroVoices.firstOrNull { it.voice == voice }
+                                ?.downloadState is VoicePackDownloadState.Downloaded,
+                    )
+                }
+            }
+        }
+        viewModelScope.launch {
+            voiceOutputPreferences.kokoroActiveSpeakerId.collect { sid ->
+                _uiState.update { it.copy(kokoroActiveSpeakerId = sid) }
+            }
+        }
+        viewModelScope.launch {
+            sherpaVoicePackDownloadManager.kokoroDownloadStates.collect { states ->
+                _uiState.update { state ->
+                    val rows = SherpaKokoroVoice.entries.map { voice ->
+                        KokoroVoiceRowUiState(
+                            voice = voice,
+                            downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
+                        )
+                    }
+                    state.copy(
+                        kokoroVoices = rows,
+                        isSelectedKokoroVoiceDownloaded =
+                            states[state.selectedKokoroVoice] is VoicePackDownloadState.Downloaded,
+                    )
+                }
             }
         }
         viewModelScope.launch {
@@ -233,6 +280,36 @@ class VoiceViewModel @Inject constructor(
         _uiState.update { it.copy(autoStartAlertVoiceCommandsEnabled = enabled) }
         viewModelScope.launch {
             voiceInputPreferences.setAutoStartAlertVoiceCommandsEnabled(enabled)
+        }
+    }
+
+    // ── Kokoro actions ────────────────────────────────────────────────────────
+
+    fun setKokoroVoice(voice: SherpaKokoroVoice) {
+        val row = _uiState.value.kokoroVoices.firstOrNull { it.voice == voice }
+        if (row?.downloadState !is VoicePackDownloadState.Downloaded) return
+        _uiState.update { it.copy(selectedKokoroVoice = voice) }
+        viewModelScope.launch {
+            voiceOutputPreferences.setSelectedKokoroVoice(voice)
+        }
+    }
+
+    fun downloadKokoroVoice(voice: SherpaKokoroVoice) {
+        sherpaVoicePackDownloadManager.startKokoroDownload(voice)
+    }
+
+    fun cancelKokoroVoiceDownload(voice: SherpaKokoroVoice) {
+        sherpaVoicePackDownloadManager.cancelKokoroDownload(voice)
+    }
+
+    fun deleteKokoroVoice(voice: SherpaKokoroVoice) {
+        sherpaVoicePackDownloadManager.deleteKokoroVoice(voice)
+    }
+
+    fun setKokoroActiveSpeakerId(sid: Int) {
+        _uiState.update { it.copy(kokoroActiveSpeakerId = sid) }
+        viewModelScope.launch {
+            voiceOutputPreferences.setKokoroActiveSpeakerId(sid)
         }
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.settings
 import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
 import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
 import com.kernel.ai.core.voice.VoiceInputEngine
@@ -48,9 +49,17 @@ class VoiceViewModelTest {
     private val autoSpeak = MutableStateFlow(true)
     private val maxSpokenSentences = MutableStateFlow(0)
     private val activeSpeakerId = MutableStateFlow(0)
+    private val selectedKokoroVoice = MutableStateFlow(SherpaKokoroVoice.KokoroMultiLangInt8)
+    private val kokoroActiveSpeakerId = MutableStateFlow(0)
     private val sherpaDownloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
         MutableStateFlow(
             SherpaPiperVoice.entries.associateWith {
+                VoicePackDownloadState.NotDownloaded
+            },
+        )
+    private val kokoroDownloadStates: MutableStateFlow<Map<SherpaKokoroVoice, VoicePackDownloadState>> =
+        MutableStateFlow(
+            SherpaKokoroVoice.entries.associateWith {
                 VoicePackDownloadState.NotDownloaded
             },
         )
@@ -81,6 +90,8 @@ class VoiceViewModelTest {
         every { voiceOutputPreferences.autoSpeak } returns autoSpeak
         every { voiceOutputPreferences.maxSpokenSentences } returns maxSpokenSentences
         every { voiceOutputPreferences.activeSpeakerId } returns activeSpeakerId
+        every { voiceOutputPreferences.selectedKokoroVoice } returns selectedKokoroVoice
+        every { voiceOutputPreferences.kokoroActiveSpeakerId } returns kokoroActiveSpeakerId
         coEvery { voiceOutputPreferences.setSpokenResponsesEnabled(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedEngine(any()) } just Runs
         coEvery { voiceOutputPreferences.setSelectedSherpaVoice(any()) } just Runs
@@ -90,10 +101,16 @@ class VoiceViewModelTest {
         coEvery { voiceOutputPreferences.setAutoSpeak(any()) } just Runs
         coEvery { voiceOutputPreferences.setMaxSpokenSentences(any()) } just Runs
         coEvery { voiceOutputPreferences.setActiveSpeakerId(any()) } just Runs
+        coEvery { voiceOutputPreferences.setSelectedKokoroVoice(any()) } just Runs
+        coEvery { voiceOutputPreferences.setKokoroActiveSpeakerId(any()) } just Runs
         every { sherpaVoicePackDownloadManager.downloadStates } returns sherpaDownloadStates
+        every { sherpaVoicePackDownloadManager.kokoroDownloadStates } returns kokoroDownloadStates
         every { sherpaVoicePackDownloadManager.startDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.cancelDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.deleteVoice(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.startKokoroDownload(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.cancelKokoroDownload(any()) } just Runs
+        every { sherpaVoicePackDownloadManager.deleteKokoroVoice(any()) } just Runs
         viewModel = VoiceViewModel(
             androidNativeRecognitionSupport,
             voiceInputPreferences,


### PR DESCRIPTION
## Summary

Adds **Kokoro-82M TTS** as a new, optional voice engine behind `VoiceOutputEngine.KokoroExperimental`. Kokoro uses the same Sherpa-ONNX `OfflineTts` class as Piper but produces noticeably higher-quality output from a much larger 82M-parameter model. The engine is off by default and requires an explicit ~130MB download.

## Changes

### New files
- `SherpaKokoroVoice.kt` — enum with `KokoroMultiLangInt8` entry (`kokoro-int8-multi-lang-v1_1`, 103 speakers, EN+ZH, Apache 2.0)

### Modified files
- `SherpaVoicePackFiles.kt` — `SHERPA_KOKORO_VOICES_FILE` constant + `hasRequiredKokoroVoicePackFiles()` (requires `voices.bin` in addition to Piper's files)
- `VoiceOutputEngine.kt` — `KokoroExperimental` engine entry
- `VoiceOutputPreferences.kt` — `selectedKokoroVoice` + `kokoroActiveSpeakerId` flows and setters
- `SherpaOnnxVoiceOutputController.kt` — `buildOfflineTtsKokoroConfig()` via reflection on `OfflineTtsKokoroModelConfig`; `initKokoro()` / `doInitializeKokoro()` / `markKokoroVoiceAvailable()` / `resetForKokoroVoice()`; speak/stream paths branch on active engine
- `FallbackVoiceOutputController.kt` — `KokoroExperimental` wired in all three `when` branches
- `SherpaVoicePackDownloadManager.kt` — `startKokoroDownload()` / `cancelKokoroDownload()` / `deleteKokoroVoice()` + download state flows
- `VoicePackDownloadWorker.kt` — extended voice resolution to fall through to `SherpaKokoroVoice`; picks correct validation function
- `VoiceViewModel.kt` — `KokoroVoiceRowUiState`, Kokoro UI state fields, all action methods
- `VoiceScreen.kt` — `KokoroVoiceRow` composable, `KokoroSpeakerSelector` (sid 0–102 slider), Kokoro section in settings
- `VoiceViewModelTest.kt` — stubs for all new prefs/download manager methods; existing 20 tests all pass

## Architecture notes

- All Sherpa classes accessed via **reflection only** — zero direct `com.k2fsa.sherpa.onnx.*` imports
- Sample rate is read dynamically from `GeneratedAudio` via reflection — Kokoro's 24kHz works without changes
- Streaming via `generateWithCallback` is identical to Piper; `maxNumSentences=1` for per-sentence progressive output
- `speakerCount` passed through to `effectiveSid()` guard so sid never exceeds 102

## Testing

- [x] `:core:voice:testDebugUnitTest` — all tests pass
- [x] `:feature:settings:testDebugUnitTest` — all 20 `VoiceViewModelTest` tests pass
- [x] `:app:assembleDebug` — clean build (0 errors, 0 new warnings)
- [ ] On-device: download Kokoro pack and confirm audio output + speaker selector

## Related issues

Closes #783
