### PR TITLE
feat(#889): list items UI — edit, due date, favourite, sort, filter, timestamps

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
@@ -44,4 +44,12 @@ interface ListItemDao {
     /** Remove a single item by id. */
     @Query("DELETE FROM list_items WHERE id = :id")
     suspend fun deleteItem(id: Long)
+
+    /** Atomically flip checked and bump updatedAt — avoids TOCTOU on rapid taps. */
+    @Query("UPDATE list_items SET checked = NOT checked, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun toggleChecked(id: Long, updatedAt: Long)
+
+    /** Atomically flip isFavourite and bump updatedAt — avoids TOCTOU on rapid taps. */
+    @Query("UPDATE list_items SET isFavourite = NOT isFavourite, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun toggleFavourite(id: Long, updatedAt: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
@@ -30,6 +30,10 @@ interface ListItemDao {
     @Query("UPDATE list_items SET checked = 0 WHERE id = :id")
     suspend fun markUnchecked(id: Long)
 
+    /** Set checked state and bump updatedAt in one round-trip. */
+    @Query("UPDATE list_items SET checked = :checked, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun setChecked(id: Long, checked: Boolean, updatedAt: Long)
+
     @Query("UPDATE list_items SET text = :text, dueAt = :dueAt, isFavourite = :isFavourite, updatedAt = :updatedAt WHERE id = :id")
     suspend fun updateItem(id: Long, text: String, dueAt: Long?, isFavourite: Boolean, updatedAt: Long)
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -70,6 +70,7 @@ import com.kernel.ai.core.memory.entity.ListItemEntity
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 // ── Date / timestamp helpers ─────────────────────────────────────────────────────────────────────
@@ -616,14 +617,28 @@ private fun EditItemSheet(
     // Date picker rendered as a separate dialog that floats over the bottom sheet
     if (showDatePicker) {
         val datePickerState = rememberDatePickerState(
-            initialSelectedDateMillis = dueAt ?: System.currentTimeMillis(),
+            initialSelectedDateMillis = dueAt?.let { localMs ->
+                Instant.ofEpochMilli(localMs)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate()
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant()
+                    .toEpochMilli()
+            } ?: System.currentTimeMillis(),
         )
         DatePickerDialog(
             onDismissRequest = { showDatePicker = false },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        dueAt = datePickerState.selectedDateMillis
+                        dueAt = datePickerState.selectedDateMillis?.let { utcMs ->
+                            Instant.ofEpochMilli(utcMs)
+                                .atZone(ZoneOffset.UTC)
+                                .toLocalDate()
+                                .atStartOfDay(ZoneId.systemDefault())
+                                .toInstant()
+                                .toEpochMilli()
+                        }
                         showDatePicker = false
                     },
                 ) { Text("OK") }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -444,41 +444,35 @@ private fun ListItemRow(
         },
         supportingContent = {
             Column {
-                // Due date chip + timestamp on same row
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    val dueAtMs = item.dueAt
-                    if (dueAtMs != null) {
-                        val overdue = isOverdue(dueAtMs, item.checked)
-                        Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.clickable(onClick = onEdit),
-                            ) {
-                            Icon(
-                                Icons.Default.Event,
-                                contentDescription = null,
-                                modifier = Modifier.padding(end = 2.dp),
-                                tint = if (overdue) MaterialTheme.colorScheme.error
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = formatDueDate(dueAtMs),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = if (overdue) MaterialTheme.colorScheme.error
-                                else MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
+                val dueAtMs = item.dueAt
+                if (dueAtMs != null) {
+                    val overdue = isOverdue(dueAtMs, item.checked)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable(onClick = onEdit),
+                    ) {
+                        Icon(
+                            Icons.Default.Event,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 2.dp),
+                            tint = if (overdue) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                         Text(
-                            text = "  ·  ",
+                            text = formatDueDate(dueAtMs),
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            color = if (overdue) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
                         )
                     }
-                    Text(
-                        text = formatTimestamp(item),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
                 }
+                Text(
+                    text = formatTimestamp(item),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
             }
         },
         leadingContent = {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -53,10 +53,10 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -158,9 +158,15 @@ fun ListItemsScreen(
     var showAddDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
     val renameInitialValue = remember(showRenameDialog) { if (showRenameDialog) displayName else "" }
-    var completedExpanded by rememberSaveable { mutableStateOf(false) }
+    var completedExpanded by remember { mutableStateOf(viewModel.itemFilter == ItemFilter.COMPLETED_ONLY) }
     var showSortMenu by remember { mutableStateOf(false) }
     var editingItem by remember { mutableStateOf<ListItemEntity?>(null) }
+
+    LaunchedEffect(viewModel.itemFilter) {
+        if (viewModel.itemFilter == ItemFilter.COMPLETED_ONLY) {
+            completedExpanded = true
+        }
+    }
 
     DisposableEffect(Unit) {
         onDispose { viewModel.clearItemSearchQuery() }
@@ -442,7 +448,10 @@ private fun ListItemRow(
                     val dueAtMs = item.dueAt
                     if (dueAtMs != null) {
                         val overdue = isOverdue(dueAtMs, item.checked)
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                        Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.clickable(onClick = onEdit),
+                            ) {
                             Icon(
                                 Icons.Default.Event,
                                 contentDescription = null,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -2,37 +2,55 @@ package com.kernel.ai.feature.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -49,7 +67,69 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ListItemEntity
-import androidx.compose.material3.AlertDialog
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+// ── Date / timestamp helpers ─────────────────────────────────────────────────────────────────────
+
+private val dayMonthFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM")
+
+private fun epochToLocalDate(epochMs: Long): LocalDate =
+    Instant.ofEpochMilli(epochMs).atZone(ZoneId.systemDefault()).toLocalDate()
+
+private fun formatRelativeDate(epochMs: Long): String {
+    val date = epochToLocalDate(epochMs)
+    val today = LocalDate.now()
+    return when {
+        date == today -> "today"
+        date == today.minusDays(1) -> "yesterday"
+        else -> date.format(dayMonthFormatter)
+    }
+}
+
+private fun formatTimestamp(item: ListItemEntity): String =
+    if (item.updatedAt > item.createdAt) {
+        "Updated ${formatRelativeDate(item.updatedAt)}"
+    } else {
+        "Added ${formatRelativeDate(item.createdAt)}"
+    }
+
+private fun formatDueDate(dueAt: Long): String {
+    val date = epochToLocalDate(dueAt)
+    val today = LocalDate.now()
+    return when {
+        date.isBefore(today) -> "Overdue"
+        date == today -> "Due today"
+        date == today.plusDays(1) -> "Due tomorrow"
+        else -> "Due ${date.format(dayMonthFormatter)}"
+    }
+}
+
+private fun isOverdue(dueAt: Long, checked: Boolean): Boolean =
+    !checked && epochToLocalDate(dueAt).isBefore(LocalDate.now())
+
+// ── Sort / filter label helpers ──────────────────────────────────────────────────────────────────
+
+private fun ItemSort.label(): String = when (this) {
+    ItemSort.CREATED_NEWEST -> "Created (newest first)"
+    ItemSort.CREATED_OLDEST -> "Created (oldest first)"
+    ItemSort.UPDATED_NEWEST -> "Updated (newest first)"
+    ItemSort.NAME_ASC -> "Name A→Z"
+    ItemSort.NAME_DESC -> "Name Z→A"
+    ItemSort.DUE_SOONEST -> "Due date (soonest first)"
+    ItemSort.FAVOURITES_FIRST -> "Favourites first"
+}
+
+private fun ItemFilter.label(): String = when (this) {
+    ItemFilter.ALL -> "All items"
+    ItemFilter.FAVOURITES_ONLY -> "Favourites only"
+    ItemFilter.ACTIVE_ONLY -> "Active only"
+    ItemFilter.COMPLETED_ONLY -> "Completed only"
+}
+
+// ── Screen ───────────────────────────────────────────────────────────────────────────────────────
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,33 +139,28 @@ fun ListItemsScreen(
     onNavigateToVoiceActions: () -> Unit = {},
     viewModel: ListsViewModel = hiltViewModel(),
 ) {
-    val grouped by viewModel.groupedItems.collectAsStateWithLifecycle()
+    val displayedItems by viewModel.observeDisplayedItems(listId).collectAsStateWithLifecycle()
     val listEntities by viewModel.listEntities.collectAsStateWithLifecycle()
     val searchQuery by viewModel.itemSearchQuery.collectAsStateWithLifecycle()
 
-    // Resolve the display name from the entities list
     val displayName = listEntities.firstOrNull { it.id == listId }?.name ?: ""
 
-    val allItems = grouped[listId] ?: emptyList()
+    // Apply text search on top of sorted/filtered results from the ViewModel
+    val (sortedActive, sortedCompleted) = displayedItems
+    val filteredActive = if (searchQuery.isBlank()) sortedActive
+    else sortedActive.filter { it.text.contains(searchQuery, ignoreCase = true) }
+    val filteredCompleted = if (searchQuery.isBlank()) sortedCompleted
+    else sortedCompleted.filter { it.text.contains(searchQuery, ignoreCase = true) }
 
-    // Split active vs completed
-    val activeItems = allItems.filter { !it.checked }
-    val completedItems = allItems.filter { it.checked }
-
-    // Apply search filter
-    val filteredActive = if (searchQuery.isBlank()) activeItems
-    else activeItems.filter { it.text.contains(searchQuery, ignoreCase = true) }
-    val filteredCompleted = if (searchQuery.isBlank()) completedItems
-    else completedItems.filter { it.text.contains(searchQuery, ignoreCase = true) }
+    val allItems = sortedActive + sortedCompleted  // for empty-state check
 
     var showAddDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
-    // Snapshot displayName at the moment the dialog opens so live Room updates
-    // don't reset text the user is actively typing.
     val renameInitialValue = remember(showRenameDialog) { if (showRenameDialog) displayName else "" }
     var completedExpanded by rememberSaveable { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
+    var editingItem by remember { mutableStateOf<ListItemEntity?>(null) }
 
-    // Clear item search when leaving the screen
     DisposableEffect(Unit) {
         onDispose { viewModel.clearItemSearchQuery() }
     }
@@ -105,9 +180,69 @@ fun ListItemsScreen(
                     }
                 },
                 actions = {
-                    if (completedItems.isNotEmpty()) {
+                    if (sortedCompleted.isNotEmpty()) {
                         TextButton(onClick = { viewModel.clearChecked(listId) }) {
                             Text("Clear done")
+                        }
+                    }
+                    // Sort / filter menu
+                    Box {
+                        IconButton(onClick = { showSortMenu = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+                        }
+                        DropdownMenu(
+                            expanded = showSortMenu,
+                            onDismissRequest = { showSortMenu = false },
+                        ) {
+                            // ── Sort section ──────────────────────────────────────────
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        "Sort by",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                },
+                                onClick = {},
+                                enabled = false,
+                            )
+                            ItemSort.entries.forEach { sort ->
+                                DropdownMenuItem(
+                                    text = { Text(sort.label()) },
+                                    onClick = {
+                                        viewModel.itemSort = sort
+                                        showSortMenu = false
+                                    },
+                                    trailingIcon = if (viewModel.itemSort == sort) {
+                                        { Icon(Icons.Default.Check, contentDescription = null) }
+                                    } else null,
+                                )
+                            }
+                            HorizontalDivider()
+                            // ── Filter section ────────────────────────────────────────
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        "Filter",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                },
+                                onClick = {},
+                                enabled = false,
+                            )
+                            ItemFilter.entries.forEach { filter ->
+                                DropdownMenuItem(
+                                    text = { Text(filter.label()) },
+                                    onClick = {
+                                        viewModel.itemFilter = filter
+                                        showSortMenu = false
+                                    },
+                                    trailingIcon = if (viewModel.itemFilter == filter) {
+                                        { Icon(Icons.Default.Check, contentDescription = null) }
+                                    } else null,
+                                )
+                            }
                         }
                     }
                 },
@@ -182,19 +317,21 @@ fun ListItemsScreen(
                         ListItemRow(
                             item = item,
                             onToggle = { viewModel.toggleChecked(item) },
-                            onDelete = { viewModel.deleteItem(item.id) },
+                            onDelete = { viewModel.deleteItem(item) },
+                            onEdit = { editingItem = item },
+                            onToggleFavourite = { viewModel.toggleFavourite(item) },
                         )
                         HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
                     }
 
-                    // Completed section header (only if there are completed items)
-                    if (completedItems.isNotEmpty()) {
+                    // Completed section header
+                    if (sortedCompleted.isNotEmpty()) {
                         item(key = "completed_header") {
                             ListItem(
                                 modifier = Modifier.fillMaxWidth(),
                                 headlineContent = {
                                     Text(
-                                        "Completed (${completedItems.size})",
+                                        "Completed (${sortedCompleted.size})",
                                         style = MaterialTheme.typography.labelLarge,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
@@ -202,8 +339,10 @@ fun ListItemsScreen(
                                 trailingContent = {
                                     IconButton(onClick = { completedExpanded = !completedExpanded }) {
                                         Icon(
-                                            if (completedExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                                            contentDescription = if (completedExpanded) "Collapse" else "Expand",
+                                            if (completedExpanded) Icons.Default.ExpandLess
+                                            else Icons.Default.ExpandMore,
+                                            contentDescription = if (completedExpanded) "Collapse"
+                                            else "Expand",
                                         )
                                     }
                                 },
@@ -218,7 +357,9 @@ fun ListItemsScreen(
                             ListItemRow(
                                 item = item,
                                 onToggle = { viewModel.toggleChecked(item) },
-                                onDelete = { viewModel.deleteItem(item.id) },
+                                onDelete = { viewModel.deleteItem(item) },
+                                onEdit = { editingItem = item },
+                                onToggleFavourite = { viewModel.toggleFavourite(item) },
                             )
                             HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
                         }
@@ -230,7 +371,19 @@ fun ListItemsScreen(
         }
     }
 
-    // Rename dialog — opened by tapping the screen title
+    // ── Edit bottom sheet ────────────────────────────────────────────────────────────────────────
+    editingItem?.let { item ->
+        EditItemSheet(
+            item = item,
+            onSave = { updated ->
+                viewModel.updateItem(updated)
+                editingItem = null
+            },
+            onDismiss = { editingItem = null },
+        )
+    }
+
+    // ── Rename dialog ────────────────────────────────────────────────────────────────────────────
     if (showRenameDialog) {
         NameInputDialog(
             title = "Rename list",
@@ -244,6 +397,7 @@ fun ListItemsScreen(
         )
     }
 
+    // ── Add item dialog ──────────────────────────────────────────────────────────────────────────
     if (showAddDialog) {
         AddItemDialog(
             onConfirm = { text ->
@@ -255,16 +409,21 @@ fun ListItemsScreen(
     }
 }
 
+// ── Item row ─────────────────────────────────────────────────────────────────────────────────────
+
 @Composable
 private fun ListItemRow(
     item: ListItemEntity,
     onToggle: () -> Unit,
     onDelete: () -> Unit,
+    onEdit: () -> Unit,
+    onToggleFavourite: () -> Unit,
 ) {
     ListItem(
         headlineContent = {
             Text(
                 text = item.text,
+                modifier = Modifier.clickable(onClick = onEdit),
                 style = if (item.checked) {
                     MaterialTheme.typography.bodyLarge.copy(
                         textDecoration = TextDecoration.LineThrough,
@@ -275,6 +434,42 @@ private fun ListItemRow(
                 },
             )
         },
+        supportingContent = {
+            Column {
+                // Due date chip + timestamp on same row
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    val dueAtMs = item.dueAt
+                    if (dueAtMs != null) {
+                        val overdue = isOverdue(dueAtMs, item.checked)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Default.Event,
+                                contentDescription = null,
+                                modifier = Modifier.padding(end = 2.dp),
+                                tint = if (overdue) MaterialTheme.colorScheme.error
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text = formatDueDate(dueAtMs),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = if (overdue) MaterialTheme.colorScheme.error
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Text(
+                            text = "  ·  ",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Text(
+                        text = formatTimestamp(item),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
         leadingContent = {
             Checkbox(
                 checked = item.checked,
@@ -282,16 +477,167 @@ private fun ListItemRow(
             )
         },
         trailingContent = {
-            IconButton(onClick = onDelete) {
-                Icon(
-                    Icons.Default.Delete,
-                    contentDescription = "Delete item",
-                    tint = MaterialTheme.colorScheme.error,
-                )
+            Row {
+                IconButton(onClick = onToggleFavourite) {
+                    Icon(
+                        imageVector = if (item.isFavourite) Icons.Default.Star
+                        else Icons.Default.StarBorder,
+                        contentDescription = if (item.isFavourite) "Unfavourite" else "Favourite",
+                        tint = if (item.isFavourite) MaterialTheme.colorScheme.tertiary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Delete item",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
             }
         },
     )
 }
+
+// ── Edit bottom sheet ─────────────────────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditItemSheet(
+    item: ListItemEntity,
+    onSave: (ListItemEntity) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var text by remember(item.id) { mutableStateOf(item.text) }
+    var dueAt by remember(item.id) { mutableStateOf(item.dueAt) }
+    var isFavourite by remember(item.id) { mutableStateOf(item.isFavourite) }
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+        ) {
+            Text("Edit item", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Text field
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Item") },
+                singleLine = true,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Due date row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.Event,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                if (dueAt != null) {
+                    Text(
+                        text = formatDueDate(dueAt!!),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { showDatePicker = true },
+                    )
+                    IconButton(onClick = { dueAt = null }) {
+                        Icon(Icons.Default.Close, contentDescription = "Clear due date")
+                    }
+                } else {
+                    TextButton(onClick = { showDatePicker = true }) {
+                        Text("Set due date")
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Favourite switch
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = if (isFavourite) Icons.Default.Star else Icons.Default.StarBorder,
+                    contentDescription = null,
+                    tint = if (isFavourite) MaterialTheme.colorScheme.tertiary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Mark as favourite",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Switch(
+                    checked = isFavourite,
+                    onCheckedChange = { isFavourite = it },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Save / Cancel
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = {
+                        onSave(item.copy(text = text.trim(), dueAt = dueAt, isFavourite = isFavourite))
+                    },
+                    enabled = text.isNotBlank(),
+                ) { Text("Save") }
+            }
+
+            // Navigation bar clearance
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+
+    // Date picker rendered as a separate dialog that floats over the bottom sheet
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = dueAt ?: System.currentTimeMillis(),
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        dueAt = datePickerState.selectedDateMillis
+                        showDatePicker = false
+                    },
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+// ── Add item dialog ───────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun AddItemDialog(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -158,7 +159,7 @@ fun ListItemsScreen(
     var showAddDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
     val renameInitialValue = remember(showRenameDialog) { if (showRenameDialog) displayName else "" }
-    var completedExpanded by remember { mutableStateOf(viewModel.itemFilter == ItemFilter.COMPLETED_ONLY) }
+    var completedExpanded by rememberSaveable { mutableStateOf(viewModel.itemFilter == ItemFilter.COMPLETED_ONLY) }
     var showSortMenu by remember { mutableStateOf(false) }
     var editingItem by remember { mutableStateOf<ListItemEntity?>(null) }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -59,6 +59,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.drop
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -163,10 +165,12 @@ fun ListItemsScreen(
     var showSortMenu by remember { mutableStateOf(false) }
     var editingItem by remember { mutableStateOf<ListItemEntity?>(null) }
 
-    LaunchedEffect(viewModel.itemFilter) {
-        if (viewModel.itemFilter == ItemFilter.COMPLETED_ONLY) {
-            completedExpanded = true
-        }
+    LaunchedEffect(Unit) {
+        snapshotFlow { viewModel.itemFilter }
+            .drop(1) // skip initial emission; rememberSaveable owns first-run state
+            .collect { filter ->
+                if (filter == ItemFilter.COMPLETED_ONLY) completedExpanded = true
+            }
     }
 
     DisposableEffect(Unit) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -24,6 +24,18 @@ import javax.inject.Inject
 enum class ListSort { LAST_MODIFIED, NAME_ASC, NAME_DESC, CREATED_ASC, CREATED_DESC }
 enum class ListFilter { ALL, PINNED_ONLY }
 
+enum class ItemSort {
+    CREATED_NEWEST,
+    CREATED_OLDEST,
+    UPDATED_NEWEST,
+    NAME_ASC,
+    NAME_DESC,
+    DUE_SOONEST,
+    FAVOURITES_FIRST,
+}
+
+enum class ItemFilter { ALL, FAVOURITES_ONLY, ACTIVE_ONLY, COMPLETED_ONLY }
+
 @HiltViewModel
 class ListsViewModel @Inject constructor(
     private val dao: ListItemDao,
@@ -67,6 +79,69 @@ class ListsViewModel @Inject constructor(
         val unpinned = base.filter { !it.pinned }.sortedWith(comparator)
         pinned + unpinned
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // ── Item sort / filter state ─────────────────────────────────────────────────────────────────
+
+    /** Current sort order for the drill-in item screen. */
+    var itemSort by mutableStateOf(ItemSort.CREATED_NEWEST)
+
+    /** Current filter for the drill-in item screen. */
+    var itemFilter by mutableStateOf(ItemFilter.ALL)
+
+    /** Cache so repeated recompositions don't create duplicate StateFlows. */
+    private val itemFlowCache =
+        mutableMapOf<Long, StateFlow<Pair<List<ListItemEntity>, List<ListItemEntity>>>>()
+
+    /**
+     * Returns a [StateFlow] of (activeItems, completedItems) for [listId].
+     * Each group is independently sorted by [itemSort] and the full set is pre-filtered by
+     * [itemFilter] before splitting.  The flow is cached by listId so recompositions are cheap.
+     */
+    fun observeDisplayedItems(
+        listId: Long,
+    ): StateFlow<Pair<List<ListItemEntity>, List<ListItemEntity>>> =
+        itemFlowCache.getOrPut(listId) {
+            combine(
+                dao.observeByList(listId),
+                snapshotFlow { itemSort },
+                snapshotFlow { itemFilter },
+            ) { items, sort, filter ->
+                val filtered = when (filter) {
+                    ItemFilter.ALL -> items
+                    ItemFilter.FAVOURITES_ONLY -> items.filter { it.isFavourite }
+                    ItemFilter.ACTIVE_ONLY -> items.filter { !it.checked }
+                    ItemFilter.COMPLETED_ONLY -> items.filter { it.checked }
+                }
+                val active = filtered.filter { !it.checked }
+                val completed = filtered.filter { it.checked }
+                val comparator: Comparator<ListItemEntity> = when (sort) {
+                    ItemSort.CREATED_NEWEST -> compareByDescending { it.createdAt }
+                    ItemSort.CREATED_OLDEST -> compareBy { it.createdAt }
+                    ItemSort.UPDATED_NEWEST -> compareByDescending { it.updatedAt }
+                    ItemSort.NAME_ASC ->
+                        Comparator { a, b -> String.CASE_INSENSITIVE_ORDER.compare(a.text, b.text) }
+                    ItemSort.NAME_DESC ->
+                        Comparator { a, b -> String.CASE_INSENSITIVE_ORDER.compare(b.text, a.text) }
+                    ItemSort.DUE_SOONEST -> Comparator { a, b ->
+                        val da = a.dueAt; val db = b.dueAt
+                        when {
+                            da == null && db == null -> 0
+                            da == null -> 1  // nulls last
+                            db == null -> -1
+                            else -> da.compareTo(db)
+                        }
+                    }
+                    ItemSort.FAVOURITES_FIRST ->
+                        compareByDescending<ListItemEntity> { it.isFavourite }
+                            .thenByDescending { it.createdAt }
+                }
+                Pair(active.sortedWith(comparator), completed.sortedWith(comparator))
+            }.stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5_000),
+                Pair(emptyList(), emptyList()),
+            )
+        }
 
     // ── Derived helpers ──────────────────────────────────────────────────────────────────────────
 
@@ -133,8 +208,10 @@ class ListsViewModel @Inject constructor(
     }
 
     fun toggleChecked(item: ListItemEntity) {
+        val now = System.currentTimeMillis()
         viewModelScope.launch {
-            if (item.checked) dao.markUnchecked(item.id) else dao.markChecked(item.id)
+            dao.setChecked(item.id, !item.checked, now)
+            listNameDao.updateTimestamp(item.listId, now)
         }
     }
 
@@ -150,6 +227,41 @@ class ListsViewModel @Inject constructor(
 
     fun deleteItem(id: Long) {
         viewModelScope.launch { dao.deleteItem(id) }
+    }
+
+    /** Entity overload — preferred from the item screen. */
+    fun deleteItem(item: ListItemEntity) {
+        viewModelScope.launch { dao.deleteItem(item.id) }
+    }
+
+    /** Toggles isFavourite and bumps updatedAt + parent list updatedAt. */
+    fun toggleFavourite(item: ListItemEntity) {
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            dao.updateItem(
+                id = item.id,
+                text = item.text,
+                dueAt = item.dueAt,
+                isFavourite = !item.isFavourite,
+                updatedAt = now,
+            )
+            listNameDao.updateTimestamp(item.listId, now)
+        }
+    }
+
+    /** Persists edits made in the edit bottom sheet (text, dueAt, isFavourite). */
+    fun updateItem(item: ListItemEntity) {
+        val now = System.currentTimeMillis()
+        viewModelScope.launch {
+            dao.updateItem(
+                id = item.id,
+                text = item.text,
+                dueAt = item.dueAt,
+                isFavourite = item.isFavourite,
+                updatedAt = now,
+            )
+            listNameDao.updateTimestamp(item.listId, now)
+        }
     }
 
     fun clearChecked(listId: Long) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -209,8 +210,8 @@ class ListsViewModel @Inject constructor(
 
     fun toggleChecked(item: ListItemEntity) {
         val now = System.currentTimeMillis()
-        viewModelScope.launch {
-            dao.setChecked(item.id, !item.checked, now)
+        viewModelScope.launch(Dispatchers.IO) {
+            dao.toggleChecked(item.id, now)
             listNameDao.updateTimestamp(item.listId, now)
         }
     }
@@ -237,14 +238,8 @@ class ListsViewModel @Inject constructor(
     /** Toggles isFavourite and bumps updatedAt + parent list updatedAt. */
     fun toggleFavourite(item: ListItemEntity) {
         val now = System.currentTimeMillis()
-        viewModelScope.launch {
-            dao.updateItem(
-                id = item.id,
-                text = item.text,
-                dueAt = item.dueAt,
-                isFavourite = !item.isFavourite,
-                updatedAt = now,
-            )
+        viewModelScope.launch(Dispatchers.IO) {
+            dao.toggleFavourite(item.id, now)
             listNameDao.updateTimestamp(item.listId, now)
         }
     }


### PR DESCRIPTION
Closes #889
Part of #662

## Summary

Implements the full list items UI for the drill-in screen: inline edit bottom sheet, due date picker, favourite toggle, sort/filter menu, and per-item timestamps.

## Changes

### `core/memory` — `ListItemDao`
- Added `setChecked(id, checked, updatedAt)` query so toggling an item's checked state also bumps `updatedAt` in a single round-trip.
- Added `toggleChecked(id, updatedAt)` — atomic `NOT checked` SQL flip (no snapshot read).
- Added `toggleFavourite(id, updatedAt)` — atomic `NOT isFavourite` SQL flip (no snapshot read).

### `feature/settings` — `ListsViewModel`
- Added `enum class ItemSort` (7 options: CREATED_NEWEST, CREATED_OLDEST, UPDATED_NEWEST, NAME_ASC, NAME_DESC, DUE_SOONEST, FAVOURITES_FIRST).
- Added `enum class ItemFilter` (ALL, FAVOURITES_ONLY, ACTIVE_ONLY, COMPLETED_ONLY).
- Added `var itemSort` and `var itemFilter` Compose state (survives recomposition, ViewModel-scoped).
- Added `observeDisplayedItems(listId)` — returns a cached `StateFlow<Pair<active, completed>>` with filter + sort applied independently to each group. Null `dueAt` sorts last for DUE_SOONEST; name sorts are case-insensitive.
- `toggleChecked`: now uses atomic `dao.toggleChecked(id, now)` — no stale snapshot read.
- `toggleFavourite`: now uses atomic `dao.toggleFavourite(id, now)` — no stale snapshot read, touches only one column.
- Added `updateItem(item)` — persists edits from the bottom sheet (text, dueAt, isFavourite), sets `updatedAt = now`.
- Added `deleteItem(item: ListItemEntity)` overload (existing `deleteItem(id)` retained).

### `feature/settings` — `ListItemsScreen`
- **Item row**: leading checkbox, tappable text (opens edit sheet, strikethrough when checked), supporting line with due date chip + timestamp, trailing star (favourite) + delete icons.
- **Due date chip**: "Due today" / "Due tomorrow" / "Due d MMM" / "Overdue" (error colour when past and unchecked). Only shown when `dueAt != null`.
- **Timestamp**: "Added [date]" or "Updated [date]"; uses "today" / "yesterday" for recent dates, "d MMM" for older.
- **Sort/filter ⋮ menu**: DropdownMenu in the TopAppBar; sort section (7 options) + filter section (4 options); active selection shown with ✓.
- **Edit bottom sheet** (`ModalBottomSheet`): text field, due date row (Set due date button → `DatePickerDialog`; selected date shown with ✕ to clear), favourite switch, Save/Cancel. State keyed to `item.id` so switching items resets fields correctly.
- **DatePicker UTC fix**: `selectedDateMillis` (UTC midnight per Material3) is converted to local midnight before storing; round-tripped back to UTC midnight when re-opening the picker. Prevents off-by-one day for users in UTC− timezones.
- Existing features preserved: add-item dialog, rename dialog, search bar, "Clear done" button, collapsible completed section, voice FAB.

## Manual Testing

| Scenario | Steps | Expected |
|----------|-------|----------|
| Check/uncheck item | Tap checkbox rapidly twice | Returns to original state (no double-tap stuck) |
| Favourite toggle | Tap ⭐ rapidly twice | Returns to original state |
| Edit item text | Tap item text → edit sheet → change text → Save | Text updated in list |
| Set due date | Edit sheet → Set due date → pick tomorrow → Save | "Due tomorrow" chip appears |
| Overdue chip | Set a due date in the past on unchecked item | Red "Overdue" chip |
| Clear due date | Edit sheet → ✕ next to date → Save | Chip disappears |
| Sort: Name A→Z | ⋮ → Sort: Name A→Z | Items sorted case-insensitively |
| Sort: Due soonest | ⋮ → Sort: Due soonest | Items with due dates first, no-date items last |
| Filter: Favourites only | ⋮ → Filter: Favourites | Only starred items shown |
| Filter: Active only | ⋮ → Filter: Active | No checked items shown |
| Delete item | Tap 🗑 on an item | Item removed immediately |
| Completed section | Check an item | Moves to collapsible "Completed" section |

## Testing
- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL**
- `./gradlew :feature:settings:testDebugUnitTest` — pre-existing failures only (`AboutViewModelTest`, `MemoryViewModelTest`); zero new failures introduced.
