### PR TITLE
fix(#865): widget inside corner radius mismatch

### DIFF
--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/KernelWidget.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/KernelWidget.kt
@@ -50,6 +50,7 @@ private fun KernelWidgetContent(packageName: String) {
                         night = Color(0xCC000000),
                     )
                 )
+                .cornerRadius(24.dp)
                 .padding(horizontal = 8.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -62,6 +63,7 @@ private fun KernelWidgetContent(packageName: String) {
                             night = Color(0x1AFFFFFF),
                         )
                     )
+                    .cornerRadius(16.dp)
                     .padding(horizontal = 16.dp, vertical = 12.dp)
                     .clickable(actionStartActivity(WidgetTextInputActivity::class.java)),
                 contentAlignment = Alignment.CenterStart,


### PR DESCRIPTION
## Summary

The widget's outer `Row` had no `cornerRadius`, so when the launcher clips the widget to its system-rounded corners, the inner text pill appeared with sharp corners — a visual mismatch.

## Changes

- Added `cornerRadius(24.dp)` to the outer `Row` (matches the mic button radius and the system clip)
- Added `cornerRadius(16.dp)` to the text pill `Box` (slightly inset to look naturally nested)

## Testing

- Build and install, add widget to home screen — inside corners of the text pill should now match the outer widget shape

## Related issues

Closes #865
