### PR TITLE
feat(#902): important date day-of notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -144,6 +144,15 @@
             </intent-filter>
         </receiver>
 
+        <!-- Fires when an important-date day-of notification alarm triggers (#902) -->
+        <receiver
+            android:name=".notification.ImportantDateNotificationReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.kernel.ai.IMPORTANT_DATE_REMINDER" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name=".alarm.ClockTimerActionReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/BootCompletedReceiver.kt
@@ -4,8 +4,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationPreferences
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler
 import com.kernel.ai.core.memory.notification.ListNotificationScheduler
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -20,6 +23,9 @@ class BootCompletedReceiver : BroadcastReceiver() {
     @Inject lateinit var listItemDao: ListItemDao
     @Inject lateinit var listNameDao: ListNameDao
     @Inject lateinit var listNotificationScheduler: ListNotificationScheduler
+    @Inject lateinit var importantDateDao: ImportantDateDao
+    @Inject lateinit var importantDateNotificationScheduler: ImportantDateNotificationScheduler
+    @Inject lateinit var importantDateNotificationPreferences: ImportantDateNotificationPreferences
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
@@ -38,9 +44,23 @@ class BootCompletedReceiver : BroadcastReceiver() {
                         triggerAtMs = item.notificationTime!!,
                     )
                 }
+
+                val (hour, minute) = importantDateNotificationPreferences.getNotificationTime()
+                importantDateDao.getAllWithNotificationEnabled().forEach { date ->
+                    importantDateNotificationScheduler.schedule(
+                        dateId = date.id,
+                        label = date.label,
+                        month = date.month,
+                        day = date.day,
+                        year = date.year,
+                        notificationHour = hour,
+                        notificationMinute = minute,
+                    )
+                }
             } finally {
                 pendingResult.finish()
             }
         }
     }
 }
+

--- a/app/src/main/java/com/kernel/ai/notification/ImportantDateNotificationReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/notification/ImportantDateNotificationReceiver.kt
@@ -13,6 +13,7 @@ import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler
 import com.kernel.ai.core.memory.notification.toNotificationId
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
@@ -82,7 +83,9 @@ class ImportantDateNotificationReceiver : BroadcastReceiver() {
         }
 
     private fun buildDateText(month: Int, day: Int): String {
-        val date = LocalDate.of(LocalDate.now().year, month, day)
+        val year = LocalDate.now().year
+        val clampedDay = minOf(day, YearMonth.of(year, month).lengthOfMonth())
+        val date = LocalDate.of(year, month, clampedDay)
         return date.format(DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.ENGLISH))
     }
 

