### PR TITLE
feat(#905): chat archive, swipe gestures, auto-delete & Chat Preferences

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,7 +119,7 @@ User input
 
 - **Jetpack Compose** with Material 3 Dynamic Color, dark default (AMOLED-friendly)
 - **Chat-centric:** conversations list as home, chat screen as primary interaction
-- **Multiple conversations** with Room-persisted history (create/delete/rename)
+- **Multiple conversations** with Room-persisted history (create/delete/rename/archive/pin/drag-to-reorder). `ConversationEntity` carries `archivedAt`, `pinned`, and `sortOrder` fields; `KernelDatabase` is at v44. `observeActive` orders by `pinned DESC, sort_order ASC, updated_at DESC`. Archived conversations are read-only (banner + hidden input bar, no model init). `ArchiveCleanupWorker` runs daily to delete archived conversations past the configurable retention period (`ChatPreferences` DataStore, default 7 days).
 - **Voice:** Push-to-talk and streaming modes with auto-stop on silence. Per-message speaker button (`VolumeUp` icon) on every assistant bubble — plays/stops TTS for that message independently of voice mode. Verbal stop commands ("stop", "cancel", "be quiet", "shut up", "silence") cancel TTS mid-stream and stop mic re-arm. Settings include a pitch slider (Sherpa, 0.5–2.0×), an `autoSpeakEnabled` toggle for chat auto-speak (decoupled from the Quick Actions `spokenResponsesEnabled` toggle), and a max spoken sentences cap — all grouped in a "Chat voice behaviour" section. `truncateForSpeech()` uses `KNOWN_ABBREV` + `INITIALS_REGEX` for abbreviation-aware sentence splitting. Future: wake word detection.
 - **Homescreen widget (issue #617, PR #847):** `androidx.glance` widget in `:feature:widget`. Two interactive elements: a text pill ("Ask Jandal…") that opens `WidgetTextInputActivity` (translucent overlay, `taskAffinity=""`, `excludeFromRecents`), and a mic button that opens `VoiceCommandActivity` (same flags). Both activities call `WidgetNavigator.navigateToActions(isVoice=true/false)`, which fires an explicit intent to `MainActivity` with `quick_action_input` + `quick_action_is_voice` extras. `KernelNavHost` encodes these into `actions?widgetQuery=<text>&widgetVoice=<bool>` nav args. `ActionsScreen` auto-executes with `InputMode.Voice` (TTS reply) or `InputMode.Text` (result card only). A `savedStateHandle` boolean (`widgetQueryConsumed`) prevents re-execution on recompose or process-death restore. `QuickIntentRouter` is not called from widget activities — `ActionsViewModel` owns all routing.
 - **Skill results:** inline rich cards in the conversation stream
@@ -141,7 +141,7 @@ This project uses a **Sonnet-orchestrates, specialists-implement** pattern with 
 
 ### Rules
 - **test-writer works independently** — never sees the implementation agent's prompt; tests based on interfaces and contracts only
-- **code-reviewer runs before every PR merge** — at minimum a quick pass
+- **code-reviewer runs before every PR merge** — at minimum a quick pass; GitHub Copilot PR review comments are optional and do not satisfy this requirement
 - **Agents can run in parallel** when work is independent (e.g., android-developer + test-writer)
 - **Owner reviews and tests on S23 Ultra before merging** — every feature delivery includes manual testing steps and ADB commands
 - If an agent fails twice, escalate or attempt the task directly as a fallback
@@ -154,6 +154,7 @@ This project uses a **Sonnet-orchestrates, specialists-implement** pattern with 
 4. Parallel: spec-writer (update docs if needed)
 5. Sonnet: raise PR with Closes #N
 6. Parallel: code-reviewer reviews the PR + CI runs
+6a. Do not substitute GitHub Copilot PR review for step 6 — the required reviewer is the repository `code-reviewer` agent.
 7. Sonnet: push any fixes from code review to the PR branch
 8. code-reviewer: re-review the fix commits (confirm issues resolved, no regressions introduced)
 9. Owner: manual test on S23 Ultra via ADB once CI passes
@@ -161,6 +162,7 @@ This project uses a **Sonnet-orchestrates, specialists-implement** pattern with 
 ```
 
 **Code review is mandatory before every merge.** The re-review pass (step 8) is scoped to the fix commits only — not a full re-review of the whole PR.
+**GitHub Copilot PR review is optional only.** It can supplement review, but it does not replace the required `code-reviewer` agent pass or scoped re-review.
 
 ## Branching & PR Standards
 
@@ -243,6 +245,7 @@ The script verifies SHA256 hashes after download. Models directory: `models/` (g
 8. Parallel: code-reviewer reviews PR + CI runs Build & Test
 9. Push any code review fixes to the PR branch
 10. code-reviewer: re-review fix commits (scoped — not a full re-review)
+10a. GitHub Copilot PR review, if used, is supplementary only and never replaces the `code-reviewer` re-review.
 11. ./gradlew installDebug                     # Deploy to S23 Ultra
 12. Manual smoke test on device
 13. Owner reviews and merges

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 💬 **Full markdown rendering** — headings, bold, italic, inline code, code blocks, tables, links, lists
 - 🎯 **Smart chat titles** — auto-generated from conversation content
 - 🗂️ **Multi-conversation** — create, delete, rename, and search conversations by title
+- 📁 **Conversation management** — archive, pin, drag-to-reorder conversations; swipe-to-archive (left) or delete (right) with confirmation; multi-select with bulk archive/restore/delete; auto-delete archived conversations after configurable retention period (default 7 days)
 - 🧠 **Core memories** — add and manage permanent facts the assistant always recalls
 - 📂 **Memory Management screen** — view, add and delete core memories and episodic memory browser
 - ⚙️ **Model selection** — switch between E-2B and E-4B in Settings

--- a/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
+++ b/app/src/main/java/com/kernel/ai/KernelAIApplication.kt
@@ -5,15 +5,21 @@ import android.content.ComponentCallbacks2
 import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.kernel.ai.alarm.ClockStopwatchNotificationCoordinator
 import com.kernel.ai.alarm.ClockTimerNotificationCoordinator
 import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.memory.worker.ArchiveCleanupWorker
 import com.kernel.ai.core.memory.worker.MemoryEmbeddingWorker
+import com.kernel.ai.core.memory.worker.WORK_NAME_ARCHIVE_CLEANUP
 import com.kernel.ai.core.memory.worker.WORK_NAME_BACKFILL
 import dagger.hilt.android.HiltAndroidApp
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -44,6 +50,17 @@ class KernelAIApplication : Application(), Configuration.Provider {
             WORK_NAME_BACKFILL,
             ExistingWorkPolicy.KEEP,
             OneTimeWorkRequestBuilder<MemoryEmbeddingWorker>().build(),
+        )
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            WORK_NAME_ARCHIVE_CLEANUP,
+            ExistingPeriodicWorkPolicy.KEEP,
+            PeriodicWorkRequestBuilder<ArchiveCleanupWorker>(1, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiresBatteryNotLow(true)
+                        .build()
+                )
+                .build(),
         )
     }
 

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -47,6 +47,7 @@ import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.ContactAliasesScreen
 import com.kernel.ai.feature.settings.ImportantDatesScreen
 import com.kernel.ai.feature.settings.ListItemsScreen
+import com.kernel.ai.feature.settings.ChatPreferencesScreen
 import com.kernel.ai.feature.settings.ListsScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelManagementScreen
@@ -72,6 +73,7 @@ private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management?scrollTo={scrollTo}"
 private const val ARG_SCROLL_TO = "scrollTo"
 private const val ROUTE_ABOUT = "settings/about"
+private const val ROUTE_CHAT_PREFERENCES = "settings/chat_preferences"
 private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
 private const val ROUTE_SCHEDULED_ALARMS = "settings/scheduled_alarms"
 private const val ROUTE_SIDE_PANEL = "settings/side_panel"
@@ -450,6 +452,9 @@ fun KernelNavHost(
                             val route = "settings/model_management?scrollTo=$preferred"
                             navController.navigate(route)
                         },
+                        onNavigateToChatPreferences = {
+                            navController.navigate(ROUTE_CHAT_PREFERENCES)
+                        },
                         onNavigateToAbout = {
                             navController.navigate(ROUTE_ABOUT)
                         },
@@ -458,6 +463,12 @@ fun KernelNavHost(
 
                 composable(ROUTE_USER_PROFILE) {
                     UserProfileScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable(ROUTE_CHAT_PREFERENCES) {
+                    ChatPreferencesScreen(
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/42.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/42.json
@@ -1,0 +1,1841 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "fe782593e6b17a224d0d9ddb485e6d4e",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, `archivedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL, `notification_hour` INTEGER, `notification_minute` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationHour",
+            "columnName": "notification_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMinute",
+            "columnName": "notification_minute",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fe782593e6b17a224d0d9ddb485e6d4e')"
+    ]
+  }
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/43.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/43.json
@@ -1,0 +1,1847 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 43,
+    "identityHash": "828ce18538aa31aff26e545aebd3c8b9",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, `archivedAt` INTEGER, `pinned` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL, `notification_hour` INTEGER, `notification_minute` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationHour",
+            "columnName": "notification_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMinute",
+            "columnName": "notification_minute",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '828ce18538aa31aff26e545aebd3c8b9')"
+    ]
+  }
+}

--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/44.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/44.json
@@ -1,0 +1,1853 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 44,
+    "identityHash": "b9a301af1317ef7f477b064008821f28",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, `archivedAt` INTEGER, `pinned` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL, `notification_hour` INTEGER, `notification_minute` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationHour",
+            "columnName": "notification_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMinute",
+            "columnName": "notification_minute",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b9a301af1317ef7f477b064008821f28')"
+    ]
+  }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 41,
+    version = 42,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -693,6 +693,13 @@ abstract class KernelDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_hour INTEGER DEFAULT NULL")
                 db.execSQL("ALTER TABLE important_dates ADD COLUMN notification_minute INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Adds archivedAt to conversations for archive feature (#905). */
+        val MIGRATION_41_42 = object : Migration(41, 42) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE conversations ADD COLUMN archivedAt INTEGER DEFAULT NULL")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 42,
+    version = 43,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -700,6 +700,13 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_41_42 = object : Migration(41, 42) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE conversations ADD COLUMN archivedAt INTEGER DEFAULT NULL")
+            }
+        }
+
+        /** Adds pinned to conversations for pin feature (#905). */
+        val MIGRATION_42_43 = object : Migration(42, 43) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE conversations ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -81,7 +81,7 @@ import java.time.ZoneId
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
     ],
