### PR TITLE
fix(#921): get_date_diff fuzzy event-name lookup and ordinal date parsing

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2280,6 +2280,7 @@ class NativeIntentHandler @Inject constructor(
         val sanitized = correctMonthSpelling(input).trim()
             .replace(Regex("""\b(\d{1,2})(st|nd|rd|th)\b""", RegexOption.IGNORE_CASE), "$1")
             .replace(",", "")
+            .replace(Regex("""^(the|a|an)\s+""", RegexOption.IGNORE_CASE), "")
         val fullDateFormatters = listOf(
             DateTimeFormatter.ISO_LOCAL_DATE,
             DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH),
@@ -2327,6 +2328,13 @@ class NativeIntentHandler @Inject constructor(
         runBlocking { importantDateRepository.findByLabel(s) }?.let { stored ->
             return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
         }
+        // Fuzzy fallback for all important dates (handles STT spelling variations, e.g. "Ruben" → "Reuben")
+        val normalizedS = ImportantDateRepository.normalizeLabel(s)
+        runBlocking { importantDateRepository.getAll() }
+            .singleOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, normalizedS) }
+            ?.let { stored ->
+                return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
+            }
         if (s.contains("birthday", ignoreCase = true)) {
             // Strip "birthday" / "'s birthday" suffix and try Room DB by name only.
             // Handles "Freya's birthday" when the stored label is "Freya".

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2331,7 +2331,8 @@ class NativeIntentHandler @Inject constructor(
         // Fuzzy fallback for all important dates (handles STT spelling variations, e.g. "Ruben" → "Reuben")
         val normalizedS = ImportantDateRepository.normalizeLabel(s)
         runBlocking { importantDateRepository.getAll() }
-            .singleOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, normalizedS) }
+            .filter { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, normalizedS) }
+            .maxByOrNull { importantDateMatchScore(it.label, normalizedS) }
             ?.let { stored ->
                 return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
             }
@@ -2347,7 +2348,8 @@ class NativeIntentHandler @Inject constructor(
                 }
                 // Fuzzy Room DB match: handles spelling variations (e.g. "Freya" query → "Freyja" stored label)
                 runBlocking { importantDateRepository.getAll() }
-                    .singleOrNull { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, namePart) }
+                    .filter { CalendarBirthdayLookup.labelsPotentiallyMatch(it.label, namePart) }
+                    .maxByOrNull { importantDateMatchScore(it.label, namePart) }
                     ?.let { stored ->
                         return resolveRecurringDate(stored.month, stored.day, today, preferPast = preferPast)
                     }
@@ -2429,6 +2431,13 @@ class NativeIntentHandler @Inject constructor(
             }
         }
         return null
+    }
+
+    /** Counts shared tokens between two already-normalized labels for use as a tie-breaker in fuzzy date lookup. */
+    private fun importantDateMatchScore(storedLabel: String, queryLabel: String): Int {
+        val storedTokens = storedLabel.split(Regex("\\s+")).toSet()
+        val queryTokens = queryLabel.split(Regex("\\s+")).toSet()
+        return storedTokens.intersect(queryTokens).size
     }
 
     // ── Get System Info ───────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1104,6 +1104,32 @@ class NativeIntentHandlerTest {
 
 
     @Test
+    fun `parseDateString resolves non-birthday important date via fuzzy match when STT spelling differs`() {
+        // Stored as "Reuben moving out", STT produces "Ruben moving out" (one letter diff)
+        val today = LocalDate.now()
+        val expected = LocalDate.of(today.year, 8, 15).let {
+            if (!it.isBefore(today)) it else LocalDate.of(today.year + 1, 8, 15)
+        }
+        val entity = ImportantDateEntity(
+            label = "Reuben moving out",
+            normalizedLabel = "reuben moving out",
+            month = 8,
+            day = 15,
+        )
+        coEvery { importantDateRepository.findByLabel("Ruben moving out") } returns null
+        coEvery { importantDateRepository.getAll() } returns listOf(entity)
+
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseDateString",
+            String::class.java,
+        ).apply { isAccessible = true }
+
+        val resolved = method.invoke(handler, "Ruben moving out") as LocalDate?
+
+        assertEquals(expected, resolved)
+    }
+
+    @Test
     fun `get_date_diff since uses the most recent recurring important date`() {
         val today = LocalDate.now()
         val expected = LocalDate.of(today.year, 3, 1).let {
@@ -1678,6 +1704,30 @@ class NativeIntentHandlerTest {
             SkillResult.DirectReply("100 USD is 100 USD."),
             result,
         )
+    }
+
+    @Test
+    fun `parseImportantDateInput parses ordinal date with leading the`() {
+        // "the 13th of June" → strip "the ", strip ordinal → "13 of June" → match "d 'of' MMMM"
+        val method = NativeIntentHandler::class.java.getDeclaredMethod(
+            "parseImportantDateInput",
+            String::class.java,
+        ).also { it.isAccessible = true }
+
+        val cases = listOf(
+            Triple("the 13th of June", 6, 13),
+            Triple("the 1st of January", 1, 1),
+            Triple("the 22nd of March", 3, 22),
+            Triple("the 3rd of September 2025", 9, 3),
+        )
+        for ((input, expectedMonth, expectedDay) in cases) {
+            val result = method.invoke(handler, input)
+            assertNotNull(result, "Expected non-null for '$input'")
+            val monthField = result!!.javaClass.getDeclaredField("month").also { it.isAccessible = true }
+            val dayField = result.javaClass.getDeclaredField("day").also { it.isAccessible = true }
+            assertEquals(expectedMonth, monthField.get(result), "month for '$input'")
+            assertEquals(expectedDay, dayField.get(result), "day for '$input'")
+        }
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1719,6 +1719,8 @@ class NativeIntentHandlerTest {
             Triple("the 1st of January", 1, 1),
             Triple("the 22nd of March", 3, 22),
             Triple("the 3rd of September 2025", 9, 3),
+            Triple("a 3rd of March", 3, 3),
+            Triple("an 8th of November", 11, 8),
         )
         for ((input, expectedMonth, expectedDay) in cases) {
             val result = method.invoke(handler, input)


### PR DESCRIPTION
## Summary

Fixes two NLU bugs in `get_date_diff` where date resolution silently failed.

## Changes

- **`parseDateString`**: after an exact `findByLabel` miss, now runs a fuzzy match across all stored important dates using `labelsPotentiallyMatch`. Previously this fuzzy fallback only applied to birthday queries. Fixes queries like _"How long until Ruben moving out"_ where STT spells a stored event name slightly differently (e.g. "Reuben moving out").

- **`parseImportantDateInput`**: strips a leading article (`the`, `a`, `an`) before running the date formatter chain. Fixes _"the 13th of June"_ which after ordinal stripping became `"the 13 of June"` — a string none of the existing formatters could match.

- Two new `NativeIntentHandlerTest` cases covering both fixes.

## Testing

- [x] `./gradlew :core:skills:testDebugUnitTest` passes (all existing + 2 new tests)
- [ ] Manual device test: "How long until Ruben moving out", "How long until the 13th of June"

## Related issues

Closes #921
