### PR TITLE
docs: sync README, ROADMAP, SPEC with PRs #848, #847, #845

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,20 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - ⚙️ **Expanded TTS settings** — pitch slider (Sherpa only, 0.5–2.0×), auto-speak chat replies toggle (decoupled from Quick Actions via `autoSpeakEnabled` field), max spoken sentences dropdown (0 = unlimited, 2, 3, 5); all grouped in a **"Chat voice behaviour"** section in Settings
 - 🛑 **Verbal stop command** — saying "stop", "stop speaking", "cancel", "be quiet", "shut up", or "silence" during TTS playback cancels speech and stops mic re-arm
 - 🗣️ **VCTK multi-speaker selection** — choose from 109 VCTK voices (gender filter, speaker ID, accent label) in Settings → Voice; sid mapping sourced directly from the Piper model config
+|- 🗣️ **Semaine multi-speaker selection** — 4 distinct voices (Prudence, Spike, Obadiah, Poppy) selectable in Settings → Voice (#818, PR #818)
+|- 📐 **Deterministic unit conversion** — length, mass, volume, temperature, speed with alias normalisation and spoken-STT variants (#676, PR #816)
+|- 💱 **Deterministic currency conversion** — ISO code resolution via Frankfurter/ECB rates with same-currency short-circuit and clear error for unsupported currencies (#831, PR #848)
+|- 🗣️ **TTS pronoun normalisation** — converts first-person pronouns (my/I → your/you) in spoken summaries so the assistant speaks in third person (#828, PR #830)
+|- 🔊 **Voice fallthrough preservation** — Actions→Chat fallthrough preserves the user's voice-speak expectation so replies are spoken even after cross-screen navigation (#832, PR #833)
+|- ⏱️ **Slot-fill retry on no-speech** — system retries the slot-fill prompt instead of failing; cancel phrases abort the flow; start-listening audio cue confirms mic activity (#790/#791, PR #825)
+|- 🔒 **Blank response guard** — retries without RAG before showing fallback when LiteRT produces 0 tokens; keeps chat awake during load and generation (#839/#841, PRs #840/#842)
+|- 🎙️ **Homescreen Glance widget** — quick actions and voice from the launcher via GlanceAppWidget; VoiceCommandActivity and WidgetTextInputActivity with task isolation (#617, PR #847)
+|- 🔧 **Audio quality fixes** — AudioTrack tail cutoff prevention via hardware-latency silence padding; expectedSlotPromptSpeech normalisation to match TTS output; SID=0 clamp for single-speaker voices; aye pronunciation correction (#837/#828/#810, PRs #838/#836/#811)
 
 ### Coming Soon
 - 💬 **Expanded multi-turn dialog** — broader confirmation, digression, and slot-filling coverage across more intents *(Phase 3G, #708 and follow-ups)*
 - 🗒️ **Lists — management upgrades** — rename, pin, sort, edit items, favorites, and due dates *(#662)*
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen *(Phase 3, #479)*
-- 📱 **Homescreen widget** — quick actions and voice from the launcher *(Phase 3F, #617)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
 - ⚡ **Semantic cache** — instant responses for repeated knowledge queries *(Phase 4)*
 - 🪪 **Self-healing identity** — structured user profile, LLM-managed via Dreaming cycle *(Phase 4)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kernel AI Assistant — Roadmap
 
-> **Last updated:** 2026-05-11 (PR #845 merged: aye pronunciation fix #843; native unit conversion #676 marked done; deterministic currency conversion #831 in progress)
+> **Last updated:** 2026-05-12 (PR #848 merged: deterministic currency conversion #831; PR #847 merged: homescreen Glance widget #617; PR #845 merged: aye pronunciation fix #843)
 >
 > This is the living roadmap for Kernel AI. It tracks what's been built, what's next,
 > and what's planned. If you have ideas, [open an issue](https://github.com/NickMonrad/kernel-ai-assistant/issues/new)
@@ -213,7 +213,7 @@ Active follow-on model/runtime investigations now live under
 | [#676](https://github.com/NickMonrad/kernel-ai-assistant/issues/676) | Native unit conversion tool | ✅ Done — PR #816 | 🟡 Medium |
 | [#677](https://github.com/NickMonrad/kernel-ai-assistant/issues/677) | World clock and timezone lookup | ✅ Done — PR #743 | 🟢 Low |
 | [#697](https://github.com/NickMonrad/kernel-ai-assistant/issues/697) | Multi-day weather forecast card in chat | ✅ Done — PR #710 | 🟡 Medium |
-| [#831](https://github.com/NickMonrad/kernel-ai-assistant/issues/831) | Deterministic currency conversion skill | 🔄 In progress — PR #848 | 🟡 Medium |
+|| [#831](https://github.com/NickMonrad/kernel-ai-assistant/issues/831) | Deterministic currency conversion skill | ✅ Done — PR #848 | 🟡 Medium |
 
 **Already completed skills:**
 - ✅ set_alarm (PR #257/#262, time param fix PR #339)
@@ -302,7 +302,7 @@ Lower-priority skill additions — third-party integrations and local utilities.
 | [#824](https://github.com/NickMonrad/kernel-ai-assistant/issues/824) | QA gate: Phase 3F real-device voice validation (current stack) | ⬜ Pending | 🟡 Medium |
 | [#828](https://github.com/NickMonrad/kernel-ai-assistant/issues/828) | TTS pronoun normalisation (my/I → your/you) | ⬜ Pending | 🟢 Low |
 | [#588](https://github.com/NickMonrad/kernel-ai-assistant/issues/588) | VoiceSession architecture for slot-fill + follow-on assistant mode | ⬜ Pending | 🟡 Medium |
-| [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | ⬜ Pending | 🟡 Medium |
+|| [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | ✅ Done — PR #847 | 🟡 Medium |
 | [#659](https://github.com/NickMonrad/kernel-ai-assistant/issues/659) | Translator skill with multilingual TTS | ⬜ Pending | 🟡 Medium |
 | [#727](https://github.com/NickMonrad/kernel-ai-assistant/issues/727) | Chat voice foundation for conversational push-to-talk | ✅ Done — PR #731 | 🟡 Medium |
 | [#728](https://github.com/NickMonrad/kernel-ai-assistant/issues/728) | Chat voice UI/UX and turn-taking controls | ✅ Done — PR #735 | 🟡 Medium |
@@ -556,7 +556,7 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#600](https://github.com/NickMonrad/kernel-ai-assistant/issues/600) | Slot fill spec: document expected multi-step interactions per intent | Phase 3G | ✅ Done — PR #712 |
 | [#601](https://github.com/NickMonrad/kernel-ai-assistant/issues/601) | Multi-slot: re-check for missing slots after each slot reply | Phase 3G | ✅ Done — PR #712 |
 | [#608](https://github.com/NickMonrad/kernel-ai-assistant/issues/608) | Colloquial weather phrases fall through to LLM instead of weather skill | Phase 3C | ✅ Done — PR #667 follow-up completed the routing/references path |
-| [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | Phase 3F | ⬜ Pending |
+|| [#617](https://github.com/NickMonrad/kernel-ai-assistant/issues/617) | Homescreen widget for quick actions / voice | Phase 3F | ✅ Done — PR #847 |
 | [#619](https://github.com/NickMonrad/kernel-ai-assistant/issues/619) | `date_diff` tool — native date arithmetic (LLM arithmetic unreliable) | Phase 3C | ✅ Done |
 | [#620](https://github.com/NickMonrad/kernel-ai-assistant/issues/620) | Bypass `needsConfirmation` for no-param MiniLM matches | Phase 3G | ✅ Done |
 | [#621](https://github.com/NickMonrad/kernel-ai-assistant/issues/621) | Multi-turn QIR: dispatch pending intent on user confirmation | Phase 3G | ✅ Done |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-05-12 (homescreen Glance widget: issue #617, PR #847)
+> **Last updated:** 2026-05-12 (PR #848: deterministic currency conversion #831; PR #847: homescreen Glance widget #617; PR #845: aye pronunciation fix #843)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -724,7 +724,107 @@ Toolbar `IconButton`s in `TopAppBar` follow M3's 48dp minimum touch target guide
 **Spacing tokens (ad-hoc, from codebase):** Vertical padding between chat bubbles: 6dp.
 Input bar top padding: 8dp. Spacers between inline UI elements: 4dp.
 
-### 6.2 Homescreen Glance Widget (issue #617, PR #847)
+
+### 6.2 Voice Interface
+
+The voice system covers two distinct interaction modes: **Quick Actions** (push-to-talk for
+device commands) and **Chat Voice** (conversational push-to-talk for dialog). Both use
+Sherpa-ONNX for speech-to-text (STT) and text-to-speech (TTS).
+
+#### 6.2.1 Speech-to-Text (STT)
+
+**Current stack:** Sherpa-ONNX CTC models for offline STT. The app also supports the Android
+native on-device recognizer as a fallback path (`#717`, PR #718), which was hardened for
+reliability on Samsung Galaxy S23 Ultra.
+
+**STT fallback-path issues** (e.g. appointment QIR bug `#773`) are tracked separately from
+the Sherpa primary path.
+
+**Remaining STT research:** Sherpa-ONNX / Sherpa-ncnn STT + VAD evaluation (`#821`),
+Parakeet CTC (`#700`), Whisper.cpp vs Vosk (`#703`).
+
+#### 6.2.2 Text-to-Speech (TTS)
+
+**Engine:** Sherpa-TTS with VITS-based voices, replacing the Android native TTS engine
+(`#729`, PR #804). This provides significantly improved conversational voice quality.
+
+**Multi-speaker support:**
+- **VCTK** (`#782`, PR #805): Multiple English speakers for Quick Actions responses
+- **Semaine** (`#817`, PR #818): 4 speakers — Prudence, Spike, Obadiah, Poppy — selected
+  via Settings → Voice. Note: Semaine exposes different *speakers*, not emotional variants;
+  the emotion detection approach was abandoned (`#781` closed).
+
+**Streaming TTS pipeline (`#755`, PR #780):** Two-coroutine producer/consumer pattern
+(`runStreamingPlayback()`) enables incremental, low-latency spoken responses during LLM
+generation. The TTS begins playback as soon as the first sentence is available, rather
+than waiting for the full response.
+
+**TTS quality fixes (PR #780):**
+- URL colon preservation in `cleanTextForSpeech()` — prevents URLs like
+  `https://example.com:8080` from being read as "eight zero eight zero"
+- Speech rate clamping — prevents unnaturally fast or slow playback
+- Abbreviation-aware sentence splitting — handles "Dr.", "Mr.", "U.S." correctly
+- Sherpa voice quality evaluation performed on Samsung Galaxy S23 Ultra (`#770`)
+
+**TTS settings (PR #789):** Expanded settings include pitch control, auto-speak toggle,
+and max spoken sentences limit. `autoSpeakEnabled` is a cached field in `ChatViewModel`,
+fully decoupled from the Quick Actions `spokenResponsesEnabled` toggle.
+
+**Per-message speaker button (PR #789):** Each chat message has a speaker icon to replay
+its TTS playback with the selected speaker.
+
+**Verbal stop command (PR #789):** Users can say "stop" or "quiet" to halt TTS playback
+mid-sentence.
+
+**TTS pronoun normalisation (`#828`, PR #830):** Converts first-person pronouns
+(my/I → your/you) in TTS output so the assistant speaks in third person when reading
+LLM responses that reference the user.
+
+#### 6.2.3 Quick Actions Voice
+
+**Push-to-talk:** Offline STT captures voice input; QIR (QuickIntentRouter) matches the
+transcript to device actions; responses are spoken via TTS.
+
+**Slot-fill retry on no-speech (PR #825, `#790`):** When the STT detects no speech,
+the system retries the slot-fill prompt instead of failing. Cancel phrases (e.g. "cancel",
+"never mind") are recognised and abort the slot-fill flow.
+
+**Start-listening audio cue (PR #825, `#791`):** A brief audio beep signals that voice
+capture has started, giving the user confidence the mic is active.
+
+#### 6.2.4 Chat Voice
+
+**Conversational push-to-talk (`#727`, PR #731; `#728`, PR #735):** Chat voice supports
+turn-taking controls — the user speaks, the assistant responds with streaming TTS, then
+the user can speak again.
+
+**Mode switch (`#741`, PR #744):** Users can choose between one-shot mode (single question
+and answer) and back-and-forth mode (continuous conversation) from the chat voice controls.
+
+**Voice-friendly spoken response rendering (`#763`, PR #771):** LLM responses are
+preprocessed for natural speech: markdown is stripped, lists are verbalised, and
+punctuation is normalised for TTS.
+
+#### 6.2.5 Remaining Voice Research
+
+- **Kokoro-82M / VoxSherpa + expressiveness (`#783`):** Research into alternative TTS
+  engines with emotional expressiveness and tone control
+- **Kiwi language corpus tuning (`#784`):** Tuning TTS pronunciation for Māori words
+  and Kiwi slang used by Jandal
+- **VITS noise_scale expressiveness (`#788`):** Fine-tuning the noise scale parameter
+  for more natural-sounding VITS voices
+- **Custom Piper voice training (`#756`):** Research into training a custom Piper voice
+  model with Jandal's Kiwi character
+- **Voice memo skill (`#823`):** Native skill for voice note-taking
+- **VoiceSession architecture (`#588`):** Unified voice session management for slot-fill
+  and follow-on assistant mode
+- **QA gate (`#824`):** Real-device voice validation for the current stack on Samsung
+  Galaxy S23 Ultra
+- **Homescreen widget (`#617`):** Quick actions / voice widget for the homescreen
+- **Translator skill (`#659`):** Multilingual translation with TTS output
+- **Wake word (`#65`):** "Hey Jandal" via Picovoice Porcupine (future)
+- **Live mode (`#64`):** Real-time streaming interaction (future)
+### 6.3 Homescreen Glance Widget (issue #617, PR #847)
 
 A Glance-based (`androidx.glance`) homescreen widget that surfaces voice and text Quick Actions
 directly from the Android homescreen, without requiring the user to open the app.


### PR DESCRIPTION
## Summary

Syncs README, ROADMAP, and SPECIFICATION with recently merged PRs (#848, #847, #845) and other undocumented features.

## Changes

### `docs/ROADMAP.md`
- Updated header date to 2026-05-12, added PR #848 and #845 notes
- Currency conversion (#831): 🔄 In progress → ✅ Done — PR #848
- Widget (#617) in Phase 3F: ⬜ Pending → ✅ Done — PR #847
- Widget (#617) in Ideas table: ⬜ Pending → ✅ Done — PR #847

### `README.md`
**Added to Delivered:**
- Semaine multi-speaker selection (#818, PR #818)
- Deterministic unit conversion (#676, PR #816)
- Deterministic currency conversion (#831, PR #848)
- TTS pronoun normalisation (#828, PR #830)
- Voice fallthrough preservation (#832, PR #833)
- Slot-fill retry on no-speech (#790/#791, PR #825)
- Blank response guard + keep chat awake (#839/#841, PRs #840/#842)
- Homescreen Glance widget (#617, PR #847)
- Audio quality fixes (AudioTrack cutoff, expectedSlotPromptSpeech, SID=0 clamp, aye pronunciation) (#837/#828/#810, PRs #838/#836/#811)

**Removed from Coming Soon:**
- Homescreen widget (moved to Delivered)

### `docs/SPECIFICATION.md`
- Updated header with PR #848, #847, #845
- Added **§6.2 Voice Interface** section covering:
  - 6.2.1 Speech-to-Text (STT)
  - 6.2.2 Text-to-Speech (TTS) — VCTK, Semaine, streaming pipeline, quality fixes, settings, pronoun normalisation
  - 6.2.3 Quick Actions Voice — slot-fill retry, start-listening cue
  - 6.2.4 Chat Voice — turn-taking, mode switch, spoken response rendering
  - 6.2.5 Remaining Voice Research — Kokoro, Kiwi corpus, VITS noise, Piper training, voice memo, VoiceSession, QA gate, translator, wake word, live mode
- Renumbered Widget from §6.2 to §6.3

## Verification
- No conflict markers in any file
- Section numbering is sequential (6.1 → 6.2 → 6.3)
- Table formatting verified correct