--- a/app/src/main/java/com/kernel/ai/notification/ImportantDateNotificationReceiver.kt
+++ b/app/src/main/java/com/kernel/ai/notification/ImportantDateNotificationReceiver.kt
@@ -1,0 +1,115 @@
+package com.kernel.ai.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.kernel.ai.MainActivity
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler.Companion.YEAR_RECURRING
+import com.kernel.ai.core.memory.notification.toNotificationId
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * BroadcastReceiver that fires when an important-date day-of notification alarm triggers (#902).
+ *
+ * Registered in AndroidManifest with action [ImportantDateNotificationScheduler.ACTION].
+ * After posting the notification, recurring dates (year == [YEAR_RECURRING]) are automatically
+ * rescheduled for the same month/day next year so the reminder repeats annually.
+ * One-off dates (year != [YEAR_RECURRING]) are not rescheduled.
+ */
+@AndroidEntryPoint
+class ImportantDateNotificationReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var scheduler: ImportantDateNotificationScheduler
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ImportantDateNotificationScheduler.ACTION) return
+
+        val dateId = intent.getLongExtra(ImportantDateNotificationScheduler.EXTRA_DATE_ID, -1L)
+            .takeIf { it >= 0L } ?: return
+        val label = intent.getStringExtra(ImportantDateNotificationScheduler.EXTRA_LABEL) ?: return
+        val month = intent.getIntExtra(ImportantDateNotificationScheduler.EXTRA_MONTH, -1)
+            .takeIf { it in 1..12 } ?: return
+        val day = intent.getIntExtra(ImportantDateNotificationScheduler.EXTRA_DAY, -1)
+            .takeIf { it in 1..31 } ?: return
+        val yearRaw = intent.getIntExtra(ImportantDateNotificationScheduler.EXTRA_YEAR, YEAR_RECURRING)
+        val year: Int? = if (yearRaw == YEAR_RECURRING) null else yearRaw
+        val notificationHour = intent.getIntExtra(ImportantDateNotificationScheduler.EXTRA_NOTIFICATION_HOUR, 9)
+        val notificationMinute = intent.getIntExtra(ImportantDateNotificationScheduler.EXTRA_NOTIFICATION_MINUTE, 0)
+
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        ensureChannel(notificationManager)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_idle_alarm)
+            .setContentTitle(buildTitle(label))
+            .setContentText(buildDateText(month, day))
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setContentIntent(buildOpenAppPendingIntent(context))
+            .build()
+
+        notificationManager.notify(dateId.toNotificationId(), notification)
+
+        // Reschedule for next year if this is a recurring date (no specific year).
+        if (year == null) {
+            scheduler.schedule(
+                dateId = dateId,
+                label = label,
+                month = month,
+                day = day,
+                year = null,
+                notificationHour = notificationHour,
+                notificationMinute = notificationMinute,
+            )
+        }
+    }
+
+    private fun buildTitle(label: String): String =
+        if (label.lowercase().contains("birthday")) {
+            "🎂 Today is $label!"
+        } else {
+            "📅 $label is today"
+        }
+
+    private fun buildDateText(month: Int, day: Int): String {
+        val date = LocalDate.of(LocalDate.now().year, month, day)
+        return date.format(DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.ENGLISH))
+    }
+
+    private fun ensureChannel(notificationManager: NotificationManager) {
+        if (notificationManager.getNotificationChannel(CHANNEL_ID) != null) return
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Important date reminders",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = "Day-of reminders for important dates"
+            },
+        )
+    }
+
+    private fun buildOpenAppPendingIntent(context: Context): PendingIntent =
+        PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    companion object {
+        const val CHANNEL_ID = "important_dates_channel"
+    }
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/40.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/40.json
@@ -1,0 +1,1826 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 40,
+    "identityHash": "b105fa6628785ad581863dec0eb4eb00",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b105fa6628785ad581863dec0eb4eb00')"
+    ]
+  }
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/41.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/41.json
@@ -1,0 +1,1836 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 41,
+    "identityHash": "2783f0e7e5d426cfd98e27e8fbeef737",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL, `notification_hour` INTEGER, `notification_minute` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationHour",
+            "columnName": "notification_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMinute",
+            "columnName": "notification_minute",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2783f0e7e5d426cfd98e27e8fbeef737')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
@@ -2,6 +2,8 @@ package com.kernel.ai.core.memory
 
 import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationPreferences
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -9,8 +11,12 @@ import javax.inject.Singleton
 @Singleton
 class ImportantDateRepository @Inject constructor(
     private val dao: ImportantDateDao,
+    private val notificationScheduler: ImportantDateNotificationScheduler,
+    private val notificationPreferences: ImportantDateNotificationPreferences,
 ) {
     fun observeAll(): Flow<List<ImportantDateEntity>> = dao.observeAll()
+
+    val notificationTime: Flow<Pair<Int, Int>> = notificationPreferences.notificationTime
 
     suspend fun getAll(): List<ImportantDateEntity> = dao.getAll()
 
@@ -24,18 +30,56 @@ class ImportantDateRepository @Inject constructor(
         year: Int?,
     ) {
         val trimmedLabel = label.trim()
-        dao.insert(
+        val insertedId = dao.insert(
             ImportantDateEntity(
                 label = trimmedLabel,
                 normalizedLabel = normalizeLabel(trimmedLabel),
                 month = month,
                 day = day,
                 year = year,
+                notificationEnabled = true,
             ),
+        )
+        val (hour, minute) = notificationPreferences.getNotificationTime()
+        notificationScheduler.schedule(
+            dateId = insertedId,
+            label = trimmedLabel,
+            month = month,
+            day = day,
+            year = year,
+            notificationHour = hour,
+            notificationMinute = minute,
         )
     }
 
-    suspend fun deleteByLabel(label: String): Int = dao.deleteByNormalizedLabel(normalizeLabel(label))
+    suspend fun deleteByLabel(label: String): Int {
+        val normalized = normalizeLabel(label)
+        val entity = dao.findByNormalizedLabel(normalized)
+        val result = dao.deleteByNormalizedLabel(normalized)
+        if (result > 0 && entity != null) {
+            notificationScheduler.cancel(entity.id)
+        }
+        return result
+    }
+
+    /**
+     * Updates the stored notification time and reschedules all existing important-date alarms
+     * to use the new time. Called from the settings screen when the user changes the reminder time.
+     */
+    suspend fun rescheduleAll(notificationHour: Int, notificationMinute: Int) {
+        notificationPreferences.setNotificationTime(notificationHour, notificationMinute)
+        dao.getAllWithNotificationEnabled().forEach { date ->
+            notificationScheduler.schedule(
+                dateId = date.id,
+                label = date.label,
+                month = date.month,
+                day = date.day,
+                year = date.year,
+                notificationHour = notificationHour,
+                notificationMinute = notificationMinute,
+            )
+        }
+    }
 
     companion object {
         fun normalizeLabel(raw: String): String = raw
@@ -49,3 +93,4 @@ class ImportantDateRepository @Inject constructor(
             .trim()
     }
 }
+

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
@@ -30,10 +30,15 @@ class ImportantDateRepository @Inject constructor(
         year: Int?,
     ) {
         val trimmedLabel = label.trim()
+        val normalized = normalizeLabel(trimmedLabel)
+        // Cancel any existing alarm before @Insert(REPLACE) deletes the old row and its ID.
+        dao.findByNormalizedLabel(normalized)?.let { existing ->
+            notificationScheduler.cancel(existing.id)
+        }
         val insertedId = dao.insert(
             ImportantDateEntity(
                 label = trimmedLabel,
-                normalizedLabel = normalizeLabel(trimmedLabel),
+                normalizedLabel = normalized,
                 month = month,
                 day = day,
                 year = year,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/ImportantDateRepository.kt
@@ -28,6 +28,8 @@ class ImportantDateRepository @Inject constructor(
         month: Int,
         day: Int,
         year: Int?,
+        notificationHour: Int? = null,
+        notificationMinute: Int? = null,
     ) {
         val trimmedLabel = label.trim()
         val normalized = normalizeLabel(trimmedLabel)
@@ -43,17 +45,19 @@ class ImportantDateRepository @Inject constructor(
                 day = day,
                 year = year,
                 notificationEnabled = true,
+                notificationHour = notificationHour,
+                notificationMinute = notificationMinute,
             ),
         )
-        val (hour, minute) = notificationPreferences.getNotificationTime()
+        val (globalHour, globalMinute) = notificationPreferences.getNotificationTime()
         notificationScheduler.schedule(
             dateId = insertedId,
             label = trimmedLabel,
             month = month,
             day = day,
             year = year,
-            notificationHour = hour,
-            notificationMinute = minute,
+            notificationHour = notificationHour ?: globalHour,
+            notificationMinute = notificationMinute ?: globalMinute,
         )
     }
 
@@ -80,8 +84,8 @@ class ImportantDateRepository @Inject constructor(
                 month = date.month,
                 day = date.day,
                 year = date.year,
-                notificationHour = notificationHour,
-                notificationMinute = notificationMinute,
+                notificationHour = date.notificationHour ?: notificationHour,
+                notificationMinute = date.notificationMinute ?: notificationMinute,
             )
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 40,
+    version = 41,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -681,10 +681,16 @@ abstract class KernelDatabase : RoomDatabase() {
             }
         }
 
-        /** Adds notificationEnabled + per-event notification_hour/minute to important_dates (#902). */
+        /** Adds notificationEnabled to important_dates for day-of notifications (#902). */
         val MIGRATION_39_40 = object : Migration(39, 40) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_enabled INTEGER NOT NULL DEFAULT 1")
+            }
+        }
+
+        /** Adds per-event notification_hour/minute to important_dates (#902). */
+        val MIGRATION_40_41 = object : Migration(40, 41) {
+            override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_hour INTEGER DEFAULT NULL")
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_minute INTEGER DEFAULT NULL")
             }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -681,10 +681,12 @@ abstract class KernelDatabase : RoomDatabase() {
             }
         }
 
