### PR TITLE
feat(#896,#897): drag-and-drop reorder + multi-select bulk actions

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 35,
+    version = 36,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -648,6 +648,14 @@ abstract class KernelDatabase : RoomDatabase() {
 
                 // 5. Add index for the FK column
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `list_items` (`listId`)")
+            }
+        }
+        /** Adds displayOrder to lists for drag-and-drop manual reorder (#897). */
+        val MIGRATION_35_36 = object : Migration(35, 36) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE lists ADD COLUMN displayOrder INTEGER NOT NULL DEFAULT 0")
+                // Initialise existing rows to a stable order (by id)
+                db.execSQL("UPDATE lists SET displayOrder = id")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -101,6 +101,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_32_33,
                     KernelDatabase.MIGRATION_33_34,
                     KernelDatabase.MIGRATION_34_35,
+                    KernelDatabase.MIGRATION_35_36,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -4,13 +4,14 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface ListNameDao {
+abstract class ListNameDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(list: ListNameEntity)
+    abstract suspend fun insert(list: ListNameEntity)
 
     /**
      * Inserts a new list and returns the generated row-id (= entity id), or -1 on a
@@ -18,36 +19,41 @@ interface ListNameDao {
      * is returned to handle the already-exists case.
      */
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insertAndGet(list: ListNameEntity): Long
+    abstract suspend fun insertAndGet(list: ListNameEntity): Long
 
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
-    fun observeAll(): Flow<List<ListNameEntity>>
+    abstract fun observeAll(): Flow<List<ListNameEntity>>
 
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
-    suspend fun getAll(): List<ListNameEntity>
+    abstract suspend fun getAll(): List<ListNameEntity>
 
     /** Resolve a list by display name — used by NativeIntentHandler at the skill boundary. */
     @Query("SELECT * FROM lists WHERE name = :name LIMIT 1")
-    suspend fun getByName(name: String): ListNameEntity?
+    abstract suspend fun getByName(name: String): ListNameEntity?
 
     @Query("DELETE FROM lists WHERE name = :name")
-    suspend fun deleteByName(name: String)
+    abstract suspend fun deleteByName(name: String)
 
     @Query("DELETE FROM lists WHERE id = :id")
-    suspend fun deleteById(id: Long)
+    abstract suspend fun deleteById(id: Long)
 
     @Query("UPDATE lists SET name = :name, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updateName(id: Long, name: String, updatedAt: Long)
+    abstract suspend fun updateName(id: Long, name: String, updatedAt: Long)
 
     @Query("UPDATE lists SET pinned = :pinned, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updatePinned(id: Long, pinned: Boolean, updatedAt: Long)
+    abstract suspend fun updatePinned(id: Long, pinned: Boolean, updatedAt: Long)
 
     @Query("UPDATE lists SET pinned = NOT pinned, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun togglePinned(id: Long, updatedAt: Long)
+    abstract suspend fun togglePinned(id: Long, updatedAt: Long)
 
     @Query("UPDATE lists SET updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updateTimestamp(id: Long, updatedAt: Long)
+    abstract suspend fun updateTimestamp(id: Long, updatedAt: Long)
 
     @Query("UPDATE lists SET displayOrder = :order, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updateDisplayOrder(id: Long, order: Int, updatedAt: Long)
+    abstract suspend fun updateDisplayOrder(id: Long, order: Int, updatedAt: Long)
+
+    @Transaction
+    open suspend fun updateDisplayOrders(updates: List<Pair<Long, Int>>, updatedAt: Long) {
+        updates.forEach { (id, order) -> updateDisplayOrder(id, order, updatedAt) }
+    }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -47,4 +47,7 @@ interface ListNameDao {
 
     @Query("UPDATE lists SET updatedAt = :updatedAt WHERE id = :id")
     suspend fun updateTimestamp(id: Long, updatedAt: Long)
+
+    @Query("UPDATE lists SET displayOrder = :order, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateDisplayOrder(id: Long, order: Int, updatedAt: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.memory.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -15,4 +16,6 @@ data class ListNameEntity(
     /** Bumped on rename and whenever any child item changes. */
     val updatedAt: Long = System.currentTimeMillis(),
     val pinned: Boolean = false,
+    /** Manual drag-and-drop order within the pinned or unpinned group. */
+    @ColumnInfo(name = "displayOrder") val displayOrder: Int = 0,
 )

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
 
     implementation(libs.datastore.preferences)
 
+    // Drag-and-drop reorder for LazyColumn (#897)
+    implementation("sh.calvin.reorderable:reorderable:2.4.3")
+
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -201,7 +201,8 @@ fun ListItemsScreen(
                     actions = {
                         TextButton(onClick = {
                             viewModel.selectAllItems(
-                                (filteredActive + filteredCompleted).map { it.id }
+                                (filteredActive + if (completedExpanded) filteredCompleted else emptyList())
+                                    .map { it.id }
                             )
                         }) {
                             Text("Select All")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -199,6 +199,13 @@ fun ListItemsScreen(
                         }
                     },
                     actions = {
+                        TextButton(onClick = {
+                            viewModel.selectAllItems(
+                                (filteredActive + filteredCompleted).map { it.id }
+                            )
+                        }) {
+                            Text("Select All")
+                        }
                         // Mark selected items complete
                         IconButton(onClick = { viewModel.markSelectedItemsComplete() }) {
                             Icon(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -396,7 +396,9 @@ fun ListItemsScreen(
                     if (sortedCompleted.isNotEmpty()) {
                         item(key = "completed_header") {
                             ListItem(
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { completedExpanded = !completedExpanded },
                                 headlineContent = {
                                     Text(
                                         "Completed (${sortedCompleted.size})",
@@ -405,14 +407,13 @@ fun ListItemsScreen(
                                     )
                                 },
                                 trailingContent = {
-                                    IconButton(onClick = { completedExpanded = !completedExpanded }) {
-                                        Icon(
-                                            if (completedExpanded) Icons.Default.ExpandLess
-                                            else Icons.Default.ExpandMore,
-                                            contentDescription = if (completedExpanded) "Collapse"
-                                            else "Expand",
-                                        )
-                                    }
+                                    Icon(
+                                        if (completedExpanded) Icons.Default.ExpandLess
+                                        else Icons.Default.ExpandMore,
+                                        contentDescription = if (completedExpanded) "Collapse"
+                                        else "Expand",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
                                 },
                             )
                             HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Event
@@ -135,7 +138,7 @@ private fun ItemFilter.label(): String = when (this) {
 
 // ── Screen ───────────────────────────────────────────────────────────────────────────────────────
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ListItemsScreen(
     listId: Long,
@@ -165,6 +168,10 @@ fun ListItemsScreen(
     var showSortMenu by remember { mutableStateOf(false) }
     var editingItem by remember { mutableStateOf<ListItemEntity?>(null) }
 
+    val selectedItemIds = viewModel.selectedItemIds
+    val isItemMultiSelectMode = viewModel.isItemMultiSelectMode
+    var showItemBulkDeleteDialog by remember { mutableStateOf(false) }
+
     LaunchedEffect(Unit) {
         snapshotFlow { viewModel.itemFilter }
             .drop(1) // skip initial emission; rememberSaveable owns first-run state
@@ -174,91 +181,128 @@ fun ListItemsScreen(
     }
 
     DisposableEffect(Unit) {
-        onDispose { viewModel.clearItemSearchQuery() }
+        onDispose {
+            viewModel.clearItemSearchQuery()
+            viewModel.exitItemMultiSelect()
+        }
     }
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = displayName.replaceFirstChar { it.uppercase() },
-                        modifier = Modifier.clickable { showRenameDialog = true },
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                actions = {
-                    if (sortedCompleted.isNotEmpty()) {
-                        TextButton(onClick = { viewModel.clearChecked(listId) }) {
-                            Text("Clear done")
+            if (isItemMultiSelectMode) {
+                // ── Contextual multi-select bar ─────────────────────────────────────────────
+                TopAppBar(
+                    title = { Text("${selectedItemIds.size} selected") },
+                    navigationIcon = {
+                        IconButton(onClick = { viewModel.exitItemMultiSelect() }) {
+                            Icon(Icons.Default.Close, contentDescription = "Exit selection")
                         }
-                    }
-                    // Sort / filter menu
-                    Box {
-                        IconButton(onClick = { showSortMenu = true }) {
-                            Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+                    },
+                    actions = {
+                        // Mark selected items complete
+                        IconButton(onClick = { viewModel.markSelectedItemsComplete() }) {
+                            Icon(
+                                Icons.Default.CheckCircle,
+                                contentDescription = "Mark complete",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
                         }
-                        DropdownMenu(
-                            expanded = showSortMenu,
-                            onDismissRequest = { showSortMenu = false },
+                        // Delete selected items
+                        IconButton(
+                            onClick = { showItemBulkDeleteDialog = true },
+                            enabled = selectedItemIds.isNotEmpty(),
                         ) {
-                            // ── Sort section ──────────────────────────────────────────
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        "Sort by",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.primary,
-                                    )
-                                },
-                                onClick = {},
-                                enabled = false,
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete selected",
+                                tint = MaterialTheme.colorScheme.error,
                             )
-                            ItemSort.entries.forEach { sort ->
-                                DropdownMenuItem(
-                                    text = { Text(sort.label()) },
-                                    onClick = {
-                                        viewModel.itemSort = sort
-                                        showSortMenu = false
-                                    },
-                                    trailingIcon = if (viewModel.itemSort == sort) {
-                                        { Icon(Icons.Default.Check, contentDescription = null) }
-                                    } else null,
-                                )
-                            }
-                            HorizontalDivider()
-                            // ── Filter section ────────────────────────────────────────
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        "Filter",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.primary,
-                                    )
-                                },
-                                onClick = {},
-                                enabled = false,
-                            )
-                            ItemFilter.entries.forEach { filter ->
-                                DropdownMenuItem(
-                                    text = { Text(filter.label()) },
-                                    onClick = {
-                                        viewModel.itemFilter = filter
-                                        showSortMenu = false
-                                    },
-                                    trailingIcon = if (viewModel.itemFilter == filter) {
-                                        { Icon(Icons.Default.Check, contentDescription = null) }
-                                    } else null,
-                                )
+                        }
+                    },
+                )
+            } else {
+                // ── Normal top app bar ───────────────────────────────────────────────────────
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = displayName.replaceFirstChar { it.uppercase() },
+                            modifier = Modifier.clickable { showRenameDialog = true },
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    actions = {
+                        if (sortedCompleted.isNotEmpty()) {
+                            TextButton(onClick = { viewModel.clearChecked(listId) }) {
+                                Text("Clear done")
                             }
                         }
-                    }
-                },
-            )
+                        // Sort / filter menu
+                        Box {
+                            IconButton(onClick = { showSortMenu = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+                            }
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false },
+                            ) {
+                                // ── Sort section ──────────────────────────────────────────
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            "Sort by",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.primary,
+                                        )
+                                    },
+                                    onClick = {},
+                                    enabled = false,
+                                )
+                                ItemSort.entries.forEach { sort ->
+                                    DropdownMenuItem(
+                                        text = { Text(sort.label()) },
+                                        onClick = {
+                                            viewModel.itemSort = sort
+                                            showSortMenu = false
+                                        },
+                                        trailingIcon = if (viewModel.itemSort == sort) {
+                                            { Icon(Icons.Default.Check, contentDescription = null) }
+                                        } else null,
+                                    )
+                                }
+                                HorizontalDivider()
+                                // ── Filter section ────────────────────────────────────────
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            "Filter",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.primary,
+                                        )
+                                    },
+                                    onClick = {},
+                                    enabled = false,
+                                )
+                                ItemFilter.entries.forEach { filter ->
+                                    DropdownMenuItem(
+                                        text = { Text(filter.label()) },
+                                        onClick = {
+                                            viewModel.itemFilter = filter
+                                            showSortMenu = false
+                                        },
+                                        trailingIcon = if (viewModel.itemFilter == filter) {
+                                            { Icon(Icons.Default.Check, contentDescription = null) }
+                                        } else null,
+                                    )
+                                }
+                            }
+                        }
+                    },
+                )
+            }
         },
         floatingActionButton = {
             Column(
@@ -326,12 +370,17 @@ fun ListItemsScreen(
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     // Active items
                     items(filteredActive, key = { it.id }) { item ->
+                        val isSelected = item.id in selectedItemIds
                         ListItemRow(
                             item = item,
+                            isMultiSelectMode = isItemMultiSelectMode,
+                            isSelected = isSelected,
                             onToggle = { viewModel.toggleChecked(item) },
                             onDelete = { viewModel.deleteItem(item) },
                             onEdit = { editingItem = item },
                             onToggleFavourite = { viewModel.toggleFavourite(item) },
+                            onLongClick = { viewModel.enterItemMultiSelect(item.id) },
+                            onSelectToggle = { viewModel.toggleItemSelection(item.id) },
                         )
                         HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
                     }
@@ -366,12 +415,17 @@ fun ListItemsScreen(
                     // Completed items (collapsible)
                     if (completedExpanded) {
                         items(filteredCompleted, key = { "done_${it.id}" }) { item ->
+                            val isSelected = item.id in selectedItemIds
                             ListItemRow(
                                 item = item,
+                                isMultiSelectMode = isItemMultiSelectMode,
+                                isSelected = isSelected,
                                 onToggle = { viewModel.toggleChecked(item) },
                                 onDelete = { viewModel.deleteItem(item) },
                                 onEdit = { editingItem = item },
                                 onToggleFavourite = { viewModel.toggleFavourite(item) },
+                                onLongClick = { viewModel.enterItemMultiSelect(item.id) },
+                                onSelectToggle = { viewModel.toggleItemSelection(item.id) },
                             )
                             HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
                         }
@@ -419,23 +473,58 @@ fun ListItemsScreen(
             onDismiss = { showAddDialog = false },
         )
     }
+
+    // ── Bulk delete dialog ───────────────────────────────────────────────────────────────────────
+    if (showItemBulkDeleteDialog) {
+        val count = selectedItemIds.size
+        AlertDialog(
+            onDismissRequest = { showItemBulkDeleteDialog = false },
+            title = { Text("Delete $count item${if (count == 1) "" else "s"}?") },
+            text = { Text("This will permanently delete the selected item${if (count == 1) "" else "s"}.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteSelectedItems()
+                        showItemBulkDeleteDialog = false
+                    },
+                ) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showItemBulkDeleteDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 // ── Item row ─────────────────────────────────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ListItemRow(
     item: ListItemEntity,
+    isMultiSelectMode: Boolean = false,
+    isSelected: Boolean = false,
     onToggle: () -> Unit,
     onDelete: () -> Unit,
     onEdit: () -> Unit,
     onToggleFavourite: () -> Unit,
+    onLongClick: () -> Unit = {},
+    onSelectToggle: () -> Unit = {},
 ) {
     ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = {
+                    if (isMultiSelectMode) onSelectToggle() else onEdit()
+                },
+                onLongClick = {
+                    if (!isMultiSelectMode) onLongClick()
+                },
+            ),
         headlineContent = {
             Text(
                 text = item.text,
-                modifier = Modifier.clickable(onClick = onEdit),
                 style = if (item.checked) {
                     MaterialTheme.typography.bodyLarge.copy(
                         textDecoration = TextDecoration.LineThrough,
@@ -453,7 +542,6 @@ private fun ListItemRow(
                     val overdue = isOverdue(dueAtMs, item.checked)
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.clickable(onClick = onEdit),
                     ) {
                         Icon(
                             Icons.Default.Event,
@@ -480,28 +568,37 @@ private fun ListItemRow(
             }
         },
         leadingContent = {
-            Checkbox(
-                checked = item.checked,
-                onCheckedChange = { onToggle() },
-            )
+            if (isMultiSelectMode) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onSelectToggle() },
+                )
+            } else {
+                Checkbox(
+                    checked = item.checked,
+                    onCheckedChange = { onToggle() },
+                )
+            }
         },
-        trailingContent = {
-            Row {
-                IconButton(onClick = onToggleFavourite) {
-                    Icon(
-                        imageVector = if (item.isFavourite) Icons.Default.Star
-                        else Icons.Default.StarBorder,
-                        contentDescription = if (item.isFavourite) "Unfavourite" else "Favourite",
-                        tint = if (item.isFavourite) MaterialTheme.colorScheme.tertiary
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                IconButton(onClick = onDelete) {
-                    Icon(
-                        Icons.Default.Delete,
-                        contentDescription = "Delete item",
-                        tint = MaterialTheme.colorScheme.error,
-                    )
+        trailingContent = if (isMultiSelectMode) null else {
+            {
+                Row {
+                    IconButton(onClick = onToggleFavourite) {
+                        Icon(
+                            imageVector = if (item.isFavourite) Icons.Default.Star
+                            else Icons.Default.StarBorder,
+                            contentDescription = if (item.isFavourite) "Unfavourite" else "Favourite",
+                            tint = if (item.isFavourite) MaterialTheme.colorScheme.tertiary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Delete item",
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
                 }
             }
         },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -144,6 +144,11 @@ fun ListsScreen(
                         }
                     },
                     actions = {
+                        TextButton(onClick = {
+                            viewModel.selectAllLists((pinnedItems + unpinnedItems).map { it.id })
+                        }) {
+                            Text("Select All")
+                        }
                         IconButton(onClick = { showBulkDeleteDialog = true }) {
                             Icon(
                                 Icons.Default.Delete,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -47,7 +47,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +60,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -103,6 +106,10 @@ fun ListsScreen(
 
     LaunchedEffect(pinnedItems) { if (!dragInProgress) localPinned = pinnedItems }
     LaunchedEffect(unpinnedItems) { if (!dragInProgress) localUnpinned = unpinnedItems }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.exitListMultiSelect() }
+    }
 
     val lazyListState = rememberLazyListState()
     val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
@@ -526,7 +533,11 @@ private fun ListOverviewRow(
                         Icons.Default.DragHandle,
                         contentDescription = "Drag to reorder",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = dragHandleModifier.padding(horizontal = 4.dp),
+                        modifier = dragHandleModifier
+                            .pointerInput(Unit) {
+                                detectTapGestures(onLongPress = { /* absorb — prevent combinedClickable from firing */ })
+                            }
+                            .padding(horizontal = 4.dp),
                     )
                 }
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -1,8 +1,9 @@
 package com.kernel.ai.feature.settings
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,18 +15,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,10 +43,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,6 +63,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import kotlinx.coroutines.launch
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -69,12 +78,15 @@ fun ListsScreen(
     val listEntities by viewModel.listEntities.collectAsStateWithLifecycle()
     val itemCounts by viewModel.itemCounts.collectAsStateWithLifecycle()
     val searchQuery by viewModel.listSearchQuery.collectAsStateWithLifecycle()
+    val selectedListIds = viewModel.selectedListIds
+    val isMultiSelect = viewModel.isListMultiSelectMode
     val scope = rememberCoroutineScope()
 
     var showCreateDialog by remember { mutableStateOf(false) }
     var pendingDeleteEntity by remember { mutableStateOf<ListNameEntity?>(null) }
     var pendingRenameEntity by remember { mutableStateOf<ListNameEntity?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var showBulkDeleteDialog by remember { mutableStateOf(false) }
 
     // Apply search on top of the already sort/filter-applied displayedLists
     val filtered = if (searchQuery.isBlank()) displayedLists
@@ -83,46 +95,99 @@ fun ListsScreen(
     val pinnedItems = filtered.filter { it.pinned }
     val unpinnedItems = filtered.filter { !it.pinned }
 
+    // ── Drag-and-drop local state ────────────────────────────────────────────────────────────────
+    // Maintain local copies for optimistic UI updates during drag; sync from ViewModel when idle.
+    var localPinned by remember { mutableStateOf(pinnedItems) }
+    var localUnpinned by remember { mutableStateOf(unpinnedItems) }
+    var dragInProgress by remember { mutableStateOf(false) }
+
+    LaunchedEffect(pinnedItems) { if (!dragInProgress) localPinned = pinnedItems }
+    LaunchedEffect(unpinnedItems) { if (!dragInProgress) localUnpinned = unpinnedItems }
+
+    val lazyListState = rememberLazyListState()
+    val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        // Only handle moves between real list entities (keys are Long IDs); skip headers
+        val fromKey = from.key as? Long ?: return@rememberReorderableLazyListState
+        val toKey = to.key as? Long ?: return@rememberReorderableLazyListState
+        // Enforce pinned/unpinned group boundary
+        val fromInPinned = localPinned.any { it.id == fromKey }
+        val toInPinned = localPinned.any { it.id == toKey }
+        if (fromInPinned != toInPinned) return@rememberReorderableLazyListState
+        // Optimistic reorder within the correct group
+        if (fromInPinned) {
+            val fi = localPinned.indexOfFirst { it.id == fromKey }
+            val ti = localPinned.indexOfFirst { it.id == toKey }
+            localPinned = localPinned.toMutableList().apply { add(ti, removeAt(fi)) }
+        } else {
+            val fi = localUnpinned.indexOfFirst { it.id == fromKey }
+            val ti = localUnpinned.indexOfFirst { it.id == toKey }
+            localUnpinned = localUnpinned.toMutableList().apply { add(ti, removeAt(fi)) }
+        }
+    }
+
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Lists") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                actions = {
-                    Box {
-                        IconButton(onClick = { showSortMenu = true }) {
-                            Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+            if (isMultiSelect) {
+                // ── Contextual multi-select top bar ──────────────────────────────────────────────
+                TopAppBar(
+                    title = { Text("${selectedListIds.size} selected") },
+                    navigationIcon = {
+                        IconButton(onClick = { viewModel.exitListMultiSelect() }) {
+                            Icon(Icons.Default.Close, contentDescription = "Exit selection")
                         }
-                        SortFilterMenu(
-                            expanded = showSortMenu,
-                            currentSort = viewModel.listSort,
-                            currentFilter = viewModel.listFilter,
-                            onSortSelected = { viewModel.listSort = it },
-                            onFilterSelected = { viewModel.listFilter = it },
-                            onDismiss = { showSortMenu = false },
-                        )
-                    }
-                },
-            )
+                    },
+                    actions = {
+                        IconButton(onClick = { showBulkDeleteDialog = true }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete selected",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    },
+                )
+            } else {
+                TopAppBar(
+                    title = { Text("Lists") },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    actions = {
+                        Box {
+                            IconButton(onClick = { showSortMenu = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "Sort and filter")
+                            }
+                            SortFilterMenu(
+                                expanded = showSortMenu,
+                                currentSort = viewModel.listSort,
+                                currentFilter = viewModel.listFilter,
+                                onSortSelected = { viewModel.listSort = it },
+                                onFilterSelected = { viewModel.listFilter = it },
+                                onDismiss = { showSortMenu = false },
+                            )
+                        }
+                    },
+                )
+            }
         },
         floatingActionButton = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                SmallFloatingActionButton(
-                    onClick = onNavigateToVoiceActions,
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            if (!isMultiSelect) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Icon(Icons.Default.Mic, contentDescription = "Voice input")
-                }
-                FloatingActionButton(onClick = { showCreateDialog = true }) {
-                    Icon(Icons.Default.Add, contentDescription = "Create list")
+                    SmallFloatingActionButton(
+                        onClick = onNavigateToVoiceActions,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ) {
+                        Icon(Icons.Default.Mic, contentDescription = "Voice input")
+                    }
+                    FloatingActionButton(onClick = { showCreateDialog = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "Create list")
+                    }
                 }
             }
         },
@@ -132,24 +197,26 @@ fun ListsScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // Search bar
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = viewModel::setListSearchQuery,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                placeholder = { Text("Search lists") },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                trailingIcon = {
-                    if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { viewModel.setListSearchQuery("") }) {
-                            Icon(Icons.Default.Close, contentDescription = "Clear")
+            // Search bar (hidden in multi-select mode to keep UI clean)
+            if (!isMultiSelect) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = viewModel::setListSearchQuery,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    placeholder = { Text("Search lists") },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = { viewModel.setListSearchQuery("") }) {
+                                Icon(Icons.Default.Close, contentDescription = "Clear")
+                            }
                         }
-                    }
-                },
-                singleLine = true,
-            )
+                    },
+                    singleLine = true,
+                )
+            }
 
             if (filtered.isEmpty()) {
                 Column(
@@ -179,40 +246,95 @@ fun ListsScreen(
                     }
                 }
             } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    state = lazyListState,
+                ) {
                     // ── Pinned section ──────────────────────────────────────────────────────
-                    if (pinnedItems.isNotEmpty()) {
+                    if (localPinned.isNotEmpty()) {
                         stickyHeader(key = "header_pinned") {
                             ListSectionHeader(label = "Pinned")
                         }
-                        items(pinnedItems, key = { it.id }) { entity ->
-                            ListOverviewRow(
-                                entity = entity,
-                                count = itemCounts[entity.id] ?: 0,
-                                onOpen = { onOpenList(entity.id) },
-                                onPin = { viewModel.togglePin(entity.id) },
-                                onRename = { pendingRenameEntity = entity },
-                                onDelete = { pendingDeleteEntity = entity },
-                            )
+                        items(localPinned, key = { it.id }) { entity ->
+                            ReorderableItem(reorderState, key = entity.id) { isDragging ->
+                                val elevation by animateDpAsState(
+                                    if (isDragging) 6.dp else 0.dp,
+                                    label = "drag_elevation_pinned",
+                                )
+                                Surface(shadowElevation = elevation) {
+                                    ListOverviewRow(
+                                        entity = entity,
+                                        count = itemCounts[entity.id] ?: 0,
+                                        isSelected = entity.id in selectedListIds,
+                                        isMultiSelectMode = isMultiSelect,
+                                        dragHandleModifier = if (!isMultiSelect) {
+                                            Modifier.draggableHandle(
+                                                onDragStarted = { dragInProgress = true },
+                                                onDragStopped = {
+                                                    dragInProgress = false
+                                                    viewModel.onListsReordered(
+                                                        localPinned.map { it.id },
+                                                        localUnpinned.map { it.id },
+                                                    )
+                                                },
+                                            )
+                                        } else Modifier,
+                                        onOpen = {
+                                            if (isMultiSelect) viewModel.toggleListSelection(entity.id)
+                                            else onOpenList(entity.id)
+                                        },
+                                        onLongClick = { viewModel.enterListMultiSelect(entity.id) },
+                                        onPin = { viewModel.togglePin(entity.id) },
+                                        onRename = { pendingRenameEntity = entity },
+                                        onDelete = { pendingDeleteEntity = entity },
+                                    )
+                                }
+                            }
                         }
                     }
 
                     // ── Unpinned section ────────────────────────────────────────────────────
-                    if (unpinnedItems.isNotEmpty()) {
-                        if (pinnedItems.isNotEmpty()) {
+                    if (localUnpinned.isNotEmpty()) {
+                        if (localPinned.isNotEmpty()) {
                             stickyHeader(key = "header_other") {
                                 ListSectionHeader(label = "Other")
                             }
                         }
-                        items(unpinnedItems, key = { it.id }) { entity ->
-                            ListOverviewRow(
-                                entity = entity,
-                                count = itemCounts[entity.id] ?: 0,
-                                onOpen = { onOpenList(entity.id) },
-                                onPin = { viewModel.togglePin(entity.id) },
-                                onRename = { pendingRenameEntity = entity },
-                                onDelete = { pendingDeleteEntity = entity },
-                            )
+                        items(localUnpinned, key = { it.id }) { entity ->
+                            ReorderableItem(reorderState, key = entity.id) { isDragging ->
+                                val elevation by animateDpAsState(
+                                    if (isDragging) 6.dp else 0.dp,
+                                    label = "drag_elevation_unpinned",
+                                )
+                                Surface(shadowElevation = elevation) {
+                                    ListOverviewRow(
+                                        entity = entity,
+                                        count = itemCounts[entity.id] ?: 0,
+                                        isSelected = entity.id in selectedListIds,
+                                        isMultiSelectMode = isMultiSelect,
+                                        dragHandleModifier = if (!isMultiSelect) {
+                                            Modifier.draggableHandle(
+                                                onDragStarted = { dragInProgress = true },
+                                                onDragStopped = {
+                                                    dragInProgress = false
+                                                    viewModel.onListsReordered(
+                                                        localPinned.map { it.id },
+                                                        localUnpinned.map { it.id },
+                                                    )
+                                                },
+                                            )
+                                        } else Modifier,
+                                        onOpen = {
+                                            if (isMultiSelect) viewModel.toggleListSelection(entity.id)
+                                            else onOpenList(entity.id)
+                                        },
+                                        onLongClick = { viewModel.enterListMultiSelect(entity.id) },
+                                        onPin = { viewModel.togglePin(entity.id) },
+                                        onRename = { pendingRenameEntity = entity },
+                                        onDelete = { pendingDeleteEntity = entity },
+                                    )
+                                }
+                            }
                         }
                     }
 
@@ -255,7 +377,7 @@ fun ListsScreen(
         )
     }
 
-    // ── Delete confirmation dialog ────────────────────────────────────────────────────────────
+    // ── Single-list delete confirmation dialog ────────────────────────────────────────────────
     pendingDeleteEntity?.let { entity ->
         val count = itemCounts[entity.id] ?: 0
         AlertDialog(
@@ -278,6 +400,29 @@ fun ListsScreen(
             },
         )
     }
+
+    // ── Bulk delete confirmation dialog ───────────────────────────────────────────────────────
+    if (showBulkDeleteDialog) {
+        val count = selectedListIds.size
+        AlertDialog(
+            onDismissRequest = { showBulkDeleteDialog = false },
+            title = { Text("Delete $count list${if (count == 1) "" else "s"}?") },
+            text = {
+                Text("This will also delete all items in ${if (count == 1) "that list" else "those lists"}.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteSelectedLists()
+                        showBulkDeleteDialog = false
+                    },
+                ) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showBulkDeleteDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 // ── Internal composables ──────────────────────────────────────────────────────────────────────────
@@ -296,12 +441,17 @@ private fun ListSectionHeader(label: String) {
     )
 }
 
-/** A single row in the lists overview. */
+/** A single row in the lists overview. Supports multi-select and drag-and-drop. */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ListOverviewRow(
     entity: ListNameEntity,
     count: Int,
+    isSelected: Boolean,
+    isMultiSelectMode: Boolean,
+    dragHandleModifier: Modifier,
     onOpen: () -> Unit,
+    onLongClick: () -> Unit,
     onPin: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
@@ -311,7 +461,10 @@ private fun ListOverviewRow(
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onOpen),
+            .combinedClickable(
+                onClick = onOpen,
+                onLongClick = onLongClick,
+            ),
         headlineContent = {
             Text(entity.name.replaceFirstChar { it.uppercase() })
         },
@@ -319,44 +472,62 @@ private fun ListOverviewRow(
             Text("$count item${if (count == 1) "" else "s"}")
         },
         leadingContent = {
-            Icon(
-                Icons.Default.Checklist,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
+            if (isMultiSelectMode) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onOpen() },
+                )
+            } else {
+                Icon(
+                    Icons.Default.Checklist,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
         },
         trailingContent = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(0.dp),
             ) {
-                // Pin toggle
-                IconButton(onClick = onPin) {
-                    Icon(
-                        if (entity.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
-                        contentDescription = if (entity.pinned) "Unpin" else "Pin",
-                        tint = if (entity.pinned) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                if (!isMultiSelectMode) {
+                    // Pin toggle
+                    IconButton(onClick = onPin) {
+                        Icon(
+                            if (entity.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                            contentDescription = if (entity.pinned) "Unpin" else "Pin",
+                            tint = if (entity.pinned) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    // Overflow: Rename / Delete
+                    Box {
+                        IconButton(onClick = { showOverflow = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                        }
+                        DropdownMenu(
+                            expanded = showOverflow,
+                            onDismissRequest = { showOverflow = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Rename") },
+                                onClick = { showOverflow = false; onRename() },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
+                                onClick = { showOverflow = false; onDelete() },
+                            )
+                        }
+                    }
                 }
-                // Overflow: Rename / Delete
-                Box {
-                    IconButton(onClick = { showOverflow = true }) {
-                        Icon(Icons.Default.MoreVert, contentDescription = "More options")
-                    }
-                    DropdownMenu(
-                        expanded = showOverflow,
-                        onDismissRequest = { showOverflow = false },
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text("Rename") },
-                            onClick = { showOverflow = false; onRename() },
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
-                            onClick = { showOverflow = false; onDelete() },
-                        )
-                    }
+                // Drag handle — always rendered but hidden in multi-select mode
+                if (!isMultiSelectMode) {
+                    Icon(
+                        Icons.Default.DragHandle,
+                        contentDescription = "Drag to reorder",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = dragHandleModifier.padding(horizontal = 4.dp),
+                    )
                 }
             }
         },
@@ -386,6 +557,11 @@ private fun SortFilterMenu(
             },
             onClick = {},
             enabled = false,
+        )
+        SortItem(
+            label = "Manual (drag to reorder)",
+            selected = currentSort == ListSort.MANUAL,
+            onClick = { onSortSelected(ListSort.MANUAL); onDismiss() },
         )
         SortItem(
             label = "Last modified",
@@ -496,4 +672,5 @@ internal fun NameInputDialog(
         },
     )
 }
+
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -220,6 +220,8 @@ class ListsViewModel @Inject constructor(
 
     fun exitListMultiSelect() { selectedListIds = emptySet() }
 
+    fun selectAllLists(ids: List<Long>) { selectedListIds = ids.toSet() }
+
     /** Bulk-deletes the currently selected lists (cascade removes all child items via FK). */
     fun deleteSelectedLists() {
         val ids = selectedListIds.toList()
@@ -243,6 +245,8 @@ class ListsViewModel @Inject constructor(
     }
 
     fun exitItemMultiSelect() { selectedItemIds = emptySet() }
+
+    fun selectAllItems(ids: List<Long>) { selectedItemIds = ids.toSet() }
 
     /** Bulk-deletes the currently selected list items. */
     fun deleteSelectedItems() {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -12,6 +12,7 @@ import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -183,9 +184,12 @@ class ListsViewModel @Inject constructor(
 
     // ── Drag-and-drop reorder (#897) ─────────────────────────────────────────────────────────────
 
+    private var reorderJob: Job? = null
+
     /**
-     * Called when the user finishes dragging a list row.  Persists the new display order for both
-     * groups and automatically switches the sort mode to [ListSort.MANUAL].
+     * Called when the user finishes dragging a list row.  Cancels any in-flight reorder job and
+     * persists the new display order atomically for both groups, automatically switching the sort
+     * mode to [ListSort.MANUAL].
      *
      * @param pinnedIds  Ordered list of pinned entity IDs after the drag.
      * @param unpinnedIds  Ordered list of unpinned entity IDs after the drag.
@@ -193,13 +197,11 @@ class ListsViewModel @Inject constructor(
     fun onListsReordered(pinnedIds: List<Long>, unpinnedIds: List<Long>) {
         listSort = ListSort.MANUAL
         val now = System.currentTimeMillis()
-        viewModelScope.launch(Dispatchers.IO) {
-            pinnedIds.forEachIndexed { index, id ->
-                listNameDao.updateDisplayOrder(id, index, now)
-            }
-            unpinnedIds.forEachIndexed { index, id ->
-                listNameDao.updateDisplayOrder(id, index, now)
-            }
+        reorderJob?.cancel()
+        reorderJob = viewModelScope.launch(Dispatchers.IO) {
+            val updates = pinnedIds.mapIndexed { i, id -> id to i } +
+                          unpinnedIds.mapIndexed { i, id -> id to i }
+            listNameDao.updateDisplayOrders(updates, now)
         }
     }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-enum class ListSort { LAST_MODIFIED, NAME_ASC, NAME_DESC, CREATED_ASC, CREATED_DESC }
+enum class ListSort { MANUAL, LAST_MODIFIED, NAME_ASC, NAME_DESC, CREATED_ASC, CREATED_DESC }
 enum class ListFilter { ALL, PINNED_ONLY }
 
 enum class ItemSort {
@@ -50,8 +50,8 @@ class ListsViewModel @Inject constructor(
 
     // ── Sort / filter state (ViewModel-scoped, survives recomposition) ──────────────────────────
 
-    /** Current sort order selected by the user on the overview screen. */
-    var listSort by mutableStateOf(ListSort.LAST_MODIFIED)
+    /** Current sort order selected by the user on the overview screen. Defaults to MANUAL. */
+    var listSort by mutableStateOf(ListSort.MANUAL)
 
     /** Current filter selected by the user on the overview screen. */
     var listFilter by mutableStateOf(ListFilter.ALL)
@@ -70,6 +70,9 @@ class ListsViewModel @Inject constructor(
             ListFilter.PINNED_ONLY -> entities.filter { it.pinned }
         }
         val comparator: Comparator<ListNameEntity> = when (sort) {
+            ListSort.MANUAL ->
+                compareBy<ListNameEntity> { it.displayOrder }
+                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
             ListSort.LAST_MODIFIED -> compareByDescending { it.updatedAt }
             ListSort.NAME_ASC -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }
             ListSort.NAME_DESC -> compareByDescending(String.CASE_INSENSITIVE_ORDER) { it.name }
@@ -177,6 +180,89 @@ class ListsViewModel @Inject constructor(
     fun setListSearchQuery(q: String) { _listSearchQuery.value = q }
     fun setItemSearchQuery(q: String) { _itemSearchQuery.value = q }
     fun clearItemSearchQuery() { _itemSearchQuery.value = "" }
+
+    // ── Drag-and-drop reorder (#897) ─────────────────────────────────────────────────────────────
+
+    /**
+     * Called when the user finishes dragging a list row.  Persists the new display order for both
+     * groups and automatically switches the sort mode to [ListSort.MANUAL].
+     *
+     * @param pinnedIds  Ordered list of pinned entity IDs after the drag.
+     * @param unpinnedIds  Ordered list of unpinned entity IDs after the drag.
+     */
+    fun onListsReordered(pinnedIds: List<Long>, unpinnedIds: List<Long>) {
+        listSort = ListSort.MANUAL
+        val now = System.currentTimeMillis()
+        viewModelScope.launch(Dispatchers.IO) {
+            pinnedIds.forEachIndexed { index, id ->
+                listNameDao.updateDisplayOrder(id, index, now)
+            }
+            unpinnedIds.forEachIndexed { index, id ->
+                listNameDao.updateDisplayOrder(id, index, now)
+            }
+        }
+    }
+
+    // ── Multi-select state — lists overview (#896) ───────────────────────────────────────────────
+
+    var selectedListIds by mutableStateOf<Set<Long>>(emptySet())
+        private set
+
+    val isListMultiSelectMode: Boolean get() = selectedListIds.isNotEmpty()
+
+    fun enterListMultiSelect(id: Long) { selectedListIds = setOf(id) }
+
+    fun toggleListSelection(id: Long) {
+        selectedListIds = if (id in selectedListIds) selectedListIds - id else selectedListIds + id
+    }
+
+    fun exitListMultiSelect() { selectedListIds = emptySet() }
+
+    /** Bulk-deletes the currently selected lists (cascade removes all child items via FK). */
+    fun deleteSelectedLists() {
+        val ids = selectedListIds.toList()
+        selectedListIds = emptySet()
+        viewModelScope.launch(Dispatchers.IO) {
+            ids.forEach { listNameDao.deleteById(it) }
+        }
+    }
+
+    // ── Multi-select state — list items (#896) ───────────────────────────────────────────────────
+
+    var selectedItemIds by mutableStateOf<Set<Long>>(emptySet())
+        private set
+
+    val isItemMultiSelectMode: Boolean get() = selectedItemIds.isNotEmpty()
+
+    fun enterItemMultiSelect(id: Long) { selectedItemIds = setOf(id) }
+
+    fun toggleItemSelection(id: Long) {
+        selectedItemIds = if (id in selectedItemIds) selectedItemIds - id else selectedItemIds + id
+    }
+
+    fun exitItemMultiSelect() { selectedItemIds = emptySet() }
+
+    /** Bulk-deletes the currently selected list items. */
+    fun deleteSelectedItems() {
+        val ids = selectedItemIds.toList()
+        selectedItemIds = emptySet()
+        viewModelScope.launch(Dispatchers.IO) {
+            ids.forEach { dao.deleteItem(it) }
+        }
+    }
+
+    /**
+     * Marks all currently selected list items as complete.
+     * Uses [ListItemDao.setChecked] to atomically set checked=true without a TOCTOU risk.
+     */
+    fun markSelectedItemsComplete() {
+        val ids = selectedItemIds.toList()
+        selectedItemIds = emptySet()
+        val now = System.currentTimeMillis()
+        viewModelScope.launch(Dispatchers.IO) {
+            ids.forEach { dao.setChecked(it, true, now) }
+        }
+    }
 
     // ── List mutations ───────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Combines drag-and-drop manual reorder (#897) and multi-select bulk actions (#896) into a single slice of the Lists overhaul (#662).

## Changes

### DB — migration 35→36
- New `displayOrder: Int` column on `list_name` table
- Existing rows initialised to `displayOrder = id` (stable insertion order)

### `core/memory`
- `ListNameEntity` — `displayOrder` field added
- `ListNameDao` — `updateDisplayOrder(id, order, updatedAt)` for batch reorder writes
- `KernelDatabase` — version bumped to 36, `MIGRATION_35_36` wired in

### `feature/settings`
- `sh.calvin.reorderable:reorderable:2.4.3` dependency added

### `ListsViewModel`
- `MANUAL` added to `ListSort` enum (default sort)
- `displayedLists` sorts by `pinned DESC, displayOrder ASC` when `MANUAL` is active
- `onListsReordered(movedId, fromIndex, toIndex, isPinned)` — recomputes display order for the affected group and batch-writes to DB; auto-switches sort to `MANUAL`
- Multi-select state for lists: `selectedListIds`, `isListMultiSelectMode`, `enterListMultiSelect`, `toggleListSelection`, `exitListMultiSelect`, `deleteSelectedLists`
- Multi-select state for items: `selectedItemIds`, `isItemMultiSelectMode`, `enterItemMultiSelect`, `toggleItemSelection`, `exitItemMultiSelect`, `deleteSelectedItems`, `markSelectedItemsComplete`

### `ListsScreen`
- Always-on ⠿ drag handles on each list row (hidden in multi-select mode)
- Reorderable `LazyColumn` via `sh.calvin.reorderable` with two independent states — one per group (pinned / unpinned) — enforcing group boundaries
- Dragging auto-switches sort to `MANUAL`; switching back to `MANUAL` from another sort restores stored order
- Long-press row → multi-select mode; contextual top bar: "N selected" + ✕ + 🗑
- Bulk delete confirm dialog: "Delete N lists? This will also delete all items in those lists."
- Drag handle hidden during multi-select to avoid gesture conflict

### `ListItemsScreen`
- Long-press row → multi-select mode; contextual top bar: "N selected" + ✕ + ✓ (mark complete) + 🗑
- `combinedClickable` on rows; leading checkbox swaps in during multi-select
- Bulk delete confirm dialog; mark-complete requires no confirm (reversible)
- `exitItemMultiSelect` called on `DisposableEffect` dispose (clears selection on back-navigate)

## Manual Testing

| Scenario | Steps | Expected |
|----------|-------|----------|
| Drag reorder | ⠿ drag a list up/down within same group | List moves; order persists on app restart |
| Boundary respected | ⠿ drag pinned list toward unpinned | Cannot cross boundary |
| Auto manual sort | Drag any list | Sort mode switches to Manual automatically |
| Restore manual order | Switch to Name A→Z, then back to Manual | Previous drag order restored |
| Lists multi-select | Long-press a list | Checkboxes appear, top bar changes |
| Bulk delete lists | Select 2+ lists → 🗑 → confirm | Lists and all their items deleted |
| Exit multi-select | Tap ✕ or back | Normal mode restored |
| Items multi-select | Long-press a list item | Checkboxes appear, top bar changes |
| Bulk mark complete | Select items → ✓ | Items move to completed section |
| Bulk delete items | Select items → 🗑 → confirm | Items deleted |
| Multi-select clears on navigate | Enter multi-select → press back | Selection cleared, no ghost state |

## Related issues

Closes #896
Closes #897
Part of #662
