### PR TITLE
fix(#856): birthday suffix stripping and phonetic fuzzy name matching

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -135,11 +135,13 @@ class CalendarBirthdayLookup @Inject constructor(
         private fun tokensEquivalent(left: String, right: String): Boolean {
             if (left == right) return true
             if (tokenVariants(left).intersect(tokenVariants(right)).isNotEmpty()) return true
+            val maxLen = maxOf(left.length, right.length)
+            // Guard applies to both Soundex and edit distance — prevents 3-letter false positives
+            // (e.g. Tim/Tom, Dan/Don share the same Soundex code)
+            if (maxLen < 4) return false
             // Phonetic match — catches Emily/Emilie, common spelling variants
             if (soundex(left) == soundex(right)) return true
             // Edit-distance fallback — catches Freya/Freyja, short insertion/deletion diffs
-            val maxLen = maxOf(left.length, right.length)
-            if (maxLen < 4) return false
             return editDistance(left, right) <= maxLen / 3
         }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -134,7 +134,13 @@ class CalendarBirthdayLookup @Inject constructor(
 
         private fun tokensEquivalent(left: String, right: String): Boolean {
             if (left == right) return true
-            return tokenVariants(left).intersect(tokenVariants(right)).isNotEmpty()
+            if (tokenVariants(left).intersect(tokenVariants(right)).isNotEmpty()) return true
+            // Phonetic match — catches Emily/Emilie, common spelling variants
+            if (soundex(left) == soundex(right)) return true
+            // Edit-distance fallback — catches Freya/Freyja, short insertion/deletion diffs
+            val maxLen = maxOf(left.length, right.length)
+            if (maxLen < 4) return false
+            return editDistance(left, right) <= maxLen / 3
         }
 
         private fun tokenVariants(token: String): Set<String> {
@@ -146,6 +152,46 @@ class CalendarBirthdayLookup @Inject constructor(
                 variants += trimmed.dropLast(1)
             }
             return variants
+        }
+
+        internal fun soundex(s: String): String {
+            val upper = s.uppercase(Locale.ENGLISH).filter { it.isLetter() }
+            if (upper.isEmpty()) return "0000"
+            fun code(c: Char): Char = when (c) {
+                'B', 'F', 'P', 'V' -> '1'
+                'C', 'G', 'J', 'K', 'Q', 'S', 'X', 'Z' -> '2'
+                'D', 'T' -> '3'
+                'L' -> '4'
+                'M', 'N' -> '5'
+                'R' -> '6'
+                else -> '0'
+            }
+            val result = StringBuilder().append(upper[0])
+            var prev = code(upper[0])
+            for (ch in upper.drop(1)) {
+                val c = code(ch)
+                if (c != '0' && c != prev) result.append(c)
+                prev = c
+                if (result.length == 4) break
+            }
+            return result.toString().padEnd(4, '0')
+        }
+
+        internal fun editDistance(a: String, b: String): Int {
+            if (a == b) return 0
+            val dp = Array(a.length + 1) { IntArray(b.length + 1) }
+            for (i in 0..a.length) dp[i][0] = i
+            for (j in 0..b.length) dp[0][j] = j
+            for (i in 1..a.length) {
+                for (j in 1..b.length) {
+                    dp[i][j] = if (a[i - 1] == b[j - 1]) {
+                        dp[i - 1][j - 1]
+                    } else {
+                        1 + minOf(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+                    }
+                }
+            }
+            return dp[a.length][b.length]
         }
 
         private fun matchTokens(raw: String): List<String> =

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookup.kt
@@ -136,9 +136,9 @@ class CalendarBirthdayLookup @Inject constructor(
             if (left == right) return true
             if (tokenVariants(left).intersect(tokenVariants(right)).isNotEmpty()) return true
             val maxLen = maxOf(left.length, right.length)
-            // Guard applies to both Soundex and edit distance — prevents 3-letter false positives
-            // (e.g. Tim/Tom, Dan/Don share the same Soundex code)
-            if (maxLen < 4) return false
+            // Guard applies to both Soundex and edit distance — prevents short-name false positives.
+            // Names ≤ 4 chars share Soundex codes too easily (Tim/Tom, John/Joan).
+            if (maxLen <= 4) return false
             // Phonetic match — catches Emily/Emilie, common spelling variants
             if (soundex(left) == soundex(right)) return true
             // Edit-distance fallback — catches Freya/Freyja, short insertion/deletion diffs

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2162,7 +2162,7 @@ class NativeIntentHandler @Inject constructor(
                 }
                 // Fuzzy Room DB match: handles spelling variations (e.g. "Freya" query → "Freyja" stored label)
                 runBlocking { importantDateRepository.getAll() }
-                    .firstOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, namePart) }
+                    .singleOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, namePart) }
                     ?.let { stored ->
                         return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
                     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2151,15 +2151,29 @@ class NativeIntentHandler @Inject constructor(
             return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
         }
         if (s.contains("birthday", ignoreCase = true)) {
+            // Strip "birthday" / "'s birthday" suffix and try Room DB by name only.
+            // Handles "Freya's birthday" when the stored label is "Freya".
+            val namePart = ImportantDateRepository.normalizeLabel(
+                s.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
+            )
+            if (namePart.isNotBlank()) {
+                runBlocking { importantDateRepository.findByLabel(namePart) }?.let { stored ->
+                    return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
+                }
+                // Fuzzy Room DB match: handles spelling variations (e.g. "Freya" query → "Freyja" stored label)
+                runBlocking { importantDateRepository.getAll() }
+                    .firstOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, namePart) }
+                    ?.let { stored ->
+                        return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
+                    }
+            }
+
             calendarBirthdayLookup.findBirthday(s)?.let { birthday ->
                 return resolveRecurringDate(birthday.month, birthday.day, today, preferPast = preferPast)
             }
 
-            val aliasBirthdayLabel = ImportantDateRepository.normalizeLabel(
-                s.replace(Regex("""\bbirthday\b""", RegexOption.IGNORE_CASE), "").trim(),
-            )
-            if (aliasBirthdayLabel.isNotBlank()) {
-                runBlocking { contactAliasRepository.getByAlias(aliasBirthdayLabel) }?.let { alias ->
+            if (namePart.isNotBlank()) {
+                runBlocking { contactAliasRepository.getByAlias(namePart) }?.let { alias ->
                     calendarBirthdayLookup.findBirthday(alias.displayName)?.let { birthday ->
                         return resolveRecurringDate(birthday.month, birthday.day, today, preferPast = preferPast)
                     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -178,11 +178,13 @@ class CalendarBirthdayLookupTest {
     }
 
     @Test
-    fun `labelsPotentiallyMatch returns false for same-initial 3-letter name variants`() {
-        // 3-letter names share Soundex codes by initial alone — must not produce false positives
+    fun `labelsPotentiallyMatch returns false for same-initial 3-letter and 4-letter name variants`() {
+        // Names ≤ 4 chars share Soundex codes too easily — guard must block all of them
         assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Tim", "Tom"))
         assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Dan", "Don"))
         assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Ben", "Ban"))
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("John", "Joan"))
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Carl", "Karl"))
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -12,8 +12,10 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.ZoneId
@@ -138,6 +140,95 @@ class CalendarBirthdayLookupTest {
 
         assertNull(lookup.findBirthday("Jane's birthday"))
         verify(exactly = 0) { context.contentResolver }
+    }
+
+    // ── Phonetic / fuzzy matching ─────────────────────────────────────────────
+
+    @Test
+    fun `soundex produces same code for Emily and Emilie`() {
+        assertEquals(CalendarBirthdayLookup.soundex("emily"), CalendarBirthdayLookup.soundex("emilie"))
+    }
+
+    @Test
+    fun `editDistance is 1 for Freya vs Freyja`() {
+        assertEquals(1, CalendarBirthdayLookup.editDistance("freya", "freyja"))
+    }
+
+    @Test
+    fun `editDistance is 2 for Emily vs Emilie`() {
+        assertEquals(2, CalendarBirthdayLookup.editDistance("emily", "emilie"))
+    }
+
+    @Test
+    fun `labelsPotentiallyMatch returns true for Freya vs Freyja via edit distance`() {
+        assertTrue(CalendarBirthdayLookup.labelsPotentiallyMatch("Freya", "Freyja"))
+        assertTrue(CalendarBirthdayLookup.labelsPotentiallyMatch("Freyja", "Freya"))
+    }
+
+    @Test
+    fun `labelsPotentiallyMatch returns true for Emily vs Emilie via Soundex`() {
+        assertTrue(CalendarBirthdayLookup.labelsPotentiallyMatch("Emily", "Emilie"))
+        assertTrue(CalendarBirthdayLookup.labelsPotentiallyMatch("Emilie", "Emily"))
+    }
+
+    @Test
+    fun `labelsPotentiallyMatch returns false for very different names`() {
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Nick", "Nicholas"))
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Kate", "Katherine"))
+    }
+
+    @Test
+    fun `findBirthday matches phonetically similar calendar name Freyja when query is Freya`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Freyja's Birthday",
+            dtStart = LocalDate.of(2020, 8, 22).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(CalendarContract.Events.CONTENT_URI, any(), any(), any(), any())
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val birthday = lookup.findBirthday("Freya's birthday")
+
+        assertNotNull(birthday)
+        assertEquals("Freyja", birthday?.label)
+        assertEquals(8, birthday?.month)
+        assertEquals(22, birthday?.day)
+    }
+
+    @Test
+    fun `findBirthday matches phonetically similar calendar name Emilie when query is Emily`() {
+        val context = mockk<Context>(relaxed = true)
+        val contentResolver = mockk<ContentResolver>(relaxed = true)
+        val cursor = birthdayCursor(
+            title = "Emilie's Birthday",
+            dtStart = LocalDate.of(2020, 3, 10).atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+            isAllDay = true,
+            calendarDisplayName = "Birthdays",
+            accountType = "com.google",
+        )
+        every { context.checkSelfPermission(Manifest.permission.READ_CALENDAR) } returns PackageManager.PERMISSION_GRANTED
+        every { context.contentResolver } returns contentResolver
+        every {
+            contentResolver.query(CalendarContract.Events.CONTENT_URI, any(), any(), any(), any())
+        } returns cursor
+
+        val lookup = CalendarBirthdayLookup(context)
+
+        val birthday = lookup.findBirthday("Emily's birthday")
+
+        assertNotNull(birthday)
+        assertEquals("Emilie", birthday?.label)
+        assertEquals(3, birthday?.month)
+        assertEquals(10, birthday?.day)
     }
 
     private fun birthdayCursor(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/CalendarBirthdayLookupTest.kt
@@ -178,6 +178,14 @@ class CalendarBirthdayLookupTest {
     }
 
     @Test
+    fun `labelsPotentiallyMatch returns false for same-initial 3-letter name variants`() {
+        // 3-letter names share Soundex codes by initial alone — must not produce false positives
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Tim", "Tom"))
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Dan", "Don"))
+        assertFalse(CalendarBirthdayLookup.labelsPotentiallyMatch("Ben", "Ban"))
+    }
+
+    @Test
     fun `findBirthday matches phonetically similar calendar name Freyja when query is Freya`() {
         val context = mockk<Context>(relaxed = true)
         val contentResolver = mockk<ContentResolver>(relaxed = true)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -946,6 +946,8 @@ class NativeIntentHandlerTest {
             if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 4, 5)
         }
         coEvery { importantDateRepository.findByLabel("jane's birthday") } returns null
+        coEvery { importantDateRepository.findByLabel("jane") } returns null
+        coEvery { importantDateRepository.getAll() } returns emptyList()
         every { calendarBirthdayLookup.findBirthday("jane's birthday") } returns CalendarBirthdayLookup.BirthdayEntry(
             label = "Jane Smith",
             normalizedLabel = "jane smith",
@@ -970,6 +972,8 @@ class NativeIntentHandlerTest {
             if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 4, 5)
         }
         coEvery { importantDateRepository.findByLabel("my wife's birthday") } returns null
+        coEvery { importantDateRepository.findByLabel("wife") } returns null
+        coEvery { importantDateRepository.getAll() } returns emptyList()
         every { calendarBirthdayLookup.findBirthday("my wife's birthday") } returns null
         coEvery { contactAliasRepository.getByAlias("wife") } returns ContactAliasEntity(
             alias = "wife",
@@ -1019,6 +1023,61 @@ class NativeIntentHandlerTest {
         assertEquals(expected, resolved)
         verify(exactly = 0) { calendarBirthdayLookup.findBirthday(any()) }
     }
+
+    @Test
+    fun `parseDateString resolves taught important date when query includes birthday suffix`() {
+        // Stored as "Freya" (name-only label), query is "Freya's birthday"
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 8, 22).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 8, 22)
+        }
+        coEvery { importantDateRepository.findByLabel("Freya's birthday") } returns null
+        coEvery { importantDateRepository.findByLabel("freya") } returns ImportantDateEntity(
+            label = "Freya",
+            normalizedLabel = "freya",
+            month = 8,
+            day = 22,
+        )
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "Freya's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+        verify(exactly = 0) { calendarBirthdayLookup.findBirthday(any()) }
+    }
+
+    @Test
+    fun `parseDateString resolves taught important date via fuzzy Room DB match when spelling differs`() {
+        // Stored as "Emilie", query uses STT spelling "Emily"
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 11, 19).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 11, 19)
+        }
+        val emilieEntity = ImportantDateEntity(
+            label = "Emilie",
+            normalizedLabel = "emilie",
+            month = 11,
+            day = 19,
+        )
+        coEvery { importantDateRepository.findByLabel("Emily's birthday") } returns null
+        coEvery { importantDateRepository.findByLabel("emily") } returns null
+        coEvery { importantDateRepository.getAll() } returns listOf(emilieEntity)
+        every { calendarBirthdayLookup.findBirthday(any()) } returns null
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "Emily's birthday") as LocalDate?
+
+        assertEquals(expected, resolved)
+    }
+
 
     @Test
     fun `get_date_diff since uses the most recent recurring important date`() {


### PR DESCRIPTION
## Summary

Fixes two root causes for "How long until Freya's birthday" failing while "When is Freya's birthday" works:

1. **Birthday suffix not stripped before Room DB lookup** — `parseDateString("Freya's birthday")` was calling `findByLabel("Freya's birthday")` directly, never matching a stored label of `"Freya"`. Now strips the suffix and retries.

2. **STT spelling variants cause mismatches** — `CalendarBirthdayLookup.labelsPotentiallyMatch()` previously only did exact token matching. Now uses Soundex phonetic matching + edit-distance fallback to handle pairs like Emily/Emilie and Freya/Freyja.

## Changes

- **`CalendarBirthdayLookup.kt`** — Added `soundex()` and `editDistance()` as `internal` companion functions; `tokensEquivalent()` now tries Soundex first, then edit distance (threshold = `maxLen / 3` for names ≥ 4 chars)
- **`NativeIntentHandler.kt`** — `parseDateString()` birthday block now: strip suffix → exact Room DB by name → fuzzy Room DB via `getAll()` + `labelsPotentiallyMatch()` → calendar → alias
- **`CalendarBirthdayLookupTest.kt`** — 8 new tests covering soundex purity, edit distance, `labelsPotentiallyMatch` true/false cases, and phonetic `findBirthday` matches
- **`NativeIntentHandlerTest.kt`** — 2 new tests: birthday-suffix stripping (stored "Freya", query "Freya's birthday") and fuzzy Room DB match (stored "Emilie", query "Emily's birthday"); plus explicit mocks added to two existing tests

## Phonetic matching details

| Pair | Method | Result |
|------|--------|--------|
| Emily / Emilie | Soundex (E540 == E540) | ✓ match |
| Freya / Freyja | Edit distance (1 ≤ threshold 2) | ✓ match |
| Nicholas / Nick | Edit distance (5 > threshold 2) | ✗ no false match |

## Testing

- [x] `./gradlew :core:skills:testDebugUnitTest` — all tests pass
- [x] `./gradlew :app:assembleDebug` — clean build

Closes #856