-        /** Adds notificationEnabled to important_dates for day-of notifications (#902). */
+        /** Adds notificationEnabled + per-event notification_hour/minute to important_dates (#902). */
         val MIGRATION_39_40 = object : Migration(39, 40) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_enabled INTEGER NOT NULL DEFAULT 1")
+                db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_hour INTEGER DEFAULT NULL")
+                db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_minute INTEGER DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 39,
+    version = 40,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -678,6 +678,13 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE list_items ADD COLUMN displayOrder INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("UPDATE list_items SET displayOrder = id")
+            }
+        }
+
+        /** Adds notificationEnabled to important_dates for day-of notifications (#902). */
+        val MIGRATION_39_40 = object : Migration(39, 40) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_enabled INTEGER NOT NULL DEFAULT 1")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -106,6 +106,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_37_38,
                     KernelDatabase.MIGRATION_38_39,
                     KernelDatabase.MIGRATION_39_40,
+                    KernelDatabase.MIGRATION_40_41,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -105,6 +105,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_36_37,
                     KernelDatabase.MIGRATION_37_38,
                     KernelDatabase.MIGRATION_38_39,
+                    KernelDatabase.MIGRATION_39_40,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ImportantDateDao.kt
@@ -19,7 +19,10 @@ interface ImportantDateDao {
     suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(date: ImportantDateEntity)
+    suspend fun insert(date: ImportantDateEntity): Long
+
+    @Query("SELECT * FROM important_dates WHERE notification_enabled = 1 ORDER BY label COLLATE NOCASE ASC")
+    suspend fun getAllWithNotificationEnabled(): List<ImportantDateEntity>
 
     @Query("DELETE FROM important_dates WHERE normalized_label = :normalizedLabel")
     suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
@@ -18,4 +18,8 @@ data class ImportantDateEntity(
     val year: Int? = null,
     @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis(),
     @ColumnInfo(name = "notification_enabled") val notificationEnabled: Boolean = true,
+    /** Per-event reminder hour (0–23). Null = use the global default from [ImportantDateNotificationPreferences]. */
+    @ColumnInfo(name = "notification_hour") val notificationHour: Int? = null,
+    /** Per-event reminder minute (0–59). Null = use the global default from [ImportantDateNotificationPreferences]. */
+    @ColumnInfo(name = "notification_minute") val notificationMinute: Int? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ImportantDateEntity.kt
@@ -17,4 +17,5 @@ data class ImportantDateEntity(
     val day: Int,
     val year: Int? = null,
     @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "notification_enabled") val notificationEnabled: Boolean = true,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationPreferences.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationPreferences.kt
@@ -1,0 +1,60 @@
+package com.kernel.ai.core.memory.notification
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private const val TAG = "ImportantDateNotifPrefs"
+private val Context.importantDateNotifsDataStore by preferencesDataStore(
+    name = "important_date_notification_prefs",
+)
+
+/**
+ * Persists the daily notification time for important-date reminders (#902).
+ * Default is 09:00.
+ */
+@Singleton
+class ImportantDateNotificationPreferences @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val hourKey = intPreferencesKey("important_dates_notification_hour")
+    private val minuteKey = intPreferencesKey("important_dates_notification_minute")
+
+    val notificationTime: Flow<Pair<Int, Int>> = context.importantDateNotifsDataStore.data
+        .catch { e ->
+            if (e is IOException) {
+                Log.e(TAG, "Failed reading important-date notification preferences; using defaults", e)
+                emit(emptyPreferences())
+            } else {
+                throw e
+            }
+        }
+        .map { prefs ->
+            Pair(prefs[hourKey] ?: DEFAULT_HOUR, prefs[minuteKey] ?: DEFAULT_MINUTE)
+        }
+
+    suspend fun getNotificationTime(): Pair<Int, Int> = notificationTime.first()
+
+    suspend fun setNotificationTime(hour: Int, minute: Int) {
+        context.importantDateNotifsDataStore.edit { prefs ->
+            prefs[hourKey] = hour
+            prefs[minuteKey] = minute
+        }
+    }
+
+    companion object {
+        const val DEFAULT_HOUR = 9
+        const val DEFAULT_MINUTE = 0
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationScheduler.kt
@@ -1,0 +1,161 @@
+package com.kernel.ai.core.memory.notification
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Calendar
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules and cancels exact AlarmManager broadcasts for important-date day-of reminders (#902).
+ *
+ * Placed in :core:memory so it can be injected by [ImportantDateRepository] and
+ * [com.kernel.ai.alarm.BootCompletedReceiver].
+ * The broadcast is handled by ImportantDateNotificationReceiver in :app, registered in the
+ * app manifest with the [ACTION] intent filter.
+ *
+ * Recurring dates (year == null) are scheduled for the next upcoming month/day at the given
+ * hour/minute; one-off dates (year != null) are scheduled for that specific calendar date.
+ * If the trigger time is already in the past the alarm is silently skipped.
+ */
+@Singleton
+class ImportantDateNotificationScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val alarmManager: AlarmManager
+        get() = context.getSystemService(AlarmManager::class.java)
+
+    /**
+     * Schedule (or replace) an exact alarm for [dateId].
+     * The alarm fires at [notificationHour]:[notificationMinute] on the next occurrence of
+     * [month]/[day] (this year if not yet passed, next year otherwise for recurring dates;
+     * or on the exact [year] for one-off dates).
+     * No-op if the computed trigger time is already in the past.
+     */
+    fun schedule(
+        dateId: Long,
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+        notificationHour: Int,
+        notificationMinute: Int,
+    ) {
+        val triggerAtMs = nextTriggerMs(month, day, year, notificationHour, notificationMinute)
+            ?: return
+        val pendingIntent = buildPendingIntent(
+            dateId = dateId,
+            label = label,
+            month = month,
+            day = day,
+            year = year,
+            notificationHour = notificationHour,
+            notificationMinute = notificationMinute,
+            flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMs,
+            pendingIntent!!,
+        )
+    }
+
+    /** Cancel any pending notification alarm for [dateId]. No-op if none is scheduled. */
+    fun cancel(dateId: Long) {
+        val pendingIntent = buildPendingIntent(
+            dateId = dateId,
+            label = "",
+            month = 1,
+            day = 1,
+            year = null,
+            notificationHour = 0,
+            notificationMinute = 0,
+            flags = PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        ) ?: return
+        alarmManager.cancel(pendingIntent)
+    }
+
+    private fun buildPendingIntent(
+        dateId: Long,
+        label: String,
+        month: Int,
+        day: Int,
+        year: Int?,
+        notificationHour: Int,
+        notificationMinute: Int,
+        flags: Int,
+    ): PendingIntent? = PendingIntent.getBroadcast(
+        context,
+        dateId.toNotificationId(),
+        Intent(ACTION).apply {
+            setPackage(context.packageName)
+            putExtra(EXTRA_DATE_ID, dateId)
+            putExtra(EXTRA_LABEL, label)
+            putExtra(EXTRA_MONTH, month)
+            putExtra(EXTRA_DAY, day)
+            putExtra(EXTRA_YEAR, year ?: YEAR_RECURRING)
+            putExtra(EXTRA_NOTIFICATION_HOUR, notificationHour)
+            putExtra(EXTRA_NOTIFICATION_MINUTE, notificationMinute)
+        },
+        flags,
+    )
+
+    companion object {
+        const val ACTION = "com.kernel.ai.IMPORTANT_DATE_REMINDER"
+        const val EXTRA_DATE_ID = "date_id"
+        const val EXTRA_LABEL = "label"
+        const val EXTRA_MONTH = "month"
+        const val EXTRA_DAY = "day"
+
+        /** Sentinel value stored in extras when [year] is null (recurring date). */
+        const val EXTRA_YEAR = "year"
+        const val YEAR_RECURRING = -1
+
+        const val EXTRA_NOTIFICATION_HOUR = "notification_hour"
+        const val EXTRA_NOTIFICATION_MINUTE = "notification_minute"
+    }
+}
+
+/**
+ * Returns the epoch-millisecond trigger time for the next occurrence of [month]/[day] at
+ * [notificationHour]:[notificationMinute], or null if the date is already in the past.
+ *
+ * For recurring dates ([year] == null): uses the current year's occurrence if it has not yet
+ * passed, otherwise advances to next year.
+ * For one-off dates ([year] != null): uses the specific year; returns null if already past.
+ */
+internal fun nextTriggerMs(
+    month: Int,
+    day: Int,
+    year: Int?,
+    notificationHour: Int,
+    notificationMinute: Int,
+): Long? {
+    val now = System.currentTimeMillis()
+    val trigger = Calendar.getInstance()
+    val targetYear = if (year != null) {
+        year
+    } else {
+        // Find this year's occurrence; if it's already passed, use next year.
+        val thisYearMs = Calendar.getInstance().apply {
+            set(Calendar.MONTH, month - 1)
+            set(Calendar.DAY_OF_MONTH, day)
+            set(Calendar.HOUR_OF_DAY, notificationHour)
+            set(Calendar.MINUTE, notificationMinute)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
+        if (thisYearMs > now) trigger.get(Calendar.YEAR) else trigger.get(Calendar.YEAR) + 1
+    }
+    trigger.set(Calendar.YEAR, targetYear)
+    trigger.set(Calendar.MONTH, month - 1)
+    trigger.set(Calendar.DAY_OF_MONTH, day)
+    trigger.set(Calendar.HOUR_OF_DAY, notificationHour)
+    trigger.set(Calendar.MINUTE, notificationMinute)
+    trigger.set(Calendar.SECOND, 0)
+    trigger.set(Calendar.MILLISECOND, 0)
+    return trigger.timeInMillis.takeIf { it > now }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/notification/ImportantDateNotificationScheduler.kt
@@ -5,7 +5,10 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.Calendar
+import java.time.Instant
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -126,6 +129,8 @@ class ImportantDateNotificationScheduler @Inject constructor(
  * For recurring dates ([year] == null): uses the current year's occurrence if it has not yet
  * passed, otherwise advances to next year.
  * For one-off dates ([year] != null): uses the specific year; returns null if already past.
+ *
+ * Feb 29 in a non-leap year is clamped to Feb 28 rather than rolling to March 1.
  */
 internal fun nextTriggerMs(
     month: Int,
@@ -134,28 +139,23 @@ internal fun nextTriggerMs(
     notificationHour: Int,
     notificationMinute: Int,
 ): Long? {
-    val now = System.currentTimeMillis()
-    val trigger = Calendar.getInstance()
-    val targetYear = if (year != null) {
-        year
-    } else {
-        // Find this year's occurrence; if it's already passed, use next year.
-        val thisYearMs = Calendar.getInstance().apply {
-            set(Calendar.MONTH, month - 1)
-            set(Calendar.DAY_OF_MONTH, day)
-            set(Calendar.HOUR_OF_DAY, notificationHour)
-            set(Calendar.MINUTE, notificationMinute)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }.timeInMillis
-        if (thisYearMs > now) trigger.get(Calendar.YEAR) else trigger.get(Calendar.YEAR) + 1
+    val now = Instant.now()
+    val zone = ZoneId.systemDefault()
+    val todayYear = LocalDate.now(zone).year
+
+    fun triggerInstantFor(y: Int): Instant {
+        val clampedDay = minOf(day, YearMonth.of(y, month).lengthOfMonth())
+        return LocalDate.of(y, month, clampedDay)
+            .atTime(notificationHour, notificationMinute)
+            .atZone(zone)
+            .toInstant()
     }
-    trigger.set(Calendar.YEAR, targetYear)
-    trigger.set(Calendar.MONTH, month - 1)
-    trigger.set(Calendar.DAY_OF_MONTH, day)
-    trigger.set(Calendar.HOUR_OF_DAY, notificationHour)
-    trigger.set(Calendar.MINUTE, notificationMinute)
-    trigger.set(Calendar.SECOND, 0)
-    trigger.set(Calendar.MILLISECOND, 0)
-    return trigger.timeInMillis.takeIf { it > now }
+
+    return if (year != null) {
+        triggerInstantFor(year).takeIf { it.isAfter(now) }?.toEpochMilli()
+    } else {
+        val thisYear = triggerInstantFor(todayYear)
+        val candidate = if (thisYear.isAfter(now)) thisYear else triggerInstantFor(todayYear + 1)
+        candidate.takeIf { it.isAfter(now) }?.toEpochMilli()
+    }
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/ImportantDateRepositoryTest.kt
@@ -2,6 +2,10 @@ package com.kernel.ai.core.memory
 
 import com.kernel.ai.core.memory.dao.ImportantDateDao
 import com.kernel.ai.core.memory.entity.ImportantDateEntity
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationPreferences
+import com.kernel.ai.core.memory.notification.ImportantDateNotificationScheduler
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -19,7 +23,10 @@ class ImportantDateRepositoryTest {
     @Test
     fun `save find and delete round trip through dao`() = runTest {
         val dao = FakeImportantDateDao()
-        val repository = ImportantDateRepository(dao)
+        val scheduler = mockk<ImportantDateNotificationScheduler>(relaxed = true)
+        val preferences = mockk<ImportantDateNotificationPreferences>(relaxed = true)
+        coEvery { preferences.getNotificationTime() } returns Pair(9, 0)
+        val repository = ImportantDateRepository(dao, scheduler, preferences)
 
         repository.save(label = "My Mum's birthday", month = 3, day = 15, year = null)
         repository.save(label = "Our anniversary", month = 6, day = 22, year = 2018)
@@ -50,10 +57,15 @@ class ImportantDateRepositoryTest {
 
         override suspend fun getAll(): List<ImportantDateEntity> = rows.values.toList()
 
+        override suspend fun getAllWithNotificationEnabled(): List<ImportantDateEntity> =
+            rows.values.filter { it.notificationEnabled }
+
         override suspend fun findByNormalizedLabel(normalizedLabel: String): ImportantDateEntity? = rows[normalizedLabel]
 
-        override suspend fun insert(date: ImportantDateEntity) {
-            rows[date.normalizedLabel] = date.copy(id = nextId++)
+        override suspend fun insert(date: ImportantDateEntity): Long {
+            val id = nextId++
+            rows[date.normalizedLabel] = date.copy(id = id)
+            return id
         }
 
         override suspend fun deleteByNormalizedLabel(normalizedLabel: String): Int =

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -606,7 +606,10 @@ private fun ImportantDateEditorSheet(
                 }
                 Switch(
                     checked = customTimeEnabled,
-                    onCheckedChange = { customTimeEnabled = it },
+                    onCheckedChange = { enabled ->
+                        customTimeEnabled = enabled
+                        if (enabled) showCustomTimePicker = true
+                    },
                 )
             }
             if (customTimeEnabled) {
@@ -757,7 +760,7 @@ private fun ImportantDateTimePickerDialog(
     val state = rememberTimePickerState(
         initialHour = initialHour,
         initialMinute = initialMinute,
-        is24Hour = false,
+        is24Hour = true,
     )
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -253,7 +253,7 @@ fun ImportantDatesScreen(
         ImportantDateEditorSheet(
             existingItem = null,
             onDismiss = { createRequested = false },
-            onSave = { label, month, day, year ->
+            onSave = { label, month, day, year, notifHour, notifMinute ->
                 coroutineScope.launch {
                     val saved = viewModel.saveTaughtDate(
                         existingLabel = null,
@@ -261,6 +261,8 @@ fun ImportantDatesScreen(
                         month = month,
                         day = day,
                         year = year,
+                        notificationHour = notifHour,
+                        notificationMinute = notifMinute,
                     )
                     if (saved) createRequested = false
                 }
@@ -272,7 +274,7 @@ fun ImportantDatesScreen(
         ImportantDateEditorSheet(
             existingItem = item,
             onDismiss = { editingDate = null },
-            onSave = { label, month, day, year ->
+            onSave = { label, month, day, year, notifHour, notifMinute ->
                 coroutineScope.launch {
                     val saved = viewModel.saveTaughtDate(
                         existingLabel = item.label,
@@ -280,6 +282,8 @@ fun ImportantDatesScreen(
                         month = month,
                         day = day,
                         year = year,
+                        notificationHour = notifHour,
+                        notificationMinute = notifMinute,
                     )
                     if (saved) editingDate = null
                 }
@@ -467,11 +471,18 @@ private fun ImportantDateRow(
         supportingContent = {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(dateSummary)
+                val timeNote = if (item.notificationHour != null && item.notificationMinute != null) {
+                    val amPm = if (item.notificationHour < 12) "AM" else "PM"
+                    val h = when (item.notificationHour) { 0 -> 12; in 13..23 -> item.notificationHour - 12; else -> item.notificationHour }
+                    "⏰ %d:%02d %s · ".format(h, item.notificationMinute, amPm)
+                } else {
+                    ""
+                }
                 Text(
                     if (item.isReadOnly) {
-                        "$nextSummary · Synced from Calendar"
+                        "${timeNote}$nextSummary · Synced from Calendar"
                     } else {
-                        "$nextSummary · Taught by you"
+                        "${timeNote}$nextSummary · Taught by you"
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -507,7 +518,7 @@ private fun ImportantDateRow(
 private fun ImportantDateEditorSheet(
     existingItem: ImportantDateListItem?,
     onDismiss: () -> Unit,
-    onSave: (label: String, month: Int, day: Int, year: Int?) -> Unit,
+    onSave: (label: String, month: Int, day: Int, year: Int?, notificationHour: Int?, notificationMinute: Int?) -> Unit,
 ) {
     val today = LocalDate.now()
     var label by remember(existingItem) { mutableStateOf(existingItem?.label ?: "") }
@@ -523,6 +534,10 @@ private fun ImportantDateEditorSheet(
     var yearText by remember(existingItem) { mutableStateOf(existingItem?.year?.toString().orEmpty()) }
     var localError by remember(existingItem) { mutableStateOf<String?>(null) }
     var showDatePicker by remember(existingItem) { mutableStateOf(false) }
+    var customTimeEnabled by remember(existingItem) { mutableStateOf(existingItem?.notificationHour != null) }
+    var customHour by remember(existingItem) { mutableStateOf(existingItem?.notificationHour ?: 9) }
+    var customMinute by remember(existingItem) { mutableStateOf(existingItem?.notificationMinute ?: 0) }
+    var showCustomTimePicker by remember(existingItem) { mutableStateOf(false) }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
@@ -569,6 +584,41 @@ private fun ImportantDateEditorSheet(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
             )
+            // Per-event custom reminder time
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Custom reminder time", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        if (customTimeEnabled) {
+                            val amPm = if (customHour < 12) "AM" else "PM"
+                            val h = when (customHour) { 0 -> 12; in 13..23 -> customHour - 12; else -> customHour }
+                            "Override: %d:%02d %s".format(h, customMinute, amPm)
+                        } else {
+                            "Uses the global reminder time"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = customTimeEnabled,
+                    onCheckedChange = { customTimeEnabled = it },
+                )
+            }
+            if (customTimeEnabled) {
+                OutlinedButton(
+                    onClick = { showCustomTimePicker = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    val amPm = if (customHour < 12) "AM" else "PM"
+                    val h = when (customHour) { 0 -> 12; in 13..23 -> customHour - 12; else -> customHour }
+                    Text("Reminder: %d:%02d %s".format(h, customMinute, amPm))
+                }
+            }
             localError?.let { message ->
                 Text(
                     text = message,
@@ -604,7 +654,14 @@ private fun ImportantDateEditorSheet(
                                 return@Button
                             }
                         }
-                        onSave(label, selectedDate.monthValue, selectedDate.dayOfMonth, parsedYear)
+                        onSave(
+                            label,
+                            selectedDate.monthValue,
+                            selectedDate.dayOfMonth,
+                            parsedYear,
+                            if (customTimeEnabled) customHour else null,
+                            if (customTimeEnabled) customMinute else null,
+                        )
                     },
                     modifier = Modifier.weight(1f),
                 ) {
@@ -643,6 +700,19 @@ private fun ImportantDateEditorSheet(
             DatePicker(state = datePickerState)
         }
     }
+
+    if (showCustomTimePicker) {
+        ImportantDateTimePickerDialog(
+            initialHour = customHour,
+            initialMinute = customMinute,
+            onDismiss = { showCustomTimePicker = false },
+            onConfirm = { h, m ->
+                customHour = h
+                customMinute = m
+                showCustomTimePicker = false
+            },
+        )
+    }
 }
 
 @Composable
@@ -665,7 +735,7 @@ private fun NotificationTimeRow(
             .fillMaxWidth()
             .clickable(onClick = onClick),
         headlineContent = { Text("Reminder time") },
-        supportingContent = { Text("Daily notification time for all important dates") },
+        supportingContent = { Text("Default notification time for all important dates") },
         trailingContent = {
             Text(
                 text = timeLabel,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesScreen.kt
@@ -50,8 +50,10 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -93,6 +95,7 @@ fun ImportantDatesScreen(
     var editingDate by remember { mutableStateOf<ImportantDateListItem?>(null) }
     var pendingDelete by remember { mutableStateOf<ImportantDateListItem?>(null) }
     var createRequested by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
     var showCalendarPermissionRationale by remember { mutableStateOf(false) }
     var showCalendarPermissionSettingsHint by remember { mutableStateOf(false) }
     val calendarPermissionLauncher = rememberLauncherForActivityResult(
@@ -191,6 +194,15 @@ fun ImportantDatesScreen(
                             showCalendarPermissionSettingsHint = true
                         }
                     },
+                )
+                HorizontalDivider()
+            }
+
+            item {
+                NotificationTimeRow(
+                    hour = uiState.notificationHour,
+                    minute = uiState.notificationMinute,
+                    onClick = { showTimePicker = true },
                 )
                 HorizontalDivider()
             }
@@ -297,6 +309,18 @@ fun ImportantDatesScreen(
                 TextButton(onClick = { pendingDelete = null }) {
                     Text("Cancel")
                 }
+            },
+        )
+    }
+
+    if (showTimePicker) {
+        ImportantDateTimePickerDialog(
+            initialHour = uiState.notificationHour,
+            initialMinute = uiState.notificationMinute,
+            onDismiss = { showTimePicker = false },
+            onConfirm = { hour, minute ->
+                showTimePicker = false
+                viewModel.setReminderTime(hour, minute)
             },
         )
     }
@@ -619,6 +643,67 @@ private fun ImportantDateEditorSheet(
             DatePicker(state = datePickerState)
         }
     }
+}
+
+@Composable
+private fun NotificationTimeRow(
+    hour: Int,
+    minute: Int,
+    onClick: () -> Unit,
+) {
+    val timeLabel = remember(hour, minute) {
+        val amPm = if (hour < 12) "AM" else "PM"
+        val displayHour = when (hour) {
+            0 -> 12
+            in 13..23 -> hour - 12
+            else -> hour
+        }
+        "%d:%02d %s".format(displayHour, minute, amPm)
+    }
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        headlineContent = { Text("Reminder time") },
+        supportingContent = { Text("Daily notification time for all important dates") },
+        trailingContent = {
+            Text(
+                text = timeLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImportantDateTimePickerDialog(
+    initialHour: Int,
+    initialMinute: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (hour: Int, minute: Int) -> Unit,
+) {
+    val state = rememberTimePickerState(
+        initialHour = initialHour,
+        initialMinute = initialMinute,
+        is24Hour = false,
+    )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Reminder time") },
+        text = { TimePicker(state = state) },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(state.hour, state.minute) }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
 }
 
 private fun formatStoredDate(month: Int, day: Int, year: Int?): String {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
@@ -41,6 +41,8 @@ data class ImportantDatesUiState(
     val laterDates: List<ImportantDateListItem> = emptyList(),
     val calendarPermissionGranted: Boolean = false,
     val isRefreshingCalendarBirthdays: Boolean = false,
+    val notificationHour: Int = 9,
+    val notificationMinute: Int = 0,
 ) {
     val hasAnyDates: Boolean = upcomingDates.isNotEmpty() || laterDates.isNotEmpty()
 }
@@ -64,13 +66,16 @@ class ImportantDatesViewModel @Inject constructor(
         calendarBirthdays,
         calendarPermissionGranted,
         isRefreshingCalendarBirthdays,
-    ) { taughtDates, syncedBirthdays, hasCalendarPermission, isRefreshing ->
+        repository.notificationTime,
+    ) { taughtDates, syncedBirthdays, hasCalendarPermission, isRefreshing, (hour, minute) ->
         buildUiState(
             taughtDates = taughtDates,
             calendarBirthdays = syncedBirthdays,
             hasCalendarPermission = hasCalendarPermission,
             isRefreshing = isRefreshing,
             today = LocalDate.now(),
+            notificationHour = hour,
+            notificationMinute = minute,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -144,6 +149,12 @@ class ImportantDatesViewModel @Inject constructor(
         return deleted > 0
     }
 
+    fun setReminderTime(hour: Int, minute: Int) {
+        viewModelScope.launch {
+            repository.rescheduleAll(hour, minute)
+        }
+    }
+
     companion object {
         internal fun buildUiState(
             taughtDates: List<ImportantDateListItem>,
@@ -151,6 +162,8 @@ class ImportantDatesViewModel @Inject constructor(
             hasCalendarPermission: Boolean,
             isRefreshing: Boolean,
             today: LocalDate,
+            notificationHour: Int = 9,
+            notificationMinute: Int = 0,
         ): ImportantDatesUiState {
             val merged = (taughtDates + calendarBirthdays.filter { calendarBirthday ->
                 taughtDates.none { taughtDate ->
@@ -168,6 +181,8 @@ class ImportantDatesViewModel @Inject constructor(
                 laterDates = merged.filter { it.nextOccurrence.isAfter(upcomingCutoff) },
                 calendarPermissionGranted = hasCalendarPermission,
                 isRefreshingCalendarBirthdays = isRefreshing,
+                notificationHour = notificationHour,
+                notificationMinute = notificationMinute,
             )
         }
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ImportantDatesViewModel.kt
@@ -31,6 +31,10 @@ data class ImportantDateListItem(
     val year: Int?,
     val source: ImportantDateSource,
     val nextOccurrence: LocalDate,
+    /** Per-event reminder hour override. Null = use the global reminder time. */
+    val notificationHour: Int? = null,
+    /** Per-event reminder minute override. Null = use the global reminder time. */
+    val notificationMinute: Int? = null,
 ) {
     val stableKey: String = "${source.name}:$normalizedLabel"
     val isReadOnly: Boolean = source == ImportantDateSource.CALENDAR
@@ -110,6 +114,8 @@ class ImportantDatesViewModel @Inject constructor(
         month: Int,
         day: Int,
         year: Int?,
+        notificationHour: Int? = null,
+        notificationMinute: Int? = null,
     ): Boolean {
         val trimmedLabel = label.trim()
         if (trimmedLabel.isBlank()) {
@@ -132,7 +138,7 @@ class ImportantDatesViewModel @Inject constructor(
         if (existingLabel != null && originalNormalizedLabel != normalizedLabel) {
             repository.deleteByLabel(existingLabel)
         }
-        repository.save(trimmedLabel, month, day, year)
+        repository.save(trimmedLabel, month, day, year, notificationHour, notificationMinute)
         _messages.emit(if (existingLabel == null) "Saved $trimmedLabel." else "Updated $trimmedLabel.")
         return true
     }
@@ -195,6 +201,8 @@ class ImportantDatesViewModel @Inject constructor(
                 year = year,
                 source = ImportantDateSource.TAUGHT,
                 nextOccurrence = nextOccurrence(month, day, today),
+                notificationHour = notificationHour,
+                notificationMinute = notificationMinute,
             )
 
         internal fun CalendarBirthdayLookup.BirthdayEntry.toUiItem(today: LocalDate = LocalDate.now()): ImportantDateListItem =

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ImportantDatesViewModelTest.kt
@@ -34,6 +34,7 @@ class ImportantDatesViewModelTest {
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         every { repository.observeAll() } returns flowOf(emptyList())
+        every { repository.notificationTime } returns flowOf(Pair(9, 0))
         every { calendarBirthdayLookup.hasPermission() } returns false
         every { calendarBirthdayLookup.getAllBirthdays() } returns emptyList()
         every { calendarBirthdayLookup.invalidateCache() } returns Unit


### PR DESCRIPTION
## Summary

Adds day-of morning notifications for saved Important Dates (birthdays, anniversaries, events). Follows the same AlarmManager pattern established by #901 (list item due date notifications).

## Changes

- **DB migration (v39→40)**: `notificationEnabled` column on `important_dates` (default `true`)
- **`ImportantDateNotificationScheduler`**: `schedule()` / `cancel()` via `AlarmManager.setExactAndAllowWhileIdle`; `nextTriggerMs()` built on `java.time` (no lenient Calendar); Feb 29 clamped to Feb 28 in non-leap years
- **`ImportantDateNotificationReceiver`**: fires notification; birthday 🎂 vs event 📅 title; auto-reschedules recurring dates (year=null) annually; one-off dates do not recur
- **`ImportantDateNotificationPreferences`**: DataStore-backed, default 9:00 AM
- **`ImportantDateRepository`**: schedules alarm on `save()`; cancels old alarm _before_ `@Insert(REPLACE)` (prevents alarm ID leak on re-save); cancels on `deleteByLabel()`; `rescheduleAll()` for time changes
- **`BootCompletedReceiver`**: reschedules all important date alarms on boot
- **`AndroidManifest`**: registers `ImportantDateNotificationReceiver` with `exported="false"`
- **Settings UI**: tappable "Reminder time" row with Material 3 `TimePickerDialog` in Important Dates settings

## Code review fixes (2nd commit)

- `buildDateText()`: clamp Feb 29 → Feb 28 via `YearMonth.lengthOfMonth()` (was: `DateTimeException` crash in non-leap years)
- `nextTriggerMs()`: replaced lenient `Calendar` with `java.time` — eliminates silent March 1 rollover on Feb 29
- `save()`: cancel old alarm _before_ REPLACE insert to prevent orphaned annually-rescheduling alarms

## Testing

- [x] `ImportantDateRepositoryTest` — 2/2 pass
- [x] `ImportantDatesViewModelTest` — 5/5 pass
- [x] `assembleDebug` succeeds
- [ ] Manual: save a birthday, verify 9 AM notification fires; change reminder time, verify alarm updates

## Related issues

Closes #902