-    version = 43,
+    version = 44,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -707,6 +707,13 @@ abstract class KernelDatabase : RoomDatabase() {
         val MIGRATION_42_43 = object : Migration(42, 43) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE conversations ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        /** Adds sort_order to conversations for drag-to-reorder (#905). */
+        val MIGRATION_43_44 = object : Migration(43, 44) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE conversations ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -109,6 +109,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_40_41,
                     KernelDatabase.MIGRATION_41_42,
                     KernelDatabase.MIGRATION_42_43,
+                    KernelDatabase.MIGRATION_43_44,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -108,6 +108,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_39_40,
                     KernelDatabase.MIGRATION_40_41,
                     KernelDatabase.MIGRATION_41_42,
+                    KernelDatabase.MIGRATION_42_43,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -107,6 +107,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_38_39,
                     KernelDatabase.MIGRATION_39_40,
                     KernelDatabase.MIGRATION_40_41,
+                    KernelDatabase.MIGRATION_41_42,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -15,7 +15,7 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations ORDER BY updatedAt DESC")
     fun observeAll(): Flow<List<ConversationEntity>>
 
-    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL ORDER BY updatedAt DESC")
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL ORDER BY pinned DESC, updatedAt DESC")
     fun observeActive(): Flow<List<ConversationEntity>>
 
     @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL ORDER BY updatedAt DESC")
@@ -53,6 +53,12 @@ interface ConversationDao {
 
     @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL AND (title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\') ORDER BY updatedAt DESC")
     fun searchArchived(query: String): Flow<List<ConversationEntity>>
+
+    @Query("UPDATE conversations SET pinned = :pinned WHERE id = :id")
+    suspend fun updatePinned(id: String, pinned: Boolean)
+
+    @Query("SELECT pinned FROM conversations WHERE id = :id")
+    suspend fun getPinned(id: String): Boolean
 
     @Query("UPDATE conversations SET archivedAt = :timestamp WHERE id = :id")
     suspend fun archiveConversation(id: String, timestamp: Long)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -15,8 +15,17 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations ORDER BY updatedAt DESC")
     fun observeAll(): Flow<List<ConversationEntity>>
 
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL ORDER BY updatedAt DESC")
+    fun observeActive(): Flow<List<ConversationEntity>>
+
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL ORDER BY updatedAt DESC")
+    fun observeArchived(): Flow<List<ConversationEntity>>
+
     @Query("SELECT * FROM conversations WHERE id = :id")
     suspend fun getById(id: String): ConversationEntity?
+
+    @Query("SELECT * FROM conversations WHERE id = :id")
+    fun observeById(id: String): Flow<ConversationEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(conversation: ConversationEntity)
@@ -38,4 +47,19 @@ interface ConversationDao {
 
     @Query("SELECT * FROM conversations WHERE title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\' ORDER BY updatedAt DESC")
     fun searchByTitle(query: String): Flow<List<ConversationEntity>>
+
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL AND (title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\') ORDER BY updatedAt DESC")
+    fun searchActive(query: String): Flow<List<ConversationEntity>>
+
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL AND (title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\') ORDER BY updatedAt DESC")
+    fun searchArchived(query: String): Flow<List<ConversationEntity>>
+
+    @Query("UPDATE conversations SET archivedAt = :timestamp WHERE id = :id")
+    suspend fun archiveConversation(id: String, timestamp: Long)
+
+    @Query("UPDATE conversations SET archivedAt = NULL WHERE id = :id")
+    suspend fun restoreConversation(id: String)
+
+    @Query("DELETE FROM conversations WHERE archivedAt IS NOT NULL AND archivedAt < :cutoffMs")
+    suspend fun deleteArchivedOlderThan(cutoffMs: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -54,11 +54,8 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL AND (title IS NULL OR title LIKE '%' || :query || '%' ESCAPE '\\') ORDER BY updatedAt DESC")
     fun searchArchived(query: String): Flow<List<ConversationEntity>>
 
-    @Query("UPDATE conversations SET pinned = :pinned WHERE id = :id")
-    suspend fun updatePinned(id: String, pinned: Boolean)
-
-    @Query("SELECT pinned FROM conversations WHERE id = :id")
-    suspend fun getPinned(id: String): Boolean
+    @Query("UPDATE conversations SET pinned = CASE WHEN pinned = 1 THEN 0 ELSE 1 END WHERE id = :id")
+    suspend fun togglePin(id: String)
 
     @Query("UPDATE conversations SET archivedAt = :timestamp WHERE id = :id")
     suspend fun archiveConversation(id: String, timestamp: Long)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -15,7 +15,7 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations ORDER BY updatedAt DESC")
     fun observeAll(): Flow<List<ConversationEntity>>
 
-    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL ORDER BY pinned DESC, updatedAt DESC")
+    @Query("SELECT * FROM conversations WHERE archivedAt IS NULL ORDER BY pinned DESC, sort_order ASC, updatedAt DESC")
     fun observeActive(): Flow<List<ConversationEntity>>
 
     @Query("SELECT * FROM conversations WHERE archivedAt IS NOT NULL ORDER BY updatedAt DESC")
@@ -77,4 +77,7 @@ interface ConversationDao {
 
     @Query("DELETE FROM conversations WHERE archivedAt IS NOT NULL AND archivedAt < :cutoffMs")
     suspend fun deleteArchivedOlderThan(cutoffMs: Long)
+
+    @Query("UPDATE conversations SET sort_order = :sortOrder WHERE id = :id")
+    suspend fun updateSortOrder(id: String, sortOrder: Int)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/ConversationDao.kt
@@ -60,6 +60,15 @@ interface ConversationDao {
     @Query("UPDATE conversations SET archivedAt = NULL WHERE id = :id")
     suspend fun restoreConversation(id: String)
 
+    @Query("UPDATE conversations SET archivedAt = :timestamp WHERE id IN (:ids)")
+    suspend fun archiveConversations(ids: Collection<String>, timestamp: Long)
+
+    @Query("UPDATE conversations SET archivedAt = NULL WHERE id IN (:ids)")
+    suspend fun restoreConversations(ids: Collection<String>)
+
+    @Query("SELECT id FROM conversations WHERE archivedAt IS NOT NULL AND archivedAt < :cutoffMs")
+    suspend fun getArchivedIdsBefore(cutoffMs: Long): List<String>
+
     @Query("DELETE FROM conversations WHERE archivedAt IS NOT NULL AND archivedAt < :cutoffMs")
     suspend fun deleteArchivedOlderThan(cutoffMs: Long)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
@@ -11,4 +11,5 @@ data class ConversationEntity(
     val updatedAt: Long,
     val lastDistilledAt: Long? = null,
     val archivedAt: Long? = null,
+    val pinned: Boolean = false,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.memory.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -12,4 +13,5 @@ data class ConversationEntity(
     val lastDistilledAt: Long? = null,
     val archivedAt: Long? = null,
     val pinned: Boolean = false,
+    @ColumnInfo(name = "sort_order") val sortOrder: Int = 0,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/ConversationEntity.kt
@@ -10,4 +10,5 @@ data class ConversationEntity(
     val createdAt: Long,
     val updatedAt: Long,
     val lastDistilledAt: Long? = null,
+    val archivedAt: Long? = null,
 )

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/prefs/ChatPreferences.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/prefs/ChatPreferences.kt
@@ -1,0 +1,39 @@
+package com.kernel.ai.core.memory.prefs
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.chatPrefsDataStore: DataStore<Preferences> by preferencesDataStore(name = "chat_preferences")
+
+/**
+ * DataStore for chat-related user preferences.
+ *
+ * [archiveRetentionDays]: How many days to keep archived conversations before auto-deletion.
+ *  - Positive values: number of days (1, 3, 7, 14, 30)
+ *  - -1: Never auto-delete
+ *  - Default: 7 days
+ */
+@Singleton
+class ChatPreferences @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val archiveRetentionDaysKey = intPreferencesKey("archive_retention_days")
+
+    val archiveRetentionDays: Flow<Int> = context.chatPrefsDataStore.data
+        .map { prefs -> prefs[archiveRetentionDaysKey] ?: 7 }
+
+    suspend fun setArchiveRetentionDays(days: Int) {
+        context.chatPrefsDataStore.edit { prefs ->
+            prefs[archiveRetentionDaysKey] = days
+        }
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -130,6 +130,11 @@ class ConversationRepository @Inject constructor(
         conversationDao.deleteArchivedOlderThan(cutoffMs)
     }
 
+    suspend fun reorderConversations(pinnedIds: List<String>, unpinnedIds: List<String>) {
+        pinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
+        unpinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
+    }
+
     suspend fun getConversation(id: String): ConversationEntity? =
         conversationDao.getById(id)
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -30,6 +30,15 @@ class ConversationRepository @Inject constructor(
     fun observeConversations(): Flow<List<ConversationEntity>> =
         conversationDao.observeAll()
 
+    fun observeActive(): Flow<List<ConversationEntity>> =
+        conversationDao.observeActive()
+
+    fun observeArchived(): Flow<List<ConversationEntity>> =
+        conversationDao.observeArchived()
+
+    fun observeConversationById(id: String): Flow<ConversationEntity?> =
+        conversationDao.observeById(id)
+
     fun observeMessages(conversationId: String): Flow<List<MessageEntity>> =
         messageDao.observeByConversation(conversationId)
 
@@ -86,6 +95,30 @@ class ConversationRepository @Inject constructor(
         conversationDao.delete(conversation)
     }
 
+    suspend fun archiveConversation(id: String) {
+        conversationDao.archiveConversation(id, System.currentTimeMillis())
+    }
+
+    suspend fun restoreConversation(id: String) {
+        conversationDao.restoreConversation(id)
+    }
+
+    suspend fun archiveSelected(ids: Set<String>) {
+        val now = System.currentTimeMillis()
+        ids.forEach { conversationDao.archiveConversation(it, now) }
+    }
+
+    suspend fun restoreSelected(ids: Set<String>) {
+        ids.forEach { conversationDao.restoreConversation(it) }
+    }
+
+    suspend fun deleteArchivedOlderThan(cutoffMs: Long) {
+        // For each archived conversation older than cutoffMs, clean vec entries first
+        // We don't have a bulk getRowIds for archived, so we'll use deleteArchivedOlderThan
+        // which handles the DB cleanup. Vec entries will be orphaned but harmless.
+        conversationDao.deleteArchivedOlderThan(cutoffMs)
+    }
+
     suspend fun getConversation(id: String): ConversationEntity? =
         conversationDao.getById(id)
 
@@ -94,4 +127,10 @@ class ConversationRepository @Inject constructor(
 
     fun searchByTitle(query: String): Flow<List<ConversationEntity>> =
         conversationDao.searchByTitle(query)
+
+    fun searchActive(query: String): Flow<List<ConversationEntity>> =
+        conversationDao.searchActive(query)
+
+    fun searchArchived(query: String): Flow<List<ConversationEntity>> =
+        conversationDao.searchArchived(query)
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -95,6 +95,11 @@ class ConversationRepository @Inject constructor(
         conversationDao.delete(conversation)
     }
 
+    suspend fun togglePin(id: String) {
+        val current = conversationDao.getPinned(id)
+        conversationDao.updatePinned(id, !current)
+    }
+
     suspend fun archiveConversation(id: String) {
         conversationDao.archiveConversation(id, System.currentTimeMillis())
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -1,6 +1,8 @@
 package com.kernel.ai.core.memory.repository
 
 import android.util.Log
+import androidx.room.withTransaction
+import com.kernel.ai.core.memory.KernelDatabase
 import com.kernel.ai.core.memory.dao.ConversationDao
 import com.kernel.ai.core.memory.dao.MessageDao
 import com.kernel.ai.core.memory.dao.MessageEmbeddingDao
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ConversationRepository @Inject constructor(
+    private val db: KernelDatabase,
     private val conversationDao: ConversationDao,
     private val messageDao: MessageDao,
     private val embeddingDao: MessageEmbeddingDao,
@@ -96,8 +99,7 @@ class ConversationRepository @Inject constructor(
     }
 
     suspend fun togglePin(id: String) {
-        val current = conversationDao.getPinned(id)
-        conversationDao.updatePinned(id, !current)
+        conversationDao.togglePin(id)
     }
 
     suspend fun archiveConversation(id: String) {
@@ -131,8 +133,10 @@ class ConversationRepository @Inject constructor(
     }
 
     suspend fun reorderConversations(pinnedIds: List<String>, unpinnedIds: List<String>) {
-        pinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
-        unpinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
+        db.withTransaction {
+            pinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
+            unpinnedIds.forEachIndexed { index, id -> conversationDao.updateSortOrder(id, index) }
+        }
     }
 
     suspend fun getConversation(id: String): ConversationEntity? =

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/ConversationRepository.kt
@@ -104,18 +104,24 @@ class ConversationRepository @Inject constructor(
     }
 
     suspend fun archiveSelected(ids: Set<String>) {
-        val now = System.currentTimeMillis()
-        ids.forEach { conversationDao.archiveConversation(it, now) }
+        conversationDao.archiveConversations(ids, System.currentTimeMillis())
     }
 
     suspend fun restoreSelected(ids: Set<String>) {
-        ids.forEach { conversationDao.restoreConversation(it) }
+        conversationDao.restoreConversations(ids)
     }
 
     suspend fun deleteArchivedOlderThan(cutoffMs: Long) {
-        // For each archived conversation older than cutoffMs, clean vec entries first
-        // We don't have a bulk getRowIds for archived, so we'll use deleteArchivedOlderThan
-        // which handles the DB cleanup. Vec entries will be orphaned but harmless.
+        val ids = conversationDao.getArchivedIdsBefore(cutoffMs)
+        withContext(Dispatchers.IO) {
+            ids.forEach { id ->
+                val rowIds = embeddingDao.getRowIdsForConversation(id)
+                rowIds.forEach { rowId ->
+                    runCatching { vectorStore.delete(MESSAGE_VEC_TABLE, rowId) }
+                        .onFailure { Log.w(TAG, "Failed to delete vec entry rowId=$rowId: ${it.message}") }
+                }
+            }
+        }
         conversationDao.deleteArchivedOlderThan(cutoffMs)
     }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/worker/ArchiveCleanupWorker.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/worker/ArchiveCleanupWorker.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.memory.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.kernel.ai.core.memory.prefs.ChatPreferences
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+private const val TAG = "ArchiveCleanupWorker"
+const val WORK_NAME_ARCHIVE_CLEANUP = "archive_cleanup"
+
+/**
+ * Daily WorkManager job that auto-deletes archived conversations older than the
+ * user-configured retention period (from [ChatPreferences]).
+ *
+ * Runs with battery-not-low constraint at most once per day.
+ */
+@HiltWorker
+class ArchiveCleanupWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val conversationRepository: ConversationRepository,
+    private val chatPreferences: ChatPreferences,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            val retentionDays = chatPreferences.archiveRetentionDays.first()
+            if (retentionDays == -1) {
+                Log.i(TAG, "Archive retention is set to Never — skipping cleanup")
+                return@withContext Result.success()
+            }
+            val cutoffMs = System.currentTimeMillis() - retentionDays * 24L * 60L * 60L * 1000L
+            conversationRepository.deleteArchivedOlderThan(cutoffMs)
+            Log.i(TAG, "Archive cleanup complete — deleted conversations archived before cutoff (retentionDays=$retentionDays)")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Archive cleanup failed", e)
+            Result.retry()
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -357,6 +357,28 @@ Deterministic multi-turn quick actions — slot filling and confirmation baselin
 | [#521](https://github.com/NickMonrad/kernel-ai-assistant/issues/521) | Add media control intents: pause, stop, skip, previous | ✅ Done | 🟡 Medium |
 
 
+### 3J: Conversation Management — Archive, Pin & Drag-to-Reorder ([#905](https://github.com/NickMonrad/kernel-ai-assistant/issues/905))
+
+Full lifecycle management for conversations: archive/restore, pinning with sticky ordering, drag-to-reorder, and configurable auto-delete. DB bumped 41 → 44 (migrations 41→42, 42→43, 43→44).
+
+| Sub-Issue | Title | Status | Priority |
+|-----------|-------|--------|----------|
+| [#905](https://github.com/NickMonrad/kernel-ai-assistant/issues/905) | Conversation archive, pin, and drag-to-reorder | ✅ Done — PR #924 | 🔴 High |
+
+**Shipped scope (PR #924, branch `feature/905-chat-archive`):**
+
+- `ConversationEntity` — added `archivedAt: Long?`, `pinned: Boolean`, `sortOrder: Int`
+- `KernelDatabase` bumped to **v44** (migrations 41→42, 42→43, 43→44)
+- `ConversationDao` — archive/restore/pin/sortOrder queries; `observeActive` orders by `pinned DESC, sort_order ASC, updated_at DESC`
+- `ConversationRepository` — archive/restore/pin/reorder/bulk operations; sqlite-vec cleanup on delete
+- `ChatPreferences` — DataStore-backed `archiveRetentionDays` (default 7, −1 = Never)
+- `ArchiveCleanupWorker` — `@HiltWorker` `CoroutineWorker`, runs daily (battery-not-low), cleans sqlite-vec entries before bulk DELETE to prevent orphaned RAG embeddings
+- Conversation list UI: pin/unpin toggle (pushpin icon), swipe-left archive + confirmation, swipe-right delete + confirmation, drag-to-reorder (`sh.calvin.reorderable:2.4.3`), multi-select (long-press) with bulk archive/restore/delete, ⋮ context menu per row, overflow "Show Archived / Show Active" toggle
+- Chat screen: "Archived · Read-only" banner; input bar hidden; `initEngineWhenReady()` and eviction re-init skipped for archived conversations
+- Settings: new "Chat Preferences" screen with archive retention picker (1d / 3d / 7d / 14d / 30d / Never)
+
+---
+
 ### 3I: Meal Planning Roadmap ([#826](https://github.com/NickMonrad/kernel-ai-assistant/issues/826))
 
 Deterministic meal planning now has its v1 foundation merged. The next phases are deliberately split so UX/resiliency work, durable artifact expansion, and recipe grounding can evolve independently without reopening the prompt-heavy architecture that #859 replaced.
@@ -609,6 +631,7 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#821](https://github.com/NickMonrad/kernel-ai-assistant/issues/821) | Sherpa-ONNX / Sherpa-ncnn STT + VAD evaluation | Phase 3F | ⬜ Pending |
 | [#675](https://github.com/NickMonrad/kernel-ai-assistant/issues/675) | Comprehensive Quick Actions + weather voice QA matrix | Phase 3F | 🔴 Closed |
 | [#588](https://github.com/NickMonrad/kernel-ai-assistant/issues/588) | VoiceSession architecture for slot-fill + follow-on assistant mode | Phase 3F | ⬜ Pending |
+| [#905](https://github.com/NickMonrad/kernel-ai-assistant/issues/905) | Conversation archive, pin, and drag-to-reorder | Phase 3J | ✅ Done — PR #924 |
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-05-13 (PR #834 spec sync: documented 18 completed roadmap items — voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; prior: PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
+> **Last updated:** 2026-05-13 (PR #924 spec sync: conversation management — archive, pin, drag-to-reorder, swipe gestures, multi-select, ArchiveCleanupWorker, KernelDatabase v44; prior: PR #834 — voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -814,6 +814,47 @@ Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime
 - **Actions tab:** History list, FAB (⚡) for new commands, bottom sheet input, Room-persisted history
 - **Voice:** Quick Actions push-to-talk with offline STT, spoken QIR responses, and streaming spoken chat replies; wake word remains future work
 - **Conversation search (#151, PR #156):** A search bar on the conversations list screen filters by conversation title. The query applies a `LIKE` wildcard match against the title column; a `NULL` guard prevents crashes for conversations that have not yet been auto-titled. Wildcard characters in the search input are escaped to avoid accidental SQL injection via the LIKE pattern.
+
+### 6.0 Conversation Management (#905, PR #924)
+
+Full lifecycle management for conversations. `KernelDatabase` is at **v44** (migrations 41→42, 42→43, 43→44).
+
+#### Data layer
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `archivedAt` | `Long?` | Epoch ms when archived; `null` = active |
+| `pinned` | `Boolean` | Sticky ordering above unpinned rows |
+| `sortOrder` | `Int` | Manual drag position within the active list |
+
+`ConversationDao.observeActive` orders by `pinned DESC, sort_order ASC, updated_at DESC`.
+
+`ConversationRepository` exposes archive/restore/pin/reorder/bulk methods. On bulk delete, `sqlite-vec` embedding entries are cleaned up first to avoid orphaned RAG vectors.
+
+`ChatPreferences` (DataStore) stores `archiveRetentionDays` (default 7, −1 = Never). `ArchiveCleanupWorker` is a `@HiltWorker` `CoroutineWorker` scheduled daily (battery-not-low constraint) that deletes archived conversations past the retention cutoff, cleaning sqlite-vec entries before the bulk DELETE.
+
+#### Conversation list UI
+
+| Gesture / Element | Behaviour |
+|-------------------|-----------|
+| Trailing `IconButton` (pushpin) | Filled = pinned; outline = unpinned. Pinned conversations appear in a sticky section above unpinned ones. |
+| Swipe left | Swipe-to-archive with green background + archive icon. Snap-back on cancel; confirmation dialog before commit. |
+| Swipe right | Swipe-to-delete with confirmation dialog. |
+| Long-press | Enters multi-select mode. Dedicated `TopAppBar` with Archive/Restore + Delete icon buttons. |
+| ⋮ icon per row | Context menu (Archive/Restore, Rename, Delete) — consistent with Lists UX. |
+| Drag handle | Drag-to-reorder via `sh.calvin.reorderable:2.4.3`; new `sortOrder` persisted on drop. |
+| Overflow menu (top-right) | "Show Archived" / "Show Active" toggle. |
+
+#### Archived chat screen behaviour
+
+- **"Archived · Read-only" banner** shown at top when `isArchived = true`.
+- **Input bar fully hidden** — no text entry, no send button.
+- `.navigationBarsPadding()` applied to content column (Scaffold uses `contentWindowInsets = WindowInsets(0)` for archived chats).
+- `initEngineWhenReady()` and eviction re-init skipped — no wasteful Gemma-4 E4B load for read-only history.
+
+#### Settings
+
+New **Chat Preferences** screen (Settings → Chat Preferences) with an archive retention picker: 1 day / 3 days / 7 days (default) / 14 days / 30 days / Never.
 
 **Chat TTS speech normalisation (`ChatTextUtils.normalizeChatTextForSpeech`):** Before TTS
 input, the text passes through a chain of `SpeechPronunciationRule` entries that rewrite

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -73,4 +73,6 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
     testImplementation("org.json:json:20240303")
+
+    implementation("sh.calvin.reorderable:reorderable:2.4.3")
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -402,7 +402,9 @@ private fun ChatContent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .imePadding(),
+                .imePadding()
+                // InputBar handles nav bar padding when visible; add it here for archived (read-only) view.
+                .then(if (isArchived) Modifier.navigationBarsPadding() else Modifier),
         ) {
             if (isArchived) {
                 Box(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -217,6 +217,7 @@ fun ChatScreen(
             val context = LocalContext.current
             val isSeeding by viewModel.isSeeding.collectAsState()
             val speakingMessageId by viewModel.speakingMessageId.collectAsStateWithLifecycle()
+            val isArchived by viewModel.isArchived.collectAsStateWithLifecycle()
 
             // Track which voice action is pending while we await the permission result.
             var pendingVoiceAction by rememberSaveable { mutableStateOf<String?>(null) }
@@ -266,6 +267,7 @@ fun ChatScreen(
             ChatContent(
                 state = state,
                 isSeeding = isSeeding,
+                isArchived = isArchived,
                 onInputChanged = viewModel::onInputChanged,
                 onSend = viewModel::sendMessage,
                 onCancel = viewModel::cancelGeneration,
@@ -309,6 +311,7 @@ fun ChatScreen(
 private fun ChatContent(
     state: ChatUiState.Ready,
     isSeeding: Boolean,
+    isArchived: Boolean = false,
     onInputChanged: (String) -> Unit,
     onSend: () -> Unit,
     onCancel: () -> Unit,
@@ -401,6 +404,20 @@ private fun ChatContent(
                 .padding(innerPadding)
                 .imePadding(),
         ) {
+            if (isArchived) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = "Archived · Read-only",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+            }
             if (state.messages.isEmpty()) {
                 EmptyConversationHint(modifier = Modifier.weight(1f))
             } else {
@@ -541,21 +558,23 @@ private fun ChatContent(
                 }
             }
 
-            InputBar(
-                text = state.inputText,
-                isGenerating = state.isGenerating,
-                voiceCaptureState = voiceCaptureState,
-                voicePlaybackState = voicePlaybackState,
-                voiceMode = voiceMode,
-                onTextChanged = onInputChanged,
-                onSend = onSend,
-                onCancel = onCancel,
-                onStartVoiceInput = onStartVoiceInput,
-                onStartBackAndForthVoiceInput = onStartBackAndForthVoiceInput,
-                onStopVoiceInput = onStopVoiceInput,
-                onStopVoiceOutput = onStopVoiceOutput,
-                modifier = Modifier.navigationBarsPadding(),
-            )
+            if (!isArchived) {
+                InputBar(
+                    text = state.inputText,
+                    isGenerating = state.isGenerating,
+                    voiceCaptureState = voiceCaptureState,
+                    voicePlaybackState = voicePlaybackState,
+                    voiceMode = voiceMode,
+                    onTextChanged = onInputChanged,
+                    onSend = onSend,
+                    onCancel = onCancel,
+                    onStartVoiceInput = onStartVoiceInput,
+                    onStartBackAndForthVoiceInput = onStartBackAndForthVoiceInput,
+                    onStopVoiceInput = onStopVoiceInput,
+                    onStopVoiceOutput = onStopVoiceOutput,
+                    modifier = Modifier.navigationBarsPadding(),
+                )
+            }
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -455,10 +456,16 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch { initializeConversation() }
         nzTruthSeedingService.seedIfNeeded()
         viewModelScope.launch {
-            // E4B first — GPU compilation needs every byte of headroom.
-            // FG's 289MB on CPU is enough to tip OOM during GPU init.
-            // Once E4B is stable, FG loads in ~0.4s with no memory pressure.
-            initEngineWhenReady()
+            // Don't load the model for archived conversations — they are read-only and need no inference.
+            // Read directly from the repository (not the StateFlow, which defaults to false) so we get
+            // the real archived state before deciding.
+            val archived = conversationRepository.observeConversationById(navConversationId ?: "")
+                .map { it?.archivedAt != null }
+                .firstOrNull() ?: false
+            if (!archived) {
+                // E4B first — GPU compilation needs every byte of headroom.
+                initEngineWhenReady()
+            }
         }
         viewModelScope.launch {
             // Re-initialize automatically when Android evicts the engine under memory pressure
@@ -469,6 +476,8 @@ class ChatViewModel @Inject constructor(
             // - waitForScreenInteractive() in initialize() is a safety net if screen goes off
             //   mid-init, but the real gate should be app-in-foreground
             inferenceEngine.evictionEvents.collect {
+                // Don't re-init for archived conversations.
+                if (isArchived.value) return@collect
                 Log.i("ChatViewModel", "Engine evicted — waiting for app to open before re-init (#609)")
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -303,7 +303,8 @@ class ChatViewModel @Inject constructor(
         downloadManager.downloadStates,
         inputState,
         _showThinkingProcess,
-    ) { engine, downloadStates, input, showThinking ->
+        isArchived,
+    ) { engine, downloadStates, input, showThinking, archived ->
         val allDownloaded = downloadManager.areRequiredModelsDownloaded()
         val tier = downloadManager.deviceTier
         val displayModels: List<KernelModel> = if (tier == HardwareTier.FLAGSHIP) {
@@ -326,7 +327,9 @@ class ChatViewModel @Inject constructor(
                 }
                 ChatUiState.ModelsNotReady(isDownloading = anyDownloading, modelProgress = progress)
             }
-            !engine.isReady || !engine.conversationInitialized -> ChatUiState.Loading
+            // Archived conversations are read-only — no engine needed. Skip the isReady gate.
+            !archived && (!engine.isReady || !engine.conversationInitialized) -> ChatUiState.Loading
+            !engine.conversationInitialized -> ChatUiState.Loading
             else -> ChatUiState.Ready(
                 conversationId = conversationId ?: "",
                 conversationTitle = input.conversationTitle,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -252,6 +253,11 @@ class ChatViewModel @Inject constructor(
      * need the model; [sendMessage] handles model loading internally for LLM-routed queries.
      */
     val isConversationReady: StateFlow<Boolean> = _conversationInitialized.asStateFlow()
+
+    val isArchived: StateFlow<Boolean> = conversationRepository.observeConversationById(navConversationId ?: "")
+        .map { it?.archivedAt != null }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     private val _showThinkingProcess = MutableStateFlow(true)
     private val _correctGroundedFactsEnabled = MutableStateFlow(false)
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -348,13 +348,14 @@ fun ConversationListScreen(
                                             else onOpenConversation(conversation.id)
                                         },
                                         onLongClick = {
-                                            if (!isInSelectionMode) contextMenuTarget = conversation
+                                            if (!isInSelectionMode) viewModel.enterSelectionMode(conversation.id)
                                         },
                                         onToggleSelect = { viewModel.toggleSelection(conversation.id) },
                                         onArchiveRequest = { pendingArchive = conversation },
                                         onRestore = { viewModel.restoreConversation(conversation.id) },
                                         onDeleteRequest = { pendingDelete = conversation },
                                         onTogglePin = { viewModel.togglePin(conversation.id) },
+                                        onMoreClick = { contextMenuTarget = conversation },
                                     )
                                 }
                             }
@@ -365,10 +366,6 @@ fun ConversationListScreen(
                                 ) {
                                     ConversationContextMenuItems(
                                         showArchived = false,
-                                        onSelect = {
-                                            contextMenuTarget = null
-                                            viewModel.enterSelectionMode(conversation.id)
-                                        },
                                         onRename = {
                                             pendingRenameId = conversation.id
                                             contextMenuTarget = null
@@ -425,13 +422,14 @@ fun ConversationListScreen(
                                             else onOpenConversation(conversation.id)
                                         },
                                         onLongClick = {
-                                            if (!isInSelectionMode) contextMenuTarget = conversation
+                                            if (!isInSelectionMode) viewModel.enterSelectionMode(conversation.id)
                                         },
                                         onToggleSelect = { viewModel.toggleSelection(conversation.id) },
                                         onArchiveRequest = { pendingArchive = conversation },
                                         onRestore = { viewModel.restoreConversation(conversation.id) },
                                         onDeleteRequest = { pendingDelete = conversation },
                                         onTogglePin = { viewModel.togglePin(conversation.id) },
+                                        onMoreClick = { contextMenuTarget = conversation },
                                     )
                                 }
                             }
@@ -442,10 +440,6 @@ fun ConversationListScreen(
                                 ) {
                                     ConversationContextMenuItems(
                                         showArchived = false,
-                                        onSelect = {
-                                            contextMenuTarget = null
-                                            viewModel.enterSelectionMode(conversation.id)
-                                        },
                                         onRename = {
                                             pendingRenameId = conversation.id
                                             contextMenuTarget = null
@@ -479,8 +473,9 @@ fun ConversationListScreen(
                                     else onOpenConversation(conversation.id)
                                 },
                                 onLongClick = {
-                                    if (!isInSelectionMode) contextMenuTarget = conversation
+                                    if (!isInSelectionMode) viewModel.enterSelectionMode(conversation.id)
                                 },
+                                onMoreClick = { contextMenuTarget = conversation },
                             )
                             if (!isInSelectionMode) {
                                 DropdownMenu(
@@ -489,10 +484,6 @@ fun ConversationListScreen(
                                 ) {
                                     ConversationContextMenuItems(
                                         showArchived = true,
-                                        onSelect = {
-                                            contextMenuTarget = null
-                                            viewModel.enterSelectionMode(conversation.id)
-                                        },
                                         onRename = {},
                                         onArchiveRequest = {},
                                         onRestore = {
@@ -615,13 +606,11 @@ fun ConversationListScreen(
 @Composable
 private fun ConversationContextMenuItems(
     showArchived: Boolean,
-    onSelect: () -> Unit,
     onRename: () -> Unit,
     onArchiveRequest: () -> Unit,
     onRestore: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    DropdownMenuItem(text = { Text("Select") }, onClick = onSelect)
     if (showArchived) {
         DropdownMenuItem(text = { Text("Restore") }, onClick = onRestore)
     } else {
@@ -651,6 +640,7 @@ private fun SwipeableConversationRow(
     onRestore: () -> Unit,
     onDeleteRequest: () -> Unit,
     onTogglePin: () -> Unit,
+    onMoreClick: () -> Unit,
 ) {
     var pendingSwipeDelete by remember { mutableStateOf(false) }
     var pendingSwipeArchive by remember { mutableStateOf(false) }
@@ -750,6 +740,7 @@ private fun SwipeableConversationRow(
                     onOpen = onOpen,
                     onLongClick = onLongClick,
                     onTogglePin = onTogglePin,
+                    onMoreClick = onMoreClick,
                 )
             },
         )
@@ -769,6 +760,7 @@ private fun ConversationListItem(
     onOpen: () -> Unit,
     onLongClick: () -> Unit,
     onTogglePin: (() -> Unit)? = null,
+    onMoreClick: (() -> Unit)? = null,
 ) {
     ListItem(
         headlineContent = {
@@ -800,10 +792,10 @@ private fun ConversationListItem(
         } else {
             null
         },
-        trailingContent = if (!isInSelectionMode && !showArchived) {
+        trailingContent = if (!isInSelectionMode) {
             {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (onTogglePin != null) {
+                    if (!showArchived && onTogglePin != null) {
                         IconButton(onClick = onTogglePin) {
                             Icon(
                                 imageVector = if (conversation.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
@@ -813,16 +805,27 @@ private fun ConversationListItem(
                             )
                         }
                     }
-                    Icon(
-                        Icons.Default.DragHandle,
-                        contentDescription = "Drag to reorder",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = dragHandleModifier
-                            .pointerInput(Unit) {
-                                detectTapGestures(onLongPress = { /* absorb — prevent combinedClickable from firing */ })
-                            }
-                            .padding(horizontal = 4.dp),
-                    )
+                    if (!showArchived) {
+                        Icon(
+                            Icons.Default.DragHandle,
+                            contentDescription = "Drag to reorder",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = dragHandleModifier
+                                .pointerInput(Unit) {
+                                    detectTapGestures(onLongPress = { /* absorb — prevent combinedClickable from firing */ })
+                                }
+                                .padding(horizontal = 4.dp),
+                        )
+                    }
+                    if (onMoreClick != null) {
+                        IconButton(onClick = onMoreClick) {
+                            Icon(
+                                Icons.Default.MoreVert,
+                                contentDescription = "More options",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
                 }
             }
         } else {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -1,25 +1,34 @@
 package com.kernel.ai.feature.chat
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -28,7 +37,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,17 +44,23 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -71,11 +85,13 @@ fun ConversationListScreen(
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedConversationIds by viewModel.selectedConversationIds.collectAsStateWithLifecycle()
     val showBulkDeleteConfirmation by viewModel.showBulkDeleteConfirmation.collectAsStateWithLifecycle()
+    val showArchived by viewModel.showArchived.collectAsStateWithLifecycle()
+
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
-    // Store ID only (String is Parcelable-safe) to survive configuration changes.
     var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
     val pendingRename = pendingRenameId?.let { id -> conversations.find { it.id == id } }
     var contextMenuTarget by remember { mutableStateOf<ConversationEntity?>(null) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
 
     // Exit selection mode on system back instead of popping the screen
     BackHandler(enabled = isInSelectionMode) {
@@ -88,6 +104,8 @@ fun ConversationListScreen(
                 title = {
                     if (isInSelectionMode) {
                         Text("${selectedConversationIds.size} / ${conversations.size} selected")
+                    } else if (showArchived) {
+                        Text("Archived")
                     } else {
                         Text("Jandal")
                     }
@@ -104,6 +122,33 @@ fun ConversationListScreen(
                         TextButton(onClick = { viewModel.selectAll(conversations.map { it.id }) }) {
                             Text("Select All")
                         }
+                        if (showArchived) {
+                            // Archived view: Restore + Delete
+                            Button(
+                                onClick = viewModel::restoreSelected,
+                                enabled = selectedConversationIds.isNotEmpty(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                ),
+                            ) {
+                                Text("Restore (${selectedConversationIds.size})")
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+                        } else {
+                            // Active view: Archive + Delete
+                            Button(
+                                onClick = viewModel::archiveSelected,
+                                enabled = selectedConversationIds.isNotEmpty(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                ),
+                            ) {
+                                Text("Archive (${selectedConversationIds.size})")
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
                         Button(
                             onClick = viewModel::requestBulkDelete,
                             enabled = selectedConversationIds.isNotEmpty(),
@@ -117,12 +162,31 @@ fun ConversationListScreen(
                         TextButton(onClick = viewModel::clearSelection) {
                             Text("Cancel")
                         }
+                    } else {
+                        // ⋮ overflow menu
+                        Box {
+                            IconButton(onClick = { showOverflowMenu = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                            }
+                            DropdownMenu(
+                                expanded = showOverflowMenu,
+                                onDismissRequest = { showOverflowMenu = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(if (showArchived) "Show Active" else "Show Archived") },
+                                    onClick = {
+                                        showOverflowMenu = false
+                                        viewModel.toggleShowArchived()
+                                    },
+                                )
+                            }
+                        }
                     }
                 },
             )
         },
         floatingActionButton = {
-            if (!isInSelectionMode) {
+            if (!isInSelectionMode && !showArchived) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -152,10 +216,6 @@ fun ConversationListScreen(
             }
         },
     ) { innerPadding ->
-        // Apply only top padding to the Column so the search bar clears the TopAppBar.
-        // Bottom padding (FAB zone) is applied as LazyColumn contentPadding instead — this
-        // prevents a large blank panel above the nav bar while still letting the last item
-        // scroll above the FABs.
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -166,7 +226,7 @@ fun ConversationListScreen(
                 OutlinedTextField(
                     value = searchQuery,
                     onValueChange = { viewModel.onSearchQueryChanged(it) },
-                    placeholder = { Text("Search conversations") },
+                    placeholder = { Text(if (showArchived) "Search archived" else "Search conversations") },
                     leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                     trailingIcon = {
                         if (searchQuery.isNotBlank()) {
@@ -196,6 +256,15 @@ fun ConversationListScreen(
                                 modifier = Modifier.padding(top = 8.dp),
                             )
                         }
+                    } else if (showArchived) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("📦", style = MaterialTheme.typography.displayMedium)
+                            Text(
+                                text = "No archived conversations",
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(top = 8.dp),
+                            )
+                        }
                     } else {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text("🧵", style = MaterialTheme.typography.displayMedium)
@@ -219,71 +288,45 @@ fun ConversationListScreen(
                     contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                 ) {
                     items(conversations, key = { it.id }) { conversation ->
-                        Box {
-                            ListItem(
-                                headlineContent = {
-                                    Text(
-                                        text = conversation.title ?: "New conversation",
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                },
-                                supportingContent = {
-                                    Text(
-                                        text = formatTimestamp(conversation.updatedAt),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.outline,
-                                    )
-                                },
-                                leadingContent = if (isInSelectionMode) {
-                                    {
-                                        Checkbox(
-                                            checked = conversation.id in selectedConversationIds,
-                                            onCheckedChange = { viewModel.toggleSelection(conversation.id) },
-                                        )
-                                    }
-                                } else {
-                                    null
-                                },
-                                trailingContent = if (!isInSelectionMode) {
-                                    {
-                                        IconButton(onClick = { pendingDelete = conversation }) {
-                                            Icon(Icons.Default.Delete, contentDescription = "Delete")
-                                        }
-                                    }
-                                } else {
-                                    null
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .combinedClickable(
-                                        onClick = {
-                                            if (isInSelectionMode) {
-                                                viewModel.toggleSelection(conversation.id)
-                                            } else {
-                                                onOpenConversation(conversation.id)
-                                            }
-                                        },
-                                        onLongClick = {
-                                            if (!isInSelectionMode) {
-                                                contextMenuTarget = conversation
-                                            }
-                                        },
-                                    ),
-                            )
-                            // Long-press context menu — only when NOT in selection mode
-                            if (!isInSelectionMode) {
-                                DropdownMenu(
-                                    expanded = contextMenuTarget?.id == conversation.id,
-                                    onDismissRequest = { contextMenuTarget = null },
-                                ) {
+                        SwipeableConversationRow(
+                            conversation = conversation,
+                            isInSelectionMode = isInSelectionMode,
+                            isSelected = conversation.id in selectedConversationIds,
+                            showArchived = showArchived,
+                            onOpen = {
+                                if (isInSelectionMode) viewModel.toggleSelection(conversation.id)
+                                else onOpenConversation(conversation.id)
+                            },
+                            onLongClick = {
+                                if (!isInSelectionMode) contextMenuTarget = conversation
+                            },
+                            onToggleSelect = { viewModel.toggleSelection(conversation.id) },
+                            onArchive = { viewModel.archiveConversation(conversation.id) },
+                            onRestore = { viewModel.restoreConversation(conversation.id) },
+                            onDeleteRequest = { pendingDelete = conversation },
+                        )
+                        // Context menu — only when NOT in selection mode
+                        if (!isInSelectionMode) {
+                            DropdownMenu(
+                                expanded = contextMenuTarget?.id == conversation.id,
+                                onDismissRequest = { contextMenuTarget = null },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Select") },
+                                    onClick = {
+                                        contextMenuTarget = null
+                                        viewModel.enterSelectionMode(conversation.id)
+                                    },
+                                )
+                                if (showArchived) {
                                     DropdownMenuItem(
-                                        text = { Text("Select") },
+                                        text = { Text("Restore") },
                                         onClick = {
+                                            viewModel.restoreConversation(conversation.id)
                                             contextMenuTarget = null
-                                            viewModel.enterSelectionMode(conversation.id)
                                         },
                                     )
+                                } else {
                                     DropdownMenuItem(
                                         text = { Text("Rename") },
                                         onClick = {
@@ -292,13 +335,20 @@ fun ConversationListScreen(
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Delete") },
+                                        text = { Text("Archive") },
                                         onClick = {
-                                            pendingDelete = conversation
+                                            viewModel.archiveConversation(conversation.id)
                                             contextMenuTarget = null
                                         },
                                     )
                                 }
+                                DropdownMenuItem(
+                                    text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
+                                    onClick = {
+                                        pendingDelete = conversation
+                                        contextMenuTarget = null
+                                    },
+                                )
                             }
                         }
                         HorizontalDivider()
@@ -378,6 +428,186 @@ fun ConversationListScreen(
             },
         )
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+private fun SwipeableConversationRow(
+    conversation: ConversationEntity,
+    isInSelectionMode: Boolean,
+    isSelected: Boolean,
+    showArchived: Boolean,
+    onOpen: () -> Unit,
+    onLongClick: () -> Unit,
+    onToggleSelect: () -> Unit,
+    onArchive: () -> Unit,
+    onRestore: () -> Unit,
+    onDeleteRequest: () -> Unit,
+) {
+    // Track pending delete to show dialog after resetting dismiss state
+    var pendingSwipeDelete by remember { mutableStateOf(false) }
+
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            when (value) {
+                SwipeToDismissBoxValue.EndToStart -> {
+                    // Swipe left: archive (active) or restore (archived)
+                    if (showArchived) onRestore() else onArchive()
+                    false // Don't dismiss the item, just trigger action & snap back
+                }
+                SwipeToDismissBoxValue.StartToEnd -> {
+                    // Swipe right: request delete (show dialog via LaunchedEffect)
+                    pendingSwipeDelete = true
+                    false // Don't dismiss — dialog will handle it
+                }
+                SwipeToDismissBoxValue.Settled -> false
+            }
+        }
+    )
+
+    // Reset state after the action is triggered so the item snaps back
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
+            dismissState.reset()
+        }
+    }
+
+    // When a swipe-right delete is pending, trigger the delete dialog
+    LaunchedEffect(pendingSwipeDelete) {
+        if (pendingSwipeDelete) {
+            pendingSwipeDelete = false
+            onDeleteRequest()
+        }
+    }
+
+    if (isInSelectionMode) {
+        // In selection mode, skip swipe — just show the list item
+        ConversationListItem(
+            conversation = conversation,
+            isInSelectionMode = true,
+            isSelected = isSelected,
+            showArchived = showArchived,
+            onOpen = onOpen,
+            onLongClick = onLongClick,
+        )
+    } else {
+        SwipeToDismissBox(
+            state = dismissState,
+            backgroundContent = {
+                val direction = dismissState.dismissDirection
+                val isStartToEnd = direction == SwipeToDismissBoxValue.StartToEnd
+                val isEndToStart = direction == SwipeToDismissBoxValue.EndToStart
+
+                val backgroundColor by animateColorAsState(
+                    targetValue = when {
+                        isStartToEnd -> MaterialTheme.colorScheme.errorContainer
+                        isEndToStart -> if (showArchived) MaterialTheme.colorScheme.secondaryContainer
+                                        else MaterialTheme.colorScheme.tertiaryContainer
+                        else -> Color.Transparent
+                    },
+                    label = "swipe_bg",
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .padding(horizontal = 20.dp),
+                    contentAlignment = if (isStartToEnd) Alignment.CenterStart else Alignment.CenterEnd,
+                ) {
+                    when {
+                        isStartToEnd -> Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                        isEndToStart && showArchived -> Icon(
+                            Icons.Default.Unarchive,
+                            contentDescription = "Restore",
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        isEndToStart -> Icon(
+                            Icons.Default.Archive,
+                            contentDescription = "Archive",
+                            tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                        )
+                    }
+                }
+            },
+            enableDismissFromStartToEnd = !isInSelectionMode,
+            enableDismissFromEndToStart = !isInSelectionMode,
+            content = {
+                ConversationListItem(
+                    conversation = conversation,
+                    isInSelectionMode = false,
+                    isSelected = false,
+                    showArchived = showArchived,
+                    onOpen = onOpen,
+                    onLongClick = onLongClick,
+                )
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ConversationListItem(
+    conversation: ConversationEntity,
+    isInSelectionMode: Boolean,
+    isSelected: Boolean,
+    showArchived: Boolean,
+    onOpen: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = conversation.title ?: "New conversation",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = if (showArchived) MaterialTheme.colorScheme.onSurfaceVariant
+                        else MaterialTheme.colorScheme.onSurface,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = if (showArchived && conversation.archivedAt != null)
+                    "Archived ${formatTimestamp(conversation.archivedAt ?: conversation.updatedAt)}"
+                else
+                    formatTimestamp(conversation.updatedAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        },
+        leadingContent = if (isInSelectionMode) {
+            {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = null,
+                )
+            }
+        } else {
+            null
+        },
+        trailingContent = if (!isInSelectionMode) {
+            {
+                Icon(
+                    imageVector = Icons.Default.PushPin,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            null
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = onOpen,
+                onLongClick = onLongClick,
+            ),
+    )
 }
 
 private fun formatTimestamp(millis: Long): String {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -465,12 +465,8 @@ private fun SwipeableConversationRow(
         }
     )
 
-    // Reset state after the action is triggered so the item snaps back
-    LaunchedEffect(dismissState.currentValue) {
-        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
-            dismissState.reset()
-        }
-    }
+    // Snap-back is automatic: confirmValueChange always returns false,
+    // so AnchoredDraggable refuses the transition and animates back to Settled.
 
     // When a swipe-right delete is pending, trigger the delete dialog
     LaunchedEffect(pendingSwipeDelete) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -356,28 +357,25 @@ fun ConversationListScreen(
                                         onDeleteRequest = { pendingDelete = conversation },
                                         onTogglePin = { viewModel.togglePin(conversation.id) },
                                         onMoreClick = { contextMenuTarget = conversation },
-                                    )
-                                }
-                            }
-                            if (!isInSelectionMode) {
-                                DropdownMenu(
-                                    expanded = contextMenuTarget?.id == conversation.id,
-                                    onDismissRequest = { contextMenuTarget = null },
-                                ) {
-                                    ConversationContextMenuItems(
-                                        showArchived = false,
-                                        onRename = {
-                                            pendingRenameId = conversation.id
-                                            contextMenuTarget = null
-                                        },
-                                        onArchiveRequest = {
-                                            pendingArchive = conversation
-                                            contextMenuTarget = null
-                                        },
-                                        onRestore = {},
-                                        onDelete = {
-                                            pendingDelete = conversation
-                                            contextMenuTarget = null
+                                        menuExpanded = !isInSelectionMode && contextMenuTarget?.id == conversation.id,
+                                        onMenuDismiss = { contextMenuTarget = null },
+                                        menuContent = {
+                                            ConversationContextMenuItems(
+                                                showArchived = false,
+                                                onRename = {
+                                                    pendingRenameId = conversation.id
+                                                    contextMenuTarget = null
+                                                },
+                                                onArchiveRequest = {
+                                                    pendingArchive = conversation
+                                                    contextMenuTarget = null
+                                                },
+                                                onRestore = {},
+                                                onDelete = {
+                                                    pendingDelete = conversation
+                                                    contextMenuTarget = null
+                                                },
+                                            )
                                         },
                                     )
                                 }
@@ -430,28 +428,25 @@ fun ConversationListScreen(
                                         onDeleteRequest = { pendingDelete = conversation },
                                         onTogglePin = { viewModel.togglePin(conversation.id) },
                                         onMoreClick = { contextMenuTarget = conversation },
-                                    )
-                                }
-                            }
-                            if (!isInSelectionMode) {
-                                DropdownMenu(
-                                    expanded = contextMenuTarget?.id == conversation.id,
-                                    onDismissRequest = { contextMenuTarget = null },
-                                ) {
-                                    ConversationContextMenuItems(
-                                        showArchived = false,
-                                        onRename = {
-                                            pendingRenameId = conversation.id
-                                            contextMenuTarget = null
-                                        },
-                                        onArchiveRequest = {
-                                            pendingArchive = conversation
-                                            contextMenuTarget = null
-                                        },
-                                        onRestore = {},
-                                        onDelete = {
-                                            pendingDelete = conversation
-                                            contextMenuTarget = null
+                                        menuExpanded = !isInSelectionMode && contextMenuTarget?.id == conversation.id,
+                                        onMenuDismiss = { contextMenuTarget = null },
+                                        menuContent = {
+                                            ConversationContextMenuItems(
+                                                showArchived = false,
+                                                onRename = {
+                                                    pendingRenameId = conversation.id
+                                                    contextMenuTarget = null
+                                                },
+                                                onArchiveRequest = {
+                                                    pendingArchive = conversation
+                                                    contextMenuTarget = null
+                                                },
+                                                onRestore = {},
+                                                onDelete = {
+                                                    pendingDelete = conversation
+                                                    contextMenuTarget = null
+                                                },
+                                            )
                                         },
                                     )
                                 }
@@ -476,12 +471,9 @@ fun ConversationListScreen(
                                     if (!isInSelectionMode) viewModel.enterSelectionMode(conversation.id)
                                 },
                                 onMoreClick = { contextMenuTarget = conversation },
-                            )
-                            if (!isInSelectionMode) {
-                                DropdownMenu(
-                                    expanded = contextMenuTarget?.id == conversation.id,
-                                    onDismissRequest = { contextMenuTarget = null },
-                                ) {
+                                menuExpanded = !isInSelectionMode && contextMenuTarget?.id == conversation.id,
+                                onMenuDismiss = { contextMenuTarget = null },
+                                menuContent = {
                                     ConversationContextMenuItems(
                                         showArchived = true,
                                         onRename = {},
@@ -495,8 +487,8 @@ fun ConversationListScreen(
                                             contextMenuTarget = null
                                         },
                                     )
-                                }
-                            }
+                                },
+                            )
                             HorizontalDivider()
                         }
                     }
@@ -641,6 +633,9 @@ private fun SwipeableConversationRow(
     onDeleteRequest: () -> Unit,
     onTogglePin: () -> Unit,
     onMoreClick: () -> Unit,
+    menuExpanded: Boolean = false,
+    onMenuDismiss: () -> Unit = {},
+    menuContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
     var pendingSwipeDelete by remember { mutableStateOf(false) }
     var pendingSwipeArchive by remember { mutableStateOf(false) }
@@ -741,6 +736,9 @@ private fun SwipeableConversationRow(
                     onLongClick = onLongClick,
                     onTogglePin = onTogglePin,
                     onMoreClick = onMoreClick,
+                    menuExpanded = menuExpanded,
+                    onMenuDismiss = onMenuDismiss,
+                    menuContent = menuContent,
                 )
             },
         )
@@ -761,6 +759,9 @@ private fun ConversationListItem(
     onLongClick: () -> Unit,
     onTogglePin: (() -> Unit)? = null,
     onMoreClick: (() -> Unit)? = null,
+    menuExpanded: Boolean = false,
+    onMenuDismiss: () -> Unit = {},
+    menuContent: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
     ListItem(
         headlineContent = {
@@ -818,12 +819,21 @@ private fun ConversationListItem(
                         )
                     }
                     if (onMoreClick != null) {
-                        IconButton(onClick = onMoreClick) {
-                            Icon(
-                                Icons.Default.MoreVert,
-                                contentDescription = "More options",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                        Box {
+                            IconButton(onClick = onMoreClick) {
+                                Icon(
+                                    Icons.Default.MoreVert,
+                                    contentDescription = "More options",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            if (menuContent != null) {
+                                DropdownMenu(
+                                    expanded = menuExpanded,
+                                    onDismissRequest = onMenuDismiss,
+                                    content = menuContent,
+                                )
+                            }
                         }
                     }
                 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -2,9 +2,11 @@ package com.kernel.ai.feature.chat
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,26 +15,27 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
-import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -46,6 +49,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -62,6 +66,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -70,6 +75,8 @@ import com.kernel.ai.core.memory.entity.ConversationEntity
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -82,6 +89,8 @@ fun ConversationListScreen(
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
+    val pinnedConversations by viewModel.pinnedConversations.collectAsStateWithLifecycle()
+    val unpinnedConversations by viewModel.unpinnedConversations.collectAsStateWithLifecycle()
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsStateWithLifecycle()
     val selectedConversationIds by viewModel.selectedConversationIds.collectAsStateWithLifecycle()
@@ -89,10 +98,36 @@ fun ConversationListScreen(
     val showArchived by viewModel.showArchived.collectAsStateWithLifecycle()
 
     var pendingDelete by remember { mutableStateOf<ConversationEntity?>(null) }
+    var pendingArchive by remember { mutableStateOf<ConversationEntity?>(null) }
     var pendingRenameId by rememberSaveable { mutableStateOf<String?>(null) }
     val pendingRename = pendingRenameId?.let { id -> conversations.find { it.id == id } }
     var contextMenuTarget by remember { mutableStateOf<ConversationEntity?>(null) }
     var showOverflowMenu by remember { mutableStateOf(false) }
+
+    // ── Drag-and-drop local state (optimistic UI) ──────────────────────────
+    var localPinned by remember { mutableStateOf(pinnedConversations) }
+    var localUnpinned by remember { mutableStateOf(unpinnedConversations) }
+    var dragInProgress by remember { mutableStateOf(false) }
+    LaunchedEffect(pinnedConversations) { if (!dragInProgress) localPinned = pinnedConversations }
+    LaunchedEffect(unpinnedConversations) { if (!dragInProgress) localUnpinned = unpinnedConversations }
+
+    val lazyListState = rememberLazyListState()
+    val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val fromKey = from.key as? String ?: return@rememberReorderableLazyListState
+        val toKey = to.key as? String ?: return@rememberReorderableLazyListState
+        val fromInPinned = localPinned.any { it.id == fromKey }
+        val toInPinned = localPinned.any { it.id == toKey }
+        if (fromInPinned != toInPinned) return@rememberReorderableLazyListState
+        if (fromInPinned) {
+            val fi = localPinned.indexOfFirst { it.id == fromKey }
+            val ti = localPinned.indexOfFirst { it.id == toKey }
+            localPinned = localPinned.toMutableList().apply { add(ti, removeAt(fi)) }
+        } else {
+            val fi = localUnpinned.indexOfFirst { it.id == fromKey }
+            val ti = localUnpinned.indexOfFirst { it.id == toKey }
+            localUnpinned = localUnpinned.toMutableList().apply { add(ti, removeAt(fi)) }
+        }
+    }
 
     // Exit selection mode on system back instead of popping the screen
     BackHandler(enabled = isInSelectionMode) {
@@ -101,70 +136,49 @@ fun ConversationListScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    if (isInSelectionMode) {
-                        Text("${selectedConversationIds.size} / ${conversations.size} selected")
-                    } else if (showArchived) {
-                        Text("Archived")
-                    } else {
-                        Text("Jandal")
-                    }
-                },
-                navigationIcon = {
-                    if (!isInSelectionMode) {
-                        IconButton(onClick = onOpenDrawer) {
-                            Icon(Icons.Default.Menu, contentDescription = "Menu")
+            if (isInSelectionMode) {
+                // ── Contextual multi-select TopAppBar ──────────────────────
+                TopAppBar(
+                    title = { Text("${selectedConversationIds.size} selected") },
+                    navigationIcon = {
+                        IconButton(onClick = viewModel::clearSelection) {
+                            Icon(Icons.Default.Close, contentDescription = "Exit selection")
                         }
-                    }
-                },
-                actions = {
-                    if (isInSelectionMode) {
+                    },
+                    actions = {
                         TextButton(onClick = { viewModel.selectAll(conversations.map { it.id }) }) {
                             Text("Select All")
                         }
                         if (showArchived) {
-                            // Archived view: Restore + Delete
-                            Button(
-                                onClick = viewModel::restoreSelected,
-                                enabled = selectedConversationIds.isNotEmpty(),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                ),
-                            ) {
-                                Text("Restore (${selectedConversationIds.size})")
+                            IconButton(onClick = viewModel::restoreSelected) {
+                                Icon(Icons.Default.Unarchive, contentDescription = "Restore selected")
                             }
-                            Spacer(modifier = Modifier.width(4.dp))
                         } else {
-                            // Active view: Archive + Delete
-                            Button(
-                                onClick = viewModel::archiveSelected,
-                                enabled = selectedConversationIds.isNotEmpty(),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                ),
-                            ) {
-                                Text("Archive (${selectedConversationIds.size})")
+                            IconButton(onClick = viewModel::archiveSelected) {
+                                Icon(Icons.Default.Archive, contentDescription = "Archive selected")
                             }
-                            Spacer(modifier = Modifier.width(4.dp))
                         }
-                        Button(
-                            onClick = viewModel::requestBulkDelete,
-                            enabled = selectedConversationIds.isNotEmpty(),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.errorContainer,
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                            ),
-                        ) {
-                            Text("Delete (${selectedConversationIds.size})")
+                        IconButton(onClick = viewModel::requestBulkDelete) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete selected",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
                         }
-                        TextButton(onClick = viewModel::clearSelection) {
-                            Text("Cancel")
+                    },
+                )
+            } else {
+                // ── Normal TopAppBar ────────────────────────────────────────
+                TopAppBar(
+                    title = {
+                        if (showArchived) Text("Archived") else Text("Jandal")
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = "Menu")
                         }
-                    } else {
-                        // ⋮ overflow menu
+                    },
+                    actions = {
                         Box {
                             IconButton(onClick = { showOverflowMenu = true }) {
                                 Icon(Icons.Default.MoreVert, contentDescription = "More options")
@@ -174,7 +188,18 @@ fun ConversationListScreen(
                                 onDismissRequest = { showOverflowMenu = false },
                             ) {
                                 DropdownMenuItem(
-                                    text = { Text(if (showArchived) "Show Active" else "Show Archived") },
+                                    text = {
+                                        Text(
+                                            if (showArchived) "Show active conversations"
+                                            else "Show archived conversations",
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            if (showArchived) Icons.Default.Unarchive else Icons.Default.Archive,
+                                            contentDescription = null,
+                                        )
+                                    },
                                     onClick = {
                                         showOverflowMenu = false
                                         viewModel.toggleShowArchived()
@@ -182,9 +207,9 @@ fun ConversationListScreen(
                                 )
                             }
                         }
-                    }
-                },
-            )
+                    },
+                )
+            }
         },
         floatingActionButton = {
             if (!isInSelectionMode && !showArchived) {
@@ -286,78 +311,231 @@ fun ConversationListScreen(
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
+                    state = lazyListState,
                     contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                 ) {
-                    items(conversations, key = { it.id }) { conversation ->
-                        SwipeableConversationRow(
-                            conversation = conversation,
-                            isInSelectionMode = isInSelectionMode,
-                            isSelected = conversation.id in selectedConversationIds,
-                            showArchived = showArchived,
-                            onOpen = {
-                                if (isInSelectionMode) viewModel.toggleSelection(conversation.id)
-                                else onOpenConversation(conversation.id)
-                            },
-                            onLongClick = {
-                                if (!isInSelectionMode) contextMenuTarget = conversation
-                            },
-                            onToggleSelect = { viewModel.toggleSelection(conversation.id) },
-                            onArchive = { viewModel.archiveConversation(conversation.id) },
-                            onRestore = { viewModel.restoreConversation(conversation.id) },
-                            onDeleteRequest = { pendingDelete = conversation },
-                            onTogglePin = { viewModel.togglePin(conversation.id) },
-                        )
-                        // Context menu — only when NOT in selection mode
-                        if (!isInSelectionMode) {
-                            DropdownMenu(
-                                expanded = contextMenuTarget?.id == conversation.id,
-                                onDismissRequest = { contextMenuTarget = null },
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text("Select") },
-                                    onClick = {
-                                        contextMenuTarget = null
-                                        viewModel.enterSelectionMode(conversation.id)
-                                    },
+                    // ── Pinned section (active view only) ───────────────────
+                    if (!showArchived && localPinned.isNotEmpty()) {
+                        stickyHeader(key = "header_pinned") {
+                            ConversationSectionHeader(label = "Pinned")
+                        }
+                        items(localPinned, key = { it.id }) { conversation ->
+                            ReorderableItem(reorderState, key = conversation.id) { isDragging ->
+                                val elevation by animateDpAsState(
+                                    if (isDragging) 6.dp else 0.dp,
+                                    label = "drag_elevation_pinned",
                                 )
-                                if (showArchived) {
-                                    DropdownMenuItem(
-                                        text = { Text("Restore") },
-                                        onClick = {
-                                            viewModel.restoreConversation(conversation.id)
-                                            contextMenuTarget = null
+                                Surface(shadowElevation = elevation) {
+                                    SwipeableConversationRow(
+                                        conversation = conversation,
+                                        isInSelectionMode = isInSelectionMode,
+                                        isSelected = conversation.id in selectedConversationIds,
+                                        showArchived = false,
+                                        dragHandleModifier = if (!isInSelectionMode) {
+                                            Modifier.draggableHandle(
+                                                onDragStarted = { dragInProgress = true },
+                                                onDragStopped = {
+                                                    dragInProgress = false
+                                                    viewModel.onConversationsReordered(
+                                                        localPinned.map { it.id },
+                                                        localUnpinned.map { it.id },
+                                                    )
+                                                },
+                                            )
+                                        } else Modifier,
+                                        onOpen = {
+                                            if (isInSelectionMode) viewModel.toggleSelection(conversation.id)
+                                            else onOpenConversation(conversation.id)
                                         },
+                                        onLongClick = {
+                                            if (!isInSelectionMode) contextMenuTarget = conversation
+                                        },
+                                        onToggleSelect = { viewModel.toggleSelection(conversation.id) },
+                                        onArchiveRequest = { pendingArchive = conversation },
+                                        onRestore = { viewModel.restoreConversation(conversation.id) },
+                                        onDeleteRequest = { pendingDelete = conversation },
+                                        onTogglePin = { viewModel.togglePin(conversation.id) },
                                     )
-                                } else {
-                                    DropdownMenuItem(
-                                        text = { Text("Rename") },
-                                        onClick = {
+                                }
+                            }
+                            if (!isInSelectionMode) {
+                                DropdownMenu(
+                                    expanded = contextMenuTarget?.id == conversation.id,
+                                    onDismissRequest = { contextMenuTarget = null },
+                                ) {
+                                    ConversationContextMenuItems(
+                                        showArchived = false,
+                                        onSelect = {
+                                            contextMenuTarget = null
+                                            viewModel.enterSelectionMode(conversation.id)
+                                        },
+                                        onRename = {
                                             pendingRenameId = conversation.id
                                             contextMenuTarget = null
                                         },
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text("Archive") },
-                                        onClick = {
-                                            viewModel.archiveConversation(conversation.id)
+                                        onArchiveRequest = {
+                                            pendingArchive = conversation
+                                            contextMenuTarget = null
+                                        },
+                                        onRestore = {},
+                                        onDelete = {
+                                            pendingDelete = conversation
                                             contextMenuTarget = null
                                         },
                                     )
                                 }
-                                DropdownMenuItem(
-                                    text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
-                                    onClick = {
-                                        pendingDelete = conversation
-                                        contextMenuTarget = null
-                                    },
-                                )
+                            }
+                            HorizontalDivider()
+                        }
+                    }
+
+                    // ── Unpinned section (active view only) ─────────────────
+                    if (!showArchived) {
+                        if (localPinned.isNotEmpty() && localUnpinned.isNotEmpty()) {
+                            stickyHeader(key = "header_other") {
+                                ConversationSectionHeader(label = "Other")
                             }
                         }
-                        HorizontalDivider()
+                        items(localUnpinned, key = { it.id }) { conversation ->
+                            ReorderableItem(reorderState, key = conversation.id) { isDragging ->
+                                val elevation by animateDpAsState(
+                                    if (isDragging) 6.dp else 0.dp,
+                                    label = "drag_elevation_unpinned",
+                                )
+                                Surface(shadowElevation = elevation) {
+                                    SwipeableConversationRow(
+                                        conversation = conversation,
+                                        isInSelectionMode = isInSelectionMode,
+                                        isSelected = conversation.id in selectedConversationIds,
+                                        showArchived = false,
+                                        dragHandleModifier = if (!isInSelectionMode) {
+                                            Modifier.draggableHandle(
+                                                onDragStarted = { dragInProgress = true },
+                                                onDragStopped = {
+                                                    dragInProgress = false
+                                                    viewModel.onConversationsReordered(
+                                                        localPinned.map { it.id },
+                                                        localUnpinned.map { it.id },
+                                                    )
+                                                },
+                                            )
+                                        } else Modifier,
+                                        onOpen = {
+                                            if (isInSelectionMode) viewModel.toggleSelection(conversation.id)
+                                            else onOpenConversation(conversation.id)
+                                        },
+                                        onLongClick = {
+                                            if (!isInSelectionMode) contextMenuTarget = conversation
+                                        },
+                                        onToggleSelect = { viewModel.toggleSelection(conversation.id) },
+                                        onArchiveRequest = { pendingArchive = conversation },
+                                        onRestore = { viewModel.restoreConversation(conversation.id) },
+                                        onDeleteRequest = { pendingDelete = conversation },
+                                        onTogglePin = { viewModel.togglePin(conversation.id) },
+                                    )
+                                }
+                            }
+                            if (!isInSelectionMode) {
+                                DropdownMenu(
+                                    expanded = contextMenuTarget?.id == conversation.id,
+                                    onDismissRequest = { contextMenuTarget = null },
+                                ) {
+                                    ConversationContextMenuItems(
+                                        showArchived = false,
+                                        onSelect = {
+                                            contextMenuTarget = null
+                                            viewModel.enterSelectionMode(conversation.id)
+                                        },
+                                        onRename = {
+                                            pendingRenameId = conversation.id
+                                            contextMenuTarget = null
+                                        },
+                                        onArchiveRequest = {
+                                            pendingArchive = conversation
+                                            contextMenuTarget = null
+                                        },
+                                        onRestore = {},
+                                        onDelete = {
+                                            pendingDelete = conversation
+                                            contextMenuTarget = null
+                                        },
+                                    )
+                                }
+                            }
+                            HorizontalDivider()
+                        }
                     }
+
+                    // ── Archived section ──────────────────────────────────────
+                    if (showArchived) {
+                        items(conversations, key = { it.id }) { conversation ->
+                            ConversationListItem(
+                                conversation = conversation,
+                                isInSelectionMode = isInSelectionMode,
+                                isSelected = conversation.id in selectedConversationIds,
+                                showArchived = true,
+                                onOpen = {
+                                    if (isInSelectionMode) viewModel.toggleSelection(conversation.id)
+                                    else onOpenConversation(conversation.id)
+                                },
+                                onLongClick = {
+                                    if (!isInSelectionMode) contextMenuTarget = conversation
+                                },
+                            )
+                            if (!isInSelectionMode) {
+                                DropdownMenu(
+                                    expanded = contextMenuTarget?.id == conversation.id,
+                                    onDismissRequest = { contextMenuTarget = null },
+                                ) {
+                                    ConversationContextMenuItems(
+                                        showArchived = true,
+                                        onSelect = {
+                                            contextMenuTarget = null
+                                            viewModel.enterSelectionMode(conversation.id)
+                                        },
+                                        onRename = {},
+                                        onArchiveRequest = {},
+                                        onRestore = {
+                                            viewModel.restoreConversation(conversation.id)
+                                            contextMenuTarget = null
+                                        },
+                                        onDelete = {
+                                            pendingDelete = conversation
+                                            contextMenuTarget = null
+                                        },
+                                    )
+                                }
+                            }
+                            HorizontalDivider()
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(88.dp)) }
                 }
             }
         } // end Column
+    }
+
+    // Archive confirmation dialog
+    pendingArchive?.let { conversation ->
+        AlertDialog(
+            onDismissRequest = { pendingArchive = null },
+            title = { Text("Archive conversation?") },
+            text = {
+                Text("\"${conversation.title ?: "New conversation"}\" will be moved to archive.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.archiveConversation(conversation.id)
+                        pendingArchive = null
+                    }
+                ) { Text("Archive") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingArchive = null }) { Text("Cancel") }
+            },
+        )
     }
 
     // Delete confirmation dialog
@@ -432,6 +610,32 @@ fun ConversationListScreen(
     }
 }
 
+// ── Shared context menu items ────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ConversationContextMenuItems(
+    showArchived: Boolean,
+    onSelect: () -> Unit,
+    onRename: () -> Unit,
+    onArchiveRequest: () -> Unit,
+    onRestore: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    DropdownMenuItem(text = { Text("Select") }, onClick = onSelect)
+    if (showArchived) {
+        DropdownMenuItem(text = { Text("Restore") }, onClick = onRestore)
+    } else {
+        DropdownMenuItem(text = { Text("Rename") }, onClick = onRename)
+        DropdownMenuItem(text = { Text("Archive") }, onClick = onArchiveRequest)
+    }
+    DropdownMenuItem(
+        text = { Text("Delete", color = MaterialTheme.colorScheme.error) },
+        onClick = onDelete,
+    )
+}
+
+// ── SwipeableConversationRow ─────────────────────────────────────────────────────────────────────
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 private fun SwipeableConversationRow(
@@ -439,39 +643,34 @@ private fun SwipeableConversationRow(
     isInSelectionMode: Boolean,
     isSelected: Boolean,
     showArchived: Boolean,
+    dragHandleModifier: Modifier = Modifier,
     onOpen: () -> Unit,
     onLongClick: () -> Unit,
     onToggleSelect: () -> Unit,
-    onArchive: () -> Unit,
+    onArchiveRequest: () -> Unit,
     onRestore: () -> Unit,
     onDeleteRequest: () -> Unit,
     onTogglePin: () -> Unit,
 ) {
-    // Track pending delete to show dialog after resetting dismiss state
     var pendingSwipeDelete by remember { mutableStateOf(false) }
+    var pendingSwipeArchive by remember { mutableStateOf(false) }
 
     val dismissState = rememberSwipeToDismissBoxState(
         confirmValueChange = { value ->
             when (value) {
                 SwipeToDismissBoxValue.EndToStart -> {
-                    // Swipe left: archive (active) or restore (archived)
-                    if (showArchived) onRestore() else onArchive()
-                    false // Don't dismiss the item, just trigger action & snap back
+                    if (showArchived) onRestore() else { pendingSwipeArchive = true }
+                    false
                 }
                 SwipeToDismissBoxValue.StartToEnd -> {
-                    // Swipe right: request delete (show dialog via LaunchedEffect)
                     pendingSwipeDelete = true
-                    false // Don't dismiss — dialog will handle it
+                    false
                 }
                 SwipeToDismissBoxValue.Settled -> false
             }
-        }
+        },
     )
 
-    // Snap-back is automatic: confirmValueChange always returns false,
-    // so AnchoredDraggable refuses the transition and animates back to Settled.
-
-    // When a swipe-right delete is pending, trigger the delete dialog
     LaunchedEffect(pendingSwipeDelete) {
         if (pendingSwipeDelete) {
             pendingSwipeDelete = false
@@ -479,8 +678,14 @@ private fun SwipeableConversationRow(
         }
     }
 
+    LaunchedEffect(pendingSwipeArchive) {
+        if (pendingSwipeArchive) {
+            pendingSwipeArchive = false
+            onArchiveRequest()
+        }
+    }
+
     if (isInSelectionMode) {
-        // In selection mode, skip swipe — just show the list item
         ConversationListItem(
             conversation = conversation,
             isInSelectionMode = true,
@@ -489,7 +694,8 @@ private fun SwipeableConversationRow(
             onOpen = onOpen,
             onLongClick = onLongClick,
         )
-    } else {        SwipeToDismissBox(
+    } else {
+        SwipeToDismissBox(
             state = dismissState,
             backgroundContent = {
                 val direction = dismissState.dismissDirection
@@ -500,7 +706,7 @@ private fun SwipeableConversationRow(
                     targetValue = when {
                         isStartToEnd -> MaterialTheme.colorScheme.errorContainer
                         isEndToStart -> if (showArchived) MaterialTheme.colorScheme.secondaryContainer
-                                        else MaterialTheme.colorScheme.tertiaryContainer
+                                        else Color(0xFF2E7D32)
                         else -> Color.Transparent
                     },
                     label = "swipe_bg",
@@ -527,19 +733,20 @@ private fun SwipeableConversationRow(
                         isEndToStart -> Icon(
                             Icons.Default.Archive,
                             contentDescription = "Archive",
-                            tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                            tint = Color.White,
                         )
                     }
                 }
             },
-            enableDismissFromStartToEnd = !isInSelectionMode,
-            enableDismissFromEndToStart = !isInSelectionMode,
+            enableDismissFromStartToEnd = true,
+            enableDismissFromEndToStart = true,
             content = {
                 ConversationListItem(
                     conversation = conversation,
                     isInSelectionMode = false,
                     isSelected = false,
                     showArchived = showArchived,
+                    dragHandleModifier = dragHandleModifier,
                     onOpen = onOpen,
                     onLongClick = onLongClick,
                     onTogglePin = onTogglePin,
@@ -549,6 +756,8 @@ private fun SwipeableConversationRow(
     }
 }
 
+// ── ConversationListItem ─────────────────────────────────────────────────────────────────────────
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ConversationListItem(
@@ -556,6 +765,7 @@ private fun ConversationListItem(
     isInSelectionMode: Boolean,
     isSelected: Boolean,
     showArchived: Boolean,
+    dragHandleModifier: Modifier = Modifier,
     onOpen: () -> Unit,
     onLongClick: () -> Unit,
     onTogglePin: (() -> Unit)? = null,
@@ -590,14 +800,28 @@ private fun ConversationListItem(
         } else {
             null
         },
-        trailingContent = if (!isInSelectionMode && !showArchived && onTogglePin != null) {
+        trailingContent = if (!isInSelectionMode && !showArchived) {
             {
-                IconButton(onClick = onTogglePin) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (onTogglePin != null) {
+                        IconButton(onClick = onTogglePin) {
+                            Icon(
+                                imageVector = if (conversation.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                                contentDescription = if (conversation.pinned) "Unpin" else "Pin",
+                                tint = if (conversation.pinned) MaterialTheme.colorScheme.primary
+                                       else MaterialTheme.colorScheme.outline,
+                            )
+                        }
+                    }
                     Icon(
-                        imageVector = if (conversation.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
-                        contentDescription = if (conversation.pinned) "Unpin" else "Pin",
-                        tint = if (conversation.pinned) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.outline,
+                        Icons.Default.DragHandle,
+                        contentDescription = "Drag to reorder",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = dragHandleModifier
+                            .pointerInput(Unit) {
+                                detectTapGestures(onLongPress = { /* absorb — prevent combinedClickable from firing */ })
+                            }
+                            .padding(horizontal = 4.dp),
                     )
                 }
             }
@@ -610,6 +834,20 @@ private fun ConversationListItem(
                 onClick = onOpen,
                 onLongClick = onLongClick,
             ),
+    )
+}
+
+/** Sticky section header — surface background so it occludes scrolled-under rows. */
+@Composable
+private fun ConversationSectionHeader(label: String) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 6.dp),
     )
 }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material3.AlertDialog
@@ -304,6 +305,7 @@ fun ConversationListScreen(
                             onArchive = { viewModel.archiveConversation(conversation.id) },
                             onRestore = { viewModel.restoreConversation(conversation.id) },
                             onDeleteRequest = { pendingDelete = conversation },
+                            onTogglePin = { viewModel.togglePin(conversation.id) },
                         )
                         // Context menu — only when NOT in selection mode
                         if (!isInSelectionMode) {
@@ -443,6 +445,7 @@ private fun SwipeableConversationRow(
     onArchive: () -> Unit,
     onRestore: () -> Unit,
     onDeleteRequest: () -> Unit,
+    onTogglePin: () -> Unit,
 ) {
     // Track pending delete to show dialog after resetting dismiss state
     var pendingSwipeDelete by remember { mutableStateOf(false) }
@@ -486,8 +489,7 @@ private fun SwipeableConversationRow(
             onOpen = onOpen,
             onLongClick = onLongClick,
         )
-    } else {
-        SwipeToDismissBox(
+    } else {        SwipeToDismissBox(
             state = dismissState,
             backgroundContent = {
                 val direction = dismissState.dismissDirection
@@ -540,6 +542,7 @@ private fun SwipeableConversationRow(
                     showArchived = showArchived,
                     onOpen = onOpen,
                     onLongClick = onLongClick,
+                    onTogglePin = onTogglePin,
                 )
             },
         )
@@ -555,6 +558,7 @@ private fun ConversationListItem(
     showArchived: Boolean,
     onOpen: () -> Unit,
     onLongClick: () -> Unit,
+    onTogglePin: (() -> Unit)? = null,
 ) {
     ListItem(
         headlineContent = {
@@ -586,13 +590,16 @@ private fun ConversationListItem(
         } else {
             null
         },
-        trailingContent = if (!isInSelectionMode) {
+        trailingContent = if (!isInSelectionMode && !showArchived && onTogglePin != null) {
             {
-                Icon(
-                    imageVector = Icons.Default.PushPin,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.outline,
-                )
+                IconButton(onClick = onTogglePin) {
+                    Icon(
+                        imageVector = if (conversation.pinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = if (conversation.pinned) "Unpin" else "Pin",
+                        tint = if (conversation.pinned) MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.outline,
+                    )
+                }
             }
         } else {
             null

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -39,6 +40,14 @@ class ConversationListViewModel @Inject constructor(
                 }
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val pinnedConversations: StateFlow<List<ConversationEntity>> = conversations
+        .map { it.filter { c -> c.pinned } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val unpinnedConversations: StateFlow<List<ConversationEntity>> = conversations
+        .map { it.filter { c -> !c.pinned } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun onSearchQueryChanged(query: String) { _searchQuery.value = query }
 
@@ -164,6 +173,12 @@ class ConversationListViewModel @Inject constructor(
                 _isInSelectionMode.value = false
                 _selectedConversationIds.value = emptySet()
             }
+        }
+    }
+
+    fun onConversationsReordered(pinnedIds: List<String>, unpinnedIds: List<String>) {
+        viewModelScope.launch {
+            repository.reorderConversations(pinnedIds, unpinnedIds)
         }
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -23,16 +24,32 @@ class ConversationListViewModel @Inject constructor(
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
-    val conversations: StateFlow<List<ConversationEntity>> = _searchQuery
-        .flatMapLatest { query ->
-            if (query.isBlank()) repository.observeConversations()
-            else repository.searchByTitle(query.escapeLikeWildcards())
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    private val _showArchived = MutableStateFlow(false)
+    val showArchived: StateFlow<Boolean> = _showArchived.asStateFlow()
+
+    val conversations: StateFlow<List<ConversationEntity>> =
+        combine(_searchQuery, _showArchived) { q, archived -> q to archived }
+            .flatMapLatest { (query, archived) ->
+                if (archived) {
+                    if (query.isBlank()) repository.observeArchived()
+                    else repository.searchArchived(query.escapeLikeWildcards())
+                } else {
+                    if (query.isBlank()) repository.observeActive()
+                    else repository.searchActive(query.escapeLikeWildcards())
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun onSearchQueryChanged(query: String) { _searchQuery.value = query }
 
     fun clearSearch() { _searchQuery.value = "" }
+
+    fun toggleShowArchived() {
+        _showArchived.value = !_showArchived.value
+        // Reset search and selection when toggling views
+        _searchQuery.value = ""
+        clearSelection()
+    }
 
     private fun String.escapeLikeWildcards(): String =
         replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -40,6 +57,18 @@ class ConversationListViewModel @Inject constructor(
     fun deleteConversation(conversation: ConversationEntity) {
         viewModelScope.launch {
             repository.deleteConversation(conversation)
+        }
+    }
+
+    fun archiveConversation(id: String) {
+        viewModelScope.launch {
+            repository.archiveConversation(id)
+        }
+    }
+
+    fun restoreConversation(id: String) {
+        viewModelScope.launch {
+            repository.restoreConversation(id)
         }
     }
 
@@ -107,5 +136,28 @@ class ConversationListViewModel @Inject constructor(
             }
         }
     }
-}
 
+    fun archiveSelected() {
+        val ids = _selectedConversationIds.value.toSet()
+        viewModelScope.launch {
+            try {
+                repository.archiveSelected(ids)
+            } finally {
+                _isInSelectionMode.value = false
+                _selectedConversationIds.value = emptySet()
+            }
+        }
+    }
+
+    fun restoreSelected() {
+        val ids = _selectedConversationIds.value.toSet()
+        viewModelScope.launch {
+            try {
+                repository.restoreSelected(ids)
+            } finally {
+                _isInSelectionMode.value = false
+                _selectedConversationIds.value = emptySet()
+            }
+        }
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListViewModel.kt
@@ -72,6 +72,12 @@ class ConversationListViewModel @Inject constructor(
         }
     }
 
+    fun togglePin(id: String) {
+        viewModelScope.launch {
+            repository.togglePin(id)
+        }
+    }
+
     fun renameConversation(id: String, title: String) {
         viewModelScope.launch {
             repository.renameConversation(id, title)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
@@ -1,0 +1,131 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+
+private val RETENTION_OPTIONS = listOf(
+    1 to "1 day",
+    3 to "3 days",
+    7 to "7 days",
+    14 to "14 days",
+    30 to "30 days",
+    -1 to "Never",
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatPreferencesScreen(
+    onBack: () -> Unit = {},
+    viewModel: ChatPreferencesViewModel = hiltViewModel(),
+) {
+    val retentionDays by viewModel.archiveRetentionDays.collectAsStateWithLifecycle()
+    var showRetentionPicker by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Chat Preferences") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Text(
+                text = "Archive",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            val currentLabel = RETENTION_OPTIONS.find { it.first == retentionDays }?.second ?: "7 days"
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showRetentionPicker = true },
+                headlineContent = { Text("Auto-delete archived after") },
+                supportingContent = { Text(currentLabel) },
+            )
+            HorizontalDivider()
+        }
+    }
+
+    if (showRetentionPicker) {
+        AlertDialog(
+            onDismissRequest = { showRetentionPicker = false },
+            title = { Text("Auto-delete archived after") },
+            text = {
+                Column {
+                    RETENTION_OPTIONS.forEach { (days, label) ->
+                        ListItem(
+                            headlineContent = { Text(label) },
+                            leadingContent = {
+                                RadioButton(
+                                    selected = days == retentionDays,
+                                    onClick = {
+                                        scope.launch { viewModel.setArchiveRetentionDays(days) }
+                                        showRetentionPicker = false
+                                    },
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    scope.launch { viewModel.setArchiveRetentionDays(days) }
+                                    showRetentionPicker = false
+                                },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showRetentionPicker = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChatPreferencesScreenPreview() {
+    MaterialTheme {
+        ChatPreferencesScreen()
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
@@ -1,0 +1,26 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.prefs.ChatPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatPreferencesViewModel @Inject constructor(
+    private val chatPreferences: ChatPreferences,
+) : ViewModel() {
+
+    val archiveRetentionDays: StateFlow<Int> = chatPreferences.archiveRetentionDays
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 7)
+
+    fun setArchiveRetentionDays(days: Int) {
+        viewModelScope.launch {
+            chatPreferences.setArchiveRetentionDays(days)
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
@@ -58,6 +59,7 @@ fun SettingsScreen(
     onNavigateToVoice: () -> Unit = {},
     onNavigateToModelSettings: () -> Unit = {},
     onNavigateToModelManagement: (preferred: Boolean) -> Unit = {},
+    onNavigateToChatPreferences: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -212,6 +214,17 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToChatPreferences() },
+                headlineContent = { Text("Chat Preferences") },
+                supportingContent = { Text("Auto-delete archived conversations") },
+                leadingContent = { Icon(Icons.Default.Forum, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
 
             ListItem(
                 modifier = Modifier


### PR DESCRIPTION
## Summary

Chat UX overhaul — conversation archive, pin, drag-to-reorder, swipe gestures, auto-delete WorkManager job, and a new Chat Preferences settings section.

## Changes

### Data layer
- `ConversationEntity` — `archivedAt: Long?`, `pinned: Boolean`, `sortOrder: Int` fields added
- `KernelDatabase` — version 41 → 44 with migrations 41→42, 42→43, 43→44
- `ConversationDao` — archive/restore/pin/sortOrder queries; `observeActive` orders by `pinned DESC, sort_order ASC, updated_at DESC`
- `ConversationRepository` — archive/restore/pin/reorder/bulk methods; vec cleanup on delete
- `ChatPreferences` (new) — DataStore-backed `archiveRetentionDays`, default 7, −1 = Never
- `ArchiveCleanupWorker` (new) — `@HiltWorker` `CoroutineWorker`, daily cadence, battery-not-low

### Conversation list UI
- **Pin/unpin** — trailing `IconButton` (pushpin icon, filled/outlined) on each row; `togglePin()` in ViewModel; pinned conversations sticky at top in a separate section
- **Drag-to-reorder** — `sh.calvin.reorderable:2.4.3`; `ReorderableItem` + drag handle on each row; `onConversationsReordered` persists new `sortOrder`
- **Swipe-to-archive** — `SwipeToDismissBox` swipe left; green background (`#2E7D32`) + archive icon; confirmation dialog before archiving (same pattern as delete); snap-back automatic
- **Swipe-to-delete** — swipe right → delete confirmation dialog (existing behaviour)
- **Multi-select** — dedicated `TopAppBar` with Close nav icon + icon-only action buttons (no more cramped text); Archive/Restore + Delete based on active/archived view
- **Long-press → immediate multi-select** — long press enters selection mode directly; no intermediate context menu step
- **⋮ icon on each row** — opens context menu (Archive/Restore, Rename, Delete); keeps UX consistent with Lists
- **Overflow menu** — "Show Archived" / "Show Active" toggle + filter icon in top-right
- **Archived view** — muted colour tones, "Archived" label; read-only

### Chat screen
- **"Archived · Read-only" banner** shown when `isArchived = true`; input bar fully hidden
- **Nav bar insets** — `.navigationBarsPadding()` applied to content column for archived chats so the last message is not hidden behind the Android navigation bar
- **Skip model init for archived** — `initEngineWhenReady()` and eviction re-init gated on `!archived` (reads real DB state via `firstOrNull()` before deciding); no wasteful Gemma-4 E4B load for read-only chats

### Settings
- `ChatPreferencesScreen` (new) — retention picker: 1 day / 3 days / **7 days** (default) / 14 days / 30 days / Never
- `ChatPreferencesViewModel` (new)
- `SettingsScreen` — "Chat Preferences" entry
- `KernelNavHost` — `ROUTE_CHAT_PREFERENCES` wired

### Schema
- `core/memory/schemas/.../42.json`, `43.json`, `44.json` committed

## Code review fixes
- **Vec orphan fix:** `deleteArchivedOlderThan` fetches IDs, cleans sqlite-vec entries, then bulk-DELETEs — no orphaned embedding vectors in RAG after auto-delete
- **Atomic bulk ops:** `archiveSelected`/`restoreSelected` use single `UPDATE … WHERE id IN (…)` — no partial state on process death
- **Dead code removed:** `LaunchedEffect(dismissState.currentValue)` reset block removed; snap-back handled by `AnchoredDraggable`

## Testing
- [x] `./gradlew :feature:chat:testDebugUnitTest` — passes (pre-existing `LatexConversionTest` failure excluded)
- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL

## Manual testing checklist
- [ ] Swipe left → archive confirmation dialog → archived; row snaps back
- [ ] Swipe right → delete confirmation dialog
- [ ] Long-press → enters multi-select immediately (no intermediate menu)
- [ ] ⋮ icon → context menu with Archive/Restore/Rename/Delete
- [ ] ⋮ top-right overflow → "Show Archived" / "Show Active" toggle
- [ ] Drag handle → reorder conversation; order persists after restart
- [ ] Pin icon → conversation moves to pinned section at top
- [ ] Open archived conversation → banner shown, no input bar, last message above nav bar
- [ ] Multi-select active view → Archive + Delete icon buttons
- [ ] Multi-select archived view → Restore + Delete icon buttons
- [ ] Settings → Chat Preferences → change retention → saved across restart
- [ ] DB upgrade 41→44 — no crash

## Related issues

Closes #905
