### PR TITLE
fix(#891): prompt meal planner resume state on return

### DIFF
--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
@@ -11,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.kernel.ai.core.memory.KernelDatabase
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.mealplan.CanonicalGroceryItem
 import com.kernel.ai.core.memory.mealplan.GroceryNormalizationStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanDraftDay
@@ -51,6 +52,7 @@ class MealPlanSessionRepositoryAndroidTest {
             .allowMainThreadQueries()
             .build()
         repository = MealPlanSessionRepository(
+            database = database,
             sessionDao = database.mealPlanSessionDao(),
             dayDao = database.mealPlanDayDao(),
             recipeVersionDao = database.mealPlanRecipeVersionDao(),
@@ -216,10 +218,13 @@ class MealPlanSessionRepositoryAndroidTest {
             ),
         )
 
+        val keepListName = "My Groceries"
+        listNameDao.insert(ListNameEntity(name = keepListName, createdAt = 1L, updatedAt = 1L))
+
         val cancelled = repository.cancelSession(session.sessionId)
 
         assertEquals(MealPlanSessionStatus.CANCELLED, cancelled.status)
-        assertTrue(listNameDao.getAll().isEmpty())
+        assertEquals(listOf(keepListName), listNameDao.getAll().map { it.name })
         assertEquals(2, projectionCount(session.sessionId, "PLAN_SHOPPING_LIST", superseded = true))
         assertEquals(2, projectionCount(session.sessionId, "RECIPE_LIST", superseded = true))
         assertEquals(0, projectionCount(session.sessionId, "PLAN_SHOPPING_LIST", superseded = false))

--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
@@ -188,6 +188,45 @@ class MealPlanSessionRepositoryAndroidTest {
     }
 
     @Test
+    fun cancelSession_deletesPlannerOwnedListsAndSupersedesProjections() = runBlocking {
+        val session = repository.startOrResume("conv-3")
+        repository.savePlanDraft(
+            session.sessionId,
+            listOf(
+                MealPlanDraftDay(
+                    dayIndex = 0,
+                    title = "Chicken Stir Fry",
+                    summary = "Quick bowl",
+                    proteinTags = listOf("chicken"),
+                ),
+            ),
+        )
+
+        repository.persistRecipeDraft(
+            sessionId = session.sessionId,
+            dayIndex = 0,
+            recipeDraft = recipeDraft(
+                title = "Chicken Stir Fry",
+                method = listOf("Prep vegetables.", "Stir-fry chicken."),
+            ),
+            rawModelJson = "{}",
+            groceries = listOf(
+                grocery(displayText = "500 g chicken thigh", quantity = "500", unit = "g", ingredientName = "chicken thigh"),
+                grocery(displayText = "2 onions", ingredientName = "onions", normalizationStatus = GroceryNormalizationStatus.OPAQUE),
+            ),
+        )
+
+        val cancelled = repository.cancelSession(session.sessionId)
+
+        assertEquals(MealPlanSessionStatus.CANCELLED, cancelled.status)
+        assertTrue(listNameDao.getAll().isEmpty())
+        assertEquals(2, projectionCount(session.sessionId, "PLAN_SHOPPING_LIST", superseded = true))
+        assertEquals(2, projectionCount(session.sessionId, "RECIPE_LIST", superseded = true))
+        assertEquals(0, projectionCount(session.sessionId, "PLAN_SHOPPING_LIST", superseded = false))
+        assertEquals(0, projectionCount(session.sessionId, "RECIPE_LIST", superseded = false))
+    }
+
+    @Test
     fun migration33To34_preservesExistingListsAndCreatesMealPlannerTables() {
         migrationHelper.createDatabase(MIGRATION_DB_NAME, 33).apply {
             execSQL("INSERT INTO `lists` (`id`, `name`, `createdAt`) VALUES (1, 'Existing list', 1234)")

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanProjectionWriteDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanProjectionWriteDao.kt
@@ -27,6 +27,16 @@ interface MealPlanProjectionWriteDao {
         UPDATE meal_plan_projection_writes
         SET supersededAt = :timestamp
         WHERE mealPlanSessionId = :sessionId
+          AND supersededAt IS NULL
+        """,
+    )
+    suspend fun markSupersededForSession(sessionId: String, timestamp: Long)
+
+    @Query(
+        """
+        UPDATE meal_plan_projection_writes
+        SET supersededAt = :timestamp
+        WHERE mealPlanSessionId = :sessionId
           AND targetKind = :targetKind
           AND sourceKey LIKE :sourceKeyPrefix
           AND supersededAt IS NULL
@@ -53,4 +63,13 @@ interface MealPlanProjectionWriteDao {
         targetKind: String,
         sourceKeyPrefix: String,
     ): List<String>
+
+    @Query(
+        """
+        SELECT DISTINCT targetName FROM meal_plan_projection_writes
+        WHERE mealPlanSessionId = :sessionId
+          AND supersededAt IS NULL
+        """,
+    )
+    suspend fun getActiveTargetNamesForSession(sessionId: String): List<String>
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -361,6 +361,7 @@ class MealPlanSessionRepository @Inject constructor(
     suspend fun cancelSession(sessionId: String): MealPlanSnapshot {
         val session = requireNotNull(sessionDao.getById(sessionId))
         val now = System.currentTimeMillis()
+        deleteActiveProjections(sessionId, supersededAt = now)
         val updated = session.copy(
             status = MealPlanSessionStatus.CANCELLED.name,
             pendingGenerationKind = null,
@@ -473,6 +474,13 @@ class MealPlanSessionRepository @Inject constructor(
     private suspend fun deleteList(name: String) {
         // With FK CASCADE on list_items.listId, deleting from lists removes all child items
         listNameDao.deleteByName(name)
+    }
+
+    private suspend fun deleteActiveProjections(sessionId: String, supersededAt: Long) {
+        for (targetName in projectionWriteDao.getActiveTargetNamesForSession(sessionId)) {
+            deleteList(targetName)
+        }
+        projectionWriteDao.markSupersededForSession(sessionId, supersededAt)
     }
 
     private suspend fun createSession(conversationId: String): MealPlanSessionEntity {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.core.memory.repository
 
+import androidx.room.withTransaction
+import com.kernel.ai.core.memory.KernelDatabase
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.MealPlanDayDao
@@ -40,6 +42,7 @@ import javax.inject.Singleton
 
 @Singleton
 class MealPlanSessionRepository @Inject constructor(
+    private val database: KernelDatabase,
     private val sessionDao: MealPlanSessionDao,
     private val dayDao: MealPlanDayDao,
     private val recipeVersionDao: MealPlanRecipeVersionDao,
@@ -477,10 +480,12 @@ class MealPlanSessionRepository @Inject constructor(
     }
 
     private suspend fun deleteActiveProjections(sessionId: String, supersededAt: Long) {
-        for (targetName in projectionWriteDao.getActiveTargetNamesForSession(sessionId)) {
-            deleteList(targetName)
+        database.withTransaction {
+            for (targetName in projectionWriteDao.getActiveTargetNamesForSession(sessionId)) {
+                deleteList(targetName)
+            }
+            projectionWriteDao.markSupersededForSession(sessionId, supersededAt)
         }
-        projectionWriteDao.markSupersededForSession(sessionId, supersededAt)
     }
 
     private suspend fun createSession(conversationId: String): MealPlanSessionEntity {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -35,6 +35,11 @@ class MealPlannerCoordinator @Inject constructor(
     suspend fun hasAnySession(conversationId: String): Boolean =
         sessionRepository.hasAnySessionForConversation(conversationId)
 
+    suspend fun activeSessionReply(conversationId: String): MealPlannerReply? {
+        val snapshot = sessionRepository.getActiveSession(conversationId) ?: return null
+        return MealPlannerReply(promptForSnapshot(snapshot))
+    }
+
     suspend fun startOrResume(conversationId: String): MealPlannerReply {
         val snapshot = sessionRepository.startOrResume(conversationId)
         return MealPlannerReply(promptForSnapshot(snapshot))

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -53,7 +53,7 @@ class MealPlannerSlotExtractor @Inject constructor() {
 
     fun isGenerateRecipesRequest(text: String): Boolean =
         Regex(
-            "\\b(?:generate(?:\\s+recipes?)?|make(?:\\s+(?:recipes?|meal plan))?|create(?:\\s+(?:recipes?|meal plan))?|start(?:\\s+(?:recipes?|meal plan))?|continue|resume|keep going)\\b",
+            "\\b(?:generate(?:\\s+recipes?)?|make(?:\\s+(?:recipes?|meal plan))|create(?:\\s+(?:recipes?|meal plan))|start(?:\\s+(?:recipes?|meal plan))|continue|resume|keep going)\\b",
             RegexOption.IGNORE_CASE,
         ).containsMatchIn(text)
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -52,8 +52,10 @@ class MealPlannerSlotExtractor @Inject constructor() {
             .find(text)?.groupValues?.getOrNull(1)?.toIntOrNull()?.minus(1)
 
     fun isGenerateRecipesRequest(text: String): Boolean =
-        Regex("\\b(?:generate|make|create|start)\\b.*\\b(?:recipes?|meal plan)\\b|\\b(?:continue|resume|keep going)\\b", RegexOption.IGNORE_CASE)
-            .containsMatchIn(text)
+        Regex(
+            "\\b(?:generate(?:\\s+recipes?)?|make(?:\\s+(?:recipes?|meal plan))?|create(?:\\s+(?:recipes?|meal plan))?|start(?:\\s+(?:recipes?|meal plan))?|continue|resume|keep going)\\b",
+            RegexOption.IGNORE_CASE,
+        ).containsMatchIn(text)
 
     fun isRetryRequest(text: String): Boolean =
         Regex("\\b(?:retry|try again)\\b", RegexOption.IGNORE_CASE).containsMatchIn(text)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -272,6 +272,42 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `plan review bare generate emits progress and recipes sequentially`() = runTest {
+        val planReview = planReviewSnapshot()
+        val afterDay1 = planReview.copy(
+            status = MealPlanSessionStatus.RECIPES_IN_PROGRESS,
+            activeDayIndex = 1,
+            pendingGenerationKind = PendingGenerationKind.RECIPE,
+            pendingGenerationDayIndex = 1,
+            days = listOf(
+                draftDay(dayIndex = 0, title = "Lemon chicken", status = MealPlanDayStatus.PERSISTED),
+                draftDay(dayIndex = 1, title = "Beef bowls", status = MealPlanDayStatus.DRAFTED),
+            ),
+        )
+        val completed = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        val emitted = mutableListOf<String>()
+
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReview
+        coEvery { sessionRepository.getSession("session-1") } returns planReview
+        coEvery { inferenceEngine.generateOnce(any(), any(), false, true) } returnsMany listOf(recipeJson("Lemon chicken"), recipeJson("Beef bowls"))
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 0, any(), any(), any()) } returns afterDay1
+        coEvery { sessionRepository.persistRecipeDraft("session-1", 1, any(), any(), any()) } returns completed
+
+        val reply = coordinator.ingestUserMessage("conv", "generate") { emitted += it }
+
+        assertEquals(
+            listOf(
+                "Generating recipe 1 of 2…",
+                expectedRecipeSection(0, "Lemon chicken"),
+                "Generating recipe 2 of 2…",
+                expectedRecipeSection(1, "Beef bowls"),
+            ),
+            emitted,
+        )
+        assertTrue(reply.content.contains("done meal planning", ignoreCase = true))
+    }
+
+    @Test
     fun `plan review change preferences returns to editable slot collection`() = runTest {
         val planReview = planReviewSnapshot()
         val editable = planReview.copy(status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -74,6 +74,7 @@ class MealPlannerSlotExtractorTest {
 
     @Test
     fun `isGenerateRecipesRequest recognizes approval and resume phrases`() {
+        assertTrue(extractor.isGenerateRecipesRequest("generate"))
         assertTrue(extractor.isGenerateRecipesRequest("generate recipes"))
         assertTrue(extractor.isGenerateRecipesRequest("resume"))
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.skills.mealplan
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -77,6 +78,12 @@ class MealPlannerSlotExtractorTest {
         assertTrue(extractor.isGenerateRecipesRequest("generate"))
         assertTrue(extractor.isGenerateRecipesRequest("generate recipes"))
         assertTrue(extractor.isGenerateRecipesRequest("resume"))
+        assertTrue(extractor.isGenerateRecipesRequest("make recipes"))
+        assertTrue(extractor.isGenerateRecipesRequest("create recipes"))
+        assertTrue(extractor.isGenerateRecipesRequest("start meal plan"))
+        assertFalse(extractor.isGenerateRecipesRequest("make the recipe less spicy"))
+        assertFalse(extractor.isGenerateRecipesRequest("create a note"))
+        assertFalse(extractor.isGenerateRecipesRequest("start from scratch"))
     }
 
     @Test

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -640,6 +640,15 @@ class ChatViewModel @Inject constructor(
                 needsHistoryReplay = true
             }
 
+            if (mealPlannerCoordinator.hasActiveSession(id)) {
+                val plannerReply = mealPlannerCoordinator.startOrResume(id)
+                val latestAssistantContent = _messages.value.lastOrNull { it.role == ChatMessage.Role.ASSISTANT }?.content
+                if (plannerReply.content.isNotBlank() && plannerReply.content != latestAssistantContent) {
+                    appendAssistantMessage(id, plannerReply.content, shouldIndex = false, speak = false)
+                    needsHistoryReplay = true
+                }
+            }
+
             // Determine whether smart-title generation should still fire on this restored session.
             // A title that looks like a first-message placeholder (ends with '…', ≤43 chars) can
             // still be overwritten if the conversation is long enough for a smart title.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -640,12 +640,10 @@ class ChatViewModel @Inject constructor(
                 needsHistoryReplay = true
             }
 
-            if (mealPlannerCoordinator.hasActiveSession(id)) {
-                val plannerReply = mealPlannerCoordinator.startOrResume(id)
+            mealPlannerCoordinator.activeSessionReply(id)?.let { plannerReply ->
                 val latestAssistantContent = _messages.value.lastOrNull { it.role == ChatMessage.Role.ASSISTANT }?.content
                 if (plannerReply.content.isNotBlank() && plannerReply.content != latestAssistantContent) {
-                    appendAssistantMessage(id, plannerReply.content, shouldIndex = false, speak = false)
-                    needsHistoryReplay = true
+                    appendTransientAssistantMessage(plannerReply.content)
                 }
             }
 
@@ -808,6 +806,19 @@ class ChatViewModel @Inject constructor(
         if (speak) {
             speakAssistantReplyIfNeeded(content, spokenSummary)
         }
+    }
+
+    /**
+     * Adds UI-only assistant guidance that should be visible immediately but must not be
+     * persisted to Room, indexed for RAG, or replayed into LiteRT history.
+     */
+    private fun appendTransientAssistantMessage(content: String) {
+        val msg = ChatMessage(
+            id = UUID.randomUUID().toString(),
+            role = ChatMessage.Role.ASSISTANT,
+            content = content,
+        )
+        _messages.update { it + msg }
     }
 
     /** Like [appendAssistantMessage] but also attaches a [ToolCallInfo] chip so the UI shows

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -2239,7 +2239,9 @@ class ChatViewModel @Inject constructor(
                 }
             }
         }
-        viewModelScope.launch { inferenceEngine.shutdown() }
+        // InferenceEngine is a process-scoped singleton. Do not shut it down just because this
+        // screen is closing — that can interrupt active meal-plan generation while the user
+        // navigates elsewhere in the app (for example to Lists).
     }
 
     private fun submitVoiceTranscript(rawTranscript: String) {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -31,6 +31,7 @@ import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.slot.SlotFillerManager
 import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
 import com.kernel.ai.core.skills.mealplan.MealPlannerReply
+import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -47,12 +48,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -194,13 +197,14 @@ class ChatViewModelInitTest {
     }
 
     @Test
-    fun `restored chat initialization appends actionable meal planner resume prompt`() = runTest(dispatcher) {
+    fun `restored chat initialization shows actionable meal planner resume prompt without persisting it`() = runTest(dispatcher) {
         val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
-        coEvery { mealPlannerCoordinator.hasActiveSession("conv-existing") } returns true
-        coEvery { mealPlannerCoordinator.startOrResume("conv-existing") } returns MealPlannerReply(prompt)
-        coEvery { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) } returns "assistant-msg"
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
 
-        ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        coEvery { mealPlannerCoordinator.activeSessionReply("conv-existing") } returns MealPlannerReply(prompt)
+
+        val viewModel = ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
         inferenceEngine = inferenceEngine,
         downloadManager = downloadManager,
         conversationRepository = conversationRepository,
@@ -228,16 +232,20 @@ class ChatViewModelInitTest {
 
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { mealPlannerCoordinator.startOrResume("conv-existing") }
-        coVerify(exactly = 1) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
+        coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
+        coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
         coVerify(exactly = 0) { ragRepository.indexMessage(any(), any(), any()) }
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertEquals(prompt, state.messages.last().content)
     }
 
     @Test
     fun `restored chat initialization does not duplicate latest meal planner resume prompt`() = runTest(dispatcher) {
         val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
-        coEvery { mealPlannerCoordinator.hasActiveSession("conv-existing") } returns true
-        coEvery { mealPlannerCoordinator.startOrResume("conv-existing") } returns MealPlannerReply(prompt)
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+
+        coEvery { mealPlannerCoordinator.activeSessionReply("conv-existing") } returns MealPlannerReply(prompt)
         coEvery { conversationRepository.getMessagesOnce("conv-existing") } returns listOf(
             com.kernel.ai.core.memory.entity.MessageEntity(
                 id = "msg-1",
@@ -249,7 +257,7 @@ class ChatViewModelInitTest {
             ),
         )
 
-        ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        val viewModel = ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
         inferenceEngine = inferenceEngine,
         downloadManager = downloadManager,
         conversationRepository = conversationRepository,
@@ -277,8 +285,79 @@ class ChatViewModelInitTest {
 
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { mealPlannerCoordinator.startOrResume("conv-existing") }
+        coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
         coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertEquals(1, state.messages.size)
+        assertEquals(prompt, state.messages.last().content)
+    }
+
+    @Test
+    fun `restored chat initialization re-shows planner guidance after later conversation turns without writing duplicates`() = runTest(dispatcher) {
+        val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        coEvery { mealPlannerCoordinator.activeSessionReply("conv-existing") } returns MealPlannerReply(prompt)
+        coEvery { conversationRepository.getMessagesOnce("conv-existing") } returns listOf(
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-1",
+                conversationId = "conv-existing",
+                role = "assistant",
+                content = prompt,
+                thinkingText = null,
+                timestamp = 1L,
+            ),
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-2",
+                conversationId = "conv-existing",
+                role = "user",
+                content = "continue please",
+                thinkingText = null,
+                timestamp = 2L,
+            ),
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-3",
+                conversationId = "conv-existing",
+                role = "assistant",
+                content = "Still working on Day 2 — give me a moment.",
+                thinkingText = null,
+                timestamp = 3L,
+            ),
+        )
+
+        val viewModel = ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+        )
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
+        coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertEquals(4, state.messages.size)
+        assertEquals(prompt, state.messages.last().content)
     }
 
     @Test

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -197,6 +197,41 @@ class ChatViewModelInitTest {
     }
 
     @Test
+    fun `closing chat never shuts down process scoped inference engine`() = runTest(dispatcher) {
+        val viewModel = ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+        )
+
+        advanceUntilIdle()
+        invokeOnCleared(viewModel)
+
+        coVerify(exactly = 0) { inferenceEngine.shutdown() }
+    }
+
+
+    @Test
     fun `restored chat initialization shows actionable meal planner resume prompt without persisting it`() = runTest(dispatcher) {
         val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
@@ -698,5 +733,11 @@ class ChatViewModelInitTest {
         coVerify(atLeast = 1) { ragRepository.indexMessage("user-msg-id", any(), "hello") }
         // Fallback text must not be indexed.
         coVerify(exactly = 0) { ragRepository.indexMessage("assistant-fallback-id", any(), any()) }
+    }
+
+    private fun invokeOnCleared(viewModel: ChatViewModel) {
+        val method = ChatViewModel::class.java.getDeclaredMethod("onCleared")
+        method.isAccessible = true
+        method.invoke(viewModel)
     }
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -30,6 +30,7 @@ import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.slot.SlotFillerManager
 import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
+import com.kernel.ai.core.skills.mealplan.MealPlannerReply
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import com.kernel.ai.core.voice.VoiceOutputPreferences
@@ -190,6 +191,94 @@ class ChatViewModelInitTest {
 
         coVerify(exactly = 0) { conversationRepository.createConversation() }
         coVerify(exactly = 0) { inferenceEngine.resetConversation() }
+    }
+
+    @Test
+    fun `restored chat initialization appends actionable meal planner resume prompt`() = runTest(dispatcher) {
+        val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
+        coEvery { mealPlannerCoordinator.hasActiveSession("conv-existing") } returns true
+        coEvery { mealPlannerCoordinator.startOrResume("conv-existing") } returns MealPlannerReply(prompt)
+        coEvery { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) } returns "assistant-msg"
+
+        ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+        )
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { mealPlannerCoordinator.startOrResume("conv-existing") }
+        coVerify(exactly = 1) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
+        coVerify(exactly = 0) { ragRepository.indexMessage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `restored chat initialization does not duplicate latest meal planner resume prompt`() = runTest(dispatcher) {
+        val prompt = "I still need to finish Day 2 of 3. Say 'generate recipes' to continue or 'cancel' to stop."
+        coEvery { mealPlannerCoordinator.hasActiveSession("conv-existing") } returns true
+        coEvery { mealPlannerCoordinator.startOrResume("conv-existing") } returns MealPlannerReply(prompt)
+        coEvery { conversationRepository.getMessagesOnce("conv-existing") } returns listOf(
+            com.kernel.ai.core.memory.entity.MessageEntity(
+                id = "msg-1",
+                conversationId = "conv-existing",
+                role = "assistant",
+                content = prompt,
+                thinkingText = null,
+                timestamp = 1L,
+            ),
+        )
+
+        ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+        )
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { mealPlannerCoordinator.startOrResume("conv-existing") }
+        coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- surface the meal-planner resume prompt automatically when reopening a conversation with an active planner session
- show that guidance as a UI-only message so it is not persisted to Room, indexed for RAG, or replayed into LiteRT history
- suppress duplication when the latest assistant message already matches the current planner guidance, while still re-showing guidance after later conversation turns
- clear meal-planner-owned shopping and recipe lists when the user cancels an in-progress planner session after projections have already been written
- add regression coverage for restored-session guidance, duplicate-prevention, and cancel cleanup of planner-owned list projections without touching unrelated lists

## Testing
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :feature:chat:testDebugUnitTest --tests "*ChatViewModelInitTest"`
- `ANDROID_HOME="$HOME/Android/Sdk" ANDROID_SDK_ROOT="$HOME/Android/Sdk" ./gradlew :core:memory:assembleDebugAndroidTest`
- GitHub Actions CI: https://github.com/NickMonrad/kernel-ai-assistant/actions/runs/25975228463

## Manual testing
Device: Samsung Galaxy S23 Ultra

### Resume prompt guidance
1. Start a meal-planner session in chat and advance it until the planner is waiting on recipe generation or resume input.
2. Leave the conversation list, then reopen the same conversation.
   - Expected: an actionable resume prompt appears immediately in the chat without sending any new user message.
3. Leave and reopen the same conversation again without any intervening turns.
   - Expected: the same resume prompt is not appended again if it is already the latest assistant message.
4. Send another user message or let the planner emit a different assistant progress message, then leave and reopen the conversation.
   - Expected: the actionable resume prompt is shown again to guide the user, but only once per reopen.
5. Continue the planner flow with the suggested command (for example `generate recipes` or `cancel`).
   - Expected: the planner resumes or cancels normally from the restored conversation.
6. Close and reopen the app, then return to the same conversation.
   - Expected: the conversation still restores cleanly and shows the current actionable meal-planner guidance once.
7. Optional log check with `adb logcat -s KernelAI` while reopening the conversation.
   - Expected: no crash, no repeated resume-prompt spam pattern, and normal chat restore logs only.

### Cancel cleanup after recipe/list generation
1. Start a meal-planner session and generate at least one recipe so the planner writes a shopping list and at least one recipe list.
2. Ensure there is at least one unrelated existing list in the Lists UI before cancelling.
3. Say `cancel` while the meal-plan session is still active.
   - Expected: Jandal confirms the meal plan session was cancelled.
4. Open the Lists UI.
   - Expected: the meal-planner shopping list and any meal-planner recipe lists created by that cancelled session are gone.
   - Expected: unrelated pre-existing user lists are still present.
5. Reopen the original conversation.
   - Expected: the cancelled session does not resume; starting meal planning again creates a fresh session.

Closes #891