### PR TITLE
fix(#876,#912,#736): TTS normalisation — fractions, pronoun scope, Kiwi corpus

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,17 @@ User input
 └─────────────────────────────┘
 ```
 
+**`save_memory` intent routing** (fix #937, commit `480fafcd`): `save_memory` spans both tiers with deliberate fall-through rules — do not add new patterns without checking these:
+
+| Input | Tier | Reason |
+|-------|------|--------|
+| `save/store/keep [to/in memory [that] \| that] <content>` | **Tier 2** | QuickIntentRouter intercepts and stores directly |
+| `save/store/keep this/it …` | **Tier 3 (E4B)** | Anaphoric — `this`/`it` need LLM context to resolve; falls through |
+| `remember [that] <content>` — content does **not** start with `I`, `I'm`, `this`, `that`, or `it` | **Tier 2** | QuickIntentRouter intercepts |
+| `remember that I …` / `remember that this/that/it …` | **Tier 3 (E4B)** | Negative lookahead excludes first-person & demonstrative openers |
+
+When Tier 2 intercepts, `NativeIntentHandler.saveMemory()` calls `normaliseSaveContent()` before storing: `\bmy\b` → `Name's` and `\bI'm\b` → `Name is`, resolved from `UserProfileRepository.getStructured()?.name`. Bare `I` is **not** replaced — verb conjugation requires the LLM, and those inputs fall through via the negative lookahead above.
+
 **Model inventory:**
 
 | Model | Role | Size | Loading |

--- a/core/inference/src/main/assets/jandal_vocab.json
+++ b/core/inference/src/main/assets/jandal_vocab.json
@@ -162,5 +162,17 @@
   {
     "phrase": "wop-wops",
     "meaning": "the middle of nowhere, a remote rural area"
+  },
+  {
+    "phrase": "kumara",
+    "meaning": "NZ sweet potato — use instead of 'sweet potato'"
+  },
+  {
+    "phrase": "chocka",
+    "meaning": "completely full or packed — a place, a vehicle, or a stomach"
+  },
+  {
+    "phrase": "hundies",
+    "meaning": "one hundred percent — used as enthusiastic agreement or to mean full commitment"
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -3,7 +3,7 @@
     "id": "nz_001",
     "term": "Always blow on the pie",
     "category": "safety",
-    "definition": "The essential rule for eating a meat pie from a dairy or gas station. Prevents thermo-nuclear mouth burns.",
+    "definition": "The essential rule for eating a meat pie from a dairy or petrol station. Prevents thermo-nuclear mouth burns.",
     "trigger_context": "When the user is rushing, acting recklessly, or asking about food safety.",
     "vibe_level": 2,
     "vector_text": "Always blow on the pie. Hot food safety. Rushing and being impatient. Thermal burns from meat pie. Patience. Slow down. Safer communities together.",
@@ -2326,6 +2326,66 @@
         "everyday"
       ],
       "era": "classic"
+    }
+  },
+  {
+    "id": "nz_140",
+    "term": "Kumara",
+    "category": "food",
+    "definition": "The undisputed king of the roast dinner. It's the Kiwi sweet potato, but infinitely better than the ones you get overseas.",
+    "trigger_context": "When the user mentions sweet potatoes, kumara, or cooking a roast dinner.",
+    "vibe_level": 2,
+    "vector_text": "Kumara. Sweet potato. Roast kumara. Kumara chips. Root vegetable. Cooking dinner.",
+    "metadata": {
+      "tags": ["food", "vegetable", "dinner"]
+    }
+  },
+  {
+    "id": "nz_141",
+    "term": "Wharepaku",
+    "category": "maori",
+    "definition": "The te reo Māori word for the toilet. Essential vocab when you're caught out and need to find the loo.",
+    "trigger_context": "When the user asks where the toilet, restroom, or bathroom is, or explicitly says wharepaku.",
+    "vibe_level": 2,
+    "vector_text": "Wharepaku. Toilet. Restroom. Bathroom. Loo. Dunny. Where is the bathroom.",
+    "metadata": {
+      "tags": ["te-reo", "daily_life", "bathroom"]
+    }
+  },
+  {
+    "id": "nz_142",
+    "term": "Chocka",
+    "category": "slang",
+    "definition": "Means completely full to the brim. Like a pub on a Friday night or your stomach after a massive feed.",
+    "trigger_context": "When the user types 'chocka', or mentions being overly full or a place being completely packed.",
+    "vibe_level": 4,
+    "vector_text": "Chocka. Chocka block. Full up. Crowded. Packed out. Stuffed. Too many people.",
+    "metadata": {
+      "tags": ["slang", "full", "crowded"]
+    }
+  },
+  {
+    "id": "nz_143",
+    "term": "Hundies",
+    "category": "slang",
+    "definition": "Going all out, giving it one hundred percent effort, or totally agreeing with someone. Pure commitment.",
+    "trigger_context": "When the user explicitly says 'hundies', expresses maximum effort, or shows absolute agreement.",
+    "vibe_level": 4,
+    "vector_text": "Hundies. One hundred percent. Full effort. Going all out. Maximum commitment. Total agreement.",
+    "metadata": {
+      "tags": ["slang", "effort", "agreement"]
+    }
+  },
+  {
+    "id": "nz_144",
+    "term": "Taniwha",
+    "category": "maori",
+    "definition": "Legendary Māori water guardians or monsters that live in rivers, lakes, or the sea. Best to respect them and their home.",
+    "trigger_context": "When the user explicitly mentions taniwha, Māori mythology, or water spirits.",
+    "vibe_level": 3,
+    "vector_text": "Taniwha. Water spirit. Guardian. Monster. Maori mythology. Deep river. Ocean creature. Legend.",
+    "metadata": {
+      "tags": ["mythology", "guardian", "te-reo"]
     }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2387,5 +2387,17 @@
     "metadata": {
       "tags": ["mythology", "guardian", "te-reo", "kaitiaki"]
     }
+  },
+  {
+    "id": "nz_145",
+    "term": "Yeah nah",
+    "category": "nz_slang",
+    "definition": "A distinctly New Zealand expression meaning polite disagreement, hesitation, or soft refusal. Despite sounding contradictory, 'yeah nah' functions as a culturally fluent way to decline or push back without being blunt. Compare with its opposite 'nah yeah' (which means yes/agreement). Together they illustrate NZ's preference for softened, indirect communication.",
+    "trigger_context": "When the user asks about NZ slang, expressions of disagreement, or hedging phrases.",
+    "vibe_level": 2,
+    "vector_text": "Yeah nah. Polite disagreement. Soft refusal. Hesitation. NZ slang. Contradictory affirmative. Nah yeah. Indirect communication. Kiwi English. Colloquial.",
+    "metadata": {
+      "tags": ["slang", "expression", "colloquial", "kiwi-english"]
+    }
   }
 ]

--- a/core/inference/src/main/assets/nz_truth_memories.json
+++ b/core/inference/src/main/assets/nz_truth_memories.json
@@ -2332,34 +2332,34 @@
     "id": "nz_140",
     "term": "Kumara",
     "category": "food",
-    "definition": "The undisputed king of the roast dinner. It's the Kiwi sweet potato, but infinitely better than the ones you get overseas.",
-    "trigger_context": "When the user mentions sweet potatoes, kumara, or cooking a roast dinner.",
+    "definition": "New Zealand sweet potato. A root vegetable brought to Aotearoa by early Māori, botanically distinct from North American yams. Sold primarily in red (Owairaka), gold (Toka Toka), and orange (Beauregard) varieties. Culturally significant and an absolute requirement for both a traditional Māori hāngī and the classic Kiwi Sunday roast.",
+    "trigger_context": "When the user mentions kumara, sweet potato, roast dinner, hāngī, or Māori traditional food.",
     "vibe_level": 2,
