### PR TITLE
feat(#869): add progressive meal planner flow

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
@@ -22,6 +22,7 @@ enum class MealPlanDayStatus {
 enum class PendingGenerationKind {
     PLAN,
     RECIPE,
+    REPLACEMENT,
 }
 
 enum class GroceryNormalizationStatus {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -102,7 +102,7 @@ class MealPlanSessionRepository @Inject constructor(
                     title = day.title,
                     summary = day.summary,
                     proteinTagsJson = day.proteinTags.distinct().toJsonArrayString(),
-                    status = MealPlanDayStatus.PENDING.name,
+                    status = MealPlanDayStatus.DRAFTED.name,
                     currentRecipeVersion = null,
                     attemptCount = 0,
                     lastErrorCode = null,
@@ -114,10 +114,10 @@ class MealPlanSessionRepository @Inject constructor(
         )
         val updatedSession = session.copy(
             status = MealPlanSessionStatus.PLAN_REVIEW.name,
-            pendingGenerationKind = PendingGenerationKind.RECIPE.name,
-            pendingGenerationDayIndex = 0,
+            pendingGenerationKind = null,
+            pendingGenerationDayIndex = null,
             pendingGenerationStartedAt = null,
-            activeDayIndex = 0,
+            activeDayIndex = null,
             planVersion = session.planVersion + 1,
             updatedAt = now,
         )
@@ -140,7 +140,7 @@ class MealPlanSessionRepository @Inject constructor(
                 title = title,
                 summary = summary,
                 proteinTagsJson = proteinTags.distinct().toJsonArrayString(),
-                status = MealPlanDayStatus.PENDING.name,
+                status = MealPlanDayStatus.DRAFTED.name,
                 updatedAt = System.currentTimeMillis(),
                 lastErrorCode = null,
                 lastErrorMessage = null,
@@ -149,11 +149,28 @@ class MealPlanSessionRepository @Inject constructor(
         val session = requireNotNull(sessionDao.getById(sessionId))
         val updatedSession = session.copy(
             status = MealPlanSessionStatus.PLAN_REVIEW.name,
-            activeDayIndex = dayIndex,
+            activeDayIndex = null,
+            pendingGenerationKind = null,
+            pendingGenerationDayIndex = null,
+            pendingGenerationStartedAt = null,
             updatedAt = System.currentTimeMillis(),
         )
         sessionDao.update(updatedSession)
         return updatedSession.toSnapshot()
+    }
+
+    suspend fun returnToSlotCollection(sessionId: String): MealPlanSnapshot {
+        val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
+        val updated = session.copy(
+            status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS.name,
+            activeDayIndex = null,
+            pendingGenerationKind = null,
+            pendingGenerationDayIndex = null,
+            pendingGenerationStartedAt = null,
+            updatedAt = System.currentTimeMillis(),
+        )
+        sessionDao.update(updated)
+        return updated.toSnapshot()
     }
 
     suspend fun persistRecipeDraft(
@@ -163,6 +180,10 @@ class MealPlanSessionRepository @Inject constructor(
         rawModelJson: String,
         groceries: List<CanonicalGroceryItem>,
     ): MealPlanSnapshot {
+        val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
+        if (session.status == MealPlanSessionStatus.CANCELLED.name) {
+            return session.toSnapshot()
+        }
         val now = System.currentTimeMillis()
         val day = requireNotNull(dayDao.getBySessionAndIndex(sessionId, dayIndex)) {
             "Unknown meal-plan day $dayIndex for session $sessionId"
@@ -215,11 +236,11 @@ class MealPlanSessionRepository @Inject constructor(
         rebuildRecipeProjection(sessionId, day.id, dayIndex, recipeVersion)
         rebuildShoppingProjection(sessionId)
 
-        val session = requireNotNull(sessionDao.getById(sessionId))
+        val currentSession = requireNotNull(sessionDao.getById(sessionId))
         val nextPending = dayDao.getBySession(sessionId)
             .firstOrNull { it.status != MealPlanDayStatus.PERSISTED.name }
         val updatedSession = if (nextPending == null) {
-            session.copy(
+            currentSession.copy(
                 status = MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY.name,
                 activeDayIndex = null,
                 pendingGenerationKind = null,
@@ -228,7 +249,7 @@ class MealPlanSessionRepository @Inject constructor(
                 updatedAt = now,
             )
         } else {
-            session.copy(
+            currentSession.copy(
                 status = MealPlanSessionStatus.RECIPES_IN_PROGRESS.name,
                 activeDayIndex = nextPending.dayIndex,
                 pendingGenerationKind = PendingGenerationKind.RECIPE.name,
@@ -267,7 +288,7 @@ class MealPlanSessionRepository @Inject constructor(
             activeDayIndex = dayIndex,
             pendingGenerationKind = if (dayIndex == null) PendingGenerationKind.PLAN.name else PendingGenerationKind.RECIPE.name,
             pendingGenerationDayIndex = dayIndex,
-            pendingGenerationStartedAt = now,
+            pendingGenerationStartedAt = null,
             updatedAt = now,
         )
         sessionDao.update(updated)
@@ -280,10 +301,13 @@ class MealPlanSessionRepository @Inject constructor(
         dayIndex: Int? = null,
     ) {
         val session = requireNotNull(sessionDao.getById(sessionId))
+        if (session.status == MealPlanSessionStatus.CANCELLED.name) {
+            return
+        }
         sessionDao.update(
             session.copy(
                 status = if (kind == PendingGenerationKind.PLAN) {
-                    MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS.name
+                    MealPlanSessionStatus.PLAN_REVIEW.name
                 } else {
                     MealPlanSessionStatus.RECIPES_IN_PROGRESS.name
                 },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2864,7 +2864,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need|would\s+like)\s+to)\s+)?(?:plan|make|create)\s+(?:some\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)\s+(?:(?:some|my)\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -2872,7 +2872,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets)\s+)?(?:plan|make|create)\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -2880,7 +2880,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:meal\s+planning|plan\s+my\s+meals|help\s+me\s+plan\s+meals)[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:meal\s+planning|plan\s+my\s+meals|help\s+me\s+plan\s+meals)[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2864,7 +2864,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)\s+(?:(?:some|my)\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:(?:some|my)\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -2872,7 +2872,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1738,11 +1738,11 @@ class QuickIntentRouter(
         ),
         // Open app — "open YouTube" / "launch Spotify"
         // Excludes timer/countdown/alarm phrases and phrases that contain "timer" anywhere
-        // Also excludes list and new-conversation/chat phrases to prevent false matches on slot-fill commands
+        // Also excludes list, meal-planner, and new-conversation/chat phrases to prevent false matches on deterministic skills
         IntentPattern(
             intentName = "open_app",
             regex = Regex(
-                """^(?:open|launch|start)\s+(?:the\s+)?(?!(?:a\s+)?(?:count(?:down|ing)|timer|alarm|(?:my\s+)?list|new\s+conversation|new\s+chat|conversation|chat)\b)(?!.*\btimer\b)(.+?)(?:\s+app)?$""",
+                """^(?:open|launch|start)\s+(?:the\s+)?(?!(?:a\s+)?(?:count(?:down|ing)|timer|alarm|(?:my\s+)?list|meal\s+planning|meal\s+plan|meal\s+prep|meals?|dinners?|menu|new\s+conversation|new\s+chat|conversation|chat)\b)(?!.*\btimer\b)(.+?)(?:\s+app)?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("app_name" to match.groupValues[1].trim()) },
@@ -2864,7 +2864,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:(?:some|my)\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|could\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:(?:some|my)\s+)?meals?(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -2872,7 +2872,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|could\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:plan|make|create)(?:\s+me)?\s+(?:a\s+)?meal\s+plan(?:\s+for\s+me)?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
@@ -2880,7 +2880,23 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "start_meal_planner",
             regex = Regex(
-                """^(?:(?:let'?s|lets|can\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:meal\s+planning|plan\s+my\s+meals|help\s+me\s+plan\s+meals)[.!?]*$""",
+                """^(?:(?:let'?s|lets|can\s+you|could\s+you|help\s+me|i\s+(?:want|need)\s+to|i\s+would\s+like\s+to|i(?:['’])?d\s+like\s+to)\s+)?(?:meal\s+planning|plan\s+my\s+meals|help\s+me\s+plan\s+meals)[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "start_meal_planner",
+            regex = Regex(
+                """^(?:(?:please\s+)?(?:can\s+you|could\s+you)|i\s+(?:want|need)|i\s+would\s+like|i(?:['’])?d\s+like|give\s+me)?\s*(?:a\s+)?(?:meal\s+plan|meal\s+planning|weekly\s+menu)(?:\s+(?:for\s+the\s+week|this\s+week|weekly))?(?:\s+please)?[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        IntentPattern(
+            intentName = "start_meal_planner",
+            regex = Regex(
+                """^(?:(?:let'?s|lets|can\s+you|could\s+you|please|help\s+me)\s+)?(?:plan|start|set\s+up|organi[sz]e|map\s+out|figure\s+out|sort\s+out|prep)\s+(?:(?:(?:my|our|the|a)\s+)?(?:weekly\s+)?)?(?:meal\s+planning|meal\s+plan|meals?|dinners?|menu|meal\s+prep)(?:\s+(?:for\s+the\s+week|this\s+week|weekly))?[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParser.kt
@@ -33,11 +33,16 @@ class MealPlanJsonParser @Inject constructor() {
             throw MealPlanValidationException("Replacement day JSON must contain exactly one day.")
         }
         val day = days.single()
-        if (day.dayIndex != expectedDayIndex) {
-            throw MealPlanValidationException("Replacement day JSON must use day_index $expectedDayIndex.")
+        val normalizedDayIndex = when (day.dayIndex) {
+            expectedDayIndex -> expectedDayIndex
+            expectedDayIndex + 1 -> expectedDayIndex
+            else -> throw MealPlanValidationException(
+                "Replacement day JSON must use day_index $expectedDayIndex (zero-based for Day ${expectedDayIndex + 1}).",
+            )
         }
-        validatePlanDayTitles(listOf(day))
-        return day
+        val normalizedDay = day.copy(dayIndex = normalizedDayIndex)
+        validatePlanDayTitles(listOf(normalizedDay))
+        return normalizedDay
     }
 
     private fun parsePlanDays(raw: String): List<MealPlanDraftDay> {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParser.kt
@@ -14,18 +14,7 @@ import javax.inject.Singleton
 @Singleton
 class MealPlanJsonParser @Inject constructor() {
     fun parsePlanDraft(raw: String, expectedDays: Int): MealPlanDraft {
-        val obj = parseRootObject(raw)
-        val daysArray = obj.optJSONArray("days")
-            ?: throw MealPlanValidationException("Plan JSON must contain a 'days' array.")
-        val days = List(daysArray.length()) { index ->
-            val item = daysArray.getJSONObject(index)
-            MealPlanDraftDay(
-                dayIndex = item.optInt("day_index", -1),
-                title = item.optString("title").trim(),
-                summary = item.optString("summary").trim().takeIf { it.isNotBlank() },
-                proteinTags = jsonArrayToStrings(item.optJSONArray("protein_tags")),
-            )
-        }
+        val days = parsePlanDays(raw)
         if (days.size != expectedDays) {
             throw MealPlanValidationException("Plan JSON returned ${days.size} days; expected $expectedDays.")
         }
@@ -34,14 +23,45 @@ class MealPlanJsonParser @Inject constructor() {
         if (actualIndexes != expectedIndexes) {
             throw MealPlanValidationException("Plan JSON day_index values must be contiguous from 0 to ${expectedDays - 1}.")
         }
+        validatePlanDayTitles(days)
+        return MealPlanDraft(days)
+    }
+
+    fun parseSinglePlanDay(raw: String, expectedDayIndex: Int): MealPlanDraftDay {
+        val days = parsePlanDays(raw)
+        if (days.size != 1) {
+            throw MealPlanValidationException("Replacement day JSON must contain exactly one day.")
+        }
+        val day = days.single()
+        if (day.dayIndex != expectedDayIndex) {
+            throw MealPlanValidationException("Replacement day JSON must use day_index $expectedDayIndex.")
+        }
+        validatePlanDayTitles(listOf(day))
+        return day
+    }
+
+    private fun parsePlanDays(raw: String): List<MealPlanDraftDay> {
+        val obj = parseRootObject(raw)
+        val daysArray = obj.optJSONArray("days")
+            ?: throw MealPlanValidationException("Plan JSON must contain a 'days' array.")
+        return List(daysArray.length()) { index ->
+            val item = daysArray.getJSONObject(index)
+            MealPlanDraftDay(
+                dayIndex = item.optInt("day_index", -1),
+                title = item.optString("title").trim(),
+                summary = item.optString("summary").trim().takeIf { it.isNotBlank() },
+                proteinTags = jsonArrayToStrings(item.optJSONArray("protein_tags")),
+            )
+        }
+    }
+
+    private fun validatePlanDayTitles(days: List<MealPlanDraftDay>) {
         days.forEach {
             if (it.title.isBlank()) {
                 throw MealPlanValidationException("Each plan day must include a non-blank title.")
             }
         }
-        return MealPlanDraft(days)
     }
-
     fun parseRecipeDraft(raw: String, expectedServings: Int): RecipeDraft {
         val obj = parseRootObject(raw)
         val title = obj.optString("title").trim()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -623,8 +623,10 @@ Remember: this is user-visible Day ${dayIndex + 1}, but the JSON day_index must 
 """.trimIndent()
 
     private fun isFinalizeRequest(text: String): Boolean =
-        Regex("\\b(?:done meal planning|done with meal planning|finalize meal plan|finalise meal plan|done)\\b", RegexOption.IGNORE_CASE)
-            .containsMatchIn(text)
+        Regex(
+            """\b(?:done(?:\s+with\s+meal\s+planning|\s+meal\s+planning)?|finali[sz]e(?:\s+(?:meal\s+plan|meal\s+planning))?)\b""",
+            RegexOption.IGNORE_CASE,
+        ).containsMatchIn(text)
 }
 
 data class MealPlannerReply(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -3,9 +3,9 @@ package com.kernel.ai.core.skills.mealplan
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.inference.InferenceEngine
 import com.kernel.ai.core.memory.mealplan.MealPlanDayStatus
-import com.kernel.ai.core.memory.mealplan.MealPlanDraftDay
 import com.kernel.ai.core.memory.mealplan.MealPlanSessionStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
+import com.kernel.ai.core.memory.mealplan.PendingGenerationKind
 import com.kernel.ai.core.memory.mealplan.RecipeDraft
 import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
@@ -40,7 +40,11 @@ class MealPlannerCoordinator @Inject constructor(
         return MealPlannerReply(promptForSnapshot(snapshot))
     }
 
-    suspend fun ingestUserMessage(conversationId: String, text: String): MealPlannerReply {
+    suspend fun ingestUserMessage(
+        conversationId: String,
+        text: String,
+        onPlannerMessage: suspend (String) -> Unit = {},
+    ): MealPlannerReply {
         val snapshot = sessionRepository.getActiveSession(conversationId)
             ?: return startOrResume(conversationId)
 
@@ -55,9 +59,9 @@ class MealPlannerCoordinator @Inject constructor(
 
         return when (snapshot.status) {
             MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS -> handleCollecting(snapshot, text)
-            MealPlanSessionStatus.PLAN_REVIEW -> handlePlanReview(snapshot, text)
+            MealPlanSessionStatus.PLAN_REVIEW -> handlePlanReview(snapshot, text, onPlannerMessage)
             MealPlanSessionStatus.RECIPES_IN_PROGRESS,
-            MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> handleActiveOrRecovery(snapshot, text)
+            MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> handleActiveOrRecovery(snapshot, text, onPlannerMessage)
             MealPlanSessionStatus.COMPLETED -> MealPlannerReply(
                 "This meal plan is already finalized. Start a new one by asking me to plan meals again.",
             )
@@ -66,34 +70,88 @@ class MealPlannerCoordinator @Inject constructor(
     }
 
     private suspend fun handleCollecting(snapshot: MealPlanSnapshot, text: String): MealPlannerReply {
+        val peopleCount = slotExtractor.extractPeopleCount(text)
+        val daysCount = slotExtractor.extractDaysCount(text)
+        val dietaryRestrictions = slotExtractor.extractDietaryRestrictions(text)
+        val proteinPreferences = slotExtractor.extractProteinPreferences(text)
         val updated = sessionRepository.updateRequiredSlots(
             sessionId = snapshot.sessionId,
-            peopleCount = slotExtractor.extractPeopleCount(text),
-            daysCount = slotExtractor.extractDaysCount(text),
-            dietaryRestrictions = slotExtractor.extractDietaryRestrictions(text),
-            proteinPreferences = slotExtractor.extractProteinPreferences(text),
+            peopleCount = peopleCount,
+            daysCount = daysCount,
+            dietaryRestrictions = dietaryRestrictions,
+            proteinPreferences = proteinPreferences,
         )
         val missing = missingSlots(updated)
         if (missing.isNotEmpty()) {
             return MealPlannerReply(promptForMissingSlots(updated, missing))
         }
-        return generatePlanAndPendingRecipes(updated)
-    }
-
-    private suspend fun handlePlanReview(snapshot: MealPlanSnapshot, text: String): MealPlannerReply {
-        val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
-        if (replaceDayIndex != null) {
-            val replaced = generateReplacementDay(snapshot, replaceDayIndex)
-            return generatePendingRecipesFrom(replaced, intro = buildPlanSummary(replaced))
+        val hadAllSlotsBefore = missingSlots(snapshot).isEmpty()
+        val hasAnySlotUpdates =
+            peopleCount != null || daysCount != null || dietaryRestrictions != null || proteinPreferences != null
+        if (hadAllSlotsBefore && !hasAnySlotUpdates) {
+            return MealPlannerReply(promptForPreferenceEditing(updated))
         }
-        return generatePendingRecipesFrom(snapshot, intro = buildPlanSummary(snapshot))
+        return generatePlanForReview(updated)
     }
 
-    private suspend fun handleActiveOrRecovery(snapshot: MealPlanSnapshot, text: String): MealPlannerReply {
+    private suspend fun handlePlanReview(
+        snapshot: MealPlanSnapshot,
+        text: String,
+        onPlannerMessage: suspend (String) -> Unit,
+    ): MealPlannerReply {
         val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
         if (replaceDayIndex != null) {
-            val replaced = generateReplacementDay(snapshot, replaceDayIndex)
-            return generateSpecificDayRecipe(replaced, replaceDayIndex, intro = "I replaced Day ${replaceDayIndex + 1}. Here’s the updated recipe:\n")
+            return try {
+                val replaced = generateReplacementDay(snapshot, replaceDayIndex)
+                MealPlannerReply(planReviewPrompt(replaced))
+            } catch (e: IllegalArgumentException) {
+                MealPlannerReply(replacementFailureMessage(replaceDayIndex, e.message))
+            } catch (e: MealPlanValidationException) {
+                MealPlannerReply(replacementFailureMessage(replaceDayIndex, e.message))
+            }
+        }
+        if (slotExtractor.isChangePreferencesRequest(text)) {
+            val editable = sessionRepository.returnToSlotCollection(snapshot.sessionId)
+            return MealPlannerReply(promptForPreferenceEditing(editable))
+        }
+        if (slotExtractor.isGenerateRecipesRequest(text)) {
+            return if (snapshot.days.isEmpty()) {
+                generatePlanForReview(snapshot)
+            } else {
+                generatePendingRecipesFrom(snapshot, onPlannerMessage = onPlannerMessage)
+            }
+        }
+        return MealPlannerReply(planReviewPrompt(snapshot))
+    }
+
+    private suspend fun handleActiveOrRecovery(
+        snapshot: MealPlanSnapshot,
+        text: String,
+        onPlannerMessage: suspend (String) -> Unit,
+    ): MealPlannerReply {
+        val failedDay = snapshot.days.firstOrNull { it.status == MealPlanDayStatus.FAILED }
+        val pendingDay = snapshot.days.firstOrNull { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
+        if (failedDay == null && pendingDay != null) {
+            if (slotExtractor.isGenerateRecipesRequest(text)) {
+                return generatePendingRecipesFrom(
+                    snapshot,
+                    intro = "Resuming your meal plan at Day ${pendingDay.dayIndex + 1} of ${snapshot.days.size}…",
+                    onPlannerMessage = onPlannerMessage,
+                )
+            }
+            return MealPlannerReply(resumePrompt(snapshot, pendingDay.dayIndex))
+        }
+
+        val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
+        if (replaceDayIndex != null) {
+            return try {
+                val replaced = generateReplacementDay(snapshot, replaceDayIndex)
+                generateSpecificDayRecipe(replaced, replaceDayIndex, intro = "I replaced Day ${replaceDayIndex + 1}. Here’s the updated recipe:\n")
+            } catch (e: IllegalArgumentException) {
+                MealPlannerReply(replacementFailureMessage(replaceDayIndex, e.message))
+            } catch (e: MealPlanValidationException) {
+                MealPlannerReply(replacementFailureMessage(replaceDayIndex, e.message))
+            }
         }
         val regenerateDayIndex = slotExtractor.extractRegenerateDayIndex(text)
         if (regenerateDayIndex != null) {
@@ -104,18 +162,17 @@ class MealPlannerCoordinator @Inject constructor(
             writeFinalSummaryIfNeeded(completed)
             return MealPlannerReply("Meal planning is finalized. Your per-plan shopping list and recipe lists are ready.")
         }
-        val pendingDay = snapshot.days.firstOrNull { it.status != MealPlanDayStatus.PERSISTED }
-        if (pendingDay != null) {
-            return generatePendingRecipesFrom(snapshot)
+        if (failedDay != null) {
+            return MealPlannerReply(recoveryPrompt(failedDay.dayIndex))
         }
         return MealPlannerReply(
             "Your meal plan is ready. Say 'regenerate day 2', 'replace day 1', or 'done meal planning' to finalize it.",
         )
     }
 
-    private suspend fun generatePlanAndPendingRecipes(snapshot: MealPlanSnapshot): MealPlannerReply =
+    private suspend fun generatePlanForReview(snapshot: MealPlanSnapshot): MealPlannerReply =
         withSessionGeneration(snapshot.sessionId) {
-            sessionRepository.markPendingGeneration(snapshot.sessionId, com.kernel.ai.core.memory.mealplan.PendingGenerationKind.PLAN)
+            sessionRepository.markPendingGeneration(snapshot.sessionId, PendingGenerationKind.PLAN)
             val rawPlan = inferenceEngine.generateOnce(
                 prompt = buildPlanUserPrompt(snapshot),
                 systemPrompt = buildPlanSystemPrompt(),
@@ -140,60 +197,68 @@ class MealPlannerCoordinator @Inject constructor(
                 return@withSessionGeneration MealPlannerReply("I couldn't generate a valid high-level plan yet. ${e.message} Try replying with the same requirements again or adjust them.")
             }
             val planned = sessionRepository.savePlanDraft(snapshot.sessionId, planDraft.days)
-            generatePendingRecipesFrom(planned, intro = buildPlanSummary(planned))
+            MealPlannerReply(planReviewPrompt(planned))
         }
 
-    private suspend fun generatePendingRecipesFrom(snapshot: MealPlanSnapshot, intro: String? = null): MealPlannerReply {
-        val builder = StringBuilder()
-        if (!intro.isNullOrBlank()) {
-            builder.append(intro.trim())
-        }
+    private suspend fun generatePendingRecipesFrom(
+        snapshot: MealPlanSnapshot,
+        intro: String? = null,
+        onPlannerMessage: suspend (String) -> Unit = {},
+    ): MealPlannerReply = withSessionGeneration(snapshot.sessionId) {
         var currentSnapshot = sessionRepository.getSession(snapshot.sessionId) ?: snapshot
-        val pendingDays = currentSnapshot.days.filter { it.status != MealPlanDayStatus.PERSISTED }
+        if (!intro.isNullOrBlank()) {
+            onPlannerMessage(intro.trim())
+        }
+        val totalDays = currentSnapshot.days.size
+        val pendingDays = currentSnapshot.days
+            .filter { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
+            .sortedBy { it.dayIndex }
         for (day in pendingDays) {
+            onPlannerMessage("Generating recipe ${day.dayIndex + 1} of $totalDays…")
             val recipeResult = try {
                 generateAndPersistRecipe(currentSnapshot, day.dayIndex)
             } catch (e: MealPlanValidationException) {
-                if (builder.isNotEmpty()) builder.append("\n\n")
-                builder.append("I hit a validation problem while generating Day ${day.dayIndex + 1}: ${e.message}")
-                builder.append("\nSay 'regenerate day ${day.dayIndex + 1}' or 'replace day ${day.dayIndex + 1}' to recover.")
-                return MealPlannerReply(builder.toString().trim())
+                return@withSessionGeneration MealPlannerReply(
+                    "I hit a validation problem while generating Day ${day.dayIndex + 1}: ${e.message}\nSay 'regenerate day ${day.dayIndex + 1}' or 'replace day ${day.dayIndex + 1}' to recover.",
+                )
             }
-            if (builder.isNotEmpty()) builder.append("\n\n")
-            builder.append(formatRecipeSection(day.dayIndex, recipeResult.recipe))
+            onPlannerMessage(formatRecipeSection(day.dayIndex, recipeResult.recipe))
             currentSnapshot = recipeResult.snapshot
         }
         if (currentSnapshot.days.all { it.status == MealPlanDayStatus.PERSISTED }) {
-            builder.append("\n\nYour meal plan is ready. Say 'regenerate day 2', 'replace day 1', or 'done meal planning' to finalize it.")
+            MealPlannerReply("Your meal plan is ready. Say 'regenerate day 2', 'replace day 1', or 'done meal planning' to finalize it.")
+        } else {
+            val nextPending = currentSnapshot.days.firstOrNull { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
+            MealPlannerReply(nextPending?.let { resumePrompt(currentSnapshot, it.dayIndex) } ?: "Your meal plan is ready.")
         }
-        return MealPlannerReply(builder.toString().trim())
     }
 
-    private suspend fun generateSpecificDayRecipe(snapshot: MealPlanSnapshot, dayIndex: Int, intro: String): MealPlannerReply {
-        val result = try {
-            generateAndPersistRecipe(snapshot, dayIndex)
-        } catch (e: MealPlanValidationException) {
-            return MealPlannerReply(
-                "I couldn't generate a valid recipe for Day ${dayIndex + 1}: ${e.message} Say 'regenerate day ${dayIndex + 1}' or 'replace day ${dayIndex + 1}'.",
-            )
+    private suspend fun generateSpecificDayRecipe(snapshot: MealPlanSnapshot, dayIndex: Int, intro: String): MealPlannerReply =
+        withSessionGeneration(snapshot.sessionId) {
+            val result = try {
+                generateAndPersistRecipe(snapshot, dayIndex)
+            } catch (e: MealPlanValidationException) {
+                return@withSessionGeneration MealPlannerReply(
+                    "I couldn't generate a valid recipe for Day ${dayIndex + 1}: ${e.message} Say 'regenerate day ${dayIndex + 1}' or 'replace day ${dayIndex + 1}'.",
+                )
+            }
+            val builder = StringBuilder()
+            builder.append(intro)
+            builder.append(formatRecipeSection(dayIndex, result.recipe))
+            if (result.snapshot.days.all { it.status == MealPlanDayStatus.PERSISTED }) {
+                builder.append("\n\nYour meal plan is ready. Say 'done meal planning' to finalize it, or regenerate another day.")
+            }
+            MealPlannerReply(builder.toString().trim())
         }
-        val builder = StringBuilder()
-        builder.append(intro)
-        builder.append(formatRecipeSection(dayIndex, result.recipe))
-        if (result.snapshot.days.all { it.status == MealPlanDayStatus.PERSISTED }) {
-            builder.append("\n\nYour meal plan is ready. Say 'done meal planning' to finalize it, or regenerate another day.")
-        }
-        return MealPlannerReply(builder.toString().trim())
-    }
 
     private suspend fun generateAndPersistRecipe(
         snapshot: MealPlanSnapshot,
         dayIndex: Int,
-    ): GeneratedRecipeResult = withSessionGeneration(snapshot.sessionId) {
+    ): GeneratedRecipeResult {
         val day = snapshot.days.firstOrNull { it.dayIndex == dayIndex }
             ?: throw MealPlanValidationException("Unknown meal-plan day ${dayIndex + 1}.")
         val servings = snapshot.peopleCount ?: throw MealPlanValidationException("Meal-plan session is missing people count.")
-        sessionRepository.markPendingGeneration(snapshot.sessionId, com.kernel.ai.core.memory.mealplan.PendingGenerationKind.RECIPE, dayIndex)
+        sessionRepository.markPendingGeneration(snapshot.sessionId, PendingGenerationKind.RECIPE, dayIndex)
         val rawRecipe = inferenceEngine.generateOnce(
             prompt = buildRecipeUserPrompt(snapshot, dayIndex),
             systemPrompt = buildRecipeSystemPrompt(),
@@ -228,7 +293,7 @@ class MealPlannerCoordinator @Inject constructor(
             rawModelJson = rawRecipe,
             groceries = groceries,
         )
-        GeneratedRecipeResult(updated, recipe, day.title ?: recipe.title)
+        return GeneratedRecipeResult(updated, recipe, day.title ?: recipe.title)
     }
 
     private suspend fun generateReplacementDay(snapshot: MealPlanSnapshot, dayIndex: Int): MealPlanSnapshot =
@@ -243,7 +308,7 @@ class MealPlannerCoordinator @Inject constructor(
             if (raw.isBlank()) {
                 throw MealPlanValidationException("The model didn't return a replacement day.")
             }
-            val replacement = jsonParser.parsePlanDraft(raw, 1).days.single()
+            val replacement = jsonParser.parseSinglePlanDay(raw, dayIndex)
             sessionRepository.replaceDayDraft(
                 sessionId = snapshot.sessionId,
                 dayIndex = dayIndex,
@@ -284,24 +349,34 @@ class MealPlannerCoordinator @Inject constructor(
     }
 
     private fun generationInProgressMessage(snapshot: MealPlanSnapshot): String = when (snapshot.pendingGenerationKind) {
-        com.kernel.ai.core.memory.mealplan.PendingGenerationKind.PLAN ->
+        PendingGenerationKind.PLAN ->
             "I'm still building your meal plan. Give me a moment."
-        com.kernel.ai.core.memory.mealplan.PendingGenerationKind.RECIPE ->
+        PendingGenerationKind.RECIPE ->
             snapshot.pendingGenerationDayIndex?.let { "I'm still finishing Day ${it + 1}. Give me a moment." }
                 ?: "I'm still finishing your meal plan. Give me a moment."
         null -> "I'm still working on your meal plan. Give me a moment."
     }
 
     private fun promptForSnapshot(snapshot: MealPlanSnapshot): String = when (snapshot.status) {
-        MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS -> promptForMissingSlots(snapshot, missingSlots(snapshot))
-        MealPlanSessionStatus.PLAN_REVIEW -> buildPlanSummary(snapshot) + "\n\nIf you want a different day, say 'replace day 2'. Otherwise I can keep going."
+        MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS -> {
+            val missing = missingSlots(snapshot)
+            if (missing.isEmpty()) {
+                promptForPreferenceEditing(snapshot)
+            } else {
+                promptForMissingSlots(snapshot, missing)
+            }
+        }
+        MealPlanSessionStatus.PLAN_REVIEW -> planReviewPrompt(snapshot)
         MealPlanSessionStatus.RECIPES_IN_PROGRESS,
         MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> {
             val failedDay = snapshot.days.firstOrNull { it.status == MealPlanDayStatus.FAILED }
-            if (failedDay != null) {
-                "I still need to finish Day ${failedDay.dayIndex + 1}. Say 'regenerate day ${failedDay.dayIndex + 1}' or 'replace day ${failedDay.dayIndex + 1}'."
-            } else {
-                "Your meal plan is ready. Say 'regenerate day 2', 'replace day 1', or 'done meal planning' to finalize it."
+            when {
+                failedDay != null -> recoveryPrompt(failedDay.dayIndex)
+                snapshot.days.any { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED } -> {
+                    val nextPending = snapshot.days.first { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
+                    resumePrompt(snapshot, nextPending.dayIndex)
+                }
+                else -> "Your meal plan is ready. Say 'regenerate day 2', 'replace day 1', or 'done meal planning' to finalize it."
             }
         }
         MealPlanSessionStatus.COMPLETED -> "Your meal plan is already finalized."
@@ -309,12 +384,7 @@ class MealPlannerCoordinator @Inject constructor(
     }
 
     private fun promptForMissingSlots(snapshot: MealPlanSnapshot, missing: List<String>): String {
-        val knownBits = buildList {
-            snapshot.peopleCount?.let { add("$it people") }
-            snapshot.daysCount?.let { add("$it days") }
-            if (snapshot.dietaryRestrictions.isNotEmpty()) add(snapshot.dietaryRestrictions.joinToString())
-            if (snapshot.proteinPreferences.isNotEmpty()) add(snapshot.proteinPreferences.joinToString())
-        }
+        val knownBits = buildKnownBits(snapshot)
         val prompt = missing.joinToString("\n") { missingSlotPrompt(it) }
         return buildString {
             if (knownBits.isNotEmpty()) {
@@ -323,6 +393,20 @@ class MealPlannerCoordinator @Inject constructor(
             append("I need a few details before I build the plan:\n")
             append(prompt)
         }
+    }
+
+    private fun promptForPreferenceEditing(snapshot: MealPlanSnapshot): String = buildString {
+        append("Current plan details: ")
+        append(buildKnownBits(snapshot).ifEmpty { listOf("no saved details yet") }.joinToString(", "))
+        append(".\n\n")
+        append("Reply with any updated people count, days, dietary requirements, or protein preferences.")
+    }
+
+    private fun buildKnownBits(snapshot: MealPlanSnapshot): List<String> = buildList {
+        snapshot.peopleCount?.let { add("$it people") }
+        snapshot.daysCount?.let { add("$it days") }
+        if (snapshot.dietaryRestrictions.isNotEmpty()) add(snapshot.dietaryRestrictions.joinToString())
+        if (snapshot.proteinPreferences.isNotEmpty()) add(snapshot.proteinPreferences.joinToString())
     }
 
     private fun missingSlots(snapshot: MealPlanSnapshot): List<String> = buildList {
@@ -339,6 +423,22 @@ class MealPlannerCoordinator @Inject constructor(
         "protein" -> "- What protein preferences should I use?"
         else -> "- $slot"
     }
+
+    private fun planReviewPrompt(snapshot: MealPlanSnapshot): String =
+        if (snapshot.days.isEmpty()) {
+            "I still need to rebuild your meal plan draft. Say 'generate recipes' to try again, 'change preferences', or 'cancel'."
+        } else {
+            buildPlanSummary(snapshot) + "\n\nSay 'generate recipes', 'replace day 2', 'change preferences', or 'cancel'."
+        }
+
+    private fun resumePrompt(snapshot: MealPlanSnapshot, dayIndex: Int): String =
+        "I still need to finish Day ${dayIndex + 1} of ${snapshot.days.size}. Say 'generate recipes' to continue or 'cancel' to stop."
+
+    private fun recoveryPrompt(dayIndex: Int): String =
+        "I still need to finish Day ${dayIndex + 1}. Say 'regenerate day ${dayIndex + 1}' or 'replace day ${dayIndex + 1}'."
+
+    private fun replacementFailureMessage(dayIndex: Int, detail: String?): String =
+        "I couldn't replace Day ${dayIndex + 1}. ${detail ?: "Try again with a different day."}"
 
     private fun buildPlanSummary(snapshot: MealPlanSnapshot): String = buildString {
         append("Here’s the meal plan I built for ${snapshot.peopleCount} people over ${snapshot.daysCount} days")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -70,10 +70,14 @@ class MealPlannerCoordinator @Inject constructor(
     }
 
     private suspend fun handleCollecting(snapshot: MealPlanSnapshot, text: String): MealPlannerReply {
+        val missingBefore = missingSlots(snapshot)
         val peopleCount = slotExtractor.extractPeopleCount(text)
         val daysCount = slotExtractor.extractDaysCount(text)
         val dietaryRestrictions = slotExtractor.extractDietaryRestrictions(text)
-        val proteinPreferences = slotExtractor.extractProteinPreferences(text)
+        val proteinPreferences = slotExtractor.extractProteinPreferences(
+            text,
+            allowBareNoPreference = missingBefore == listOf("protein"),
+        )
         val updated = sessionRepository.updateRequiredSlots(
             sessionId = snapshot.sessionId,
             peopleCount = peopleCount,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -552,7 +552,8 @@ Output ONLY valid JSON with this exact shape:
   ]
 }
 Rules:
-- output exactly one replacement day object for day_index $dayIndex
+- output exactly one replacement day object
+- day_index is zero-based, so user-visible Day ${dayIndex + 1} must use day_index $dayIndex
 - do not repeat the existing day title verbatim if you can avoid it
 - do not include ingredients, quantities, steps, markdown, commentary, or code fences
 """.trimIndent()
@@ -564,6 +565,7 @@ ${snapshot.days.joinToString("\n") { "Day ${it.dayIndex + 1}: ${it.title}" }}
 Dietary requirements: ${snapshot.dietaryRestrictions.ifEmpty { listOf("none provided") }.joinToString()}
 Protein preferences: ${snapshot.proteinPreferences.ifEmpty { listOf("no preference provided") }.joinToString()}
 Return one alternative day that fits the plan without duplicating the current Day ${dayIndex + 1} dish.
+Remember: this is user-visible Day ${dayIndex + 1}, but the JSON day_index must be zero-based and equal $dayIndex.
 """.trimIndent()
 
     private fun isFinalizeRequest(text: String): Boolean =

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -131,8 +131,39 @@ class MealPlannerCoordinator @Inject constructor(
     ): MealPlannerReply {
         val failedDay = snapshot.days.firstOrNull { it.status == MealPlanDayStatus.FAILED }
         val pendingDay = snapshot.days.firstOrNull { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
+        val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
+        val regenerateDayIndex = slotExtractor.extractRegenerateDayIndex(text)
+        val interruptedReplacementDayIndex = snapshot.pendingGenerationDayIndex?.takeIf {
+            snapshot.pendingGenerationKind == PendingGenerationKind.REPLACEMENT && snapshot.days.all { day -> day.status == MealPlanDayStatus.PERSISTED }
+        }
+        if (interruptedReplacementDayIndex != null) {
+            if (slotExtractor.isRetryRequest(text) || replaceDayIndex == interruptedReplacementDayIndex) {
+                return try {
+                    val replaced = generateReplacementDay(snapshot, interruptedReplacementDayIndex)
+                    generateSpecificDayRecipe(replaced, interruptedReplacementDayIndex, intro = "I replaced Day ${interruptedReplacementDayIndex + 1}. Here’s the updated recipe:\n")
+                } catch (e: IllegalArgumentException) {
+                    MealPlannerReply(replacementFailureMessage(interruptedReplacementDayIndex, e.message))
+                } catch (e: MealPlanValidationException) {
+                    MealPlannerReply(replacementFailureMessage(interruptedReplacementDayIndex, e.message))
+                }
+            }
+            if (replaceDayIndex == null && regenerateDayIndex == null) {
+                return MealPlannerReply(replacementRetryPrompt(interruptedReplacementDayIndex))
+            }
+        }
+        val interruptedRecipeDayIndex = snapshot.pendingGenerationDayIndex?.takeIf {
+            snapshot.pendingGenerationKind == PendingGenerationKind.RECIPE && snapshot.days.all { day -> day.status == MealPlanDayStatus.PERSISTED }
+        }
+        if (interruptedRecipeDayIndex != null) {
+            if (slotExtractor.isRetryRequest(text) || regenerateDayIndex == interruptedRecipeDayIndex) {
+                return generateSpecificDayRecipe(snapshot, interruptedRecipeDayIndex, intro = "I regenerated Day ${interruptedRecipeDayIndex + 1}. Here’s the updated recipe:\n")
+            }
+            if (replaceDayIndex == null && regenerateDayIndex == null) {
+                return MealPlannerReply(regenerateRetryPrompt(snapshot, interruptedRecipeDayIndex))
+            }
+        }
         if (failedDay == null && pendingDay != null) {
-            if (slotExtractor.isGenerateRecipesRequest(text)) {
+            if (slotExtractor.isGenerateRecipesRequest(text) || slotExtractor.isRetryRequest(text)) {
                 return generatePendingRecipesFrom(
                     snapshot,
                     intro = "Resuming your meal plan at Day ${pendingDay.dayIndex + 1} of ${snapshot.days.size}…",
@@ -142,7 +173,6 @@ class MealPlannerCoordinator @Inject constructor(
             return MealPlannerReply(resumePrompt(snapshot, pendingDay.dayIndex))
         }
 
-        val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
         if (replaceDayIndex != null) {
             return try {
                 val replaced = generateReplacementDay(snapshot, replaceDayIndex)
@@ -153,7 +183,6 @@ class MealPlannerCoordinator @Inject constructor(
                 MealPlannerReply(replacementFailureMessage(replaceDayIndex, e.message))
             }
         }
-        val regenerateDayIndex = slotExtractor.extractRegenerateDayIndex(text)
         if (regenerateDayIndex != null) {
             return generateSpecificDayRecipe(snapshot, regenerateDayIndex, intro = "I regenerated Day ${regenerateDayIndex + 1}. Here’s the updated recipe:\n")
         }
@@ -299,23 +328,32 @@ class MealPlannerCoordinator @Inject constructor(
     private suspend fun generateReplacementDay(snapshot: MealPlanSnapshot, dayIndex: Int): MealPlanSnapshot =
         withSessionGeneration(snapshot.sessionId) {
             require(dayIndex in snapshot.days.indices) { "Invalid day index: $dayIndex" }
-            val raw = inferenceEngine.generateOnce(
-                prompt = buildReplacementDayUserPrompt(snapshot, dayIndex),
-                systemPrompt = buildReplacementDaySystemPrompt(dayIndex),
-                thinkingEnabled = false,
-                stopOnFirstJsonObject = true,
-            )
-            if (raw.isBlank()) {
-                throw MealPlanValidationException("The model didn't return a replacement day.")
+            sessionRepository.markPendingGeneration(snapshot.sessionId, PendingGenerationKind.REPLACEMENT, dayIndex)
+            try {
+                val raw = inferenceEngine.generateOnce(
+                    prompt = buildReplacementDayUserPrompt(snapshot, dayIndex),
+                    systemPrompt = buildReplacementDaySystemPrompt(dayIndex),
+                    thinkingEnabled = false,
+                    stopOnFirstJsonObject = true,
+                )
+                if (raw.isBlank()) {
+                    throw MealPlanValidationException("The model didn't return a replacement day.")
+                }
+                val replacement = jsonParser.parseSinglePlanDay(raw, dayIndex)
+                sessionRepository.replaceDayDraft(
+                    sessionId = snapshot.sessionId,
+                    dayIndex = dayIndex,
+                    title = replacement.title,
+                    summary = replacement.summary,
+                    proteinTags = replacement.proteinTags,
+                )
+            } catch (e: MealPlanValidationException) {
+                sessionRepository.clearPendingGeneration(snapshot.sessionId)
+                throw e
+            } catch (e: IllegalArgumentException) {
+                sessionRepository.clearPendingGeneration(snapshot.sessionId)
+                throw e
             }
-            val replacement = jsonParser.parseSinglePlanDay(raw, dayIndex)
-            sessionRepository.replaceDayDraft(
-                sessionId = snapshot.sessionId,
-                dayIndex = dayIndex,
-                title = replacement.title,
-                summary = replacement.summary,
-                proteinTags = replacement.proteinTags,
-            )
         }
 
     private suspend fun writeFinalSummaryIfNeeded(snapshot: MealPlanSnapshot) {
@@ -354,6 +392,9 @@ class MealPlannerCoordinator @Inject constructor(
         PendingGenerationKind.RECIPE ->
             snapshot.pendingGenerationDayIndex?.let { "I'm still finishing Day ${it + 1}. Give me a moment." }
                 ?: "I'm still finishing your meal plan. Give me a moment."
+        PendingGenerationKind.REPLACEMENT ->
+            snapshot.pendingGenerationDayIndex?.let { "I'm still replacing Day ${it + 1}. Give me a moment." }
+                ?: "I'm still updating your meal plan. Give me a moment."
         null -> "I'm still working on your meal plan. Give me a moment."
     }
 
@@ -370,8 +411,15 @@ class MealPlannerCoordinator @Inject constructor(
         MealPlanSessionStatus.RECIPES_IN_PROGRESS,
         MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> {
             val failedDay = snapshot.days.firstOrNull { it.status == MealPlanDayStatus.FAILED }
+            val pendingGenerationDayIndex = snapshot.pendingGenerationDayIndex
             when {
                 failedDay != null -> recoveryPrompt(failedDay.dayIndex)
+                snapshot.pendingGenerationKind == PendingGenerationKind.REPLACEMENT && pendingGenerationDayIndex != null &&
+                    snapshot.days.all { it.status == MealPlanDayStatus.PERSISTED } ->
+                    replacementRetryPrompt(pendingGenerationDayIndex)
+                snapshot.pendingGenerationKind == PendingGenerationKind.RECIPE && pendingGenerationDayIndex != null &&
+                    snapshot.days.all { it.status == MealPlanDayStatus.PERSISTED } ->
+                    regenerateRetryPrompt(snapshot, pendingGenerationDayIndex)
                 snapshot.days.any { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED } -> {
                     val nextPending = snapshot.days.first { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
                     resumePrompt(snapshot, nextPending.dayIndex)
@@ -433,6 +481,12 @@ class MealPlannerCoordinator @Inject constructor(
 
     private fun resumePrompt(snapshot: MealPlanSnapshot, dayIndex: Int): String =
         "I still need to finish Day ${dayIndex + 1} of ${snapshot.days.size}. Say 'generate recipes' to continue or 'cancel' to stop."
+
+    private fun replacementRetryPrompt(dayIndex: Int): String =
+        "I still need to replace Day ${dayIndex + 1}. Say 'retry' or 'replace day ${dayIndex + 1}' to try again, or 'cancel' to stop."
+
+    private fun regenerateRetryPrompt(snapshot: MealPlanSnapshot, dayIndex: Int): String =
+        "I still need to finish Day ${dayIndex + 1} of ${snapshot.days.size}. Say 'retry' or 'regenerate day ${dayIndex + 1}' to try again, or 'cancel' to stop."
 
     private fun recoveryPrompt(dayIndex: Int): String =
         "I still need to finish Day ${dayIndex + 1}. Say 'regenerate day ${dayIndex + 1}' or 'replace day ${dayIndex + 1}'."

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -52,6 +52,9 @@ class MealPlannerSlotExtractor @Inject constructor() {
         Regex("\\b(?:generate|make|create|start)\\b.*\\b(?:recipes?|meal plan)\\b|\\b(?:continue|resume|keep going)\\b", RegexOption.IGNORE_CASE)
             .containsMatchIn(text)
 
+    fun isRetryRequest(text: String): Boolean =
+        Regex("\\b(?:retry|try again)\\b", RegexOption.IGNORE_CASE).containsMatchIn(text)
+
     fun isChangePreferencesRequest(text: String): Boolean =
         Regex("\\b(?:change|edit|update|revise)\\s+(?:preferences?|details?|requirements?)\\b", RegexOption.IGNORE_CASE)
             .containsMatchIn(text)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -20,7 +20,7 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun extractDietaryRestrictions(text: String): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:none|no\\s+dietary(?:\\s+(?:requirements?|restrictions?))?|anything is fine)\\b").containsMatchIn(normalized)) {
+        if (Regex("\\b(?:none|no\\s+(?:dietary(?:\\s+(?:requirements?|restrictions?))?|restrictions?)|anything is fine)\\b").containsMatchIn(normalized)) {
             return listOf(NO_DIETARY_REQUIREMENTS)
         }
         val matches = DIETARY_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -20,7 +20,7 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun extractDietaryRestrictions(text: String): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:none|no\\s+(?:dietary(?:\\s+(?:requirements?|restrictions?))?|restrictions?)|anything is fine)\\b").containsMatchIn(normalized)) {
+        if (Regex("\\b(?:none|no\\s+(?:(?:dietary(?:\\s+(?:requirements?|restrictions?))?)|requirements?|restrictions?)|anything is fine)\\b").containsMatchIn(normalized)) {
             return listOf(NO_DIETARY_REQUIREMENTS)
         }
         val matches = DIETARY_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -20,8 +20,8 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun extractDietaryRestrictions(text: String): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:none|no dietary restrictions|anything is fine)\\b").containsMatchIn(normalized)) {
-            return emptyList()
+        if (Regex("\\b(?:none|no\\s+(?:dietary\\s+)?(?:requirements?|restrictions?)|anything is fine)\\b").containsMatchIn(normalized)) {
+            return listOf(NO_DIETARY_REQUIREMENTS)
         }
         val matches = DIETARY_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct()
         return matches.takeIf { it.isNotEmpty() }
@@ -29,8 +29,8 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun extractProteinPreferences(text: String): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:anything|any protein|surprise me)\\b").containsMatchIn(normalized)) {
-            return emptyList()
+        if (Regex("\\b(?:anything|any\\s+protein|surprise me|no\\s+protein\\s+preference)\\b").containsMatchIn(normalized)) {
+            return listOf(NO_PROTEIN_PREFERENCE)
         }
         val matches = PROTEIN_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct().toMutableList()
         if ("beef mince" in matches) matches.remove("beef")
@@ -80,6 +80,9 @@ class MealPlannerSlotExtractor @Inject constructor() {
             "nine" to "9",
             "ten" to "10",
         )
+        const val NO_DIETARY_REQUIREMENTS = "no dietary requirements"
+        const val NO_PROTEIN_PREFERENCE = "no protein preference"
+
         val DIETARY_KEYWORDS = listOf(
             "low lactose" to "low lactose",
             "lactose intolerant" to "lactose intolerant",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -38,7 +38,7 @@ class MealPlannerSlotExtractor @Inject constructor() {
     }
 
     fun isCancelRequest(text: String): Boolean =
-        Regex("\\b(?:cancel|stop|nevermind|never mind|forget it|abort)\\b", RegexOption.IGNORE_CASE).containsMatchIn(text)
+        Regex("\\b(?:cancel|nevermind|never mind|forget it|abort)\\b", RegexOption.IGNORE_CASE).containsMatchIn(text)
 
     fun extractReplaceDayIndex(text: String): Int? =
         Regex("\\b(?:replace|swap|change)\\s+day\\s+(\\d+)\\b", RegexOption.IGNORE_CASE)
@@ -47,6 +47,15 @@ class MealPlannerSlotExtractor @Inject constructor() {
     fun extractRegenerateDayIndex(text: String): Int? =
         Regex("\\b(?:regenerate|redo|retry)\\s+day\\s+(\\d+)\\b", RegexOption.IGNORE_CASE)
             .find(text)?.groupValues?.getOrNull(1)?.toIntOrNull()?.minus(1)
+
+    fun isGenerateRecipesRequest(text: String): Boolean =
+        Regex("\\b(?:generate|make|create|start)\\b.*\\b(?:recipes?|meal plan)\\b|\\b(?:continue|resume|keep going)\\b", RegexOption.IGNORE_CASE)
+            .containsMatchIn(text)
+
+    fun isChangePreferencesRequest(text: String): Boolean =
+        Regex("\\b(?:change|edit|update|revise)\\s+(?:preferences?|details?|requirements?)\\b", RegexOption.IGNORE_CASE)
+            .containsMatchIn(text)
+
 
     private fun normalizeWords(text: String): String {
         var normalized = text.lowercase()

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -20,16 +20,19 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun extractDietaryRestrictions(text: String): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:none|no\\s+(?:dietary\\s+)?(?:requirements?|restrictions?)|anything is fine)\\b").containsMatchIn(normalized)) {
+        if (Regex("\\b(?:none|no\\s+dietary(?:\\s+(?:requirements?|restrictions?))?|anything is fine)\\b").containsMatchIn(normalized)) {
             return listOf(NO_DIETARY_REQUIREMENTS)
         }
         val matches = DIETARY_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct()
         return matches.takeIf { it.isNotEmpty() }
     }
 
-    fun extractProteinPreferences(text: String): List<String>? {
+    fun extractProteinPreferences(text: String, allowBareNoPreference: Boolean = false): List<String>? {
         val normalized = normalizeWords(text)
-        if (Regex("\\b(?:anything|any\\s+protein|surprise me|no\\s+protein\\s+preference)\\b").containsMatchIn(normalized)) {
+        if (
+            Regex("\\b(?:any\\s+protein(?:\\s+is\\s+fine)?|surprise me|no\\s+preferences?|no\\s+protein\\s+preferences?)\\b").containsMatchIn(normalized) ||
+                (allowBareNoPreference && normalized.matches(Regex("^\\s*(?:none|any)\\s*[.!?]*$")))
+        ) {
             return listOf(NO_PROTEIN_PREFERENCE)
         }
         val matches = PROTEIN_KEYWORDS.filter { normalized.contains(it.first) }.map { it.second }.distinct().toMutableList()

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
@@ -17,6 +17,19 @@ class QuickIntentRouterMealPlannerTest {
             "I'd like to plan meals",
             "I’d like to plan my meals",
             "Make me a meal plan",
+            "I need a meal plan",
+            "I want a meal plan",
+            "I'd like a meal plan",
+            "meal plan please",
+            "could you make me a meal plan",
+            "start meal planning",
+            "set up a meal plan",
+            "organize the weekly menu",
+            "plan the menu",
+            "let's plan dinners",
+            "map out our meals",
+            "start meal prep",
+            "prep meals for the week",
         )
 
         phrases.forEach { input ->

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
@@ -16,6 +16,7 @@ class QuickIntentRouterMealPlannerTest {
             "plan my meals",
             "I'd like to plan meals",
             "I’d like to plan my meals",
+            "Make me a meal plan",
         )
 
         phrases.forEach { input ->

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterMealPlannerTest.kt
@@ -14,6 +14,8 @@ class QuickIntentRouterMealPlannerTest {
             "let's plan meals",
             "create a meal plan",
             "plan my meals",
+            "I'd like to plan meals",
+            "I’d like to plan my meals",
         )
 
         phrases.forEach { input ->

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParserTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParserTest.kt
@@ -61,6 +61,23 @@ class MealPlanJsonParserTest {
     }
 
     @Test
+    fun `parseSinglePlanDay normalizes one based replacement day index`() {
+        val result = parser.parseSinglePlanDay(
+            raw = """
+                {
+                  "days": [
+                    {"day_index": 2, "title": "Turkey skillet", "summary": "Quick dinner", "protein_tags": ["turkey"]}
+                  ]
+                }
+            """.trimIndent(),
+            expectedDayIndex = 1,
+        )
+
+        assertEquals(1, result.dayIndex)
+        assertEquals("Turkey skillet", result.title)
+    }
+
+    @Test
     fun `parseRecipeDraft parses structured recipe`() {
         val result = parser.parseRecipeDraft(
             raw = """

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParserTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlanJsonParserTest.kt
@@ -44,6 +44,23 @@ class MealPlanJsonParserTest {
     }
 
     @Test
+    fun `parseSinglePlanDay accepts explicit replacement day index`() {
+        val result = parser.parseSinglePlanDay(
+            raw = """
+                {
+                  "days": [
+                    {"day_index": 2, "title": "Lemon chicken", "summary": "Quick dinner", "protein_tags": ["chicken"]}
+                  ]
+                }
+            """.trimIndent(),
+            expectedDayIndex = 2,
+        )
+
+        assertEquals(2, result.dayIndex)
+        assertEquals("Lemon chicken", result.title)
+    }
+
+    @Test
     fun `parseRecipeDraft parses structured recipe`() {
         val result = parser.parseRecipeDraft(
             raw = """

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -158,6 +158,45 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `collecting no requirements completes slot collection`() = runTest {
+        val ready = collectingSnapshot().copy(
+            peopleCount = 3,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken"),
+        )
+        val reviewed = planReviewSnapshot().copy(
+            peopleCount = 3,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken"),
+        )
+        coEvery {
+            sessionRepository.getActiveSession("conv")
+        } returns collectingSnapshot().copy(
+            peopleCount = 3,
+            daysCount = 2,
+            proteinPreferences = listOf("chicken"),
+        )
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = listOf("no dietary requirements"),
+                proteinPreferences = null,
+            )
+        } returns ready
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns planJson()
+        coEvery { sessionRepository.savePlanDraft("session-1", any()) } returns reviewed
+
+        val reply = coordinator.ingestUserMessage("conv", "No requirements")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        coVerify(exactly = 1) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) }
+    }
+
+    @Test
     fun `collecting bare any as final protein answer completes slot collection`() = runTest {
         val ready = collectingSnapshot().copy(
             peopleCount = 2,

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -12,21 +12,22 @@ import com.kernel.ai.core.memory.repository.MemoryRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
-import org.junit.jupiter.api.Assertions.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MealPlannerCoordinatorTest {
-    private val sessionRepository = mockk<MealPlanSessionRepository>()
+    private val sessionRepository = mockk<MealPlanSessionRepository>(relaxed = true)
     private val slotExtractor = MealPlannerSlotExtractor()
     private val jsonParser = MealPlanJsonParser()
     private val quantityValidator = MealPlanQuantityValidator()
     private val inferenceEngine = mockk<InferenceEngine>()
     private val embeddingEngine = mockk<EmbeddingEngine>()
-    private val memoryRepository = mockk<MemoryRepository>()
+    private val memoryRepository = mockk<MemoryRepository>(relaxed = true)
 
     private val coordinator = MealPlannerCoordinator(
         sessionRepository = sessionRepository,
@@ -46,6 +47,106 @@ class MealPlannerCoordinatorTest {
 
         assertTrue(reply.content.contains("How many people"))
         assertTrue(reply.content.contains("How many days"))
+    }
+
+    @Test
+    fun `collecting final slots returns plan review instead of auto generating recipes`() = runTest {
+        val ready = collectingSnapshot().copy(
+            peopleCount = 4,
+            daysCount = 2,
+            dietaryRestrictions = listOf("low lactose"),
+            proteinPreferences = listOf("chicken"),
+        )
+        val reviewed = planReviewSnapshot()
+        coEvery { sessionRepository.getActiveSession("conv") } returns collectingSnapshot().copy(peopleCount = 4, daysCount = 2)
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = listOf("low lactose"),
+                proteinPreferences = listOf("chicken"),
+            )
+        } returns ready
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns planJson()
+        coEvery { sessionRepository.savePlanDraft("session-1", any()) } returns reviewed
+
+        val reply = coordinator.ingestUserMessage("conv", "low lactose, chicken")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        assertTrue(reply.content.contains("change preferences", ignoreCase = true))
+        coVerify(exactly = 1) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) }
+        coVerify(exactly = 0) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.RECIPE, any()) }
+    }
+
+    @Test
+    fun `plan review generate recipes emits progress and recipes sequentially`() = runTest {
+        val planReview = planReviewSnapshot()
+        val afterDay1 = planReview.copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 1,
+            pendingGenerationKind = PendingGenerationKind.RECIPE,
+            pendingGenerationDayIndex = 1,
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Lemon chicken", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Beef bowls", status = MealPlanDayStatus.DRAFTED),
+            ),
+        )
+        val completed = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        val emitted = mutableListOf<String>()
+
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReview
+        coEvery { sessionRepository.getSession("session-1") } returns planReview
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returnsMany listOf(recipeJson("Lemon chicken"), recipeJson("Beef bowls"))
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 0, any(), any(), any()) } returns afterDay1
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 1, any(), any(), any()) } returns completed
+
+        val reply = coordinator.ingestUserMessage("conv", "generate recipes") { emitted += it }
+
+        assertEquals(
+            listOf(
+                "Generating recipe 1 of 2…",
+                expectedRecipeSection(0, "Lemon chicken"),
+                "Generating recipe 2 of 2…",
+                expectedRecipeSection(1, "Beef bowls"),
+            ),
+            emitted,
+        )
+        assertTrue(reply.content.contains("done meal planning", ignoreCase = true))
+    }
+
+    @Test
+    fun `plan review change preferences returns to editable slot collection`() = runTest {
+        val planReview = planReviewSnapshot()
+        val editable = planReview.copy(status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS)
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReview
+        coEvery { sessionRepository.returnToSlotCollection("session-1") } returns editable
+
+        val reply = coordinator.ingestUserMessage("conv", "change preferences")
+
+        assertTrue(reply.content.contains("Current plan details", ignoreCase = true))
+        assertTrue(reply.content.contains("updated", ignoreCase = true))
+        coVerify { sessionRepository.returnToSlotCollection("session-1") }
+    }
+
+    @Test
+    fun `interrupted recipe generation requires explicit resume`() = runTest {
+        val inProgress = planReviewSnapshot().copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 1,
+            pendingGenerationKind = PendingGenerationKind.RECIPE,
+            pendingGenerationDayIndex = 1,
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Lemon chicken", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Beef bowls", status = MealPlanDayStatus.DRAFTED),
+            ),
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns inProgress
+
+        val reply = coordinator.ingestUserMessage("conv", "hello")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        assertTrue(reply.content.contains("Day 2 of 2", ignoreCase = true))
     }
 
     @Test
@@ -71,7 +172,6 @@ class MealPlannerCoordinatorTest {
                 proteinPreferences = listOf("chicken"),
             )
         } returns ready
-        coEvery { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) } returns Unit
         coEvery { sessionRepository.markGenerationFailure("session-1", null, "PLAN_NO_OUTPUT", "The model did not return a plan.") } returns ready
         coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } coAnswers {
             started.complete(Unit)
@@ -90,37 +190,8 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
-    fun `ingestUserMessage surfaces blank plan output cleanly`() = runTest {
-        val ready = collectingSnapshot().copy(
-            peopleCount = 4,
-            daysCount = 2,
-            dietaryRestrictions = listOf("low lactose"),
-            proteinPreferences = listOf("chicken"),
-        )
-        val collecting = collectingSnapshot().copy(peopleCount = 4, daysCount = 2)
-        coEvery { sessionRepository.getActiveSession("conv") } returns collecting
-        coEvery {
-            sessionRepository.updateRequiredSlots(
-                sessionId = "session-1",
-                peopleCount = null,
-                daysCount = null,
-                dietaryRestrictions = listOf("low lactose"),
-                proteinPreferences = listOf("chicken"),
-            )
-        } returns ready
-        coEvery { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) } returns Unit
-        coEvery { sessionRepository.markGenerationFailure("session-1", null, "PLAN_NO_OUTPUT", "The model did not return a plan.") } returns ready
-        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns ""
-
-        val reply = coordinator.ingestUserMessage("conv", "low lactose, chicken")
-
-        assertTrue(reply.content.contains("didn't return one", ignoreCase = true))
-        assertFalse(reply.content.contains("JSON object", ignoreCase = true))
-    }
-
-    @Test
     fun `regenerate day recipe uses non-thinking structured generation`() = runTest {
-        val active = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+        val failed = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
             days = readyForFinalizeSnapshot(finalSummaryWritten = false).days.map { day ->
                 if (day.dayIndex == 0) {
                     day.copy(
@@ -132,15 +203,12 @@ class MealPlannerCoordinatorTest {
                     day
                 }
             },
-        )
-        val failed = active.copy(
             pendingGenerationKind = PendingGenerationKind.RECIPE,
             pendingGenerationDayIndex = 0,
             activeDayIndex = 0,
         )
 
         coEvery { sessionRepository.getActiveSession("conv") } returns failed
-        coEvery { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.RECIPE, 0) } returns Unit
         coEvery { sessionRepository.markGenerationFailure("session-1", 0, "RECIPE_NO_OUTPUT", "The model did not return a recipe.") } returns failed
         coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns ""
 
@@ -158,7 +226,6 @@ class MealPlannerCoordinatorTest {
         coEvery { sessionRepository.completeSession("session-1") } returns completed
         coEvery { sessionRepository.buildFinalSummary("session-1") } returns "Created a 2-day meal plan."
         coEvery { embeddingEngine.embed("Created a 2-day meal plan.") } returns floatArrayOf(1f, 2f)
-        coEvery { memoryRepository.addEpisodicMemory("conv", "Created a 2-day meal plan.", any()) } returns "mem-1"
         coEvery { sessionRepository.markFinalSummaryWritten("session-1") } returns Unit
 
         val reply = coordinator.ingestUserMessage("conv", "done meal planning")
@@ -190,6 +257,29 @@ class MealPlannerCoordinatorTest {
         days = emptyList(),
     )
 
+    private fun planReviewSnapshot(): MealPlanSnapshot = MealPlanSnapshot(
+        sessionId = "session-1",
+        conversationId = "conv",
+        status = MealPlanSessionStatus.PLAN_REVIEW,
+        peopleCount = 4,
+        daysCount = 2,
+        dietaryRestrictions = listOf("low lactose"),
+        proteinPreferences = listOf("chicken"),
+        activeDayIndex = null,
+        pendingGenerationKind = null,
+        pendingGenerationDayIndex = null,
+        planVersion = 1,
+        finalSummaryWritten = false,
+        createdAt = 1L,
+        updatedAt = 1L,
+        completedAt = null,
+        cancelledAt = null,
+        days = listOf(
+            draftDay(dayIndex = 0, title = "Lemon chicken", status = MealPlanDayStatus.DRAFTED),
+            draftDay(dayIndex = 1, title = "Beef bowls", status = MealPlanDayStatus.DRAFTED),
+        ),
+    )
+
     private fun readyForFinalizeSnapshot(finalSummaryWritten: Boolean): MealPlanSnapshot = MealPlanSnapshot(
         sessionId = "session-1",
         conversationId = "conv",
@@ -208,32 +298,59 @@ class MealPlannerCoordinatorTest {
         completedAt = null,
         cancelledAt = null,
         days = listOf(
-            MealPlanSnapshotDay(
-                id = "day-1",
-                dayIndex = 0,
-                title = "Chicken stir-fry",
-                summary = "Quick dinner",
-                proteinTags = listOf("chicken"),
-                status = MealPlanDayStatus.PERSISTED,
-                currentRecipeVersion = 1,
-                attemptCount = 1,
-                lastErrorCode = null,
-                lastErrorMessage = null,
-                currentRecipe = null,
-            ),
-            MealPlanSnapshotDay(
-                id = "day-2",
-                dayIndex = 1,
-                title = "Chicken curry",
-                summary = "Comfort food",
-                proteinTags = listOf("chicken"),
-                status = MealPlanDayStatus.PERSISTED,
-                currentRecipeVersion = 1,
-                attemptCount = 1,
-                lastErrorCode = null,
-                lastErrorMessage = null,
-                currentRecipe = null,
-            ),
+            draftDay(dayIndex = 0, title = "Chicken stir-fry", status = MealPlanDayStatus.PERSISTED),
+            draftDay(dayIndex = 1, title = "Chicken curry", status = MealPlanDayStatus.PERSISTED),
         ),
     )
+
+    private fun draftDay(dayIndex: Int, title: String, status: MealPlanDayStatus): MealPlanSnapshotDay = MealPlanSnapshotDay(
+        id = "day-${dayIndex + 1}",
+        dayIndex = dayIndex,
+        title = title,
+        summary = "Quick dinner",
+        proteinTags = listOf("chicken"),
+        status = status,
+        currentRecipeVersion = if (status == MealPlanDayStatus.PERSISTED) 1 else null,
+        attemptCount = if (status == MealPlanDayStatus.PERSISTED) 1 else 0,
+        lastErrorCode = null,
+        lastErrorMessage = null,
+        currentRecipe = null,
+    )
+
+    private fun planJson(): String = """
+        {
+          "days": [
+            {"day_index": 0, "title": "Lemon chicken", "summary": "Quick dinner", "protein_tags": ["chicken"]},
+            {"day_index": 1, "title": "Beef bowls", "summary": "Weeknight bowl", "protein_tags": ["beef"]}
+          ]
+        }
+    """.trimIndent()
+
+    private fun recipeJson(title: String): String = """
+        {
+          "title": "$title",
+          "servings": 4,
+          "ingredients": [
+            "500 g chicken thigh",
+            "1 tbsp olive oil"
+          ],
+          "method_steps": [
+            "Heat the pan.",
+            "Cook until done."
+          ]
+        }
+    """.trimIndent()
+
+    private fun expectedRecipeSection(dayIndex: Int, title: String): String = """
+        Day ${dayIndex + 1}: $title
+        Serves 4
+
+        Ingredients:
+        - 500 g chicken thigh
+        - 1 tbsp olive oil
+
+        Method:
+        1. Heat the pan.
+        2. Cook until done.
+    """.trimIndent()
 }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -80,6 +80,45 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `collecting no dietary requirements completes slot collection`() = runTest {
+        val ready = collectingSnapshot().copy(
+            peopleCount = 5,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken", "beef"),
+        )
+        val reviewed = planReviewSnapshot().copy(
+            peopleCount = 5,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken", "beef"),
+        )
+        coEvery {
+            sessionRepository.getActiveSession("conv")
+        } returns collectingSnapshot().copy(
+            peopleCount = 5,
+            daysCount = 2,
+            proteinPreferences = listOf("chicken", "beef"),
+        )
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = listOf("no dietary requirements"),
+                proteinPreferences = null,
+            )
+        } returns ready
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns planJson()
+        coEvery { sessionRepository.savePlanDraft("session-1", any()) } returns reviewed
+
+        val reply = coordinator.ingestUserMessage("conv", "No dietary requirements")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        coVerify(exactly = 1) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) }
+    }
+
+    @Test
     fun `plan review generate recipes emits progress and recipes sequentially`() = runTest {
         val planReview = planReviewSnapshot()
         val afterDay1 = planReview.copy(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -377,6 +377,25 @@ class MealPlannerCoordinatorTest {
         coVerify { memoryRepository.addEpisodicMemory("conv", "Created a 2-day meal plan.", any()) }
     }
 
+    @Test
+    fun `ingestUserMessage finalise finalizes completed meal plan`() = runTest {
+        val active = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        val completed = active.copy(status = MealPlanSessionStatus.COMPLETED, completedAt = 1234L)
+        coEvery { sessionRepository.getActiveSession("conv") } returns active
+        coEvery { sessionRepository.completeSession("session-1") } returns completed
+        coEvery { sessionRepository.buildFinalSummary("session-1") } returns "Created a 2-day meal plan."
+        coEvery { embeddingEngine.embed("Created a 2-day meal plan.") } returns floatArrayOf(1f, 2f)
+        coEvery { sessionRepository.markFinalSummaryWritten("session-1") } returns Unit
+
+        val reply = coordinator.ingestUserMessage("conv", "finalise")
+
+        assertTrue(reply.content.contains("finalized", ignoreCase = true))
+        coVerify { sessionRepository.completeSession("session-1") }
+        coVerify { sessionRepository.buildFinalSummary("session-1") }
+        coVerify { sessionRepository.markFinalSummaryWritten("session-1") }
+        coVerify { memoryRepository.addEpisodicMemory("conv", "Created a 2-day meal plan.", any()) }
+    }
+
     private fun collectingSnapshot(): MealPlanSnapshot = MealPlanSnapshot(
         sessionId = "session-1",
         conversationId = "conv",

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -189,6 +189,77 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `interrupted replacement generation prompts for retry`() = runTest {
+        val interrupted = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 0,
+            pendingGenerationKind = PendingGenerationKind.REPLACEMENT,
+            pendingGenerationDayIndex = 0,
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns interrupted
+
+        val reply = coordinator.ingestUserMessage("conv", "hello")
+
+        assertTrue(reply.content.contains("retry", ignoreCase = true))
+        assertTrue(reply.content.contains("replace day 1", ignoreCase = true))
+    }
+
+    @Test
+    fun `retry resumes interrupted replacement generation`() = runTest {
+        val interrupted = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 0,
+            pendingGenerationKind = PendingGenerationKind.REPLACEMENT,
+            pendingGenerationDayIndex = 0,
+        )
+        val replaced = interrupted.copy(
+            status = MealPlanSessionStatus.PLAN_REVIEW,
+            pendingGenerationKind = null,
+            pendingGenerationDayIndex = null,
+            activeDayIndex = null,
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Pan-Seared Chicken", status = MealPlanDayStatus.DRAFTED),
+                draftDay(dayIndex = 1, title = "Chicken curry", status = MealPlanDayStatus.PERSISTED),
+            ),
+        )
+        val completed = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Pan-Seared Chicken", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Chicken curry", status = MealPlanDayStatus.PERSISTED),
+            ),
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns interrupted
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returnsMany listOf(
+            replacementJson(dayIndex = 1, title = "Pan-Seared Chicken"),
+            recipeJson("Pan-Seared Chicken"),
+        )
+        coEvery { sessionRepository.replaceDayDraft("session-1", 0, "Pan-Seared Chicken", any(), any()) } returns replaced
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 0, any(), any(), any()) } returns completed
+
+        val reply = coordinator.ingestUserMessage("conv", "Retry")
+
+        assertTrue(reply.content.contains("I replaced Day 1", ignoreCase = true))
+        assertTrue(reply.content.contains("Pan-Seared Chicken", ignoreCase = true))
+        coVerify { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.REPLACEMENT, 0) }
+    }
+
+    @Test
+    fun `interrupted regenerate day prompts for retry`() = runTest {
+        val interrupted = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 0,
+            pendingGenerationKind = PendingGenerationKind.RECIPE,
+            pendingGenerationDayIndex = 0,
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns interrupted
+
+        val reply = coordinator.ingestUserMessage("conv", "hello")
+
+        assertTrue(reply.content.contains("retry", ignoreCase = true))
+        assertTrue(reply.content.contains("regenerate day 1", ignoreCase = true))
+    }
+
+    @Test
     fun `replace day after recipe generation accepts one based replacement JSON`() = runTest {
         val active = readyForFinalizeSnapshot(finalSummaryWritten = false)
         val replaced = active.copy(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -150,6 +150,36 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `replace day after recipe generation accepts one based replacement JSON`() = runTest {
+        val active = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        val replaced = active.copy(
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Chicken stir-fry", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Turkey skillet", status = MealPlanDayStatus.DRAFTED),
+            ),
+        )
+        val persisted = active.copy(
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Chicken stir-fry", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Turkey skillet", status = MealPlanDayStatus.PERSISTED),
+            ),
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns active
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returnsMany listOf(
+            replacementJson(dayIndex = 2, title = "Turkey skillet"),
+            recipeJson("Turkey skillet"),
+        )
+        coEvery { sessionRepository.replaceDayDraft("session-1", 1, "Turkey skillet", any(), any()) } returns replaced
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 1, any(), any(), any()) } returns persisted
+
+        val reply = coordinator.ingestUserMessage("conv", "replace day 2")
+
+        assertTrue(reply.content.contains("I replaced Day 2", ignoreCase = true))
+        assertTrue(reply.content.contains("Turkey skillet", ignoreCase = true))
+        coVerify { sessionRepository.replaceDayDraft("session-1", 1, "Turkey skillet", any(), any()) }
+    }
+
+    @Test
     fun `ingestUserMessage waits while generation is already running`() = runTest {
         val ready = collectingSnapshot().copy(
             peopleCount = 4,
@@ -322,6 +352,14 @@ class MealPlannerCoordinatorTest {
           "days": [
             {"day_index": 0, "title": "Lemon chicken", "summary": "Quick dinner", "protein_tags": ["chicken"]},
             {"day_index": 1, "title": "Beef bowls", "summary": "Weeknight bowl", "protein_tags": ["beef"]}
+          ]
+        }
+    """.trimIndent()
+
+    private fun replacementJson(dayIndex: Int, title: String): String = """
+        {
+          "days": [
+            {"day_index": $dayIndex, "title": "$title", "summary": "Quick dinner", "protein_tags": ["turkey"]}
           ]
         }
     """.trimIndent()

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -119,6 +119,45 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `collecting no restrictions completes slot collection`() = runTest {
+        val ready = collectingSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken"),
+        )
+        val reviewed = planReviewSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("chicken"),
+        )
+        coEvery {
+            sessionRepository.getActiveSession("conv")
+        } returns collectingSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            proteinPreferences = listOf("chicken"),
+        )
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = listOf("no dietary requirements"),
+                proteinPreferences = null,
+            )
+        } returns ready
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns planJson()
+        coEvery { sessionRepository.savePlanDraft("session-1", any()) } returns reviewed
+
+        val reply = coordinator.ingestUserMessage("conv", "No restrictions")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        coVerify(exactly = 1) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) }
+    }
+
+    @Test
     fun `collecting bare any as final protein answer completes slot collection`() = runTest {
         val ready = collectingSnapshot().copy(
             peopleCount = 2,

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -119,6 +119,45 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `collecting bare any as final protein answer completes slot collection`() = runTest {
+        val ready = collectingSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("no protein preference"),
+        )
+        val reviewed = planReviewSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+            proteinPreferences = listOf("no protein preference"),
+        )
+        coEvery {
+            sessionRepository.getActiveSession("conv")
+        } returns collectingSnapshot().copy(
+            peopleCount = 2,
+            daysCount = 2,
+            dietaryRestrictions = listOf("no dietary requirements"),
+        )
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = null,
+                proteinPreferences = listOf("no protein preference"),
+            )
+        } returns ready
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returns planJson()
+        coEvery { sessionRepository.savePlanDraft("session-1", any()) } returns reviewed
+
+        val reply = coordinator.ingestUserMessage("conv", "Any")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        coVerify(exactly = 1) { sessionRepository.markPendingGeneration("session-1", PendingGenerationKind.PLAN) }
+    }
+
+    @Test
     fun `plan review generate recipes emits progress and recipes sequentially`() = runTest {
         val planReview = planReviewSnapshot()
         val afterDay1 = planReview.copy(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -29,6 +29,10 @@ class MealPlannerSlotExtractorTest {
         )
         assertEquals(
             listOf("no dietary requirements"),
+            extractor.extractDietaryRestrictions("No restrictions"),
+        )
+        assertEquals(
+            listOf("no dietary requirements"),
             extractor.extractDietaryRestrictions("None"),
         )
         assertEquals(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -18,6 +18,26 @@ class MealPlannerSlotExtractorTest {
     }
 
     @Test
+    fun `extractDietaryRestrictions recognizes explicit no requirements`() {
+        assertEquals(
+            listOf("no dietary requirements"),
+            extractor.extractDietaryRestrictions("No dietary requirements"),
+        )
+        assertEquals(
+            listOf("no dietary requirements"),
+            extractor.extractDietaryRestrictions("None"),
+        )
+    }
+
+    @Test
+    fun `extractProteinPreferences recognizes explicit no preference`() {
+        assertEquals(
+            listOf("no protein preference"),
+            extractor.extractProteinPreferences("Any protein is fine"),
+        )
+    }
+
+    @Test
     fun `extractReplaceDayIndex parses one based day number`() {
         assertEquals(1, extractor.extractReplaceDayIndex("replace day 2"))
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -18,22 +18,34 @@ class MealPlannerSlotExtractorTest {
     }
 
     @Test
-    fun `extractDietaryRestrictions recognizes explicit no requirements`() {
+    fun `negative dietary and protein answers normalize to concrete markers`() {
         assertEquals(
             listOf("no dietary requirements"),
             extractor.extractDietaryRestrictions("No dietary requirements"),
         )
         assertEquals(
             listOf("no dietary requirements"),
+            extractor.extractDietaryRestrictions("No dietary"),
+        )
+        assertEquals(
+            listOf("no dietary requirements"),
             extractor.extractDietaryRestrictions("None"),
         )
-    }
-
-    @Test
-    fun `extractProteinPreferences recognizes explicit no preference`() {
         assertEquals(
             listOf("no protein preference"),
             extractor.extractProteinPreferences("Any protein is fine"),
+        )
+        assertEquals(
+            listOf("no protein preference"),
+            extractor.extractProteinPreferences("No preferences"),
+        )
+        assertEquals(
+            listOf("no protein preference"),
+            extractor.extractProteinPreferences("None", allowBareNoPreference = true),
+        )
+        assertEquals(
+            listOf("no protein preference"),
+            extractor.extractProteinPreferences("Any", allowBareNoPreference = true),
         )
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -59,6 +59,12 @@ class MealPlannerSlotExtractorTest {
     }
 
     @Test
+    fun `isRetryRequest recognizes retry phrases`() {
+        assertTrue(extractor.isRetryRequest("Retry"))
+        assertTrue(extractor.isRetryRequest("try again"))
+    }
+
+    @Test
     fun `isChangePreferencesRequest recognizes edit request`() {
         assertTrue(extractor.isChangePreferencesRequest("change preferences"))
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -33,6 +33,10 @@ class MealPlannerSlotExtractorTest {
         )
         assertEquals(
             listOf("no dietary requirements"),
+            extractor.extractDietaryRestrictions("No requirements"),
+        )
+        assertEquals(
+            listOf("no dietary requirements"),
             extractor.extractDietaryRestrictions("None"),
         )
         assertEquals(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -31,4 +31,15 @@ class MealPlannerSlotExtractorTest {
     fun `isCancelRequest recognizes meal planning cancellation`() {
         assertTrue(extractor.isCancelRequest("cancel the meal plan"))
     }
+
+    @Test
+    fun `isGenerateRecipesRequest recognizes approval and resume phrases`() {
+        assertTrue(extractor.isGenerateRecipesRequest("generate recipes"))
+        assertTrue(extractor.isGenerateRecipesRequest("resume"))
+    }
+
+    @Test
+    fun `isChangePreferencesRequest recognizes edit request`() {
+        assertTrue(extractor.isChangePreferencesRequest("change preferences"))
+    }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -785,6 +785,7 @@ class ChatViewModel @Inject constructor(
         content: String,
         shouldIndex: Boolean = true,
         spokenSummary: String? = null,
+        speak: Boolean = true,
     ) {
         val msgId = UUID.randomUUID().toString()
         val msg = ChatMessage(
@@ -795,7 +796,9 @@ class ChatViewModel @Inject constructor(
         _messages.update { it + msg }
         val savedId = conversationRepository.addMessage(convId, "assistant", content)
         if (shouldIndex) ragRepository.indexMessage(savedId, convId, content)
-        speakAssistantReplyIfNeeded(content, spokenSummary)
+        if (speak) {
+            speakAssistantReplyIfNeeded(content, spokenSummary)
+        }
     }
 
     /** Like [appendAssistantMessage] but also attaches a [ToolCallInfo] chip so the UI shows
@@ -809,6 +812,7 @@ class ChatViewModel @Inject constructor(
         isSuccess: Boolean,
         presentation: ToolPresentation? = null,
         spokenSummary: String? = null,
+        speak: Boolean = true,
     ) {
         val msgId = UUID.randomUUID().toString()
         val toolCall = ToolCallInfo(
@@ -831,7 +835,9 @@ class ChatViewModel @Inject constructor(
             toolCallJson = toolCall.toJsonString(),
         )
         if (shouldIndexToolCallResult(skillName)) ragRepository.indexMessage(savedId, convId, content)
-        speakAssistantReplyIfNeeded(content, spokenSummary)
+        if (speak) {
+            speakAssistantReplyIfNeeded(content, spokenSummary)
+        }
     }
 
     fun retryDownload(model: KernelModel) {
@@ -1141,9 +1147,13 @@ class ChatViewModel @Inject constructor(
                 val plannerReply = if (explicitMealPlannerStart) {
                     mealPlannerCoordinator.startOrResume(convId)
                 } else {
-                    mealPlannerCoordinator.ingestUserMessage(convId, text)
+                    mealPlannerCoordinator.ingestUserMessage(convId, text) { plannerMessage ->
+                        appendAssistantMessage(convId, plannerMessage, shouldIndex = false, speak = false)
+                    }
                 }
-                appendAssistantMessage(convId, plannerReply.content, shouldIndex = false)
+                if (plannerReply.content.isNotBlank()) {
+                    appendAssistantMessage(convId, plannerReply.content, shouldIndex = false)
+                }
                 return@launch
             }
 


### PR DESCRIPTION
## Summary
- pause meal planning after the high-level draft and require explicit `generate recipes` approval before recipe generation starts
- emit per-day progress and recipe reveal messages through chat while preserving in-session preference edits and resume prompts
- harden planner state transitions for replacement parsing, cancellation races, and interrupted recipe generation

## Testing
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :core:skills:testDebugUnitTest --tests "*MealPlanJsonParserTest" --tests "*MealPlannerCoordinatorTest" --tests "*MealPlannerSlotExtractorTest" --tests "*MealPlanQuantityValidatorTest" :feature:chat:compileDebugKotlin :core:memory:compileDebugKotlin :core:memory:compileDebugAndroidTestKotlin`

Closes #869