### PR TITLE
feat(#882): add favourite recipe groundwork

### DIFF
--- a/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/46.json
+++ b/core/memory/schemas/com.kernel.ai.core.memory.KernelDatabase/46.json
@@ -1,0 +1,1927 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "ff53929b35b8e34b78be6db4f835442d",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastDistilledAt` INTEGER, `archivedAt` INTEGER, `pinned` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDistilledAt",
+            "columnName": "lastDistilledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `thinkingText` TEXT, `timestamp` INTEGER NOT NULL, `toolCallJson` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thinkingText",
+            "columnName": "thinkingText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolCallJson",
+            "columnName": "toolCallJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "message_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` TEXT NOT NULL, `conversationId` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `messages`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_embeddings_messageId",
+            "unique": true,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_message_embeddings_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_message_embeddings_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_embeddings_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "messages",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `profileText` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `structuredJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileText",
+            "columnName": "profileText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredJson",
+            "columnName": "structuredJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episodic_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `vectorized` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodic_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodic_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "core_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_core_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_core_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "kiwi_memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `accessCount` INTEGER NOT NULL, `source` TEXT NOT NULL, `vectorized` INTEGER NOT NULL, `category` TEXT NOT NULL, `term` TEXT NOT NULL, `definition` TEXT NOT NULL, `triggerContext` TEXT NOT NULL, `vibeLevel` INTEGER NOT NULL, `metadataJson` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessCount",
+            "columnName": "accessCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vectorized",
+            "columnName": "vectorized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definition",
+            "columnName": "definition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "triggerContext",
+            "columnName": "triggerContext",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vibeLevel",
+            "columnName": "vibeLevel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_kiwi_memories_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_kiwi_memories_id` ON `${TABLE_NAME}` (`id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "model_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`modelId` TEXT NOT NULL, `contextWindowSize` INTEGER NOT NULL, `temperature` REAL NOT NULL, `topP` REAL NOT NULL, `topK` INTEGER NOT NULL, `showThinkingProcess` INTEGER NOT NULL, `correctGroundedFactsEnabled` INTEGER NOT NULL, `speculativeDecodingEnabled` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`modelId`))",
+        "fields": [
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextWindowSize",
+            "columnName": "contextWindowSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "topP",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topK",
+            "columnName": "topK",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showThinkingProcess",
+            "columnName": "showThinkingProcess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctGroundedFactsEnabled",
+            "columnName": "correctGroundedFactsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speculativeDecodingEnabled",
+            "columnName": "speculativeDecodingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "modelId"
+          ]
+        }
+      },
+      {
+        "tableName": "quick_actions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `userQuery` TEXT NOT NULL, `skillName` TEXT, `resultText` TEXT NOT NULL, `isSuccess` INTEGER NOT NULL, `presentationJson` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "userQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skillName",
+            "columnName": "skillName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultText",
+            "columnName": "resultText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentationJson",
+            "columnName": "presentationJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "scheduled_alarms",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `owner_id` TEXT, `triggerAtMillis` INTEGER NOT NULL, `label` TEXT, `createdAt` INTEGER NOT NULL, `fired` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `entry_type` TEXT NOT NULL, `duration_ms` INTEGER, `started_at_ms` INTEGER, `alarm_hour` INTEGER, `alarm_minute` INTEGER, `repeat_type` TEXT, `repeat_days_mask` INTEGER, `one_off_date_epoch_day` INTEGER, `time_zone_id` TEXT, `sound_uri` TEXT, `snoozed_until_ms` INTEGER, `completed_at_ms` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "triggerAtMillis",
+            "columnName": "triggerAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fired",
+            "columnName": "fired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entry_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAtMs",
+            "columnName": "started_at_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmHour",
+            "columnName": "alarm_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alarmMinute",
+            "columnName": "alarm_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeatType",
+            "columnName": "repeat_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repeatDaysMask",
+            "columnName": "repeat_days_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "oneOffDateEpochDay",
+            "columnName": "one_off_date_epoch_day",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timeZoneId",
+            "columnName": "time_zone_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "soundUri",
+            "columnName": "sound_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snoozedUntilMs",
+            "columnName": "snoozed_until_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completed_at_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "world_clocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `zone_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zoneId",
+            "columnName": "zone_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_world_clocks_zone_id",
+            "unique": true,
+            "columnNames": [
+              "zone_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_world_clocks_zone_id` ON `${TABLE_NAME}` (`zone_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stopwatch_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `status` TEXT NOT NULL, `accumulated_elapsed_ms` INTEGER NOT NULL, `running_since_elapsed_realtime_ms` INTEGER, `running_since_wall_clock_ms` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accumulatedElapsedMs",
+            "columnName": "accumulated_elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningSinceElapsedRealtimeMs",
+            "columnName": "running_since_elapsed_realtime_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSinceWallClockMs",
+            "columnName": "running_since_wall_clock_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stopwatch_laps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `stopwatch_id` TEXT NOT NULL, `lap_number` INTEGER NOT NULL, `elapsed_ms` INTEGER NOT NULL, `split_ms` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`stopwatch_id`) REFERENCES `stopwatch_state`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopwatchId",
+            "columnName": "stopwatch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lapNumber",
+            "columnName": "lap_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedMs",
+            "columnName": "elapsed_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "splitMs",
+            "columnName": "split_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stopwatch_laps_stopwatch_id",
+            "unique": false,
+            "columnNames": [
+              "stopwatch_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id` ON `${TABLE_NAME}` (`stopwatch_id`)"
+          },
+          {
+            "name": "index_stopwatch_laps_stopwatch_id_lap_number",
+            "unique": true,
+            "columnNames": [
+              "stopwatch_id",
+              "lap_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stopwatch_laps_stopwatch_id_lap_number` ON `${TABLE_NAME}` (`stopwatch_id`, `lap_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stopwatch_state",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "stopwatch_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contact_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `displayName` TEXT NOT NULL, `contactId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`alias`))",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias"
+          ]
+        }
+      },
+      {
+        "tableName": "important_dates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT NOT NULL, `normalized_label` TEXT NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `year` INTEGER, `created_at` INTEGER NOT NULL, `notification_enabled` INTEGER NOT NULL, `notification_hour` INTEGER, `notification_minute` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedLabel",
+            "columnName": "normalized_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationEnabled",
+            "columnName": "notification_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationHour",
+            "columnName": "notification_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMinute",
+            "columnName": "notification_minute",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_important_dates_normalized_label",
+            "unique": true,
+            "columnNames": [
+              "normalized_label"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_important_dates_normalized_label` ON `${TABLE_NAME}` (`normalized_label`)"
+          }
+        ]
+      },
+      {
+        "tableName": "list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `listId` INTEGER NOT NULL, `text` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `checked` INTEGER NOT NULL, `dueAt` INTEGER, `isFavourite` INTEGER NOT NULL, `notificationTime` INTEGER, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`listId`) REFERENCES `lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationTime",
+            "columnName": "notificationTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, `archivedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedAt",
+            "columnName": "archivedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lists_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversion_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `input_amount` TEXT NOT NULL, `from_label` TEXT NOT NULL, `to_label` TEXT NOT NULL, `output_amount` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputAmount",
+            "columnName": "input_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromLabel",
+            "columnName": "from_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toLabel",
+            "columnName": "to_label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputAmount",
+            "columnName": "output_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_favourites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_code` TEXT NOT NULL, `to_code` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromCode",
+            "columnName": "from_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCode",
+            "columnName": "to_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "meal_plan_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `status` TEXT NOT NULL, `peopleCount` INTEGER, `daysCount` INTEGER, `dietaryRestrictionsJson` TEXT NOT NULL, `proteinPreferencesJson` TEXT NOT NULL, `optionalSlotsJson` TEXT NOT NULL, `favouriteRecipeMode` TEXT NOT NULL, `activeDayIndex` INTEGER, `pendingGenerationKind` TEXT, `pendingGenerationDayIndex` INTEGER, `pendingGenerationStartedAt` INTEGER, `displayCode` INTEGER NOT NULL, `planVersion` INTEGER NOT NULL, `finalSummaryWritten` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `completedAt` INTEGER, `cancelledAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peopleCount",
+            "columnName": "peopleCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "daysCount",
+            "columnName": "daysCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dietaryRestrictionsJson",
+            "columnName": "dietaryRestrictionsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proteinPreferencesJson",
+            "columnName": "proteinPreferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionalSlotsJson",
+            "columnName": "optionalSlotsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favouriteRecipeMode",
+            "columnName": "favouriteRecipeMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeDayIndex",
+            "columnName": "activeDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationKind",
+            "columnName": "pendingGenerationKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingGenerationDayIndex",
+            "columnName": "pendingGenerationDayIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingGenerationStartedAt",
+            "columnName": "pendingGenerationStartedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "displayCode",
+            "columnName": "displayCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planVersion",
+            "columnName": "planVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finalSummaryWritten",
+            "columnName": "finalSummaryWritten",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cancelledAt",
+            "columnName": "cancelledAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_sessions_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_sessions_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_meal_plan_sessions_displayCode",
+            "unique": true,
+            "columnNames": [
+              "displayCode"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_sessions_displayCode` ON `${TABLE_NAME}` (`displayCode`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `dayIndex` INTEGER NOT NULL, `title` TEXT, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `status` TEXT NOT NULL, `currentRecipeVersion` INTEGER, `attemptCount` INTEGER NOT NULL, `lastErrorCode` TEXT, `lastErrorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanSessionId`) REFERENCES `meal_plan_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentRecipeVersion",
+            "columnName": "currentRecipeVersion",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorCode",
+            "columnName": "lastErrorCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastErrorMessage",
+            "columnName": "lastErrorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanSessionId_dayIndex",
+            "unique": true,
+            "columnNames": [
+              "mealPlanSessionId",
+              "dayIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanSessionId_dayIndex` ON `${TABLE_NAME}` (`mealPlanSessionId`, `dayIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanSessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_recipe_versions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `version` INTEGER NOT NULL, `recipeKey` TEXT NOT NULL, `title` TEXT NOT NULL, `servings` INTEGER NOT NULL, `ingredientsJson` TEXT NOT NULL, `methodStepsJson` TEXT NOT NULL, `rawModelJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`mealPlanDayId`) REFERENCES `meal_plan_days`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeKey",
+            "columnName": "recipeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "methodStepsJson",
+            "columnName": "methodStepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawModelJson",
+            "columnName": "rawModelJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_recipe_versions_mealPlanDayId_version",
+            "unique": true,
+            "columnNames": [
+              "mealPlanDayId",
+              "version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_recipe_versions_mealPlanDayId_version` ON `${TABLE_NAME}` (`mealPlanDayId`, `version`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_days",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanDayId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_grocery_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `mealPlanDayId` TEXT NOT NULL, `recipeVersionId` TEXT NOT NULL, `ingredientIndex` INTEGER NOT NULL, `displayText` TEXT NOT NULL, `originalText` TEXT NOT NULL, `quantity` TEXT, `unit` TEXT, `ingredientName` TEXT, `note` TEXT, `normalizationStatus` TEXT NOT NULL, `mergeKey` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`recipeVersionId`) REFERENCES `meal_plan_recipe_versions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanDayId",
+            "columnName": "mealPlanDayId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeVersionId",
+            "columnName": "recipeVersionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientIndex",
+            "columnName": "ingredientIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayText",
+            "columnName": "displayText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredientName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizationStatus",
+            "columnName": "normalizationStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergeKey",
+            "columnName": "mergeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_grocery_items_recipeVersionId_ingredientIndex",
+            "unique": true,
+            "columnNames": [
+              "recipeVersionId",
+              "ingredientIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_grocery_items_recipeVersionId_ingredientIndex` ON `${TABLE_NAME}` (`recipeVersionId`, `ingredientIndex`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plan_recipe_versions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeVersionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_projection_writes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mealPlanSessionId` TEXT NOT NULL, `targetKind` TEXT NOT NULL, `targetName` TEXT NOT NULL, `sourceKey` TEXT NOT NULL, `sourceVersion` INTEGER NOT NULL, `listItemId` INTEGER, `projectedAt` INTEGER NOT NULL, `supersededAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanSessionId",
+            "columnName": "mealPlanSessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetKind",
+            "columnName": "targetKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceKey",
+            "columnName": "sourceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVersion",
+            "columnName": "sourceVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "listItemId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "projectedAt",
+            "columnName": "projectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "supersededAt",
+            "columnName": "supersededAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_projection_writes_mealPlanSessionId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanSessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_mealPlanSessionId` ON `${TABLE_NAME}` (`mealPlanSessionId`)"
+          },
+          {
+            "name": "index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion",
+            "unique": true,
+            "columnNames": [
+              "targetKind",
+              "targetName",
+              "sourceKey",
+              "sourceVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_meal_plan_projection_writes_targetKind_targetName_sourceKey_sourceVersion` ON `${TABLE_NAME}` (`targetKind`, `targetName`, `sourceKey`, `sourceVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_favourite_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeKey` TEXT NOT NULL, `title` TEXT NOT NULL, `summary` TEXT, `proteinTagsJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`recipeKey`))",
+        "fields": [
+          {
+            "fieldPath": "recipeKey",
+            "columnName": "recipeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "proteinTagsJson",
+            "columnName": "proteinTagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeKey"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ff53929b35b8e34b78be6db4f835442d')"
+    ]
+  }
+}

--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
@@ -70,6 +70,7 @@ class MealPlanSessionRepositoryAndroidTest {
             dayDao = database.mealPlanDayDao(),
             recipeVersionDao = database.mealPlanRecipeVersionDao(),
             groceryItemDao = database.mealPlanGroceryItemDao(),
+            favouriteRecipeDao = database.mealPlanFavouriteRecipeDao(),
             projectionWriteDao = database.mealPlanProjectionWriteDao(),
             listItemDao = database.listItemDao(),
             listNameDao = database.listNameDao(),
@@ -427,6 +428,45 @@ class MealPlanSessionRepositoryAndroidTest {
         val listNames = listNameDao.getAll().map { it.name }
         assertFalse(listNames.contains(legacyListName))
         assertTrue(listNames.any { it.matches(Regex("""Meal Plan \d{4}-\d{2}-\d{2} \(MP-001\) Shopping List""")) })
+    }
+
+    @Test
+    fun setRecipeFavourite_persistsFavouriteRecipesAndSupportsUndo() = runBlocking {
+        val session = repository.startOrResume("conv-favourites")
+        repository.savePlanDraft(
+            session.sessionId,
+            listOf(
+                MealPlanDraftDay(
+                    dayIndex = 0,
+                    title = "Chicken Stir Fry",
+                    summary = "Quick bowl",
+                    proteinTags = listOf("chicken"),
+                ),
+            ),
+        )
+        repository.persistRecipeDraft(
+            sessionId = session.sessionId,
+            dayIndex = 0,
+            recipeDraft = recipeDraft(
+                title = "Chicken Stir Fry",
+                method = listOf("Slice the vegetables.", "Stir-fry everything until glossy."),
+            ),
+            rawModelJson = "{}",
+            groceries = listOf(
+                grocery(displayText = "500 g chicken thigh", quantity = "500", unit = "g", ingredientName = "chicken thigh"),
+            ),
+        )
+
+        val favourited = repository.setRecipeFavourite(session.sessionId, 0, true)
+
+        assertTrue(favourited.days.single().isFavouriteRecipe)
+        assertNotNull(favourited.days.single().recipeKey)
+        assertEquals(1, rawQueryInt("SELECT COUNT(*) FROM meal_plan_favourite_recipes"))
+
+        val unfavourited = repository.setRecipeFavourite(session.sessionId, 0, false)
+
+        assertFalse(unfavourited.days.single().isFavouriteRecipe)
+        assertEquals(0, rawQueryInt("SELECT COUNT(*) FROM meal_plan_favourite_recipes"))
     }
 
     @Test
@@ -827,6 +867,72 @@ class MealPlanSessionRepositoryAndroidTest {
         }
         migratedDb.close()
     }
+
+    @Test
+    fun migration45To46_addsFavouriteRecipeSupport() {
+        migrationHelper.createDatabase(MIGRATION_DB_NAME, 45).apply {
+            execSQL(
+                """
+                INSERT INTO `meal_plan_sessions` (
+                    `id`, `conversationId`, `status`, `peopleCount`, `daysCount`,
+                    `dietaryRestrictionsJson`, `proteinPreferencesJson`, `optionalSlotsJson`,
+                    `activeDayIndex`, `pendingGenerationKind`, `pendingGenerationDayIndex`,
+                    `pendingGenerationStartedAt`, `displayCode`, `planVersion`, `finalSummaryWritten`,
+                    `createdAt`, `updatedAt`, `completedAt`, `cancelledAt`
+                ) VALUES (
+                    'session-a', 'conv-a', 'PLAN_REVIEW', 2, 3, '[]', '[]', '{}', NULL, NULL, NULL, NULL, 1, 1, 0, 1000, 1000, NULL, NULL
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO `meal_plan_days` (
+                    `id`, `mealPlanSessionId`, `dayIndex`, `title`, `summary`, `proteinTagsJson`,
+                    `status`, `currentRecipeVersion`, `attemptCount`, `lastErrorCode`, `lastErrorMessage`,
+                    `createdAt`, `updatedAt`
+                ) VALUES (
+                    'day-a', 'session-a', 0, 'Chicken Stir Fry', 'Quick bowl', '["chicken"]',
+                    'PERSISTED', 1, 1, NULL, NULL, 1000, 1000
+                )
+                """.trimIndent(),
+            )
+            execSQL(
+                """
+                INSERT INTO `meal_plan_recipe_versions` (
+                    `id`, `mealPlanSessionId`, `mealPlanDayId`, `version`, `title`, `servings`,
+                    `ingredientsJson`, `methodStepsJson`, `rawModelJson`, `createdAt`
+                ) VALUES (
+                    'recipe-a', 'session-a', 'day-a', 1, 'Chicken Stir Fry', 4, '[]', '[]', '{}', 1000
+                )
+                """.trimIndent(),
+            )
+            close()
+        }
+
+        val migratedDb = migrationHelper.runMigrationsAndValidate(
+            MIGRATION_DB_NAME,
+            46,
+            true,
+            KernelDatabase.MIGRATION_45_46,
+        )
+
+        assertTrue(tableExists(migratedDb, "meal_plan_favourite_recipes"))
+        migratedDb.query("SELECT favouriteRecipeMode FROM `meal_plan_sessions` WHERE id = 'session-a'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("NONE", cursor.getString(0))
+        }
+        migratedDb.query("SELECT recipeKey FROM `meal_plan_recipe_versions` WHERE id = 'recipe-a'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("", cursor.getString(0))
+        }
+        migratedDb.close()
+    }
+
+    private fun rawQueryInt(sql: String): Int =
+        database.openHelper.writableDatabase.query(sql).use { cursor ->
+            cursor.moveToFirst()
+            cursor.getInt(0)
+        }
 
     private companion object {
         private const val MIGRATION_DB_NAME = "meal-plan-migration-test"

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/KernelDatabase.kt
@@ -16,6 +16,7 @@ import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.MealPlanDayDao
+import com.kernel.ai.core.memory.dao.MealPlanFavouriteRecipeDao
 import com.kernel.ai.core.memory.dao.MealPlanGroceryItemDao
 import com.kernel.ai.core.memory.dao.MealPlanProjectionWriteDao
 import com.kernel.ai.core.memory.dao.MealPlanRecipeVersionDao
@@ -39,6 +40,7 @@ import com.kernel.ai.core.memory.entity.KiwiMemoryEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.entity.MealPlanDayEntity
+import com.kernel.ai.core.memory.entity.MealPlanFavouriteRecipeEntity
 import com.kernel.ai.core.memory.entity.MealPlanGroceryItemEntity
 import com.kernel.ai.core.memory.entity.MealPlanProjectionWriteEntity
 import com.kernel.ai.core.memory.entity.MealPlanRecipeVersionEntity
@@ -80,8 +82,9 @@ import java.time.ZoneId
         MealPlanRecipeVersionEntity::class,
         MealPlanGroceryItemEntity::class,
         MealPlanProjectionWriteEntity::class,
+        MealPlanFavouriteRecipeEntity::class,
     ],
-    version = 45,
+    version = 46,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -111,6 +114,7 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun mealPlanRecipeVersionDao(): MealPlanRecipeVersionDao
     abstract fun mealPlanGroceryItemDao(): MealPlanGroceryItemDao
     abstract fun mealPlanProjectionWriteDao(): MealPlanProjectionWriteDao
+    abstract fun mealPlanFavouriteRecipeDao(): MealPlanFavouriteRecipeDao
 
     companion object {
         /** Adds lastDistilledAt to conversations (#165) and lastAccessedAt to episodic_memories (#167). */
@@ -734,6 +738,27 @@ abstract class KernelDatabase : RoomDatabase() {
                     """.trimIndent(),
                 )
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_meal_plan_sessions_displayCode ON meal_plan_sessions(displayCode)")
+            }
+        }
+
+        /** Adds favourite recipe support for deterministic meal planning (#882). */
+        val MIGRATION_45_46 = object : Migration(45, 46) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE meal_plan_sessions ADD COLUMN favouriteRecipeMode TEXT NOT NULL DEFAULT 'NONE'")
+                db.execSQL("ALTER TABLE meal_plan_recipe_versions ADD COLUMN recipeKey TEXT NOT NULL DEFAULT ''")
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `meal_plan_favourite_recipes` (
+                        `recipeKey` TEXT NOT NULL,
+                        `title` TEXT NOT NULL,
+                        `summary` TEXT,
+                        `proteinTagsJson` TEXT NOT NULL,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        PRIMARY KEY(`recipeKey`)
+                    )
+                    """.trimIndent(),
+                )
             }
         }
     }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/MemoryModule.kt
@@ -15,6 +15,7 @@ import com.kernel.ai.core.memory.dao.KiwiMemoryDao
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.MealPlanDayDao
+import com.kernel.ai.core.memory.dao.MealPlanFavouriteRecipeDao
 import com.kernel.ai.core.memory.dao.MealPlanGroceryItemDao
 import com.kernel.ai.core.memory.dao.MealPlanProjectionWriteDao
 import com.kernel.ai.core.memory.dao.MealPlanRecipeVersionDao
@@ -111,6 +112,7 @@ abstract class MemoryModule {
                     KernelDatabase.MIGRATION_42_43,
                     KernelDatabase.MIGRATION_43_44,
                     KernelDatabase.MIGRATION_44_45,
+                    KernelDatabase.MIGRATION_45_46,
                 )
                 .addCallback(object : RoomDatabase.Callback() {
                     // SQLite disables FK enforcement by default — enable it per-connection
@@ -196,5 +198,8 @@ abstract class MemoryModule {
 
         @Provides
         fun provideMealPlanProjectionWriteDao(db: KernelDatabase): MealPlanProjectionWriteDao = db.mealPlanProjectionWriteDao()
+
+        @Provides
+        fun provideMealPlanFavouriteRecipeDao(db: KernelDatabase): MealPlanFavouriteRecipeDao = db.mealPlanFavouriteRecipeDao()
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanFavouriteRecipeDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanFavouriteRecipeDao.kt
@@ -1,0 +1,28 @@
+package com.kernel.ai.core.memory.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.kernel.ai.core.memory.entity.MealPlanFavouriteRecipeEntity
+
+@Dao
+interface MealPlanFavouriteRecipeDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: MealPlanFavouriteRecipeEntity)
+
+    @Query("DELETE FROM meal_plan_favourite_recipes WHERE recipeKey = :recipeKey")
+    suspend fun delete(recipeKey: String)
+
+    @Query("SELECT * FROM meal_plan_favourite_recipes WHERE recipeKey = :recipeKey LIMIT 1")
+    suspend fun getByKey(recipeKey: String): MealPlanFavouriteRecipeEntity?
+
+    @Query("SELECT EXISTS(SELECT 1 FROM meal_plan_favourite_recipes WHERE recipeKey = :recipeKey)")
+    suspend fun exists(recipeKey: String): Boolean
+
+    @Query("SELECT recipeKey FROM meal_plan_favourite_recipes WHERE recipeKey IN (:recipeKeys)")
+    suspend fun getExistingKeys(recipeKeys: List<String>): List<String>
+
+    @Query("SELECT * FROM meal_plan_favourite_recipes ORDER BY updatedAt DESC LIMIT :limit")
+    suspend fun getRecent(limit: Int): List<MealPlanFavouriteRecipeEntity>
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanFavouriteRecipeEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanFavouriteRecipeEntity.kt
@@ -1,0 +1,14 @@
+package com.kernel.ai.core.memory.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "meal_plan_favourite_recipes")
+data class MealPlanFavouriteRecipeEntity(
+    @PrimaryKey val recipeKey: String,
+    val title: String,
+    val summary: String?,
+    val proteinTagsJson: String = "[]",
+    val createdAt: Long,
+    val updatedAt: Long,
+)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanRecipeVersionEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanRecipeVersionEntity.kt
@@ -22,6 +22,7 @@ data class MealPlanRecipeVersionEntity(
     val mealPlanSessionId: String,
     val mealPlanDayId: String,
     val version: Int,
+    val recipeKey: String,
     val title: String,
     val servings: Int,
     val ingredientsJson: String,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanSessionEntity.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/entity/MealPlanSessionEntity.kt
@@ -21,6 +21,7 @@ data class MealPlanSessionEntity(
     val dietaryRestrictionsJson: String = "[]",
     val proteinPreferencesJson: String = "[]",
     val optionalSlotsJson: String = "{}",
+    val favouriteRecipeMode: String = "NONE",
     val activeDayIndex: Int? = null,
     val pendingGenerationKind: String? = null,
     val pendingGenerationDayIndex: Int? = null,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
@@ -25,6 +25,13 @@ enum class PendingGenerationKind {
     REPLACEMENT,
 }
 
+enum class FavouriteRecipeMode {
+    NONE,
+    INCLUDE,
+    PREFER,
+    AVOID,
+}
+
 enum class GroceryNormalizationStatus {
     OPAQUE,
     NORMALIZED,
@@ -43,6 +50,13 @@ data class MealPlanDraft(
 )
 
 data class RecentMealHistoryEntry(
+    val title: String,
+    val summary: String?,
+    val proteinTags: List<String> = emptyList(),
+)
+
+data class FavouriteRecipeSummary(
+    val recipeKey: String,
     val title: String,
     val summary: String?,
     val proteinTags: List<String> = emptyList(),
@@ -88,6 +102,7 @@ data class MealPlanSnapshot(
     val daysCount: Int?,
     val dietaryRestrictions: List<String>,
     val proteinPreferences: List<String>,
+    val favouriteRecipeMode: FavouriteRecipeMode,
     val activeDayIndex: Int?,
     val pendingGenerationKind: PendingGenerationKind?,
     val pendingGenerationDayIndex: Int?,
@@ -112,6 +127,8 @@ data class MealPlanSnapshotDay(
     val lastErrorCode: String?,
     val lastErrorMessage: String?,
     val currentRecipe: RecipeDraft?,
+    val recipeKey: String?,
+    val isFavouriteRecipe: Boolean,
 )
 
 fun List<String>.toJsonArrayString(): String = JSONArray(this).toString()

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -6,6 +6,7 @@ import com.kernel.ai.core.memory.KernelDatabase
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.dao.MealPlanDayDao
+import com.kernel.ai.core.memory.dao.MealPlanFavouriteRecipeDao
 import com.kernel.ai.core.memory.dao.MealPlanGroceryItemDao
 import com.kernel.ai.core.memory.dao.MealPlanProjectionWriteDao
 import com.kernel.ai.core.memory.dao.MealPlanRecipeVersionDao
@@ -13,11 +14,14 @@ import com.kernel.ai.core.memory.dao.MealPlanSessionDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.entity.MealPlanDayEntity
+import com.kernel.ai.core.memory.entity.MealPlanFavouriteRecipeEntity
 import com.kernel.ai.core.memory.entity.MealPlanGroceryItemEntity
 import com.kernel.ai.core.memory.entity.MealPlanProjectionWriteEntity
 import com.kernel.ai.core.memory.entity.MealPlanRecipeVersionEntity
 import com.kernel.ai.core.memory.entity.MealPlanSessionEntity
 import com.kernel.ai.core.memory.mealplan.CanonicalGroceryItem
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
 import com.kernel.ai.core.memory.mealplan.GroceryNormalizationStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanDayStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanDraftDay
@@ -49,6 +53,7 @@ class MealPlanSessionRepository @Inject constructor(
     private val dayDao: MealPlanDayDao,
     private val recipeVersionDao: MealPlanRecipeVersionDao,
     private val groceryItemDao: MealPlanGroceryItemDao,
+    private val favouriteRecipeDao: MealPlanFavouriteRecipeDao,
     private val projectionWriteDao: MealPlanProjectionWriteDao,
     private val listItemDao: ListItemDao,
     private val listNameDao: ListNameDao,
@@ -79,6 +84,29 @@ class MealPlanSessionRepository @Inject constructor(
     suspend fun getPendingCompletedSummarySessions(limit: Int): List<MealPlanSnapshot> =
         sessionDao.getCompletedWithoutSummary(limit).map { it.toSnapshot() }
 
+    suspend fun getFavouriteRecipes(limit: Int): List<FavouriteRecipeSummary> =
+        favouriteRecipeDao.getRecent(limit).map { favourite ->
+            FavouriteRecipeSummary(
+                recipeKey = favourite.recipeKey,
+                title = favourite.title,
+                summary = favourite.summary,
+                proteinTags = jsonArrayToStringList(favourite.proteinTagsJson),
+            )
+        }
+
+    suspend fun setFavouriteRecipeMode(sessionId: String, mode: FavouriteRecipeMode): MealPlanSnapshot = database.withTransaction {
+        val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
+        if (session.status == MealPlanSessionStatus.CANCELLED.name) {
+            return@withTransaction session.toSnapshot()
+        }
+        val updated = session.copy(
+            favouriteRecipeMode = mode.name,
+            updatedAt = System.currentTimeMillis(),
+        )
+        sessionDao.update(updated)
+        updated.toSnapshot()
+    }
+
     /**
      * Planner retention pruning runs here before resuming/creating a session so old terminal
      * planner state does not accumulate indefinitely between active planner uses.
@@ -96,6 +124,7 @@ class MealPlanSessionRepository @Inject constructor(
         daysCount: Int? = null,
         dietaryRestrictions: List<String>? = null,
         proteinPreferences: List<String>? = null,
+        favouriteRecipeMode: FavouriteRecipeMode? = null,
     ): MealPlanSnapshot = database.withTransaction {
         val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
         if (session.status == MealPlanSessionStatus.CANCELLED.name) {
@@ -106,12 +135,49 @@ class MealPlanSessionRepository @Inject constructor(
             daysCount = daysCount ?: session.daysCount,
             dietaryRestrictionsJson = dietaryRestrictions?.distinct()?.toJsonArrayString() ?: session.dietaryRestrictionsJson,
             proteinPreferencesJson = proteinPreferences?.distinct()?.toJsonArrayString() ?: session.proteinPreferencesJson,
+            favouriteRecipeMode = favouriteRecipeMode?.name ?: session.favouriteRecipeMode,
             updatedAt = System.currentTimeMillis(),
         )
         sessionDao.update(updated)
         updated.toSnapshot()
     }
 
+    suspend fun setRecipeFavourite(
+        sessionId: String,
+        dayIndex: Int,
+        favourite: Boolean,
+    ): MealPlanSnapshot = database.withTransaction {
+        val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
+        if (session.status == MealPlanSessionStatus.CANCELLED.name) {
+            return@withTransaction session.toSnapshot()
+        }
+        val day = requireNotNull(dayDao.getBySessionAndIndex(sessionId, dayIndex)) {
+            "Unknown meal-plan day $dayIndex for session $sessionId"
+        }
+        val recipeVersion = requireNotNull(currentRecipeVersion(day)) {
+            "Day ${dayIndex + 1} does not have a recipe yet."
+        }
+        val recipeKey = resolvedRecipeKey(recipeVersion, jsonArrayToStringList(day.proteinTagsJson))
+        require(recipeKey.isNotBlank()) { "Day ${dayIndex + 1} does not have a stable favourite-recipe key yet." }
+        val now = System.currentTimeMillis()
+        if (favourite) {
+            favouriteRecipeDao.upsert(
+                MealPlanFavouriteRecipeEntity(
+                    recipeKey = recipeKey,
+                    title = recipeVersion.title,
+                    summary = day.summary,
+                    proteinTagsJson = day.proteinTagsJson,
+                    createdAt = favouriteRecipeDao.getByKey(recipeKey)?.createdAt ?: now,
+                    updatedAt = now,
+                ),
+            )
+        } else {
+            favouriteRecipeDao.delete(recipeKey)
+        }
+        val updatedSession = session.copy(updatedAt = now)
+        sessionDao.update(updatedSession)
+        updatedSession.toSnapshot()
+    }
     suspend fun savePlanDraft(
         sessionId: String,
         days: List<MealPlanDraftDay>,
@@ -231,6 +297,7 @@ class MealPlanSessionRepository @Inject constructor(
             mealPlanSessionId = sessionId,
             mealPlanDayId = day.id,
             version = nextVersion,
+            recipeKey = normalizeRecipeKey(recipeDraft.title, jsonArrayToStringList(day.proteinTagsJson)),
             title = recipeDraft.title,
             servings = recipeDraft.servings,
             ingredientsJson = ingredientsToJson(recipeDraft.ingredients),
@@ -630,6 +697,7 @@ class MealPlanSessionRepository @Inject constructor(
                 dietaryRestrictionsJson = "[]",
                 proteinPreferencesJson = "[]",
                 optionalSlotsJson = "{}",
+                favouriteRecipeMode = FavouriteRecipeMode.NONE.name,
                 activeDayIndex = null,
                 pendingGenerationKind = null,
                 pendingGenerationDayIndex = null,
@@ -648,6 +716,19 @@ class MealPlanSessionRepository @Inject constructor(
 
     private suspend fun MealPlanSessionEntity.toSnapshot(): MealPlanSnapshot {
         val days = dayDao.getBySession(id)
+        val dayRecipes = days.associateWith { day -> currentRecipeVersion(day) }
+        val favouriteKeys = dayRecipes.entries
+            .mapNotNull { (day, recipeVersion) ->
+                recipeVersion?.let { current ->
+                    resolvedRecipeKey(current, jsonArrayToStringList(day.proteinTagsJson)).takeIf { it.isNotBlank() }
+                }
+            }
+            .distinct()
+        val favouriteKeySet = if (favouriteKeys.isEmpty()) {
+            emptySet()
+        } else {
+            favouriteRecipeDao.getExistingKeys(favouriteKeys).toSet()
+        }
         return MealPlanSnapshot(
             sessionId = id,
             conversationId = conversationId,
@@ -657,6 +738,7 @@ class MealPlanSessionRepository @Inject constructor(
             daysCount = daysCount,
             dietaryRestrictions = jsonArrayToStringList(dietaryRestrictionsJson),
             proteinPreferences = jsonArrayToStringList(proteinPreferencesJson),
+            favouriteRecipeMode = FavouriteRecipeMode.valueOf(favouriteRecipeMode),
             activeDayIndex = activeDayIndex,
             pendingGenerationKind = pendingGenerationKind?.let(PendingGenerationKind::valueOf),
             pendingGenerationDayIndex = pendingGenerationDayIndex,
@@ -667,19 +749,17 @@ class MealPlanSessionRepository @Inject constructor(
             completedAt = completedAt,
             cancelledAt = cancelledAt,
             days = days.map { day ->
-                val recipe = day.currentRecipeVersion?.let {
-                    recipeVersionDao.getLatestForDay(day.id)?.let { latest ->
-                        if (latest.version == it) {
-                            RecipeDraft(
-                                title = latest.title,
-                                servings = latest.servings,
-                                ingredients = jsonToIngredients(latest.ingredientsJson),
-                                methodSteps = jsonToMethodSteps(latest.methodStepsJson),
-                            )
-                        } else {
-                            null
-                        }
-                    }
+                val currentRecipeVersionEntity = dayRecipes.getValue(day)
+                val recipe = currentRecipeVersionEntity?.let { current ->
+                    RecipeDraft(
+                        title = current.title,
+                        servings = current.servings,
+                        ingredients = jsonToIngredients(current.ingredientsJson),
+                        methodSteps = jsonToMethodSteps(current.methodStepsJson),
+                    )
+                }
+                val recipeKey = currentRecipeVersionEntity?.let { current ->
+                    resolvedRecipeKey(current, jsonArrayToStringList(day.proteinTagsJson)).takeIf { it.isNotBlank() }
                 }
                 MealPlanSnapshotDay(
                     id = day.id,
@@ -693,6 +773,8 @@ class MealPlanSessionRepository @Inject constructor(
                     lastErrorCode = day.lastErrorCode,
                     lastErrorMessage = day.lastErrorMessage,
                     currentRecipe = recipe,
+                    recipeKey = recipeKey,
+                    isFavouriteRecipe = recipeKey != null && recipeKey in favouriteKeySet,
                 )
             },
         )
@@ -710,6 +792,29 @@ class MealPlanSessionRepository @Inject constructor(
 
     private fun recipeListName(session: MealPlanSessionEntity, dayIndex: Int, title: String): String =
         "${canonicalDisplayName(session)} Day ${dayIndex + 1} — $title"
+
+    private suspend fun currentRecipeVersion(day: MealPlanDayEntity): MealPlanRecipeVersionEntity? {
+        val version = day.currentRecipeVersion ?: return null
+        return recipeVersionDao.getLatestForDay(day.id)?.takeIf { it.version == version }
+    }
+
+    private fun resolvedRecipeKey(recipeVersion: MealPlanRecipeVersionEntity, proteinTags: List<String>): String =
+        recipeVersion.recipeKey.takeIf { it.isNotBlank() }
+            ?: normalizeRecipeKey(recipeVersion.title, proteinTags)
+
+    private fun normalizeRecipeKey(title: String, proteinTags: List<String>): String {
+        val normalizedTitle = title.lowercase(Locale.ENGLISH)
+            .replace(NON_ALNUM_REGEX, " ")
+            .replace(MULTISPACE_REGEX, " ")
+            .trim()
+        val normalizedProteins = proteinTags.map { it.lowercase(Locale.ENGLISH).trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .sorted()
+        return listOf(normalizedTitle, normalizedProteins.joinToString("-"))
+            .filter { it.isNotBlank() }
+            .joinToString("|")
+    }
 
     private fun ingredientsToJson(ingredients: List<RecipeDraftIngredient>): String = JSONArray(
         ingredients.map { ingredient ->
@@ -766,5 +871,7 @@ class MealPlanSessionRepository @Inject constructor(
         private const val COMPLETED_SESSION_RETENTION_MS = 30L * DAY_MS
         private const val COMPLETED_SESSION_FALLBACK_RETENTION_MS = 90L * DAY_MS
         private const val CANCELLED_SESSION_RETENTION_MS = 7L * DAY_MS
+        private val NON_ALNUM_REGEX = Regex("[^a-z0-9 ]")
+        private val MULTISPACE_REGEX = Regex("\\s+")
     }
 }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -94,19 +94,6 @@ class MealPlanSessionRepository @Inject constructor(
             )
         }
 
-    suspend fun setFavouriteRecipeMode(sessionId: String, mode: FavouriteRecipeMode): MealPlanSnapshot = database.withTransaction {
-        val session = requireNotNull(sessionDao.getById(sessionId)) { "Unknown meal-plan session: $sessionId" }
-        if (session.status == MealPlanSessionStatus.CANCELLED.name) {
-            return@withTransaction session.toSnapshot()
-        }
-        val updated = session.copy(
-            favouriteRecipeMode = mode.name,
-            updatedAt = System.currentTimeMillis(),
-        )
-        sessionDao.update(updated)
-        updated.toSnapshot()
-    }
-
     /**
      * Planner retention pruning runs here before resuming/creating a session so old terminal
      * planner state does not accumulate indefinitely between active planner uses.

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -1278,7 +1278,7 @@ class MealPlannerCoordinator @Inject constructor(
             if (snapshot.days.isEmpty()) {
                 "I still need to rebuild your meal plan draft. You can say 'generate recipes' to try again, 'change preferences' to edit the plan details, 'show current plan' to inspect what I have, or 'cancel' to stop."
             } else {
-                "You're reviewing the draft meal plan. You can say 'show current plan' to inspect it again, 'generate recipes' to build the recipe details, 'replace day 1' to swap one meal, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust favourite bias, 'change preferences' to edit people, days, dietary needs, or proteins, or 'cancel' to stop."
+                "You're reviewing the draft meal plan. You can say 'show current plan' to inspect it again, 'generate recipes' to build the recipe details, 'replace day 1' to swap one meal, 'change preferences' to edit people, days, dietary needs, or proteins, or 'cancel' to stop."
             }
         MealPlanSessionStatus.RECIPES_IN_PROGRESS,
         MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> activeOrRecoveryHelpPrompt(snapshot, generationActive)
@@ -1297,7 +1297,7 @@ class MealPlannerCoordinator @Inject constructor(
                 appendLine("- 5 days")
                 appendLine("- gluten free, kid friendly, no coriander")
                 appendLine("- chicken, salmon")
-                appendLine("- prefer favourites")
+                appendLine("- 4 people, 5 days, chicken")
                 appendLine("- remove gluten free")
                 appendLine("- remove no chicken")
                 append("Then say 'generate' to rebuild the plan, 'show current plan' to inspect it, or 'cancel' to stop.")
@@ -1341,7 +1341,7 @@ class MealPlannerCoordinator @Inject constructor(
             pendingDay != null ->
                 "Recipe generation is paused at Day ${pendingDay.dayIndex + 1} of ${snapshot.days.size}. Say 'generate recipes' to continue, 'show current plan' to inspect the draft, or 'cancel' to stop."
             else ->
-                "You're at the final review step. Say 'show current plan' to inspect it, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust future bias, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
+                "You're at the final review step. Say 'show current plan' to inspect it, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
         }
     }
 
@@ -1362,7 +1362,7 @@ class MealPlannerCoordinator @Inject constructor(
         append("Current plan details: ")
         append(buildKnownBits(snapshot).ifEmpty { listOf("no saved details yet") }.joinToString(", "))
         append(".\n\n")
-        append("Reply with any updated people count, days, dietary requirements, allergens, ingredients to avoid, protein preferences, or favourite recipe preference. Say 'help' for examples or 'cancel' to stop.")
+        append("Reply with any updated people count, days, dietary requirements, allergens, ingredients to avoid, or protein preferences. Say 'help' for examples or 'cancel' to stop.")
     }
 
     private fun buildKnownBits(snapshot: MealPlanSnapshot): List<String> = buildList {
@@ -1370,7 +1370,7 @@ class MealPlannerCoordinator @Inject constructor(
         snapshot.daysCount?.let { add("$it days") }
         if (snapshot.dietaryRestrictions.isNotEmpty()) add(snapshot.dietaryRestrictions.joinToString())
         if (snapshot.proteinPreferences.isNotEmpty()) add(snapshot.proteinPreferences.joinToString())
-        if (snapshot.favouriteRecipeMode != FavouriteRecipeMode.NONE) add(favouriteModeLabel(snapshot.favouriteRecipeMode))
+
     }
 
     private fun missingSlots(snapshot: MealPlanSnapshot): List<String> = buildList {
@@ -1495,9 +1495,6 @@ class MealPlannerCoordinator @Inject constructor(
         append("Here’s the meal plan I built for ${snapshot.peopleCount} people over ${snapshot.daysCount} days")
         if (snapshot.dietaryRestrictions.isNotEmpty()) {
             append(" (${snapshot.dietaryRestrictions.joinToString()})")
-        }
-        if (snapshot.favouriteRecipeMode != FavouriteRecipeMode.NONE) {
-            append(" with ${favouriteModeLabel(snapshot.favouriteRecipeMode)}")
         }
         append(":\n")
         snapshot.days.sortedBy { it.dayIndex }.forEach { day ->
@@ -1809,7 +1806,6 @@ Rules:
         primaryEditableDay(snapshot)?.let { dayIndex ->
             add(suggestion("Replace day ${dayIndex + 1}", "replace day ${dayIndex + 1}"))
         }
-        favouriteModeSuggestion(snapshot)?.let(::add)
         add(suggestion("Change preferences", "change preferences"))
         add(suggestion("Help", "help"))
     }
@@ -1947,19 +1943,7 @@ Rules:
         snapshot.days.firstOrNull { it.status == MealPlanDayStatus.PERSISTED }?.dayIndex
             ?: snapshot.days.firstOrNull()?.dayIndex
 
-    private fun favouriteModeSuggestion(snapshot: MealPlanSnapshot): MealPlannerSuggestion? = when (snapshot.favouriteRecipeMode) {
-        FavouriteRecipeMode.NONE -> suggestion("Prefer favourites", "prefer favourites")
-        FavouriteRecipeMode.PREFER -> suggestion("Avoid favourites", "avoid favourites")
-        FavouriteRecipeMode.AVOID -> suggestion("Include favourites", "include favourites")
-        FavouriteRecipeMode.INCLUDE -> suggestion("Prefer favourites", "prefer favourites")
-    }
 
-    private fun favouriteModeLabel(mode: FavouriteRecipeMode): String = when (mode) {
-        FavouriteRecipeMode.NONE -> "no favourite recipe bias"
-        FavouriteRecipeMode.INCLUDE -> "some saved favourites mixed in"
-        FavouriteRecipeMode.PREFER -> "saved favourites preferred"
-        FavouriteRecipeMode.AVOID -> "saved favourites avoided"
-    }
 
     private fun suggestion(
         label: String,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -178,13 +178,12 @@ class MealPlannerCoordinator @Inject constructor(
             return MealPlannerReply(promptForMissingSlots(updated, missing))
         }
         val hadAllSlotsBefore = missingSlots(snapshot).isEmpty()
-        val hasAnySlotUpdates =
+        val hasStructuralSlotUpdates =
             peopleCount != null ||
                 daysCount != null ||
                 updatedDietaryRestrictions != null ||
-                updatedProteinPreferences != null ||
-                favouriteRecipeMode != null
-        if (hadAllSlotsBefore && !hasAnySlotUpdates) {
+                updatedProteinPreferences != null
+        if (hadAllSlotsBefore && !hasStructuralSlotUpdates) {
             if (slotExtractor.isGenerateRecipesRequest(text)) {
                 return generatePlanForReview(updated, onPlannerActivityChanged)
             }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -135,6 +135,14 @@ class MealPlannerCoordinator @Inject constructor(
         if (slotExtractor.isShowCurrentPlanRequest(text)) {
             return MealPlannerReply(currentPlanReply(snapshot))
         }
+        val favouriteDayIndex = slotExtractor.extractFavouriteDayIndex(text)
+        if (favouriteDayIndex != null) {
+            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
+        }
+        val unfavouriteDayIndex = slotExtractor.extractUnfavouriteDayIndex(text)
+        if (unfavouriteDayIndex != null) {
+            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
+        }
         val missingBefore = missingSlots(snapshot)
         val peopleCount = slotExtractor.extractPeopleCount(text)
         val daysCount = slotExtractor.extractDaysCount(text)
@@ -200,6 +208,14 @@ class MealPlannerCoordinator @Inject constructor(
     ): MealPlannerReply {
         if (slotExtractor.isShowCurrentPlanRequest(text)) {
             return MealPlannerReply(currentPlanReply(snapshot))
+        }
+        val favouriteDayIndex = slotExtractor.extractFavouriteDayIndex(text)
+        if (favouriteDayIndex != null) {
+            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
+        }
+        val unfavouriteDayIndex = slotExtractor.extractUnfavouriteDayIndex(text)
+        if (unfavouriteDayIndex != null) {
+            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
         }
         val favouriteRecipeMode = slotExtractor.extractFavouriteRecipeMode(text)
         if (favouriteRecipeMode != null) {
@@ -320,20 +336,10 @@ class MealPlannerCoordinator @Inject constructor(
             return MealPlannerReply(planReviewPrompt(snapshot))
         }
         if (favouriteDayIndex != null) {
-            return try {
-                val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, favouriteDayIndex, true)
-                MealPlannerReply("Saved Day ${favouriteDayIndex + 1} as a favourite recipe for future meal plans.\n\n${currentPlanReply(updated)}")
-            } catch (e: IllegalArgumentException) {
-                MealPlannerReply(e.message ?: "I couldn't favourite that recipe yet.")
-            }
+            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
         }
         if (unfavouriteDayIndex != null) {
-            return try {
-                val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, unfavouriteDayIndex, false)
-                MealPlannerReply("Removed Day ${unfavouriteDayIndex + 1} from your favourite recipes.\n\n${currentPlanReply(updated)}")
-            } catch (e: IllegalArgumentException) {
-                MealPlannerReply(e.message ?: "I couldn't remove that favourite yet.")
-            }
+            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
         }
         if (replaceDayIndex != null) {
             return replaceDayAndGenerateRecipe(
@@ -1396,6 +1402,43 @@ class MealPlannerCoordinator @Inject constructor(
             buildPlanSummary(snapshot) + "\n\n" + statusPrompt(snapshot)
         }
 
+
+    private suspend fun handleFavouriteRecipeToggle(
+        snapshot: MealPlanSnapshot,
+        dayIndex: Int,
+        favourite: Boolean,
+    ): MealPlannerReply {
+        val day = snapshot.days.firstOrNull { it.dayIndex == dayIndex }
+            ?: return MealPlannerReply(invalidFavouriteDayMessage(dayIndex, snapshot.days.size))
+        if (day.currentRecipeVersion == null) {
+            val action = if (favourite) "save" else "remove"
+            return MealPlannerReply("I can $action favourites once Day ${dayIndex + 1} has a generated recipe. Say 'generate recipes' first.")
+        }
+        if (favourite && day.isFavouriteRecipe) {
+            return MealPlannerReply("Day ${dayIndex + 1} is already saved as a favourite recipe.\n\n${currentPlanReply(snapshot)}")
+        }
+        if (!favourite && !day.isFavouriteRecipe) {
+            return MealPlannerReply("Day ${dayIndex + 1} isn't saved as a favourite recipe yet.\n\n${currentPlanReply(snapshot)}")
+        }
+        return try {
+            val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, dayIndex, favourite)
+            val lead =
+                if (favourite) {
+                    "Saved Day ${dayIndex + 1} as a favourite recipe for future meal plans."
+                } else {
+                    "Removed Day ${dayIndex + 1} from your favourite recipes."
+                }
+            MealPlannerReply("$lead\n\n${currentPlanReply(updated)}")
+        } catch (e: IllegalArgumentException) {
+            MealPlannerReply(e.message ?: if (favourite) "I couldn't favourite that recipe yet." else "I couldn't remove that favourite yet.")
+        }
+    }
+
+    private fun invalidFavouriteDayMessage(dayIndex: Int, totalDays: Int): String = when {
+        totalDays <= 0 -> "I don't have Day ${dayIndex + 1} ready to favourite yet. Say 'generate recipes' first."
+        totalDays == 1 -> "Your current plan only has Day 1, so I can only manage favourites for Day 1."
+        else -> "Your current plan only has $totalDays days, so I can only manage favourites for Day 1 to Day $totalDays."
+    }
     private fun planReviewActionsPrompt(): String =
         "Say 'generate recipes', 'replace day 2', 'change preferences', 'help' for more options, or 'cancel'."
 
@@ -1929,7 +1972,6 @@ Rules:
             add(suggestion("Replace day ${dayIndex + 1}", "replace day ${dayIndex + 1}"))
             favouriteDaySuggestion(snapshot, dayIndex)?.let(::add)
         }
-        favouriteModeSuggestion(snapshot)?.let(::add)
         add(suggestion("Help", "help"))
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -137,11 +137,11 @@ class MealPlannerCoordinator @Inject constructor(
         }
         val favouriteDayIndex = slotExtractor.extractFavouriteDayIndex(text)
         if (favouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         val unfavouriteDayIndex = slotExtractor.extractUnfavouriteDayIndex(text)
         if (unfavouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         val missingBefore = missingSlots(snapshot)
         val peopleCount = slotExtractor.extractPeopleCount(text)
@@ -211,11 +211,11 @@ class MealPlannerCoordinator @Inject constructor(
         }
         val favouriteDayIndex = slotExtractor.extractFavouriteDayIndex(text)
         if (favouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         val unfavouriteDayIndex = slotExtractor.extractUnfavouriteDayIndex(text)
         if (unfavouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         val favouriteRecipeMode = slotExtractor.extractFavouriteRecipeMode(text)
         if (favouriteRecipeMode != null) {
@@ -336,10 +336,10 @@ class MealPlannerCoordinator @Inject constructor(
             return MealPlannerReply(planReviewPrompt(snapshot))
         }
         if (favouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, favouriteDayIndex, true)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         if (unfavouriteDayIndex != null) {
-            return handleFavouriteRecipeToggle(snapshot, unfavouriteDayIndex, false)
+            return favouriteManagementMovedToUiReply(snapshot)
         }
         if (replaceDayIndex != null) {
             return replaceDayAndGenerateRecipe(
@@ -1231,7 +1231,7 @@ class MealPlannerCoordinator @Inject constructor(
             )
             else -> MealPlannerActivity(
                 title = "Meal plan ready",
-                subtitle = "Say 'show current plan', 'favourite day 1', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help'.",
+                subtitle = "Say 'show current plan', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help'.",
                 state = MealPlannerActivityState.WAITING,
                 suggestions = finalizeSuggestions(snapshot),
             )
@@ -1341,7 +1341,7 @@ class MealPlannerCoordinator @Inject constructor(
             pendingDay != null ->
                 "Recipe generation is paused at Day ${pendingDay.dayIndex + 1} of ${snapshot.days.size}. Say 'generate recipes' to continue, 'show current plan' to inspect the draft, or 'cancel' to stop."
             else ->
-                "You're at the final review step. Say 'show current plan' to inspect it, 'favourite day 1' or 'unfavourite day 1' to manage saved favourites, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust future bias, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
+                "You're at the final review step. Say 'show current plan' to inspect it, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust future bias, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
         }
     }
 
@@ -1403,47 +1403,16 @@ class MealPlannerCoordinator @Inject constructor(
         }
 
 
-    private suspend fun handleFavouriteRecipeToggle(
-        snapshot: MealPlanSnapshot,
-        dayIndex: Int,
-        favourite: Boolean,
-    ): MealPlannerReply {
-        val day = snapshot.days.firstOrNull { it.dayIndex == dayIndex }
-            ?: return MealPlannerReply(invalidFavouriteDayMessage(dayIndex, snapshot.days.size))
-        if (day.currentRecipeVersion == null) {
-            val action = if (favourite) "save" else "remove"
-            return MealPlannerReply("I can $action favourites once Day ${dayIndex + 1} has a generated recipe. Say 'generate recipes' first.")
-        }
-        if (favourite && day.isFavouriteRecipe) {
-            return MealPlannerReply("Day ${dayIndex + 1} is already saved as a favourite recipe.\n\n${currentPlanReply(snapshot)}")
-        }
-        if (!favourite && !day.isFavouriteRecipe) {
-            return MealPlannerReply("Day ${dayIndex + 1} isn't saved as a favourite recipe yet.\n\n${currentPlanReply(snapshot)}")
-        }
-        return try {
-            val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, dayIndex, favourite)
-            val lead =
-                if (favourite) {
-                    "Saved Day ${dayIndex + 1} as a favourite recipe for future meal plans."
-                } else {
-                    "Removed Day ${dayIndex + 1} from your favourite recipes."
-                }
-            MealPlannerReply("$lead\n\n${currentPlanReply(updated)}")
-        } catch (e: IllegalArgumentException) {
-            MealPlannerReply(e.message ?: if (favourite) "I couldn't favourite that recipe yet." else "I couldn't remove that favourite yet.")
-        }
-    }
+    private fun favouriteManagementMovedToUiReply(snapshot: MealPlanSnapshot): MealPlannerReply =
+        MealPlannerReply(
+            "Favourite and unfavourite actions will move to a dedicated favourites and recent meal plans screen instead of this chat.\n\n${currentPlanReply(snapshot)}",
+        )
 
-    private fun invalidFavouriteDayMessage(dayIndex: Int, totalDays: Int): String = when {
-        totalDays <= 0 -> "I don't have Day ${dayIndex + 1} ready to favourite yet. Say 'generate recipes' first."
-        totalDays == 1 -> "Your current plan only has Day 1, so I can only manage favourites for Day 1."
-        else -> "Your current plan only has $totalDays days, so I can only manage favourites for Day 1 to Day $totalDays."
-    }
     private fun planReviewActionsPrompt(): String =
         "Say 'generate recipes', 'replace day 2', 'change preferences', 'help' for more options, or 'cancel'."
 
     private fun readyToFinalizePrompt(): String =
-        "Say 'show current plan', 'favourite day 1', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help' for more options."
+        "Say 'show current plan', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help' for more options."
 
     private fun statusPrompt(snapshot: MealPlanSnapshot): String = when (snapshot.status) {
         MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS -> {
@@ -1970,7 +1939,6 @@ Rules:
         primaryEditableDay(snapshot)?.let { dayIndex ->
             add(suggestion("Regenerate day ${dayIndex + 1}", "regenerate day ${dayIndex + 1}"))
             add(suggestion("Replace day ${dayIndex + 1}", "replace day ${dayIndex + 1}"))
-            favouriteDaySuggestion(snapshot, dayIndex)?.let(::add)
         }
         add(suggestion("Help", "help"))
     }
@@ -1978,15 +1946,6 @@ Rules:
     private fun primaryEditableDay(snapshot: MealPlanSnapshot): Int? =
         snapshot.days.firstOrNull { it.status == MealPlanDayStatus.PERSISTED }?.dayIndex
             ?: snapshot.days.firstOrNull()?.dayIndex
-
-    private fun favouriteDaySuggestion(snapshot: MealPlanSnapshot, dayIndex: Int): MealPlannerSuggestion? {
-        val day = snapshot.days.firstOrNull { it.dayIndex == dayIndex } ?: return null
-        return if (day.isFavouriteRecipe) {
-            suggestion("Unfavourite day ${dayIndex + 1}", "unfavourite day ${dayIndex + 1}")
-        } else {
-            suggestion("Favourite day ${dayIndex + 1}", "favourite day ${dayIndex + 1}")
-        }
-    }
 
     private fun favouriteModeSuggestion(snapshot: MealPlanSnapshot): MealPlannerSuggestion? = when (snapshot.favouriteRecipeMode) {
         FavouriteRecipeMode.NONE -> suggestion("Prefer favourites", "prefer favourites")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinator.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.core.skills.mealplan
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
 import com.kernel.ai.core.memory.mealplan.MealPlanDayStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanDraft
 import com.kernel.ai.core.memory.mealplan.MealPlanDraftDay
@@ -22,6 +24,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val MAX_FAVOURITE_PROMPT_RECIPES = 6
 
 @Singleton
 class MealPlannerCoordinator @Inject constructor(
@@ -151,6 +155,7 @@ class MealPlannerCoordinator @Inject constructor(
             added = proteinPreferences,
             removed = removedProteinPreferences,
         )
+        val favouriteRecipeMode = slotExtractor.extractFavouriteRecipeMode(text)
         val mergedDietaryRestrictions = updatedDietaryRestrictions ?: snapshot.dietaryRestrictions
         val mergedProteinPreferences = updatedProteinPreferences ?: snapshot.proteinPreferences
         val shouldClearProteinPreferences =
@@ -162,6 +167,7 @@ class MealPlannerCoordinator @Inject constructor(
             daysCount = daysCount,
             dietaryRestrictions = updatedDietaryRestrictions,
             proteinPreferences = if (shouldClearProteinPreferences) emptyList() else updatedProteinPreferences,
+            favouriteRecipeMode = favouriteRecipeMode,
         )
         if (shouldClearProteinPreferences) {
             val conflicts = detectProteinPreferenceConflicts(updated.dietaryRestrictions, mergedProteinPreferences)
@@ -176,7 +182,8 @@ class MealPlannerCoordinator @Inject constructor(
             peopleCount != null ||
                 daysCount != null ||
                 updatedDietaryRestrictions != null ||
-                updatedProteinPreferences != null
+                updatedProteinPreferences != null ||
+                favouriteRecipeMode != null
         if (hadAllSlotsBefore && !hasAnySlotUpdates) {
             if (slotExtractor.isGenerateRecipesRequest(text)) {
                 return generatePlanForReview(updated, onPlannerActivityChanged)
@@ -194,6 +201,15 @@ class MealPlannerCoordinator @Inject constructor(
     ): MealPlannerReply {
         if (slotExtractor.isShowCurrentPlanRequest(text)) {
             return MealPlannerReply(currentPlanReply(snapshot))
+        }
+        val favouriteRecipeMode = slotExtractor.extractFavouriteRecipeMode(text)
+        if (favouriteRecipeMode != null) {
+            sessionRepository.returnToSlotCollection(snapshot.sessionId)
+            val updated = sessionRepository.updateRequiredSlots(
+                sessionId = snapshot.sessionId,
+                favouriteRecipeMode = favouriteRecipeMode,
+            )
+            return MealPlannerReply(promptForPreferenceEditing(updated))
         }
         val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
         if (replaceDayIndex != null) {
@@ -227,8 +243,19 @@ class MealPlannerCoordinator @Inject constructor(
         val pendingDay = snapshot.days.firstOrNull { it.status != MealPlanDayStatus.PERSISTED && it.status != MealPlanDayStatus.FAILED }
         val replaceDayIndex = slotExtractor.extractReplaceDayIndex(text)
         val regenerateDayIndex = slotExtractor.extractRegenerateDayIndex(text)
+        val favouriteRecipeMode = slotExtractor.extractFavouriteRecipeMode(text)
+        val favouriteDayIndex = slotExtractor.extractFavouriteDayIndex(text)
+        val unfavouriteDayIndex = slotExtractor.extractUnfavouriteDayIndex(text)
         if (slotExtractor.isShowCurrentPlanRequest(text)) {
             return MealPlannerReply(currentPlanReply(snapshot))
+        }
+        if (favouriteRecipeMode != null) {
+            sessionRepository.returnToSlotCollection(snapshot.sessionId)
+            val updated = sessionRepository.updateRequiredSlots(
+                sessionId = snapshot.sessionId,
+                favouriteRecipeMode = favouriteRecipeMode,
+            )
+            return MealPlannerReply(promptForPreferenceEditing(updated))
         }
         val interruptedReviewReplacementDayIndex = snapshot.pendingGenerationDayIndex?.takeIf {
             snapshot.pendingGenerationKind == PendingGenerationKind.REPLACEMENT &&
@@ -293,7 +320,22 @@ class MealPlannerCoordinator @Inject constructor(
         if (snapshot.pendingGenerationKind == PendingGenerationKind.PLAN && snapshot.days.isEmpty()) {
             return MealPlannerReply(planReviewPrompt(snapshot))
         }
-
+        if (favouriteDayIndex != null) {
+            return try {
+                val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, favouriteDayIndex, true)
+                MealPlannerReply("Saved Day ${favouriteDayIndex + 1} as a favourite recipe for future meal plans.\n\n${currentPlanReply(updated)}")
+            } catch (e: IllegalArgumentException) {
+                MealPlannerReply(e.message ?: "I couldn't favourite that recipe yet.")
+            }
+        }
+        if (unfavouriteDayIndex != null) {
+            return try {
+                val updated = sessionRepository.setRecipeFavourite(snapshot.sessionId, unfavouriteDayIndex, false)
+                MealPlannerReply("Removed Day ${unfavouriteDayIndex + 1} from your favourite recipes.\n\n${currentPlanReply(updated)}")
+            } catch (e: IllegalArgumentException) {
+                MealPlannerReply(e.message ?: "I couldn't remove that favourite yet.")
+            }
+        }
         if (replaceDayIndex != null) {
             return replaceDayAndGenerateRecipe(
                 snapshot = snapshot,
@@ -340,8 +382,9 @@ class MealPlannerCoordinator @Inject constructor(
             sessionRepository.markPendingGeneration(snapshot.sessionId, PendingGenerationKind.PLAN)
             onPlannerActivityChanged(generatingPlanActivity(snapshot))
             val recentHistory = sessionRepository.getRecentMealHistory(RECENT_MEAL_HISTORY_LIMIT)
+            val favouriteRecipes = sessionRepository.getFavouriteRecipes(MAX_FAVOURITE_PROMPT_RECIPES)
             val rawPlan = inferenceEngine.generateOnce(
-                prompt = buildPlanUserPrompt(snapshot, recentHistory),
+                prompt = buildPlanUserPrompt(snapshot, recentHistory, favouriteRecipes),
                 systemPrompt = buildPlanSystemPrompt(),
                 thinkingEnabled = false,
                 stopOnFirstJsonObject = true,
@@ -433,9 +476,10 @@ class MealPlannerCoordinator @Inject constructor(
         recentHistory: List<RecentMealHistoryEntry>,
     ): MealPlanDraftDay {
         val enforceRecentPatternDiversity = shouldEnforceRecentPatternDiversity(snapshot)
+        val favouriteRecipes = sessionRepository.getFavouriteRecipes(MAX_FAVOURITE_PROMPT_RECIPES)
         repeat(MAX_DAY_VARIETY_REPAIR_ATTEMPTS) {
             val raw = inferenceEngine.generateOnce(
-                prompt = buildReplacementDayUserPrompt(snapshot, currentDays, dayIndex, recentHistory),
+                prompt = buildReplacementDayUserPrompt(snapshot, currentDays, dayIndex, recentHistory, favouriteRecipes),
                 systemPrompt = buildReplacementDaySystemPrompt(dayIndex),
                 thinkingEnabled = false,
                 stopOnFirstJsonObject = true,
@@ -965,9 +1009,10 @@ class MealPlannerCoordinator @Inject constructor(
         }
         try {
             val recentHistory = sessionRepository.getRecentMealHistory(RECENT_MEAL_HISTORY_LIMIT)
+            val favouriteRecipes = sessionRepository.getFavouriteRecipes(MAX_FAVOURITE_PROMPT_RECIPES)
             val enforceRecentPatternDiversity = shouldEnforceRecentPatternDiversity(snapshot)
             val raw = inferenceEngine.generateOnce(
-                prompt = buildReplacementDayUserPrompt(snapshot, dayIndex, recentHistory),
+                prompt = buildReplacementDayUserPrompt(snapshot, dayIndex, recentHistory, favouriteRecipes),
                 systemPrompt = buildReplacementDaySystemPrompt(dayIndex),
                 thinkingEnabled = false,
                 stopOnFirstJsonObject = true,
@@ -1181,7 +1226,7 @@ class MealPlannerCoordinator @Inject constructor(
             )
             else -> MealPlannerActivity(
                 title = "Meal plan ready",
-                subtitle = "Say 'show current plan', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help'.",
+                subtitle = "Say 'show current plan', 'favourite day 1', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help'.",
                 state = MealPlannerActivityState.WAITING,
                 suggestions = finalizeSuggestions(snapshot),
             )
@@ -1228,7 +1273,7 @@ class MealPlannerCoordinator @Inject constructor(
             if (snapshot.days.isEmpty()) {
                 "I still need to rebuild your meal plan draft. You can say 'generate recipes' to try again, 'change preferences' to edit the plan details, 'show current plan' to inspect what I have, or 'cancel' to stop."
             } else {
-                "You're reviewing the draft meal plan. You can say 'show current plan' to inspect it again, 'generate recipes' to build the recipe details, 'replace day 1' to swap one meal, 'change preferences' to edit people, days, dietary needs, or proteins, or 'cancel' to stop."
+                "You're reviewing the draft meal plan. You can say 'show current plan' to inspect it again, 'generate recipes' to build the recipe details, 'replace day 1' to swap one meal, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust favourite bias, 'change preferences' to edit people, days, dietary needs, or proteins, or 'cancel' to stop."
             }
         MealPlanSessionStatus.RECIPES_IN_PROGRESS,
         MealPlanSessionStatus.AWAITING_USER_EDIT_OR_RECOVERY -> activeOrRecoveryHelpPrompt(snapshot, generationActive)
@@ -1247,6 +1292,7 @@ class MealPlannerCoordinator @Inject constructor(
                 appendLine("- 5 days")
                 appendLine("- gluten free, kid friendly, no coriander")
                 appendLine("- chicken, salmon")
+                appendLine("- prefer favourites")
                 appendLine("- remove gluten free")
                 appendLine("- remove no chicken")
                 append("Then say 'generate' to rebuild the plan, 'show current plan' to inspect it, or 'cancel' to stop.")
@@ -1290,7 +1336,7 @@ class MealPlannerCoordinator @Inject constructor(
             pendingDay != null ->
                 "Recipe generation is paused at Day ${pendingDay.dayIndex + 1} of ${snapshot.days.size}. Say 'generate recipes' to continue, 'show current plan' to inspect the draft, or 'cancel' to stop."
             else ->
-                "You're at the final review step. Say 'show current plan' to inspect it, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
+                "You're at the final review step. Say 'show current plan' to inspect it, 'favourite day 1' or 'unfavourite day 1' to manage saved favourites, 'prefer favourites', 'include favourites', or 'avoid favourites' to adjust future bias, 'done meal planning' to finalize it, 'regenerate day 1' or 'replace day 1' to revise a day, or 'cancel' to stop."
         }
     }
 
@@ -1311,7 +1357,7 @@ class MealPlannerCoordinator @Inject constructor(
         append("Current plan details: ")
         append(buildKnownBits(snapshot).ifEmpty { listOf("no saved details yet") }.joinToString(", "))
         append(".\n\n")
-        append("Reply with any updated people count, days, dietary requirements, allergens, ingredients to avoid, or protein preferences. Say 'help' for examples or 'cancel' to stop.")
+        append("Reply with any updated people count, days, dietary requirements, allergens, ingredients to avoid, protein preferences, or favourite recipe preference. Say 'help' for examples or 'cancel' to stop.")
     }
 
     private fun buildKnownBits(snapshot: MealPlanSnapshot): List<String> = buildList {
@@ -1319,6 +1365,7 @@ class MealPlannerCoordinator @Inject constructor(
         snapshot.daysCount?.let { add("$it days") }
         if (snapshot.dietaryRestrictions.isNotEmpty()) add(snapshot.dietaryRestrictions.joinToString())
         if (snapshot.proteinPreferences.isNotEmpty()) add(snapshot.proteinPreferences.joinToString())
+        if (snapshot.favouriteRecipeMode != FavouriteRecipeMode.NONE) add(favouriteModeLabel(snapshot.favouriteRecipeMode))
     }
 
     private fun missingSlots(snapshot: MealPlanSnapshot): List<String> = buildList {
@@ -1354,7 +1401,7 @@ class MealPlannerCoordinator @Inject constructor(
         "Say 'generate recipes', 'replace day 2', 'change preferences', 'help' for more options, or 'cancel'."
 
     private fun readyToFinalizePrompt(): String =
-        "Say 'show current plan', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help' for more options."
+        "Say 'show current plan', 'favourite day 1', 'replace day 1', 'regenerate day 2', 'done meal planning', or 'help' for more options."
 
     private fun statusPrompt(snapshot: MealPlanSnapshot): String = when (snapshot.status) {
         MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS -> {
@@ -1438,9 +1485,13 @@ class MealPlannerCoordinator @Inject constructor(
         if (snapshot.dietaryRestrictions.isNotEmpty()) {
             append(" (${snapshot.dietaryRestrictions.joinToString()})")
         }
+        if (snapshot.favouriteRecipeMode != FavouriteRecipeMode.NONE) {
+            append(" with ${favouriteModeLabel(snapshot.favouriteRecipeMode)}")
+        }
         append(":\n")
         snapshot.days.sortedBy { it.dayIndex }.forEach { day ->
             append("- Day ${day.dayIndex + 1}: ${day.title ?: "Meal"}")
+            if (day.isFavouriteRecipe) append(" ★ favourite")
             day.summary?.let { append(" — $it") }
             append('\n')
         }
@@ -1486,9 +1537,11 @@ Rules:
     private fun buildPlanUserPrompt(
         snapshot: MealPlanSnapshot,
         recentHistory: List<RecentMealHistoryEntry>,
+        favouriteRecipes: List<FavouriteRecipeSummary>,
     ): String {
         val now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy", Locale.ENGLISH))
         val recentHistoryBlock = buildRecentHistoryPromptBlock(recentHistory)
+        val favouritePromptBlock = buildFavouriteRecipePromptBlock(snapshot.favouriteRecipeMode, favouriteRecipes)
         return buildString {
             appendLine("Build a ${snapshot.daysCount}-day dinner meal plan for ${snapshot.peopleCount} people.")
             appendLine("Date: $now")
@@ -1498,6 +1551,10 @@ Rules:
             if (recentHistoryBlock.isNotBlank()) {
                 appendLine()
                 append(recentHistoryBlock)
+            }
+            if (favouritePromptBlock.isNotBlank()) {
+                appendLine()
+                append(favouritePromptBlock)
             }
         }.trim()
     }
@@ -1570,6 +1627,7 @@ Rules:
         snapshot: MealPlanSnapshot,
         dayIndex: Int,
         recentHistory: List<RecentMealHistoryEntry>,
+        favouriteRecipes: List<FavouriteRecipeSummary>,
     ): String =
         buildReplacementDayUserPrompt(
             snapshot = snapshot,
@@ -1583,6 +1641,7 @@ Rules:
             },
             dayIndex = dayIndex,
             recentHistory = recentHistory,
+            favouriteRecipes = favouriteRecipes,
         )
 
     private fun buildReplacementDayUserPrompt(
@@ -1590,9 +1649,11 @@ Rules:
         currentDays: List<MealPlanDraftDay>,
         dayIndex: Int,
         recentHistory: List<RecentMealHistoryEntry>,
+        favouriteRecipes: List<FavouriteRecipeSummary>,
     ): String {
         val currentTitle = currentDays.firstOrNull { it.dayIndex == dayIndex }?.title ?: "Day ${dayIndex + 1}"
         val recentHistoryBlock = buildRecentHistoryPromptBlock(recentHistory)
+        val favouritePromptBlock = buildFavouriteRecipePromptBlock(snapshot.favouriteRecipeMode, favouriteRecipes)
         return buildString {
             appendLine("Replace Day ${dayIndex + 1} in this meal plan.")
             appendLine("Current plan:")
@@ -1602,6 +1663,10 @@ Rules:
             if (recentHistoryBlock.isNotBlank()) {
                 appendLine()
                 appendLine(recentHistoryBlock)
+            }
+            if (favouritePromptBlock.isNotBlank()) {
+                appendLine()
+                appendLine(favouritePromptBlock)
             }
             appendLine()
             appendLine("Return one alternative day that fits the plan without duplicating '$currentTitle' or clashing with the surrounding days.")
@@ -1633,6 +1698,33 @@ Rules:
                 append("Also vary away from these recent protein + cooking styles: ${recentPatterns.joinToString()}")
             }
         }.trim()
+    }
+
+    private fun buildFavouriteRecipePromptBlock(
+        mode: FavouriteRecipeMode,
+        favouriteRecipes: List<FavouriteRecipeSummary>,
+    ): String {
+        if (mode == FavouriteRecipeMode.NONE) return ""
+        if (favouriteRecipes.isEmpty()) {
+            return when (mode) {
+                FavouriteRecipeMode.INCLUDE -> "The user asked to include favourites, but no favourite recipes are saved yet. Build a fresh plan."
+                FavouriteRecipeMode.PREFER -> "The user asked to prefer favourites, but no favourite recipes are saved yet. Build a fresh plan and avoid pretending favourites exist."
+                FavouriteRecipeMode.AVOID -> "Avoid leaning on saved favourites; keep this plan fresh."
+                FavouriteRecipeMode.NONE -> ""
+            }
+        }
+        val favouritesText = favouriteRecipes.joinToString("; ") { favourite ->
+            buildString {
+                append(favourite.title)
+                favourite.summary?.takeIf { it.isNotBlank() }?.let { append(" — $it") }
+            }
+        }
+        return when (mode) {
+            FavouriteRecipeMode.INCLUDE -> "Include 1-2 saved favourite meals if they fit naturally: $favouritesText"
+            FavouriteRecipeMode.PREFER -> "Bias the plan toward these saved favourite meals when they fit naturally: $favouritesText"
+            FavouriteRecipeMode.AVOID -> "Avoid these saved favourite meals for this plan: $favouritesText"
+            FavouriteRecipeMode.NONE -> ""
+        }
     }
 
     private fun generatingPlanActivity(snapshot: MealPlanSnapshot): MealPlannerActivity = MealPlannerActivity(
@@ -1706,6 +1798,7 @@ Rules:
         primaryEditableDay(snapshot)?.let { dayIndex ->
             add(suggestion("Replace day ${dayIndex + 1}", "replace day ${dayIndex + 1}"))
         }
+        favouriteModeSuggestion(snapshot)?.let(::add)
         add(suggestion("Change preferences", "change preferences"))
         add(suggestion("Help", "help"))
     }
@@ -1762,6 +1855,7 @@ Rules:
             add(suggestion("Cancel plan", "cancel plan"))
         }.distinctBy(MealPlannerSuggestion::command)
     }
+
     private fun starterDietarySuggestions(): List<String> =
         listOf("no dietary requirements", "kid friendly", "gluten free", "nut free")
 
@@ -1827,19 +1921,45 @@ Rules:
             append(" or say 'no protein preference'.")
         }
     }
+
     private fun finalizeSuggestions(snapshot: MealPlanSnapshot): List<MealPlannerSuggestion> = buildList {
         add(suggestion("Show current plan", "show current plan"))
         add(suggestion("Done meal planning", "done meal planning"))
         primaryEditableDay(snapshot)?.let { dayIndex ->
             add(suggestion("Regenerate day ${dayIndex + 1}", "regenerate day ${dayIndex + 1}"))
             add(suggestion("Replace day ${dayIndex + 1}", "replace day ${dayIndex + 1}"))
+            favouriteDaySuggestion(snapshot, dayIndex)?.let(::add)
         }
+        favouriteModeSuggestion(snapshot)?.let(::add)
         add(suggestion("Help", "help"))
     }
 
     private fun primaryEditableDay(snapshot: MealPlanSnapshot): Int? =
         snapshot.days.firstOrNull { it.status == MealPlanDayStatus.PERSISTED }?.dayIndex
             ?: snapshot.days.firstOrNull()?.dayIndex
+
+    private fun favouriteDaySuggestion(snapshot: MealPlanSnapshot, dayIndex: Int): MealPlannerSuggestion? {
+        val day = snapshot.days.firstOrNull { it.dayIndex == dayIndex } ?: return null
+        return if (day.isFavouriteRecipe) {
+            suggestion("Unfavourite day ${dayIndex + 1}", "unfavourite day ${dayIndex + 1}")
+        } else {
+            suggestion("Favourite day ${dayIndex + 1}", "favourite day ${dayIndex + 1}")
+        }
+    }
+
+    private fun favouriteModeSuggestion(snapshot: MealPlanSnapshot): MealPlannerSuggestion? = when (snapshot.favouriteRecipeMode) {
+        FavouriteRecipeMode.NONE -> suggestion("Prefer favourites", "prefer favourites")
+        FavouriteRecipeMode.PREFER -> suggestion("Avoid favourites", "avoid favourites")
+        FavouriteRecipeMode.AVOID -> suggestion("Include favourites", "include favourites")
+        FavouriteRecipeMode.INCLUDE -> suggestion("Prefer favourites", "prefer favourites")
+    }
+
+    private fun favouriteModeLabel(mode: FavouriteRecipeMode): String = when (mode) {
+        FavouriteRecipeMode.NONE -> "no favourite recipe bias"
+        FavouriteRecipeMode.INCLUDE -> "some saved favourites mixed in"
+        FavouriteRecipeMode.PREFER -> "saved favourites preferred"
+        FavouriteRecipeMode.AVOID -> "saved favourites avoided"
+    }
 
     private fun suggestion(
         label: String,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractor.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.skills.mealplan
 
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -263,6 +264,24 @@ class MealPlannerSlotExtractor @Inject constructor() {
     fun isChangePreferencesRequest(text: String): Boolean =
         Regex("\\b(?:change|edit|update|revise)\\s+(?:preferences?|details?|requirements?)\\b", RegexOption.IGNORE_CASE)
             .containsMatchIn(text)
+
+    fun extractFavouriteDayIndex(text: String): Int? =
+        Regex("\\b(?:favo(?:u)?rite|star|save)\\s+(?:recipe\\s+for\\s+)?day\\s+(\\d+)\\b", RegexOption.IGNORE_CASE)
+            .find(text)?.groupValues?.getOrNull(1)?.toIntOrNull()?.minus(1)
+
+    fun extractUnfavouriteDayIndex(text: String): Int? =
+        Regex("\\b(?:unfavo(?:u)?rite|remove\\s+favo(?:u)?rite\\s+from|unstar)\\s+(?:recipe\\s+for\\s+)?day\\s+(\\d+)\\b", RegexOption.IGNORE_CASE)
+            .find(text)?.groupValues?.getOrNull(1)?.toIntOrNull()?.minus(1)
+
+    fun extractFavouriteRecipeMode(text: String): FavouriteRecipeMode? {
+        val normalized = normalizeWords(text)
+        return when {
+            Regex("\\b(?:prefer|use|bring\\s+back|plan\\s+with)\\s+(?:my\\s+)?favo(?:u)?rites?\\b", RegexOption.IGNORE_CASE).containsMatchIn(normalized) -> FavouriteRecipeMode.PREFER
+            Regex("\\b(?:include|mix\\s+in|add)\\s+(?:my\\s+)?favo(?:u)?rites?\\b", RegexOption.IGNORE_CASE).containsMatchIn(normalized) -> FavouriteRecipeMode.INCLUDE
+            Regex("\\b(?:avoid|skip|no)\\s+(?:my\\s+)?favo(?:u)?rites?(?:\\s+(?:for\\s+(?:this\\s+)?plan|this\\s+week|for\\s+now))?\\b", RegexOption.IGNORE_CASE).containsMatchIn(normalized) -> FavouriteRecipeMode.AVOID
+            else -> null
+        }
+    }
 
 
     private fun normalizeWords(text: String): String {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -800,43 +800,26 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
-    fun `ready plan favourite day marks recipe as favourite`() = runTest {
+    fun `ready plan favourite day redirects to future dedicated UI`() = runTest {
         val ready = readyForFinalizeSnapshot(finalSummaryWritten = false)
-        val updated = ready.copy(
-            days = ready.days.mapIndexed { index, day ->
-                if (index == 0) day.copy(isFavouriteRecipe = true) else day
-            },
-        )
         coEvery { sessionRepository.getActiveSession("conv") } returns ready
-        coEvery { sessionRepository.setRecipeFavourite("session-1", 0, true) } returns updated
 
         val reply = coordinator.ingestUserMessage("conv", "favourite day 1")
 
-        assertTrue(reply.content.contains("Saved Day 1 as a favourite recipe", ignoreCase = true))
-        assertTrue(reply.content.contains("★ favourite"))
-        coVerify { sessionRepository.setRecipeFavourite("session-1", 0, true) }
-    }
-
-    @Test
-    fun `ready plan unfavourite day that is not saved returns guidance`() = runTest {
-        val ready = readyForFinalizeSnapshot(finalSummaryWritten = false)
-        coEvery { sessionRepository.getActiveSession("conv") } returns ready
-
-        val reply = coordinator.ingestUserMessage("conv", "unfavourite day 1")
-
-        assertTrue(reply.content.contains("isn't saved as a favourite recipe yet", ignoreCase = true))
+        assertTrue(reply.content.contains("dedicated favourites and recent meal plans screen", ignoreCase = true))
+        assertTrue(reply.content.contains("Day 1: Chicken stir-fry", ignoreCase = true))
         coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
     }
 
     @Test
-    fun `plan review favourite day asks for recipes first`() = runTest {
+    fun `plan review favourite day redirects to future dedicated UI`() = runTest {
         val planReview = planReviewSnapshot()
         coEvery { sessionRepository.getActiveSession("conv") } returns planReview
 
         val reply = coordinator.ingestUserMessage("conv", "favourite day 2")
 
-        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
-        assertTrue(reply.content.contains("Day 2", ignoreCase = true))
+        assertTrue(reply.content.contains("dedicated favourites and recent meal plans screen", ignoreCase = true))
+        assertTrue(reply.content.contains("Day 2: Beef bowls", ignoreCase = true))
         coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
     }
 
@@ -1143,27 +1126,18 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
-    fun `collecting state can unfavourite a generated day while editing preferences`() = runTest {
+    fun `collecting state favourite commands redirect to future dedicated UI`() = runTest {
         val collecting = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
             status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS,
             favouriteRecipeMode = FavouriteRecipeMode.AVOID,
-            days = readyForFinalizeSnapshot(finalSummaryWritten = false).days.mapIndexed { index, day ->
-                if (index == 1) day.copy(isFavouriteRecipe = true) else day
-            },
-        )
-        val updated = collecting.copy(
-            days = collecting.days.mapIndexed { index, day ->
-                if (index == 1) day.copy(isFavouriteRecipe = false) else day
-            },
         )
         coEvery { sessionRepository.getActiveSession("conv") } returns collecting
-        coEvery { sessionRepository.setRecipeFavourite("session-1", 1, false) } returns updated
 
         val reply = coordinator.ingestUserMessage("conv", "unfavourite day 2")
 
-        assertTrue(reply.content.contains("Removed Day 2", ignoreCase = true))
-        assertFalse(reply.content.contains("★ favourite"))
-        coVerify { sessionRepository.setRecipeFavourite("session-1", 1, false) }
+        assertTrue(reply.content.contains("dedicated favourites and recent meal plans screen", ignoreCase = true))
+        assertTrue(reply.content.contains("saved favourites avoided", ignoreCase = true))
+        coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
         coVerify(exactly = 0) { sessionRepository.updateRequiredSlots(any(), any(), any(), any(), any()) }
     }
     @Test
@@ -1328,7 +1302,7 @@ class MealPlannerCoordinatorTest {
         val activity = coordinator.activeSessionActivity("conv")
 
         assertEquals(
-            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "favourite day 1", "help"),
+            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "help"),
             activity?.suggestions?.map { it.command },
         )
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -818,6 +818,29 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `ready plan unfavourite day that is not saved returns guidance`() = runTest {
+        val ready = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        coEvery { sessionRepository.getActiveSession("conv") } returns ready
+
+        val reply = coordinator.ingestUserMessage("conv", "unfavourite day 1")
+
+        assertTrue(reply.content.contains("isn't saved as a favourite recipe yet", ignoreCase = true))
+        coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
+    }
+
+    @Test
+    fun `plan review favourite day asks for recipes first`() = runTest {
+        val planReview = planReviewSnapshot()
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReview
+
+        val reply = coordinator.ingestUserMessage("conv", "favourite day 2")
+
+        assertTrue(reply.content.contains("generate recipes", ignoreCase = true))
+        assertTrue(reply.content.contains("Day 2", ignoreCase = true))
+        coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
+    }
+
+    @Test
     fun `plan review replacement emits working activity before draft update`() = runTest {
         val planReview = planReviewSnapshot()
         val replaced = planReview.copy(
@@ -1118,6 +1141,31 @@ class MealPlannerCoordinatorTest {
         assertTrue(reply.content.contains("Reply with any updated people count", ignoreCase = true))
         coVerify(exactly = 0) { sessionRepository.updateRequiredSlots(any(), any(), any(), any(), any()) }
     }
+
+    @Test
+    fun `collecting state can unfavourite a generated day while editing preferences`() = runTest {
+        val collecting = readyForFinalizeSnapshot(finalSummaryWritten = false).copy(
+            status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS,
+            favouriteRecipeMode = FavouriteRecipeMode.AVOID,
+            days = readyForFinalizeSnapshot(finalSummaryWritten = false).days.mapIndexed { index, day ->
+                if (index == 1) day.copy(isFavouriteRecipe = true) else day
+            },
+        )
+        val updated = collecting.copy(
+            days = collecting.days.mapIndexed { index, day ->
+                if (index == 1) day.copy(isFavouriteRecipe = false) else day
+            },
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns collecting
+        coEvery { sessionRepository.setRecipeFavourite("session-1", 1, false) } returns updated
+
+        val reply = coordinator.ingestUserMessage("conv", "unfavourite day 2")
+
+        assertTrue(reply.content.contains("Removed Day 2", ignoreCase = true))
+        assertFalse(reply.content.contains("★ favourite"))
+        coVerify { sessionRepository.setRecipeFavourite("session-1", 1, false) }
+        coVerify(exactly = 0) { sessionRepository.updateRequiredSlots(any(), any(), any(), any(), any()) }
+    }
     @Test
     fun `collecting state generate rebuilds plan instead of looping edit prompt`() = runTest {
         val collecting = planReviewSnapshot().copy(status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS)
@@ -1280,7 +1328,7 @@ class MealPlannerCoordinatorTest {
         val activity = coordinator.activeSessionActivity("conv")
 
         assertEquals(
-            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "favourite day 1", "prefer favourites", "help"),
+            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "favourite day 1", "help"),
             activity?.suggestions?.map { it.command },
         )
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -1047,6 +1047,29 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `collecting state prefer favourites stays in editable flow until generate`() = runTest {
+        val collecting = planReviewSnapshot().copy(status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS)
+        val updated = collecting.copy(favouriteRecipeMode = FavouriteRecipeMode.PREFER)
+        coEvery { sessionRepository.getActiveSession("conv") } returns collecting
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = null,
+                proteinPreferences = null,
+                favouriteRecipeMode = FavouriteRecipeMode.PREFER,
+            )
+        } returns updated
+
+        val reply = coordinator.ingestUserMessage("conv", "prefer favourites")
+
+        assertTrue(reply.content.contains("Current plan details", ignoreCase = true))
+        assertTrue(reply.content.contains("saved favourites preferred", ignoreCase = true))
+        coVerify(exactly = 0) { inferenceEngine.generateOnce(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `collecting state can replace a protein in one message`() = runTest {
         val collecting = planReviewSnapshot().copy(
             status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS,

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.core.skills.mealplan
 
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
 import com.kernel.ai.core.memory.mealplan.MealPlanDayStatus
 import com.kernel.ai.core.memory.mealplan.MealPlanDraftDay
 import com.kernel.ai.core.memory.mealplan.MealPlanSessionStatus
@@ -26,6 +27,7 @@ class MealPlannerCoordinatorTest {
     private val sessionRepository = mockk<MealPlanSessionRepository>(relaxed = true) {
         coEvery { getRecentMealHistory(any()) } returns emptyList()
         coEvery { getPendingCompletedSummarySessions(any()) } returns emptyList()
+        coEvery { getFavouriteRecipes(any()) } returns emptyList()
     }
     private val slotExtractor = MealPlannerSlotExtractor()
     private val jsonParser = MealPlanJsonParser()
@@ -760,6 +762,62 @@ class MealPlannerCoordinatorTest {
     }
 
     @Test
+    fun `plan review prefer favourites returns to editable preference flow`() = runTest {
+        val planReview = planReviewSnapshot()
+        val editable = planReview.copy(
+            status = MealPlanSessionStatus.COLLECTING_REQUIRED_SLOTS,
+            favouriteRecipeMode = FavouriteRecipeMode.PREFER,
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReview
+        coEvery { sessionRepository.returnToSlotCollection("session-1") } returns editable
+        coEvery {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = null,
+                proteinPreferences = null,
+                favouriteRecipeMode = FavouriteRecipeMode.PREFER,
+            )
+        } returns editable
+
+        val reply = coordinator.ingestUserMessage("conv", "prefer favourites")
+
+        assertTrue(reply.content.contains("Current plan details", ignoreCase = true))
+        assertTrue(reply.content.contains("saved favourites preferred", ignoreCase = true))
+        coVerify { sessionRepository.returnToSlotCollection("session-1") }
+        coVerify {
+            sessionRepository.updateRequiredSlots(
+                sessionId = "session-1",
+                peopleCount = null,
+                daysCount = null,
+                dietaryRestrictions = null,
+                proteinPreferences = null,
+                favouriteRecipeMode = FavouriteRecipeMode.PREFER,
+            )
+        }
+        coVerify(exactly = 0) { inferenceEngine.generateOnce(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `ready plan favourite day marks recipe as favourite`() = runTest {
+        val ready = readyForFinalizeSnapshot(finalSummaryWritten = false)
+        val updated = ready.copy(
+            days = ready.days.mapIndexed { index, day ->
+                if (index == 0) day.copy(isFavouriteRecipe = true) else day
+            },
+        )
+        coEvery { sessionRepository.getActiveSession("conv") } returns ready
+        coEvery { sessionRepository.setRecipeFavourite("session-1", 0, true) } returns updated
+
+        val reply = coordinator.ingestUserMessage("conv", "favourite day 1")
+
+        assertTrue(reply.content.contains("Saved Day 1 as a favourite recipe", ignoreCase = true))
+        assertTrue(reply.content.contains("★ favourite"))
+        coVerify { sessionRepository.setRecipeFavourite("session-1", 0, true) }
+    }
+
+    @Test
     fun `plan review replacement emits working activity before draft update`() = runTest {
         val planReview = planReviewSnapshot()
         val replaced = planReview.copy(
@@ -1175,7 +1233,7 @@ class MealPlannerCoordinatorTest {
         val activity = coordinator.activeSessionActivity("conv")
 
         assertEquals(
-            listOf("generate recipes", "show current plan", "replace day 1", "change preferences", "help"),
+            listOf("generate recipes", "show current plan", "replace day 1", "prefer favourites", "change preferences", "help"),
             activity?.suggestions?.map { it.command },
         )
     }
@@ -1199,7 +1257,7 @@ class MealPlannerCoordinatorTest {
         val activity = coordinator.activeSessionActivity("conv")
 
         assertEquals(
-            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "help"),
+            listOf("show current plan", "done meal planning", "regenerate day 1", "replace day 1", "favourite day 1", "prefer favourites", "help"),
             activity?.suggestions?.map { it.command },
         )
     }
@@ -1566,6 +1624,7 @@ class MealPlannerCoordinatorTest {
         daysCount = null,
         dietaryRestrictions = emptyList(),
         proteinPreferences = emptyList(),
+        favouriteRecipeMode = FavouriteRecipeMode.NONE,
         activeDayIndex = null,
         pendingGenerationKind = null,
         pendingGenerationDayIndex = null,
@@ -1587,6 +1646,7 @@ class MealPlannerCoordinatorTest {
         daysCount = 2,
         dietaryRestrictions = listOf("low lactose"),
         proteinPreferences = listOf("chicken"),
+        favouriteRecipeMode = FavouriteRecipeMode.NONE,
         activeDayIndex = null,
         pendingGenerationKind = null,
         pendingGenerationDayIndex = null,
@@ -1617,6 +1677,8 @@ class MealPlannerCoordinatorTest {
                     lastErrorCode = null,
                     lastErrorMessage = null,
                     currentRecipe = null,
+                    recipeKey = null,
+                    isFavouriteRecipe = false,
                 )
             },
         )
@@ -1630,6 +1692,7 @@ class MealPlannerCoordinatorTest {
         daysCount = 2,
         dietaryRestrictions = listOf("low lactose"),
         proteinPreferences = listOf("chicken"),
+        favouriteRecipeMode = FavouriteRecipeMode.NONE,
         activeDayIndex = null,
         pendingGenerationKind = null,
         pendingGenerationDayIndex = null,
@@ -1657,6 +1720,8 @@ class MealPlannerCoordinatorTest {
         lastErrorCode = null,
         lastErrorMessage = null,
         currentRecipe = null,
+        recipeKey = if (status == MealPlanDayStatus.PERSISTED) title.lowercase() else null,
+        isFavouriteRecipe = false,
     )
 
     private fun planJson(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerCoordinatorTest.kt
@@ -784,7 +784,7 @@ class MealPlannerCoordinatorTest {
         val reply = coordinator.ingestUserMessage("conv", "prefer favourites")
 
         assertTrue(reply.content.contains("Current plan details", ignoreCase = true))
-        assertTrue(reply.content.contains("saved favourites preferred", ignoreCase = true))
+        assertFalse(reply.content.contains("saved favourites preferred", ignoreCase = true))
         coVerify { sessionRepository.returnToSlotCollection("session-1") }
         coVerify {
             sessionRepository.updateRequiredSlots(
@@ -1071,7 +1071,7 @@ class MealPlannerCoordinatorTest {
         val reply = coordinator.ingestUserMessage("conv", "prefer favourites")
 
         assertTrue(reply.content.contains("Current plan details", ignoreCase = true))
-        assertTrue(reply.content.contains("saved favourites preferred", ignoreCase = true))
+        assertFalse(reply.content.contains("saved favourites preferred", ignoreCase = true))
         coVerify(exactly = 0) { inferenceEngine.generateOnce(any(), any(), any(), any()) }
     }
 
@@ -1136,7 +1136,7 @@ class MealPlannerCoordinatorTest {
         val reply = coordinator.ingestUserMessage("conv", "unfavourite day 2")
 
         assertTrue(reply.content.contains("dedicated favourites and recent meal plans screen", ignoreCase = true))
-        assertTrue(reply.content.contains("saved favourites avoided", ignoreCase = true))
+        assertFalse(reply.content.contains("saved favourites avoided", ignoreCase = true))
         coVerify(exactly = 0) { sessionRepository.setRecipeFavourite(any(), any(), any()) }
         coVerify(exactly = 0) { sessionRepository.updateRequiredSlots(any(), any(), any(), any(), any()) }
     }
@@ -1278,9 +1278,33 @@ class MealPlannerCoordinatorTest {
         val activity = coordinator.activeSessionActivity("conv")
 
         assertEquals(
-            listOf("generate recipes", "show current plan", "replace day 1", "prefer favourites", "change preferences", "help"),
+            listOf("generate recipes", "show current plan", "replace day 1", "change preferences", "help"),
             activity?.suggestions?.map { it.command },
         )
+    }
+
+    @Test
+    fun `plan review help omits favourite bias affordances`() = runTest {
+        coEvery { sessionRepository.getActiveSession("conv") } returns planReviewSnapshot()
+
+        val reply = coordinator.ingestUserMessage("conv", "help")
+
+        assertTrue(reply.content.contains("replace day 1", ignoreCase = true))
+        assertFalse(reply.content.contains("prefer favourites", ignoreCase = true))
+        assertFalse(reply.content.contains("include favourites", ignoreCase = true))
+        assertFalse(reply.content.contains("avoid favourites", ignoreCase = true))
+    }
+
+    @Test
+    fun `ready help omits favourite bias affordances`() = runTest {
+        coEvery { sessionRepository.getActiveSession("conv") } returns readyForFinalizeSnapshot(finalSummaryWritten = false)
+
+        val reply = coordinator.ingestUserMessage("conv", "help")
+
+        assertTrue(reply.content.contains("done meal planning", ignoreCase = true))
+        assertFalse(reply.content.contains("prefer favourites", ignoreCase = true))
+        assertFalse(reply.content.contains("include favourites", ignoreCase = true))
+        assertFalse(reply.content.contains("avoid favourites", ignoreCase = true))
     }
 
     @Test

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/mealplan/MealPlannerSlotExtractorTest.kt
@@ -186,4 +186,23 @@ class MealPlannerSlotExtractorTest {
     fun `isChangePreferencesRequest recognizes edit request`() {
         assertTrue(extractor.isChangePreferencesRequest("change preferences"))
     }
+
+    @Test
+    fun `extractFavouriteDayIndex parses favourite commands`() {
+        assertEquals(0, extractor.extractFavouriteDayIndex("favourite day 1"))
+        assertEquals(1, extractor.extractFavouriteDayIndex("save recipe for day 2"))
+    }
+
+    @Test
+    fun `extractUnfavouriteDayIndex parses unfavourite commands`() {
+        assertEquals(0, extractor.extractUnfavouriteDayIndex("unfavourite day 1"))
+        assertEquals(2, extractor.extractUnfavouriteDayIndex("remove favourite from day 3"))
+    }
+
+    @Test
+    fun `extractFavouriteRecipeMode recognizes include prefer and avoid phrases`() {
+        assertEquals(com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode.INCLUDE, extractor.extractFavouriteRecipeMode("include favourites"))
+        assertEquals(com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode.PREFER, extractor.extractFavouriteRecipeMode("prefer my favourites"))
+        assertEquals(com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode.AVOID, extractor.extractFavouriteRecipeMode("avoid favourites for this plan"))
+    }
 }


### PR DESCRIPTION
## Summary

Adds the canonical groundwork for favourite recipes on top of the post-#925 deterministic meal planner, while deferring favourite-management UX to a dedicated follow-up UI.

## What changed
- add a canonical favourite recipe store in Room (`meal_plan_favourite_recipes`)
- add stable recipe keys on `meal_plan_recipe_versions`
- add a persisted per-session favourite bias mode (`NONE` / `INCLUDE` / `PREFER` / `AVOID`)
- expose favourite metadata on meal-plan snapshots so future UI can surface curated favourites cleanly
- compose favourite bias into the current post-#925 prompt path without regressing recent-history / anti-repetition guidance
- preserve favourite-bias groundwork in the planner implementation without advertising it through current chat smart replies or help text
- remove chat-based favourite / unfavourite recipe management as the primary UX
- redirect chat favourite-management attempts toward a future dedicated favourites / recent-meal-plans UI
- avoid showing favourite-management or favourite-bias smart reply chips in the planner review surfaces
- add Room migration `45 -> 46` for favourite recipe groundwork on top of the merged planner schema

## Scope note
This PR intentionally keeps the **groundwork** and defers favourite-management UI to follow-up issue #933.

## Testing
- [x] `./gradlew --rerun-tasks :core:skills:testDebugUnitTest --tests "*MealPlannerCoordinatorTest" --tests "*MealPlannerSlotExtractorTest" :core:memory:assembleDebugAndroidTest`
- [x] `./gradlew --rerun-tasks :core:skills:testDebugUnitTest --tests "*MealPlannerCoordinatorTest"`
- [x] required repository `code-reviewer` pass on final branch

## Manual testing
### Scenario 1 — chat favourite management is deferred to dedicated UI
- At draft-plan review or after recipes are generated, say `favourite day 1` or `unfavourite day 1`.
- Confirm the assistant explains that favourite management is moving to a dedicated favourites / recent meal plans screen.
- Confirm the current plan remains visible and no recipe is silently mutated in chat.

### Scenario 2 — planner review surfaces stay free of favourite affordances
- Start a new meal-planner flow and reach draft-plan review.
- Confirm the visible planner prompt does not advertise `prefer favourites`, `include favourites`, or `avoid favourites`.
- Confirm smart reply chips stay focused on `generate recipes`, `show current plan`, `replace day N`, `change preferences`, and `help`.
- After recipes are generated, confirm final-review help/suggestions also remain free of favourite affordances.

### Scenario 3 — migration upgrade from schema 45
- Install a build from current `main` (schema 45) and create at least one meal plan.
- Upgrade to this PR build.
- Launch the app and confirm database migration succeeds without crash.
- Open the meal planner and confirm existing plans still load.

Closes #882