-    "vector_text": "Kumara. Sweet potato. Roast kumara. Kumara chips. Root vegetable. Cooking dinner.",
+    "vector_text": "Kumara. Sweet potato. Roast kumara. Owairaka red kumara. Toka Toka gold. Beauregard orange. Hangi. Sunday roast. Root vegetable. Maori food. Aotearoa.",
     "metadata": {
-      "tags": ["food", "vegetable", "dinner"]
+      "tags": ["food", "vegetable", "dinner", "maori", "hangi"]
     }
   },
   {
     "id": "nz_141",
     "term": "Wharepaku",
     "category": "maori",
-    "definition": "The te reo Māori word for the toilet. Essential vocab when you're caught out and need to find the loo.",
-    "trigger_context": "When the user asks where the toilet, restroom, or bathroom is, or explicitly says wharepaku.",
+    "definition": "The te reo Māori term for toilet, restroom, or bathroom. A compound word literally translating to 'small house' (whare = building/house, paku = small). Heavily integrated into modern New Zealand English and serves as the standard term found on public signage, in schools, and across government buildings nationwide.",
+    "trigger_context": "When the user asks where the toilet, restroom, or bathroom is, mentions wharepaku, or needs directions to the loo.",
     "vibe_level": 2,
-    "vector_text": "Wharepaku. Toilet. Restroom. Bathroom. Loo. Dunny. Where is the bathroom.",
+    "vector_text": "Wharepaku. Toilet. Restroom. Bathroom. Loo. Dunny. Where is the bathroom. Small house. Whare. Public signage. School. Government building.",
     "metadata": {
-      "tags": ["te-reo", "daily_life", "bathroom"]
+      "tags": ["te-reo", "daily_life", "bathroom", "signage"]
     }
   },
   {
     "id": "nz_142",
     "term": "Chocka",
     "category": "slang",
-    "definition": "Means completely full to the brim. Like a pub on a Friday night or your stomach after a massive feed.",
-    "trigger_context": "When the user types 'chocka', or mentions being overly full or a place being completely packed.",
+    "definition": "Completely full to the brim; packed. A ubiquitous colloquialism abbreviated from 'chock-a-block.' Highly versatile: used to describe a crowded physical space ('the pub is chocka'), a vehicle packed with gear for a road trip, or the physical sensation of being completely stuffed after a mean feed.",
+    "trigger_context": "When the user says 'chocka', describes a crowded or overly full place, or mentions being stuffed after eating.",
     "vibe_level": 4,
-    "vector_text": "Chocka. Chocka block. Full up. Crowded. Packed out. Stuffed. Too many people.",
+    "vector_text": "Chocka. Chocka block. Chock-a-block. Full up. Crowded. Packed out. Stuffed. Too many people. No room. Bursting. Rammed.",
     "metadata": {
       "tags": ["slang", "full", "crowded"]
     }
@@ -2368,10 +2368,10 @@
     "id": "nz_143",
     "term": "Hundies",
     "category": "slang",
-    "definition": "Going all out, giving it one hundred percent effort, or totally agreeing with someone. Pure commitment.",
-    "trigger_context": "When the user explicitly says 'hundies', expresses maximum effort, or shows absolute agreement.",
+    "definition": "Absolute agreement, confirmation, or maximum effort. Colloquial shorthand for 'one hundred percent.' Functions as an enthusiastic affirmative response (similar to 'absolutely' or 'I agree entirely') or as an adverb to describe committing full energy and focus to an action or task (e.g. 'we're going hundies on this project').",
+    "trigger_context": "When the user says 'hundies', expresses maximum effort, or signals absolute agreement or commitment.",
     "vibe_level": 4,
-    "vector_text": "Hundies. One hundred percent. Full effort. Going all out. Maximum commitment. Total agreement.",
+    "vector_text": "Hundies. One hundred percent. Full effort. Going all out. Maximum commitment. Total agreement. Absolutely. One hundred. Giving it everything.",
     "metadata": {
       "tags": ["slang", "effort", "agreement"]
     }
@@ -2380,12 +2380,12 @@
     "id": "nz_144",
     "term": "Taniwha",
     "category": "maori",
-    "definition": "Legendary Māori water guardians or monsters that live in rivers, lakes, or the sea. Best to respect them and their home.",
-    "trigger_context": "When the user explicitly mentions taniwha, Māori mythology, or water spirits.",
+    "definition": "Supernatural creatures from Māori mythology, strongly associated with waterways. Powerful, mythological beings that dwell in deep rivers, dark caves, lakes, or the ocean. They hold a dual nature in Māori tradition: often serving as respected kaitiaki (protective guardians) for a specific iwi (tribe) and their local environment, but can also act as dangerous, predatory monsters that enforce respect for natural boundaries.",
+    "trigger_context": "When the user explicitly mentions taniwha, Māori mythology, water spirits, kaitiaki, or guardians of the land.",
     "vibe_level": 3,
-    "vector_text": "Taniwha. Water spirit. Guardian. Monster. Maori mythology. Deep river. Ocean creature. Legend.",
+    "vector_text": "Taniwha. Water spirit. Guardian. Kaitiaki. Monster. Maori mythology. Deep river. Ocean creature. Legend. Iwi. Supernatural. Protector. Predator. Dark cave. Lake.",
     "metadata": {
-      "tags": ["mythology", "guardian", "te-reo"]
+      "tags": ["mythology", "guardian", "te-reo", "kaitiaki"]
     }
   }
 ]

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"  // bumped: enriched nz_140-nz_144 definitions + Kiwi corpus additions (#736)
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v31"  // bumped: added nz_145 (Yeah nah) corpus entry; added kumara/chocka/hundies to jandal_vocab.json (#736)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val KEY_PERSONA_MODE = "persona_mode"
 private const val SESSION_VOCAB_COUNT_FULL = 2

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v29"  // bumped: kiwi memories migrated to kiwi_memories table
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"  // bumped: enriched nz_140-nz_144 definitions + Kiwi corpus additions (#736)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val KEY_PERSONA_MODE = "persona_mode"
 private const val SESSION_VOCAB_COUNT_FULL = 2

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 private const val TAG = "JandalPersona"
 private const val PREFS_NAME = "jandal_persona"
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v31"  // bumped: added nz_145 (Yeah nah) corpus entry; added kumara/chocka/hundies to jandal_vocab.json (#736)
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v32"  // bumped: force reseed to reindex nz_140–nz_145 embeddings (sweet potato/kumara recall fix)
 private const val KEY_LAST_VOCAB_INDICES = "last_vocab_indices"
 private const val KEY_PERSONA_MODE = "persona_mode"
 private const val SESSION_VOCAB_COUNT_FULL = 2

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -32,7 +32,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
-        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative established facts about New Zealand culture. State these facts with confidence and Kiwi pride — do NOT hedge or present alternative viewpoints on contested claims (e.g. NZ vs Australia). Do NOT add details not explicitly in the context. " +
         "IMPORTANT: When [Memory] blocks are present, only state details explicitly provided. Do not embellish with additional names, dates, or specifics drawn from your training data."
@@ -50,7 +50,7 @@ const val HALF_JANDAL_SYSTEM_PROMPT =
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
-        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative context. State these facts with confidence, but only use them when clearly relevant. Do NOT add details not explicitly in the context. " +
         "IMPORTANT: When [Memory] blocks are present, only state details explicitly provided. Do not embellish with additional names, dates, or specifics drawn from your training data."
@@ -64,7 +64,7 @@ const val BORING_AI_SYSTEM_PROMPT =
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action, do NOT call any tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
-        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [Memory] blocks are present, only state details explicitly provided. Do not embellish with additional names, dates, or specifics drawn from your training data."
 
@@ -90,7 +90,10 @@ const val MINIMAL_SYSTEM_PROMPT =
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such " +
         "as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the " +
-        "saveMemory tool — NEVER confirm that you saved something without the tool having been called."
+        "saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "When calling saveMemory, store the content in third person using the user's name " +
+        "(e.g. 'Nick likes dark mode', not 'I like dark mode'). " +
+        "If 'remember it/this' has no clear personal fact in the current message, ask what they'd like saved."
 
 const val BORING_MINIMAL_SYSTEM_PROMPT =
     "You are Jandal — a concise, on-device AI assistant. " +
@@ -106,7 +109,10 @@ const val BORING_MINIMAL_SYSTEM_PROMPT =
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such " +
         "as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the " +
-        "saveMemory tool — NEVER confirm that you saved something without the tool having been called."
+        "saveMemory tool — NEVER confirm that you saved something without the tool having been called. " +
+        "When calling saveMemory, store the content in third person using the user's name " +
+        "(e.g. 'Nick likes dark mode', not 'I like dark mode'). " +
+        "If 'remember it/this' has no clear personal fact in the current message, ask what they'd like saved."
 
 /** Maximum context window tokens (KV-cache size). Set high — hardware profile caps it per tier. */
 const val DEFAULT_MAX_TOKENS = 8000

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MemoryRepositoryImpl.kt
@@ -75,7 +75,7 @@ class MemoryRepositoryImpl @Inject constructor(
             vectorized = false,
         )
         val rowId = episodicDao.insert(entity)
