### PR TITLE
fix(#895): worded square/cube root patterns in QuickIntentRouter

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2437,11 +2437,11 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("expression" to match.groupValues[1].trim()) },
         ),
-        // Worded root phrases: "square root of 144", "what's the cube root of 27"
+        // Worded root phrases: "square root of 144", "square root 144", "what's the cube root of 27"
         IntentPattern(
             intentName = "calculate_arithmetic",
             regex = Regex(
-                """^(?:(?:what(?:'s|\s+is)|calculate|compute)\s+)?(?:the\s+)?(square|cube)\s+root\s+of\s+(-?\d+(?:\.\d+)?)$""",
+                """^(?:(?:what(?:'s|\s+is)|calculate|compute)\s+)?(?:the\s+)?(square|cube)\s+root\s+(?:of\s+)?(-?\d+(?:\.\d+)?)$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2437,6 +2437,20 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("expression" to match.groupValues[1].trim()) },
         ),
+        // Worded root phrases: "square root of 144", "what's the cube root of 27"
+        IntentPattern(
+            intentName = "calculate_arithmetic",
+            regex = Regex(
+                """^(?:(?:what(?:'s|\s+is)|calculate|compute)\s+)?(?:the\s+)?(square|cube)\s+root\s+of\s+(-?\d+(?:\.\d+)?)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val kind = match.groupValues[1].lowercase()
+                val n = match.groupValues[2]
+                val expression = if (kind == "cube") "($n)^(1/3)" else "sqrt($n)"
+                mapOf("expression" to expression)
+            },
+        ),
         // Unit conversion phrases: "convert 5 miles to km", "what is 60 mph in km/h", "100m to yards"
         IntentPattern(
             intentName = "convert_units",


### PR DESCRIPTION
## Summary

`QuickIntentRouter` had a pattern for symbolic `sqrt(143)` notation but no pattern for natural language. Typing or saying "what's the square root of 143" fell through to E4B — a 2–3 second round-trip for a computation that takes microseconds natively.

This PR adds the missing worded patterns so `calculate_arithmetic` is matched immediately in Tier 2, and the existing `ArithmeticExpressionEvaluator` handles the result.

## Root cause

The `calculate_arithmetic` intent matched symbolic expressions like `sqrt(143)` and worded arithmetic like "12 divided by 3", but had no entry for the natural English form "square root of N". The regex at the time only covered: plus, minus, times, multiplied by, divided by, over, mod, to the power of, raised to — not root functions.

Device testing revealed a second wrinkle: Android STT sometimes drops the word "of", transcribing "square root of 143" as "square root 143". The pattern handles both forms by making "of" optional.

## Changes

- New `IntentPattern` for `calculate_arithmetic` matching `(square|cube) root [of] <number>`
- "of" is optional — handles STT dropping it ("square root 143" also matches)
- Square root maps to `sqrt(N)` — already supported by `ArithmeticExpressionEvaluator`
- Cube root maps to `(N)^(1/3)` — handled by the existing power evaluator
- Matches optional prefixes: "what's the", "what is the", "calculate the", "compute the"

## Manual Testing

| Input | Expected result |
|-------|----------------|
| "what's the square root of 144" | 12 |
| "square root of 143" | 11.958… |
| "square root 143" (STT drops "of") | 11.958… |
| "what is the cube root of 27" | 3 |
| "calculate the square root of 2" | 1.414… |

## Related issues

Closes #895
