### PR TITLE
feat(#901,#903): lists archive + due date notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,6 +135,15 @@
             android:name=".alarm.AlarmBroadcastReceiver"
             android:exported="false" />
 
+        <!-- Fires when a list-item due-date notification alarm triggers (#901) -->
+        <receiver
+            android:name=".notification.ListDueNotificationReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.kernel.ai.LIST_ITEM_DUE" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name=".alarm.ClockTimerActionReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
@@ -4,6 +4,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.dao.ListItemDao
+import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.notification.ListNotificationScheduler
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -14,6 +17,9 @@ import kotlinx.coroutines.launch
 class BootCompletedReceiver : BroadcastReceiver() {
 
     @Inject lateinit var clockRepository: ClockRepository
+    @Inject lateinit var listItemDao: ListItemDao
+    @Inject lateinit var listNameDao: ListNameDao
+    @Inject lateinit var listNotificationScheduler: ListNotificationScheduler
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
@@ -22,6 +28,16 @@ class BootCompletedReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 clockRepository.restoreScheduledEntries()
+                listItemDao.getAllActiveWithNotification().forEach { item ->
+                    val listName = listNameDao.getById(item.listId)?.name ?: ""
+                    listNotificationScheduler.schedule(
+                        itemId = item.id,
+                        itemText = item.text,
+                        listId = item.listId,
+                        listName = listName,
+                        triggerAtMs = item.notificationTime!!,
+                    )
+                }
             } finally {
                 pendingResult.finish()
             }

--- a/app/src/main/java/com/kernel/ai/notification/ListDueNotificationReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/notification/ListDueNotificationReceiver.kt
@@ -1,0 +1,74 @@
+package com.kernel.ai.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.kernel.ai.MainActivity
+import com.kernel.ai.core.memory.notification.ListNotificationScheduler
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * BroadcastReceiver that fires when a list-item due-date notification alarm triggers (#901).
+ *
+ * Registered in AndroidManifest with action [ListNotificationScheduler.ACTION].
+ * Uses Hilt entry-point injection via [AndroidEntryPoint] (no injected fields needed here —
+ * all data arrives via intent extras).
+ */
+@AndroidEntryPoint
+class ListDueNotificationReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ListNotificationScheduler.ACTION) return
+
+        val itemId = intent.getLongExtra(ListNotificationScheduler.EXTRA_ITEM_ID, -1L)
+            .takeIf { it >= 0L } ?: return
+        val itemText = intent.getStringExtra(ListNotificationScheduler.EXTRA_ITEM_TEXT) ?: return
+        val listName = intent.getStringExtra(ListNotificationScheduler.EXTRA_LIST_NAME) ?: ""
+
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        ensureChannel(notificationManager)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_idle_alarm)
+            .setContentTitle(listName.replaceFirstChar { it.uppercase() }.ifBlank { "List reminder" })
+            .setContentText(itemText)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setContentIntent(buildOpenAppPendingIntent(context))
+            .build()
+
+        notificationManager.notify(itemId.toInt(), notification)
+    }
+
+    private fun ensureChannel(notificationManager: NotificationManager) {
+        if (notificationManager.getNotificationChannel(CHANNEL_ID) != null) return
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "List reminders",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = "Reminders for list items with a due date"
+            },
+        )
+    }
+
+    private fun buildOpenAppPendingIntent(context: Context): PendingIntent =
+        PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    companion object {
+        const val CHANNEL_ID = "list_due_channel"
+    }
+}

--- a/app/src/main/java/com/kernel/ai/notification/ListDueNotificationReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/notification/ListDueNotificationReceiver.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import com.kernel.ai.MainActivity
 import com.kernel.ai.core.memory.notification.ListNotificationScheduler