-        if (rowId > 0) {
+        if (rowId > 0 && embeddingVector.isNotEmpty()) {
             ensureEpisodicVecTable(embeddingVector.size)
             vectorStore.upsert(EPISODIC_VEC_TABLE, rowId, embeddingVector)
             episodicDao.markVectorized(rowId)
@@ -116,7 +116,7 @@ class MemoryRepositoryImpl @Inject constructor(
             metadataJson = metadataJson,
         )
         val rowId = coreDao.insert(entity)
-        if (rowId > 0) {
+        if (rowId > 0 && embeddingVector.isNotEmpty()) {
             ensureCoreVecTable(embeddingVector.size)
             vectorStore.upsert(CORE_VEC_TABLE, rowId, embeddingVector)
             coreDao.markVectorized(rowId)

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
@@ -39,9 +39,21 @@ class UserProfileRepository @Inject constructor(
      * parsing of the raw profile text if [structuredJson] is not yet populated.
      * Returns null if no name can be determined.
      */
-    suspend fun getName(): String? =
-        getStructured()?.name
-            ?: UserProfileParser.parse(get()).name
+    suspend fun getName(): String? {
+        val structuredName = getStructured()?.name
+        if (structuredName != null) return structuredName
+        val profileText = get()
+        val parsedName = UserProfileParser.parse(profileText).name
+        if (parsedName == null) {
+            Log.w(
+                "KernelAI",
+                "UserProfileRepository.getName(): both paths returned null " +
+                    "(profileText length=${profileText.length}). " +
+                    "Profile may not contain a recognisable name field.",
+            )
+        }
+        return parsedName
+    }
 
     /**
      * Save [text] as the user profile. Trims to [maxLength] if needed.

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/UserProfileRepository.kt
@@ -35,6 +35,15 @@ class UserProfileRepository @Inject constructor(
         dao.get()?.structuredJson?.let { UserProfileYaml.fromJson(it) }
 
     /**
+     * Get the user's name from the structured profile, falling back to heuristic
+     * parsing of the raw profile text if [structuredJson] is not yet populated.
+     * Returns null if no name can be determined.
+     */
+    suspend fun getName(): String? =
+        getStructured()?.name
+            ?: UserProfileParser.parse(get()).name
+
+    /**
      * Save [text] as the user profile. Trims to [maxLength] if needed.
      * Attempts LLM-based extraction (#374 Phase 2b) first; falls back to heuristic regex
      * if the inference engine is not ready. The parsed YAML is logged to logcat (tag KernelAI)

--- a/core/skills/build.gradle.kts
+++ b/core/skills/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     }
 
     testOptions {
+        unitTests.isReturnDefaultValues = true
         unitTests.all { it.useJUnitPlatform() }
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2188,6 +2188,16 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
         ),
+        // "find a nearby pharmacy" / "find the nearest cafe" (article before nearby/nearest)
+        // Must precede the lazy "find X nearby" catch-all to avoid capturing "a" as the query.
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|show|locate|search\s+for|look\s+for)\s+(?:a|an|the)\s+near(?:by|est)\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
         // "find cafes nearby" / "show me petrol stations close by" — general pattern
         IntentPattern(
             intentName = "find_nearby",
@@ -2195,7 +2205,13 @@ class QuickIntentRouter(
                 """(?:find|show\s+me|look\s+for|search\s+for|locate)\s+(.+?)\s+(?:near(?:by|\s+me)|close\s+by|around\s+(?:here|me))""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ ->
+                // Strip leading article (a/an/the) that the lazy match can capture as the whole query
+                // e.g. "find a chemist nearby" → lazy captures "a chemist" → strip "a " → "chemist"
+                val raw = match.groupValues[1].trim()
+                val stripped = raw.replace(Regex("""^(?:a|an|the)\s+""", RegexOption.IGNORE_CASE), "")
+                mapOf("query" to stripped.ifBlank { raw })
+            },
         ),
         // "show me dog parks on the map" / "find cafes on the map"
         IntentPattern(
@@ -3143,19 +3159,19 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """remember\s+(?:that\s+)?[:\-–]?\s*(?!(?:I|I'm|this|that|it)\b)(.+)""",
+                """remember\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
             requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "note that X" / "make a note that X" / "don't forget that X"
-        // Same negative lookahead as the "remember" pattern — first-person and demonstrative
-        // openers fall through to E4B so the LLM can resolve conjugation and anaphora.
+        // First-person ("I prefer X") is now handled by normaliseSaveContent so no longer falls
+        // through to E4B. Only true anaphoric tokens (this/that/it) still fall through.
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(?!(?:I|I'm|this|that|it)\b)(.+)""",
+                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -3067,21 +3067,31 @@ class QuickIntentRouter(
             paramExtractor = { _, _ -> emptyMap() },
             requiredSlots = slotContract("save_memory"),
         ),
-        // Pattern: "save [to/that/...] memory that X" / "save this to memory: X"
+        // Pattern: "save to memory that X" / "save to memory: X" / "save that X"
+        // NOTE: "save this/it to memory" is intentionally excluded — "this" and "it" are
+        // anaphoric references that require LLM context to resolve (see #937).
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:save|store|keep)\s+(?:(?:to|in)\s+memory(?:\s+that)?|that|this|it)\s*[:\-–]?\s*(.+)""",
+                """(?:save|store|keep)\s+(?:(?:to|in)\s+memory(?:\s+that)?|that)\s*[:\-–]?\s*(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
-            paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
+            paramExtractor = { match, _ ->
+                // Strip trailing "to/in memory" that can appear when "that" is used as a
+                // demonstrative (e.g. "save that to memory") rather than a conjunction.
+                val content = match.groupValues[1].trim()
+                    .removeSuffix(" to memory").removeSuffix(" in memory").trim()
+                if (content.isBlank()) emptyMap() else mapOf("content" to content)
+            },
             requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "remember that X" / "remember: X"
+        // Excludes first-person + context-reference openers (I, I'm, this, that, it) —
+        // those need LLM to resolve conjugation and anaphora.
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """remember\s+(?:that\s+)?[:\-–]?\s*(.+)""",
+                """remember\s+(?:that\s+)?[:\-–]?\s*(?!(?:I|I'm|this|that|it)\b)(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2238,10 +2238,11 @@ class QuickIntentRouter(
                 ),
             ),
         ),
-        // "I need to find a gas station" / "I'm looking for a cafe" — assumed nearby
+        // "I'm looking for a cafe" — assumed nearby. Marked isFallback so non-location queries
+        // like "I'm looking for my car keys" can fall through to the classifier / E4B first.
         // Note: "I need to" is stripped by INTENT_PREFIX_RE before pattern matching, so
-        // "I need to find a gas station" arrives here as "find a gas station" — handled by
-        // the isFallback catch-all below. "I'm looking for" is NOT stripped, so it matches here.
+        // "I need to find a gas station" arrives as "find a gas station" — caught by the
+        // isFallback catch-all below. "I'm looking for" is NOT stripped.
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
@@ -2249,14 +2250,17 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+            isFallback = true,
         ),
         // "find a gas station" / "find an ATM" — catch-all after prefix strip (e.g. "I need to
-        // find a gas station" → "find a gas station" after prefix strip). Requires article "a/an"
-        // to avoid colliding with "find my way to X" (navigate_to via classifier).
+        // find a gas station" → "find a gas station" after INTENT_PREFIX_RE strips "I need to").
+        // Requires article "a/an" to avoid stealing bare "find my way to X" phrases.
+        // Negative lookahead blocks navigation nouns so "find a route/way/path to X" can
+        // fall through to the navigate_to classifier.
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
-                """^find\s+(?:a|an)\s+(.+)$""",
+                """^find\s+(?:a|an)\s+(?!(?:route|way|path|shortcut|directions?)\b)(.+)$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -3159,7 +3159,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """remember\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(.+)""",
+                """remember\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(\S.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },
@@ -3171,7 +3171,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(.+)""",
+                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(?!(?:this|that|it)\b)(\S.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -3079,9 +3079,14 @@ class QuickIntentRouter(
             paramExtractor = { match, _ ->
                 // Strip trailing "to/in memory" that can appear when "that" is used as a
                 // demonstrative (e.g. "save that to memory") rather than a conjunction.
-                val content = match.groupValues[1].trim()
-                    .removeSuffix(" to memory").removeSuffix(" in memory").trim()
-                if (content.isBlank()) emptyMap() else mapOf("content" to content)
+                // Use a regex replace (IGNORE_CASE) because removeSuffix is case-sensitive.
+                val stripped = match.groupValues[1].trim()
+                    .replace(Regex("\\s+(?:to|in)\\s+memory$", RegexOption.IGNORE_CASE), "")
+                    .trim()
+                // Reject single anaphoric tokens that survived stripping (e.g. "save that it to memory").
+                val ANAPHORIC = setOf("it", "this", "that")
+                if (stripped.isBlank() || stripped.lowercase() in ANAPHORIC) emptyMap()
+                else mapOf("content" to stripped)
             },
             requiredSlots = slotContract("save_memory"),
         ),
@@ -3098,10 +3103,12 @@ class QuickIntentRouter(
             requiredSlots = slotContract("save_memory"),
         ),
         // Pattern: "note that X" / "make a note that X" / "don't forget that X"
+        // Same negative lookahead as the "remember" pattern — first-person and demonstrative
+        // openers fall through to E4B so the LLM can resolve conjugation and anaphora.
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(.+)""",
+                """(?:(?:make\s+a\s+)?note|don't\s+forget)\s+(?:that\s+)?[:\-–]?\s*(?!(?:I|I'm|this|that|it)\b)(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("content" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2256,7 +2256,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
-                """I(?:'m|\s+am)\s+looking\s+for\s+(?:a|an)\s+(.+)""",
+                """I(?:'m|\s+am)\s+looking\s+for\s+(?:a|an)\s+(?!(?:route|way|path|shortcut|directions?)\b)(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
@@ -3120,7 +3120,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "save_memory",
             regex = Regex(
-                """(?:save|store|keep)\s+(?:(?:to|in)\s+memory(?:\s+that)?|that)\s*[:\-–]?\s*(.+)""",
+                """(?:save|store|keep)\s+(?:(?:to|in)\s+memory(?:\s+that)?|that(?!\s+to\s+memory|\s+in\s+memory))\s*[:\-–]?\s*(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -3128,7 +3128,7 @@ class QuickIntentRouter(
                 // demonstrative (e.g. "save that to memory") rather than a conjunction.
                 // Use a regex replace (IGNORE_CASE) because removeSuffix is case-sensitive.
                 val stripped = match.groupValues[1].trim()
-                    .replace(Regex("\\s+(?:to|in)\\s+memory$", RegexOption.IGNORE_CASE), "")
+                    .replace(Regex("(?:^|\\s+)(?:to|in)\\s+memory$", RegexOption.IGNORE_CASE), "")
                     .trim()
                 // Reject single anaphoric tokens that survived stripping (e.g. "save that it to memory").
                 val ANAPHORIC = setOf("it", "this", "that")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2133,6 +2133,15 @@ class QuickIntentRouter(
             ),
         ),
         // ── Find Nearby (most specific first to avoid greedy mis-capture) ──
+        // "find me the nearest cafe" — verb + me + the nearest + query
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """(?:find|show|get)\s+me\s+the\s+nearest\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
         // "find me nearby cafes" — verb + me + nearby + query
         IntentPattern(
             intentName = "find_nearby",
@@ -2228,6 +2237,30 @@ class QuickIntentRouter(
                     promptTemplate = "What are you looking for?",
                 ),
             ),
+        ),
+        // "I need to find a gas station" / "I'm looking for a cafe" — assumed nearby
+        // Note: "I need to" is stripped by INTENT_PREFIX_RE before pattern matching, so
+        // "I need to find a gas station" arrives here as "find a gas station" — handled by
+        // the isFallback catch-all below. "I'm looking for" is NOT stripped, so it matches here.
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """I(?:'m|\s+am)\s+looking\s+for\s+(?:a\s+|an\s+)?(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+        ),
+        // "find a gas station" / "find an ATM" — catch-all after prefix strip (e.g. "I need to
+        // find a gas station" → "find a gas station" after prefix strip). Requires article "a/an"
+        // to avoid colliding with "find my way to X" (navigate_to via classifier).
+        IntentPattern(
+            intentName = "find_nearby",
+            regex = Regex(
+                """^find\s+(?:a|an)\s+(.+)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },
+            isFallback = true,
         ),
 
         // ── Communication ──

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -2112,7 +2112,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "navigate_to",
             regex = Regex(
-                """(?:navigate|directions?|drive|take\s+me|get\s+me)(?:\s+to)?\s+(.+)""",
+                """(?:navigate|directions?|drive|take\s+me|get\s+me(?!\s+the\s+nearest))(?:\s+to)?\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("destination" to match.groupValues[1].trim()) },
@@ -2131,6 +2131,16 @@ class QuickIntentRouter(
                     promptTemplate = "Where would you like to go?",
                 ),
             ),
+        ),
+        // "find a route/way/path/shortcut to X" / "find my way home" — navigation phrases
+        // blocked from the find_nearby catch-all by negative lookahead; routed here instead.
+        IntentPattern(
+            intentName = "navigate_to",
+            regex = Regex(
+                """^find\s+(?:(?:a|my)\s+)?(?:route|way|path|shortcut|directions?)\s+(?:to\s+)?(.+)$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("destination" to match.groupValues[1].trim()) },
         ),
         // ── Find Nearby (most specific first to avoid greedy mis-capture) ──
         // "find me the nearest cafe" — verb + me + the nearest + query
@@ -2246,7 +2256,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "find_nearby",
             regex = Regex(
-                """I(?:'m|\s+am)\s+looking\s+for\s+(?:a\s+|an\s+)?(.+)""",
+                """I(?:'m|\s+am)\s+looking\s+for\s+(?:a|an)\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("query" to match.groupValues[1].trim()) },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/MemoryNormaliser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/MemoryNormaliser.kt
@@ -1,0 +1,34 @@
+package com.kernel.ai.core.skills.natives
+
+/**
+ * Converts first-person pronouns in a memory content string to third-person using the given name.
+ *
+ * Example: normaliseSaveContent("I prefer tea over coffee", "Nick")
+ *       → "Nick prefers tea over coffee"
+ *
+ * Applied on both the regex (NativeIntentHandler) and E4B (SaveMemorySkill) code paths so that
+ * saved facts are always in third person regardless of how the save was triggered.
+ *
+ * Returns [raw] unchanged when [userName] is null or blank.
+ */
+internal fun normaliseSaveContent(raw: String, userName: String?): String {
+    if (userName.isNullOrBlank()) return raw
+    val name = userName.trim()
+    return raw
+        // Specific irregular / special-case verbs first (order matters — more specific before general).
+        .replace(Regex("""\bI(?:'m| am)\b""", RegexOption.IGNORE_CASE)) { "$name is" }
+        .replace(Regex("""\bI have\b""", RegexOption.IGNORE_CASE)) { "$name has" }
+        .replace(Regex("""\bI go\b""", RegexOption.IGNORE_CASE)) { "$name goes" }
+        .replace(Regex("""\bI do\b""", RegexOption.IGNORE_CASE)) { "$name does" }
+        // Common regular verbs — append "s" for third-person singular.
+        .replace(
+            Regex(
+                """\bI (prefer|like|want|love|hate|enjoy|use|eat|drink|play|watch|listen|read|own|know|think|believe|feel|speak|drive|live|work|run|support|follow|need|find|see|hear|make|take|keep|put|get|give|bring|buy|sell|build|create|write|design|test|code|manage|lead|help|try|start|stop|send|show|check|set|turn|open|close|hold|leave|move|stay|say|ask|tell|call|visit)\b""",
+                RegexOption.IGNORE_CASE,
+            ),
+        ) { match -> "$name ${match.groupValues[1].lowercase()}s" }
+        // Catch-all: remaining "I" subject (verb may not conjugate perfectly, acceptable trade-off).
+        .replace(Regex("""\bI\b""")) { name }
+        // Possessives.
+        .replace(Regex("""\bmy\b""", RegexOption.IGNORE_CASE)) { "${name}'s" }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/MemoryNormaliser.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/MemoryNormaliser.kt
@@ -19,16 +19,23 @@ internal fun normaliseSaveContent(raw: String, userName: String?): String {
         .replace(Regex("""\bI(?:'m| am)\b""", RegexOption.IGNORE_CASE)) { "$name is" }
         .replace(Regex("""\bI have\b""", RegexOption.IGNORE_CASE)) { "$name has" }
         .replace(Regex("""\bI go\b""", RegexOption.IGNORE_CASE)) { "$name goes" }
+        // Negation before bare "do": "I don't" → "Nick doesn't" (must precede "I do" → "Nick does")
+        .replace(Regex("""\bI don't\b""", RegexOption.IGNORE_CASE)) { "$name doesn't" }
         .replace(Regex("""\bI do\b""", RegexOption.IGNORE_CASE)) { "$name does" }
+        // -ch/-sh/-x/-o endings need "-es" (not "-s")
+        .replace(Regex("""\bI watch\b""", RegexOption.IGNORE_CASE)) { "$name watches" }
+        // "-y" after consonant → "-ies"
+        .replace(Regex("""\bI try\b""", RegexOption.IGNORE_CASE)) { "$name tries" }
         // Common regular verbs — append "s" for third-person singular.
         .replace(
             Regex(
-                """\bI (prefer|like|want|love|hate|enjoy|use|eat|drink|play|watch|listen|read|own|know|think|believe|feel|speak|drive|live|work|run|support|follow|need|find|see|hear|make|take|keep|put|get|give|bring|buy|sell|build|create|write|design|test|code|manage|lead|help|try|start|stop|send|show|check|set|turn|open|close|hold|leave|move|stay|say|ask|tell|call|visit)\b""",
+                """\bI (prefer|like|want|love|hate|enjoy|use|eat|drink|play|listen|read|own|know|think|believe|feel|speak|drive|live|work|run|support|follow|need|find|see|hear|make|take|keep|put|get|give|bring|buy|sell|build|create|write|design|test|code|manage|lead|help|start|stop|send|show|check|set|turn|open|close|hold|leave|move|stay|say|ask|tell|call|visit)\b""",
                 RegexOption.IGNORE_CASE,
             ),
         ) { match -> "$name ${match.groupValues[1].lowercase()}s" }
-        // Catch-all: remaining "I" subject (verb may not conjugate perfectly, acceptable trade-off).
-        .replace(Regex("""\bI\b""")) { name }
+        // Catch-all: remaining "I" subject — require at least one more token to avoid storing bare name
+        // (e.g. a truncated "remember that I" → content="I" would otherwise save the username alone).
+        .replace(Regex("""\bI(?=\s+\S)""")) { name }
         // Possessives.
         .replace(Regex("""\bmy\b""", RegexOption.IGNORE_CASE)) { "${name}'s" }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2509,16 +2509,8 @@ class NativeIntentHandler @Inject constructor(
      * Bare "I" is NOT replaced — verb conjugation requires LLM, and those inputs are
      * now excluded from regex routing via the negative lookahead on the remember pattern.
      */
-    private fun normaliseSaveContent(raw: String, userName: String?): String {
-        if (userName.isNullOrBlank()) return raw
-        val name = userName.trim()
-        // Use the lambda overload of replace so the replacement string is treated literally —
-        // the String overload delegates to Matcher.replaceAll() where $ and \ are metacharacters
-        // and would throw IllegalArgumentException if the name contains them.
-        return raw
-            .replace(Regex("\\bI'm\\b", RegexOption.IGNORE_CASE)) { "$name is" }
-            .replace(Regex("\\bmy\\b", RegexOption.IGNORE_CASE)) { "${name}'s" }
-    }
+    private fun normaliseSaveContent(raw: String, userName: String?): String =
+        com.kernel.ai.core.skills.natives.normaliseSaveContent(raw, userName)
 
     // ── Set Brightness ────────────────────────────────────────────────────────
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -246,6 +246,16 @@ class NativeIntentHandler @Inject constructor(
             "get_list" to "get_list_items",
         )
 
+        /** Translates NZ/informal search terms to standard English for Maps queries. */
+        private val NZ_SEARCH_TERMS = mapOf(
+            "gas station" to "petrol station",
+            "gas stations" to "petrol stations",
+            "wharepaku" to "toilet",
+            "wharepakus" to "toilets",
+            "freeway" to "motorway",
+            "freeways" to "motorways",
+        )
+
         private val KNOWN_INTENTS = setOf(
             "toggle_flashlight_on", "toggle_flashlight_off",
             "send_email", "send_sms", "make_call",
@@ -1170,7 +1180,8 @@ class NativeIntentHandler @Inject constructor(
     // ── Find Nearby ───────────────────────────────────────────────────────────
 
     private fun findNearby(params: Map<String, String>): SkillResult {
-        val query = params["query"] ?: return SkillResult.Failure("find_nearby", "No search query provided")
+        val rawQuery = params["query"] ?: return SkillResult.Failure("find_nearby", "No search query provided")
+        val query = NZ_SEARCH_TERMS[rawQuery.lowercase()] ?: rawQuery
         return try {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("geo:0,0?q=${Uri.encode(query)}")).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2481,7 +2481,7 @@ class NativeIntentHandler @Inject constructor(
             ?: return SkillResult.Failure("save_memory", "No content to save")
         return try {
             runBlocking {
-                val userName = userProfileRepository.getStructured()?.name
+                val userName = userProfileRepository.getName()
                 val content = normaliseSaveContent(raw, userName)
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
                 memoryRepository.addCoreMemory(

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -2501,9 +2501,12 @@ class NativeIntentHandler @Inject constructor(
     private fun normaliseSaveContent(raw: String, userName: String?): String {
         if (userName.isNullOrBlank()) return raw
         val name = userName.trim()
+        // Use the lambda overload of replace so the replacement string is treated literally —
+        // the String overload delegates to Matcher.replaceAll() where $ and \ are metacharacters
+        // and would throw IllegalArgumentException if the name contains them.
         return raw
-            .replace(Regex("\\bI'm\\b", RegexOption.IGNORE_CASE), "$name is")
-            .replace(Regex("\\bmy\\b", RegexOption.IGNORE_CASE), "${name}'s")
+            .replace(Regex("\\bI'm\\b", RegexOption.IGNORE_CASE)) { "$name is" }
+            .replace(Regex("\\bmy\\b", RegexOption.IGNORE_CASE)) { "${name}'s" }
     }
 
     // ── Set Brightness ────────────────────────────────────────────────────────

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -31,6 +31,7 @@ import com.kernel.ai.core.memory.dao.ListNameDao
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.skills.QuickIntentRouter
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.ToolPresentation
@@ -135,6 +136,7 @@ class NativeIntentHandler @Inject constructor(
     private val embeddingEngine: EmbeddingEngine,
     private val cookingConversionService: CookingConversionService,
     private val currencyConversionService: CurrencyConversionService,
+    private val userProfileRepository: UserProfileRepository,
 ) {
 
     suspend fun handle(intentName: String, params: Map<String, String>): SkillResult {
@@ -2464,22 +2466,44 @@ class NativeIntentHandler @Inject constructor(
     // ── Save Memory ───────────────────────────────────────────────────────────
 
     private fun saveMemory(params: Map<String, String>): SkillResult {
-        val content = params["content"]?.takeIf { it.isNotBlank() }
+        val raw = params["content"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure("save_memory", "No content to save")
         return try {
             runBlocking {
+                val userName = userProfileRepository.getStructured()?.name
+                val content = normaliseSaveContent(raw, userName)
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
                 memoryRepository.addCoreMemory(
                     content = content,
                     source = "agent",
                     embeddingVector = vector ?: floatArrayOf(),
                 )
+                SkillResult.Success("✓ Saved: \"${content.take(100)}\"")
             }
-            SkillResult.Success("✓ Saved: \"${content.take(100)}\"")
         } catch (e: Exception) {
             Log.e(TAG, "save_memory failed", e)
             SkillResult.Failure("save_memory", e.message ?: "Failed to save memory")
         }
+    }
+
+    /**
+     * Normalises first-person possessive pronouns in regex-captured save content.
+     * When the QuickIntentRouter intercepts "remember that my X is Y", the LLM is bypassed
+     * and has no chance to substitute the user's name. This function does it instead.
+     *
+     * Only safe transformations are applied:
+     * - "my" → "Nick's" (possessive, no conjugation needed)
+     * - "I'm" → "Nick is" (safe contraction expansion)
+     *
+     * Bare "I" is NOT replaced — verb conjugation requires LLM, and those inputs are
+     * now excluded from regex routing via the negative lookahead on the remember pattern.
+     */
+    private fun normaliseSaveContent(raw: String, userName: String?): String {
+        if (userName.isNullOrBlank()) return raw
+        val name = userName.trim()
+        return raw
+            .replace(Regex("\\bI'm\\b", RegexOption.IGNORE_CASE), "$name is")
+            .replace(Regex("\\bmy\\b", RegexOption.IGNORE_CASE), "${name}'s")
     }
 
     // ── Set Brightness ────────────────────────────────────────────────────────

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.skills.natives
 import android.util.Log
 import com.kernel.ai.core.inference.EmbeddingEngine
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.skills.Skill
 import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillParameter
@@ -23,6 +24,7 @@ private const val TAG = "KernelAI"
 class SaveMemorySkill @Inject constructor(
     private val memoryRepository: MemoryRepository,
     private val embeddingEngine: EmbeddingEngine,
+    private val userProfileRepository: UserProfileRepository,
 ) : Skill {
 
     override val name = "save_memory"
@@ -72,10 +74,17 @@ bulk_add_to_list (two or more items) for that instead.
     """.trimIndent()
 
     override suspend fun execute(call: SkillCall): SkillResult {
-        val content = call.arguments["content"]
+        val rawContent = call.arguments["content"]
             ?: return SkillResult.Failure(name, "Missing 'content' argument")
         return withContext(Dispatchers.IO) {
             try {
+                // Defense-in-depth: normalise first-person pronouns even if E4B didn't convert
+                // them (e.g. "my mum's name is Susan" → "Nick's mum's name is Susan").
+                val userName = userProfileRepository.getName()
+                val content = normaliseSaveContent(rawContent, userName)
+                if (content != rawContent) {
+                    Log.d(TAG, "SaveMemorySkill: normalised content from \"${rawContent.take(60)}\" to \"${content.take(60)}\"")
+                }
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
                 if (vector == null) {
                     Log.w(TAG, "SaveMemorySkill: embedding engine not ready — saving without vector")

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -35,7 +35,10 @@ class SaveMemorySkill @Inject constructor(
         parameters = mapOf(
             "content" to SkillParameter(
                 type = "string",
-                description = "The exact fact or preference to remember, verbatim as the user stated it — NOT a meta-summary. e.g. 'Nick prefers dark mode', never 'User wants to save a preference'."
+                description = "The fact or preference to remember, written in third person using the user's name. " +
+                    "Convert first-person pronouns: 'I' → user's name, 'my' → user's name + 's', 'I'm' → user's name + ' is'. " +
+                    "e.g. if the user says 'I like dark mode', store 'Nick likes dark mode'. " +
+                    "NEVER store as 'I like dark mode' or use a meta-summary like 'User wants to save a preference'."
             )
         ),
         required = listOf("content"),
@@ -45,16 +48,23 @@ class SaveMemorySkill @Inject constructor(
 save_memory: Save an important fact or preference to the user's long-term memory.
 
 Parameters:
-- content (required, string): The exact fact verbatim as the user stated it — NOT a meta-description.
-  CORRECT: "Nick's cat is called Whiskers"
-  WRONG:   "The user wants to remember the name of their cat"
+- content (required, string): The fact in THIRD PERSON using the user's actual name from context.
+  Convert first-person before storing:
+    "I like dark mode"           → "Nick likes dark mode"
+    "my mum's name is Susan"     → "Nick's mum's name is Susan"
+    "I'm vegetarian"             → "Nick is vegetarian"
+    "I prefer tea over coffee"   → "Nick prefers tea over coffee"
+  WRONG: storing "I like dark mode" or "my mum's name is Susan" verbatim.
+  WRONG: meta-descriptions like "The user wants to remember their preference".
 
 Memory rule: whenever the user says 'remember', 'note that', 'don't forget',
 'keep that in mind', 'remember that', or asks you to keep something in mind —
 you MUST immediately call saveMemory. NEVER output 'Got it', 'I'll remember that',
 or any confirmation text without calling the tool first.
-If the user says 'remember that', infer what 'that' refers to from recent context.
-Do NOT ask what to save — always infer and call the tool.
+
+If 'remember it', 'remember this', or 'remember that' has no clear personal fact
+from the user's CURRENT message, ask: "What would you like me to remember?" —
+do NOT infer from system instructions or tool-use format descriptions.
 
 NEVER use save_memory to add items to a shopping list, grocery list, to-do list, or
 any other named list — use run_intent with add_to_list (single item) or

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/SaveMemorySkill.kt
@@ -77,14 +77,13 @@ bulk_add_to_list (two or more items) for that instead.
         return withContext(Dispatchers.IO) {
             try {
                 val vector = embeddingEngine.embed(content).takeIf { it.isNotEmpty() }
-                    ?: run {
-                        Log.w(TAG, "SaveMemorySkill: embedding engine not ready, skipping")
-                        return@withContext SkillResult.Failure(name, "Embedding engine not ready")
-                    }
+                if (vector == null) {
+                    Log.w(TAG, "SaveMemorySkill: embedding engine not ready — saving without vector")
+                }
                 memoryRepository.addCoreMemory(
                     content = content,
                     source = "agent",
-                    embeddingVector = vector,
+                    embeddingVector = vector ?: floatArrayOf(),
                 )
                 Log.d(TAG, "SaveMemorySkill: stored core memory — '${content.take(60)}'")
                 // Success: action result — LLM narration appropriate

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3009,9 +3009,7 @@ class QuickIntentRouterTest {
         @JvmStatic
         fun saveMemoryRegexPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("save that we're meeting Tuesday", "we're meeting Tuesday"),
-            Arguments.of("remember that I prefer dark mode", "I prefer dark mode"),
             Arguments.of("remember that my wifi password is 12345", "my wifi password is 12345"),
-            Arguments.of("can you remember that I have a dog named Xena", "I have a dog named Xena"),
             Arguments.of("remember my favourite colour is blue", "my favourite colour is blue"),
             Arguments.of("save to memory: important note", "important note"),
             Arguments.of("can you save to memory that my dog is named Xena", "my dog is named Xena"),
@@ -3340,6 +3338,15 @@ class QuickIntentRouterTest {
             Arguments.of("what month is this charge for"),
             Arguments.of("what month is this invoice for"),
             Arguments.of("what week is this training on"),
+            // save_memory — anaphoric references must fall to LLM (#937)
+            Arguments.of("save this to memory"),
+            Arguments.of("save it to memory"),
+            Arguments.of("save this recipe to memory"),
+            Arguments.of("remember that I like dark mode"),
+            Arguments.of("remember that I prefer dark mode"),
+            Arguments.of("remember that I have a dog named Xena"),
+            Arguments.of("remember that this is important"),
+            Arguments.of("can you remember that I have a dog named Xena"),
         )
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2723,6 +2723,15 @@ class QuickIntentRouterTest {
             Arguments.of("I need to find a pharmacy", "pharmacy"),
             Arguments.of("I'm looking for a cafe", "cafe"),
             Arguments.of("I am looking for an ATM", "ATM"),
+            // Article-capture regression fixes — "find a nearby X" must not capture "a" as query
+            Arguments.of("Find a nearby Pharmacy", "Pharmacy"),
+            Arguments.of("find a nearby cafe", "cafe"),
+            Arguments.of("find the nearby supermarket", "supermarket"),
+            Arguments.of("find an nearby ATM", "ATM"),
+            // Leading article stripped from lazy "find X nearby" pattern
+            Arguments.of("find a chemist nearby", "chemist"),
+            Arguments.of("find a pharmacy near me", "pharmacy"),
+            Arguments.of("find an ATM nearby", "ATM"),
         )
 
         @JvmStatic
@@ -3064,6 +3073,14 @@ class QuickIntentRouterTest {
             Arguments.of("can you save to memory that my dog is named Xena", "my dog is named Xena"),
             Arguments.of("note that the gate code is 4567", "the gate code is 4567"),
             Arguments.of("store that my doctor is Dr Smith", "my doctor is Dr Smith"),
+            // First-person "I" patterns — now routed via regex (lookahead no longer excludes I/I'm)
+            Arguments.of("remember that I like dark mode", "I like dark mode"),
+            Arguments.of("remember that I prefer dark mode", "I prefer dark mode"),
+            Arguments.of("remember that I have a dog named Xena", "I have a dog named Xena"),
+            Arguments.of("can you remember that I have a dog named Xena", "I have a dog named Xena"),
+            Arguments.of("note that I prefer email", "I prefer email"),
+            Arguments.of("don't forget that I like dark mode", "I like dark mode"),
+            Arguments.of("make a note that I'm vegetarian", "I'm vegetarian"),
         )
         @JvmStatic
         fun saveMemoryNeedsSlotPhrases(): Stream<Arguments> = Stream.of(
@@ -3392,14 +3409,7 @@ class QuickIntentRouterTest {
             Arguments.of("save it to memory"),
             Arguments.of("save that to memory"),
             Arguments.of("save this recipe to memory"),
-            Arguments.of("remember that I like dark mode"),
-            Arguments.of("remember that I prefer dark mode"),
-            Arguments.of("remember that I have a dog named Xena"),
             Arguments.of("remember that this is important"),
-            Arguments.of("can you remember that I have a dog named Xena"),
-            Arguments.of("note that I prefer email"),
-            Arguments.of("don't forget that I like dark mode"),
-            Arguments.of("make a note that I'm vegetarian"),
         )
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3347,6 +3347,9 @@ class QuickIntentRouterTest {
             Arguments.of("remember that I have a dog named Xena"),
             Arguments.of("remember that this is important"),
             Arguments.of("can you remember that I have a dog named Xena"),
+            Arguments.of("note that I prefer email"),
+            Arguments.of("don't forget that I like dark mode"),
+            Arguments.of("make a note that I'm vegetarian"),
         )
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2671,6 +2671,14 @@ class QuickIntentRouterTest {
             Arguments.of("directions to the airport", "the airport"),
             Arguments.of("navigate to the beach", "the beach"),
             Arguments.of("drive to the city", "the city"),
+            // E1/E2: "find a route/way/path to X" must route to navigate_to
+            Arguments.of("find a route to the airport", "the airport"),
+            Arguments.of("find a way home", "home"),
+            Arguments.of("find a path to the station", "the station"),
+            Arguments.of("find a shortcut to work", "work"),
+            Arguments.of("find directions to the museum", "the museum"),
+            Arguments.of("find my way home", "home"),
+            Arguments.of("find my way to the airport", "the airport"),
         )
 
         @JvmStatic
@@ -2706,6 +2714,10 @@ class QuickIntentRouterTest {
             Arguments.of("find me the nearest wharepaku", "wharepaku"),
             Arguments.of("find me the nearest cafe", "cafe"),
             Arguments.of("find me the nearest petrol station", "petrol station"),
+            // D3: "get me the nearest X" must route to find_nearby (not navigate_to)
+            Arguments.of("get me the nearest chemist", "chemist"),
+            Arguments.of("get me the nearest pharmacy", "pharmacy"),
+            Arguments.of("get me the nearest cafe", "cafe"),
             // "I need to find a/an X" — new pattern
             Arguments.of("I need to find a gas station", "gas station"),
             Arguments.of("I need to find a pharmacy", "pharmacy"),
@@ -2728,6 +2740,11 @@ class QuickIntentRouterTest {
             Arguments.of("find a shortcut to work"),
             Arguments.of("find directions to the museum"),
             Arguments.of("I need to find a route to Auckland"),
+            // D1/D2: "I'm looking for" without article must NOT route to find_nearby
+            Arguments.of("I'm looking for my car keys"),
+            Arguments.of("I'm looking for information about taniwha"),
+            Arguments.of("I am looking for help"),
+            Arguments.of("I'm looking for something to do"),
         )
 
         // ── Communication ─────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2745,6 +2745,9 @@ class QuickIntentRouterTest {
             Arguments.of("I'm looking for information about taniwha"),
             Arguments.of("I am looking for help"),
             Arguments.of("I'm looking for something to do"),
+            // "I'm looking for a route/way to X" must NOT route to find_nearby (nav phrase)
+            Arguments.of("I'm looking for a route to Auckland"),
+            Arguments.of("I'm looking for a way home"),
         )
 
         // ── Communication ─────────────────────────────────────────────────────────
@@ -3387,6 +3390,7 @@ class QuickIntentRouterTest {
             // save_memory — anaphoric references must fall to LLM (#937)
             Arguments.of("save this to memory"),
             Arguments.of("save it to memory"),
+            Arguments.of("save that to memory"),
             Arguments.of("save this recipe to memory"),
             Arguments.of("remember that I like dark mode"),
             Arguments.of("remember that I prefer dark mode"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1353,6 +1353,15 @@ class QuickIntentRouterTest {
             assertEquals("find_nearby", needsSlot.intent.intentName, "intent for '$input'")
             assertEquals("query", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
+
+        @ParameterizedTest(name = "Must not steal: \"{0}\"")
+        @MethodSource("com.kernel.ai.core.skills.QuickIntentRouterTest#findNearbyMustNotStealPhrases")
+        fun `catch-all must not steal navigation phrases`(input: String) {
+            val result = regexOnlyRouter.route(input)
+            val isStolen = result is QuickIntentRouter.RouteResult.RegexMatch &&
+                (result as QuickIntentRouter.RouteResult.RegexMatch).intent.intentName == "find_nearby"
+            assertFalse(isStolen, "'$input' must not route to find_nearby via regex")
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -2708,6 +2717,17 @@ class QuickIntentRouterTest {
         fun findNearbyClassifierPhrases(): Stream<Arguments> = Stream.of(
             Arguments.of("where's the closest supermarket"),
             Arguments.of("is there a cafe around here"),
+        )
+
+        @JvmStatic
+        fun findNearbyMustNotStealPhrases(): Stream<Arguments> = Stream.of(
+            // Navigation phrases must not be claimed by the find_nearby catch-all
+            Arguments.of("find a route to the airport"),
+            Arguments.of("find a way home"),
+            Arguments.of("find a path to the station"),
+            Arguments.of("find a shortcut to work"),
+            Arguments.of("find directions to the museum"),
+            Arguments.of("I need to find a route to Auckland"),
         )
 
         // ── Communication ─────────────────────────────────────────────────────────

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2693,6 +2693,15 @@ class QuickIntentRouterTest {
             Arguments.of("find ATMs near me", "ATMs"),
             Arguments.of("show nearby supermarkets", "supermarkets"),
             Arguments.of("show nearby cafes", "cafes"),
+            // "find me the nearest X" — new pattern
+            Arguments.of("find me the nearest wharepaku", "wharepaku"),
+            Arguments.of("find me the nearest cafe", "cafe"),
+            Arguments.of("find me the nearest petrol station", "petrol station"),
+            // "I need to find a/an X" — new pattern
+            Arguments.of("I need to find a gas station", "gas station"),
+            Arguments.of("I need to find a pharmacy", "pharmacy"),
+            Arguments.of("I'm looking for a cafe", "cafe"),
+            Arguments.of("I am looking for an ATM", "ATM"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -24,6 +24,7 @@ import com.kernel.ai.core.memory.entity.ContactAliasEntity
 import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
 import com.kernel.ai.core.skills.SkillResult
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -75,6 +76,7 @@ class NativeIntentHandlerTest {
         embeddingEngine = mockk<EmbeddingEngine>(relaxed = true),
         cookingConversionService = cookingConversionService,
         currencyConversionService = currencyConversionService,
+        userProfileRepository = mockk<UserProfileRepository>(relaxed = true),
     )
 
     private fun handleIntent(intentName: String, params: Map<String, String>): SkillResult =

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1897,6 +1897,35 @@ class NativeIntentHandlerTest {
         }
     }
 
+    @Nested
+    @DisplayName("Find Nearby — NZ term translation")
+    inner class FindNearbyNzTranslation {
+
+        @Test
+        fun `gas station is translated to petrol station`() {
+            every { context.startActivity(any()) } just Runs
+            val result = handleIntent("find_nearby", mapOf("query" to "gas station"))
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertTrue((result as SkillResult.Success).content.contains("petrol station"), "Expected 'petrol station' in: ${result.content}")
+        }
+
+        @Test
+        fun `wharepaku is translated to toilet`() {
+            every { context.startActivity(any()) } just Runs
+            val result = handleIntent("find_nearby", mapOf("query" to "wharepaku"))
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertTrue((result as SkillResult.Success).content.contains("toilet"), "Expected 'toilet' in: ${result.content}")
+        }
+
+        @Test
+        fun `unrecognised term is passed through unchanged`() {
+            every { context.startActivity(any()) } just Runs
+            val result = handleIntent("find_nearby", mapOf("query" to "cafe"))
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertTrue((result as SkillResult.Success).content.contains("cafe"), "Expected 'cafe' in: ${result.content}")
+        }
+    }
+
     private fun emailCursor(vararg rows: EmailRow): Cursor {
         val cursor = mockk<Cursor>()
         val columns = mapOf(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -25,6 +25,7 @@ import com.kernel.ai.core.memory.entity.ImportantDateEntity
 import com.kernel.ai.core.memory.entity.ListItemEntity
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.profile.UserProfileYaml
 import com.kernel.ai.core.skills.SkillResult
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -33,15 +34,19 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
@@ -1821,6 +1826,75 @@ class NativeIntentHandlerTest {
         every { cursor.close() } just Runs
 
         return cursor
+    }
+
+    // ── Save Memory ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Save Memory — pronoun normalisation")
+    inner class SaveMemoryPronounNormalisation {
+
+        private val memoryRepository = mockk<MemoryRepository>(relaxed = true)
+        private val embeddingEngine = mockk<EmbeddingEngine>(relaxed = true)
+        private val profileRepository = mockk<UserProfileRepository>(relaxed = true)
+
+        private fun handlerWithName(name: String?) = NativeIntentHandler(
+            context = context,
+            clockRepository = clockRepository,
+            clockAlertController = clockAlertController,
+            listItemDao = listItemDao,
+            listNameDao = listNameDao,
+            contactAliasRepository = contactAliasRepository,
+            importantDateRepository = importantDateRepository,
+            calendarBirthdayLookup = calendarBirthdayLookup,
+            memoryRepository = memoryRepository,
+            embeddingEngine = embeddingEngine,
+            cookingConversionService = cookingConversionService,
+            currencyConversionService = currencyConversionService,
+            userProfileRepository = profileRepository,
+        ).also {
+            coEvery { profileRepository.getStructured() } returns
+                if (name != null) UserProfileYaml(name = name) else null
+            coEvery { embeddingEngine.embed(any()) } returns floatArrayOf()
+        }
+
+        @Test
+        fun `my is replaced with name possessive`() {
+            val h = handlerWithName("Nick")
+            val contentSlot = slot<String>()
+            coEvery { memoryRepository.addCoreMemory(capture(contentSlot), any(), any(), any(), any(), any(), any(), any(), any()) } returns "row1"
+            runBlocking { h.handle("save_memory", mapOf("content" to "my wifi password is 12345")) }
+            assertEquals("Nick's wifi password is 12345", contentSlot.captured)
+        }
+
+        @Test
+        fun `I'm is replaced with name is`() {
+            val h = handlerWithName("Nick")
+            val contentSlot = slot<String>()
+            coEvery { memoryRepository.addCoreMemory(capture(contentSlot), any(), any(), any(), any(), any(), any(), any(), any()) } returns "row1"
+            runBlocking { h.handle("save_memory", mapOf("content" to "I'm allergic to peanuts")) }
+            assertEquals("Nick is allergic to peanuts", contentSlot.captured)
+        }
+
+        @Test
+        fun `name with dollar sign does not crash`() {
+            val h = handlerWithName("A\$B")
+            val contentSlot = slot<String>()
+            coEvery { memoryRepository.addCoreMemory(capture(contentSlot), any(), any(), any(), any(), any(), any(), any(), any()) } returns "row1"
+            val result = runBlocking { h.handle("save_memory", mapOf("content" to "my name is unusual")) }
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            // Stored content must contain the dollar sign literally, not crash
+            assertTrue(contentSlot.captured.contains("A\$B's"))
+        }
+
+        @Test
+        fun `no profile — content stored verbatim`() {
+            val h = handlerWithName(null)
+            val contentSlot = slot<String>()
+            coEvery { memoryRepository.addCoreMemory(capture(contentSlot), any(), any(), any(), any(), any(), any(), any(), any()) } returns "row1"
+            runBlocking { h.handle("save_memory", mapOf("content" to "my favourite colour is blue")) }
+            assertEquals("my favourite colour is blue", contentSlot.captured)
+        }
     }
 
     private fun emailCursor(vararg rows: EmailRow): Cursor {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1855,6 +1855,7 @@ class NativeIntentHandlerTest {
         ).also {
             coEvery { profileRepository.getStructured() } returns
                 if (name != null) UserProfileYaml(name = name) else null
+            coEvery { profileRepository.getName() } returns name
             coEvery { embeddingEngine.embed(any()) } returns floatArrayOf()
         }
 

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -10,7 +10,7 @@ Jandal's NZ cultural knowledge lives in a structured JSON corpus that is embedde
 ```
 core/inference/src/main/assets/nz_truth_memories.json
 ```
-Contains all 135 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
+Contains all 143 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
 
 ### 2. The seed guard key
 ```
@@ -18,7 +18,7 @@ core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
 ```
 Line near the top:
 ```kotlin
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v3"
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"
 ```
 **Bump the version number every time you change the corpus.** On next app launch, the app detects the new key, wipes all existing `agent_identity` memories, and reseeds from scratch.
 
@@ -115,10 +115,10 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 1. **Open the corpus:**
    `core/inference/src/main/assets/nz_truth_memories.json`
 
-2. **Add your entry** at the end of the array. Use the next available ID (`nz_137`, `nz_138`, etc.):
+2. **Add your entry** at the end of the array. Use the next available ID (`nz_145`, `nz_146`, etc.):
    ```json
    {
-     "id": "nz_137",
+     "id": "nz_145",
      "term": "Your term here",
      "category": "slang",
      "definition": "Confident one-liner Jandal will say.",
@@ -136,17 +136,17 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 4. **Bump the seed guard** in `JandalPersona.kt`:
    ```kotlin
    // Before:
-   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v11"
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"
    // After:
-   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v12"
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v31"
    ```
    Add a comment explaining what changed.
 
 5. **Build and install** the app. On first launch after update, logcat will show:
    ```
-   JandalPersona: Loaded 136 NZ truth entries
+   JandalPersona: Loaded 144 NZ truth entries
    ChatViewModel: Seeding NZ truth memories...
-   ChatViewModel: Seeded 136 NZ truth memories
+   ChatViewModel: Seeded 144 NZ truth memories
    ```
 
 5. **Test** by asking Jandal something related to your new entry. Check logcat for:
@@ -286,3 +286,5 @@ The `definition` is injected directly into Jandal's prompt as:
 | `truths_seeded_v9` | Added Carked it (nz_093), Flight of the Conchords + Binary Solo (nz_094), Hungus (nz_095) |
 | `truths_seeded_v10` | Removed nz_003 (The 6-7 — not a real named NZ term); fixed nz_007 Munted (added drunk/intoxicated meaning); corpus 95 → 94 |
 | `truths_seeded_v11` | 41 new entries (nz_096–nz_136) from three-source slang audit + jandal_vocab.json cross-check. Every term Jandal uses in conversation now has a RAG corpus entry. New categories: `attitude`, `daily_life`, `maori`. Corpus 94 → 135 |
+| `truths_seeded_v12`–`v29` | Incremental fixes, vibe tuning, and migration to `kiwi_memories` table (see git log for details) |
+| `truths_seeded_v30` | #736: nz_001 "gas station" → "petrol station"; new entries nz_140–nz_144 (Kumara, Wharepaku, Chocka, Hundies, Taniwha) with rich definitions, cultural context, and expanded vector_text. Corpus 138 → 143 |

--- a/docs/nz-truth-memories.md
+++ b/docs/nz-truth-memories.md
@@ -10,7 +10,7 @@ Jandal's NZ cultural knowledge lives in a structured JSON corpus that is embedde
 ```
 core/inference/src/main/assets/nz_truth_memories.json
 ```
-Contains all 143 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
+Contains all 144 (and growing) NZ truth entries. Edit this to add, change, or remove entries.
 
 ### 2. The seed guard key
 ```
@@ -18,7 +18,7 @@ core/inference/src/main/java/com/kernel/ai/core/inference/JandalPersona.kt
 ```
 Line near the top:
 ```kotlin
-private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"
+private const val KEY_TRUTHS_SEEDED = "truths_seeded_v31"
 ```
 **Bump the version number every time you change the corpus.** On next app launch, the app detects the new key, wipes all existing `agent_identity` memories, and reseeds from scratch.
 
@@ -115,10 +115,10 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 1. **Open the corpus:**
    `core/inference/src/main/assets/nz_truth_memories.json`
 
-2. **Add your entry** at the end of the array. Use the next available ID (`nz_145`, `nz_146`, etc.):
+2. **Add your entry** at the end of the array. Use the next available ID (`nz_146`, `nz_147`, etc.):
    ```json
    {
-     "id": "nz_145",
+     "id": "nz_146",
      "term": "Your term here",
      "category": "slang",
      "definition": "Confident one-liner Jandal will say.",
@@ -136,17 +136,17 @@ The vibe level controls how loosely the RAG will match this entry. Lower = stric
 4. **Bump the seed guard** in `JandalPersona.kt`:
    ```kotlin
    // Before:
-   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v30"
-   // After:
    private const val KEY_TRUTHS_SEEDED = "truths_seeded_v31"
+   // After:
+   private const val KEY_TRUTHS_SEEDED = "truths_seeded_v32"
    ```
    Add a comment explaining what changed.
 
 5. **Build and install** the app. On first launch after update, logcat will show:
    ```
-   JandalPersona: Loaded 144 NZ truth entries
+   JandalPersona: Loaded 145 NZ truth entries
    ChatViewModel: Seeding NZ truth memories...
-   ChatViewModel: Seeded 144 NZ truth memories
+   ChatViewModel: Seeded 145 NZ truth memories
    ```
 
 5. **Test** by asking Jandal something related to your new entry. Check logcat for:
@@ -288,3 +288,4 @@ The `definition` is injected directly into Jandal's prompt as:
 | `truths_seeded_v11` | 41 new entries (nz_096–nz_136) from three-source slang audit + jandal_vocab.json cross-check. Every term Jandal uses in conversation now has a RAG corpus entry. New categories: `attitude`, `daily_life`, `maori`. Corpus 94 → 135 |
 | `truths_seeded_v12`–`v29` | Incremental fixes, vibe tuning, and migration to `kiwi_memories` table (see git log for details) |
 | `truths_seeded_v30` | #736: nz_001 "gas station" → "petrol station"; new entries nz_140–nz_144 (Kumara, Wharepaku, Chocka, Hundies, Taniwha) with rich definitions, cultural context, and expanded vector_text. Corpus 138 → 143 |
+| `truths_seeded_v31` | #736: Added nz_145 (Yeah nah) corpus entry; added kumara, chocka, hundies to jandal_vocab.json (vocab←→corpus sync). Corpus 143 → 144 |

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -882,7 +882,8 @@ class ActionsViewModel @Inject constructor(
     ) {
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
-        val summary = normalisePronounsForTts(spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text))
+        val rawSummary = spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text)
+        val summary = if (spokenOverride.isNullOrBlank()) normalisePronounsForTts(rawSummary) else rawSummary
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -883,7 +883,7 @@ class ActionsViewModel @Inject constructor(
         if (inputMode != InputMode.Voice) return
         if (!spokenResponsesEnabled) return
         val rawSummary = spokenOverride?.takeIf { it.isNotBlank() } ?: toSpokenSummary(text)
-        val summary = if (spokenOverride.isNullOrBlank()) normalisePronounsForTts(rawSummary) else rawSummary
+        val summary = normalisePronounsForTts(rawSummary)
         if (summary.isBlank()) return
         cancelPendingVoiceSlotReplyRestart()
         cancelPendingVoiceSpeech()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -255,20 +255,24 @@ private val MIXED_NUMBER_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
     Regex("""\b(\d+)\s+3/8\b""") to "$1 and three eighths",
 )
 
+// Negative lookahead to prevent matching date-format strings (e.g. "2/3 May", "1/2/2024").
+// Rejects: followed by "/" (full date like 2/3/2024) or a digit, or a space + month name.
+private val DATE_GUARD = """(?![/\d]|\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b)"""
+
 private val SIMPLE_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
-    Regex("""\b1/2\b""") to "half",
-    Regex("""\b1/4\b""") to "quarter",
-    Regex("""\b3/4\b""") to "three quarters",
-    Regex("""\b1/3\b""") to "one third",
-    Regex("""\b2/3\b""") to "two thirds",
-    Regex("""\b1/8\b""") to "one eighth",
-    Regex("""\b3/8\b""") to "three eighths",
-    Regex("""\b1/16\b""") to "one sixteenth",
+    Regex("""\b1/2${DATE_GUARD}""") to "half",
+    Regex("""\b1/4${DATE_GUARD}""") to "quarter",
+    Regex("""\b3/4${DATE_GUARD}""") to "three quarters",
+    Regex("""\b1/3${DATE_GUARD}""") to "one third",
+    Regex("""\b2/3${DATE_GUARD}""") to "two thirds",
+    Regex("""\b1/8${DATE_GUARD}""") to "one eighth",
+    Regex("""\b3/8${DATE_GUARD}""") to "three eighths",
+    Regex("""\b1/16${DATE_GUARD}""") to "one sixteenth",
 )
 
 private val UNIT_ABBREV_RULES: List<Pair<Regex, String>> = listOf(
-    Regex("""\btbsp\b""", RegexOption.IGNORE_CASE) to "tablespoon",
-    Regex("""\btsp\b""", RegexOption.IGNORE_CASE) to "teaspoon",
+    Regex("""\b[Tt]bsp\b""") to "tablespoon",
+    Regex("""\b[Tt]sp\b""") to "teaspoon",
 )
 
 private fun normalizeFractionsForSpeech(text: String): String {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -55,6 +55,7 @@ internal fun normalizeChatTextForSpeech(text: String): String =
         .replace(Regex("""(?m)^\s*\d+\.\s+"""), "")      // strip leading numbered marker at start
         .replace(Regex("""(?m)^\s*[-*•]\s*"""), "")       // strip bullet markers at line start (lone * has no trailing ws)
         .replace(Regex("""[•‣◦∙⋅·]\s*"""), "")           // strip any remaining inline bullet chars
+        .let(::normalizeFractionsForSpeech)               // expand fractions/units before pronunciation overrides
         .replace(Regex("""(?<!\d):(?!\d)(?!//)\s*"""), ". ")   // non-numeric colons → sentence break (preserves ://)
         .replace(Regex("""[—–]\s*"""), ", ")              // em/en dashes → natural comma pause
         .replace(Regex("""\s*(?:\r?\n){2,}\s*"""), ". ")
@@ -228,6 +229,74 @@ private fun findSpeechChunkBoundary(
     }
 
     return null
+}
+
+/**
+ * Expands common cooking fractions and unit abbreviations to spoken words so TTS does not
+ * read "1/4 tsp" as "one slash four tee ess pee".
+ *
+ * Order of substitutions:
+ * 1. Unicode fraction characters (½ ¼ ¾ ⅓ ⅔ ⅛)
+ * 2. Mixed numbers — must run BEFORE simple fractions so "1 1/2" → "one and a half",
+ *    not "1 half" via two separate replacements.
+ * 3. Simple ASCII fractions (1/2, 1/4, 3/4, 1/3, 2/3, 1/8, 3/8, 1/16)
+ * 4. Cooking unit abbreviations (tsp, tbsp) — whole-word, case-insensitive.
+ *
+ * Unknown fractions (e.g. 5/7, dates written as 15/3) are left untouched to avoid
+ * false positives.
+ */
+private val MIXED_NUMBER_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
+    Regex("""\b(\d+)\s+1/2\b""") to "$1 and a half",
+    Regex("""\b(\d+)\s+1/4\b""") to "$1 and a quarter",
+    Regex("""\b(\d+)\s+3/4\b""") to "$1 and three quarters",
+    Regex("""\b(\d+)\s+1/3\b""") to "$1 and one third",
+    Regex("""\b(\d+)\s+2/3\b""") to "$1 and two thirds",
+    Regex("""\b(\d+)\s+1/8\b""") to "$1 and one eighth",
+    Regex("""\b(\d+)\s+3/8\b""") to "$1 and three eighths",
+)
+
+private val SIMPLE_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
+    Regex("""\b1/2\b""") to "half",
+    Regex("""\b1/4\b""") to "quarter",
+    Regex("""\b3/4\b""") to "three quarters",
+    Regex("""\b1/3\b""") to "one third",
+    Regex("""\b2/3\b""") to "two thirds",
+    Regex("""\b1/8\b""") to "one eighth",
+    Regex("""\b3/8\b""") to "three eighths",
+    Regex("""\b1/16\b""") to "one sixteenth",
+)
+
+private val UNIT_ABBREV_RULES: List<Pair<Regex, String>> = listOf(
+    Regex("""\btbsp\b""", RegexOption.IGNORE_CASE) to "tablespoon",
+    Regex("""\btsp\b""", RegexOption.IGNORE_CASE) to "teaspoon",
+)
+
+private fun normalizeFractionsForSpeech(text: String): String {
+    // Step 1: Unicode fraction characters
+    var result = text
+        .replace("½", "half")
+        .replace("¼", "quarter")
+        .replace("¾", "three quarters")
+        .replace("⅓", "one third")
+        .replace("⅔", "two thirds")
+        .replace("⅛", "one eighth")
+
+    // Step 2: Mixed numbers (must precede simple fractions)
+    result = MIXED_NUMBER_FRACTION_RULES.fold(result) { current, (pattern, replacement) ->
+        pattern.replace(current, replacement)
+    }
+
+    // Step 3: Simple ASCII fractions
+    result = SIMPLE_FRACTION_RULES.fold(result) { current, (pattern, replacement) ->
+        pattern.replace(current, replacement)
+    }
+
+    // Step 4: Unit abbreviations
+    result = UNIT_ABBREV_RULES.fold(result) { current, (pattern, replacement) ->
+        pattern.replace(current, replacement)
+    }
+
+    return result
 }
 
 private fun applySpeechPronunciationOverrides(text: String): String =

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -257,7 +257,7 @@ private val MIXED_NUMBER_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
 
 // Negative lookahead to prevent matching date-format strings (e.g. "2/3 May", "1/2/2024").
 // Rejects: followed by "/" (full date like 2/3/2024) or a digit, or a space + month name.
-private val DATE_GUARD = """(?![/\d]|\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b)"""
+private val DATE_GUARD = """(?![/\d]|\s+(?i:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b)"""
 
 private val SIMPLE_FRACTION_RULES: List<Pair<Regex, String>> = listOf(
     Regex("""\b1/2${DATE_GUARD}""") to "half",

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -235,6 +235,42 @@ class ChatTextUtilsTest {
                 normalizeChatTextForSpeech("a warm bath—like a story—signals bedtime"),
             )
         }
+
+        // ── #912 fraction and unit abbreviation normalization ──────────────────
+
+        @Test
+        fun `bullet with quarter fraction — no minus or slash`() {
+            val result = normalizeChatTextForSpeech("- 1/4 cup breadcrumbs")
+            assertFalse(result.contains("minus"), "should not contain 'minus', got: $result")
+            assertFalse(result.contains("/"), "should not contain '/', got: $result")
+            assertTrue(result.contains("quarter"), "should contain 'quarter', got: $result")
+        }
+
+        @Test
+        fun `bullet with half fraction and tsp abbreviation`() {
+            val result = normalizeChatTextForSpeech("- 1/2 tsp garlic")
+            assertTrue(result.contains("half"), "should contain 'half', got: $result")
+            assertTrue(result.contains("teaspoon"), "should contain 'teaspoon', got: $result")
+        }
+
+        @Test
+        fun `bullet with three quarters fraction`() {
+            val result = normalizeChatTextForSpeech("- 3/4 cup")
+            assertTrue(result.contains("three quarters"), "should contain 'three quarters', got: $result")
+        }
+
+        @Test
+        fun `mixed number one and a half cups`() {
+            val result = normalizeChatTextForSpeech("1 1/2 cups")
+            assertTrue(result.contains("and a half"), "should contain 'and a half', got: $result")
+            assertFalse(result.contains("/"), "should not contain '/', got: $result")
+        }
+
+        @Test
+        fun `unicode half cup`() {
+            val result = normalizeChatTextForSpeech("½ cup")
+            assertTrue(result.contains("half"), "should contain 'half', got: $result")
+        }
     }
 
     @Nested

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -271,6 +271,24 @@ class ChatTextUtilsTest {
             val result = normalizeChatTextForSpeech("½ cup")
             assertTrue(result.contains("half"), "should contain 'half', got: $result")
         }
+
+        @Test
+        fun `fraction before month name is not converted — date guard`() {
+            val result = normalizeChatTextForSpeech("meeting on 2/3 May")
+            assertFalse(result.contains("two thirds"), "should not convert date fraction, got: $result")
+        }
+
+        @Test
+        fun `fraction in dd-mm-yyyy format is not converted — date guard`() {
+            val result = normalizeChatTextForSpeech("deadline 2/3/2024")
+            assertFalse(result.contains("two thirds"), "should not convert date fraction, got: $result")
+        }
+
+        @Test
+        fun `TSP all-caps acronym is not converted to teaspoon`() {
+            val result = normalizeChatTextForSpeech("TSP contribution limits")
+            assertFalse(result.contains("teaspoon"), "should not convert acronym TSP, got: $result")
+        }
     }
 
     @Nested

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -279,6 +279,18 @@ class ChatTextUtilsTest {
         }
 
         @Test
+        fun `fraction before lowercase month name is not converted — date guard`() {
+            val result = normalizeChatTextForSpeech("meeting on 2/3 may")
+            assertFalse(result.contains("two thirds"), "should not convert date fraction, got: $result")
+        }
+
+        @Test
+        fun `fraction before lowercase full month is not converted — date guard`() {
+            val result = normalizeChatTextForSpeech("deadline 1/2 january")
+            assertFalse(result.contains("half"), "should not convert date fraction, got: $result")
+        }
+
+        @Test
         fun `fraction in dd-mm-yyyy format is not converted — date guard`() {
             val result = normalizeChatTextForSpeech("deadline 2/3/2024")
             assertFalse(result.contains("two thirds"), "should not convert date fraction, got: $result")

--- a/specification.md
+++ b/specification.md
@@ -70,7 +70,7 @@ The resident Gemma-4 model handles complex tool calls requiring NLU and reasonin
 * `get_weather_gps` — GPS-based current weather + forecast
 * `run_js{get-weather-city}` — named city weather + forecast via Open-Meteo
 * `get_system_info` — battery, connectivity, device stats
-* `save_memory` — persist notes/facts to Room
+* `save_memory` — persist notes/facts to Room *(simple explicit-content patterns are also intercepted at Tier 2; anaphoric and first-person inputs fall through to E4B — see #937)*
 * `set_timer`, `run_intent` — OS action delegation
 
 ### 4.3 Extensible Skills (WebAssembly)


### PR DESCRIPTION
## Summary

Three TTS voice quality fixes addressing fraction/unit normalisation, Kiwi English corpus terms, and pronoun normalisation scope — plus code-review fixes for date false-positives, TSP acronym sensitivity, case-insensitive month guard, and unconditional pronoun normalisation.

## Changes

### #912 — Recipe fraction normalisation
- `normalizeFractionsForSpeech()` added to `ChatTextUtils` — converts Unicode fraction chars (`½ ¼ ¾ ⅓ ⅔ ⅛`), mixed numbers (`1 1/2` → "1 and a half"), simple ASCII fractions (`1/4` → "quarter"), and unit abbreviations (`tsp` → "teaspoon", `tbsp` → "tablespoon")
- Called as step 2 in `normalizeChatTextForSpeech()` pipeline (after bullet/markdown strip, before sentence splitting)
- `DATE_GUARD` negative lookahead prevents fraction conversion on date-format strings (`2/3 May`, `2/3 may`, `1/2 january`, `2/3/2024`). Uses `(?i:...)` inline flag so month matching is fully case-insensitive.
- `UNIT_ABBREV_RULES` uses `\b[Tt]sp\b` / `\b[Tt]bsp\b` (no `IGNORE_CASE`) so all-caps `TSP` / `TBSP` acronyms are not converted

### #876 — Pronoun normalisation scope
- `speakForVoice()` now applies `normalisePronounsForTts()` unconditionally (previously skipped when `spokenOverride` was set, leaving presentation-fallback text unnormalised)

### #736 — Kiwi English corpus (`nz_truth_memories.json`)

Schema fields per entry: `id`, `term`, `category`, `definition`, `trigger_context`, `vibe_level`, `vector_text`, `metadata.tags`

| ID | Term | Change | Category | vibe_level |
|----|------|--------|----------|-----------|
| `nz_001` | Always blow on the pie | Fix: "gas station" → "petrol station" | safety | — |
| `nz_140` | Kumara | New | food | 2 |
| `nz_141` | Wharepaku | New | maori | 2 |
| `nz_142` | Chocka | New | slang | 4 |
| `nz_143` | Hundies | New | slang | 4 |
| `nz_144` | Taniwha | New | maori | 3 |

**nz_140 — Kumara**
> New Zealand sweet potato. A root vegetable brought to Aotearoa by early Māori, botanically distinct from North American yams. Sold primarily in red (Owairaka), gold (Toka Toka), and orange (Beauregard) varieties. Culturally significant and an absolute requirement for both a traditional Māori hāngī and the classic Kiwi Sunday roast.

**nz_141 — Wharepaku**
> The te reo Māori term for toilet, restroom, or bathroom. A compound word literally translating to "small house" (*whare* = building/house, *paku* = small). Heavily integrated into modern New Zealand English and serves as the standard term found on public signage, in schools, and across government buildings nationwide.

**nz_142 — Chocka**
> Completely full to the brim; packed. A ubiquitous colloquialism abbreviated from "chock-a-block." Highly versatile: used to describe a crowded physical space ("the pub is chocka"), a vehicle packed with gear for a road trip, or the physical sensation of being completely stuffed after a mean feed.

**nz_143 — Hundies**
> Absolute agreement, confirmation, or maximum effort. Colloquial shorthand for "one hundred percent." Functions as an enthusiastic affirmative response (similar to "absolutely" or "I agree entirely") or as an adverb to describe committing full energy and focus to an action or task (e.g. "we're going hundies on this project").

**nz_144 — Taniwha**
> Supernatural creatures from Māori mythology, strongly associated with waterways. Powerful, mythological beings that dwell in deep rivers, dark caves, lakes, or the ocean. They hold a dual nature in Māori tradition: often serving as respected *kaitiaki* (protective guardians) for a specific iwi (tribe) and their local environment, but can also act as dangerous, predatory monsters that enforce respect for natural boundaries.

## Testing

### Unit tests
- [x] 358 tests pass (1 pre-existing failure: `LatexConversionTest > nested fractions are handled`)
- [x] `./gradlew assembleDebug` clean

### Manual test scenarios — S23 Ultra

**Fraction normalisation (#912)**
1. Ask: *"How do I make pancakes?"* — response includes `1/2 cup`, `1 1/4 cup`, `1/8 tsp`. Verify TTS says "half cup", "one and a quarter cup", "one eighth teaspoon" (no slashes)
2. Ask Jandal about a meeting: *"Remind me about the 2/3 May standup"* — verify TTS does NOT say "two thirds May" (date guard)
3. Type a message with `½` or `¾` unicode chars — verify TTS renders as "half" / "three quarters"
4. Ask a finance question: *"What are the TSP contribution limits?"* — verify TTS does NOT say "teaspoon"

**Pronoun normalisation (#876)**
1. Save a memory: *"Remember that I prefer dark mode"* — verify TTS confirmation uses normalised pronouns
2. Check weather for Wellington — verify spoken output includes "Partly cloudy" and "degrees Celsius" (presentation fallback + normalisation both applied)

**Kiwi corpus (#736)**
1. *"What's kumara?"* — verify Jandal knows Māori origin, Owairaka/Toka Toka/Beauregard varieties, hāngī connection
2. *"Where's the wharepaku?"* — verify Jandal understands and responds; knows it means "small house" in te reo
3. *"The pub is chocka tonight"* — verify Jandal recognises slang and responds naturally
4. *"I'm going hundies on this project"* — verify Jandal understands as full commitment / 100%
5. *"Tell me about taniwha"* — verify Jandal references kaitiaki guardian role and iwi connection
6. *"I need to find a gas station"* — verify Jandal responds with "petrol station" (nz_001 fix)

## Related issues

Closes #876
Closes #912
Closes #736
