### PR TITLE
feat(#967): add meal plans FAB to start new planner

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -1,6 +1,5 @@
 package com.kernel.ai.navigation
 
-import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -59,8 +58,9 @@ import com.kernel.ai.feature.settings.SettingsScreen
 import com.kernel.ai.feature.settings.SidePanelScreen
 import com.kernel.ai.feature.settings.UserProfileScreen
 import com.kernel.ai.feature.settings.VoiceScreen
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.launch
-
 private const val ROUTE_LIST = "conversation_list"
 private const val ROUTE_ACTIONS = "actions"
 private const val ROUTE_ACTIONS_OPEN = "actions?openSheet=true"
@@ -94,9 +94,34 @@ private const val ARG_WIDGET_VOICE = "widgetVoice"
 private const val STATE_OPEN_SHEET_CONSUMED = "openSheetConsumed"
 private const val STATE_START_VOICE_CONSUMED = "startVoiceConsumed"
 private const val STATE_WIDGET_QUERY_CONSUMED = "widgetQueryConsumed"
+private const val NEW_MEAL_PLAN_INITIAL_QUERY = "plan meals"
 
 /** Routes that show the bottom navigation bar. */
 private val BOTTOM_NAV_ROUTES = setOf(ROUTE_LIST, ROUTE_ACTIONS)
+
+internal fun buildChatRoute(
+    initialQuery: String? = null,
+    minimalContext: Boolean = false,
+    speakResponse: Boolean = false,
+): String {
+    val encodedQuery = initialQuery?.trim()?.takeIf { it.isNotEmpty() }?.let(::encodeRouteQueryValue)
+    val params = buildList {
+        encodedQuery?.let { add("$ARG_INITIAL_QUERY=$it") }
+        if (minimalContext) add("$ARG_MINIMAL_CONTEXT=true")
+        if (speakResponse) add("$ARG_SPEAK_RESPONSE=true")
+    }
+    return if (params.isEmpty()) ROUTE_CHAT else "$ROUTE_CHAT?${params.joinToString("&")}"
+}
+
+internal fun buildNewMealPlanChatRoute(): String =
+    buildChatRoute(
+        initialQuery = NEW_MEAL_PLAN_INITIAL_QUERY,
+        minimalContext = true,
+    )
+
+internal fun encodeRouteQueryValue(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8)
+        .replace("+", "%20")
 
 @Composable
 fun KernelNavHost(
@@ -116,8 +141,7 @@ fun KernelNavHost(
     // ADB test harness: navigate to chat from any screen when chat_input extra is delivered
     LaunchedEffect(initialChatQuery) {
         if (!initialChatQuery.isNullOrBlank()) {
-            val encoded = Uri.encode(initialChatQuery)
-            navController.navigate("$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded") {
+            navController.navigate(buildChatRoute(initialQuery = initialChatQuery)) {
                 popUpTo(ROUTE_LIST)
             }
         }
@@ -128,7 +152,7 @@ fun KernelNavHost(
     // before ActionsScreen's LaunchedEffect fires).
     LaunchedEffect(initialQuickActionQuery, initialQuickActionIsVoice) {
         if (!initialQuickActionQuery.isNullOrBlank()) {
-            val encoded = Uri.encode(initialQuickActionQuery)
+            val encoded = encodeRouteQueryValue(initialQuickActionQuery)
             navController.navigate(
                 "$ROUTE_ACTIONS?$ARG_WIDGET_QUERY=$encoded&$ARG_WIDGET_VOICE=$initialQuickActionIsVoice"
             ) {
@@ -373,9 +397,12 @@ fun KernelNavHost(
                                 backStackEntry.arguments?.putString(ARG_WIDGET_QUERY, "")
                             },
                             onNavigateToChat = { query, speakResponse ->
-                                val encoded = Uri.encode(query)
                                 navController.navigate(
-                                    "$ROUTE_CHAT?$ARG_INITIAL_QUERY=$encoded&$ARG_MINIMAL_CONTEXT=true&$ARG_SPEAK_RESPONSE=$speakResponse"
+                                    buildChatRoute(
+                                        initialQuery = query,
+                                        minimalContext = true,
+                                        speakResponse = speakResponse,
+                                    ),
                                 )
                             },
                             onNewConversation = {
@@ -499,6 +526,11 @@ fun KernelNavHost(
                 composable(ROUTE_MEAL_PLANS) {
                     MealPlansScreen(
                         onBack = { navController.popBackStack() },
+                        onStartNewMealPlan = {
+                            navController.navigate(buildNewMealPlanChatRoute()) {
+                                popUpTo(ROUTE_CHAT) { inclusive = true }
+                            }
+                        },
                     )
                 }
 

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -527,9 +527,7 @@ fun KernelNavHost(
                     MealPlansScreen(
                         onBack = { navController.popBackStack() },
                         onStartNewMealPlan = {
-                            navController.navigate(buildNewMealPlanChatRoute()) {
-                                popUpTo(ROUTE_CHAT) { inclusive = true }
-                            }
+                            navController.navigate(buildNewMealPlanChatRoute())
                         },
                     )
                 }

--- a/app/src/test/java/com/kernel/ai/navigation/KernelNavHostRouteTest.kt
+++ b/app/src/test/java/com/kernel/ai/navigation/KernelNavHostRouteTest.kt
@@ -1,0 +1,31 @@
+package com.kernel.ai.navigation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KernelNavHostRouteTest {
+    @Test
+    fun `buildChatRoute returns base route when no extras requested`() {
+        assertEquals("chat", buildChatRoute())
+    }
+
+    @Test
+    fun `buildChatRoute encodes initial query and flags`() {
+        assertEquals(
+            "chat?initialQuery=plan%20meals%20%26%20snacks&minimalContext=true&speakResponse=true",
+            buildChatRoute(
+                initialQuery = "plan meals & snacks",
+                minimalContext = true,
+                speakResponse = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `buildNewMealPlanChatRoute starts fresh planner handoff`() {
+        assertEquals(
+            "chat?initialQuery=plan%20meals&minimalContext=true",
+            buildNewMealPlanChatRoute(),
+        )
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/MealPlansScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -30,6 +31,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -78,6 +80,7 @@ private data class IngredientListRequest(
 @Composable
 fun MealPlansScreen(
     onBack: () -> Unit = {},
+    onStartNewMealPlan: () -> Unit = {},
     viewModel: MealPlansViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -100,6 +103,11 @@ fun MealPlansScreen(
                     }
                 },
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onStartNewMealPlan) {
+                Icon(Icons.Default.Add, contentDescription = "Start new meal plan")
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->


### PR DESCRIPTION
## Summary
- add a `+` FAB to the Meal plans screen using the existing settings-screen FAB pattern
- route the FAB through the existing chat initial-query path so it opens chat and starts a fresh meal-planner session
- add route-construction unit tests for the new fresh-planner handoff

## Testing
- ./gradlew --rerun-tasks :app:testDebugUnitTest --tests "*KernelNavHostRouteTest" :feature:settings:compileDebugKotlin :app:assembleDebug

## Manual test checklist
- Open the drawer and go to **Meal plans**
- Confirm a `+` FAB is visible on the screen
- Tap the FAB and confirm the app opens chat in a fresh conversation
- Confirm the initial `plan meals` handoff is auto-submitted and the meal planner starts
- Confirm the flow does not resume an older planner session from another conversation

Closes #967