### PR TITLE
feat(#933): add meal plans and favourites browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 🧩 **Quick intent slot filling** — supported fast-path intents can pause for missing required parameters instead of failing silently
 - 🪪 **Rich tool presentations** — weather cards, list cards, confirmation chips, expandable previews, and surfaced fallback links
 - 🔎 **Tool call debugging** — expand any tool call chip to see request/result, tap to copy
-- 🧭 **Nav drawer** — Lists and Alarms accessible from Chat, Actions, and all main screens via hamburger menu
+- 🧭 **Nav drawer** — Lists, Alarms, and Meal plans accessible from Chat, Actions, and all main screens via hamburger menu
 - 📋 **Lists** — create and manage named lists via chat ("add milk to shopping list") or the Lists UI; full CRUD with active/completed sections
 - 🗓️ **Scheduled Alarms** — date-specific alarms scheduled via Jandal appear in the Alarms screen for review and cancellation
 - 📟 **Side panel** — slide-out drawer accessible from Chat and Settings shows active alarms and timers with live countdown; cancel any from the panel
@@ -67,7 +67,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 🔊 **Per-message speaker button** — `VolumeUp` icon on every assistant bubble; tap to play or stop that message's TTS independently of voice mode
 - ⚙️ **Expanded TTS settings** — pitch slider (Sherpa only, 0.5–2.0×), auto-speak chat replies toggle (decoupled from Quick Actions via `autoSpeakEnabled` field), max spoken sentences dropdown (0 = unlimited, 2, 3, 5); all grouped in a **"Chat voice behaviour"** section in Settings
 - 🛑 **Verbal stop command** — saying "stop", "stop speaking", "cancel", "be quiet", "shut up", or "silence" during TTS playback cancels speech and stops mic re-arm
-- 🗣️ **VCTK multi-speaker selection** — choose from 109 VCTK voices (gender filter, speaker ID, accent label) in Settings → Voice; sid mapping sourced directly from the Piper model config
+|- 🗣️ **VCTK multi-speaker selection** — choose from 109 VCTK voices (gender filter, speaker ID, accent label) in Settings → Voice; sid mapping sourced directly from the Piper model config
 |- 🗣️ **Semaine multi-speaker selection** — 4 distinct voices (Prudence, Spike, Obadiah, Poppy) selectable in Settings → Voice (#818, PR #818)
 |- 📐 **Deterministic unit conversion** — length, mass, volume, temperature, speed with alias normalisation and spoken-STT variants (#676, PR #816)
 |- 💱 **Deterministic currency conversion** — ISO code resolution via Frankfurter/ECB rates with same-currency short-circuit and clear error for unsupported currencies (#831, PR #848)
@@ -77,11 +77,11 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 |- 🔒 **Blank response guard** — retries without RAG before showing fallback when LiteRT produces 0 tokens; keeps chat awake during load and generation (#839/#841, PRs #840/#842)
 |- 🎙️ **Homescreen Glance widget** — quick actions and voice from the launcher via GlanceAppWidget; VoiceCommandActivity and WidgetTextInputActivity with task isolation (#617, PR #847)
 |- 🔧 **Audio quality fixes** — AudioTrack tail cutoff prevention via hardware-latency silence padding; expectedSlotPromptSpeech normalisation to match TTS output; SID=0 clamp for single-speaker voices; aye pronunciation correction (#837/#828/#810, PRs #838/#836/#811)
-- 🍽️ **Deterministic meal planner foundation** — app-owned meal-planning sessions with bounded JSON generation, per-day recipe persistence, shopping-list projection, quantity sanity validation, and quick-action/chat handoff (#859, PR #864)
+- 🍽️ **Deterministic meal planner** — app-owned meal-planning sessions with bounded JSON generation, draft-plan approval, progressive recipe reveal, visible `x of y` progress, interruption-safe resume, quantity sanity validation, and quick-action/chat handoff (#859/#869, PRs #864/#875)
+- 📚 **Meal plans browser** — drawer-accessible Recent plans and Favourites tabs with recipe search, canonical favourite toggles, recipe re-add to Lists, and ingredient export into existing user lists (#933, PR #934)
 
 ### Coming Soon
 - 💬 **Expanded multi-turn dialog** — broader confirmation, digression, and slot-filling coverage across more intents *(Phase 3G, #708 and follow-ups)*
-- 🍽️ **Meal planner phase 2** — progressive day-by-day reveal, visible `x of y` generation progress, and interruption-safe resume/background handling *(#869)*
 - 🗒️ **Lists — management upgrades** — rename, pin, sort, edit items, favorites, and due dates *(#662)*
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen *(Phase 3, #479)*
 - 🌙 **Dreaming Engine** — overnight WorkManager consolidation (Light Sleep → REM → Deep Sleep) *(Phase 4)*
@@ -93,114 +93,3 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 3F)*
 
 ## Roadmap
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| 1 | Core LiteRT-LM integration + GPU/NPU acceleration + Chat UI | ✅ |
-| 2 | sqlite-vec + EmbeddingGemma for local RAG + memory, UI polish, model selection | ✅ |
-| 3 | Native Skills (alarms, lists, weather, media, navigation) + multi-turn dialog + episodic distillation + nav drawer + Brand refresh | 🔄 |
-| 4 | Dreaming Engine (WorkManager overnight cycle) + Semantic Cache + Self-Healing Identity System | ⬜ |
-| 5 | Chicory Wasm runtime + GitHub Skill Store | ⬜ |
-| 6 | 8GB device optimization (dynamic weight loading) | ⬜ |
-
-## Getting Started
-
-### Tested devices
-
-| Device | Chip | RAM | Backend | Status |
-|--------|------|-----|---------|--------|
-| Samsung Galaxy S23 Ultra | Snapdragon 8 Gen 2 (SM8550) | 12 GB | GPU (OpenCL / Adreno 740) | ✅ Tested |
-| Google Pixel 10 | Tensor G5 | 12 GB | GPU (Immortalis-G925) | ✅ Expected compatible |
-
-> **Backend note:** On Qualcomm devices the app uses the GPU (OpenCL) delegate via LiteRT. Hardware tier detection automatically selects the right delegate. See [`models/README.md`](models/README.md) for per-device model setup.
-
-### Performance — Samsung Galaxy S23 Ultra (Gemma-4 E-4B, GPU)
-
-Measured on-device from production logs. "tok/s" counts output tokens delivered to the UI.
-
-| Metric | Value |
-|--------|-------|
-| Time to First Token (TTFT) | 2–5s (cold), ~2s (warm KV cache) |
-| Generation speed | ~9–10 tok/s |
-| Engine init | ~2s (warm, kernel cache hit) |
-
-**Multi-Token Prediction (MTP / speculative decoding)**
-
-MTP speeds up decode by speculatively generating multiple tokens per step. LiteRT-LM recommends it on GPU backends, and Jandal enables it during engine initialisation only when the loaded Gemma 4 model reports support. The toggle is available in Settings → Model for Gemma 4 model cards and requires an app restart. The benefit scales with response length — on long responses (~400+ tokens) we observed a **~2× wall-time speedup**; on short responses the overhead is negligible.
-
-| Response length | MTP off | MTP on | Speedup |
-|----------------|---------|--------|---------|
-| Short (~100 tok) | ~15s | ~12s | ~1.2× |
-| Long (~400 tok) | ~69s | ~30s | ~2.3× |
-
-> **Note:** A formal repeatable benchmark (fixed prompts, greedy decoding, N-run average) is tracked in [#803](https://github.com/NickMonrad/kernel-ai-assistant/issues/803). The numbers above are from manual device testing with variable-length responses.
-
-### Prerequisites
-
-- Android Studio Ladybug (2024.2.1) or newer
-- Android NDK (for sqlite-vec)
-- JDK 17
-- Physical Android device with 8–12GB RAM (emulator cannot test GPU/NPU)
-
-### Setup
-
-```bash
-git clone https://github.com/NickMonrad/kernel-ai-assistant.git
-cd kernel-ai-assistant
-./gradlew assembleDebug
-```
-
-Model files are managed manually for local development. Place the required `.litertlm`,
-`.tflite`, and `sentencepiece.model` files under `models/` and push them to the device
-using the instructions in [`models/README.md`](models/README.md).
-
-Open in Android Studio, connect your device via USB, and run.
-
-### Optional: Android CLI for agent workflows
-
-This repo can use the official `android` CLI as a low-noise accelerator for agentic Android work:
-
-```bash
-./scripts/setup-android-cli.sh
-android describe --project_dir=.
-android docs search 'edge-to-edge Compose guidance'
-```
-
-Useful commands in this repo:
-
-- `android describe --project_dir=.` — discover project metadata and build outputs
-- `android docs search ...` / `android docs fetch ...` — fetch official Android guidance
-- `android layout --pretty` — inspect the active app UI from a connected device/emulator
-- `android run --apks=app/build/outputs/apk/debug/app-debug.apk` — deploy a known APK
-
-`./scripts/setup-android-cli.sh` installs the official Google CLI into `~/.local/bin` on supported platforms, runs `android init`, and wires the `android-cli` skill into detected agents such as OpenCode and Copilot.
-
-If the CLI is unavailable on your platform, keep using the normal Gradle + `adb` workflow.
-
-## Testing
-
-- Automated test overview: [`docs/automated-testing.md`](docs/automated-testing.md)
-- Device setup and logcat guide: [`docs/adb-testing.md`](docs/adb-testing.md)
-- Detailed backlog/specification: [`docs/testing/automated-test-specification.md`](docs/testing/automated-test-specification.md)
-
-Common commands:
-
-```bash
-./gradlew testDebugUnitTest
-./gradlew connectedDebugAndroidTest
-python3 scripts/adb_skill_test.py --phases weather,lists
-python3 scripts/adb_skill_test.py --profile
-```
-
-## Key Technical Pillars
-
-* **Inference:** Google AI Edge (LiteRT) with INT4 quantization, GPU + NPU delegates
-* **Extensibility:** GitHub-indexed Skill Store (Rust → Wasm) + Native Kotlin skills
-* **Context:** Recursive context window management with semantic summarization
-* **Privacy:** 100% offline-capable; no telemetry or external LLM API dependencies
-
-## License
-
-Apache License 2.0 — see [LICENSE](LICENSE) for details.
-
-This project adapts code from [Google AI Edge Gallery](https://github.com/google-ai-edge/gallery) and uses the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) library. See [NOTICE](NOTICE) for attribution.

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.ChatBubble
@@ -49,6 +50,7 @@ import com.kernel.ai.feature.settings.ImportantDatesScreen
 import com.kernel.ai.feature.settings.ListItemsScreen
 import com.kernel.ai.feature.settings.ChatPreferencesScreen
 import com.kernel.ai.feature.settings.ListsScreen
+import com.kernel.ai.feature.settings.MealPlansScreen
 import com.kernel.ai.feature.settings.MemoryScreen
 import com.kernel.ai.feature.settings.ModelManagementScreen
 import com.kernel.ai.feature.settings.ModelSettingsScreen
@@ -77,6 +79,7 @@ private const val ROUTE_CHAT_PREFERENCES = "settings/chat_preferences"
 private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
 private const val ROUTE_SCHEDULED_ALARMS = "settings/scheduled_alarms"
 private const val ROUTE_SIDE_PANEL = "settings/side_panel"
+private const val ROUTE_MEAL_PLANS = "meal_plans"
 private const val ROUTE_LISTS = "lists"
 private const val ROUTE_LIST_ITEMS = "lists/{listId}"
 private const val ROUTE_CONVERT = "convert"
@@ -210,6 +213,20 @@ fun KernelNavHost(
                     onClick = {
                         coroutineScope.launch { drawerState.close() }
                         navController.navigate(ROUTE_CONTACT_ALIASES) {
+                            popUpTo(ROUTE_LIST) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+                )
+                NavigationDrawerItem(
+                    label = { Text("Meal plans") },
+                    icon = { Icon(Icons.Default.Bookmarks, contentDescription = null) },
+                    selected = currentBaseRoute == ROUTE_MEAL_PLANS,
+                    onClick = {
+                        coroutineScope.launch { drawerState.close() }
+                        navController.navigate(ROUTE_MEAL_PLANS) {
                             popUpTo(ROUTE_LIST) { saveState = true }
                             launchSingleTop = true
                             restoreState = true
@@ -475,6 +492,12 @@ fun KernelNavHost(
 
                 composable(ROUTE_MEMORY) {
                     MemoryScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable(ROUTE_MEAL_PLANS) {
+                    MealPlansScreen(
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
@@ -512,6 +512,42 @@ class MealPlanSessionRepositoryAndroidTest {
     }
 
     @Test
+    fun recreateRecipeList_createsStandaloneChecklistListsWithUniqueNames() = runBlocking {
+        val completed = createCompletedSessionWithRecipe("conv-recreate-recipe-list")
+
+        val firstListName = repository.recreateRecipeList(completed.sessionId, 0)
+        val secondListName = repository.recreateRecipeList(completed.sessionId, 0)
+
+        assertEquals("Chicken Stir Fry", firstListName)
+        assertEquals("Chicken Stir Fry (2)", secondListName)
+        val firstListId = requireNotNull(listNameDao.getByName(firstListName)).id
+        val secondListId = requireNotNull(listNameDao.getByName(secondListName)).id
+        val expectedItems = listOf(
+            "Ingredients",
+            "placeholder ingredient",
+            "Method",
+            "1. Slice the vegetables.",
+            "2. Stir-fry everything until glossy.",
+        )
+
+        assertEquals(expectedItems, listItemDao.getByList(firstListId).map { it.text })
+        assertEquals(expectedItems, listItemDao.getByList(secondListId).map { it.text })
+    }
+
+    @Test
+    fun addRecipeIngredientsToList_appendsCanonicalIngredientsToExistingList() = runBlocking {
+        val completed = createCompletedSessionWithRecipe("conv-add-ingredients-list")
+        val now = System.currentTimeMillis()
+        val listId = listNameDao.insertAndGet(ListNameEntity(name = "weeknight shopping", createdAt = now, updatedAt = now))
+        assertTrue(listId > 0L)
+
+        val listName = repository.addRecipeIngredientsToList(completed.sessionId, 0, listId)
+
+        assertEquals("weeknight shopping", listName)
+        assertEquals(listOf("500 g chicken thigh"), listItemDao.getByList(listId).map { it.text })
+    }
+
+    @Test
     fun getRecentMealHistory_reads_recent_terminal_days_from_canonical_session_rows() = runBlocking {
         val completed = repository.startOrResume("conv-history-completed")
         repository.savePlanDraft(

--- a/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
+++ b/core/memory/src/androidTest/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepositoryAndroidTest.kt
@@ -25,6 +25,7 @@ import com.kernel.ai.core.memory.mealplan.RecipeDraftMethodStep
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -470,6 +471,47 @@ class MealPlanSessionRepositoryAndroidTest {
     }
 
     @Test
+    fun observeRecentCompletedPlans_updatesFavouriteFlagsFromCanonicalStore() = runBlocking {
+        val completed = createCompletedSessionWithRecipe("conv-browser")
+
+        val initial = repository.observeRecentCompletedPlans(10).first { it.isNotEmpty() }.single()
+        assertEquals(completed.displayName, initial.displayName)
+        assertFalse(initial.days.single().isFavouriteRecipe)
+
+        val favourited = repository.setRecipeFavourite(completed.sessionId, 0, true)
+        val favouriteKey = requireNotNull(favourited.days.single().recipeKey)
+
+        val favouritedPlans = repository.observeRecentCompletedPlans(10)
+            .first { plans -> plans.single().days.single().isFavouriteRecipe }
+            .single()
+        assertTrue(favouritedPlans.days.single().isFavouriteRecipe)
+        assertEquals(favouriteKey, favouritedPlans.days.single().recipeKey)
+
+        repository.removeFavouriteRecipe(favouriteKey)
+
+        val unfavouritedPlans = repository.observeRecentCompletedPlans(10)
+            .first { plans -> plans.isNotEmpty() && !plans.single().days.single().isFavouriteRecipe }
+            .single()
+        assertFalse(unfavouritedPlans.days.single().isFavouriteRecipe)
+    }
+
+    @Test
+    fun observeFavouriteRecipes_readsCanonicalFavouriteStore() = runBlocking {
+        val completed = createCompletedSessionWithRecipe("conv-favourite-library")
+        val favourited = repository.setRecipeFavourite(completed.sessionId, 0, true)
+        val favouriteKey = requireNotNull(favourited.days.single().recipeKey)
+
+        val favourite = repository.observeFavouriteRecipes(10)
+            .first { it.isNotEmpty() }
+            .single()
+
+        assertEquals(favouriteKey, favourite.recipeKey)
+        assertEquals("Chicken Stir Fry", favourite.title)
+        assertEquals("Quick bowl", favourite.summary)
+        assertEquals(listOf("chicken"), favourite.proteinTags)
+    }
+
+    @Test
     fun getRecentMealHistory_reads_recent_terminal_days_from_canonical_session_rows() = runBlocking {
         val completed = repository.startOrResume("conv-history-completed")
         repository.savePlanDraft(
@@ -743,6 +785,39 @@ class MealPlanSessionRepositoryAndroidTest {
             "UPDATE meal_plan_sessions SET updatedAt = ? WHERE id = ?",
             arrayOf<Any>(cutoff, sessionId),
         )
+    }
+
+    private fun createCompletedSessionWithRecipe(conversationId: String) = runBlocking {
+        val session = repository.startOrResume(conversationId)
+        repository.savePlanDraft(
+            session.sessionId,
+            listOf(
+                MealPlanDraftDay(
+                    dayIndex = 0,
+                    title = "Chicken Stir Fry",
+                    summary = "Quick bowl",
+                    proteinTags = listOf("chicken"),
+                ),
+            ),
+        )
+        repository.persistRecipeDraft(
+            sessionId = session.sessionId,
+            dayIndex = 0,
+            recipeDraft = recipeDraft(
+                title = "Chicken Stir Fry",
+                method = listOf("Slice the vegetables.", "Stir-fry everything until glossy."),
+            ),
+            rawModelJson = "{}",
+            groceries = listOf(
+                grocery(
+                    displayText = "500 g chicken thigh",
+                    quantity = "500",
+                    unit = "g",
+                    ingredientName = "chicken thigh",
+                ),
+            ),
+        )
+        repository.completeSession(session.sessionId)
     }
 
     private fun tableExists(db: androidx.sqlite.db.SupportSQLiteDatabase, tableName: String): Boolean =

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanFavouriteRecipeDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanFavouriteRecipeDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.kernel.ai.core.memory.entity.MealPlanFavouriteRecipeEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MealPlanFavouriteRecipeDao {
@@ -22,6 +23,12 @@ interface MealPlanFavouriteRecipeDao {
 
     @Query("SELECT recipeKey FROM meal_plan_favourite_recipes WHERE recipeKey IN (:recipeKeys)")
     suspend fun getExistingKeys(recipeKeys: List<String>): List<String>
+
+    @Query("SELECT * FROM meal_plan_favourite_recipes ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<MealPlanFavouriteRecipeEntity>>
+
+    @Query("SELECT * FROM meal_plan_favourite_recipes ORDER BY updatedAt DESC LIMIT :limit")
+    fun observeRecent(limit: Int): Flow<List<MealPlanFavouriteRecipeEntity>>
 
     @Query("SELECT * FROM meal_plan_favourite_recipes ORDER BY updatedAt DESC LIMIT :limit")
     suspend fun getRecent(limit: Int): List<MealPlanFavouriteRecipeEntity>

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanSessionDao.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/dao/MealPlanSessionDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.kernel.ai.core.memory.entity.MealPlanSessionEntity
+import kotlinx.coroutines.flow.Flow
 
 data class RecentTerminalMealHistoryRow(
     val title: String,
@@ -61,6 +62,16 @@ interface MealPlanSessionDao {
 
     @Query("SELECT MAX(displayCode) FROM meal_plan_sessions")
     suspend fun getMaxDisplayCode(): Int?
+
+    @Query(
+        """
+        SELECT * FROM meal_plan_sessions
+        WHERE status = 'COMPLETED'
+        ORDER BY COALESCE(completedAt, updatedAt) DESC, createdAt DESC
+        LIMIT :limit
+        """,
+    )
+    fun observeCompleted(limit: Int): Flow<List<MealPlanSessionEntity>>
 
     @Query(
         """

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/mealplan/MealPlanModels.kt
@@ -62,6 +62,17 @@ data class FavouriteRecipeSummary(
     val proteinTags: List<String> = emptyList(),
 )
 
+data class FavouriteRecipeBrowserItem(
+    val recipeKey: String,
+    val title: String,
+    val summary: String?,
+    val proteinTags: List<String> = emptyList(),
+    val recentPlanDisplayName: String?,
+    val recentPlanSessionId: String?,
+    val recentDayIndex: Int?,
+    val recipe: RecipeDraft?,
+)
+
 data class RecipeDraftIngredient(
     val originalText: String,
     val amount: String?,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -117,6 +117,44 @@ class MealPlanSessionRepository @Inject constructor(
         combine(sessionDao.observeCompleted(limit), favouriteRecipeDao.observeRecent(1)) { sessions, _ -> sessions }
             .mapLatest { sessions -> sessions.map { it.toSnapshot() } }
 
+    fun observeActiveLists(): Flow<List<ListNameEntity>> =
+        listNameDao.observeActiveLists()
+
+    suspend fun recreateRecipeList(sessionId: String, dayIndex: Int): String = database.withTransaction {
+        val (_, recipeVersion) = requireCurrentRecipeVersion(sessionId, dayIndex)
+        val targetName = nextAvailableListName(recipeVersion.title.ifBlank { "Recipe" })
+        val now = System.currentTimeMillis()
+        val listId = listNameDao.insertAndGet(ListNameEntity(name = targetName, createdAt = now, updatedAt = now))
+            .takeIf { it != -1L }
+            ?: error("Failed to create recipe list: $targetName")
+        buildRecipeListTexts(recipeVersion).forEach { text ->
+            listItemDao.insert(
+                ListItemEntity(listId = listId, text = text, createdAt = now, updatedAt = now),
+            )
+        }
+        targetName
+    }
+
+    suspend fun addRecipeIngredientsToList(sessionId: String, dayIndex: Int, listId: Long): String = database.withTransaction {
+        val list = requireNotNull(listNameDao.getById(listId)?.takeIf { it.archivedAt == null }) { "Unknown active list: $listId" }
+        val (_, recipeVersion) = requireCurrentRecipeVersion(sessionId, dayIndex)
+        val ingredientLines = groceryItemDao.getByRecipeVersion(recipeVersion.id)
+            .map { grocery -> grocery.displayText.ifBlank { grocery.originalText } }
+            .ifEmpty { buildRecipeIngredientTexts(recipeVersion) }
+            .filter { it.isNotBlank() }
+        require(ingredientLines.isNotEmpty()) {
+            "Day ${dayIndex + 1} has no ingredient data to add."
+        }
+        val now = System.currentTimeMillis()
+        ingredientLines.forEach { text ->
+            listItemDao.insert(
+                ListItemEntity(listId = listId, text = text, createdAt = now, updatedAt = now),
+            )
+        }
+        listNameDao.updateTimestamp(listId, now)
+        list.name
+    }
+
 
     /**
      * Planner retention pruning runs here before resuming/creating a session so old terminal
@@ -815,6 +853,43 @@ class MealPlanSessionRepository @Inject constructor(
     private suspend fun currentRecipeVersion(day: MealPlanDayEntity): MealPlanRecipeVersionEntity? {
         val version = day.currentRecipeVersion ?: return null
         return recipeVersionDao.getLatestForDay(day.id)?.takeIf { it.version == version }
+    }
+
+    private suspend fun requireCurrentRecipeVersion(
+        sessionId: String,
+        dayIndex: Int,
+    ): Pair<MealPlanDayEntity, MealPlanRecipeVersionEntity> {
+        val day = requireNotNull(dayDao.getBySessionAndIndex(sessionId, dayIndex)) {
+            "Unknown meal-plan day $dayIndex for session $sessionId"
+        }
+        val recipeVersion = requireNotNull(currentRecipeVersion(day)) {
+            "Day ${dayIndex + 1} does not have a recipe yet."
+        }
+        return day to recipeVersion
+    }
+
+    private fun buildRecipeListTexts(recipeVersion: MealPlanRecipeVersionEntity): List<String> = buildList {
+        add("Ingredients")
+        addAll(buildRecipeIngredientTexts(recipeVersion))
+        add("Method")
+        addAll(buildRecipeMethodTexts(recipeVersion))
+    }
+
+    private fun buildRecipeIngredientTexts(recipeVersion: MealPlanRecipeVersionEntity): List<String> =
+        jsonToIngredients(recipeVersion.ingredientsJson).map { ingredient -> ingredient.originalText }
+
+    private fun buildRecipeMethodTexts(recipeVersion: MealPlanRecipeVersionEntity): List<String> =
+        jsonToMethodSteps(recipeVersion.methodStepsJson).map { step -> "${step.stepNumber}. ${step.text}" }
+
+    private suspend fun nextAvailableListName(baseName: String): String {
+        val normalizedBaseName = baseName.trim().ifBlank { "Recipe" }
+        var candidate = normalizedBaseName
+        var suffix = 2
+        while (listNameDao.getByName(candidate) != null) {
+            candidate = "$normalizedBaseName ($suffix)"
+            suffix += 1
+        }
+        return candidate
     }
 
     private fun resolvedRecipeKey(recipeVersion: MealPlanRecipeVersionEntity, proteinTags: List<String>): String =

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -35,6 +35,11 @@ import com.kernel.ai.core.memory.mealplan.RecipeDraftIngredient
 import com.kernel.ai.core.memory.mealplan.RecipeDraftMethodStep
 import com.kernel.ai.core.memory.mealplan.jsonArrayToStringList
 import com.kernel.ai.core.memory.mealplan.toJsonArrayString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.json.JSONArray
@@ -93,6 +98,25 @@ class MealPlanSessionRepository @Inject constructor(
                 proteinTags = jsonArrayToStringList(favourite.proteinTagsJson),
             )
         }
+
+    fun observeFavouriteRecipes(limit: Int): Flow<List<FavouriteRecipeSummary>> =
+        favouriteRecipeDao.observeRecent(limit).map { favourites ->
+            favourites.map { favourite ->
+                FavouriteRecipeSummary(
+                    recipeKey = favourite.recipeKey,
+                    title = favourite.title,
+                    summary = favourite.summary,
+                    proteinTags = jsonArrayToStringList(favourite.proteinTagsJson),
+                )
+            }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+
+    fun observeRecentCompletedPlans(limit: Int): Flow<List<MealPlanSnapshot>> =
+        combine(sessionDao.observeCompleted(limit), favouriteRecipeDao.observeRecent(1)) { sessions, _ -> sessions }
+            .mapLatest { sessions -> sessions.map { it.toSnapshot() } }
+
 
     /**
      * Planner retention pruning runs here before resuming/creating a session so old terminal
@@ -161,10 +185,18 @@ class MealPlanSessionRepository @Inject constructor(
         } else {
             favouriteRecipeDao.delete(recipeKey)
         }
+        if (session.status == MealPlanSessionStatus.COMPLETED.name) {
+            return@withTransaction session.toSnapshot()
+        }
         val updatedSession = session.copy(updatedAt = now)
         sessionDao.update(updatedSession)
         updatedSession.toSnapshot()
     }
+
+    suspend fun removeFavouriteRecipe(recipeKey: String) = database.withTransaction {
+        favouriteRecipeDao.delete(recipeKey)
+    }
+
     suspend fun savePlanDraft(
         sessionId: String,
         days: List<MealPlanDraftDay>,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/repository/MealPlanSessionRepository.kt
@@ -51,6 +51,10 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
+class MealPlanIngredientDataUnavailableException(
+    val dayIndex: Int,
+) : IllegalArgumentException("Day ${dayIndex + 1} has no ingredient data to add.")
+
 @Singleton
 class MealPlanSessionRepository @Inject constructor(
     private val database: KernelDatabase,
@@ -142,8 +146,8 @@ class MealPlanSessionRepository @Inject constructor(
             .map { grocery -> grocery.displayText.ifBlank { grocery.originalText } }
             .ifEmpty { buildRecipeIngredientTexts(recipeVersion) }
             .filter { it.isNotBlank() }
-        require(ingredientLines.isNotEmpty()) {
-            "Day ${dayIndex + 1} has no ingredient data to add."
+        if (ingredientLines.isEmpty()) {
+            throw MealPlanIngredientDataUnavailableException(dayIndex)
         }
         val now = System.currentTimeMillis()
         ingredientLines.forEach { text ->

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -387,14 +387,15 @@ Deterministic meal planning now has its v1 foundation merged. The next phases ar
 |-----------|-------|--------|----------|
 | [#827](https://github.com/NickMonrad/kernel-ai-assistant/issues/827) | Cooking weights and measures for meal planning | ✅ Done — PR #855 | 🟡 Medium |
 | [#859](https://github.com/NickMonrad/kernel-ai-assistant/issues/859) | Deterministic meal planner foundation | ✅ Done — PR #864 | 🔴 High |
-| [#869](https://github.com/NickMonrad/kernel-ai-assistant/issues/869) | Meal planner phase 2 — progressive reveal + interruption-safe generation | ⬜ Pending | 🔴 High |
+| [#869](https://github.com/NickMonrad/kernel-ai-assistant/issues/869) | Meal planner phase 2 — progressive reveal + interruption-safe generation | ✅ Done — PR #875 | 🔴 High |
+| [#933](https://github.com/NickMonrad/kernel-ai-assistant/issues/933) | Recent meal plans and favourite recipes browser | ✅ Done — PR #934 | 🟡 Medium |
 | [#235](https://github.com/NickMonrad/kernel-ai-assistant/issues/235) | Artifact entity — persistent structured documents in Room DB | ⬜ Pending | 🟡 Medium |
 | [#43](https://github.com/NickMonrad/kernel-ai-assistant/issues/43) | Recipe skill datasources & regional produce | ⬜ Pending | 🟢 Low |
 
-**Current state after PR #864:**
+**Current state after PR #934:**
 
-- Shipped: app-owned meal-planner session/day/recipe/grocery tables, bounded JSON generation, quantity sanity validation, deterministic shopping/recipe projections, and quick-action/widget handoff into chat.
-- Next UX gap: longer multi-day plans still complete as one long foreground experience; users need progressive day-by-day reveal, explicit `Generating recipe x of y` feedback, and clean resume after interruption/backgrounding (#869).
+- Shipped: app-owned meal-planner session/day/recipe/grocery tables, bounded JSON generation, draft approval before recipe generation, progressive per-day recipe reveal, visible `Generating recipe x of y` status, interruption-safe resume prompts, deterministic shopping/recipe projections, and quick-action/widget handoff into chat.
+- Shipped: a drawer-accessible Meal plans browser with Recent plans and Favourites tabs, recipe-name search, canonical favourite toggles outside chat, and export actions to recreate recipe lists or append ingredients into existing user lists.
 - Later platform/data phases stay separate by design: #235 expands durable structured artifacts; #43 adds recipe grounding and regional produce data.
 
 ---

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-05-21 (PR #946 spec sync: thinking-mode/tool-turn hardening, direct native tool wrappers, DirectReply bypass notes, known QIR/anaphora follow-up gaps; prior: PR #925 deterministic meal planner architecture, planner status surface, friendly meal-plan IDs, conversation title sync, Room v45; PR #924 conversation management — archive, pin, drag-to-reorder, swipe gestures, multi-select, ArchiveCleanupWorker; PR #834 voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
+> **Last updated:** 2026-05-21 (PR #946 spec sync: thinking-mode/tool-turn hardening, direct native tool wrappers, DirectReply bypass notes, known QIR/anaphora follow-up gaps; PR #934 meal plans browser: recent/favourites tabs, recipe search, list export actions; prior: PR #925 deterministic meal planner architecture, planner status surface, friendly meal-plan IDs, conversation title sync, Room v45; PR #924 conversation management — archive, pin, drag-to-reorder, swipe gestures, multi-select, ArchiveCleanupWorker; PR #834 voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -906,6 +906,24 @@ That surface also publishes planner-smart-reply commands such as:
 - `done meal planning`
 
 `shouldKeepChatScreenAwake(...)` treats planner `WORKING` activity the same as active generation so the device does not sleep mid-run while the planner is doing foreground-visible work.
+
+#### 4.3.6 Meal plans browser and favourites management
+
+Post-cook browsing and favourite management live outside chat in a dedicated **Meal plans** screen reachable from the navigation drawer.
+
+The screen has two tabs:
+- **Recent plans** — completed meal plans with expandable day cards and recipe details
+- **Favourites** — canonical favourite recipes derived from planner-owned recipe identity keys
+
+Key behaviour:
+- Recent-plan recipe search filters by recipe name and auto-expands matching plans so the matching day cards are immediately visible
+- Favourite search filters canonical favourite recipes by recipe name
+- Favourite / unfavourite actions update the canonical `meal_plan_favourite_recipes` store outside the chat planner flow
+- Recipe actions can either recreate a standalone recipe checklist in Lists or append the recipe's ingredient lines into an existing user-managed list
+- Planner-managed projection lists are excluded from the ingredient target picker so users do not accidentally append back into generated planner artifacts
+
+This browser intentionally reuses the planner's canonical Room state instead of introducing a second source of truth or reviving chat-only favourite management.
+
 ### 4.4 Extensible Skills (WebAssembly — Phase 5)
 
 Community-extensible skills run sandboxed via **Chicory** (pure JVM Wasm runtime, v1.0+).

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
@@ -4,14 +4,19 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bookmarks
@@ -19,12 +24,17 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -32,11 +42,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -44,6 +57,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeBrowserItem
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
@@ -51,6 +65,13 @@ import com.kernel.ai.core.memory.mealplan.RecipeDraft
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+
+private data class IngredientListRequest(
+    val sessionId: String,
+    val dayIndex: Int,
+    val recipeKey: String,
+    val recipeTitle: String,
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,6 +81,7 @@ fun MealPlansScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    var pendingIngredientListRequest by remember { mutableStateOf<IngredientListRequest?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.messages.collect { message ->
@@ -101,93 +123,162 @@ fun MealPlansScreen(
                 when (uiState.selectedTab) {
                     MealPlansBrowserTab.RECENT_PLANS -> RecentPlansTab(
                         plans = uiState.recentPlans,
+                        query = uiState.recentPlansQuery,
                         expandedPlanIds = uiState.expandedPlanIds,
                         expandedDetailIds = uiState.expandedDetailIds,
                         pendingRecipeKeys = uiState.pendingRecipeKeys,
+                        onQueryChange = viewModel::updateRecentPlansQuery,
                         onTogglePlan = viewModel::togglePlanExpanded,
                         onToggleDay = viewModel::toggleDayExpanded,
                         onToggleFavourite = viewModel::toggleDayFavourite,
+                        onAddRecipeToLists = viewModel::addRecipeToLists,
+                        onAddIngredientsToList = { sessionId, dayIndex, recipeKey, recipeTitle ->
+                            pendingIngredientListRequest = IngredientListRequest(
+                                sessionId = sessionId,
+                                dayIndex = dayIndex,
+                                recipeKey = recipeKey,
+                                recipeTitle = recipeTitle,
+                            )
+                        },
                     )
 
                     MealPlansBrowserTab.FAVOURITES -> FavouriteRecipesTab(
                         favourites = uiState.favouriteRecipes,
+                        query = uiState.favouriteRecipesQuery,
                         expandedDetailIds = uiState.expandedDetailIds,
                         pendingRecipeKeys = uiState.pendingRecipeKeys,
+                        onQueryChange = viewModel::updateFavouriteRecipesQuery,
                         onToggleExpanded = viewModel::toggleFavouriteExpanded,
                         onRemoveFavourite = viewModel::removeFavourite,
+                        onAddRecipeToLists = viewModel::addRecipeToLists,
+                        onAddIngredientsToList = { sessionId, dayIndex, recipeKey, recipeTitle ->
+                            pendingIngredientListRequest = IngredientListRequest(
+                                sessionId = sessionId,
+                                dayIndex = dayIndex,
+                                recipeKey = recipeKey,
+                                recipeTitle = recipeTitle,
+                            )
+                        },
                     )
                 }
             }
         }
+    }
+
+    pendingIngredientListRequest?.let { request ->
+        IngredientListDialog(
+            recipeTitle = request.recipeTitle,
+            lists = uiState.availableLists,
+            onDismiss = { pendingIngredientListRequest = null },
+            onConfirm = { listId ->
+                pendingIngredientListRequest = null
+                viewModel.addIngredientsToList(
+                    sessionId = request.sessionId,
+                    dayIndex = request.dayIndex,
+                    recipeKey = request.recipeKey,
+                    listId = listId,
+                )
+            },
+        )
     }
 }
 
 @Composable
 private fun RecentPlansTab(
     plans: List<MealPlanSnapshot>,
+    query: String,
     expandedPlanIds: Set<String>,
     expandedDetailIds: Set<String>,
     pendingRecipeKeys: Set<String>,
+    onQueryChange: (String) -> Unit,
     onTogglePlan: (String) -> Unit,
     onToggleDay: (String, Int) -> Unit,
     onToggleFavourite: (String, MealPlanSnapshotDay) -> Unit,
+    onAddRecipeToLists: (String, Int, String) -> Unit,
+    onAddIngredientsToList: (String, Int, String, String) -> Unit,
 ) {
-    if (plans.isEmpty()) {
-        EmptyMealPlansState(
-            title = "No completed meal plans yet",
-            body = "Finish a meal plan in chat and it will appear here for browsing and favouriting later.",
+    Column(modifier = Modifier.fillMaxSize()) {
+        BrowserSearchField(
+            query = query,
+            onQueryChange = onQueryChange,
+            placeholder = "Search recent recipes",
         )
-        return
-    }
+        Box(modifier = Modifier.weight(1f)) {
+            when {
+                plans.isEmpty() && query.isNotBlank() -> EmptyMealPlansState(
+                    title = "No matching recipes",
+                    body = "Try a different recipe name to search your recent meal plans.",
+                )
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        items(plans, key = { it.sessionId }) { plan ->
-            val expanded = plan.sessionId in expandedPlanIds
-            ElevatedCard(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onTogglePlan(plan.sessionId) },
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(verticalAlignment = Alignment.Top) {
-                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Text(plan.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                            Text(
-                                text = planSummary(plan),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            if (plan.dietaryRestrictions.isNotEmpty()) {
-                                Text(
-                                    text = plan.dietaryRestrictions.joinToString(),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-                        Icon(
-                            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                            contentDescription = if (expanded) "Collapse plan" else "Expand plan",
-                        )
-                    }
+                plans.isEmpty() -> EmptyMealPlansState(
+                    title = "No completed meal plans yet",
+                    body = "Finish a meal plan in chat and it will appear here for browsing and favouriting later.",
+                )
 
-                    if (expanded) {
-                        Spacer(modifier = Modifier.height(12.dp))
-                        plan.days.forEachIndexed { index, day ->
-                            RecentPlanDayCard(
-                                sessionId = plan.sessionId,
-                                day = day,
-                                expanded = MealPlansViewModel.dayDetailId(plan.sessionId, day.dayIndex) in expandedDetailIds,
-                                isPending = day.recipeKey != null && day.recipeKey in pendingRecipeKeys,
-                                onToggleExpanded = { onToggleDay(plan.sessionId, day.dayIndex) },
-                                onToggleFavourite = { onToggleFavourite(plan.sessionId, day) },
-                            )
-                            if (index != plan.days.lastIndex) {
-                                Spacer(modifier = Modifier.height(8.dp))
+                else -> LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(plans, key = { it.sessionId }) { plan ->
+                        val expanded = plan.sessionId in expandedPlanIds
+                        ElevatedCard(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onTogglePlan(plan.sessionId) },
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Row(verticalAlignment = Alignment.Top) {
+                                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        Text(plan.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                                        Text(
+                                            text = planSummary(plan),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                        if (plan.dietaryRestrictions.isNotEmpty()) {
+                                            Text(
+                                                text = plan.dietaryRestrictions.joinToString(),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                    Icon(
+                                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                        contentDescription = if (expanded) "Collapse plan" else "Expand plan",
+                                    )
+                                }
+
+                                if (expanded) {
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                    plan.days.forEachIndexed { index, day ->
+                                        RecentPlanDayCard(
+                                            sessionId = plan.sessionId,
+                                            day = day,
+                                            expanded = MealPlansViewModel.dayDetailId(plan.sessionId, day.dayIndex) in expandedDetailIds,
+                                            isPending = day.recipeKey != null && day.recipeKey in pendingRecipeKeys,
+                                            onToggleExpanded = { onToggleDay(plan.sessionId, day.dayIndex) },
+                                            onToggleFavourite = { onToggleFavourite(plan.sessionId, day) },
+                                            onAddRecipeToLists = day.recipeKey?.let { recipeKey ->
+                                                { onAddRecipeToLists(plan.sessionId, day.dayIndex, recipeKey) }
+                                            },
+                                            onAddIngredientsToList = day.recipeKey?.let { recipeKey ->
+                                                {
+                                                    onAddIngredientsToList(
+                                                        plan.sessionId,
+                                                        day.dayIndex,
+                                                        recipeKey,
+                                                        day.currentRecipe?.title ?: day.title ?: "Recipe",
+                                                    )
+                                                }
+                                            },
+                                        )
+                                        if (index != plan.days.lastIndex) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -205,6 +296,8 @@ private fun RecentPlanDayCard(
     isPending: Boolean,
     onToggleExpanded: () -> Unit,
     onToggleFavourite: () -> Unit,
+    onAddRecipeToLists: (() -> Unit)?,
+    onAddIngredientsToList: (() -> Unit)?,
 ) {
     Surface(
         tonalElevation = 2.dp,
@@ -256,7 +349,12 @@ private fun RecentPlanDayCard(
             val recipe = day.currentRecipe
             if (expanded && recipe != null) {
                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                RecipeDetails(recipe = recipe)
+                RecipeDetails(
+                    recipe = recipe,
+                    actionsEnabled = !isPending,
+                    onAddRecipeToLists = onAddRecipeToLists,
+                    onAddIngredientsToList = onAddIngredientsToList,
+                )
             }
         }
     }
@@ -265,84 +363,130 @@ private fun RecentPlanDayCard(
 @Composable
 private fun FavouriteRecipesTab(
     favourites: List<FavouriteRecipeBrowserItem>,
+    query: String,
     expandedDetailIds: Set<String>,
     pendingRecipeKeys: Set<String>,
+    onQueryChange: (String) -> Unit,
     onToggleExpanded: (String) -> Unit,
     onRemoveFavourite: (String) -> Unit,
+    onAddRecipeToLists: (String, Int, String) -> Unit,
+    onAddIngredientsToList: (String, Int, String, String) -> Unit,
 ) {
-    if (favourites.isEmpty()) {
-        EmptyMealPlansState(
-            title = "No favourite recipes yet",
-            body = "Favourite a recipe from a recent meal plan and it will be collected here.",
+    Column(modifier = Modifier.fillMaxSize()) {
+        BrowserSearchField(
+            query = query,
+            onQueryChange = onQueryChange,
+            placeholder = "Search favourite recipes",
         )
-        return
-    }
+        Box(modifier = Modifier.weight(1f)) {
+            when {
+                favourites.isEmpty() && query.isNotBlank() -> EmptyMealPlansState(
+                    title = "No matching favourites",
+                    body = "Try a different recipe name to search your favourites.",
+                )
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        items(favourites, key = { it.recipeKey }) { favourite ->
-            val expanded = MealPlansViewModel.favouriteDetailId(favourite.recipeKey) in expandedDetailIds
-            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(verticalAlignment = Alignment.Top) {
-                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Text(
-                                text = favourite.title,
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            favourite.summary?.takeIf { it.isNotBlank() }?.let { summary ->
-                                Text(
-                                    text = summary,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            if (favourite.proteinTags.isNotEmpty()) {
-                                Text(
-                                    text = favourite.proteinTags.joinToString(),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            favourite.recentPlanDisplayName?.let { planName ->
-                                val dayLabel = favourite.recentDayIndex?.let { " · Day ${it + 1}" }.orEmpty()
-                                Text(
-                                    text = "Saved from $planName$dayLabel",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-                        IconButton(
-                            onClick = { onRemoveFavourite(favourite.recipeKey) },
-                            enabled = favourite.recipeKey !in pendingRecipeKeys,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Favorite,
-                                contentDescription = "Remove favourite",
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                        if (favourite.recipe != null) {
-                            IconButton(onClick = { onToggleExpanded(favourite.recipeKey) }) {
-                                Icon(
-                                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                                    contentDescription = if (expanded) "Hide recipe" else "Show recipe",
-                                )
-                            }
-                        }
-                    }
+                favourites.isEmpty() -> EmptyMealPlansState(
+                    title = "No favourite recipes yet",
+                    body = "Favourite a recipe from a recent meal plan and it will be collected here.",
+                )
 
-                    val recipe = favourite.recipe
-                    if (expanded && recipe != null) {
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                        RecipeDetails(recipe = recipe)
+                else -> LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(favourites, key = { it.recipeKey }) { favourite ->
+                        val expanded = MealPlansViewModel.favouriteDetailId(favourite.recipeKey) in expandedDetailIds
+                        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Row(verticalAlignment = Alignment.Top) {
+                                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        Text(
+                                            text = favourite.title,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.SemiBold,
+                                            maxLines = 2,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                        favourite.summary?.takeIf { it.isNotBlank() }?.let { summary ->
+                                            Text(
+                                                text = summary,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                        if (favourite.proteinTags.isNotEmpty()) {
+                                            Text(
+                                                text = favourite.proteinTags.joinToString(),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                        if (favourite.recentPlanDisplayName != null) {
+                                            val dayLabel = favourite.recentDayIndex?.let { " · Day ${it + 1}" }.orEmpty()
+                                            Text(
+                                                text = "Saved from ${favourite.recentPlanDisplayName}$dayLabel",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        } else if (favourite.recipe == null) {
+                                            Text(
+                                                text = "Recipe details are only available while the source meal plan is still in your recent history.",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                    IconButton(
+                                        onClick = { onRemoveFavourite(favourite.recipeKey) },
+                                        enabled = favourite.recipeKey !in pendingRecipeKeys,
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Favorite,
+                                            contentDescription = "Remove favourite",
+                                            tint = MaterialTheme.colorScheme.primary,
+                                        )
+                                    }
+                                    if (favourite.recipe != null) {
+                                        IconButton(onClick = { onToggleExpanded(favourite.recipeKey) }) {
+                                            Icon(
+                                                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                                contentDescription = if (expanded) "Hide recipe" else "Show recipe",
+                                            )
+                                        }
+                                    }
+                                }
+
+                                val recipe = favourite.recipe
+                                if (expanded && recipe != null) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                                    val isPending = favourite.recipeKey in pendingRecipeKeys
+                                    val sessionId = favourite.recentPlanSessionId
+                                    val dayIndex = favourite.recentDayIndex
+                                    RecipeDetails(
+                                        recipe = recipe,
+                                        actionsEnabled = !isPending,
+                                        onAddRecipeToLists = if (sessionId != null && dayIndex != null) {
+                                            { onAddRecipeToLists(sessionId, dayIndex, favourite.recipeKey) }
+                                        } else {
+                                            null
+                                        },
+                                        onAddIngredientsToList = if (sessionId != null && dayIndex != null) {
+                                            {
+                                                onAddIngredientsToList(
+                                                    sessionId,
+                                                    dayIndex,
+                                                    favourite.recipeKey,
+                                                    favourite.title,
+                                                )
+                                            }
+                                        } else {
+                                            null
+                                        },
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -351,13 +495,32 @@ private fun FavouriteRecipesTab(
 }
 
 @Composable
-private fun RecipeDetails(recipe: RecipeDraft) {
+private fun RecipeDetails(
+    recipe: RecipeDraft,
+    actionsEnabled: Boolean,
+    onAddRecipeToLists: (() -> Unit)?,
+    onAddIngredientsToList: (() -> Unit)?,
+) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
             text = "Serves ${recipe.servings}",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        if (onAddRecipeToLists != null || onAddIngredientsToList != null) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                onAddRecipeToLists?.let { action ->
+                    OutlinedButton(onClick = action, enabled = actionsEnabled) {
+                        Text("Add recipe to Lists")
+                    }
+                }
+                onAddIngredientsToList?.let { action ->
+                    OutlinedButton(onClick = action, enabled = actionsEnabled) {
+                        Text("Add ingredients to list")
+                    }
+                }
+            }
+        }
         Text("Ingredients", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Medium)
         recipe.ingredients.forEach { ingredient ->
             Text("• ${ingredient.originalText}", style = MaterialTheme.typography.bodyMedium)
@@ -367,6 +530,93 @@ private fun RecipeDetails(recipe: RecipeDraft) {
             Text("${step.stepNumber}. ${step.text}", style = MaterialTheme.typography.bodyMedium)
         }
     }
+}
+
+@Composable
+private fun BrowserSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    placeholder: String,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        singleLine = true,
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+        placeholder = { Text(placeholder) },
+    )
+}
+
+@Composable
+private fun IngredientListDialog(
+    recipeTitle: String,
+    lists: List<ListNameEntity>,
+    onDismiss: () -> Unit,
+    onConfirm: (Long) -> Unit,
+) {
+    var selectedListId by remember(recipeTitle) { mutableStateOf(lists.firstOrNull()?.id) }
+    LaunchedEffect(lists) {
+        selectedListId = when {
+            lists.isEmpty() -> null
+            selectedListId == null -> lists.first().id
+            lists.none { it.id == selectedListId } -> lists.first().id
+            else -> selectedListId
+        }
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add ingredients to list") },
+        text = {
+            if (lists.isEmpty()) {
+                Text("Create a list first, then you can add the ingredients from $recipeTitle into it.")
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = recipeTitle,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    lists.forEach { list ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { selectedListId = list.id }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = selectedListId == list.id,
+                                onClick = { selectedListId = list.id },
+                            )
+                            Text(list.name)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { selectedListId?.let(onConfirm) },
+                enabled = lists.any { it.id == selectedListId },
+            ) {
+                Text("Add")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(if (lists.isEmpty()) "Close" else "Cancel")
+            }
+        },
+    )
 }
 
 @Composable
@@ -399,10 +649,11 @@ private fun EmptyMealPlansState(
 
 private fun planSummary(plan: MealPlanSnapshot): String = buildString {
     val completedLabel = plan.completedAt?.let(::formatDate) ?: formatDate(plan.updatedAt)
+    val totalMeals = plan.daysCount ?: plan.days.size
     append(completedLabel)
     append(" · ")
-    append(plan.days.size)
-    append(if (plan.days.size == 1) " meal" else " meals")
+    append(totalMeals)
+    append(if (totalMeals == 1) " meal" else " meals")
     plan.peopleCount?.let {
         append(" · ")
         append(it)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
@@ -26,13 +26,14 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
@@ -510,12 +511,26 @@ private fun RecipeDetails(
         if (onAddRecipeToLists != null || onAddIngredientsToList != null) {
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 onAddRecipeToLists?.let { action ->
-                    OutlinedButton(onClick = action, enabled = actionsEnabled) {
+                    Button(
+                        onClick = action,
+                        enabled = actionsEnabled,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        ),
+                    ) {
                         Text("Add recipe to Lists")
                     }
                 }
                 onAddIngredientsToList?.let { action ->
-                    OutlinedButton(onClick = action, enabled = actionsEnabled) {
+                    Button(
+                        onClick = action,
+                        enabled = actionsEnabled,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        ),
+                    ) {
                         Text("Add ingredients to list")
                     }
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
@@ -1,0 +1,417 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeBrowserItem
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
+import com.kernel.ai.core.memory.mealplan.RecipeDraft
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MealPlansScreen(
+    onBack: () -> Unit = {},
+    viewModel: MealPlansViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.messages.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Meal plans & favourites") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            TabRow(selectedTabIndex = if (uiState.selectedTab == MealPlansBrowserTab.RECENT_PLANS) 0 else 1) {
+                Tab(
+                    selected = uiState.selectedTab == MealPlansBrowserTab.RECENT_PLANS,
+                    onClick = { viewModel.setTab(MealPlansBrowserTab.RECENT_PLANS) },
+                    text = { Text("Recent plans") },
+                )
+                Tab(
+                    selected = uiState.selectedTab == MealPlansBrowserTab.FAVOURITES,
+                    onClick = { viewModel.setTab(MealPlansBrowserTab.FAVOURITES) },
+                    text = { Text("Favourites") },
+                )
+            }
+            Box(modifier = Modifier.weight(1f)) {
+                when (uiState.selectedTab) {
+                    MealPlansBrowserTab.RECENT_PLANS -> RecentPlansTab(
+                        plans = uiState.recentPlans,
+                        expandedPlanIds = uiState.expandedPlanIds,
+                        expandedDetailIds = uiState.expandedDetailIds,
+                        pendingRecipeKeys = uiState.pendingRecipeKeys,
+                        onTogglePlan = viewModel::togglePlanExpanded,
+                        onToggleDay = viewModel::toggleDayExpanded,
+                        onToggleFavourite = viewModel::toggleDayFavourite,
+                    )
+
+                    MealPlansBrowserTab.FAVOURITES -> FavouriteRecipesTab(
+                        favourites = uiState.favouriteRecipes,
+                        expandedDetailIds = uiState.expandedDetailIds,
+                        pendingRecipeKeys = uiState.pendingRecipeKeys,
+                        onToggleExpanded = viewModel::toggleFavouriteExpanded,
+                        onRemoveFavourite = viewModel::removeFavourite,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentPlansTab(
+    plans: List<MealPlanSnapshot>,
+    expandedPlanIds: Set<String>,
+    expandedDetailIds: Set<String>,
+    pendingRecipeKeys: Set<String>,
+    onTogglePlan: (String) -> Unit,
+    onToggleDay: (String, Int) -> Unit,
+    onToggleFavourite: (String, MealPlanSnapshotDay) -> Unit,
+) {
+    if (plans.isEmpty()) {
+        EmptyMealPlansState(
+            title = "No completed meal plans yet",
+            body = "Finish a meal plan in chat and it will appear here for browsing and favouriting later.",
+        )
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(plans, key = { it.sessionId }) { plan ->
+            val expanded = plan.sessionId in expandedPlanIds
+            ElevatedCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onTogglePlan(plan.sessionId) },
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.Top) {
+                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(plan.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                            Text(
+                                text = planSummary(plan),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            if (plan.dietaryRestrictions.isNotEmpty()) {
+                                Text(
+                                    text = plan.dietaryRestrictions.joinToString(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        Icon(
+                            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = if (expanded) "Collapse plan" else "Expand plan",
+                        )
+                    }
+
+                    if (expanded) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        plan.days.forEachIndexed { index, day ->
+                            RecentPlanDayCard(
+                                sessionId = plan.sessionId,
+                                day = day,
+                                expanded = MealPlansViewModel.dayDetailId(plan.sessionId, day.dayIndex) in expandedDetailIds,
+                                isPending = day.recipeKey != null && day.recipeKey in pendingRecipeKeys,
+                                onToggleExpanded = { onToggleDay(plan.sessionId, day.dayIndex) },
+                                onToggleFavourite = { onToggleFavourite(plan.sessionId, day) },
+                            )
+                            if (index != plan.days.lastIndex) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentPlanDayCard(
+    sessionId: String,
+    day: MealPlanSnapshotDay,
+    expanded: Boolean,
+    isPending: Boolean,
+    onToggleExpanded: () -> Unit,
+    onToggleFavourite: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 2.dp,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.Top) {
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = "Day ${day.dayIndex + 1}: ${day.title ?: "Meal"}",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    day.summary?.takeIf { it.isNotBlank() }?.let { summary ->
+                        Text(
+                            text = summary,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    if (day.proteinTags.isNotEmpty()) {
+                        Text(
+                            text = day.proteinTags.joinToString(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                if (day.recipeKey != null) {
+                    IconButton(onClick = onToggleFavourite, enabled = !isPending) {
+                        Icon(
+                            imageVector = if (day.isFavouriteRecipe) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                            contentDescription = if (day.isFavouriteRecipe) "Unfavourite recipe" else "Favourite recipe",
+                            tint = if (day.isFavouriteRecipe) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                if (day.currentRecipe != null) {
+                    IconButton(onClick = onToggleExpanded) {
+                        Icon(
+                            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = if (expanded) "Hide recipe" else "Show recipe",
+                        )
+                    }
+                }
+            }
+
+            val recipe = day.currentRecipe
+            if (expanded && recipe != null) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                RecipeDetails(recipe = recipe)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavouriteRecipesTab(
+    favourites: List<FavouriteRecipeBrowserItem>,
+    expandedDetailIds: Set<String>,
+    pendingRecipeKeys: Set<String>,
+    onToggleExpanded: (String) -> Unit,
+    onRemoveFavourite: (String) -> Unit,
+) {
+    if (favourites.isEmpty()) {
+        EmptyMealPlansState(
+            title = "No favourite recipes yet",
+            body = "Favourite a recipe from a recent meal plan and it will be collected here.",
+        )
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(favourites, key = { it.recipeKey }) { favourite ->
+            val expanded = MealPlansViewModel.favouriteDetailId(favourite.recipeKey) in expandedDetailIds
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.Top) {
+                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                text = favourite.title,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            favourite.summary?.takeIf { it.isNotBlank() }?.let { summary ->
+                                Text(
+                                    text = summary,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            if (favourite.proteinTags.isNotEmpty()) {
+                                Text(
+                                    text = favourite.proteinTags.joinToString(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            favourite.recentPlanDisplayName?.let { planName ->
+                                val dayLabel = favourite.recentDayIndex?.let { " · Day ${it + 1}" }.orEmpty()
+                                Text(
+                                    text = "Saved from $planName$dayLabel",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        IconButton(
+                            onClick = { onRemoveFavourite(favourite.recipeKey) },
+                            enabled = favourite.recipeKey !in pendingRecipeKeys,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Favorite,
+                                contentDescription = "Remove favourite",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        if (favourite.recipe != null) {
+                            IconButton(onClick = { onToggleExpanded(favourite.recipeKey) }) {
+                                Icon(
+                                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                    contentDescription = if (expanded) "Hide recipe" else "Show recipe",
+                                )
+                            }
+                        }
+                    }
+
+                    val recipe = favourite.recipe
+                    if (expanded && recipe != null) {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        RecipeDetails(recipe = recipe)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecipeDetails(recipe: RecipeDraft) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "Serves ${recipe.servings}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text("Ingredients", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Medium)
+        recipe.ingredients.forEach { ingredient ->
+            Text("• ${ingredient.originalText}", style = MaterialTheme.typography.bodyMedium)
+        }
+        Text("Method", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Medium)
+        recipe.methodSteps.forEach { step ->
+            Text("${step.stepNumber}. ${step.text}", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun EmptyMealPlansState(
+    title: String,
+    body: String,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Bookmarks,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun planSummary(plan: MealPlanSnapshot): String = buildString {
+    val completedLabel = plan.completedAt?.let(::formatDate) ?: formatDate(plan.updatedAt)
+    append(completedLabel)
+    append(" · ")
+    append(plan.days.size)
+    append(if (plan.days.size == 1) " meal" else " meals")
+    plan.peopleCount?.let {
+        append(" · ")
+        append(it)
+        append(if (it == 1) " person" else " people")
+    }
+}
+
+private fun formatDate(epochMillis: Long): String = DATE_FORMATTER.format(
+    Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()).toLocalDate(),
+)
+
+private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
@@ -1,7 +1,9 @@
 package com.kernel.ai.feature.settings
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeBrowserItem
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -28,9 +31,20 @@ data class MealPlansUiState(
     val selectedTab: MealPlansBrowserTab = MealPlansBrowserTab.RECENT_PLANS,
     val recentPlans: List<MealPlanSnapshot> = emptyList(),
     val favouriteRecipes: List<FavouriteRecipeBrowserItem> = emptyList(),
+    val availableLists: List<ListNameEntity> = emptyList(),
+    val recentPlansQuery: String = "",
+    val favouriteRecipesQuery: String = "",
     val expandedPlanIds: Set<String> = emptySet(),
     val expandedDetailIds: Set<String> = emptySet(),
     val pendingRecipeKeys: Set<String> = emptySet(),
+)
+
+private data class BrowserChrome(
+    val recentPlansQuery: String,
+    val favouriteRecipesQuery: String,
+    val expandedPlanIds: Set<String>,
+    val expandedDetailIds: Set<String>,
+    val pendingRecipeKeys: Set<String>,
 )
 
 @HiltViewModel
@@ -38,31 +52,58 @@ class MealPlansViewModel @Inject constructor(
     private val mealPlanSessionRepository: MealPlanSessionRepository,
 ) : ViewModel() {
     private val selectedTab = MutableStateFlow(MealPlansBrowserTab.RECENT_PLANS)
+    private val recentPlansQuery = MutableStateFlow("")
+    private val favouriteRecipesQuery = MutableStateFlow("")
     private val expandedPlanIds = MutableStateFlow<Set<String>>(emptySet())
     private val expandedDetailIds = MutableStateFlow<Set<String>>(emptySet())
     private val pendingRecipeKeys = MutableStateFlow<Set<String>>(emptySet())
     private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 1)
 
     private val recentPlans = mealPlanSessionRepository.observeRecentCompletedPlans(RECENT_PLAN_LIMIT)
+    private val availableLists = mealPlanSessionRepository.observeActiveLists()
+        .map { lists -> lists.filter(::isUserSelectableList) }
     private val favouriteRecipes = combine(
         mealPlanSessionRepository.observeFavouriteRecipes(FAVOURITE_LIMIT),
         recentPlans,
     ) { favourites, plans ->
         buildFavouriteBrowserItems(favourites, plans)
     }
-    private val browserState = combine(
-        recentPlans,
-        favouriteRecipes,
+    private val filteredRecentPlans = combine(recentPlans, recentPlansQuery) { plans, query ->
+        filterRecentPlans(plans, query)
+    }
+    private val filteredFavouriteRecipes = combine(favouriteRecipes, favouriteRecipesQuery) { favourites, query ->
+        filterFavouriteRecipes(favourites, query)
+    }
+    private val browserChrome = combine(
+        recentPlansQuery,
+        favouriteRecipesQuery,
         expandedPlanIds,
         expandedDetailIds,
         pendingRecipeKeys,
-    ) { plans, favourites, planIds, detailIds, pendingKeys ->
-        MealPlansUiState(
-            recentPlans = plans,
-            favouriteRecipes = favourites,
+    ) { recentQuery, favouriteQuery, planIds, detailIds, pendingKeys ->
+        BrowserChrome(
+            recentPlansQuery = recentQuery,
+            favouriteRecipesQuery = favouriteQuery,
             expandedPlanIds = planIds,
             expandedDetailIds = detailIds,
             pendingRecipeKeys = pendingKeys,
+        )
+    }
+    private val browserState = combine(
+        filteredRecentPlans,
+        filteredFavouriteRecipes,
+        availableLists,
+        browserChrome,
+    ) { plans, favourites, lists, chrome ->
+        MealPlansUiState(
+            recentPlans = plans,
+            favouriteRecipes = favourites,
+            availableLists = lists,
+            recentPlansQuery = chrome.recentPlansQuery,
+            favouriteRecipesQuery = chrome.favouriteRecipesQuery,
+            expandedPlanIds = chrome.expandedPlanIds,
+            expandedDetailIds = chrome.expandedDetailIds,
+            pendingRecipeKeys = chrome.pendingRecipeKeys,
         )
     }
 
@@ -74,6 +115,14 @@ class MealPlansViewModel @Inject constructor(
 
     fun setTab(tab: MealPlansBrowserTab) {
         selectedTab.value = tab
+    }
+
+    fun updateRecentPlansQuery(query: String) {
+        recentPlansQuery.value = query
+    }
+
+    fun updateFavouriteRecipesQuery(query: String) {
+        favouriteRecipesQuery.value = query
     }
 
     fun togglePlanExpanded(sessionId: String) {
@@ -100,8 +149,45 @@ class MealPlansViewModel @Inject constructor(
                     dayIndex = day.dayIndex,
                     favourite = !day.isFavouriteRecipe,
                 )
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.w(TAG, "toggleDayFavourite failed for $sessionId day ${day.dayIndex}", e)
                 _messages.tryEmit("Couldn't update that favourite recipe.")
+            } finally {
+                pendingRecipeKeys.update { it - recipeKey }
+            }
+        }
+    }
+
+    fun addRecipeToLists(sessionId: String, dayIndex: Int, recipeKey: String) {
+        if (!beginPending(recipeKey)) return
+        viewModelScope.launch {
+            try {
+                val listName = mealPlanSessionRepository.recreateRecipeList(sessionId, dayIndex)
+                _messages.tryEmit("Saved recipe to \"$listName\".")
+            } catch (e: Exception) {
+                Log.w(TAG, "addRecipeToLists failed for $sessionId day $dayIndex", e)
+                _messages.tryEmit("Couldn't save that recipe to Lists.")
+            } finally {
+                pendingRecipeKeys.update { it - recipeKey }
+            }
+        }
+    }
+
+    fun addIngredientsToList(sessionId: String, dayIndex: Int, recipeKey: String, listId: Long) {
+        if (!beginPending(recipeKey)) return
+        viewModelScope.launch {
+            try {
+                val listName = mealPlanSessionRepository.addRecipeIngredientsToList(sessionId, dayIndex, listId)
+                _messages.tryEmit("Added ingredients to \"$listName\".")
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "addIngredientsToList rejected for $sessionId day $dayIndex list $listId", e)
+                _messages.tryEmit(
+                    e.message?.takeIf { it.endsWith("has no ingredient data to add.") }
+                        ?: "Couldn't add those ingredients to your list.",
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "addIngredientsToList failed for $sessionId day $dayIndex list $listId", e)
+                _messages.tryEmit("Couldn't add those ingredients to your list.")
             } finally {
                 pendingRecipeKeys.update { it - recipeKey }
             }
@@ -113,7 +199,8 @@ class MealPlansViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 mealPlanSessionRepository.removeFavouriteRecipe(recipeKey)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.w(TAG, "removeFavourite failed for $recipeKey", e)
                 _messages.tryEmit("Couldn't remove that favourite recipe.")
             } finally {
                 pendingRecipeKeys.update { it - recipeKey }
@@ -170,9 +257,46 @@ class MealPlansViewModel @Inject constructor(
         }
     }
 
+    private fun filterRecentPlans(plans: List<MealPlanSnapshot>, query: String): List<MealPlanSnapshot> {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return plans
+        return plans.mapNotNull { plan ->
+            val matchingDays = plan.days.filter { day ->
+                matchesRecipeQuery(day.currentRecipe?.title ?: day.title, day.summary, normalizedQuery)
+            }
+            plan.takeIf { matchingDays.isNotEmpty() }?.let { snapshot ->
+                val totalDays = snapshot.daysCount ?: snapshot.days.size
+                snapshot.copy(daysCount = totalDays, days = matchingDays)
+            }
+        }
+    }
+
+    private fun filterFavouriteRecipes(
+        favourites: List<FavouriteRecipeBrowserItem>,
+        query: String,
+    ): List<FavouriteRecipeBrowserItem> {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return favourites
+        return favourites.filter { favourite ->
+            matchesRecipeQuery(favourite.title, favourite.summary, normalizedQuery)
+        }
+    }
+
+    private fun matchesRecipeQuery(title: String?, summary: String?, query: String): Boolean {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return true
+        return title.orEmpty().contains(normalizedQuery, ignoreCase = true) ||
+            summary.orEmpty().contains(normalizedQuery, ignoreCase = true)
+    }
+
+    private fun isUserSelectableList(list: ListNameEntity): Boolean =
+        !PLANNER_LIST_NAME_RE.containsMatchIn(list.name)
+
     companion object {
         private const val RECENT_PLAN_LIMIT = 12
         private const val FAVOURITE_LIMIT = 50
+        private const val TAG = "MealPlansVM"
+        private val PLANNER_LIST_NAME_RE = Regex("""^Meal Plan \d{4}-\d{2}-\d{2} \(MP-\d+\)""")
 
         fun dayDetailId(sessionId: String, dayIndex: Int): String = "plan:$sessionId:$dayIndex"
         fun favouriteDetailId(recipeKey: String): String = "favourite:$recipeKey"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
@@ -1,0 +1,180 @@
+package com.kernel.ai.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeBrowserItem
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
+import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+enum class MealPlansBrowserTab {
+    RECENT_PLANS,
+    FAVOURITES,
+}
+
+data class MealPlansUiState(
+    val selectedTab: MealPlansBrowserTab = MealPlansBrowserTab.RECENT_PLANS,
+    val recentPlans: List<MealPlanSnapshot> = emptyList(),
+    val favouriteRecipes: List<FavouriteRecipeBrowserItem> = emptyList(),
+    val expandedPlanIds: Set<String> = emptySet(),
+    val expandedDetailIds: Set<String> = emptySet(),
+    val pendingRecipeKeys: Set<String> = emptySet(),
+)
+
+@HiltViewModel
+class MealPlansViewModel @Inject constructor(
+    private val mealPlanSessionRepository: MealPlanSessionRepository,
+) : ViewModel() {
+    private val selectedTab = MutableStateFlow(MealPlansBrowserTab.RECENT_PLANS)
+    private val expandedPlanIds = MutableStateFlow<Set<String>>(emptySet())
+    private val expandedDetailIds = MutableStateFlow<Set<String>>(emptySet())
+    private val pendingRecipeKeys = MutableStateFlow<Set<String>>(emptySet())
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    private val recentPlans = mealPlanSessionRepository.observeRecentCompletedPlans(RECENT_PLAN_LIMIT)
+    private val favouriteRecipes = combine(
+        mealPlanSessionRepository.observeFavouriteRecipes(FAVOURITE_LIMIT),
+        recentPlans,
+    ) { favourites, plans ->
+        buildFavouriteBrowserItems(favourites, plans)
+    }
+    private val browserState = combine(
+        recentPlans,
+        favouriteRecipes,
+        expandedPlanIds,
+        expandedDetailIds,
+        pendingRecipeKeys,
+    ) { plans, favourites, planIds, detailIds, pendingKeys ->
+        MealPlansUiState(
+            recentPlans = plans,
+            favouriteRecipes = favourites,
+            expandedPlanIds = planIds,
+            expandedDetailIds = detailIds,
+            pendingRecipeKeys = pendingKeys,
+        )
+    }
+
+    val uiState: StateFlow<MealPlansUiState> = combine(selectedTab, browserState) { tab, state ->
+        state.copy(selectedTab = tab)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MealPlansUiState())
+
+    val messages = _messages.asSharedFlow()
+
+    fun setTab(tab: MealPlansBrowserTab) {
+        selectedTab.value = tab
+    }
+
+    fun togglePlanExpanded(sessionId: String) {
+        expandedPlanIds.update { ids ->
+            if (sessionId in ids) ids - sessionId else ids + sessionId
+        }
+    }
+
+    fun toggleDayExpanded(sessionId: String, dayIndex: Int) {
+        toggleDetailExpanded(dayDetailId(sessionId, dayIndex))
+    }
+
+    fun toggleFavouriteExpanded(recipeKey: String) {
+        toggleDetailExpanded(favouriteDetailId(recipeKey))
+    }
+
+    fun toggleDayFavourite(sessionId: String, day: MealPlanSnapshotDay) {
+        val recipeKey = day.recipeKey ?: return
+        if (!beginPending(recipeKey)) return
+        viewModelScope.launch {
+            try {
+                mealPlanSessionRepository.setRecipeFavourite(
+                    sessionId = sessionId,
+                    dayIndex = day.dayIndex,
+                    favourite = !day.isFavouriteRecipe,
+                )
+            } catch (_: Exception) {
+                _messages.tryEmit("Couldn't update that favourite recipe.")
+            } finally {
+                pendingRecipeKeys.update { it - recipeKey }
+            }
+        }
+    }
+
+    fun removeFavourite(recipeKey: String) {
+        if (!beginPending(recipeKey)) return
+        viewModelScope.launch {
+            try {
+                mealPlanSessionRepository.removeFavouriteRecipe(recipeKey)
+            } catch (_: Exception) {
+                _messages.tryEmit("Couldn't remove that favourite recipe.")
+            } finally {
+                pendingRecipeKeys.update { it - recipeKey }
+            }
+        }
+    }
+
+    private fun toggleDetailExpanded(id: String) {
+        expandedDetailIds.update { ids ->
+            if (id in ids) ids - id else ids + id
+        }
+    }
+
+    private fun beginPending(recipeKey: String): Boolean {
+        if (recipeKey in pendingRecipeKeys.value) return false
+        pendingRecipeKeys.update { it + recipeKey }
+        return true
+    }
+
+    private fun buildFavouriteBrowserItems(
+        favourites: List<FavouriteRecipeSummary>,
+        recentPlans: List<MealPlanSnapshot>,
+    ): List<FavouriteRecipeBrowserItem> {
+        val recentPlansByRecipeKey = linkedMapOf<String, FavouriteRecipeBrowserItem>()
+        recentPlans.forEach { snapshot ->
+            snapshot.days.forEach { day ->
+                val recipeKey = day.recipeKey ?: return@forEach
+                if (recipeKey !in recentPlansByRecipeKey) {
+                    recentPlansByRecipeKey[recipeKey] = FavouriteRecipeBrowserItem(
+                        recipeKey = recipeKey,
+                        title = day.currentRecipe?.title ?: day.title.orEmpty(),
+                        summary = day.summary,
+                        proteinTags = day.proteinTags,
+                        recentPlanDisplayName = snapshot.displayName,
+                        recentPlanSessionId = snapshot.sessionId,
+                        recentDayIndex = day.dayIndex,
+                        recipe = day.currentRecipe,
+                    )
+                }
+            }
+        }
+        return favourites.map { favourite ->
+            val fromRecentPlan = recentPlansByRecipeKey[favourite.recipeKey]
+            FavouriteRecipeBrowserItem(
+                recipeKey = favourite.recipeKey,
+                title = favourite.title,
+                summary = favourite.summary,
+                proteinTags = favourite.proteinTags,
+                recentPlanDisplayName = fromRecentPlan?.recentPlanDisplayName,
+                recentPlanSessionId = fromRecentPlan?.recentPlanSessionId,
+                recentDayIndex = fromRecentPlan?.recentDayIndex,
+                recipe = fromRecentPlan?.recipe,
+            )
+        }
+    }
+
+    companion object {
+        private const val RECENT_PLAN_LIMIT = 12
+        private const val FAVOURITE_LIMIT = 50
+
+        fun dayDetailId(sessionId: String, dayIndex: Int): String = "plan:$sessionId:$dayIndex"
+        fun favouriteDetailId(recipeKey: String): String = "favourite:$recipeKey"
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
@@ -8,6 +8,7 @@ import com.kernel.ai.core.memory.mealplan.FavouriteRecipeBrowserItem
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
 import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
+import com.kernel.ai.core.memory.repository.MealPlanIngredientDataUnavailableException
 import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -179,12 +180,12 @@ class MealPlansViewModel @Inject constructor(
             try {
                 val listName = mealPlanSessionRepository.addRecipeIngredientsToList(sessionId, dayIndex, listId)
                 _messages.tryEmit("Added ingredients to \"$listName\".")
+            } catch (e: MealPlanIngredientDataUnavailableException) {
+                Log.w(TAG, "addIngredientsToList missing ingredients for $sessionId day $dayIndex list $listId", e)
+                _messages.tryEmit(e.message ?: "That recipe has no ingredient data to add.")
             } catch (e: IllegalArgumentException) {
                 Log.w(TAG, "addIngredientsToList rejected for $sessionId day $dayIndex list $listId", e)
-                _messages.tryEmit(
-                    e.message?.takeIf { it.endsWith("has no ingredient data to add.") }
-                        ?: "Couldn't add those ingredients to your list.",
-                )
+                _messages.tryEmit("Couldn't add those ingredients to your list.")
             } catch (e: Exception) {
                 Log.w(TAG, "addIngredientsToList failed for $sessionId day $dayIndex list $listId", e)
                 _messages.tryEmit("Couldn't add those ingredients to your list.")

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansViewModel.kt
@@ -101,7 +101,7 @@ class MealPlansViewModel @Inject constructor(
             availableLists = lists,
             recentPlansQuery = chrome.recentPlansQuery,
             favouriteRecipesQuery = chrome.favouriteRecipesQuery,
-            expandedPlanIds = chrome.expandedPlanIds,
+            expandedPlanIds = effectiveExpandedPlanIds(plans, chrome),
             expandedDetailIds = chrome.expandedDetailIds,
             pendingRecipeKeys = chrome.pendingRecipeKeys,
         )
@@ -269,6 +269,13 @@ class MealPlansViewModel @Inject constructor(
                 snapshot.copy(daysCount = totalDays, days = matchingDays)
             }
         }
+    }
+    private fun effectiveExpandedPlanIds(
+        plans: List<MealPlanSnapshot>,
+        chrome: BrowserChrome,
+    ): Set<String> {
+        if (chrome.recentPlansQuery.isBlank()) return chrome.expandedPlanIds
+        return chrome.expandedPlanIds + plans.mapTo(mutableSetOf()) { it.sessionId }
     }
 
     private fun filterFavouriteRecipes(

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
@@ -1,0 +1,193 @@
+package com.kernel.ai.feature.settings
+
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
+import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
+import com.kernel.ai.core.memory.mealplan.MealPlanSessionStatus
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshot
+import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
+import com.kernel.ai.core.memory.mealplan.RecipeDraft
+import com.kernel.ai.core.memory.mealplan.RecipeDraftIngredient
+import com.kernel.ai.core.memory.mealplan.RecipeDraftMethodStep
+import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.Runs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockKExtension::class)
+class MealPlansViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository: MealPlanSessionRepository = mockk()
+    private val recentPlansFlow = MutableStateFlow(emptyList<MealPlanSnapshot>())
+    private val favouriteRecipesFlow = MutableStateFlow(emptyList<FavouriteRecipeSummary>())
+
+    private lateinit var viewModel: MealPlansViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { repository.observeRecentCompletedPlans(12) } returns recentPlansFlow
+        every { repository.observeFavouriteRecipes(50) } returns favouriteRecipesFlow
+        viewModel = MealPlansViewModel(repository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `uiState reflects repository flows and selected tab`() = runTest {
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        recentPlansFlow.value = listOf(planSnapshot())
+        favouriteRecipesFlow.value = listOf(favouriteRecipe())
+        viewModel.setTab(MealPlansBrowserTab.FAVOURITES)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = states.last()
+        assertEquals(MealPlansBrowserTab.FAVOURITES, state.selectedTab)
+        assertEquals(1, state.recentPlans.size)
+        assertEquals(1, state.favouriteRecipes.size)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `toggle expansion updates ui state`() = runTest {
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.togglePlanExpanded("session-1")
+        viewModel.toggleDayExpanded("session-1", 0)
+        viewModel.toggleFavouriteExpanded("recipe-1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = states.last()
+        assertTrue("session-1" in state.expandedPlanIds)
+        assertTrue(MealPlansViewModel.dayDetailId("session-1", 0) in state.expandedDetailIds)
+        assertTrue(MealPlansViewModel.favouriteDetailId("recipe-1") in state.expandedDetailIds)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `toggleDayFavourite delegates with inverted favourite state`() = runTest {
+        val day = planDay(isFavourite = false)
+        val updated = planSnapshot(days = listOf(day.copy(isFavouriteRecipe = true)))
+        coEvery { repository.setRecipeFavourite("session-1", 0, true) } returns updated
+
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.toggleDayFavourite("session-1", day)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.setRecipeFavourite("session-1", 0, true) }
+        assertFalse("recipe-1" in states.last().pendingRecipeKeys)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `removeFavourite delegates to repository`() = runTest {
+        coEvery { repository.removeFavouriteRecipe("recipe-1") } just Runs
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.removeFavourite("recipe-1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.removeFavouriteRecipe("recipe-1") }
+        assertFalse("recipe-1" in states.last().pendingRecipeKeys)
+
+        collectJob.cancel()
+    }
+
+    private fun favouriteRecipe() = FavouriteRecipeSummary(
+        recipeKey = "recipe-1",
+        title = "Chicken Stir Fry",
+        summary = "Quick bowl",
+        proteinTags = listOf("chicken"),
+    )
+
+    private fun planSnapshot(days: List<MealPlanSnapshotDay> = listOf(planDay())) = MealPlanSnapshot(
+        sessionId = "session-1",
+        conversationId = "conv-1",
+        displayName = "Meal Plan 2026-05-19 (MP-001)",
+        status = MealPlanSessionStatus.COMPLETED,
+        peopleCount = 4,
+        daysCount = days.size,
+        dietaryRestrictions = listOf("no dietary requirements"),
+        proteinPreferences = listOf("chicken"),
+        favouriteRecipeMode = FavouriteRecipeMode.NONE,
+        activeDayIndex = null,
+        pendingGenerationKind = null,
+        pendingGenerationDayIndex = null,
+        planVersion = 1,
+        finalSummaryWritten = true,
+        createdAt = 1_000L,
+        updatedAt = 2_000L,
+        completedAt = 2_000L,
+        cancelledAt = null,
+        days = days,
+    )
+
+    private fun planDay(isFavourite: Boolean = false) = MealPlanSnapshotDay(
+        id = "day-1",
+        dayIndex = 0,
+        title = "Chicken Stir Fry",
+        summary = "Quick bowl",
+        proteinTags = listOf("chicken"),
+        status = com.kernel.ai.core.memory.mealplan.MealPlanDayStatus.PERSISTED,
+        currentRecipeVersion = 1,
+        attemptCount = 1,
+        lastErrorCode = null,
+        lastErrorMessage = null,
+        currentRecipe = recipeDraft(),
+        recipeKey = "recipe-1",
+        isFavouriteRecipe = isFavourite,
+    )
+
+    private fun recipeDraft() = RecipeDraft(
+        title = "Chicken Stir Fry",
+        servings = 4,
+        ingredients = listOf(
+            RecipeDraftIngredient(
+                originalText = "500 g chicken thigh",
+                amount = "500",
+                unit = "g",
+                item = "chicken thigh",
+                note = null,
+            ),
+        ),
+        methodSteps = listOf(
+            RecipeDraftMethodStep(stepNumber = 1, text = "Slice the vegetables."),
+            RecipeDraftMethodStep(stepNumber = 2, text = "Stir-fry everything until glossy."),
+        ),
+    )
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
@@ -9,6 +9,7 @@ import com.kernel.ai.core.memory.mealplan.MealPlanSnapshotDay
 import com.kernel.ai.core.memory.mealplan.RecipeDraft
 import com.kernel.ai.core.memory.mealplan.RecipeDraftIngredient
 import com.kernel.ai.core.memory.mealplan.RecipeDraftMethodStep
+import com.kernel.ai.core.memory.repository.MealPlanIngredientDataUnavailableException
 import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -207,6 +208,25 @@ class MealPlansViewModelTest {
 
         collectJob.cancel()
     }
+    @Test
+    fun `addIngredientsToList surfaces missing ingredient data message`() = runTest {
+        coEvery { repository.addRecipeIngredientsToList("session-1", 0, 7L) } throws MealPlanIngredientDataUnavailableException(dayIndex = 0)
+
+        val messages = mutableListOf<String>()
+        val messageJob = launch { viewModel.messages.collect { messages += it } }
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.addIngredientsToList("session-1", 0, "recipe-1", 7L)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("Day 1 has no ingredient data to add."), messages)
+        assertFalse("recipe-1" in states.last().pendingRecipeKeys)
+        collectJob.cancel()
+        messageJob.cancel()
+    }
+
 
     @Test
     fun `removeFavourite delegates to repository`() = runTest {

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
@@ -105,6 +105,11 @@ class MealPlansViewModelTest {
         assertEquals("tofu", state.recentPlansQuery)
         assertEquals(1, state.recentPlans.size)
         assertEquals(listOf("Tofu Curry"), state.recentPlans.single().days.map { it.title })
+        assertTrue("session-1" in state.expandedPlanIds)
+
+        viewModel.updateRecentPlansQuery("")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse("session-1" in states.last().expandedPlanIds)
 
         collectJob.cancel()
     }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MealPlansViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import com.kernel.ai.core.memory.entity.ListNameEntity
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeMode
 import com.kernel.ai.core.memory.mealplan.FavouriteRecipeSummary
 import com.kernel.ai.core.memory.mealplan.MealPlanSessionStatus
@@ -39,6 +40,7 @@ class MealPlansViewModelTest {
     private val repository: MealPlanSessionRepository = mockk()
     private val recentPlansFlow = MutableStateFlow(emptyList<MealPlanSnapshot>())
     private val favouriteRecipesFlow = MutableStateFlow(emptyList<FavouriteRecipeSummary>())
+    private val availableListsFlow = MutableStateFlow(emptyList<ListNameEntity>())
 
     private lateinit var viewModel: MealPlansViewModel
 
@@ -47,6 +49,7 @@ class MealPlansViewModelTest {
         Dispatchers.setMain(testDispatcher)
         every { repository.observeRecentCompletedPlans(12) } returns recentPlansFlow
         every { repository.observeFavouriteRecipes(50) } returns favouriteRecipesFlow
+        every { repository.observeActiveLists() } returns availableListsFlow
         viewModel = MealPlansViewModel(repository)
     }
 
@@ -63,6 +66,11 @@ class MealPlansViewModelTest {
 
         recentPlansFlow.value = listOf(planSnapshot())
         favouriteRecipesFlow.value = listOf(favouriteRecipe())
+        availableListsFlow.value = listOf(
+            ListNameEntity(id = 6L, name = "Meal Plan 2026-05-19 (MP-001) Shopping List", createdAt = 1_000L, updatedAt = 1_000L),
+            ListNameEntity(id = 8L, name = "Meal Plan Party", createdAt = 1_000L, updatedAt = 1_000L),
+            listEntity(),
+        )
         viewModel.setTab(MealPlansBrowserTab.FAVOURITES)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -70,6 +78,55 @@ class MealPlansViewModelTest {
         assertEquals(MealPlansBrowserTab.FAVOURITES, state.selectedTab)
         assertEquals(1, state.recentPlans.size)
         assertEquals(1, state.favouriteRecipes.size)
+        assertEquals(listOf("Meal Plan Party", "shopping list"), state.availableLists.map { it.name })
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `recent plan search keeps only matching recipe days`() = runTest {
+        recentPlansFlow.value = listOf(
+            planSnapshot(
+                days = listOf(
+                    planDay(recipeKey = "recipe-1", title = "Chicken Stir Fry"),
+                    planDay(recipeKey = "recipe-2", title = "Tofu Curry", dayIndex = 1),
+                ),
+            ),
+        )
+
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.updateRecentPlansQuery("tofu")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = states.last()
+        assertEquals("tofu", state.recentPlansQuery)
+        assertEquals(1, state.recentPlans.size)
+        assertEquals(listOf("Tofu Curry"), state.recentPlans.single().days.map { it.title })
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `favourite search filters favourite recipes by title`() = runTest {
+        recentPlansFlow.value = listOf(planSnapshot())
+        favouriteRecipesFlow.value = listOf(
+            favouriteRecipe(recipeKey = "recipe-1", title = "Chicken Stir Fry"),
+            favouriteRecipe(recipeKey = "recipe-2", title = "Tofu Curry"),
+        )
+
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.updateFavouriteRecipesQuery("chicken")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = states.last()
+        assertEquals("chicken", state.favouriteRecipesQuery)
+        assertEquals(listOf("Chicken Stir Fry"), state.favouriteRecipes.map { it.title })
 
         collectJob.cancel()
     }
@@ -113,6 +170,40 @@ class MealPlansViewModelTest {
     }
 
     @Test
+    fun `addRecipeToLists delegates to repository`() = runTest {
+        coEvery { repository.recreateRecipeList("session-1", 0) } returns "Chicken Stir Fry"
+
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.addRecipeToLists("session-1", 0, "recipe-1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.recreateRecipeList("session-1", 0) }
+        assertFalse("recipe-1" in states.last().pendingRecipeKeys)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `addIngredientsToList delegates to repository`() = runTest {
+        coEvery { repository.addRecipeIngredientsToList("session-1", 0, 7L) } returns "shopping list"
+
+        val states = mutableListOf<MealPlansUiState>()
+        val collectJob = launch { viewModel.uiState.collect { states += it } }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.addIngredientsToList("session-1", 0, "recipe-1", 7L)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.addRecipeIngredientsToList("session-1", 0, 7L) }
+        assertFalse("recipe-1" in states.last().pendingRecipeKeys)
+
+        collectJob.cancel()
+    }
+
+    @Test
     fun `removeFavourite delegates to repository`() = runTest {
         coEvery { repository.removeFavouriteRecipe("recipe-1") } just Runs
         val states = mutableListOf<MealPlansUiState>()
@@ -128,9 +219,14 @@ class MealPlansViewModelTest {
         collectJob.cancel()
     }
 
-    private fun favouriteRecipe() = FavouriteRecipeSummary(
-        recipeKey = "recipe-1",
-        title = "Chicken Stir Fry",
+    private fun listEntity() = ListNameEntity(id = 7L, name = "shopping list", createdAt = 2_000L, updatedAt = 2_000L)
+
+    private fun favouriteRecipe(
+        recipeKey: String = "recipe-1",
+        title: String = "Chicken Stir Fry",
+    ) = FavouriteRecipeSummary(
+        recipeKey = recipeKey,
+        title = title,
         summary = "Quick bowl",
         proteinTags = listOf("chicken"),
     )
@@ -157,24 +253,29 @@ class MealPlansViewModelTest {
         days = days,
     )
 
-    private fun planDay(isFavourite: Boolean = false) = MealPlanSnapshotDay(
-        id = "day-1",
-        dayIndex = 0,
-        title = "Chicken Stir Fry",
+    private fun planDay(
+        recipeKey: String = "recipe-1",
+        title: String = "Chicken Stir Fry",
+        dayIndex: Int = 0,
+        isFavourite: Boolean = false,
+    ) = MealPlanSnapshotDay(
+        id = "day-${dayIndex + 1}",
+        dayIndex = dayIndex,
+        title = title,
         summary = "Quick bowl",
-        proteinTags = listOf("chicken"),
+        proteinTags = listOf(if (title.contains("tofu", ignoreCase = true)) "tofu" else "chicken"),
         status = com.kernel.ai.core.memory.mealplan.MealPlanDayStatus.PERSISTED,
         currentRecipeVersion = 1,
         attemptCount = 1,
         lastErrorCode = null,
         lastErrorMessage = null,
-        currentRecipe = recipeDraft(),
-        recipeKey = "recipe-1",
+        currentRecipe = recipeDraft(title = title),
+        recipeKey = recipeKey,
         isFavouriteRecipe = isFavourite,
     )
 
-    private fun recipeDraft() = RecipeDraft(
-        title = "Chicken Stir Fry",
+    private fun recipeDraft(title: String = "Chicken Stir Fry") = RecipeDraft(
+        title = title,
         servings = 4,
         ingredients = listOf(
             RecipeDraftIngredient(


### PR DESCRIPTION
## Summary
- add a dedicated Meal plans browser screen with Recent plans and Favourites tabs
- expose observable repository APIs for recent completed meal plans and canonical favourite recipes
- wire the new screen into app navigation and the main drawer, with favourite/unfavourite actions outside chat
- add per-tab recipe search plus recipe re-add / ingredient-to-list actions from recipe details

## Testing
- ./gradlew --rerun-tasks :feature:settings:testDebugUnitTest --tests "*MealPlansViewModelTest" :core:memory:assembleDebugAndroidTest :app:assembleDebug

## Manual test checklist
- Open the drawer and tap **Meal plans**
- Confirm recent completed meal plans are listed and expand correctly
- Confirm the search bar in **Recent plans** filters recipes by name while preserving the plan's original total meal count
- Confirm the search bar in **Favourites** filters favourite recipes by name
- Expand a recent recipe and tap **Add recipe to Lists**; verify a standalone checklist list is created
- Expand a recent recipe and tap **Add ingredients to list**; choose an existing user list and verify the ingredients are appended there
- Favourite a recipe from Recent plans and verify it appears in Favourites
- Unfavourite a recipe from Favourites and verify it disappears without affecting chat state
- Restart the app and verify favourites still persist

Closes #933