+import com.kernel.ai.core.memory.notification.toNotificationId
 import dagger.hilt.android.AndroidEntryPoint
 
 /**
@@ -42,7 +43,7 @@ class ListDueNotificationReceiver : BroadcastReceiver() {
             .setContentIntent(buildOpenAppPendingIntent(context))
             .build()
 
-        notificationManager.notify(itemId.toInt(), notification)
+        notificationManager.notify(itemId.toNotificationId(), notification)
     }
 
     private fun ensureChannel(notificationManager: NotificationManager) {

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/38.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/38.json
@@ -1,0 +1,1814 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 38,
+    "identityHash": "45a8ca9f7291f6a67ca702f622a7e2e5",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '45a8ca9f7291f6a67ca702f622a7e2e5')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 36,
+    version = 38,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -656,6 +656,20 @@ abstract class KernelDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE lists ADD COLUMN displayOrder INTEGER NOT NULL DEFAULT 0")
                 // Initialise existing rows to a stable order (by id)
                 db.execSQL("UPDATE lists SET displayOrder = id")
+            }
+        }
+
+        /** Adds archivedAt to lists for archive feature (#903). */
+        val MIGRATION_36_37 = object : Migration(36, 37) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE lists ADD COLUMN archivedAt INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Adds notificationTime to list_items for due-date notifications (#901). */
+        val MIGRATION_37_38 = object : Migration(37, 38) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE list_items ADD COLUMN notificationTime INTEGER DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -102,6 +102,8 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_33_34,
                     KernelDatabase.MIGRATION_34_35,
                     KernelDatabase.MIGRATION_35_36,
+                    KernelDatabase.MIGRATION_36_37,
+                    KernelDatabase.MIGRATION_37_38,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
@@ -37,6 +37,18 @@ interface ListItemDao {
     @Query("UPDATE list_items SET text = :text, dueAt = :dueAt, isFavourite = :isFavourite, notificationTime = :notificationTime, updatedAt = :updatedAt WHERE id = :id")
     suspend fun updateItem(id: Long, text: String, dueAt: Long?, isFavourite: Boolean, notificationTime: Long?, updatedAt: Long)
 
+    /** Checked items with a pending notification — used by clearChecked() to cancel alarms first. */
+    @Query("SELECT * FROM list_items WHERE listId = :listId AND checked = 1 AND notificationTime IS NOT NULL")
+    suspend fun getCheckedWithNotification(listId: Long): List<ListItemEntity>
+
+    /** All items in a list (any checked state) that have a scheduled notification. */
+    @Query("SELECT * FROM list_items WHERE listId = :listId AND notificationTime IS NOT NULL")
+    suspend fun getAllWithNotification(listId: Long): List<ListItemEntity>
+
+    /** All unchecked items across all lists with a scheduled notification — used on device reboot. */
+    @Query("SELECT * FROM list_items WHERE notificationTime IS NOT NULL AND checked = 0")
+    suspend fun getAllActiveWithNotification(): List<ListItemEntity>
+
     /** Remove all checked items from a list. */
     @Query("DELETE FROM list_items WHERE listId = :listId AND checked = 1")
     suspend fun deleteChecked(listId: Long)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListItemDao.kt
@@ -34,8 +34,8 @@ interface ListItemDao {
     @Query("UPDATE list_items SET checked = :checked, updatedAt = :updatedAt WHERE id = :id")
     suspend fun setChecked(id: Long, checked: Boolean, updatedAt: Long)
 
-    @Query("UPDATE list_items SET text = :text, dueAt = :dueAt, isFavourite = :isFavourite, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updateItem(id: Long, text: String, dueAt: Long?, isFavourite: Boolean, updatedAt: Long)
+    @Query("UPDATE list_items SET text = :text, dueAt = :dueAt, isFavourite = :isFavourite, notificationTime = :notificationTime, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateItem(id: Long, text: String, dueAt: Long?, isFavourite: Boolean, notificationTime: Long?, updatedAt: Long)
 
     /** Remove all checked items from a list. */
     @Query("DELETE FROM list_items WHERE listId = :listId AND checked = 1")

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -24,6 +24,10 @@ abstract class ListNameDao {
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
     abstract fun observeAll(): Flow<List<ListNameEntity>>
 
+    /** Active lists only (archivedAt IS NULL), used by the main overview screen. */
+    @Query("SELECT * FROM lists WHERE archivedAt IS NULL ORDER BY pinned DESC, createdAt ASC")
+    abstract fun observeActiveLists(): Flow<List<ListNameEntity>>
+
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
     abstract suspend fun getAll(): List<ListNameEntity>
 
@@ -51,6 +55,18 @@ abstract class ListNameDao {
 
     @Query("UPDATE lists SET displayOrder = :order, updatedAt = :updatedAt WHERE id = :id")
     abstract suspend fun updateDisplayOrder(id: Long, order: Int, updatedAt: Long)
+
+    /** Archive a list by recording the epoch-ms timestamp; null = active. */
+    @Query("UPDATE lists SET archivedAt = :archivedAt, updatedAt = :updatedAt WHERE id = :id")
+    abstract suspend fun archiveList(id: Long, archivedAt: Long, updatedAt: Long)
+
+    /** Restore a list by clearing the archivedAt timestamp. */
+    @Query("UPDATE lists SET archivedAt = NULL, updatedAt = :updatedAt WHERE id = :id")
+    abstract suspend fun restoreList(id: Long, updatedAt: Long)
+
+    /** Archived lists, newest-archive-date first. */
+    @Query("SELECT * FROM lists WHERE archivedAt IS NOT NULL ORDER BY archivedAt DESC")
+    abstract fun observeArchivedLists(): Flow<List<ListNameEntity>>
 
     @Transaction
     open suspend fun updateDisplayOrders(updates: List<Pair<Long, Int>>, updatedAt: Long) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ListNameDao.kt
@@ -31,6 +31,9 @@ abstract class ListNameDao {
     @Query("SELECT * FROM lists ORDER BY pinned DESC, createdAt ASC")
     abstract suspend fun getAll(): List<ListNameEntity>
 
+    @Query("SELECT * FROM lists WHERE id = :id LIMIT 1")
+    abstract suspend fun getById(id: Long): ListNameEntity?
+
     /** Resolve a list by display name — used by NativeIntentHandler at the skill boundary. */
     @Query("SELECT * FROM lists WHERE name = :name LIMIT 1")
     abstract suspend fun getByName(name: String): ListNameEntity?

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListItemEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListItemEntity.kt
@@ -29,4 +29,6 @@ data class ListItemEntity(
     val checked: Boolean = false,
     val dueAt: Long? = null,
     val isFavourite: Boolean = false,
+    /** Epoch-ms when a notification should fire, or null for no notification. */
+    val notificationTime: Long? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ListNameEntity.kt
@@ -18,4 +18,6 @@ data class ListNameEntity(
     val pinned: Boolean = false,
     /** Manual drag-and-drop order within the pinned or unpinned group. */
     @ColumnInfo(name = "displayOrder") val displayOrder: Int = 0,
+    /** Epoch-ms when the list was archived, or null if active. */
+    val archivedAt: Long? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ListNotificationScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ListNotificationScheduler.kt
@@ -67,7 +67,7 @@ class ListNotificationScheduler @Inject constructor(
         flags: Int,
     ): PendingIntent? = PendingIntent.getBroadcast(
         context,
-        itemId.toInt(),
+        itemId.toNotificationId(),
         Intent(ACTION).apply {
             setPackage(context.packageName)
             putExtra(EXTRA_ITEM_ID, itemId)
@@ -86,3 +86,10 @@ class ListNotificationScheduler @Inject constructor(
         const val EXTRA_LIST_NAME = "list_name"
     }
 }
+
+/**
+ * Folds a Long item ID into an Int notification/request-code without silent wrap-around.
+ * XOR-folds the upper 32 bits into the lower 32, so IDs differing only in the upper half
+ * still produce distinct Int values within the realistic Room ID range.
+ */
+fun Long.toNotificationId(): Int = (this xor (this ushr 32)).toInt()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ListNotificationScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ListNotificationScheduler.kt
@@ -1,0 +1,88 @@
+package com.kernel.ai.core.memory.notification
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules and cancels exact AlarmManager broadcasts for list-item due-date reminders (#901).
+ *
+ * Placed in :core:memory so it can be injected by ListsViewModel in :feature:settings.
+ * The broadcast is handled by ListDueNotificationReceiver in :app, which is registered in
+ * the app manifest with the [ACTION] intent filter.
+ */
+@Singleton
+class ListNotificationScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val alarmManager: AlarmManager
+        get() = context.getSystemService(AlarmManager::class.java)
+
+    /**
+     * Schedule (or replace) an exact alarm for [itemId] that fires at [triggerAtMs].
+     * Any existing pending intent for the same [itemId] is cancelled first.
+     */
+    fun schedule(
+        itemId: Long,
+        itemText: String,
+        listId: Long,
+        listName: String,
+        triggerAtMs: Long,
+    ) {
+        val pendingIntent = buildPendingIntent(
+            itemId = itemId,
+            itemText = itemText,
+            listId = listId,
+            listName = listName,
+            flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMs,
+            pendingIntent!!,
+        )
+    }
+
+    /** Cancel any pending notification alarm for [itemId]. No-op if none is scheduled. */
+    fun cancel(itemId: Long) {
+        val pendingIntent = buildPendingIntent(
+            itemId = itemId,
+            itemText = "",
+            listId = 0L,
+            listName = "",
+            flags = PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        ) ?: return
+        alarmManager.cancel(pendingIntent)
+    }
+
+    private fun buildPendingIntent(
+        itemId: Long,
+        itemText: String,
+        listId: Long,
+        listName: String,
+        flags: Int,
+    ): PendingIntent? = PendingIntent.getBroadcast(
+        context,
+        itemId.toInt(),
+        Intent(ACTION).apply {
+            setPackage(context.packageName)
+            putExtra(EXTRA_ITEM_ID, itemId)
+            putExtra(EXTRA_ITEM_TEXT, itemText)
+            putExtra(EXTRA_LIST_ID, listId)
+            putExtra(EXTRA_LIST_NAME, listName)
+        },
+        flags,
+    )
+
+    companion object {
+        const val ACTION = "com.kernel.ai.LIST_ITEM_DUE"
+        const val EXTRA_ITEM_ID = "item_id"
+        const val EXTRA_ITEM_TEXT = "item_text"
+        const val EXTRA_LIST_ID = "list_id"
+        const val EXTRA_LIST_NAME = "list_name"
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -732,7 +732,12 @@ private fun EditItemSheet(
             if (dueAt != null) {
                 Spacer(modifier = Modifier.height(4.dp))
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (notifyEnabled) Modifier.clickable { showTimePicker = true }
+                            else Modifier
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
@@ -758,7 +763,6 @@ private fun EditItemSheet(
                                 ),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.clickable { showTimePicker = true },
                             )
                         }
                     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsNone
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
@@ -51,9 +53,12 @@ import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -75,6 +80,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -566,6 +572,15 @@ private fun ListItemRow(
                             else MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
                         )
+                        if (item.notificationTime != null) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Icon(
+                                Icons.Default.Notifications,
+                                contentDescription = "Notification set",
+                                modifier = Modifier.padding(end = 2.dp),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
                     }
                 }
                 Text(
@@ -627,7 +642,10 @@ private fun EditItemSheet(
     var text by remember(item.id) { mutableStateOf(item.text) }
     var dueAt by remember(item.id) { mutableStateOf(item.dueAt) }
     var isFavourite by remember(item.id) { mutableStateOf(item.isFavourite) }
+    var notificationTime by remember(item.id) { mutableStateOf(item.notificationTime) }
+    var notifyEnabled by remember(item.id) { mutableStateOf(item.notificationTime != null) }
     var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -671,7 +689,11 @@ private fun EditItemSheet(
                             .weight(1f)
                             .clickable { showDatePicker = true },
                     )
-                    IconButton(onClick = { dueAt = null }) {
+                    IconButton(onClick = {
+                        dueAt = null
+                        notificationTime = null
+                        notifyEnabled = false
+                    }) {
                         Icon(Icons.Default.Close, contentDescription = "Clear due date")
                     }
                 } else {
@@ -706,6 +728,64 @@ private fun EditItemSheet(
                 )
             }
 
+            // Notify me row (only when a due date is set)
+            if (dueAt != null) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = if (notifyEnabled) Icons.Default.Notifications
+                        else Icons.Default.NotificationsNone,
+                        contentDescription = null,
+                        tint = if (notifyEnabled) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Notify me",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        if (notifyEnabled && notificationTime != null) {
+                            val notifTime = LocalTime.ofSecondOfDay(
+                                (notificationTime!! % 86_400_000L) / 1_000L,
+                            )
+                            Text(
+                                text = notifTime.format(
+                                    java.time.format.DateTimeFormatter.ofPattern("HH:mm"),
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.clickable { showTimePicker = true },
+                            )
+                        }
+                    }
+                    Switch(
+                        checked = notifyEnabled,
+                        onCheckedChange = { enabled ->
+                            notifyEnabled = enabled
+                            if (enabled) {
+                                // Default: due-date day at 09:00 local
+                                val base = dueAt ?: System.currentTimeMillis()
+                                val localDate = Instant.ofEpochMilli(base)
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
+                                notificationTime = localDate
+                                    .atTime(9, 0)
+                                    .atZone(ZoneId.systemDefault())
+                                    .toInstant()
+                                    .toEpochMilli()
+                                showTimePicker = true
+                            } else {
+                                notificationTime = null
+                            }
+                        },
+                    )
+                }
+            }
+
             Spacer(modifier = Modifier.height(16.dp))
 
             // Save / Cancel
@@ -717,7 +797,14 @@ private fun EditItemSheet(
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = {
-                        onSave(item.copy(text = text.trim(), dueAt = dueAt, isFavourite = isFavourite))
+                        onSave(
+                            item.copy(
+                                text = text.trim(),
+                                dueAt = dueAt,
+                                isFavourite = isFavourite,
+                                notificationTime = if (notifyEnabled) notificationTime else null,
+                            ),
+                        )
                     },
                     enabled = text.isNotBlank(),
                 ) { Text("Save") }
@@ -763,6 +850,48 @@ private fun EditItemSheet(
         ) {
             DatePicker(state = datePickerState)
         }
+    }
+
+    // Time picker for notification time
+    if (showTimePicker) {
+        val initialTime = notificationTime?.let { epochMs ->
+            Instant.ofEpochMilli(epochMs).atZone(ZoneId.systemDefault()).toLocalTime()
+        } ?: LocalTime.of(9, 0)
+        val timePickerState = rememberTimePickerState(
+            initialHour = initialTime.hour,
+            initialMinute = initialTime.minute,
+            is24Hour = true,
+        )
+        AlertDialog(
+            onDismissRequest = { showTimePicker = false },
+            title = { Text("Set notification time") },
+            text = {
+                TimePicker(state = timePickerState)
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val base = dueAt ?: System.currentTimeMillis()
+                        val localDate = Instant.ofEpochMilli(base)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDate()
+                        notificationTime = localDate
+                            .atTime(timePickerState.hour, timePickerState.minute)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant()
+                            .toEpochMilli()
+                        showTimePicker = false
+                    },
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    // If toggling on for the first time and dismissed, revert the switch
+                    if (notificationTime == null) notifyEnabled = false
+                    showTimePicker = false
+                }) { Text("Cancel") }
+            },
+        )
     }
 }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListItemsScreen.kt
@@ -749,9 +749,9 @@ private fun EditItemSheet(
                             style = MaterialTheme.typography.bodyMedium,
                         )
                         if (notifyEnabled && notificationTime != null) {
-                            val notifTime = LocalTime.ofSecondOfDay(
-                                (notificationTime!! % 86_400_000L) / 1_000L,
-                            )
+                            val notifTime = java.time.Instant.ofEpochMilli(notificationTime!!)
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .toLocalTime()
                             Text(
                                 text = notifTime.format(
                                     java.time.format.DateTimeFormatter.ofPattern("HH:mm"),

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Close
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -60,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -79,6 +82,8 @@ fun ListsScreen(
 ) {
     val displayedLists by viewModel.displayedLists.collectAsStateWithLifecycle()
     val listEntities by viewModel.listEntities.collectAsStateWithLifecycle()
+    val archivedLists by viewModel.archivedLists.collectAsStateWithLifecycle()
+    val showArchived = viewModel.showArchived
     val itemCounts by viewModel.itemCounts.collectAsStateWithLifecycle()
     val searchQuery by viewModel.listSearchQuery.collectAsStateWithLifecycle()
     val selectedListIds = viewModel.selectedListIds
@@ -90,13 +95,19 @@ fun ListsScreen(
     var pendingRenameEntity by remember { mutableStateOf<ListNameEntity?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showBulkDeleteDialog by remember { mutableStateOf(false) }
+    var showBulkArchiveDialog by remember { mutableStateOf(false) }
 
-    // Apply search on top of the already sort/filter-applied displayedLists
-    val filtered = if (searchQuery.isBlank()) displayedLists
-    else displayedLists.filter { it.name.contains(searchQuery, ignoreCase = true) }
+    // Active view: apply search on top of already sort/filter-applied displayedLists
+    // Archived view: show archivedLists (no search/sort/filter applied)
+    val filtered = if (showArchived) {
+        archivedLists
+    } else {
+        if (searchQuery.isBlank()) displayedLists
+        else displayedLists.filter { it.name.contains(searchQuery, ignoreCase = true) }
+    }
 
-    val pinnedItems = filtered.filter { it.pinned }
-    val unpinnedItems = filtered.filter { !it.pinned }
+    val pinnedItems = if (showArchived) emptyList() else filtered.filter { it.pinned }
+    val unpinnedItems = if (showArchived) filtered else filtered.filter { !it.pinned }
 
     // ── Drag-and-drop local state ────────────────────────────────────────────────────────────────
     // Maintain local copies for optimistic UI updates during drag; sync from ViewModel when idle.
@@ -149,6 +160,28 @@ fun ListsScreen(
                         }) {
                             Text("Select All")
                         }
+                        if (!showArchived) {
+                            // Archive selected (active view)
+                            IconButton(onClick = { showBulkArchiveDialog = true }) {
+                                Icon(
+                                    Icons.Default.Archive,
+                                    contentDescription = "Archive selected",
+                                )
+                            }
+                        } else {
+                            // Restore selected (archived view)
+                            IconButton(onClick = {
+                                val ids = selectedListIds.toList()
+                                viewModel.exitListMultiSelect()
+                                val now = System.currentTimeMillis()
+                                ids.forEach { viewModel.restoreList(it) }
+                            }) {
+                                Icon(
+                                    Icons.Default.Unarchive,
+                                    contentDescription = "Restore selected",
+                                )
+                            }
+                        }
                         IconButton(onClick = { showBulkDeleteDialog = true }) {
                             Icon(
                                 Icons.Default.Delete,
@@ -160,9 +193,11 @@ fun ListsScreen(
                 )
             } else {
                 TopAppBar(
-                    title = { Text("Lists") },
+                    title = { Text(if (showArchived) "Archived Lists" else "Lists") },
                     navigationIcon = {
-                        IconButton(onClick = onBack) {
+                        IconButton(onClick = {
+                            if (showArchived) viewModel.showArchived = false else onBack()
+                        }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                         }
                     },
@@ -173,8 +208,10 @@ fun ListsScreen(
                             }
                             SortFilterMenu(
                                 expanded = showSortMenu,
+                                showArchived = showArchived,
                                 currentSort = viewModel.listSort,
                                 currentFilter = viewModel.listFilter,
+                                onToggleArchived = { viewModel.showArchived = !showArchived; showSortMenu = false },
                                 onSortSelected = { viewModel.listSort = it },
                                 onFilterSelected = { viewModel.listFilter = it },
                                 onDismiss = { showSortMenu = false },
@@ -185,7 +222,8 @@ fun ListsScreen(
             }
         },
         floatingActionButton = {
-            if (!isMultiSelect) {
+            // Hide FAB in archived view and multi-select
+            if (!isMultiSelect && !showArchived) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -209,8 +247,8 @@ fun ListsScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // Search bar (hidden in multi-select mode to keep UI clean)
-            if (!isMultiSelect) {
+            // Search bar (hidden in multi-select mode and archived view)
+            if (!isMultiSelect && !showArchived) {
                 OutlinedTextField(
                     value = searchQuery,
                     onValueChange = viewModel::setListSearchQuery,
@@ -240,6 +278,7 @@ fun ListsScreen(
                     Spacer(modifier = Modifier.height(32.dp))
                     Text(
                         text = when {
+                            showArchived -> "No archived lists."
                             listEntities.isEmpty() -> "No lists yet."
                             searchQuery.isNotBlank() -> "No lists match \"$searchQuery\"."
                             viewModel.listFilter == ListFilter.PINNED_ONLY -> "No pinned lists."
@@ -248,7 +287,7 @@ fun ListsScreen(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    if (listEntities.isEmpty()) {
+                    if (!showArchived && listEntities.isEmpty()) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
                             text = "Tap + to create a list, or ask Jandal — e.g. \"Add milk to my shopping list\".",
@@ -279,6 +318,7 @@ fun ListsScreen(
                                         count = itemCounts[entity.id] ?: 0,
                                         isSelected = entity.id in selectedListIds,
                                         isMultiSelectMode = isMultiSelect,
+                                        isArchivedView = false,
                                         dragHandleModifier = if (!isMultiSelect) {
                                             Modifier.draggableHandle(
                                                 onDragStarted = { dragInProgress = true },
@@ -299,13 +339,15 @@ fun ListsScreen(
                                         onPin = { viewModel.togglePin(entity.id) },
                                         onRename = { pendingRenameEntity = entity },
                                         onDelete = { pendingDeleteEntity = entity },
+                                        onArchive = { viewModel.archiveList(entity.id) },
+                                        onRestore = {},
                                     )
                                 }
                             }
                         }
                     }
 
-                    // ── Unpinned section ────────────────────────────────────────────────────
+                    // ── Unpinned / archived section ──────────────────────────────────────────
                     if (localUnpinned.isNotEmpty()) {
                         if (localPinned.isNotEmpty()) {
                             stickyHeader(key = "header_other") {
@@ -324,7 +366,8 @@ fun ListsScreen(
                                         count = itemCounts[entity.id] ?: 0,
                                         isSelected = entity.id in selectedListIds,
                                         isMultiSelectMode = isMultiSelect,
-                                        dragHandleModifier = if (!isMultiSelect) {
+                                        isArchivedView = showArchived,
+                                        dragHandleModifier = if (!isMultiSelect && !showArchived) {
                                             Modifier.draggableHandle(
                                                 onDragStarted = { dragInProgress = true },
                                                 onDragStopped = {
@@ -338,12 +381,14 @@ fun ListsScreen(
                                         } else Modifier,
                                         onOpen = {
                                             if (isMultiSelect) viewModel.toggleListSelection(entity.id)
-                                            else onOpenList(entity.id)
+                                            else if (!showArchived) onOpenList(entity.id)
                                         },
                                         onLongClick = { viewModel.enterListMultiSelect(entity.id) },
                                         onPin = { viewModel.togglePin(entity.id) },
                                         onRename = { pendingRenameEntity = entity },
                                         onDelete = { pendingDeleteEntity = entity },
+                                        onArchive = { viewModel.archiveList(entity.id) },
+                                        onRestore = { viewModel.restoreList(entity.id) },
                                     )
                                 }
                             }
@@ -435,6 +480,27 @@ fun ListsScreen(
             },
         )
     }
+
+    // ── Bulk archive confirmation dialog ──────────────────────────────────────────────────────
+    if (showBulkArchiveDialog) {
+        val count = selectedListIds.size
+        AlertDialog(
+            onDismissRequest = { showBulkArchiveDialog = false },
+            title = { Text("Archive $count list${if (count == 1) "" else "s"}?") },
+            text = { Text("Archived lists can be restored from the ⋮ menu.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.bulkArchiveSelected()
+                        showBulkArchiveDialog = false
+                    },
+                ) { Text("Archive") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showBulkArchiveDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 // ── Internal composables ──────────────────────────────────────────────────────────────────────────
@@ -461,18 +527,22 @@ private fun ListOverviewRow(
     count: Int,
     isSelected: Boolean,
     isMultiSelectMode: Boolean,
+    isArchivedView: Boolean,
     dragHandleModifier: Modifier,
     onOpen: () -> Unit,
     onLongClick: () -> Unit,
     onPin: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
+    onArchive: () -> Unit,
+    onRestore: () -> Unit,
 ) {
     var showOverflow by remember { mutableStateOf(false) }
 
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
+            .then(if (isArchivedView) Modifier.graphicsLayer { alpha = 0.6f } else Modifier)
             .combinedClickable(
                 onClick = onOpen,
                 onLongClick = onLongClick,
@@ -491,9 +561,10 @@ private fun ListOverviewRow(
                 )
             } else {
                 Icon(
-                    Icons.Default.Checklist,
+                    if (isArchivedView) Icons.Default.Archive else Icons.Default.Checklist,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = if (isArchivedView) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.primary,
                 )
             }
         },
@@ -503,16 +574,18 @@ private fun ListOverviewRow(
                 horizontalArrangement = Arrangement.spacedBy(0.dp),
             ) {
                 if (!isMultiSelectMode) {
-                    // Pin toggle
-                    IconButton(onClick = onPin) {
-                        Icon(
-                            if (entity.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
-                            contentDescription = if (entity.pinned) "Unpin" else "Pin",
-                            tint = if (entity.pinned) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                    if (!isArchivedView) {
+                        // Pin toggle (active view only)
+                        IconButton(onClick = onPin) {
+                            Icon(
+                                if (entity.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                                contentDescription = if (entity.pinned) "Unpin" else "Pin",
+                                tint = if (entity.pinned) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
-                    // Overflow: Rename / Delete
+                    // Overflow menu
                     Box {
                         IconButton(onClick = { showOverflow = true }) {
                             Icon(Icons.Default.MoreVert, contentDescription = "More options")
@@ -521,10 +594,21 @@ private fun ListOverviewRow(
                             expanded = showOverflow,
                             onDismissRequest = { showOverflow = false },
                         ) {
-                            DropdownMenuItem(
-                                text = { Text("Rename") },
-                                onClick = { showOverflow = false; onRename() },
-                            )
+                            if (!isArchivedView) {
+                                DropdownMenuItem(
+                                    text = { Text("Rename") },
+                                    onClick = { showOverflow = false; onRename() },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Archive") },
+                                    onClick = { showOverflow = false; onArchive() },
+                                )
+                            } else {
+                                DropdownMenuItem(
+                                    text = { Text("Restore") },
+                                    onClick = { showOverflow = false; onRestore() },
+                                )
+                            }
                             DropdownMenuItem(
                                 text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
                                 onClick = { showOverflow = false; onDelete() },
@@ -532,8 +616,8 @@ private fun ListOverviewRow(
                         }
                     }
                 }
-                // Drag handle — always rendered but hidden in multi-select mode
-                if (!isMultiSelectMode) {
+                // Drag handle — only in active view, hidden in archived/multi-select
+                if (!isMultiSelectMode && !isArchivedView) {
                     Icon(
                         Icons.Default.DragHandle,
                         contentDescription = "Drag to reorder",
@@ -557,11 +641,27 @@ private fun SortFilterMenu(
     expanded: Boolean,
     currentSort: ListSort,
     currentFilter: ListFilter,
+    showArchived: Boolean,
     onSortSelected: (ListSort) -> Unit,
     onFilterSelected: (ListFilter) -> Unit,
+    onToggleArchived: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        // ── Archive toggle ──────────────────────────────────────────────────
+        DropdownMenuItem(
+            text = { Text(if (showArchived) "Show Active Lists" else "Show Archived Lists") },
+            leadingIcon = {
+                Icon(
+                    if (showArchived) Icons.Default.Unarchive else Icons.Default.Archive,
+                    contentDescription = null,
+                )
+            },
+            onClick = { onToggleArchived(); onDismiss() },
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
         // ── Sort section ────────────────────────────────────────────────────
         DropdownMenuItem(
             text = {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -434,10 +434,22 @@ class ListsViewModel @Inject constructor(
         }
     }
 
-    /** Restores an archived list back to the active view. */
+    /** Restores an archived list back to the active view, re-scheduling any future alarms. */
     fun restoreList(id: Long) {
         viewModelScope.launch(Dispatchers.IO) {
             listNameDao.restoreList(id = id, updatedAt = System.currentTimeMillis())
+            val listName = listNameDao.getById(id)?.name ?: return@launch
+            val now = System.currentTimeMillis()
+            dao.getAllWithNotification(id).forEach { item ->
+                    val triggerAtMs = item.notificationTime?.takeIf { it > now } ?: return@forEach
+                    scheduler.schedule(
+                        itemId = item.id,
+                        itemText = item.text,
+                        listId = id,
+                        listName = listName,
+                        triggerAtMs = triggerAtMs,
+                    )
+                }
         }
     }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -429,6 +429,7 @@ class ListsViewModel @Inject constructor(
         selectedListIds = selectedListIds - id
         val now = System.currentTimeMillis()
         viewModelScope.launch(Dispatchers.IO) {
+            dao.getAllWithNotification(id).forEach { scheduler.cancel(it.id) }
             listNameDao.archiveList(id = id, archivedAt = now, updatedAt = now)
         }
     }
@@ -446,7 +447,10 @@ class ListsViewModel @Inject constructor(
         selectedListIds = emptySet()
         val now = System.currentTimeMillis()
         viewModelScope.launch(Dispatchers.IO) {
-            ids.forEach { listNameDao.archiveList(id = it, archivedAt = now, updatedAt = now) }
+            ids.forEach { listId ->
+                dao.getAllWithNotification(listId).forEach { scheduler.cancel(it.id) }
+                listNameDao.archiveList(id = listId, archivedAt = now, updatedAt = now)
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -276,6 +276,7 @@ class ListsViewModel @Inject constructor(
         val ids = selectedItemIds.toList()
         selectedItemIds = emptySet()
         val now = System.currentTimeMillis()
+        ids.forEach { scheduler.cancel(it) }
         viewModelScope.launch(Dispatchers.IO) {
             ids.forEach { dao.setChecked(it, true, now) }
         }
@@ -382,12 +383,18 @@ class ListsViewModel @Inject constructor(
     }
 
     fun clearChecked(listId: Long) {
-        viewModelScope.launch { dao.deleteChecked(listId) }
+        viewModelScope.launch(Dispatchers.IO) {
+            dao.getByList(listId).forEach { scheduler.cancel(it.id) }
+            dao.deleteChecked(listId)
+        }
     }
 
     /** Deletes a list by ID; cascade FK removes all child items automatically. */
     fun deleteList(listId: Long) {
-        viewModelScope.launch { listNameDao.deleteById(listId) }
+        viewModelScope.launch(Dispatchers.IO) {
+            dao.getByList(listId).forEach { scheduler.cancel(it.id) }
+            listNameDao.deleteById(listId)
+        }
     }
 
     /** Renames a list, bumping the updatedAt timestamp. */

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -237,7 +237,10 @@ class ListsViewModel @Inject constructor(
         val ids = selectedListIds.toList()
         selectedListIds = emptySet()
         viewModelScope.launch(Dispatchers.IO) {
-            ids.forEach { listNameDao.deleteById(it) }
+            ids.forEach { listId ->
+                dao.getAllWithNotification(listId).forEach { scheduler.cancel(it.id) }
+                listNameDao.deleteById(listId)
+            }
         }
     }
 
@@ -384,7 +387,7 @@ class ListsViewModel @Inject constructor(
 
     fun clearChecked(listId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
-            dao.getByList(listId).forEach { scheduler.cancel(it.id) }
+            dao.getCheckedWithNotification(listId).forEach { scheduler.cancel(it.id) }
             dao.deleteChecked(listId)
         }
     }
@@ -392,7 +395,7 @@ class ListsViewModel @Inject constructor(
     /** Deletes a list by ID; cascade FK removes all child items automatically. */
     fun deleteList(listId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
-            dao.getByList(listId).forEach { scheduler.cancel(it.id) }
+            dao.getAllWithNotification(listId).forEach { scheduler.cancel(it.id) }
             listNameDao.deleteById(listId)
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ListsViewModel.kt
@@ -10,6 +10,7 @@ import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
+import com.kernel.ai.core.memory.notification.ListNotificationScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -42,12 +43,21 @@ enum class ItemFilter { ALL, FAVOURITES_ONLY, ACTIVE_ONLY, COMPLETED_ONLY }
 class ListsViewModel @Inject constructor(
     private val dao: ListItemDao,
     private val listNameDao: ListNameDao,
+    private val scheduler: ListNotificationScheduler,
 ) : ViewModel() {
 
     /** Full list entities — exposes id, name, pinned, updatedAt for the overview screen. */
     val listEntities: StateFlow<List<ListNameEntity>> =
-        listNameDao.observeAll()
+        listNameDao.observeActiveLists()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Archived lists, newest-archived-first — exposed when [showArchived] is true. */
+    val archivedLists: StateFlow<List<ListNameEntity>> =
+        listNameDao.observeArchivedLists()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** When true the UI shows the archived lists view instead of the active lists. */
+    var showArchived by mutableStateOf(false)
 
     // ── Sort / filter state (ViewModel-scoped, survives recomposition) ──────────────────────────
 
@@ -252,6 +262,7 @@ class ListsViewModel @Inject constructor(
     fun deleteSelectedItems() {
         val ids = selectedItemIds.toList()
         selectedItemIds = emptySet()
+        ids.forEach { scheduler.cancel(it) }
         viewModelScope.launch(Dispatchers.IO) {
             ids.forEach { dao.deleteItem(it) }
         }
@@ -305,6 +316,8 @@ class ListsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             dao.toggleChecked(item.id, now)
             listNameDao.updateTimestamp(item.listId, now)
+            // When an item is being checked (completing), cancel any pending notification
+            if (!item.checked) scheduler.cancel(item.id)
         }
     }
 
@@ -319,11 +332,13 @@ class ListsViewModel @Inject constructor(
     }
 
     fun deleteItem(id: Long) {
+        scheduler.cancel(id)
         viewModelScope.launch { dao.deleteItem(id) }
     }
 
     /** Entity overload — preferred from the item screen. */
     fun deleteItem(item: ListItemEntity) {
+        scheduler.cancel(item.id)
         viewModelScope.launch { dao.deleteItem(item.id) }
     }
 
@@ -336,18 +351,33 @@ class ListsViewModel @Inject constructor(
         }
     }
 
-    /** Persists edits made in the edit bottom sheet (text, dueAt, isFavourite). */
+    /** Persists edits made in the edit bottom sheet (text, dueAt, isFavourite, notificationTime). */
     fun updateItem(item: ListItemEntity) {
         val now = System.currentTimeMillis()
+        val listName = listEntities.value.firstOrNull { it.id == item.listId }?.name ?: ""
         viewModelScope.launch {
             dao.updateItem(
                 id = item.id,
                 text = item.text,
                 dueAt = item.dueAt,
                 isFavourite = item.isFavourite,
+                notificationTime = item.notificationTime,
                 updatedAt = now,
             )
             listNameDao.updateTimestamp(item.listId, now)
+            // Schedule or cancel the notification alarm
+            val nt = item.notificationTime
+            if (nt != null) {
+                scheduler.schedule(
+                    itemId = item.id,
+                    itemText = item.text,
+                    listId = item.listId,
+                    listName = listName,
+                    triggerAtMs = nt,
+                )
+            } else {
+                scheduler.cancel(item.id)
+            }
         }
     }
 
@@ -381,6 +411,34 @@ class ListsViewModel @Inject constructor(
      * a name string (e.g. NativeIntentHandler at the skill boundary).
      */
     suspend fun resolveListByName(name: String): ListNameEntity? = listNameDao.getByName(name)
+
+    // ── Archive / restore (#903) ──────────────────────────────────────────────────────────────────
+
+    /** Archives a single list, removing it from the active view. */
+    fun archiveList(id: Long) {
+        selectedListIds = selectedListIds - id
+        val now = System.currentTimeMillis()
+        viewModelScope.launch(Dispatchers.IO) {
+            listNameDao.archiveList(id = id, archivedAt = now, updatedAt = now)
+        }
+    }
+
+    /** Restores an archived list back to the active view. */
+    fun restoreList(id: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            listNameDao.restoreList(id = id, updatedAt = System.currentTimeMillis())
+        }
+    }
+
+    /** Archives all currently selected lists and clears the selection. */
+    fun bulkArchiveSelected() {
+        val ids = selectedListIds.toList()
+        selectedListIds = emptySet()
+        val now = System.currentTimeMillis()
+        viewModelScope.launch(Dispatchers.IO) {
+            ids.forEach { listNameDao.archiveList(id = it, archivedAt = now, updatedAt = now) }
+        }
+    }
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,11 @@ targetSdk = "36"
 
 # Kotlin & Android
 agp = "8.7.3"
-kotlin = "2.1.0"
-ksp = "2.1.0-1.0.29"
+kotlin = "2.1.20"
+ksp = "2.1.20-1.0.32"
 
 # Compose
-composeBom = "2025.01.01"
-composeCompiler = "2.1.0"
+composeBom = "2026.05.00"
 activityCompose = "1.10.1"
 navigationCompose = "2.8.9"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ targetSdk = "36"
 
 # Kotlin & Android
 agp = "8.7.3"
-kotlin = "2.1.20"
-ksp = "2.1.20-1.0.32"
+kotlin = "2.2.21"
+ksp = "2.2.21-2.0.5"
 
 # Compose
 composeBom = "2026.05.00"
@@ -21,7 +21,7 @@ room = "2.7.1"
 datastore = "1.1.4"
 
 # Hilt
-hilt = "2.54"
+hilt = "2.58"
 hiltNavigationCompose = "1.2.0"
 
 # Testing


### PR DESCRIPTION
## Summary

Combines two Lists overhaul features into a single PR:

- **#903 — Lists archive:** Archive lists instead of hard-deleting them, with a dedicated archived view, restore support, and bulk archive in multi-select.
- **#901 — Due date notifications:** Opt-in per-item notifications via `AlarmManager`, with a time picker in the edit bottom sheet opening a time picker defaulting to 09:00.

## Changes

### #903 — Lists Archive

- `ListNameEntity` — `archivedAt: Long?` column (null = active)
- `ListNameDao` — `archiveList`, `restoreList`, `observeActiveLists`, `observeArchivedLists`
- `KernelDatabase` — migration 36→37 (`ADD COLUMN archivedAt INTEGER`)
- `ListsViewModel` — `showArchived` toggle, `archiveList`, `restoreList`, `bulkArchiveSelected`
- `ListsScreen`:
  - "Show Archived" / "Show Active" toggle in existing ⋮ sort/filter menu
  - Per-list overflow ⋮ adds "Archive" (active view) or "Restore" (archived view)
  - Multi-select top bar: Archive button (active) / Restore button (archived)
  - Archived list rows shown at `alpha = 0.6f`; pin icon and drag handles hidden in archived view

### #901 — Due Date Notifications

- `ListItemEntity` — `notificationTime: Long?` column (null = no notification)
- `ListItemDao.updateItem` — includes `notificationTime`
- `KernelDatabase` — migration 37→38 (`ADD COLUMN notificationTime INTEGER`)
- `ListNotificationScheduler` (`:core:memory`) — `schedule()` / `cancel()` via `AlarmManager.setExactAndAllowWhileIdle`
- `ListDueNotificationReceiver` (`:app`) — `@AndroidEntryPoint` BroadcastReceiver; posts notification with deep link to `MainActivity`
- `AndroidManifest.xml` — receiver registered with `android:exported="false"`; `LIST_ITEM_DUE` intent-filter
- `ListsViewModel` — schedules/cancels notification on item save, toggleChecked, clearChecked, deleteItem, deleteSelectedItems, deleteList (cascade)
- `ListItemsScreen`:
  - "Notify me" Switch in edit bottom sheet (only shown when due date is set); opens the time picker immediately, defaulting to 09:00
  - Optional time picker row — tap the time label to open a `TimePicker` dialog
  - Clearing the due date also clears the notification toggle
  - Bell icon badge on item rows when a notification is scheduled

### Bug fixes (from code review)

- `markSelectedItemsComplete` — now cancels alarms for all selected items before marking complete
- `clearChecked` — fetches child item IDs, cancels their alarms before bulk delete
- `deleteList` — fetches child item IDs, cancels their alarms before cascade delete
- Notification time display — fixed UTC modulo bug; now uses `Instant.atZone(systemDefault()).toLocalTime()` for correct display in all non-UTC timezones

## Manual Test Scenarios

### Archive (#903)

**S1 — Archive a single list**
1. Go to Lists overview
2. Tap ⋮ on any list → tap "Archive"
3. **Expected:** list disappears from active view immediately

**S2 — View archived lists**
1. Tap the ⋮ sort/filter menu in the top bar
2. Tap "Show Archived"
3. **Expected:** archived list appears, muted (faded), no drag handle, no pin icon

**S3 — Restore a list**
1. In archived view, tap ⋮ on an archived list → tap "Restore"
2. **Expected:** list disappears from archived view; switch back to active view — list is back in its original position

**S4 — Bulk archive**
1. In active view, long-press a list to enter multi-select
2. Select two or more lists
3. Tap the Archive icon in the top bar → confirm
4. **Expected:** all selected lists disappear; switch to archived view to confirm they appear there

**S5 — Bulk restore**
1. In archived view, long-press to enter multi-select
2. Select two or more archived lists
3. Tap the Restore icon in the top bar
4. **Expected:** selected lists disappear from archived view; switch to active to confirm they're back

**S6 — Delete from archived view**
1. In archived view, tap ⋮ on a list → "Delete"
2. Confirm the dialog
3. **Expected:** list is permanently deleted (not restored to active)

---

### Due Date Notifications (#901)

**S7 — Enable notification**
1. Open any list → long-press an item → edit
2. Set a due date (e.g. tomorrow)
3. Toggle "Notify me" on — picker opens immediately defaulting to 09:00
4. Save
5. **Expected:** bell icon appears next to the item's due date chip

**S8 — Change notification time**
1. Edit the same item
2. Tap the time label next to "Notify me"
3. Select a different time (e.g. 09:00)
4. Save
5. **Expected:** bell icon still shown; time updated in the edit sheet when reopened

**S9 — Notification fires (quick test)**
1. Edit an item, set due date to today, enable notification, set time to ~2 minutes from now
2. Save, background the app
3. **Expected:** notification appears at the set time with the item text and list name; tapping it opens the app

**S10 — Check off item cancels notification**
1. Set up a notification as in S7 (future time)
2. Check off the item before the notification fires
3. **Expected:** no notification fires at the scheduled time (verify via `adb shell dumpsys alarm | grep kernel`)

**S11 — Clear due date removes notification**
1. Edit an item that has a notification set
2. Tap the ✕ on the due date chip to clear the date
3. **Expected:** "Notify me" switch turns off and disappears; bell icon gone from item row

**S12 — Delete item cancels notification**
1. Set up a notification (future time)
2. Swipe to delete the item (or delete from edit sheet)
3. **Expected:** no notification fires (`adb shell dumpsys alarm | grep kernel` shows no pending alarm for that item)

**S13 — Delete list cancels all child notifications**
1. Set notifications on two items in the same list
2. Delete the list from the Lists overview
3. **Expected:** no notifications fire for either item

## Closes

Closes #901
Closes #903

