### PR TITLE
chore: manual cleanup-old-releases workflow

### DIFF
--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -1,0 +1,42 @@
+name: Cleanup old releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      days_older_than:
+        description: 'Delete pre-releases published more than this many days ago'
+        required: true
+        default: '7'
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  cleanup:
+    name: Delete old pre-releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Delete pre-releases older than N days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYS: ${{ inputs.days_older_than }}
+        run: |
+          CUTOFF=$(date -d "$DAYS days ago" --utc +%Y-%m-%dT%H:%M:%SZ)
+          echo "Deleting pre-releases published before $CUTOFF"
+
+          gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName,publishedAt,isPrerelease \
+            --jq --arg cutoff "$CUTOFF" \
+              '.[] | select(.isPrerelease == true and .publishedAt < $cutoff) | .tagName' \
+          | while read -r TAG; do
+              echo "Deleting release + tag: $TAG"
+              gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag 2>/dev/null || true
+            done
+
+          echo "Done."


### PR DESCRIPTION
## Summary

Adds a manual GitHub Actions workflow to delete old pre-releases, with a configurable age threshold.

## Changes

- `.github/workflows/cleanup-old-releases.yml` — new `workflow_dispatch` workflow with a `days_older_than` input (default: 7)
- Deletes all pre-releases (and their tags) published before the cutoff date
- Only targets pre-releases — draft and full releases are left untouched

## Usage

Actions → **Cleanup old releases** → Run workflow → set `days_older_than` (default 7) → Run.

## Testing

- [ ] Trigger manually via Actions tab with default (7 days)
- [ ] Confirm only pre-releases older than threshold are deleted
