### PR TITLE
feat(#888): lists overview UI — rename, pin, sort, filter

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -42,6 +42,9 @@ interface ListNameDao {
     @Query("UPDATE lists SET pinned = :pinned, updatedAt = :updatedAt WHERE id = :id")
     suspend fun updatePinned(id: Long, pinned: Boolean, updatedAt: Long)
 
+    @Query("UPDATE lists SET pinned = NOT pinned, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun togglePinned(id: Long, updatedAt: Long)
+
     @Query("UPDATE lists SET updatedAt = :updatedAt WHERE id = :id")
     suspend fun updateTimestamp(id: Long, updatedAt: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -12,6 +12,14 @@ interface ListNameDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(list: ListNameEntity)
 
+    /**
+     * Inserts a new list and returns the generated row-id (= entity id), or -1 on a
+     * name-unique conflict (IGNORE strategy).  Callers can fall back to [getByName] when -1
+     * is returned to handle the already-exists case.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertAndGet(list: ListNameEntity): Long
+
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
     fun observeAll(): Flow<List<ListNameEntity>>
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -1,6 +1,6 @@
 package com.kernel.ai.feature.settings
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -79,6 +79,7 @@ fun ListItemsScreen(
     else completedItems.filter { it.text.contains(searchQuery, ignoreCase = true) }
 
     var showAddDialog by remember { mutableStateOf(false) }
+    var showRenameDialog by remember { mutableStateOf(false) }
     var completedExpanded by rememberSaveable { mutableStateOf(false) }
 
     // Clear item search when leaving the screen
@@ -89,7 +90,12 @@ fun ListItemsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(displayName.replaceFirstChar { it.uppercase() }) },
+                title = {
+                    Text(
+                        text = displayName.replaceFirstChar { it.uppercase() },
+                        modifier = Modifier.clickable { showRenameDialog = true },
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -219,6 +225,20 @@ fun ListItemsScreen(
                 }
             }
         }
+    }
+
+    // Rename dialog — opened by tapping the screen title
+    if (showRenameDialog) {
+        NameInputDialog(
+            title = "Rename list",
+            confirmLabel = "Save",
+            initialValue = displayName,
+            onConfirm = { newName ->
+                viewModel.renameList(listId, newName)
+                showRenameDialog = false
+            },
+            onDismiss = { showRenameDialog = false },
+        )
     }
 
     if (showAddDialog) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -80,6 +80,9 @@ fun ListItemsScreen(
 
     var showAddDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
+    // Snapshot displayName at the moment the dialog opens so live Room updates
+    // don't reset text the user is actively typing.
+    val renameInitialValue = remember(showRenameDialog) { if (showRenameDialog) displayName else "" }
     var completedExpanded by rememberSaveable { mutableStateOf(false) }
 
     // Clear item search when leaving the screen
@@ -232,7 +235,7 @@ fun ListItemsScreen(
         NameInputDialog(
             title = "Rename list",
             confirmLabel = "Save",
-            initialValue = displayName,
+            initialValue = renameInitialValue,
             onConfirm = { newName ->
                 viewModel.renameList(listId, newName)
                 showRenameDialog = false

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -1,7 +1,10 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,16 +17,19 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Checklist
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,6 +37,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -38,6 +45,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,8 +55,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ListNameEntity
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ListsScreen(
     onBack: () -> Unit = {},
@@ -56,15 +65,23 @@ fun ListsScreen(
     onNavigateToVoiceActions: () -> Unit = {},
     viewModel: ListsViewModel = hiltViewModel(),
 ) {
+    val displayedLists by viewModel.displayedLists.collectAsStateWithLifecycle()
     val listEntities by viewModel.listEntities.collectAsStateWithLifecycle()
     val itemCounts by viewModel.itemCounts.collectAsStateWithLifecycle()
     val searchQuery by viewModel.listSearchQuery.collectAsStateWithLifecycle()
+    val scope = rememberCoroutineScope()
 
     var showCreateDialog by remember { mutableStateOf(false) }
     var pendingDeleteEntity by remember { mutableStateOf<ListNameEntity?>(null) }
+    var pendingRenameEntity by remember { mutableStateOf<ListNameEntity?>(null) }
+    var showSortMenu by remember { mutableStateOf(false) }
 
-    val filtered = if (searchQuery.isBlank()) listEntities
-    else listEntities.filter { it.name.contains(searchQuery, ignoreCase = true) }
+    // Apply search on top of the already sort/filter-applied displayedLists
+    val filtered = if (searchQuery.isBlank()) displayedLists
+    else displayedLists.filter { it.name.contains(searchQuery, ignoreCase = true) }
+
+    val pinnedItems = filtered.filter { it.pinned }
+    val unpinnedItems = filtered.filter { !it.pinned }
 
     Scaffold(
         topBar = {
@@ -73,6 +90,21 @@ fun ListsScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    Box {
+                        IconButton(onClick = { showSortMenu = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+                        }
+                        SortFilterMenu(
+                            expanded = showSortMenu,
+                            currentSort = viewModel.listSort,
+                            currentFilter = viewModel.listFilter,
+                            onSortSelected = { viewModel.listSort = it },
+                            onFilterSelected = { viewModel.listFilter = it },
+                            onDismiss = { showSortMenu = false },
+                        )
                     }
                 },
             )
@@ -128,7 +160,12 @@ fun ListsScreen(
                 ) {
                     Spacer(modifier = Modifier.height(32.dp))
                     Text(
-                        text = if (listEntities.isEmpty()) "No lists yet." else "No lists match \"$searchQuery\".",
+                        text = when {
+                            listEntities.isEmpty() -> "No lists yet."
+                            searchQuery.isNotBlank() -> "No lists match \"$searchQuery\"."
+                            viewModel.listFilter == ListFilter.PINNED_ONLY -> "No pinned lists."
+                            else -> "No lists found."
+                        },
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -143,65 +180,82 @@ fun ListsScreen(
                 }
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(filtered, key = { it.id }) { entity ->
-                        val count = itemCounts[entity.id] ?: 0
-                        ListItem(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onOpenList(entity.id) },
-                            headlineContent = {
-                                Text(entity.name.replaceFirstChar { it.uppercase() })
-                            },
-                            supportingContent = {
-                                Text("$count item${if (count == 1) "" else "s"}")
-                            },
-                            leadingContent = {
-                                Icon(
-                                    Icons.Default.Checklist,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            },
-                            trailingContent = {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(0.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    IconButton(onClick = { pendingDeleteEntity = entity }) {
-                                        Icon(
-                                            Icons.Default.Delete,
-                                            contentDescription = "Delete list",
-                                            tint = MaterialTheme.colorScheme.error,
-                                        )
-                                    }
-                                    Icon(Icons.Default.ChevronRight, contentDescription = null)
-                                }
-                            },
-                        )
-                        HorizontalDivider()
+                    // ── Pinned section ──────────────────────────────────────────────────────
+                    if (pinnedItems.isNotEmpty()) {
+                        stickyHeader(key = "header_pinned") {
+                            ListSectionHeader(label = "Pinned")
+                        }
+                        items(pinnedItems, key = { it.id }) { entity ->
+                            ListOverviewRow(
+                                entity = entity,
+                                count = itemCounts[entity.id] ?: 0,
+                                onOpen = { onOpenList(entity.id) },
+                                onPin = { viewModel.togglePin(entity.id) },
+                                onRename = { pendingRenameEntity = entity },
+                                onDelete = { pendingDeleteEntity = entity },
+                            )
+                        }
                     }
+
+                    // ── Unpinned section ────────────────────────────────────────────────────
+                    if (unpinnedItems.isNotEmpty()) {
+                        if (pinnedItems.isNotEmpty()) {
+                            stickyHeader(key = "header_other") {
+                                ListSectionHeader(label = "Other")
+                            }
+                        }
+                        items(unpinnedItems, key = { it.id }) { entity ->
+                            ListOverviewRow(
+                                entity = entity,
+                                count = itemCounts[entity.id] ?: 0,
+                                onOpen = { onOpenList(entity.id) },
+                                onPin = { viewModel.togglePin(entity.id) },
+                                onRename = { pendingRenameEntity = entity },
+                                onDelete = { pendingDeleteEntity = entity },
+                            )
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(88.dp)) } // FAB clearance
                 }
             }
         }
     }
 
-    // Create list dialog
+    // ── Create list dialog ────────────────────────────────────────────────────────────────────
     if (showCreateDialog) {
-        CreateListDialog(
+        NameInputDialog(
+            title = "New list",
+            confirmLabel = "Create",
+            initialValue = "",
             onConfirm = { name ->
                 showCreateDialog = false
                 if (name.isNotBlank()) {
-                    viewModel.addList(name)
-                    // Navigate immediately — the list will be created and visible on return
-                    // We can't navigate by ID here since the row is inserted async;
-                    // in slice 2 this will be improved. For now, stay on overview after create.
+                    scope.launch {
+                        val newId = viewModel.createList(name)
+                        if (newId > 0L) onOpenList(newId)
+                    }
                 }
             },
             onDismiss = { showCreateDialog = false },
         )
     }
 
-    // Delete confirmation dialog
+    // ── Rename dialog ─────────────────────────────────────────────────────────────────────────
+    pendingRenameEntity?.let { entity ->
+        NameInputDialog(
+            title = "Rename list",
+            confirmLabel = "Save",
+            initialValue = entity.name,
+            onConfirm = { newName ->
+                viewModel.renameList(entity.id, newName)
+                pendingRenameEntity = null
+            },
+            onDismiss = { pendingRenameEntity = null },
+        )
+    }
+
+    // ── Delete confirmation dialog ────────────────────────────────────────────────────────────
     pendingDeleteEntity?.let { entity ->
         val count = itemCounts[entity.id] ?: 0
         AlertDialog(
@@ -226,20 +280,204 @@ fun ListsScreen(
     }
 }
 
+// ── Internal composables ──────────────────────────────────────────────────────────────────────────
+
+/** Sticky section header — surface background so it occludes scrolled-under rows. */
 @Composable
-private fun CreateListDialog(
+private fun ListSectionHeader(label: String) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+    )
+}
+
+/** A single row in the lists overview. */
+@Composable
+private fun ListOverviewRow(
+    entity: ListNameEntity,
+    count: Int,
+    onOpen: () -> Unit,
+    onPin: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var showOverflow by remember { mutableStateOf(false) }
+
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpen),
+        headlineContent = {
+            Text(entity.name.replaceFirstChar { it.uppercase() })
+        },
+        supportingContent = {
+            Text("$count item${if (count == 1) "" else "s"}")
+        },
+        leadingContent = {
+            Icon(
+                Icons.Default.Checklist,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        },
+        trailingContent = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(0.dp),
+            ) {
+                // Pin toggle
+                IconButton(onClick = onPin) {
+                    Icon(
+                        if (entity.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = if (entity.pinned) "Unpin" else "Pin",
+                        tint = if (entity.pinned) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                // Overflow: Rename / Delete
+                Box {
+                    IconButton(onClick = { showOverflow = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                    }
+                    DropdownMenu(
+                        expanded = showOverflow,
+                        onDismissRequest = { showOverflow = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Rename") },
+                            onClick = { showOverflow = false; onRename() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
+                            onClick = { showOverflow = false; onDelete() },
+                        )
+                    }
+                }
+            }
+        },
+    )
+    HorizontalDivider()
+}
+
+/** Sort & filter drop-down menu anchored on the top-bar ⋮ button. */
+@Composable
+private fun SortFilterMenu(
+    expanded: Boolean,
+    currentSort: ListSort,
+    currentFilter: ListFilter,
+    onSortSelected: (ListSort) -> Unit,
+    onFilterSelected: (ListFilter) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        // ── Sort section ────────────────────────────────────────────────────
+        DropdownMenuItem(
+            text = {
+                Text(
+                    "Sort by",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            },
+            onClick = {},
+            enabled = false,
+        )
+        SortItem(
+            label = "Last modified",
+            selected = currentSort == ListSort.LAST_MODIFIED,
+            onClick = { onSortSelected(ListSort.LAST_MODIFIED); onDismiss() },
+        )
+        SortItem(
+            label = "Name A → Z",
+            selected = currentSort == ListSort.NAME_ASC,
+            onClick = { onSortSelected(ListSort.NAME_ASC); onDismiss() },
+        )
+        SortItem(
+            label = "Name Z → A",
+            selected = currentSort == ListSort.NAME_DESC,
+            onClick = { onSortSelected(ListSort.NAME_DESC); onDismiss() },
+        )
+        SortItem(
+            label = "Created (newest)",
+            selected = currentSort == ListSort.CREATED_DESC,
+            onClick = { onSortSelected(ListSort.CREATED_DESC); onDismiss() },
+        )
+        SortItem(
+            label = "Created (oldest)",
+            selected = currentSort == ListSort.CREATED_ASC,
+            onClick = { onSortSelected(ListSort.CREATED_ASC); onDismiss() },
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+        // ── Filter section ──────────────────────────────────────────────────
+        DropdownMenuItem(
+            text = {
+                Text(
+                    "Filter",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            },
+            onClick = {},
+            enabled = false,
+        )
+        SortItem(
+            label = "All",
+            selected = currentFilter == ListFilter.ALL,
+            onClick = { onFilterSelected(ListFilter.ALL); onDismiss() },
+        )
+        SortItem(
+            label = "Pinned only",
+            selected = currentFilter == ListFilter.PINNED_ONLY,
+            onClick = { onFilterSelected(ListFilter.PINNED_ONLY); onDismiss() },
+        )
+    }
+}
+
+@Composable
+private fun SortItem(label: String, selected: Boolean, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(label) },
+        onClick = onClick,
+        trailingIcon = {
+            if (selected) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+    )
+}
+
+/**
+ * Reusable single-field dialog for both "New list" (create) and "Rename list".
+ * Exposed as [internal] so [ListItemsScreen] can use it without a separate file.
+ */
+@Composable
+internal fun NameInputDialog(
+    title: String,
+    confirmLabel: String,
+    initialValue: String,
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var name by remember { mutableStateOf("") }
+    var text by remember(initialValue) { mutableStateOf(initialValue) }
     val focusRequester = remember { FocusRequester() }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("New list") },
+        title = { Text(title) },
         text = {
             OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
+                value = text,
+                onValueChange = { text = it },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
@@ -249,12 +487,13 @@ private fun CreateListDialog(
         },
         confirmButton = {
             TextButton(
-                onClick = { onConfirm(name) },
-                enabled = name.isNotBlank(),
-            ) { Text("Create") }
+                onClick = { onConfirm(text) },
+                enabled = text.isNotBlank(),
+            ) { Text(confirmLabel) }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
 }
+

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -1,5 +1,9 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.dao.ListItemDao
@@ -11,10 +15,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+enum class ListSort { LAST_MODIFIED, NAME_ASC, NAME_DESC, CREATED_ASC, CREATED_DESC }
+enum class ListFilter { ALL, PINNED_ONLY }
 
 @HiltViewModel
 class ListsViewModel @Inject constructor(
@@ -26,6 +34,41 @@ class ListsViewModel @Inject constructor(
     val listEntities: StateFlow<List<ListNameEntity>> =
         listNameDao.observeAll()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // ── Sort / filter state (ViewModel-scoped, survives recomposition) ──────────────────────────
+
+    /** Current sort order selected by the user on the overview screen. */
+    var listSort by mutableStateOf(ListSort.LAST_MODIFIED)
+
+    /** Current filter selected by the user on the overview screen. */
+    var listFilter by mutableStateOf(ListFilter.ALL)
+
+    /**
+     * Derived list for the overview screen — pinned group first, then unpinned; each group sorted
+     * independently per [listSort]; optionally narrowed by [listFilter].
+     */
+    val displayedLists: StateFlow<List<ListNameEntity>> = combine(
+        listEntities,
+        snapshotFlow { listSort },
+        snapshotFlow { listFilter },
+    ) { entities, sort, filter ->
+        val base = when (filter) {
+            ListFilter.ALL -> entities
+            ListFilter.PINNED_ONLY -> entities.filter { it.pinned }
+        }
+        val comparator: Comparator<ListNameEntity> = when (sort) {
+            ListSort.LAST_MODIFIED -> compareByDescending { it.updatedAt }
+            ListSort.NAME_ASC -> compareBy { it.name }
+            ListSort.NAME_DESC -> compareByDescending { it.name }
+            ListSort.CREATED_ASC -> compareBy { it.createdAt }
+            ListSort.CREATED_DESC -> compareByDescending { it.createdAt }
+        }
+        val pinned = base.filter { it.pinned }.sortedWith(comparator)
+        val unpinned = base.filter { !it.pinned }.sortedWith(comparator)
+        pinned + unpinned
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // ── Derived helpers ──────────────────────────────────────────────────────────────────────────
 
     /** List names derived from listEntities — kept for search filtering. */
     val listNames: StateFlow<List<String>> =
@@ -45,6 +88,8 @@ class ListsViewModel @Inject constructor(
             .map { items -> items.groupBy { it.listId }.mapValues { it.value.size } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
+    // ── Search ───────────────────────────────────────────────────────────────────────────────────
+
     /** Search query for the list overview screen. */
     private val _listSearchQuery = MutableStateFlow("")
     val listSearchQuery: StateFlow<String> = _listSearchQuery.asStateFlow()
@@ -57,7 +102,12 @@ class ListsViewModel @Inject constructor(
     fun setItemSearchQuery(q: String) { _itemSearchQuery.value = q }
     fun clearItemSearchQuery() { _itemSearchQuery.value = "" }
 
-    /** Creates a new list entry in the lists table (idempotent — IGNORE conflict). */
+    // ── List mutations ───────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a new list entry (idempotent — IGNORE conflict) without returning the id.
+     * Prefer [createList] when you need to navigate into the newly created list.
+     */
     fun addList(name: String) {
         val trimmed = name.trim().lowercase()
         if (trimmed.isBlank()) return
@@ -65,6 +115,21 @@ class ListsViewModel @Inject constructor(
         viewModelScope.launch {
             listNameDao.insert(ListNameEntity(name = trimmed, createdAt = now, updatedAt = now))
         }
+    }
+
+    /**
+     * Creates a new list and returns the auto-generated [ListNameEntity.id] so the caller can
+     * navigate directly into the new list.  Returns -1 if [name] is blank.
+     * Falls back to [ListNameDao.getByName] when the name already exists (IGNORE conflict).
+     */
+    suspend fun createList(name: String): Long {
+        val trimmed = name.trim().lowercase()
+        if (trimmed.isBlank()) return -1L
+        val now = System.currentTimeMillis()
+        val id = listNameDao.insertAndGet(
+            ListNameEntity(name = trimmed, createdAt = now, updatedAt = now),
+        )
+        return if (id > 0L) id else listNameDao.getByName(trimmed)?.id ?: -1L
     }
 
     fun toggleChecked(item: ListItemEntity) {
@@ -96,7 +161,7 @@ class ListsViewModel @Inject constructor(
         viewModelScope.launch { listNameDao.deleteById(listId) }
     }
 
-    /** Stub — renames a list. Full implementation in slice 2. */
+    /** Renames a list, bumping the updatedAt timestamp. */
     fun renameList(id: Long, newName: String) {
         val trimmed = newName.trim().lowercase()
         if (trimmed.isBlank()) return
@@ -105,7 +170,7 @@ class ListsViewModel @Inject constructor(
         }
     }
 
-    /** Stub — toggles the pinned state of a list. Full implementation in slice 2. */
+    /** Toggles the pinned state of a list, bumping the updatedAt timestamp. */
     fun togglePin(id: Long) {
         viewModelScope.launch {
             val entity = listEntities.value.firstOrNull { it.id == id } ?: return@launch
@@ -119,4 +184,5 @@ class ListsViewModel @Inject constructor(
      */
     suspend fun resolveListByName(name: String): ListNameEntity? = listNameDao.getByName(name)
 }
+
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -58,8 +58,8 @@ class ListsViewModel @Inject constructor(
         }
         val comparator: Comparator<ListNameEntity> = when (sort) {
             ListSort.LAST_MODIFIED -> compareByDescending { it.updatedAt }
-            ListSort.NAME_ASC -> compareBy { it.name }
-            ListSort.NAME_DESC -> compareByDescending { it.name }
+            ListSort.NAME_ASC -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }
+            ListSort.NAME_DESC -> compareByDescending(String.CASE_INSENSITIVE_ORDER) { it.name }
             ListSort.CREATED_ASC -> compareBy { it.createdAt }
             ListSort.CREATED_DESC -> compareByDescending { it.createdAt }
         }
@@ -170,11 +170,10 @@ class ListsViewModel @Inject constructor(
         }
     }
 
-    /** Toggles the pinned state of a list, bumping the updatedAt timestamp. */
+    /** Toggles the pinned state of a list atomically, bumping the updatedAt timestamp. */
     fun togglePin(id: Long) {
         viewModelScope.launch {
-            val entity = listEntities.value.firstOrNull { it.id == id } ?: return@launch
-            listNameDao.updatePinned(id, !entity.pinned, System.currentTimeMillis())
+            listNameDao.togglePinned(id, System.currentTimeMillis())
         }
     }
 


### PR DESCRIPTION
Closes #888
Part of #662

## Summary

Implements the full lists overview UI — rename, pin, sort, and filter — as specified in issue #888 (slice 2 on top of the slice 1 schema from #890).

## Changes

### `core/memory` — `ListNameDao`
- Added `insertAndGet(entity): Long` — inserts a new list and returns the auto-generated row-id so the ViewModel can navigate directly into the newly created list (falls back to `getByName` on name-unique conflict).

### `feature/settings` — `ListsViewModel`
- Added `enum class ListSort` (`LAST_MODIFIED`, `NAME_ASC`, `NAME_DESC`, `CREATED_ASC`, `CREATED_DESC`) and `enum class ListFilter` (`ALL`, `PINNED_ONLY`).
- Added `var listSort` and `var listFilter` as Compose `mutableStateOf` (ViewModel-scoped, survives recomposition).
- Added `displayedLists: StateFlow<List<ListNameEntity>>` — derived from `listEntities` + `snapshotFlow { listSort }` + `snapshotFlow { listFilter }` via `combine`; pinned group always first, each group independently sorted.
- Added `suspend fun createList(name: String): Long` — inserts via `insertAndGet`, returns the new id for navigate-on-create; falls back gracefully if the name already exists.
- Filled in `renameList` and `togglePin` stubs.
- Kept `addList` for backward compatibility with existing callers.

### `feature/settings` — `ListsScreen`
- Top bar: ⋮ button opens a `SortFilterMenu` dropdown with a **Sort by** section (5 options, active option shown with ✓) and a **Filter** section (All / Pinned only).
- `LazyColumn` uses `stickyHeader` for "Pinned" and "Other" group headers.
- Each row: name + item count · pin toggle (filled when pinned) · ⋮ overflow (Rename / Delete).
- Rename: `NameInputDialog` pre-filled with current name.
- Navigate-on-create: New list dialog → `viewModel.createList(name)` → `onOpenList(newId)`.
- Empty-state message accounts for `PINNED_ONLY` filter.

### `feature/settings` — `ListItemsScreen`
- Title is now tappable → opens rename dialog → calls `viewModel.renameList(listId, newName)`.

## Automated testing

- `./gradlew :feature:settings:testDebugUnitTest :core:memory:testDebugUnitTest :app:assembleDebug --no-daemon` — **BUILD SUCCESSFUL**
- Pre-existing failures (`AboutViewModelTest`, `MemoryViewModelTest`, `MemoryRepositoryImplTest`) confirmed unaffected

## Manual testing (S23 Ultra)

### 1. Create list — navigates directly into it
- Open Settings → Lists
- Tap **+** / New list → type "Test list" → confirm
- [ ] Navigates immediately into "Test list" (no need to tap the row separately)

### 2. Rename list — from overview
- Long-press or tap ⋮ on a list row → Rename
- Change name → Save
- [ ] Row name updates immediately
- [ ] Navigating into the list shows the new name as the title

### 3. Rename list — from inside the list
- Open any list → tap the title
- Rename → Save
- [ ] Title updates immediately
- [ ] Returning to overview shows the new name on the row

### 4. Pin / unpin
- Tap the pin icon on an unpinned list
- [ ] List moves to the **Pinned** section at the top
- [ ] Pin icon is filled/coloured
- Tap again to unpin
- [ ] List returns to the **Other** section
- [ ] When no lists are pinned, the "Pinned" header does not appear

### 5. Sort — all 5 options
Open ⋮ → Sort by:
- [ ] **Name A→Z** — lists sorted alphabetically ascending
- [ ] **Name Z→A** — lists sorted alphabetically descending
- [ ] **Created (newest first)** — most recently created list at top
- [ ] **Created (oldest first)** — oldest list at top
- [ ] **Last modified** (default) — most recently changed list at top
- Active option has a ✓ checkmark

### 6. Filter — Pinned only
- Pin at least one list
- Open ⋮ → Filter → Pinned only
- [ ] Only pinned lists are shown
- [ ] Empty state "No pinned lists." shown when filter is active but nothing is pinned
- Switch back to All
- [ ] All lists return

### 7. Sort + filter combined
- Set filter to Pinned only, sort to Name A→Z
- [ ] Only pinned lists shown, in alphabetical order

### 8. Delete from overflow
- Tap ⋮ → Delete on a list
- [x] Confirmation dialog appears
- [x] On confirm, list and all its items are removed (cascade)
- [x] Returning to overview: list is gone
