### PR TITLE
fix(#941): pass enable_thinking extraContext to activate Gemma thinking mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,11 +74,26 @@ When Tier 2 intercepts, `NativeIntentHandler.saveMemory()` calls `normaliseSaveC
 | FunctionGemma-270M | ~~Intent router~~ **Deprecated** | 289MB | Not loaded at startup; class retained pending #358 cleanup |
 | all-MiniLM-L6-v2 int8 | Zero-shot intent classifier (Tier 2) | ~15MB | Lazy — downloaded via KernelModel on first use; graceful null fallback |
 
+> **Note:** Both E-4B and E-2B support thinking mode (confirmed from HuggingFace model cards). See the "Thinking mode" section below for activation requirements.
+
 - All models use **quantized weights** (INT4/INT8) via LiteRT
 - E4B runs on **GPU (OpenCL / Adreno 740)** — loaded first with full memory headroom
 - `safeTokenCount()` guard: nudges powers-of-2 down ~2.4% to avoid LiteRT `reshape::Eval` buffer-alignment bug on Adreno (4096→4000, 8192→8000)
 - **E4B-first loading:** E4B initialises on GPU before FunctionGemma is considered — prevents lmkd OOM during ~20s GPU kernel compilation peak
 - Backend fallback chain: NPU → GPU → CPU
+
+#### Thinking mode (confirmed in PR #946, branch `feature/941-thinking-enable-context`)
+
+Two requirements are **both** needed to produce thinking tokens — either alone produces zero chain-of-thought:
+
+1. **Channel registration** — `Channel("thought", "<|think|>", "<|/think|>")` must be registered in `ConversationConfig.channels`. This routes tokens between the delimiters to `message.channels["thought"]`.
+2. **`extraContext` flag** — `extraContext = mapOf("enable_thinking" to true)` must be passed in `sendMessageAsync`. This injects the opening `<|think|>` tag via the model's Jinja template. **Without this flag, zero thinking tokens are produced even when the Channel is registered.**
+
+**SDK behaviour quirk:** Even with Channel registration, `message.toString()` still includes thinking content wrapped in the SDK's internal format: `<|channel>thought\n...\n<channel|>`. This must be stripped before emitting `GenerationResult.Token` to avoid leaking raw channel markup into the chat stream. Strip is applied in `LiteRtInferenceEngine.generate()` via `CHANNEL_WRAPPER_RE`.
+
+**E2B also supports thinking** — confirmed from HuggingFace model cards for both Gemma-4 E-4B and E-2B. The settings UI currently exposes the thinking toggle for E4B only; E2B support in settings UI is tracked in a follow-up GitHub issue.
+
+**Background / utility `generateOnce()` calls** (title generation, episodic distillation, user profile extraction) **must explicitly pass `thinkingEnabled = false`**. Omitting this flag silently wastes GPU time on chain-of-thought for non-user-facing tasks.
 
 ### Memory — Local RAG
 

--- a/core/inference/build.gradle.kts
+++ b/core/inference/build.gradle.kts
@@ -9,10 +9,6 @@ android {
     namespace = "com.kernel.ai.core.inference"
     compileSdk = libs.versions.compileSdk.get().toInt()
 
-    buildFeatures {
-        buildConfig = true
-    }
-
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core/inference/build.gradle.kts
+++ b/core/inference/build.gradle.kts
@@ -9,6 +9,10 @@ android {
     namespace = "com.kernel.ai.core.inference"
     compileSdk = libs.versions.compileSdk.get().toInt()
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -358,6 +358,7 @@ class LiteRtInferenceEngine @Inject constructor(
         var firstTokenMs: Long = -1
         var outputTokenCount = 0
         var thinkingCharCount = 0
+        var emittedResponseText = StringBuilder()
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.
@@ -410,6 +411,7 @@ class LiteRtInferenceEngine @Inject constructor(
                                     Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
                                 }
                                 outputTokenCount++
+                                emittedResponseText.append(afterClose)
                                 trySend(GenerationResult.Token(afterClose))
                             }
                         } else {
@@ -432,6 +434,31 @@ class LiteRtInferenceEngine @Inject constructor(
                     //     Skip — we'll receive the same content via the channel delta path.
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
+                    if (thinkingComplete && raw.contains("<channel|>")) {
+                        // Some post-thinking callbacks still surface the already-closed thought
+                        // payload via toString(), but without the opening <|channel> header.
+                        // Keep only the response suffix and drop any prefix we've already emitted.
+                        val afterClose = raw.substringAfterLast("<channel|>").trimStart()
+                        if (afterClose.isBlank() || afterClose.startsWith("<ctrl")) {
+                            return
+                        }
+                        val delta = emittedResponseText.toString()
+                            .takeIf { afterClose.startsWith(it) }
+                            ?.let { afterClose.removePrefix(it) }
+                            ?: afterClose
+                        if (delta.isBlank()) {
+                            Log.d(TAG, "Skipping mirrored post-close toString() payload [len=${raw.length}]")
+                            return
+                        }
+                        if (firstTokenMs < 0) {
+                            firstTokenMs = System.currentTimeMillis() - start
+                            Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
+                        }
+                        outputTokenCount++
+                        emittedResponseText.append(delta)
+                        trySend(GenerationResult.Token(delta))
+                        return
+                    }
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
                         // Partial channel header — skip, content will arrive via channels["thought"].
                         // Log so any false-positive drops are observable in logcat.
@@ -446,6 +473,7 @@ class LiteRtInferenceEngine @Inject constructor(
                             Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
                         }
                         outputTokenCount++
+                        emittedResponseText.append(text)
                         trySend(GenerationResult.Token(text))
                     }
                 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -361,8 +361,6 @@ class LiteRtInferenceEngine @Inject constructor(
         var emittedResponseText = StringBuilder()
         var emittedThinkingText = StringBuilder()
         var sawThinkingTraffic = false
-        var callbackIndex = 0
-        val traceEnabled = BuildConfig.DEBUG
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.
@@ -376,17 +374,7 @@ class LiteRtInferenceEngine @Inject constructor(
                 Contents.of(Content.Text(userMessage)),
                 object : MessageCallback {
                 override fun onMessage(message: Message) {
-                    val callbackId = ++callbackIndex
                     val channelDelta = message.channels["thought"]
-                    if (traceEnabled) {
-                        Log.d(
-                            TAG,
-                            "thinking_trace[$callbackId]: channelLen=${channelDelta?.length ?: -1}, " +
-                                "channelHasClose=${channelDelta?.contains("<channel|>") == true}, " +
-                                "thinkingComplete=$thinkingComplete, sawThinkingTraffic=$sawThinkingTraffic, " +
-                                "thinkingOutLen=${emittedThinkingText.length}, responseOutLen=${emittedResponseText.length}",
-                        )
-                    }
                     // Route thinking tokens separately (Gemma thinking mode).
                     // The SDK delivers thinking content as deltas via message.channels["thought"].
                     // The FINAL thinking delta includes the closing <channel|> marker, and may
@@ -418,9 +406,6 @@ class LiteRtInferenceEngine @Inject constructor(
                             if (pureThinking.isNotBlank()) {
                                 thinkingCharCount += pureThinking.length
                                 emittedThinkingText.append(pureThinking)
-                                if (traceEnabled) {
-                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-thinking-close len=${pureThinking.length}")
-                                }
                                 trySend(GenerationResult.Thinking(pureThinking))
                             }
                             // Response text that arrived in the same delta as the channel close
@@ -431,9 +416,6 @@ class LiteRtInferenceEngine @Inject constructor(
                                 }
                                 outputTokenCount++
                                 emittedResponseText.append(afterClose)
-                                if (traceEnabled) {
-                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-response-after-close len=${afterClose.length}")
-                                }
                                 trySend(GenerationResult.Token(afterClose))
                             }
                         } else {
@@ -441,9 +423,6 @@ class LiteRtInferenceEngine @Inject constructor(
                             thinkingCharCount += withoutHeader.length
                             if (withoutHeader.isNotBlank()) {
                                 emittedThinkingText.append(withoutHeader)
-                                if (traceEnabled) {
-                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-thinking-mid len=${withoutHeader.length}")
-                                }
                                 trySend(GenerationResult.Thinking(withoutHeader))
                             }
                         }
@@ -458,14 +437,9 @@ class LiteRtInferenceEngine @Inject constructor(
                             current = channelDelta,
                             emitted = emittedResponseText.toString(),
                             allowOverlap = true,
+                            minOverlapLength = 3,
                         )
                         if (responseDelta.isEmpty() || responseDelta.startsWith("<ctrl")) {
-                            if (traceEnabled) {
-                                Log.d(
-                                    TAG,
-                                    "thinking_trace[$callbackId]: skip-post-close channel replay len=${channelDelta.length}",
-                                )
-                            }
                             return
                         }
                         if (firstTokenMs < 0) {
@@ -474,9 +448,6 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         outputTokenCount++
                         emittedResponseText.append(responseDelta)
-                        if (traceEnabled) {
-                            Log.d(TAG, "thinking_trace[$callbackId]: emit-post-close channel len=${responseDelta.length}")
-                        }
                         trySend(GenerationResult.Token(responseDelta))
                         return
                     }
@@ -489,13 +460,6 @@ class LiteRtInferenceEngine @Inject constructor(
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
                     val hasThoughtMarker = raw.contains("<|channel>thought")
-                    if (traceEnabled) {
-                        Log.d(
-                            TAG,
-                            "thinking_trace[$callbackId]: rawLen=${raw.length}, rawHasClose=${raw.contains("<channel|>")}, " +
-                                "rawHasThoughtHeader=$hasThoughtMarker",
-                        )
-                    }
                     val emittedThinking = emittedThinkingText.toString()
                     val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
                     val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
@@ -550,12 +514,6 @@ class LiteRtInferenceEngine @Inject constructor(
                             emitted = emittedResponseText.toString(),
                         )
                         if (responseDelta.isEmpty()) {
-                            if (traceEnabled) {
-                                Log.d(
-                                    TAG,
-                                    "thinking_trace[$callbackId]: skip-post-close replay rawLen=${raw.length}, afterCloseLen=${afterClose.length}",
-                                )
-                            }
                             return
                         }
                         if (firstTokenMs < 0) {
@@ -564,18 +522,11 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         outputTokenCount++
                         emittedResponseText.append(responseDelta)
-                        if (traceEnabled) {
-                            Log.d(TAG, "thinking_trace[$callbackId]: emit-post-close responseLen=${responseDelta.length}")
-                        }
                         trySend(GenerationResult.Token(responseDelta))
                         return
                     }
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
                         // Partial channel header — skip, content will arrive via channels["thought"].
-                        // Log so any false-positive drops are observable in logcat.
-                        if (traceEnabled) {
-                            Log.d(TAG, "thinking_trace[$callbackId]: skip-partial-header rawLen=${raw.length}")
-                        }
                         return
                     }
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
@@ -586,9 +537,6 @@ class LiteRtInferenceEngine @Inject constructor(
                             emitted = emittedResponseText.toString(),
                         )
                         if (responseDelta.isEmpty()) {
-                            if (traceEnabled) {
-                                Log.d(TAG, "thinking_trace[$callbackId]: skip-plain replay rawLen=${raw.length}, textLen=${text.length}")
-                            }
                             return
                         }
                         if (firstTokenMs < 0) {
@@ -597,9 +545,6 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         outputTokenCount++
                         emittedResponseText.append(responseDelta)
-                        if (traceEnabled) {
-                            Log.d(TAG, "thinking_trace[$callbackId]: emit-plain responseLen=${responseDelta.length}")
-                        }
                         trySend(GenerationResult.Token(responseDelta))
                     }
                 }
@@ -900,6 +845,7 @@ class LiteRtInferenceEngine @Inject constructor(
         emitted: String,
         trimBoundaryWhitespace: Boolean = false,
         allowOverlap: Boolean = false,
+        minOverlapLength: Int = 1,
     ): String {
         if (emitted.isEmpty()) return current
         if (current.startsWith(emitted)) return current.removePrefix(emitted)
@@ -911,11 +857,11 @@ class LiteRtInferenceEngine @Inject constructor(
             return if (trimBoundaryWhitespace) remainder.trimStart() else remainder
         }
         if (allowOverlap) {
-            val exactOverlapRemainder = stripOverlappingReplayPrefix(current, emitted)
+            val exactOverlapRemainder = stripOverlappingReplayPrefix(current, emitted, minOverlapLength)
             if (exactOverlapRemainder != current) {
                 return if (trimBoundaryWhitespace) exactOverlapRemainder.trimStart() else exactOverlapRemainder
             }
-            val trimmedOverlapRemainder = stripOverlappingReplayPrefix(currentTrimmed, emittedTrimmed)
+            val trimmedOverlapRemainder = stripOverlappingReplayPrefix(currentTrimmed, emittedTrimmed, minOverlapLength)
             if (trimmedOverlapRemainder != currentTrimmed) {
                 return if (trimBoundaryWhitespace) trimmedOverlapRemainder.trimStart() else trimmedOverlapRemainder
             }
@@ -923,9 +869,9 @@ class LiteRtInferenceEngine @Inject constructor(
         return current
     }
 
-    private fun stripOverlappingReplayPrefix(current: String, emitted: String): String {
+    private fun stripOverlappingReplayPrefix(current: String, emitted: String, minOverlapLength: Int): String {
         val maxOverlap = minOf(current.length, emitted.length)
-        for (overlapLength in maxOverlap downTo 1) {
+        for (overlapLength in maxOverlap downTo minOverlapLength) {
             if (emitted.endsWith(current.take(overlapLength))) {
                 return current.drop(overlapLength)
             }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -360,6 +360,7 @@ class LiteRtInferenceEngine @Inject constructor(
         var thinkingCharCount = 0
         var emittedResponseText = StringBuilder()
         var emittedThinkingText = StringBuilder()
+        var sawThinkingTraffic = false
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.
@@ -384,6 +385,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     //      that our regex cannot reliably strip token-by-token).
                     val channelDelta = message.channels["thought"]
                     if (!channelDelta.isNullOrEmpty() && !thinkingComplete) {
+                        sawThinkingTraffic = true
                         // Only strip the SDK header prefix on the delta that actually carries it.
                         // Mid-thinking deltas that start with '\n' (paragraph breaks, list items)
                         // must not have their leading newline consumed unconditionally.
@@ -437,22 +439,47 @@ class LiteRtInferenceEngine @Inject constructor(
                     //     Skip — we'll receive the same content via the channel delta path.
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
-                    if (raw.contains("<channel|>")) {
+                    val hasThoughtMarker = raw.contains("<|channel>thought")
+                    val emittedThinking = emittedThinkingText.toString()
+                    val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
+                    val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
+                        beforeCloseCandidate.removePrefix("<|channel>thought").removePrefix("\n")
+                    } else {
+                        beforeCloseCandidate
+                    }
+                    val thoughtRemainder = stripReplayedPrefix(
+                        current = beforeCloseSansHeader,
+                        emitted = emittedThinking,
+                        trimBoundaryWhitespace = true,
+                        allowOverlap = true,
+                    )
+                    val thoughtReplayMatch = thoughtRemainder != beforeCloseSansHeader ||
+                        beforeCloseSansHeader.isBlank()
+                    val headerlessInitialClose = !thinkingComplete &&
+                        !sawThinkingTraffic &&
+                        !hasThoughtMarker &&
+                        emittedResponseText.isEmpty() &&
+                        beforeCloseSansHeader.isNotBlank()
+                    if (raw.contains("<channel|>") && (
+                        hasThoughtMarker ||
+                            (sawThinkingTraffic && thoughtReplayMatch) ||
+                            headerlessInitialClose
+                    )) {
+                        if (hasThoughtMarker || headerlessInitialClose) {
+                            sawThinkingTraffic = true
+                        }
                         // Some callbacks surface the close marker only in toString(), with either
                         // a full/partial thought payload before it or a replay of the already-seen
                         // response after it. Split defensively on the final close marker so the
                         // thought prefix never leaks into the visible assistant reply.
-                        val beforeCloseRaw = raw.substringBeforeLast("<channel|>")
-                        val beforeClose = if (beforeCloseRaw.startsWith("<|channel>thought")) {
-                            beforeCloseRaw.removePrefix("<|channel>thought").removePrefix("\n")
-                        } else {
-                            beforeCloseRaw
-                        }.trimEnd()
+                        val beforeClose = beforeCloseSansHeader
                         val afterClose = raw.substringAfterLast("<channel|>").trimStart()
-                        val thinkingDelta = emittedThinkingText.toString()
-                            .takeIf { beforeClose.startsWith(it) }
-                            ?.let { beforeClose.removePrefix(it) }
-                            ?: beforeClose
+                        val thinkingDelta = stripReplayedPrefix(
+                            current = beforeClose,
+                            emitted = emittedThinking,
+                            trimBoundaryWhitespace = true,
+                            allowOverlap = true,
+                        ).trimEnd()
                         if (!thinkingComplete && thinkingDelta.isNotBlank()) {
                             thinkingCharCount += thinkingDelta.length
                             emittedThinkingText.append(thinkingDelta)
@@ -462,10 +489,10 @@ class LiteRtInferenceEngine @Inject constructor(
                         if (afterClose.isBlank() || afterClose.startsWith("<ctrl")) {
                             return
                         }
-                        val responseDelta = emittedResponseText.toString()
-                            .takeIf { afterClose.startsWith(it) }
-                            ?.let { afterClose.removePrefix(it) }
-                            ?: afterClose
+                        val responseDelta = stripReplayedPrefix(
+                            current = afterClose,
+                            emitted = emittedResponseText.toString(),
+                        )
                         if (responseDelta.isBlank()) {
                             Log.d(TAG, "Skipping mirrored post-close toString() payload [len=${raw.length}]")
                             return
@@ -787,6 +814,44 @@ class LiteRtInferenceEngine @Inject constructor(
 
     private fun safeClose(closeable: AutoCloseable?, label: String) {
         try { closeable?.close() } catch (e: Exception) { Log.w(TAG, "close $label: ${e.message}") }
+    }
+
+    private fun stripReplayedPrefix(
+        current: String,
+        emitted: String,
+        trimBoundaryWhitespace: Boolean = false,
+        allowOverlap: Boolean = false,
+    ): String {
+        if (emitted.isEmpty()) return current
+        if (current.startsWith(emitted)) return current.removePrefix(emitted)
+
+        val currentTrimmed = current.trimEnd()
+        val emittedTrimmed = emitted.trimEnd()
+        if (emittedTrimmed.isNotEmpty() && currentTrimmed.startsWith(emittedTrimmed)) {
+            val remainder = currentTrimmed.removePrefix(emittedTrimmed)
+            return if (trimBoundaryWhitespace) remainder.trimStart() else remainder
+        }
+        if (allowOverlap) {
+            val exactOverlapRemainder = stripOverlappingReplayPrefix(current, emitted)
+            if (exactOverlapRemainder != current) {
+                return if (trimBoundaryWhitespace) exactOverlapRemainder.trimStart() else exactOverlapRemainder
+            }
+            val trimmedOverlapRemainder = stripOverlappingReplayPrefix(currentTrimmed, emittedTrimmed)
+            if (trimmedOverlapRemainder != currentTrimmed) {
+                return if (trimBoundaryWhitespace) trimmedOverlapRemainder.trimStart() else trimmedOverlapRemainder
+            }
+        }
+        return current
+    }
+
+    private fun stripOverlappingReplayPrefix(current: String, emitted: String): String {
+        val maxOverlap = minOf(current.length, emitted.length)
+        for (overlapLength in maxOverlap downTo 1) {
+            if (emitted.endsWith(current.take(overlapLength))) {
+                return current.drop(overlapLength)
+            }
+        }
+        return current
     }
 
     /**

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -359,6 +359,9 @@ class LiteRtInferenceEngine @Inject constructor(
         var outputTokenCount = 0
         var thinkingCharCount = 0
 
+        val thinkingContext: Map<String, Any> =
+            if (currentConfig?.thinkingEnabled == true) mapOf("enable_thinking" to true) else emptyMap()
+
         try {
             conv.sendMessageAsync(
                 Contents.of(Content.Text(userMessage)),
@@ -411,6 +414,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     }
                 }
             },
+            thinkingContext,
         )
         } catch (e: Exception) {
             _isGenerating.value = false
@@ -517,6 +521,7 @@ class LiteRtInferenceEngine @Inject constructor(
                             }
                         }
                     },
+                    if (requestedThinkingEnabled) mapOf("enable_thinking" to true) else emptyMap(),
                 )
                 try {
                     withTimeout(timeoutMs) { latch.await() }
@@ -630,9 +635,12 @@ class LiteRtInferenceEngine @Inject constructor(
 
         val tools = config.toolProvider?.let { listOf(it) } ?: emptyList()
 
-        // When thinking is enabled, register the thought channel so the model emits
-        // chain-of-thought tokens via message.channels["thought"]. Omitting the channel
-        // disables thinking entirely — the model skips reasoning and responds directly.
+        // Two things are required to enable thinking:
+        // 1. Register the "thought" channel in ConversationConfig — this routes tokens between
+        //    <|think|> and <|/think|> to message.channels["thought"] instead of message.toString().
+        // 2. Pass extraContext = mapOf("enable_thinking" to true) in sendMessageAsync — this sets
+        //    the Jinja template variable that injects <|think|> before the model's response,
+        //    triggering chain-of-thought generation. Without this, no thinking tokens are emitted.
         val channels = if (config.thinkingEnabled) {
             listOf(Channel("thought", "<|think|>", "<|/think|>"))
         } else {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -46,6 +46,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "LiteRtInferenceEngine"
+internal const val THINKING_CHANNEL_HEADER = "<|channel>thought"
+internal const val THINKING_CLOSE_MARKER = "<channel|>"
+private val CHANNEL_WRAPPER_RE = Regex(
+    "<\\|channel>\\w+.*?<channel\\|>",
+    setOf(RegexOption.DOT_MATCHES_ALL),
+)
 
 @OptIn(ExperimentalApi::class)
 internal inline fun <T> withSpeculativeDecodingEnabledForInit(enabled: Boolean, block: () -> T): T {
@@ -137,6 +143,284 @@ internal class JsonObjectAccumulator(
         }
         return null
     }
+}
+
+private data class MarkerSpan(
+    val start: Int,
+    val endExclusive: Int,
+)
+
+internal data class ThinkingStreamEmission(
+    val thinkingDeltas: List<String> = emptyList(),
+    val responseDeltas: List<String> = emptyList(),
+)
+
+internal class ThinkingStreamStateMachine(
+    private val closeMarker: String = THINKING_CLOSE_MARKER,
+    private val thinkingHeader: String = THINKING_CHANNEL_HEADER,
+) {
+    private enum class Phase {
+        PRE_CLOSE,
+        POST_CLOSE,
+    }
+
+    private val preCloseBuffer = StringBuilder()
+    private val responseBuffer = StringBuilder()
+    private val emittedThinking = StringBuilder()
+    private val emittedResponse = StringBuilder()
+    private var phase = Phase.PRE_CLOSE
+
+    fun consume(channelDelta: String?, rawMessage: String): ThinkingStreamEmission {
+        val thinking = mutableListOf<String>()
+        val response = mutableListOf<String>()
+        val candidates = buildList {
+            channelDelta?.takeIf { it.isNotEmpty() }?.let { add(StreamCandidate(Source.CHANNEL, it)) }
+            rawMessage.takeIf { it.isNotEmpty() }?.let { add(StreamCandidate(Source.RAW, it)) }
+        }
+
+        candidates.forEach { candidate ->
+            when (phase) {
+                Phase.PRE_CLOSE -> consumePreClose(candidate, thinking, response)
+                Phase.POST_CLOSE -> consumePostClose(candidate, response)
+            }
+        }
+
+        return ThinkingStreamEmission(
+            thinkingDeltas = thinking,
+            responseDeltas = response,
+        )
+    }
+
+    private fun consumePreClose(
+        candidate: StreamCandidate,
+        thinking: MutableList<String>,
+        response: MutableList<String>,
+    ) {
+        val sanitized = stripLeadingThinkingHeader(candidate.text)
+        if (sanitized.isEmpty()) return
+
+        appendNovelSuffix(preCloseBuffer, sanitized)
+        val buffered = preCloseBuffer.toString()
+        val markerSpan = findCloseMarkerSpan(buffered)
+        if (markerSpan == null) {
+            emitThinkingThrough(stableThinkingBoundary(buffered), thinking)
+            return
+        }
+
+        emitThinkingThrough(markerSpan.start, thinking)
+        phase = Phase.POST_CLOSE
+        appendNovelSuffix(responseBuffer, buffered.substring(markerSpan.endExclusive))
+        emitResponseDelta(responseBuffer.toString(), response)
+    }
+
+    private fun consumePostClose(
+        candidate: StreamCandidate,
+        response: MutableList<String>,
+    ) {
+        val visibleText = when (candidate.source) {
+            Source.CHANNEL -> candidate.text
+            Source.RAW -> extractPostCloseVisibleText(candidate.text)
+        }
+        if (visibleText.isEmpty()) return
+
+        appendNovelSuffix(responseBuffer, visibleText)
+        emitResponseDelta(responseBuffer.toString(), response)
+    }
+
+    private fun emitThinkingThrough(
+        endExclusive: Int,
+        thinking: MutableList<String>,
+    ) {
+        val candidate = preCloseBuffer.substring(0, endExclusive)
+        val delta = stripReplayedPrefix(
+            current = candidate,
+            emitted = emittedThinking.toString(),
+            allowOverlap = true,
+            minOverlapLength = 3,
+        )
+        if (delta.isEmpty()) return
+        emittedThinking.append(delta)
+        thinking += delta
+    }
+
+    private fun emitResponseDelta(
+        candidate: String,
+        response: MutableList<String>,
+    ) {
+        val delta = stripReplayedPrefix(
+            current = candidate,
+            emitted = emittedResponse.toString(),
+            allowOverlap = true,
+            minOverlapLength = 3,
+        )
+        if (delta.isEmpty() || delta.startsWith("<ctrl")) return
+        emittedResponse.append(delta)
+        response += delta
+    }
+
+    private fun appendNovelSuffix(target: StringBuilder, candidate: String) {
+        if (candidate.isEmpty()) return
+
+        val observed = target.toString()
+        if (observed.isEmpty()) {
+            target.append(candidate)
+            return
+        }
+        if (observed.endsWith(candidate)) return
+
+        val delta = stripReplayedPrefix(
+            current = candidate,
+            emitted = observed,
+            allowOverlap = true,
+            minOverlapLength = 3,
+        )
+        if (delta.isNotEmpty()) {
+            target.append(delta)
+        }
+    }
+
+    private fun stableThinkingBoundary(buffered: String): Int =
+        findTrailingMarkerPrefixStart(buffered) ?: buffered.length
+
+    private fun stripLeadingThinkingHeader(text: String): String =
+        if (text.startsWith(thinkingHeader)) {
+            text.removePrefix(thinkingHeader).removePrefix("\n")
+        } else {
+            text
+        }
+
+    private fun extractPostCloseVisibleText(text: String): String {
+        val markerSpan = findCloseMarkerSpan(text)
+        if (text.startsWith("<|channel>") && markerSpan != null) {
+            val headerEnd = text.indexOf('\n')
+            if (headerEnd in 0 until markerSpan.start) {
+                val channelName = text.substring("<|channel>".length, headerEnd)
+                val body = text.substring(headerEnd + 1, markerSpan.start)
+                if (channelName != "thought") {
+                    return body + text.substring(markerSpan.endExclusive)
+                }
+            }
+        }
+        if (markerSpan != null) {
+            return text.substring(markerSpan.endExclusive)
+        }
+        if (text.contains("<|channel>")) {
+            return ""
+        }
+        return CHANNEL_WRAPPER_RE.replace(text, "")
+    }
+
+    private fun findCloseMarkerSpan(text: String): MarkerSpan? {
+        var markerIndex = 0
+        var start = -1
+        var lastMatched = -1
+
+        text.forEachIndexed { index, ch ->
+            if (markerIndex > 0 && ch.isWhitespace()) {
+                lastMatched = index
+                return@forEachIndexed
+            }
+
+            when {
+                ch == closeMarker[markerIndex] -> {
+                    if (markerIndex == 0) start = index
+                    markerIndex++
+                    lastMatched = index
+                    if (markerIndex == closeMarker.length) {
+                        return MarkerSpan(start = start, endExclusive = lastMatched + 1)
+                    }
+                }
+                ch == closeMarker[0] -> {
+                    start = index
+                    markerIndex = 1
+                    lastMatched = index
+                }
+                else -> {
+                    markerIndex = 0
+                    start = -1
+                    lastMatched = -1
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun findTrailingMarkerPrefixStart(text: String): Int? {
+        for (start in text.indices.reversed()) {
+            if (text[start] != closeMarker[0]) continue
+
+            var textIndex = start
+            var markerIndex = 0
+            while (textIndex < text.length) {
+                val ch = text[textIndex]
+                if (markerIndex > 0 && ch.isWhitespace()) {
+                    textIndex++
+                    continue
+                }
+                if (markerIndex >= closeMarker.length || ch != closeMarker[markerIndex]) {
+                    markerIndex = -1
+                    break
+                }
+                markerIndex++
+                textIndex++
+            }
+
+            if (textIndex == text.length && markerIndex in 1 until closeMarker.length) {
+                return start
+            }
+        }
+        return null
+    }
+
+    private data class StreamCandidate(
+        val source: Source,
+        val text: String,
+    )
+
+    private enum class Source {
+        CHANNEL,
+        RAW,
+    }
+}
+
+internal fun stripReplayedPrefix(
+    current: String,
+    emitted: String,
+    trimBoundaryWhitespace: Boolean = false,
+    allowOverlap: Boolean = false,
+    minOverlapLength: Int = 1,
+): String {
+    if (emitted.isEmpty()) return current
+    if (current.startsWith(emitted)) return current.removePrefix(emitted)
+
+    val currentTrimmed = current.trimEnd()
+    val emittedTrimmed = emitted.trimEnd()
+    if (emittedTrimmed.isNotEmpty() && currentTrimmed.startsWith(emittedTrimmed)) {
+        val remainder = currentTrimmed.removePrefix(emittedTrimmed)
+        return if (trimBoundaryWhitespace) remainder.trimStart() else remainder
+    }
+    if (allowOverlap) {
+        val exactOverlapRemainder = stripOverlappingReplayPrefix(current, emitted, minOverlapLength)
+        if (exactOverlapRemainder != current) {
+            return if (trimBoundaryWhitespace) exactOverlapRemainder.trimStart() else exactOverlapRemainder
+        }
+        val trimmedOverlapRemainder = stripOverlappingReplayPrefix(currentTrimmed, emittedTrimmed, minOverlapLength)
+        if (trimmedOverlapRemainder != currentTrimmed) {
+            return if (trimBoundaryWhitespace) trimmedOverlapRemainder.trimStart() else trimmedOverlapRemainder
+        }
+    }
+    return current
+}
+
+private fun stripOverlappingReplayPrefix(current: String, emitted: String, minOverlapLength: Int): String {
+    val maxOverlap = minOf(current.length, emitted.length)
+    for (overlapLength in maxOverlap downTo minOverlapLength) {
+        if (emitted.endsWith(current.take(overlapLength))) {
+            return current.drop(overlapLength)
+        }
+    }
+    return current
 }
 
 /**
@@ -359,15 +643,12 @@ class LiteRtInferenceEngine @Inject constructor(
         var outputTokenCount = 0
         var thinkingCharCount = 0
         var emittedResponseText = StringBuilder()
-        var emittedThinkingText = StringBuilder()
-        var sawThinkingTraffic = false
-        // Set to true once we process the <channel|> close marker so that subsequent
-        // callbacks with channels["thought"] still non-null don't misroute response
-        // tokens into the thinking bubble.
-        var thinkingComplete = false
+        val thinkingEnabledForGeneration = currentConfig?.thinkingEnabled == true
+        val thinkingStateMachine = if (thinkingEnabledForGeneration) ThinkingStreamStateMachine() else null
+        var thinkingStateMachineActive = false
 
         val thinkingContext: Map<String, Any> =
-            if (currentConfig?.thinkingEnabled == true) mapOf("enable_thinking" to true) else emptyMap()
+            if (thinkingEnabledForGeneration) mapOf("enable_thinking" to true) else emptyMap()
 
         try {
             conv.sendMessageAsync(
@@ -375,115 +656,36 @@ class LiteRtInferenceEngine @Inject constructor(
                 object : MessageCallback {
                 override fun onMessage(message: Message) {
                     val channelDelta = message.channels["thought"]
-                    // Route thinking tokens separately (Gemma thinking mode).
-                    // The SDK delivers thinking content as deltas via message.channels["thought"].
-                    // The FINAL thinking delta includes the closing <channel|> marker, and may
-                    // also include the start of the response text after it. We must:
-                    //   1. Strip the <|channel>thought prefix from the first delta
-                    //   2. Split on <channel|> — before it is thinking, after it is response
-                    //   3. Return early so message.toString() is never processed during thinking
-                    //      (toString() contains a partial/full channel wrapper during this phase
-                    //      that our regex cannot reliably strip token-by-token).
-                    if (!channelDelta.isNullOrEmpty() && !thinkingComplete) {
-                        sawThinkingTraffic = true
-                        // Only strip the SDK header prefix on the delta that actually carries it.
-                        // Mid-thinking deltas that start with '\n' (paragraph breaks, list items)
-                        // must not have their leading newline consumed unconditionally.
-                        val withoutHeader = if (channelDelta.startsWith("<|channel>thought")) {
-                            channelDelta.removePrefix("<|channel>thought").removePrefix("\n")
-                        } else {
-                            channelDelta
+                    val raw = message.toString()
+
+                    val hasThinkingEvidence = !channelDelta.isNullOrEmpty() ||
+                        raw.contains(THINKING_CHANNEL_HEADER)
+
+                    if (thinkingStateMachine != null && (thinkingStateMachineActive || hasThinkingEvidence)) {
+                        thinkingStateMachineActive = true
+                        val emission = thinkingStateMachine.consume(
+                            channelDelta = channelDelta,
+                            rawMessage = raw,
+                        )
+                        emission.thinkingDeltas.forEach { delta ->
+                            if (delta.isEmpty()) return@forEach
+                            thinkingCharCount += delta.length
+                            trySend(GenerationResult.Thinking(delta))
                         }
-                        val closeIdx = withoutHeader.indexOf("<channel|>")
-                        if (closeIdx >= 0) {
-                            // Thinking phase ended in this delta — mark complete so subsequent
-                            // callbacks with channels["thought"] still non-null don't misroute
-                            // response tokens into the thinking bubble.
-                            thinkingComplete = true
-                            val pureThinking = withoutHeader.substring(0, closeIdx).trimEnd()
-                            val afterClose = withoutHeader.substring(closeIdx + "<channel|>".length)
-                                .trimStart()
-                            if (pureThinking.isNotBlank()) {
-                                thinkingCharCount += pureThinking.length
-                                emittedThinkingText.append(pureThinking)
-                                trySend(GenerationResult.Thinking(pureThinking))
+                        emission.responseDeltas.forEach { delta ->
+                            if (delta.isEmpty()) return@forEach
+                            if (firstTokenMs < 0) {
+                                firstTokenMs = System.currentTimeMillis() - start
+                                Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
                             }
-                            // Response text that arrived in the same delta as the channel close
-                            if (afterClose.isNotBlank() && !afterClose.startsWith("<ctrl")) {
-                                if (firstTokenMs < 0) {
-                                    firstTokenMs = System.currentTimeMillis() - start
-                                    Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
-                                }
-                                outputTokenCount++
-                                emittedResponseText.append(afterClose)
-                                trySend(GenerationResult.Token(afterClose))
-                            }
-                        } else {
-                            val raw = message.toString()
-                            val emittedThinking = emittedThinkingText.toString()
-                            val rawHasThoughtMarker = raw.contains("<|channel>thought")
-                            if (raw.contains("<channel|>")) {
-                                val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
-                                val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
-                                    beforeCloseCandidate.removePrefix("<|channel>thought").removePrefix("\n")
-                                } else {
-                                    beforeCloseCandidate
-                                }
-                                val thoughtRemainder = stripReplayedPrefix(
-                                    current = beforeCloseSansHeader,
-                                    emitted = emittedThinking,
-                                    trimBoundaryWhitespace = true,
-                                    allowOverlap = true,
-                                )
-                                val rawLooksLikeThinkingClose = rawHasThoughtMarker ||
-                                    beforeCloseSansHeader.isBlank() ||
-                                    thoughtRemainder != beforeCloseSansHeader
-                                if (rawLooksLikeThinkingClose) {
-                                    val thinkingDelta = stripReplayedPrefix(
-                                        current = beforeCloseSansHeader,
-                                        emitted = emittedThinking,
-                                        trimBoundaryWhitespace = true,
-                                        allowOverlap = true,
-                                    ).trimEnd()
-                                    if (thinkingDelta.isNotBlank()) {
-                                        thinkingCharCount += thinkingDelta.length
-                                        emittedThinkingText.append(thinkingDelta)
-                                        trySend(GenerationResult.Thinking(thinkingDelta))
-                                    }
-                                    thinkingComplete = true
-                                    val afterClose = raw.substringAfterLast("<channel|>").trimStart()
-                                    if (afterClose.isNotBlank() && !afterClose.startsWith("<ctrl")) {
-                                        val responseDelta = stripReplayedPrefix(
-                                            current = afterClose,
-                                            emitted = emittedResponseText.toString(),
-                                        )
-                                        if (responseDelta.isNotEmpty()) {
-                                            if (firstTokenMs < 0) {
-                                                firstTokenMs = System.currentTimeMillis() - start
-                                                Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
-                                            }
-                                            outputTokenCount++
-                                            emittedResponseText.append(responseDelta)
-                                            trySend(GenerationResult.Token(responseDelta))
-                                        }
-                                    }
-                                    return
-                                }
-                            }
-                            // Mid-thinking delta — no closing marker yet
-                            thinkingCharCount += withoutHeader.length
-                            if (withoutHeader.isNotBlank()) {
-                                emittedThinkingText.append(withoutHeader)
-                                trySend(GenerationResult.Thinking(withoutHeader))
-                            }
+                            outputTokenCount++
+                            emittedResponseText.append(delta)
+                            trySend(GenerationResult.Token(delta))
                         }
-                        // Early return: don't also process message.toString() during thinking.
-                        // toString() contains the accumulating channel wrapper text which cannot
-                        // be reliably stripped on a per-token basis before the channel closes.
                         return
                     }
 
-                    if (!channelDelta.isNullOrEmpty() && thinkingComplete) {
+                    if (!channelDelta.isNullOrEmpty()) {
                         val responseDelta = stripReplayedPrefix(
                             current = channelDelta,
                             emitted = emittedResponseText.toString(),
@@ -509,73 +711,6 @@ class LiteRtInferenceEngine @Inject constructor(
                     //     the SDK hasn't finished routing this content to channels["thought"] yet.
                     //     Skip — we'll receive the same content via the channel delta path.
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
-                    val raw = message.toString()
-                    val hasThoughtMarker = raw.contains("<|channel>thought")
-                    val emittedThinking = emittedThinkingText.toString()
-                    val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
-                    val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
-                        beforeCloseCandidate.removePrefix("<|channel>thought").removePrefix("\n")
-                    } else {
-                        beforeCloseCandidate
-                    }
-                    val thoughtRemainder = stripReplayedPrefix(
-                        current = beforeCloseSansHeader,
-                        emitted = emittedThinking,
-                        trimBoundaryWhitespace = true,
-                        allowOverlap = true,
-                    )
-                    val thoughtReplayMatch = thoughtRemainder != beforeCloseSansHeader ||
-                        beforeCloseSansHeader.isBlank()
-                    val headerlessInitialClose = !thinkingComplete &&
-                        !sawThinkingTraffic &&
-                        !hasThoughtMarker &&
-                        emittedResponseText.isEmpty() &&
-                        beforeCloseSansHeader.isNotBlank()
-                    if (raw.contains("<channel|>") && (
-                        hasThoughtMarker ||
-                            (sawThinkingTraffic && thoughtReplayMatch) ||
-                            headerlessInitialClose
-                    )) {
-                        if (hasThoughtMarker || headerlessInitialClose) {
-                            sawThinkingTraffic = true
-                        }
-                        // Some callbacks surface the close marker only in toString(), with either
-                        // a full/partial thought payload before it or a replay of the already-seen
-                        // response after it. Split defensively on the final close marker so the
-                        // thought prefix never leaks into the visible assistant reply.
-                        val beforeClose = beforeCloseSansHeader
-                        val afterClose = raw.substringAfterLast("<channel|>").trimStart()
-                        val thinkingDelta = stripReplayedPrefix(
-                            current = beforeClose,
-                            emitted = emittedThinking,
-                            trimBoundaryWhitespace = true,
-                            allowOverlap = true,
-                        ).trimEnd()
-                        if (!thinkingComplete && thinkingDelta.isNotBlank()) {
-                            thinkingCharCount += thinkingDelta.length
-                            emittedThinkingText.append(thinkingDelta)
-                            trySend(GenerationResult.Thinking(thinkingDelta))
-                        }
-                        thinkingComplete = true
-                        if (afterClose.isBlank() || afterClose.startsWith("<ctrl")) {
-                            return
-                        }
-                        val responseDelta = stripReplayedPrefix(
-                            current = afterClose,
-                            emitted = emittedResponseText.toString(),
-                        )
-                        if (responseDelta.isEmpty()) {
-                            return
-                        }
-                        if (firstTokenMs < 0) {
-                            firstTokenMs = System.currentTimeMillis() - start
-                            Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
-                        }
-                        outputTokenCount++
-                        emittedResponseText.append(responseDelta)
-                        trySend(GenerationResult.Token(responseDelta))
-                        return
-                    }
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
                         // Partial channel header — skip, content will arrive via channels["thought"].
                         return
@@ -891,45 +1026,6 @@ class LiteRtInferenceEngine @Inject constructor(
         try { closeable?.close() } catch (e: Exception) { Log.w(TAG, "close $label: ${e.message}") }
     }
 
-    private fun stripReplayedPrefix(
-        current: String,
-        emitted: String,
-        trimBoundaryWhitespace: Boolean = false,
-        allowOverlap: Boolean = false,
-        minOverlapLength: Int = 1,
-    ): String {
-        if (emitted.isEmpty()) return current
-        if (current.startsWith(emitted)) return current.removePrefix(emitted)
-
-        val currentTrimmed = current.trimEnd()
-        val emittedTrimmed = emitted.trimEnd()
-        if (emittedTrimmed.isNotEmpty() && currentTrimmed.startsWith(emittedTrimmed)) {
-            val remainder = currentTrimmed.removePrefix(emittedTrimmed)
-            return if (trimBoundaryWhitespace) remainder.trimStart() else remainder
-        }
-        if (allowOverlap) {
-            val exactOverlapRemainder = stripOverlappingReplayPrefix(current, emitted, minOverlapLength)
-            if (exactOverlapRemainder != current) {
-                return if (trimBoundaryWhitespace) exactOverlapRemainder.trimStart() else exactOverlapRemainder
-            }
-            val trimmedOverlapRemainder = stripOverlappingReplayPrefix(currentTrimmed, emittedTrimmed, minOverlapLength)
-            if (trimmedOverlapRemainder != currentTrimmed) {
-                return if (trimBoundaryWhitespace) trimmedOverlapRemainder.trimStart() else trimmedOverlapRemainder
-            }
-        }
-        return current
-    }
-
-    private fun stripOverlappingReplayPrefix(current: String, emitted: String, minOverlapLength: Int): String {
-        val maxOverlap = minOf(current.length, emitted.length)
-        for (overlapLength in maxOverlap downTo minOverlapLength) {
-            if (emitted.endsWith(current.take(overlapLength))) {
-                return current.drop(overlapLength)
-            }
-        }
-        return current
-    }
-
     /**
      * Returns a rough expected byte count for the given model path.
      * Falls back to 0 (skips quantization check) if the model isn't in [KernelModel].
@@ -942,17 +1038,6 @@ class LiteRtInferenceEngine @Inject constructor(
     }
 
     companion object {
-        /**
-         * Strips residual SDK-internal channel wrappers from message.toString() on non-thinking
-         * token callbacks. The primary thinking-channel handling now uses an early-return path
-         * that avoids message.toString() entirely; this regex is a defensive fallback for retries
-         * or cases where thinking state differs (e.g. second sendMessageAsync on same session).
-         */
-        private val CHANNEL_WRAPPER_RE = Regex(
-            "<\\|channel>\\w+.*?<channel\\|>",
-            setOf(RegexOption.DOT_MATCHES_ALL),
-        )
-
         /**
          * Avoids exact powers-of-2 token counts that trigger a buffer-alignment bug
          * in LiteRT's GPU `reshape::Eval` operation (observed on Adreno 740 / SM8550).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -426,7 +426,9 @@ class LiteRtInferenceEngine @Inject constructor(
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
-                        // Partial channel header — skip, content will arrive via channels["thought"]
+                        // Partial channel header — skip, content will arrive via channels["thought"].
+                        // Log so any false-positive drops are observable in logcat.
+                        Log.d(TAG, "Skipping partial channel header in toString() [len=${raw.length}] — expecting thought delta")
                         return
                     }
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -362,7 +362,7 @@ class LiteRtInferenceEngine @Inject constructor(
         var emittedThinkingText = StringBuilder()
         var sawThinkingTraffic = false
         var callbackIndex = 0
-        val traceEnabled = Log.isLoggable(TAG, Log.DEBUG)
+        val traceEnabled = BuildConfig.DEBUG
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -380,7 +380,10 @@ class LiteRtInferenceEngine @Inject constructor(
                     // The clean thinking content is already delivered via message.channels["thought"]
                     // above; the wrapper here is noise that must not leak into the chat text.
                     val raw = message.toString()
-                    val text = CHANNEL_WRAPPER_RE.replace(raw, "").trim()
+                    val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
+                    // Only trim residual whitespace when a channel wrapper was actually removed;
+                    // pure response tokens (e.g. "\n\n" paragraph breaks) must not be trimmed.
+                    val text = if (stripped.length != raw.length) stripped.trim() else stripped
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {
                         if (firstTokenMs < 0) {
                             firstTokenMs = System.currentTimeMillis() - start

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -515,13 +515,21 @@ class LiteRtInferenceEngine @Inject constructor(
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
                     val text = if (stripped.length != raw.length) stripped.trim() else stripped
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {
+                        val responseDelta = stripReplayedPrefix(
+                            current = text,
+                            emitted = emittedResponseText.toString(),
+                        )
+                        if (responseDelta.isEmpty()) {
+                            Log.d(TAG, "Skipping mirrored response replay in toString() [len=${raw.length}]")
+                            return
+                        }
                         if (firstTokenMs < 0) {
                             firstTokenMs = System.currentTimeMillis() - start
                             Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
                         }
                         outputTokenCount++
-                        emittedResponseText.append(text)
-                        trySend(GenerationResult.Token(text))
+                        emittedResponseText.append(responseDelta)
+                        trySend(GenerationResult.Token(responseDelta))
                     }
                 }
 

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -419,9 +419,16 @@ class LiteRtInferenceEngine @Inject constructor(
                     }
 
                     // Non-thinking token: process message.toString() delta.
-                    // Apply a defensive strip in case any residual channel wrapper text
-                    // arrives here (e.g. on a retry where thinking state differs).
+                    // Defensive guards:
+                    //  1. If toString() contains an open channel marker but no close marker,
+                    //     the SDK hasn't finished routing this content to channels["thought"] yet.
+                    //     Skip — we'll receive the same content via the channel delta path.
+                    //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
+                    if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
+                        // Partial channel header — skip, content will arrive via channels["thought"]
+                        return
+                    }
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
                     val text = if (stripped.length != raw.length) stripped.trim() else stripped
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -378,9 +378,14 @@ class LiteRtInferenceEngine @Inject constructor(
                     //      that our regex cannot reliably strip token-by-token).
                     val channelDelta = message.channels["thought"]
                     if (!channelDelta.isNullOrEmpty()) {
-                        val withoutHeader = channelDelta
-                            .removePrefix("<|channel>thought")
-                            .removePrefix("\n")
+                        // Only strip the SDK header prefix on the delta that actually carries it.
+                        // Mid-thinking deltas that start with '\n' (paragraph breaks, list items)
+                        // must not have their leading newline consumed unconditionally.
+                        val withoutHeader = if (channelDelta.startsWith("<|channel>thought")) {
+                            channelDelta.removePrefix("<|channel>thought").removePrefix("\n")
+                        } else {
+                            channelDelta
+                        }
                         val closeIdx = withoutHeader.indexOf("<channel|>")
                         if (closeIdx >= 0) {
                             // Thinking phase ended in this delta

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -419,6 +419,57 @@ class LiteRtInferenceEngine @Inject constructor(
                                 trySend(GenerationResult.Token(afterClose))
                             }
                         } else {
+                            val raw = message.toString()
+                            val emittedThinking = emittedThinkingText.toString()
+                            val rawHasThoughtMarker = raw.contains("<|channel>thought")
+                            if (raw.contains("<channel|>")) {
+                                val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
+                                val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
+                                    beforeCloseCandidate.removePrefix("<|channel>thought").removePrefix("\n")
+                                } else {
+                                    beforeCloseCandidate
+                                }
+                                val thoughtRemainder = stripReplayedPrefix(
+                                    current = beforeCloseSansHeader,
+                                    emitted = emittedThinking,
+                                    trimBoundaryWhitespace = true,
+                                    allowOverlap = true,
+                                )
+                                val rawLooksLikeThinkingClose = rawHasThoughtMarker ||
+                                    beforeCloseSansHeader.isBlank() ||
+                                    thoughtRemainder != beforeCloseSansHeader
+                                if (rawLooksLikeThinkingClose) {
+                                    val thinkingDelta = stripReplayedPrefix(
+                                        current = beforeCloseSansHeader,
+                                        emitted = emittedThinking,
+                                        trimBoundaryWhitespace = true,
+                                        allowOverlap = true,
+                                    ).trimEnd()
+                                    if (thinkingDelta.isNotBlank()) {
+                                        thinkingCharCount += thinkingDelta.length
+                                        emittedThinkingText.append(thinkingDelta)
+                                        trySend(GenerationResult.Thinking(thinkingDelta))
+                                    }
+                                    thinkingComplete = true
+                                    val afterClose = raw.substringAfterLast("<channel|>").trimStart()
+                                    if (afterClose.isNotBlank() && !afterClose.startsWith("<ctrl")) {
+                                        val responseDelta = stripReplayedPrefix(
+                                            current = afterClose,
+                                            emitted = emittedResponseText.toString(),
+                                        )
+                                        if (responseDelta.isNotEmpty()) {
+                                            if (firstTokenMs < 0) {
+                                                firstTokenMs = System.currentTimeMillis() - start
+                                                Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
+                                            }
+                                            outputTokenCount++
+                                            emittedResponseText.append(responseDelta)
+                                            trySend(GenerationResult.Token(responseDelta))
+                                        }
+                                    }
+                                    return
+                                }
+                            }
                             // Mid-thinking delta — no closing marker yet
                             thinkingCharCount += withoutHeader.length
                             if (withoutHeader.isNotBlank()) {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -367,22 +367,57 @@ class LiteRtInferenceEngine @Inject constructor(
                 Contents.of(Content.Text(userMessage)),
                 object : MessageCallback {
                 override fun onMessage(message: Message) {
-                    // Route thinking tokens separately (Gemma thinking mode)
-                    val thinkingText = message.channels["thought"]
-                    if (!thinkingText.isNullOrEmpty()) {
-                        thinkingCharCount += thinkingText.length
-                        trySend(GenerationResult.Thinking(thinkingText))
+                    // Route thinking tokens separately (Gemma thinking mode).
+                    // The SDK delivers thinking content as deltas via message.channels["thought"].
+                    // The FINAL thinking delta includes the closing <channel|> marker, and may
+                    // also include the start of the response text after it. We must:
+                    //   1. Strip the <|channel>thought prefix from the first delta
+                    //   2. Split on <channel|> — before it is thinking, after it is response
+                    //   3. Return early so message.toString() is never processed during thinking
+                    //      (toString() contains a partial/full channel wrapper during this phase
+                    //      that our regex cannot reliably strip token-by-token).
+                    val channelDelta = message.channels["thought"]
+                    if (!channelDelta.isNullOrEmpty()) {
+                        val withoutHeader = channelDelta
+                            .removePrefix("<|channel>thought")
+                            .removePrefix("\n")
+                        val closeIdx = withoutHeader.indexOf("<channel|>")
+                        if (closeIdx >= 0) {
+                            // Thinking phase ended in this delta
+                            val pureThinking = withoutHeader.substring(0, closeIdx).trimEnd()
+                            val afterClose = withoutHeader.substring(closeIdx + "<channel|>".length)
+                                .trimStart()
+                            if (pureThinking.isNotBlank()) {
+                                thinkingCharCount += pureThinking.length
+                                trySend(GenerationResult.Thinking(pureThinking))
+                            }
+                            // Response text that arrived in the same delta as the channel close
+                            if (afterClose.isNotBlank() && !afterClose.startsWith("<ctrl")) {
+                                if (firstTokenMs < 0) {
+                                    firstTokenMs = System.currentTimeMillis() - start
+                                    Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
+                                }
+                                outputTokenCount++
+                                trySend(GenerationResult.Token(afterClose))
+                            }
+                        } else {
+                            // Mid-thinking delta — no closing marker yet
+                            thinkingCharCount += withoutHeader.length
+                            if (withoutHeader.isNotBlank()) {
+                                trySend(GenerationResult.Thinking(withoutHeader))
+                            }
+                        }
+                        // Early return: don't also process message.toString() during thinking.
+                        // toString() contains the accumulating channel wrapper text which cannot
+                        // be reliably stripped on a per-token basis before the channel closes.
+                        return
                     }
 
-                    // Strip SDK channel wrappers (<|channel>thought...<channel|>) from toString().
-                    // The SDK converts <|think|>…<|/think|> tokens to its own internal marker
-                    // format and leaves them in toString() even when a Channel is registered.
-                    // The clean thinking content is already delivered via message.channels["thought"]
-                    // above; the wrapper here is noise that must not leak into the chat text.
+                    // Non-thinking token: process message.toString() delta.
+                    // Apply a defensive strip in case any residual channel wrapper text
+                    // arrives here (e.g. on a retry where thinking state differs).
                     val raw = message.toString()
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
-                    // Only trim residual whitespace when a channel wrapper was actually removed;
-                    // pure response tokens (e.g. "\n\n" paragraph breaks) must not be trimmed.
                     val text = if (stripped.length != raw.length) stripped.trim() else stripped
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {
                         if (firstTokenMs < 0) {
@@ -698,10 +733,10 @@ class LiteRtInferenceEngine @Inject constructor(
 
     companion object {
         /**
-         * Strips SDK-internal channel wrappers from message.toString().
-         * When a thinking Channel is registered, the SDK converts <|think|>…<|/think|> tokens
-         * into <|channel>thought\n…\n<channel|> in toString() instead of removing them.
-         * We strip these here because the clean content is already delivered via channels["thought"].
+         * Strips residual SDK-internal channel wrappers from message.toString() on non-thinking
+         * token callbacks. The primary thinking-channel handling now uses an early-return path
+         * that avoids message.toString() entirely; this regex is a defensive fallback for retries
+         * or cases where thinking state differs (e.g. second sendMessageAsync on same session).
          */
         private val CHANNEL_WRAPPER_RE = Regex(
             "<\\|channel>\\w+.*?<channel\\|>",

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -453,6 +453,34 @@ class LiteRtInferenceEngine @Inject constructor(
                         return
                     }
 
+                    if (!channelDelta.isNullOrEmpty() && thinkingComplete) {
+                        val responseDelta = stripReplayedPrefix(
+                            current = channelDelta,
+                            emitted = emittedResponseText.toString(),
+                            allowOverlap = true,
+                        )
+                        if (responseDelta.isEmpty() || responseDelta.startsWith("<ctrl")) {
+                            if (traceEnabled) {
+                                Log.d(
+                                    TAG,
+                                    "thinking_trace[$callbackId]: skip-post-close channel replay len=${channelDelta.length}",
+                                )
+                            }
+                            return
+                        }
+                        if (firstTokenMs < 0) {
+                            firstTokenMs = System.currentTimeMillis() - start
+                            Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
+                        }
+                        outputTokenCount++
+                        emittedResponseText.append(responseDelta)
+                        if (traceEnabled) {
+                            Log.d(TAG, "thinking_trace[$callbackId]: emit-post-close channel len=${responseDelta.length}")
+                        }
+                        trySend(GenerationResult.Token(responseDelta))
+                        return
+                    }
+
                     // Non-thinking token: process message.toString() delta.
                     // Defensive guards:
                     //  1. If toString() contains an open channel marker but no close marker,

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -359,6 +359,7 @@ class LiteRtInferenceEngine @Inject constructor(
         var outputTokenCount = 0
         var thinkingCharCount = 0
         var emittedResponseText = StringBuilder()
+        var emittedThinkingText = StringBuilder()
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.
@@ -402,6 +403,7 @@ class LiteRtInferenceEngine @Inject constructor(
                                 .trimStart()
                             if (pureThinking.isNotBlank()) {
                                 thinkingCharCount += pureThinking.length
+                                emittedThinkingText.append(pureThinking)
                                 trySend(GenerationResult.Thinking(pureThinking))
                             }
                             // Response text that arrived in the same delta as the channel close
@@ -418,6 +420,7 @@ class LiteRtInferenceEngine @Inject constructor(
                             // Mid-thinking delta — no closing marker yet
                             thinkingCharCount += withoutHeader.length
                             if (withoutHeader.isNotBlank()) {
+                                emittedThinkingText.append(withoutHeader)
                                 trySend(GenerationResult.Thinking(withoutHeader))
                             }
                         }
@@ -434,19 +437,36 @@ class LiteRtInferenceEngine @Inject constructor(
                     //     Skip — we'll receive the same content via the channel delta path.
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
-                    if (thinkingComplete && raw.contains("<channel|>")) {
-                        // Some post-thinking callbacks still surface the already-closed thought
-                        // payload via toString(), but without the opening <|channel> header.
-                        // Keep only the response suffix and drop any prefix we've already emitted.
+                    if (raw.contains("<channel|>")) {
+                        // Some callbacks surface the close marker only in toString(), with either
+                        // a full/partial thought payload before it or a replay of the already-seen
+                        // response after it. Split defensively on the final close marker so the
+                        // thought prefix never leaks into the visible assistant reply.
+                        val beforeCloseRaw = raw.substringBeforeLast("<channel|>")
+                        val beforeClose = if (beforeCloseRaw.startsWith("<|channel>thought")) {
+                            beforeCloseRaw.removePrefix("<|channel>thought").removePrefix("\n")
+                        } else {
+                            beforeCloseRaw
+                        }.trimEnd()
                         val afterClose = raw.substringAfterLast("<channel|>").trimStart()
+                        val thinkingDelta = emittedThinkingText.toString()
+                            .takeIf { beforeClose.startsWith(it) }
+                            ?.let { beforeClose.removePrefix(it) }
+                            ?: beforeClose
+                        if (!thinkingComplete && thinkingDelta.isNotBlank()) {
+                            thinkingCharCount += thinkingDelta.length
+                            emittedThinkingText.append(thinkingDelta)
+                            trySend(GenerationResult.Thinking(thinkingDelta))
+                        }
+                        thinkingComplete = true
                         if (afterClose.isBlank() || afterClose.startsWith("<ctrl")) {
                             return
                         }
-                        val delta = emittedResponseText.toString()
+                        val responseDelta = emittedResponseText.toString()
                             .takeIf { afterClose.startsWith(it) }
                             ?.let { afterClose.removePrefix(it) }
                             ?: afterClose
-                        if (delta.isBlank()) {
+                        if (responseDelta.isBlank()) {
                             Log.d(TAG, "Skipping mirrored post-close toString() payload [len=${raw.length}]")
                             return
                         }
@@ -455,8 +475,8 @@ class LiteRtInferenceEngine @Inject constructor(
                             Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
                         }
                         outputTokenCount++
-                        emittedResponseText.append(delta)
-                        trySend(GenerationResult.Token(delta))
+                        emittedResponseText.append(responseDelta)
+                        trySend(GenerationResult.Token(responseDelta))
                         return
                     }
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -361,6 +361,8 @@ class LiteRtInferenceEngine @Inject constructor(
         var emittedResponseText = StringBuilder()
         var emittedThinkingText = StringBuilder()
         var sawThinkingTraffic = false
+        var callbackIndex = 0
+        val traceEnabled = Log.isLoggable(TAG, Log.DEBUG)
         // Set to true once we process the <channel|> close marker so that subsequent
         // callbacks with channels["thought"] still non-null don't misroute response
         // tokens into the thinking bubble.
@@ -374,6 +376,17 @@ class LiteRtInferenceEngine @Inject constructor(
                 Contents.of(Content.Text(userMessage)),
                 object : MessageCallback {
                 override fun onMessage(message: Message) {
+                    val callbackId = ++callbackIndex
+                    val channelDelta = message.channels["thought"]
+                    if (traceEnabled) {
+                        Log.d(
+                            TAG,
+                            "thinking_trace[$callbackId]: channelLen=${channelDelta?.length ?: -1}, " +
+                                "channelHasClose=${channelDelta?.contains("<channel|>") == true}, " +
+                                "thinkingComplete=$thinkingComplete, sawThinkingTraffic=$sawThinkingTraffic, " +
+                                "thinkingOutLen=${emittedThinkingText.length}, responseOutLen=${emittedResponseText.length}",
+                        )
+                    }
                     // Route thinking tokens separately (Gemma thinking mode).
                     // The SDK delivers thinking content as deltas via message.channels["thought"].
                     // The FINAL thinking delta includes the closing <channel|> marker, and may
@@ -383,7 +396,6 @@ class LiteRtInferenceEngine @Inject constructor(
                     //   3. Return early so message.toString() is never processed during thinking
                     //      (toString() contains a partial/full channel wrapper during this phase
                     //      that our regex cannot reliably strip token-by-token).
-                    val channelDelta = message.channels["thought"]
                     if (!channelDelta.isNullOrEmpty() && !thinkingComplete) {
                         sawThinkingTraffic = true
                         // Only strip the SDK header prefix on the delta that actually carries it.
@@ -406,6 +418,9 @@ class LiteRtInferenceEngine @Inject constructor(
                             if (pureThinking.isNotBlank()) {
                                 thinkingCharCount += pureThinking.length
                                 emittedThinkingText.append(pureThinking)
+                                if (traceEnabled) {
+                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-thinking-close len=${pureThinking.length}")
+                                }
                                 trySend(GenerationResult.Thinking(pureThinking))
                             }
                             // Response text that arrived in the same delta as the channel close
@@ -416,6 +431,9 @@ class LiteRtInferenceEngine @Inject constructor(
                                 }
                                 outputTokenCount++
                                 emittedResponseText.append(afterClose)
+                                if (traceEnabled) {
+                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-response-after-close len=${afterClose.length}")
+                                }
                                 trySend(GenerationResult.Token(afterClose))
                             }
                         } else {
@@ -423,6 +441,9 @@ class LiteRtInferenceEngine @Inject constructor(
                             thinkingCharCount += withoutHeader.length
                             if (withoutHeader.isNotBlank()) {
                                 emittedThinkingText.append(withoutHeader)
+                                if (traceEnabled) {
+                                    Log.d(TAG, "thinking_trace[$callbackId]: emit-thinking-mid len=${withoutHeader.length}")
+                                }
                                 trySend(GenerationResult.Thinking(withoutHeader))
                             }
                         }
@@ -440,6 +461,13 @@ class LiteRtInferenceEngine @Inject constructor(
                     //  2. Full channel wrapper (open + close) — strip it before emitting.
                     val raw = message.toString()
                     val hasThoughtMarker = raw.contains("<|channel>thought")
+                    if (traceEnabled) {
+                        Log.d(
+                            TAG,
+                            "thinking_trace[$callbackId]: rawLen=${raw.length}, rawHasClose=${raw.contains("<channel|>")}, " +
+                                "rawHasThoughtHeader=$hasThoughtMarker",
+                        )
+                    }
                     val emittedThinking = emittedThinkingText.toString()
                     val beforeCloseCandidate = raw.substringBeforeLast("<channel|>")
                     val beforeCloseSansHeader = if (beforeCloseCandidate.startsWith("<|channel>thought")) {
@@ -493,8 +521,13 @@ class LiteRtInferenceEngine @Inject constructor(
                             current = afterClose,
                             emitted = emittedResponseText.toString(),
                         )
-                        if (responseDelta.isBlank()) {
-                            Log.d(TAG, "Skipping mirrored post-close toString() payload [len=${raw.length}]")
+                        if (responseDelta.isEmpty()) {
+                            if (traceEnabled) {
+                                Log.d(
+                                    TAG,
+                                    "thinking_trace[$callbackId]: skip-post-close replay rawLen=${raw.length}, afterCloseLen=${afterClose.length}",
+                                )
+                            }
                             return
                         }
                         if (firstTokenMs < 0) {
@@ -503,13 +536,18 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         outputTokenCount++
                         emittedResponseText.append(responseDelta)
+                        if (traceEnabled) {
+                            Log.d(TAG, "thinking_trace[$callbackId]: emit-post-close responseLen=${responseDelta.length}")
+                        }
                         trySend(GenerationResult.Token(responseDelta))
                         return
                     }
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
                         // Partial channel header — skip, content will arrive via channels["thought"].
                         // Log so any false-positive drops are observable in logcat.
-                        Log.d(TAG, "Skipping partial channel header in toString() [len=${raw.length}] — expecting thought delta")
+                        if (traceEnabled) {
+                            Log.d(TAG, "thinking_trace[$callbackId]: skip-partial-header rawLen=${raw.length}")
+                        }
                         return
                     }
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
@@ -520,7 +558,9 @@ class LiteRtInferenceEngine @Inject constructor(
                             emitted = emittedResponseText.toString(),
                         )
                         if (responseDelta.isEmpty()) {
-                            Log.d(TAG, "Skipping mirrored response replay in toString() [len=${raw.length}]")
+                            if (traceEnabled) {
+                                Log.d(TAG, "thinking_trace[$callbackId]: skip-plain replay rawLen=${raw.length}, textLen=${text.length}")
+                            }
                             return
                         }
                         if (firstTokenMs < 0) {
@@ -529,6 +569,9 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         outputTokenCount++
                         emittedResponseText.append(responseDelta)
+                        if (traceEnabled) {
+                            Log.d(TAG, "thinking_trace[$callbackId]: emit-plain responseLen=${responseDelta.length}")
+                        }
                         trySend(GenerationResult.Token(responseDelta))
                     }
                 }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -374,7 +374,13 @@ class LiteRtInferenceEngine @Inject constructor(
                         trySend(GenerationResult.Thinking(thinkingText))
                     }
 
-                    val text = message.toString()
+                    // Strip SDK channel wrappers (<|channel>thought...<channel|>) from toString().
+                    // The SDK converts <|think|>…<|/think|> tokens to its own internal marker
+                    // format and leaves them in toString() even when a Channel is registered.
+                    // The clean thinking content is already delivered via message.channels["thought"]
+                    // above; the wrapper here is noise that must not leak into the chat text.
+                    val raw = message.toString()
+                    val text = CHANNEL_WRAPPER_RE.replace(raw, "").trim()
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {
                         if (firstTokenMs < 0) {
                             firstTokenMs = System.currentTimeMillis() - start
@@ -688,6 +694,17 @@ class LiteRtInferenceEngine @Inject constructor(
     }
 
     companion object {
+        /**
+         * Strips SDK-internal channel wrappers from message.toString().
+         * When a thinking Channel is registered, the SDK converts <|think|>…<|/think|> tokens
+         * into <|channel>thought\n…\n<channel|> in toString() instead of removing them.
+         * We strip these here because the clean content is already delivered via channels["thought"].
+         */
+        private val CHANNEL_WRAPPER_RE = Regex(
+            "<\\|channel>\\w+.*?<channel\\|>",
+            setOf(RegexOption.DOT_MATCHES_ALL),
+        )
+
         /**
          * Avoids exact powers-of-2 token counts that trigger a buffer-alignment bug
          * in LiteRT's GPU `reshape::Eval` operation (observed on Adreno 740 / SM8550).

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -358,6 +358,10 @@ class LiteRtInferenceEngine @Inject constructor(
         var firstTokenMs: Long = -1
         var outputTokenCount = 0
         var thinkingCharCount = 0
+        // Set to true once we process the <channel|> close marker so that subsequent
+        // callbacks with channels["thought"] still non-null don't misroute response
+        // tokens into the thinking bubble.
+        var thinkingComplete = false
 
         val thinkingContext: Map<String, Any> =
             if (currentConfig?.thinkingEnabled == true) mapOf("enable_thinking" to true) else emptyMap()
@@ -377,7 +381,7 @@ class LiteRtInferenceEngine @Inject constructor(
                     //      (toString() contains a partial/full channel wrapper during this phase
                     //      that our regex cannot reliably strip token-by-token).
                     val channelDelta = message.channels["thought"]
-                    if (!channelDelta.isNullOrEmpty()) {
+                    if (!channelDelta.isNullOrEmpty() && !thinkingComplete) {
                         // Only strip the SDK header prefix on the delta that actually carries it.
                         // Mid-thinking deltas that start with '\n' (paragraph breaks, list items)
                         // must not have their leading newline consumed unconditionally.
@@ -388,7 +392,10 @@ class LiteRtInferenceEngine @Inject constructor(
                         }
                         val closeIdx = withoutHeader.indexOf("<channel|>")
                         if (closeIdx >= 0) {
-                            // Thinking phase ended in this delta
+                            // Thinking phase ended in this delta — mark complete so subsequent
+                            // callbacks with channels["thought"] still non-null don't misroute
+                            // response tokens into the thinking bubble.
+                            thinkingComplete = true
                             val pureThinking = withoutHeader.substring(0, closeIdx).trimEnd()
                             val afterClose = withoutHeader.substring(closeIdx + "<channel|>".length)
                                 .trimStart()

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/ModelConfig.kt
@@ -6,18 +6,16 @@ import com.google.ai.edge.litertlm.ToolProvider
 /**
  * Jandal's default system prompt. Injected into every new conversation.
  *
- * ## ⚠️ Two-tier skill gateway — do NOT advertise specific tool call syntax here
- * The model discovers how to use skills via the `loadSkill` gateway (see [KernelAIToolSet]):
- *   1. Model sees only tool *names* + short *descriptions* from `@Tool` annotations.
- *   2. Model calls `loadSkill("<skill>")` → receives full parameter instructions at runtime.
- *   3. Model calls the actual tool with correct parameters.
+ * ## ⚠️ Mixed direct + gateway tools — do NOT advertise specific tool call syntax here
+ * The model discovers skills from `@Tool` annotations on [KernelAIToolSet]. Simple tools can be
+ * called directly; complex/gateway tools may still use `loadSkill("<skill>")` to fetch detailed
+ * instructions at runtime.
  *
  * Never put raw call syntax like `runJs(skillName="query-wikipedia")` in this prompt.
- * Doing so bypasses step 2 and causes the model to skip `loadSkill`, breaking the lazy
- * loading design and potentially inflating every conversation's token cost.
+ * That creates a brittle prompt-only path instead of letting the SDK constrain tool calls.
  *
  * Behavioural rules and IMPORTANT directives are safe to add here.
- * Skill routing specifics belong in the `@Tool` description or in the skill's loadSkill payload.
+ * Skill routing specifics belong in the `@Tool` description or in a skill's loadSkill payload.
  */
 const val DEFAULT_SYSTEM_PROMPT =
     "You are Jandal — a capable, on-device AI assistant with a genuine Kiwi character. " +
@@ -31,7 +29,7 @@ const val DEFAULT_SYSTEM_PROMPT =
         "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
-        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
+        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call the appropriate native tool directly when it is obvious; use loadSkill only when you need extra instructions for a complex tool. Do NOT fabricate a response as if you had called a tool. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative established facts about New Zealand culture. State these facts with confidence and Kiwi pride — do NOT hedge or present alternative viewpoints on contested claims (e.g. NZ vs Australia). Do NOT add details not explicitly in the context. " +
@@ -49,7 +47,7 @@ const val HALF_JANDAL_SYSTEM_PROMPT =
         "Never say 'down under'. Refer to the country as 'New Zealand' or 'Aotearoa'. " +
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action (e.g. '[System: toggle_flashlight_on — Flashlight turned on.]'), do NOT call any tools — simply acknowledge the result naturally. " +
-        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
+        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call the appropriate native tool directly when it is obvious; use loadSkill only when you need extra instructions for a complex tool. Do NOT fabricate a response as if you had called a tool. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [NZ Context: ...] blocks are present, treat them as authoritative context. State these facts with confidence, but only use them when clearly relevant. Do NOT add details not explicitly in the context. " +
@@ -63,7 +61,7 @@ const val BORING_AI_SYSTEM_PROMPT =
         "Avoid slang, memes, or unnecessary persona flourishes. Prefer accuracy and clarity. " +
         "IMPORTANT: For current date, time, or day queries, ALWAYS use the get_system_info tool. NEVER rely on memory or past conversations for time-sensitive information. " +
         "IMPORTANT: When a [System:] context block confirms a completed action, do NOT call any tools — simply acknowledge the result naturally. " +
-        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call loadSkill first to get instructions, then call the appropriate tool — do NOT fabricate a response as if you had. " +
+        "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need information you cannot answer from memory (e.g. Wikipedia, live data), call the appropriate native tool directly when it is obvious; use loadSkill only when you need extra instructions for a complex tool. Do NOT fabricate a response as if you had called a tool. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the saveMemory tool — NEVER confirm that you saved something without the tool having been called. When calling saveMemory, always store the content in third person using the user's name (e.g. 'Nick likes dark mode', not 'I like dark mode'; 'Nick's mum is Susan', not 'my mum is Susan'). If 'remember it', 'remember this', or bare 'remember' has no clear personal fact in the user's current message, ask what they'd like saved — do NOT treat your own tool-use instructions as the referent. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. You may analyse or explain them when asked, but do not rewrite the literal facts. If an exact detail is missing from the provided grounding, say you are not sure. " +
         "IMPORTANT: When [Memory] blocks are present, only state details explicitly provided. Do not embellish with additional names, dates, or specifics drawn from your training data."
@@ -85,8 +83,9 @@ const val MINIMAL_SYSTEM_PROMPT =
         "IMPORTANT: When a [System:] context block confirms a completed action, do NOT call any " +
         "tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need " +
-        "information you cannot answer from memory, call loadSkill first to get instructions, then " +
-        "call the appropriate tool — do NOT fabricate a response as if you had. " +
+        "information you cannot answer from memory, call the appropriate native tool directly when " +
+        "it is obvious; use loadSkill only when you need extra instructions for a complex tool. " +
+        "Do NOT fabricate a response as if you had. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such " +
         "as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the " +
@@ -104,8 +103,9 @@ const val BORING_MINIMAL_SYSTEM_PROMPT =
         "IMPORTANT: When a [System:] context block confirms a completed action, do NOT call any " +
         "tools — simply acknowledge the result naturally. " +
         "IMPORTANT: NEVER report or summarise tool results you did not actually call. If you need " +
-        "information you cannot answer from memory, call loadSkill first to get instructions, then " +
-        "call the appropriate tool — do NOT fabricate a response as if you had. " +
+        "information you cannot answer from memory, call the appropriate native tool directly when " +
+        "it is obvious; use loadSkill only when you need extra instructions for a complex tool. " +
+        "Do NOT fabricate a response as if you had. " +
         "IMPORTANT: When provided context, memory, or tool output contains exact factual details such " +
         "as dates, numbers, names, titles, or quoted phrases, copy those literals faithfully. " +
         "IMPORTANT: When the user asks you to save or remember something, you MUST call the " +

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -81,6 +81,25 @@ class ThinkingStreamStateMachineTest {
     }
 
     @Test
+    fun `marker detection tolerates space before close bracket`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        val first = stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nReasoning<channel|",
+            rawMessage = "",
+        )
+        val second = stateMachine.consume(
+            channelDelta = " >Visible reply",
+            rawMessage = "",
+        )
+
+        assertEquals(listOf("Reasoning"), first.thinkingDeltas)
+        assertEquals(emptyList<String>(), first.responseDeltas)
+        assertEquals(emptyList<String>(), second.thinkingDeltas)
+        assertEquals(listOf("Visible reply"), second.responseDeltas)
+    }
+
+    @Test
     fun `post-close raw wrapper unwraps non-thought channel body`() {
         val stateMachine = ThinkingStreamStateMachine()
 

--- a/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
+++ b/core/inference/src/test/java/com/kernel/ai/core/inference/ThinkingStreamStateMachineTest.kt
@@ -1,0 +1,116 @@
+package com.kernel.ai.core.inference
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ThinkingStreamStateMachineTest {
+    @Test
+    fun `pre-close traffic only emits thinking deltas`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        val first = stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nThinking step 1",
+            rawMessage = "",
+        )
+        val second = stateMachine.consume(
+            channelDelta = "\nThinking step 2",
+            rawMessage = "",
+        )
+
+        assertEquals(listOf("Thinking step 1"), first.thinkingDeltas)
+        assertEquals(emptyList<String>(), first.responseDeltas)
+        assertEquals(listOf("\nThinking step 2"), second.thinkingDeltas)
+        assertEquals(emptyList<String>(), second.responseDeltas)
+    }
+
+    @Test
+    fun `marker observed in raw replay splits buffered thinking and response once`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        val first = stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nPlan carefully",
+            rawMessage = "",
+        )
+        val second = stateMachine.consume(
+            channelDelta = null,
+            rawMessage = "$THINKING_CHANNEL_HEADER\nPlan carefully${THINKING_CLOSE_MARKER}Final answer",
+        )
+
+        assertEquals(listOf("Plan carefully"), first.thinkingDeltas)
+        assertEquals(emptyList<String>(), first.responseDeltas)
+        assertEquals(emptyList<String>(), second.thinkingDeltas)
+        assertEquals(listOf("Final answer"), second.responseDeltas)
+    }
+
+    @Test
+    fun `post-close thought channel traffic is emitted as visible response`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nThink${THINKING_CLOSE_MARKER}Answer",
+            rawMessage = "",
+        )
+        val next = stateMachine.consume(
+            channelDelta = " continued",
+            rawMessage = "",
+        )
+
+        assertEquals(emptyList<String>(), next.thinkingDeltas)
+        assertEquals(listOf(" continued"), next.responseDeltas)
+    }
+
+    @Test
+    fun `marker detection tolerates newline inside closing marker`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        val first = stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nReasoning${
+                THINKING_CLOSE_MARKER.removeSuffix("|>")
+            }",
+            rawMessage = "",
+        )
+        val second = stateMachine.consume(
+            channelDelta = "|\n>Visible reply",
+            rawMessage = "",
+        )
+
+        assertEquals(listOf("Reasoning"), first.thinkingDeltas)
+        assertEquals(emptyList<String>(), first.responseDeltas)
+        assertEquals(emptyList<String>(), second.thinkingDeltas)
+        assertEquals(listOf("Visible reply"), second.responseDeltas)
+    }
+
+    @Test
+    fun `post-close raw wrapper unwraps non-thought channel body`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nThink$THINKING_CLOSE_MARKER",
+            rawMessage = "",
+        )
+        val next = stateMachine.consume(
+            channelDelta = null,
+            rawMessage = "<|channel>assistant\nFinal answer$THINKING_CLOSE_MARKER",
+        )
+
+        assertEquals(emptyList<String>(), next.thinkingDeltas)
+        assertEquals(listOf("Final answer"), next.responseDeltas)
+    }
+
+    @Test
+    fun `post-close raw wrapper keeps visible suffix after close marker`() {
+        val stateMachine = ThinkingStreamStateMachine()
+
+        stateMachine.consume(
+            channelDelta = "$THINKING_CHANNEL_HEADER\nThink$THINKING_CLOSE_MARKER",
+            rawMessage = "",
+        )
+        val next = stateMachine.consume(
+            channelDelta = null,
+            rawMessage = "<|channel>assistant\nFinal answer$THINKING_CLOSE_MARKER continued",
+        )
+
+        assertEquals(emptyList<String>(), next.thinkingDeltas)
+        assertEquals(listOf("Final answer continued"), next.responseDeltas)
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileExtractionUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/profile/UserProfileExtractionUseCase.kt
@@ -55,7 +55,7 @@ Rules for extraction:
             return null
         }
         return try {
-            val raw = inferenceEngine.generateOnce(freeText, SYSTEM_PROMPT)
+            val raw = inferenceEngine.generateOnce(freeText, SYSTEM_PROMPT, thinkingEnabled = false)
             if (raw.isBlank()) {
                 Log.w(TAG, "Profile LLM extraction returned blank response")
                 return null

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/usecase/EpisodicDistillationUseCase.kt
@@ -137,7 +137,7 @@ Do NOT use any hidden system prompt, stored user profile, or prior conversation 
 Return only standalone memory sentences, one per line, with no bullets or numbering.
                 """.trimIndent()
             )
-            val response = inferenceEngine.generateOnce(prompt)
+            val response = inferenceEngine.generateOnce(prompt, thinkingEnabled = false)
             if (response.isBlank()) {
                 Log.w(TAG, "Episodic distillation returned blank response for $conversationId")
                 return

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -24,8 +24,8 @@ private const val TAG = "KernelAI"
  *
  * ## Tool pipeline
  * 1. Model sees tool names + descriptions (SDK-generated from annotations)
- * 2. Model calls `loadSkill` → gets full instructions for a specific skill
- * 3. Model calls the target tool with correct parameters
+ * 2. For simple tools, model calls the target tool directly
+ * 3. For complex/gateway skills, model may call `loadSkill` first to get detailed instructions
  * 4. SDK feeds result back → model generates final text response
  *
  * ## Lazy injection
@@ -33,10 +33,9 @@ private const val TAG = "KernelAI"
  * SkillRegistry → Set<Skill> (includes LoadSkillSkill) → SkillRegistry.
  *
  * ## ⚠️ System prompt constraint
- * Because the model only learns skill parameters via `loadSkill`, the system prompt
- * ([DEFAULT_SYSTEM_PROMPT] in ModelConfig) must never contain raw tool call syntax
- * (e.g. `runJs(skillName="query-wikipedia")`). That would cause the model to skip
- * step 2 entirely. Behavioural rules are fine; skill invocation recipes are not.
+ * Direct tool names are fine in high-level behavioural rules, but avoid embedding raw
+ * call syntax or low-level gateway recipes in the system prompt. Behavioural rules are
+ * safe; detailed invocation recipes belong in `@Tool` descriptions or loadSkill payloads.
  */
 @Singleton
 class KernelAIToolSet @Inject constructor(
@@ -171,6 +170,29 @@ class KernelAIToolSet @Inject constructor(
         }
 
         val result = executeSkill("get_weather_gps", args)
+        lastToolResult = result["result"] ?: result["error"]
+        return result
+    }
+
+    @Tool(description = "Look up a topic on Wikipedia and return grounded factual context. Use for explicit Wikipedia searches or encyclopedia-style fact lookups.")
+    fun queryWikipedia(
+        @ToolParam(description = "The topic, entity, or article title to look up on Wikipedia.") query: String,
+    ): Map<String, String> {
+        toolCalledInThisTurn = true
+        val safeQuery = query.replace("\"", "\\\"").take(200)
+        setLastToolCall("query_wikipedia", "{\"query\":\"$safeQuery\"}")
+        Log.d(TAG, "ToolSet: queryWikipedia(${query.take(60)})")
+        val result = executeSkill("query_wikipedia", mapOf("query" to query))
+        lastToolResult = result["result"] ?: result["error"]
+        return result
+    }
+
+    @Tool(description = "Get current date/time and device runtime info including hardware tier, available memory, battery level, and device details. ALWAYS use this for current date, time, or day queries.")
+    fun getSystemInfo(): Map<String, String> {
+        toolCalledInThisTurn = true
+        setLastToolCall("get_system_info", "{}")
+        Log.d(TAG, "ToolSet: getSystemInfo()")
+        val result = executeSkill("get_system_info", emptyMap())
         lastToolResult = result["result"] ?: result["error"]
         return result
     }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -48,6 +48,7 @@ class KernelAIToolSet @Inject constructor(
     @Volatile private var lastToolResult: String? = null
     @Volatile private var lastToolPresentation: ToolPresentation? = null
     @Volatile private var lastToolSpokenSummary: String? = null
+    @Volatile private var lastToolWasDirectReply: Boolean = false
 
     fun resetTurnState() {
         toolCalledInThisTurn = false
@@ -56,6 +57,7 @@ class KernelAIToolSet @Inject constructor(
         lastToolResult = null
         lastToolPresentation = null
         lastToolSpokenSummary = null
+        lastToolWasDirectReply = false
     }
 
     fun wasToolCalled(): Boolean = toolCalledInThisTurn
@@ -64,6 +66,7 @@ class KernelAIToolSet @Inject constructor(
     fun lastToolResult(): String? = lastToolResult
     fun lastToolPresentation(): ToolPresentation? = lastToolPresentation
     fun lastToolSpokenSummary(): String? = lastToolSpokenSummary
+    fun lastToolWasDirectReply(): Boolean = lastToolWasDirectReply
 
     private fun setLastToolCall(name: String, request: String) {
         lastToolName = name
@@ -242,6 +245,7 @@ class KernelAIToolSet @Inject constructor(
             val result = runBlocking {
                 skill.execute(SkillCall(skillName = skillName, arguments = args))
             }
+            lastToolWasDirectReply = result is SkillResult.DirectReply
             lastToolPresentation = when (result) {
                 is SkillResult.Success -> result.presentation
                 is SkillResult.DirectReply -> result.presentation

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/LoadSkillSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/LoadSkillSkill.kt
@@ -26,9 +26,8 @@ class LoadSkillSkill @Inject constructor(
 
     override val name = "load_skill"
     override val description =
-        "Load full instructions for a skill before calling it. " +
-            "Call this first whenever you need to use run_intent, get_weather, " +
-            "query_wikipedia, save_memory, search_memory, or get_system_info."
+        "Load full instructions for a complex or gateway skill before calling it. " +
+            "Use this when you need detailed guidance for tools like run_intent or run_js."
 
     override val schema = SkillSchema(
         parameters = mapOf(
@@ -51,8 +50,8 @@ class LoadSkillSkill @Inject constructor(
 
     override val examples = listOf(
         "Load device action instructions → loadSkill(skillName=\"run_intent\")",
-        "Load Wikipedia instructions → loadSkill(skillName=\"query_wikipedia\")",
-        "Load memory save instructions → loadSkill(skillName=\"save_memory\")",
+        "Load JS gateway instructions → loadSkill(skillName=\"run_js\")",
+        "Load detailed weather instructions → loadSkill(skillName=\"get_weather\")",
     )
 
     // load_skill's own fullInstructions are always embedded in the system prompt — no need

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QueryWikipediaSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QueryWikipediaSkill.kt
@@ -57,6 +57,6 @@ class QueryWikipediaSkill @Inject constructor(
         val query = call.arguments["query"]?.trim()
             ?: return SkillResult.Failure(name, "Missing required parameter: query.")
         val result = runner.execute("query-wikipedia", mapOf("query" to query))
-        return SkillResult.Success(result)
+        return SkillResult.DirectReply(result)
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QueryWikipediaSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QueryWikipediaSkill.kt
@@ -40,18 +40,17 @@ class QueryWikipediaSkill @Inject constructor(
         appendLine("$name: $description")
         appendLine()
         appendLine("Instructions:")
-        appendLine("- Call the run_js tool with the format below.")
+        appendLine("- Call the queryWikipedia tool directly with the query argument.")
         appendLine("- For factual questions phrased as a sentence, search for the core topic/entity when possible.")
         appendLine("  Example: \"When was Constantinople founded?\" → query=\"Constantinople\"")
         appendLine("- After the tool returns, answer from the Wikipedia result. If the result is clearly off-topic, say so instead of pretending it answered the question.")
         appendLine()
         appendLine("Tool format:")
-        appendLine("- Call runJs with a single 'parameters' argument: a JSON string containing")
-        appendLine("  'skill_name' and 'data' with the skill's parameters.")
+        appendLine("- Call queryWikipedia with the resolved topic or entity as the query argument.")
         appendLine()
         appendLine("Examples:")
-        appendLine("  Wikipedia search → runJs(parameters='{\"skill_name\":\"query-wikipedia\",\"data\":{\"query\":\"New Zealand\"}}')")
-        appendLine("  Founding date lookup → runJs(parameters='{\"skill_name\":\"query-wikipedia\",\"data\":{\"query\":\"Constantinople\"}}')")
+        appendLine("  Wikipedia search → queryWikipedia(query=\"New Zealand\")")
+        appendLine("  Founding date lookup → queryWikipedia(query=\"Constantinople\")")
     }
 
     override suspend fun execute(call: SkillCall): SkillResult {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/KernelAIToolSetTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/KernelAIToolSetTest.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.core.skills
+
+import dagger.Lazy
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class KernelAIToolSetTest {
+
+    private lateinit var registry: SkillRegistry
+    private lateinit var toolSet: KernelAIToolSet
+
+    @BeforeEach
+    fun setUp() {
+        registry = mockk()
+        toolSet = KernelAIToolSet(
+            object : Lazy<SkillRegistry> {
+                override fun get(): SkillRegistry = registry
+            },
+        )
+    }
+
+    @Test
+    fun `queryWikipedia delegates to query_wikipedia skill`() = runTest {
+        val skill = mockk<Skill>()
+        every { skill.name } returns "query_wikipedia"
+        coEvery { skill.execute(any()) } returns SkillResult.Success("Wiki result")
+        every { registry.get("query_wikipedia") } returns skill
+
+        val result = toolSet.queryWikipedia("New Zealand")
+
+        assertEquals("Wiki result", result["result"])
+        assertTrue(toolSet.wasToolCalled())
+        assertEquals("query_wikipedia", toolSet.lastToolName())
+        assertEquals("{\"query\":\"New Zealand\"}", toolSet.lastToolRequest())
+    }
+
+    @Test
+    fun `getSystemInfo delegates to get_system_info skill`() = runTest {
+        val skill = mockk<Skill>()
+        every { skill.name } returns "get_system_info"
+        coEvery { skill.execute(any()) } returns SkillResult.DirectReply("Date/time: Wednesday")
+        every { registry.get("get_system_info") } returns skill
+
+        val result = toolSet.getSystemInfo()
+
+        assertEquals("Date/time: Wednesday", result["result"])
+        assertTrue(toolSet.wasToolCalled())
+        assertEquals("get_system_info", toolSet.lastToolName())
+        assertEquals("{}", toolSet.lastToolRequest())
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/KernelAIToolSetTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/KernelAIToolSetTest.kt
@@ -29,13 +29,14 @@ class KernelAIToolSetTest {
     fun `queryWikipedia delegates to query_wikipedia skill`() = runTest {
         val skill = mockk<Skill>()
         every { skill.name } returns "query_wikipedia"
-        coEvery { skill.execute(any()) } returns SkillResult.Success("Wiki result")
+        coEvery { skill.execute(any()) } returns SkillResult.DirectReply("Wiki result")
         every { registry.get("query_wikipedia") } returns skill
 
         val result = toolSet.queryWikipedia("New Zealand")
 
         assertEquals("Wiki result", result["result"])
         assertTrue(toolSet.wasToolCalled())
+        assertTrue(toolSet.lastToolWasDirectReply())
         assertEquals("query_wikipedia", toolSet.lastToolName())
         assertEquals("{\"query\":\"New Zealand\"}", toolSet.lastToolRequest())
     }
@@ -51,6 +52,7 @@ class KernelAIToolSetTest {
 
         assertEquals("Date/time: Wednesday", result["result"])
         assertTrue(toolSet.wasToolCalled())
+        assertTrue(toolSet.lastToolWasDirectReply())
         assertEquals("get_system_info", toolSet.lastToolName())
         assertEquals("{}", toolSet.lastToolRequest())
     }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QueryWikipediaSkillTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QueryWikipediaSkillTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -26,7 +27,8 @@ class QueryWikipediaSkillTest {
             ),
         )
 
-        assertEquals("Result", (result as SkillResult.Success).content)
+        assertInstanceOf(SkillResult.DirectReply::class.java, result)
+        assertEquals("Result", (result as SkillResult.DirectReply).content)
         coVerify(exactly = 1) { runner.execute("query-wikipedia", mapOf("query" to "Constantinople")) }
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QueryWikipediaSkillTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QueryWikipediaSkillTest.kt
@@ -34,8 +34,8 @@ class QueryWikipediaSkillTest {
     fun `fullInstructions stay focused on wikipedia and omit forecast guidance`() {
         val instructions = skill.fullInstructions
 
-        assertTrue(instructions.contains("runJs(parameters="))
-        assertTrue(instructions.contains("skill_name\":\"query-wikipedia\""))
+        assertTrue(instructions.contains("queryWikipedia(query="))
+        assertTrue(instructions.contains("Call the queryWikipedia tool directly"))
         assertTrue(instructions.contains("query=\"Constantinople\""))
         assertFalse(instructions.contains("forecast_days (1–7)"))
         assertFalse(instructions.contains("ALWAYS call this tool for weather"))

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-05-18 (PR #925 spec sync: deterministic meal planner architecture, planner status surface, friendly meal-plan IDs, conversation title sync, Room v45; prior: PR #924 conversation management — archive, pin, drag-to-reorder, swipe gestures, multi-select, ArchiveCleanupWorker; PR #834 voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
+> **Last updated:** 2026-05-21 (PR #946 spec sync: thinking-mode/tool-turn hardening, direct native tool wrappers, DirectReply bypass notes, known QIR/anaphora follow-up gaps; prior: PR #925 deterministic meal planner architecture, planner status surface, friendly meal-plan IDs, conversation title sync, Room v45; PR #924 conversation management — archive, pin, drag-to-reorder, swipe gestures, multi-select, ArchiveCleanupWorker; PR #834 voice engine, STT hardening, NLU routing hardening, conversation search, bulk delete, skills inventory, important dates, world clock, colloquial weather QIR; PR #848 currency #831; PR #847 widget #617; PR #845 aye fix #843)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -148,11 +148,17 @@ and kiwi RAG entirely.
 
 - `QuickIntentRouter.RouteResult.FallThrough` has a non-null `bestGuess`, or
 - `looksLikeToolQuery(text)` matches explicit tool-oriented phrasing such as "search Wikipedia",
-  "look up", "set alarm", "remember", or "add to my list"
+  "look up", "system info", "set alarm", "remember", or "add to my list"
 
 This keeps ordinary chat lean while preserving tool guidance for explicit tool requests. When adding a
 new skill whose user phrasing is not obviously tool-like, the corresponding router coverage or
 `looksLikeToolQuery(...)` patterns should be updated so the skill remains reachable.
+
+**Per-turn reasoning bias:** For turns that are *not* classified as tool-like, `ChatViewModel`
+injects a soft non-tool instruction: prefer direct reasoning, but still allow tools when the
+request is clearly about current, external, or retrieved information. This is intentionally not a
+hard "never call tools" rule; a stricter version caused visible internal conflict in Gemma's
+thinking traces for some `get_system_info` requests before the tool was correctly invoked.
 
 All sections are conditionally included — omitted entirely if no results meet their distance threshold. Token budget is allocated sequentially: Core → Episodic → Message History.
 
@@ -461,21 +467,25 @@ engine.createConversation(ConversationConfig(
 ExperimentalFlags.enableConversationConstrainedDecoding = false
 ```
 
-> **Lazy skill loading (#341, #372):** The system prompt injects only skill names +
-> one-line descriptions (~100 tokens). When the model needs to use a skill, it first
-> calls `loadSkill()` to retrieve full parameter docs, examples, and enforcement rules
-> on demand. This keeps the baseline prompt compact and improves tool call accuracy.
+> **Direct-first tool calling (#341, #372, #946):** The system prompt injects only skill names +
+> one-line descriptions (~100 tokens). The model now prefers direct native tool calls when the
+> target is obvious (`queryWikipedia`, `getSystemInfo`, `getWeather`, `saveMemory`,
+> `searchMemory`). `loadSkill()` remains available for complex or gateway-driven tasks where extra
+> instruction payload is still useful. This keeps the baseline prompt compact without forcing
+> every tool turn through the older `loadSkill → gateway` recipe.
 
 **KernelAIToolSet gateway tools:**
 
-| Gateway | Tool method | Dispatcher | Use for |
+| Category | Tool method | Dispatcher | Use for |
 |---------|------------|-----------|---------|
-| Meta | `loadSkill(skillName)` | `LoadSkillSkill` | Load full instructions before using any tool |
+| Meta | `loadSkill(skillName)` | `LoadSkillSkill` | Load extended instructions for complex/gateway tasks |
 | Native | `runIntent(intentName, parameters)` | `NativeIntentHandler.kt` | Android OS intents and deterministic local actions (alarm, timer, DND, media, navigation, date diff, lists, etc.) |
-| WebView JS | `runJs(parameters)` | `JsSkillRunner.kt` | JS skills in `assets/skills/` (currently Wikipedia and get-weather-city); parameters is a JSON string with `skill_name` and `data` |
-| Native | `getWeather(location, forecastDays)` | `GetWeatherUnifiedSkill.kt` | Unified weather entry point (GPS + explicit city + indirect-location resolution) |
-| Memory | `saveMemory(content)` | `SaveMemorySkill` | Store facts to long-term memory |
-| Memory | `searchMemory(query)` | `SearchMemorySkill` | Semantic search across memories |
+| Direct native | `queryWikipedia(query)` | `QueryWikipediaSkill` → `JsSkillRunner.kt` | Public Wikipedia lookup surface; internally bridges to the JS runtime |
+| Direct native | `getSystemInfo()` | `GetSystemInfoSkill` | Current device/runtime/date-time snapshot |
+| Direct native | `getWeather(location, forecastDays)` | `GetWeatherUnifiedSkill.kt` | Unified weather entry point (GPS + explicit city + indirect-location resolution) |
+| Direct native | `saveMemory(content)` | `SaveMemorySkill` | Store facts to long-term memory |
+| Direct native | `searchMemory(query)` | `SearchMemorySkill` | Semantic search across memories |
+| Gateway | `runJs(parameters)` | `JsSkillRunner.kt` | Internal JS skills in `assets/skills/`; parameters is a JSON string with `skill_name` and `data` |
 
 Each `@Tool` method delegates to the matching `Skill.execute()` via `SkillRegistry`, bridging
 the SDK's synchronous callback with `runBlocking` (acceptable since the SDK already blocks its
@@ -494,9 +504,46 @@ interface Skill {
 ```
 
 **Response handling:** The SDK handles tool calls transparently during `generate()`.
-`KernelAIToolSet` tracks turn state (`wasToolCalled()`, `lastToolName()`, `lastToolResult()`)
-so `ChatViewModel` can attach tool call metadata to the UI. A `ToolCallExtractor` text-parsing
-fallback exists for edge cases where the model emits raw JSON outside the SDK path.
+`KernelAIToolSet` tracks turn state (`wasToolCalled()`, `lastToolName()`, `lastToolResult()`,
+`lastToolWasDirectReply()`) so `ChatViewModel` can attach tool call metadata to the UI. For tools
+that return `SkillResult.DirectReply`, `ChatViewModel` now prefers the tool result text itself over
+the model's post-tool synthesis. This guards against visible meta-leaks such as "I used
+query_wikipedia..." or "The result says..." appearing in chat after a successful tool turn. A
+`ToolCallExtractor` text-parsing fallback still exists for edge cases where the model emits raw
+JSON outside the SDK path.
+
+#### 4.2.1 Thinking Mode on Tool Turns
+
+Thinking mode for Gemma-4 is enabled only when **both** of these are true:
+
+1. `ConversationConfig.channels` registers `Channel("thought", "<|think|>", "<|/think|>")`
+2. `sendMessageAsync(..., extraContext = mapOf("enable_thinking" to true))` is used for the turn
+
+Either requirement on its own produces zero thinking tokens.
+
+**Streaming quirk:** Even with channel registration, LiteRT-LM can still mirror wrapped thought
+content through `message.toString()` in the SDK's internal form:
+
+```text
+<|channel>thought
+...
+<channel|>
+```
+
+`LiteRtInferenceEngine` strips this wrapper with `CHANNEL_WRAPPER_RE` and uses
+`ThinkingStreamStateMachine` to split hidden thought deltas from visible response deltas.
+
+**Current hardening for tool turns (PR #946):**
+- explicit tool-like turns get the `[Tool Use]` block
+- follow-up tool turns suppress repeated greetings
+- `query_wikipedia`, `get_system_info`, weather, and memory-search style direct replies are shown
+  from the tool result itself when they return `SkillResult.DirectReply`
+- leaked raw tool syntax / instruction dumps are filtered by `looksLikeRawToolCall(...)`
+
+**Known open gaps / follow-up issues:**
+- #956 — relative weekday phrasing with "tomorrow" can still misroute in QIR
+- #957 — `What do you remember about me` can still misroute to `save_memory`
+- #958 — anaphoric `remember that` follow-ups still need better prior-turn fact resolution
 
 **Registered `run_intent` intents:**
 
@@ -716,8 +763,8 @@ and awaits the result with a 15s timeout.
 
 | Skill name | Description | Status |
 |------------|-------------|--------|
-| `get_system_info` | Device/model/backend/battery stats | ✅ |
-| `query_wikipedia` | Public Wikipedia lookup skill; loads focused instructions, then calls `run_js` with `skill_name="query-wikipedia"` | ✅ |
+| `get_system_info` | Device/model/backend/battery stats; returns `DirectReply` so grounded output wins over post-tool narration | ✅ |
+| `query_wikipedia` | Public Wikipedia lookup skill; exposed as direct `queryWikipedia(query)` wrapper and internally bridged to JS; returns `DirectReply` | ✅ |
 | `save_memory` | Persist a note/fact to `core_memories_vec` | ✅ (explicit trigger only — see memory rule below) |
 | `search_memory` | Semantic search across core memories, episodic memories, and `message_embeddings` | ✅ |
 | `get_weather_gps` / `get_weather` | Weather retrieval with GPS, explicit locations, and indirect-location resolution | ✅ |
@@ -741,10 +788,10 @@ The following skills are all shipped and registered in `SkillRegistry` / `Native
 | `send_email` | `run_intent` → `ACTION_SEND` | Explicit intent only; PR #247 |
 | `send_sms` | `run_intent` → `ACTION_SENDTO` | Background SMS via `SEND_SMS`; PR #247 |
 | `get_weather` | `getWeather()` (unified) | GPS + city + profile location fallback + colloquial QIR routing + indirect-location Nominatim; PR #274, #412, #667 |
-| `query_wikipedia` | `run_js` → WebView | PR #257 |
+| `query_wikipedia` | `queryWikipedia()` → `QueryWikipediaSkill` → `run_js` → WebView | PR #257, hardened PR #946 |
 | `save_memory` | `SaveMemorySkill` | Explicit user trigger; PR #257/#270 |
 | `search_memory` | `SearchMemorySkill` | Cross-conversation semantic search; PR #270, quality PR #326 |
-| `get_system_info` | native Kotlin | datetime fix PR #339 |
+| `get_system_info` | `getSystemInfo()` → native Kotlin | datetime fix PR #339, hardened PR #946 |
 | `create_calendar_event` | `run_intent` → `ACTION_INSERT` | PR #309, date parsing PR #325 |
 | `set_dnd` | `run_intent` → `NotificationManager` | PR #390 |
 | `rich tool result UI` | `ToolResultCard` Compose | Weather cards, confirmation chips, list cards; #222, PR #661 |
@@ -774,7 +821,8 @@ The following skills are all shipped and registered in `SkillRegistry` / `Native
 - Memory rule: user says "remember", "save", "don't forget", "can you remember", or "make a note of" → MUST call `save_memory`
 - Alarm rule: user asks to set an alarm → MUST call `run_intent{intent_name: set_alarm}`
 - Weather rule: `GetWeatherSkill` description includes "ALWAYS call this tool, never use memory" to prevent Gemma-4 from serving stale weather from episodic memory instead of fetching fresh data (#322)
-- Wikipedia rule: `query_wikipedia` is the public skill surface for encyclopedia lookups; it loads focused instructions and then executes the internal `run_js` gateway with `skill_name="query-wikipedia"`
+- Wikipedia rule: `query_wikipedia` is the public skill surface for encyclopedia lookups; the model should prefer direct `queryWikipedia(query=...)`, which internally bridges to the JS runtime
+- System info rule: prompts like "system info" / "device info" should be treated as tool-like so they receive `[Tool Use]` context instead of the softer non-tool reasoning bias
 
 > **Adding new skills:** Registering a skill automatically makes it available in the dynamically
 > generated tool list. If the skill serves requests that do not already look obviously tool-like,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -669,17 +669,20 @@ private fun MessageBubble(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
     ) {
-        // Thinking bubble — expandable, shows chain-of-thought content when tapped
+        // Thinking bubble — auto-expands while streaming, collapses when done, user-toggleable
         if (showThinkingProcess && !message.thinkingText.isNullOrBlank()) {
-            var expanded by rememberSaveable { mutableStateOf(false) }
+            var userExpanded by rememberSaveable { mutableStateOf(false) }
+            val expanded = userExpanded || message.isStreaming
             Column(modifier = Modifier.padding(bottom = 4.dp).testTag("think_bubble")) {
                 Row(
-                    modifier = Modifier.clickable { expanded = !expanded },
+                    modifier = Modifier.clickable { userExpanded = !expanded },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "Thinking…",
-                        style = MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic),
+                        text = if (message.isStreaming) "Thinking…" else "Thinking",
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontStyle = if (message.isStreaming) FontStyle.Italic else FontStyle.Normal,
+                        ),
                         color = MaterialTheme.colorScheme.outline,
                     )
                     Icon(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -688,6 +688,17 @@ private fun MessageBubble(
                         tint = MaterialTheme.colorScheme.outline,
                         modifier = Modifier.size(14.dp),
                     )
+                    IconButton(
+                        onClick = { onCopy(message.thinkingText!!) },
+                        modifier = Modifier.size(20.dp).padding(start = 2.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy thinking",
+                            tint = MaterialTheme.colorScheme.outline,
+                            modifier = Modifier.size(12.dp),
+                        )
+                    }
                 }
                 AnimatedVisibility(visible = expanded) {
                     Surface(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -671,11 +671,11 @@ private fun MessageBubble(
     ) {
         // Thinking bubble — auto-expands while streaming, collapses when done, user-toggleable
         if (showThinkingProcess && !message.thinkingText.isNullOrBlank()) {
-            var userExpanded by rememberSaveable { mutableStateOf(false) }
+            var userExpanded by rememberSaveable(key = "thinking_userExpanded") { mutableStateOf(false) }
             val expanded = userExpanded || message.isStreaming
             Column(modifier = Modifier.padding(bottom = 4.dp).testTag("think_bubble")) {
                 Row(
-                    modifier = Modifier.clickable { userExpanded = !expanded },
+                    modifier = Modifier.clickable { userExpanded = !userExpanded },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -464,7 +464,8 @@ internal fun toolTurnInstruction(isFirstReply: Boolean): String? =
     }
 
 internal fun nonToolTurnInstruction(): String =
-    "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call any tool for this reply."
+    "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. " +
+        "Do NOT call tools unless the user explicitly asks you to look something up or fetch external/current information."
 
 /**
  * Returns true if [response] looks like the model confirmed a tool action without

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -456,6 +456,16 @@ internal fun looksLikeToolFollowUp(
         ).any { context.contains(it) }
 }
 
+internal fun toolTurnInstruction(isFirstReply: Boolean): String? =
+    if (isFirstReply) {
+        null
+    } else {
+        "Do NOT start this reply with a greeting. This is a follow-up tool turn, so answer directly with the tool result."
+    }
+
+internal fun nonToolTurnInstruction(): String =
+    "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call any tool for this reply."
+
 /**
  * Returns true if [response] looks like the model confirmed a tool action without
  * actually calling any tool — the classic Gemma-4 hallucination pattern.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -379,6 +379,7 @@ internal fun looksLikeToolQuery(query: String): Boolean {
         "turn on", "turn off", "toggle", "open app",
         "play ", "navigate to", "directions to",
         "what time", "what's the time", "battery", "get battery",
+        "system info", "device info",
         "meal plan", "plan my meals", "meal planner", "plan meals",
     )
     return toolKeywords.any { keyword ->
@@ -464,8 +465,8 @@ internal fun toolTurnInstruction(isFirstReply: Boolean): String? =
     }
 
 internal fun nonToolTurnInstruction(): String =
-    "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. " +
-        "Do NOT call tools unless the user explicitly asks you to look something up or fetch external/current information."
+    "This looks like a normal conversational or reasoning reply. Prefer answering directly from your own knowledge and reasoning. " +
+        "Only call tools if the user is clearly asking for current, external, or retrieved information."
 
 /**
  * Returns true if [response] looks like the model confirmed a tool action without

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatTextUtils.kt
@@ -497,6 +497,18 @@ internal fun looksLikeToolConfirmation(response: String): Boolean {
 internal fun looksLikeRawToolCall(response: String): Boolean {
     if (response.contains("<|tool_call>") || response.contains("<tool_call|>")) return true
 
+    val lower = response.lowercase()
+    if (
+        ("instructions:" in lower && "tool format:" in lower && "runjs(" in lower) ||
+        Regex(
+            """^[a-z_]+:\s+.*wikipedia""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE),
+        )
+            .containsMatchIn(response)
+    ) {
+        return true
+    }
+
     return Regex(
         """\bcall:(?:load[_ ]?skill|run[_ ]?intent|run[_ ]?js|get[_ ]?weather|save[_ ]?memory|search[_ ]?memory|get[_ ]?system[_ ]?info)\b|
            \{\s*"name"\s*:\s*"(?:load_skill|run_intent|run_js|get_weather|save_memory|search_memory|get_system_info)"""",

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -651,6 +651,8 @@ class ChatViewModel @Inject constructor(
 
             val persisted = conversationRepository.getMessagesOnce(id)
             if (persisted.isNotEmpty()) {
+                val thinkingCount = persisted.count { !it.thinkingText.isNullOrBlank() }
+                if (thinkingCount > 0) Log.d("KernelAI", "thinking_restore: $thinkingCount/${persisted.size} messages have thinkingText")
                 _messages.value = persisted.map { entity ->
                     ChatMessage(
                         id = entity.id,
@@ -1700,6 +1702,7 @@ class ChatViewModel @Inject constructor(
                                 rawContent
                             }
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
+                            Log.d("KernelAI", "thinking_save: thinkingLen=${thinking?.length ?: 0}, contentLen=${fullContent.length}")
 
                             // Guard: LiteRT occasionally produces 0 tokens (TTFT=-1ms) when the model
                             // generates an immediate EOS — often triggered by an unusual RAG injection

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1663,6 +1663,7 @@ class ChatViewModel @Inject constructor(
                 hallucinationRetryAttempted = false
                 var rawToolCallRetryAttempted = false
                 var blankResponseRetryAttempted = false
+                var preservedThinkingText: String? = null
                 var currentPrompt = prompt
                 var needsHallucinationRetry: Boolean
 
@@ -1702,6 +1703,7 @@ class ChatViewModel @Inject constructor(
                                 rawContent
                             }
                             val thinking = accumulatedThinking.toString().takeIf { it.isNotBlank() }
+                                ?: preservedThinkingText
                             Log.d("KernelAI", "thinking_save: thinkingLen=${thinking?.length ?: 0}, contentLen=${fullContent.length}")
 
                             // Guard: LiteRT occasionally produces 0 tokens (TTFT=-1ms) when the model
@@ -1712,6 +1714,10 @@ class ChatViewModel @Inject constructor(
                             if (fullContent.isBlank()) {
                                 if (!blankResponseRetryAttempted) {
                                     blankResponseRetryAttempted = true
+                                    // Preserve thinking from first attempt — the retry runs without RAG
+                                    // and may produce no thinking tokens, which would overwrite a valid
+                                    // chain-of-thought with an empty string.
+                                    if (thinking != null) preservedThinkingText = thinking
                                     Log.w("KernelAI", "blank_response_guard: 0 tokens — retrying without RAG context")
                                     // Null out grounding context so correctGroundedFacts does not
                                     // mutate the retry response using stale RAG-injected data.

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1629,12 +1629,15 @@ class ChatViewModel @Inject constructor(
                     buildToolUsePrompt()
                         .takeIf { it.isNotBlank() }
                         ?.let { append("$it\n\n") }
+                    toolTurnInstruction(isFirstReply)
+                        ?.let { append("[System: $it]\n\n") }
                 }
                 // Greeting instruction injected per-turn so turn 1 says "Kia ora" and
                 // subsequent turns explicitly suppress greetings — without invalidating the KV cache.
                 // Suppressed entirely for tool queries to keep the prompt focused.
                 if (!isToolQuery) {
                     append("[System: ${jandalPersona.buildGreetingInstruction(isFirstReply, jandalPersona.currentPersonaMode)}]\n\n")
+                    append("[System: ${nonToolTurnInstruction()}]\n\n")
                 }
                 append(text)
             }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -597,19 +597,17 @@ class ChatViewModel @Inject constructor(
         if (skillNames.isBlank()) return ""
         return buildString {
             append("[Tool Use]\n")
-            append("You are an AI assistant that helps users by answering questions and completes tasks using skills.\n")
-            append("For EVERY new task, request, or question that needs a tool, you MUST execute these steps in exact order.\n")
-            append("You MUST NOT skip any steps.\n\n")
-            append("1. First, find the most relevant skill from this list:\n")
+            append("You are an AI assistant that helps users by answering questions and completing tasks using skills.\n")
+            append("Use native tools directly whenever the right tool and required arguments are obvious.\n")
+            append("Use load_skill only when you need extra instructions for a complex or gateway skill.\n\n")
+            append("Available skills:\n")
             append(skillNames)
             append("\n\n")
-            append("After this step you MUST go to the next step. ")
-            append("You MUST NOT use run_intent under any circumstances at this step.\n\n")
-            append("2. If a relevant skill exists, call load_skill with the skill name to get its full instructions.\n\n")
-            append("You MUST NOT use run_intent under any circumstances at this step.\n\n")
-            append("3. Follow the skill's instructions exactly to complete the task. ")
-            append("Only use run_intent after steps 1 and 2 are complete and only when the loaded skill tells you to. ")
-            append("Output ONLY the final result to the user when successful.\n\n")
+            append("Rules:\n")
+            append("1. Choose the most relevant native tool for the user's request.\n")
+            append("2. Call that tool directly when its name and parameters are clear from the request.\n")
+            append("3. If you are unsure about parameters or need gateway-specific rules, call load_skill first, then follow its instructions.\n")
+            append("4. Output ONLY the final user-facing result when successful.\n\n")
             append("CRITICAL: Execute all steps silently. Do NOT output intermediate reasoning, status updates, or tool call text.")
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -2097,7 +2097,7 @@ class ChatViewModel @Inject constructor(
         try {
             // generateOnce() reuses the existing conversation session (LiteRT only supports
             // one session at a time) and acquires generationMutex so it waits if engine is busy.
-            val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = null)
+            val raw = inferenceEngine.generateOnce(titlePrompt, systemPrompt = null, thinkingEnabled = false)
             Log.d("KernelAI", "Raw title output: \"$raw\"")
             val title = raw
                 .trim()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1787,7 +1787,11 @@ class ChatViewModel @Inject constructor(
 
                             if (nativeToolCall != null || toolCallResult != null) {
                                 val toolCall = nativeToolCall ?: toolCallResult!!.first
+                                val nativeToolWasDirectReply =
+                                    nativeToolCall != null && kernelAIToolSet.lastToolWasDirectReply()
                                 val resultContent = when {
+                                    nativeToolWasDirectReply ->
+                                        toolCall.resultText
                                     nativeToolCall != null && toolCall.presentation != null && toolCall.isSuccess ->
                                         toolCall.resultText
                                     nativeToolCall != null -> fullContent

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -523,6 +523,7 @@ class ChatTextUtilsTest {
                 "save this meal plan to my shopping list",
                 "open app settings",
                 "toggle flashlight",
+                "what's the current system info",
                 "note that my password is 1234",
                 "don't forget the meeting",
                 "store my preference",
@@ -637,9 +638,9 @@ class ChatTextUtilsTest {
         }
 
         @Test
-        fun `non tool instruction forbids tools`() {
+        fun `non tool instruction softly prefers reasoning`() {
             assertEquals(
-                "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call tools unless the user explicitly asks you to look something up or fetch external/current information.",
+                "This looks like a normal conversational or reasoning reply. Prefer answering directly from your own knowledge and reasoning. Only call tools if the user is clearly asking for current, external, or retrieved information.",
                 nonToolTurnInstruction(),
             )
         }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -642,6 +642,23 @@ class ChatTextUtilsTest {
         }
 
         @Test
+        fun `returns true for leaked skill instructions`() {
+            assertTrue(
+                looksLikeRawToolCall(
+                    """
+                    query_wikipedia: Look up a topic on Wikipedia and return grounded factual context.
+
+                    Instructions:
+                    - Call the run_js tool with the format below.
+
+                    Tool format:
+                    - Call runJs with a single 'parameters' argument.
+                    """.trimIndent(),
+                ),
+            )
+        }
+
+        @Test
         fun `returns false for normal assistant reply`() {
             assertFalse(looksLikeRawToolCall("Here are the three meals I came up with."))
         }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -639,7 +639,7 @@ class ChatTextUtilsTest {
         @Test
         fun `non tool instruction forbids tools`() {
             assertEquals(
-                "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call any tool for this reply.",
+                "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call tools unless the user explicitly asks you to look something up or fetch external/current information.",
                 nonToolTurnInstruction(),
             )
         }
@@ -687,6 +687,15 @@ class ChatTextUtilsTest {
         @Test
         fun `returns false for normal assistant reply`() {
             assertFalse(looksLikeRawToolCall("Here are the three meals I came up with."))
+        }
+
+        @Test
+        fun `returns false for normal response mentioning wikipedia with colon`() {
+            assertFalse(
+                looksLikeRawToolCall(
+                    "On Wikipedia: the week is a unit of time equal to seven days.",
+                ),
+            )
         }
     }
 

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatTextUtilsTest.kt
@@ -620,6 +620,32 @@ class ChatTextUtilsTest {
     }
 
     @Nested
+    @DisplayName("turn instructions")
+    inner class TurnInstructionTests {
+
+        @Test
+        fun `tool turn instruction is omitted on first reply`() {
+            assertEquals(null, toolTurnInstruction(isFirstReply = true))
+        }
+
+        @Test
+        fun `tool turn instruction suppresses greeting on follow up`() {
+            assertEquals(
+                "Do NOT start this reply with a greeting. This is a follow-up tool turn, so answer directly with the tool result.",
+                toolTurnInstruction(isFirstReply = false),
+            )
+        }
+
+        @Test
+        fun `non tool instruction forbids tools`() {
+            assertEquals(
+                "This is a normal conversational or reasoning reply. Answer directly from your own knowledge and reasoning. Do NOT call any tool for this reply.",
+                nonToolTurnInstruction(),
+            )
+        }
+    }
+
+    @Nested
     @DisplayName("looksLikeRawToolCall")
     inner class RawToolCallTests {
 


### PR DESCRIPTION
## Summary

Fixes thinking mode (chain-of-thought) for Gemma-4 E-4B. The model was silently skipping all reasoning — zero thinking tokens were emitted during inference despite the `Channel` being registered.

## Root Cause

Two things are required to enable Gemma thinking via the LiteRT-LM SDK:

1. **`Channel("thought", "<|think|>", "<|/think|>")` in `ConversationConfig`** — routes tokens between the thinking delimiters to `message.channels["thought"]` instead of the main text output. We had this ✅
2. **`extraContext = mapOf("enable_thinking" to true)` in `sendMessageAsync`** — sets the Jinja template variable that injects `<|think|>` before the model's response, triggering chain-of-thought generation. We were missing this ❌

Without `enable_thinking` in `extraContext`, the prompt template never injects `<|think|>` and the model responds directly without reasoning, regardless of the Channel config.

This was confirmed by:
- Live ADB logcat showing `thinkingCharCount == 0` on the farmer maths prompt
- Reading the [LiteRT-LM Kotlin API docs](https://github.com/google-ai-edge/LiteRT-LM/blob/main/docs/api/kotlin/getting_started.md#7-extra-template-context-variables) which explicitly document `enable_thinking` as a template context variable
- Inspecting Edge Gallery source — they also call `message.channels["thought"]` without Channel registration (standard chat doesn't pass `enable_thinking` either, so their standard chat also doesn't think)

## Changes

- `LiteRtInferenceEngine.kt` — pass `extraContext = mapOf("enable_thinking" to true)` in both `sendMessageAsync` call sites (`generate()` and `generateOnce()`) when `thinkingEnabled` is true
- Updated the Channel registration comment to document both requirements

## Testing

- [ ] Unit tests pass (`./gradlew :core:inference:testDebugUnitTest`)
- [ ] Install debug APK from CI and run a reasoning-heavy prompt (e.g. multi-step maths)
- [ ] Confirm `Thinking tokens: N chars` appears in `adb logcat -s KernelAI`
- [ ] Confirm thinking bubble appears and is expandable in the chat UI

## Related issues

Closes #941
