### PR TITLE
docs(#826): capture meal planner follow-up phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 |- 🔒 **Blank response guard** — retries without RAG before showing fallback when LiteRT produces 0 tokens; keeps chat awake during load and generation (#839/#841, PRs #840/#842)
 |- 🎙️ **Homescreen Glance widget** — quick actions and voice from the launcher via GlanceAppWidget; VoiceCommandActivity and WidgetTextInputActivity with task isolation (#617, PR #847)
 |- 🔧 **Audio quality fixes** — AudioTrack tail cutoff prevention via hardware-latency silence padding; expectedSlotPromptSpeech normalisation to match TTS output; SID=0 clamp for single-speaker voices; aye pronunciation correction (#837/#828/#810, PRs #838/#836/#811)
+- 🍽️ **Deterministic meal planner foundation** — app-owned meal-planning sessions with bounded JSON generation, per-day recipe persistence, shopping-list projection, quantity sanity validation, and quick-action/chat handoff (#859, PR #864)
 
 ### Coming Soon
 - 💬 **Expanded multi-turn dialog** — broader confirmation, digression, and slot-filling coverage across more intents *(Phase 3G, #708 and follow-ups)*
+- 🍽️ **Meal planner phase 2** — progressive day-by-day reveal, visible `x of y` generation progress, and interruption-safe resume/background handling *(#869)*
 - 🗒️ **Lists — management upgrades** — rename, pin, sort, edit items, favorites, and due dates *(#662)*
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen *(Phase 3, #479)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -214,7 +214,7 @@ Active follow-on model/runtime investigations now live under
 | [#676](https://github.com/NickMonrad/kernel-ai-assistant/issues/676) | Native unit conversion tool | ✅ Done — PR #816 | 🟡 Medium |
 | [#677](https://github.com/NickMonrad/kernel-ai-assistant/issues/677) | World clock and timezone lookup | ✅ Done — PR #743 | 🟢 Low |
 | [#697](https://github.com/NickMonrad/kernel-ai-assistant/issues/697) | Multi-day weather forecast card in chat | ✅ Done — PR #710 | 🟡 Medium |
-| [#827](https://github.com/NickMonrad/kernel-ai-assistant/issues/827) | Cooking weights and measures for meal planning | 🔄 In progress | 🟡 Medium |
+| [#827](https://github.com/NickMonrad/kernel-ai-assistant/issues/827) | Cooking weights and measures for meal planning | ✅ Done — PR #855 | 🟡 Medium |
 | [#831](https://github.com/NickMonrad/kernel-ai-assistant/issues/831) | Deterministic currency conversion skill | ✅ Done — PR #848 | 🟡 Medium |
 
 **Already completed skills:**
@@ -355,6 +355,25 @@ Deterministic multi-turn quick actions — slot filling and confirmation baselin
 | Sub-Issue | Title | Status | Priority |
 |-----------|-------|--------|----------|
 | [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Add media control intents: pause, stop, skip, previous | ✅ Done | 🟡 Medium |
+
+
+### 3I: Meal Planning Roadmap ([#826](https://github.com/NickMonrad/kernel-ai-assistant/issues/826))
+
+Deterministic meal planning now has its v1 foundation merged. The next phases are deliberately split so UX/resiliency work, durable artifact expansion, and recipe grounding can evolve independently without reopening the prompt-heavy architecture that #859 replaced.
+
+| Sub-Issue | Title | Status | Priority |
+|-----------|-------|--------|----------|
+| [#827](https://github.com/NickMonrad/kernel-ai-assistant/issues/827) | Cooking weights and measures for meal planning | ✅ Done — PR #855 | 🟡 Medium |
+| [#859](https://github.com/NickMonrad/kernel-ai-assistant/issues/859) | Deterministic meal planner foundation | ✅ Done — PR #864 | 🔴 High |
+| [#869](https://github.com/NickMonrad/kernel-ai-assistant/issues/869) | Meal planner phase 2 — progressive reveal + interruption-safe generation | ⬜ Pending | 🔴 High |
+| [#235](https://github.com/NickMonrad/kernel-ai-assistant/issues/235) | Artifact entity — persistent structured documents in Room DB | ⬜ Pending | 🟡 Medium |
+| [#43](https://github.com/NickMonrad/kernel-ai-assistant/issues/43) | Recipe skill datasources & regional produce | ⬜ Pending | 🟢 Low |
+
+**Current state after PR #864:**
+
+- Shipped: app-owned meal-planner session/day/recipe/grocery tables, bounded JSON generation, quantity sanity validation, deterministic shopping/recipe projections, and quick-action/widget handoff into chat.
+- Next UX gap: longer multi-day plans still complete as one long foreground experience; users need progressive day-by-day reveal, explicit `Generating recipe x of y` feedback, and clean resume after interruption/backgrounding (#869).
+- Later platform/data phases stay separate by design: #235 expands durable structured artifacts; #43 adds recipe grounding and regional produce data.
 
 ---
 

--- a/specification.md
+++ b/specification.md
@@ -116,3 +116,5 @@ Current phase summary:
 4. **Phase 4 ⬜:** Dreaming Engine — overnight consolidation, semantic cache, and self-healing identity.
 5. **Phase 5 ⬜:** Chicory Wasm Runtime + GitHub-based Skill Store.
 6. **Phase 6 ⬜:** 8GB device optimisation and compatibility-tier loading strategy.
+
+Phase 3 also now includes the merged deterministic meal-planner foundation from [#859](https://github.com/NickMonrad/kernel-ai-assistant/issues/859) / PR #864. The next planned meal-planner slice is [#869](https://github.com/NickMonrad/kernel-ai-assistant/issues/869): progressive reveal, explicit progress, and interruption-safe generation on top of the existing app-owned state machine.


### PR DESCRIPTION
## Summary
- mark cooking weights and measures (#827) as shipped in the roadmap
- add a dedicated meal-planning roadmap section covering the merged #859 foundation and the next follow-up phases
- update README/specification to point at the new progressive reveal + interruption-safe generation issue (#869)

## Testing
- not run (documentation-only changes)

Refs #826