### PR TITLE
fix(#929): add QIR patterns for weather queries without 'forecast' keyword

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1251,6 +1251,38 @@ class QuickIntentRouter(
                 }
             },
         ),
+        // Multi-day forecast (digit): "what's the weather for the next N days" (no "forecast" word)
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(\d+)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // Multi-day forecast (word): "what's the weather for the next seven days" (no "forecast" word)
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
+                val daysWord = match.groupValues[1].takeIf { it != "one" }
+                buildMap<String, String> {
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                }
+            },
+        ),
         // Tomorrow weather: "is it going to rain tomorrow", "will it rain tomorrow"
         IntentPattern(
             intentName = "get_weather",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1302,6 +1302,79 @@ class QuickIntentRouter(
                 }
             },
         ),
+        // ── Location-aware multi-day forecast patterns (must precede generic ones) ──
+        // Digit, location before "next N days": "what's the weather for Brisbane next 3 days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(\d+)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[2].takeIf { it != "1" }
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // Digit, location after "next N days in <city>": "what's the weather for the next 3 days in Paris"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // Word, location before "next N days": "what's the weather for Brisbane next seven days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
+                val daysWord = match.groupValues[2].takeIf { it != "one" }
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
+                }
+            },
+        ),
+        // Word, location after "next N days in <city>": "what's the weather for the next seven days in Paris"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
+                val daysWord = match.groupValues[1].takeIf { it != "one" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
+                }
+            },
+        ),
         // Multi-day forecast (word): "what's the forecast for the next seven days" /
         // "what's the weather forecast for the next seven days"
         IntentPattern(
@@ -1317,7 +1390,7 @@ class QuickIntentRouter(
                 )
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 buildMap<String, String> {
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
                 }
             },
         ),
@@ -1335,7 +1408,7 @@ class QuickIntentRouter(
                 )
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 buildMap<String, String> {
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
                 }
             },
         ),
@@ -1355,27 +1428,7 @@ class QuickIntentRouter(
                 val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
                 buildMap<String, String> {
                     if (location != null) put("location", location)
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
-                }
-            },
-        ),
-        // Multi-day forecast (word): "what's the weather forecast for Paris next seven days"
-        IntentPattern(
-            intentName = "get_weather",
-            regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+forecast\s+for\s+([\w\s,]+?)\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ ->
-                val wordToNum = mapOf(
-                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
-                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
-                )
-                val daysWord = match.groupValues[2].takeIf { it != "one" }
-                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
-                buildMap<String, String> {
-                    if (location != null) put("location", location)
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
                 }
             },
         ),
@@ -1407,7 +1460,7 @@ class QuickIntentRouter(
                 )
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 buildMap<String, String> {
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
                 }
             },
         ),

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1452,7 +1452,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1464,7 +1464,7 @@ class QuickIntentRouter(
                 val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
                 buildMap<String, String> {
                     if (location != null) put("location", location)
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", when (daysWord.lowercase()) { "few" -> "3"; else -> wordToNum[daysWord.lowercase()] ?: daysWord })
                 }
             },
         ),
@@ -1543,7 +1543,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s*$""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1553,7 +1553,7 @@ class QuickIntentRouter(
                 )
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 buildMap<String, String> {
-                    if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
+                    if (daysWord != null) put("forecast_days", when (daysWord.lowercase()) { "few" -> "3"; else -> wordToNum[daysWord.lowercase()] ?: daysWord })
                 }
             },
         ),

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1529,7 +1529,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
+                """(?:what|how)(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1543,7 +1543,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s*$""",
+                """(?:what|how)(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1562,7 +1562,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """(?:what|how)(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1578,15 +1578,19 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """(?:what|how)(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(few|one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
                 buildMap<String, String> {
                     if (location != null) put("location", location)
-                    if (daysWord != null) put("forecast_days", daysWord.lowercase())
+                    if (daysWord != null) put("forecast_days", when (daysWord.lowercase()) { "few" -> "3"; else -> wordToNum[daysWord.lowercase()] ?: daysWord })
                 }
             },
         ),

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1290,7 +1290,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+forecast\s+for\s+([\w\s,]+?)\s+next\s+(\d+)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+forecast\s+(?:for|over)\s+([\w\s,]+?)\s+next\s+(\d+)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1307,7 +1307,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(\d+)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(\d+)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1323,7 +1323,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1339,7 +1339,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+(?!the\s+next|a\s+next|an\s+next)([\w\s,]+?)\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1359,7 +1359,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1380,7 +1380,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+(?:for|over)\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1398,7 +1398,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+(?:for|over)\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1416,7 +1416,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(one|two|three|four|five|six|seven|eight|nine|ten)\s+day\s+(?:weather\s+)?forecast\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                """(one|two|three|four|five|six|seven|eight|nine|ten)\s+day\s+(?:weather\s+)?forecast\s+(?:in|for|at|over)\s+([\w\s,]+?)\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1436,7 +1436,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(\d+)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1256,6 +1256,22 @@ class QuickIntentRouter(
                 }
             },
         ),
+        // "what's the weather forecast for the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
         // Multi-day forecast (digit): "how's the weather looking for the next 5 days"
         IntentPattern(
             intentName = "get_weather",
@@ -1709,7 +1725,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:will\s+it\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?\s*$|is\s+it\s+(?:going\s+to|gonna)\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?\s*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?)""",
+"""(?:will\s+it\s+rain(?:\s+today|\s+tonight)?\s*$|is\s+it\s+(?:going\s+to|gonna)\s+rain(?:\s+today|\s+tonight)?\s*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight)?)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1246,7 +1246,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(\d+)\s+days""",
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(?:weather\s+)?forecast\s+for\s+the\s+next\s+(\d+)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1260,12 +1260,89 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+for\s+the\s+next\s+(\d+)\s+days""",
+                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+looking\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
                 val days = match.groupValues[1].takeIf { it != "1" }
                 buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "how's the weather over the next N days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s|\s+is)\s+(?:the\s+)?weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "what's the weather looking like over the next N days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s|\s+is)\s+the\s+weather\s+looking\s+like\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // ── Location-aware over variants ──
+        // "how's the weather over the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s| is)\s+(?:the\s+)?weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "what's the weather looking like over the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+looking\s+like\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "how's the weather looking over the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s| is)\s+(?:the\s+)?weather\s+looking\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
                     if (days != null) put("forecast_days", days)
                 }
             },
@@ -1436,7 +1513,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1450,7 +1527,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days""",
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1461,6 +1538,39 @@ class QuickIntentRouter(
                 val daysWord = match.groupValues[1].takeIf { it != "one" }
                 buildMap<String, String> {
                     if (daysWord != null) put("forecast_days", wordToNum[daysWord.lowercase()] ?: daysWord)
+                }
+            },
+        ),
+        // ── Location-aware next-N-days variants ──
+        // "what's the weather for the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+(?:for|over)\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "what's the weather for the next N days in <city>" (word form)
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+for\s+the\s+next\s+(one|two|three|four|five|six|seven|eight|nine|ten)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val daysWord = match.groupValues[1].takeIf { it != "one" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (daysWord != null) put("forecast_days", daysWord.lowercase())
                 }
             },
         ),
@@ -1492,6 +1602,77 @@ class QuickIntentRouter(
             intentName = "get_weather",
             regex = Regex(
                 """(?:what(?:'s| is)\s+(?:the\s+)?weather\s+(?:looking\s+)?tomorrow\s*$|tomorrow(?:'s)?\s+(?:weather|temperature)\s*$|how(?:'s|\s+is)\s+(?:the\s+)?weather\s+(?:looking\s+)?tomorrow\s*$)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> mapOf("day" to "tomorrow") },
+        ),
+        // ── Location-aware tomorrow variants ──
+        // "what's the weather looking like tomorrow in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+looking\s+like\s+tomorrow\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    put("day", "tomorrow")
+                }
+            },
+        ),
+        // "how's the weather looking tomorrow in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s| is)\s+(?:the\s+)?weather\s+looking\s+tomorrow\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    put("day", "tomorrow")
+                }
+            },
+        ),
+        // "how's the weather tomorrow in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """how(?:'s| is)\s+(?:the\s+)?weather\s+tomorrow\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    put("day", "tomorrow")
+                }
+            },
+        ),
+        // "is it going to rain tomorrow in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """is\s+it\s+(?:going\s+to|gonna)\s+rain\s+tomorrow\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    put("day", "tomorrow")
+                }
+            },
+        ),
+        // "what's the weather looking like tomorrow" — not covered by the generic
+        // "what's the weather looking like tomorrow"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """what(?:'s| is)\s+the\s+weather\s+looking\s+like\s+tomorrow\s*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> mapOf("day" to "tomorrow") },
@@ -1528,10 +1709,66 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:will\s+it\s+rain(?:\s+today|\s+tonight)?\s*$|is\s+it\s+(?:going\s+to|gonna)\s+rain(?:\s+today|\s+tonight)?\s*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight)?)""",
+                """(?:will\s+it\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?\s*$|is\s+it\s+(?:going\s+to|gonna)\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?\s*$|is\s+it\s+raining|do\s+i\s+need\s+(?:an?\s+)?umbrella|chance\s+of\s+rain(?:\s+today|\s+tonight|\s+tomorrow)?)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
+        ),
+        // ── Rain over the next N days ──
+        // "is it going to rain over the next N days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """is\s+it\s+(?:going\s+to|gonna)\s+rain\s+over\s+the\s+next\s+(\d+)\s+days\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                buildMap<String, String> {
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "is it going to rain over the next few days"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """is\s+it\s+(?:going\s+to|gonna)\s+rain\s+over\s+the\s+next\s+few\s+days\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> mapOf("forecast_days" to "3") },
+        ),
+        // ── Location-aware rain-over variants ──
+        // "is it going to rain over the next N days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """is\s+it\s+(?:going\s+to|gonna)\s+rain\s+over\s+the\s+next\s+(\d+)\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val days = match.groupValues[1].takeIf { it != "1" }
+                val location = match.groupValues[2].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    if (days != null) put("forecast_days", days)
+                }
+            },
+        ),
+        // "is it going to rain over the next few days in <city>"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """is\s+it\s+(?:going\s+to|gonna)\s+rain\s+over\s+the\s+next\s+few\s+days\s+(?:in|for|at)\s+([\w\s,]+?)\s*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val location = match.groupValues[1].trim().takeIf { it.isNotEmpty() }
+                buildMap<String, String> {
+                    if (location != null) put("location", location)
+                    put("forecast_days", "3")
+                }
+            },
         ),
         // Temperature queries: "how hot/cold is it", "what's the temperature outside", "temperature in Wellington"
         IntentPattern(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3127,6 +3127,14 @@ class QuickIntentRouterTest {
             // "over" preposition word-form: "what's the weather over the next few days" (#972)
             Arguments.of("what's the weather over the next few days", "3", null),
             Arguments.of("what's the weather over the next seven days", "7", null),
+            // "how's" word-form: "how's the weather for/over the next few/seven days" (Nick bug report)
+            Arguments.of("how's the weather for the next few days", "3", null),
+            Arguments.of("how's the weather over the next few days", "3", null),
+            Arguments.of("how's the weather for the next seven days", "7", null),
+            Arguments.of("how is the weather over the next few days", "3", null),
+            // "how's" location-aware word-form
+            Arguments.of("how's the weather for the next few days in Auckland", "3", "Auckland"),
+            Arguments.of("how's the weather over the next seven days in Melbourne", "7", "Melbourne"),
             // Location-aware "over" variants
             Arguments.of("how's the weather over the next 3 days in Paris", "3", "Paris"),
             Arguments.of("what's the weather looking like over the next 5 days in Auckland", "5", "Auckland"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -2939,6 +2939,10 @@ class QuickIntentRouterTest {
             Arguments.of("how is the weather looking for the next five days", "5", null),
             Arguments.of("7 day weather forecast for Brisbane", "7", "Brisbane"),
             Arguments.of("what's the weather forecast for Paris next 4 days", "4", "Paris"),
+            // #929: "what's the weather for the next N days" — no "forecast" word (was falling through to LLM)
+            Arguments.of("what's the weather for the next 3 days", "3", null),
+            Arguments.of("What's the weather for the next 3 days", "3", null),
+            Arguments.of("what's the weather for the next seven days", "7", null),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3111,6 +3111,9 @@ class QuickIntentRouterTest {
             Arguments.of("what's the weather for Brisbane next 3 days", "3", "Brisbane"),
             Arguments.of("what's the weather for Paris next 7 days", "7", "Paris"),
             // Location-aware variants: city after "next N days in <city>"
+            // Location-aware forecast: "what's the weather forecast for the next N days in <city>"
+            Arguments.of("what's the weather forecast for the next 3 days in Paris", "3", "Paris"),
+            Arguments.of("what's the weather forecast for the next 5 days in Auckland", "5", "Auckland"),
             Arguments.of("what's the weather for the next 3 days in Paris", "3", "Paris"),
             Arguments.of("what's the weather for the next seven days in Auckland", "7", "Auckland"),
             // Capitalized word variant (lowercase() fix)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3124,10 +3124,16 @@ class QuickIntentRouterTest {
             Arguments.of("how is the weather over the next 5 days", "5", null),
             Arguments.of("what's the weather looking like over the next 3 days", "3", null),
             Arguments.of("what's the weather looking like over the next 5 days", "5", null),
+            // "over" preposition word-form: "what's the weather over the next few days" (#972)
+            Arguments.of("what's the weather over the next few days", "3", null),
+            Arguments.of("what's the weather over the next seven days", "7", null),
             // Location-aware "over" variants
             Arguments.of("how's the weather over the next 3 days in Paris", "3", "Paris"),
             Arguments.of("what's the weather looking like over the next 5 days in Auckland", "5", "Auckland"),
             Arguments.of("how's the weather looking over the next 3 days in Melbourne", "3", "Melbourne"),
+            // Location-aware "over" word-form: "what's the weather over the next few days in <city>" (#972)
+            Arguments.of("what's the weather over the next few days in Auckland", "3", "Auckland"),
+            Arguments.of("what's the weather over the next seven days in Melbourne", "7", "Melbourne"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3116,6 +3116,15 @@ class QuickIntentRouterTest {
             // Capitalized word variant (lowercase() fix)
             Arguments.of("What's the weather for the next Seven days", "7", null),
             Arguments.of("what's the weather for Brisbane next Seven days", "7", "Brisbane"),
+            // "over" preposition variants
+            Arguments.of("how's the weather over the next 3 days", "3", null),
+            Arguments.of("how is the weather over the next 5 days", "5", null),
+            Arguments.of("what's the weather looking like over the next 3 days", "3", null),
+            Arguments.of("what's the weather looking like over the next 5 days", "5", null),
+            // Location-aware "over" variants
+            Arguments.of("how's the weather over the next 3 days in Paris", "3", "Paris"),
+            Arguments.of("what's the weather looking like over the next 5 days in Auckland", "5", "Auckland"),
+            Arguments.of("how's the weather looking over the next 3 days in Melbourne", "3", "Melbourne"),
         )
 
         @JvmStatic
@@ -3125,6 +3134,14 @@ class QuickIntentRouterTest {
             Arguments.of("is it raining"),
             Arguments.of("do I need an umbrella"),
             Arguments.of("chance of rain"),
+            // "over" preposition rain variants
+            Arguments.of("is it going to rain over the next 5 days"),
+            Arguments.of("is it going to rain over the next 3 days"),
+            Arguments.of("is it going to rain over the next few days"),
+            // Location-aware rain-over variants
+            Arguments.of("is it going to rain over the next 5 days in Brisbane"),
+            Arguments.of("is it going to rain over the next few days in Auckland"),
+            Arguments.of("is it going to rain over the next 3 days in Perth"),
         )
         @JvmStatic
         fun weatherTomorrowRegexPhrases(): Stream<Arguments> = Stream.of(
@@ -3138,6 +3155,14 @@ class QuickIntentRouterTest {
             Arguments.of("is it going to be cloudy tomorrow", "tomorrow", null),
             Arguments.of("what's the weather in Brisbane tomorrow", "tomorrow", "Brisbane"),
             Arguments.of("tomorrow weather in Auckland", "tomorrow", "Auckland"),
+            // New tomorrow patterns (missing from existing set)
+            Arguments.of("what's the weather looking like tomorrow", "tomorrow", null),
+            Arguments.of("how's the weather looking tomorrow", "tomorrow", null),
+            // Location-aware tomorrow variants
+            Arguments.of("what's the weather looking like tomorrow in Wellington", "tomorrow", "Wellington"),
+            Arguments.of("how's the weather looking tomorrow in Melbourne", "tomorrow", "Melbourne"),
+            Arguments.of("how's the weather tomorrow in Sydney", "tomorrow", "Sydney"),
+            Arguments.of("is it going to rain tomorrow in Perth", "tomorrow", "Perth"),
         )
 
         @JvmStatic

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3107,6 +3107,15 @@ class QuickIntentRouterTest {
             Arguments.of("what's the weather for the next 3 days", "3", null),
             Arguments.of("What's the weather for the next 3 days", "3", null),
             Arguments.of("what's the weather for the next seven days", "7", null),
+            // Location-aware variants (oracle review #972): city before "next N days"
+            Arguments.of("what's the weather for Brisbane next 3 days", "3", "Brisbane"),
+            Arguments.of("what's the weather for Paris next 7 days", "7", "Paris"),
+            // Location-aware variants: city after "next N days in <city>"
+            Arguments.of("what's the weather for the next 3 days in Paris", "3", "Paris"),
+            Arguments.of("what's the weather for the next seven days in Auckland", "7", "Auckland"),
+            // Capitalized word variant (lowercase() fix)
+            Arguments.of("What's the weather for the next Seven days", "7", null),
+            Arguments.of("what's the weather for Brisbane next Seven days", "7", "Brisbane"),
         )
 
         @JvmStatic


### PR DESCRIPTION
## Problem

User query `"What's the weather for the next 3 days"` was not matched by any QuickIntentRouter regex. The query fell through to Gemma-4, which incorrectly extracted `"the next 3 days"` as the `location` parameter, producing:

```
Action failed: Couldn't find location: the next 3 days. Please try a different city or location name.
```

## Root cause

All "for the next N days" QIR patterns required the word **"forecast"** between "weather" and "for". Queries like `"What's the weather for the next 3 days"` (no "forecast" keyword) had no match and fell through to the LLM.

## Fix

Added two new `IntentPattern` entries in `QuickIntentRouter.kt`:

| Variant | Pattern | Example |
|---------|---------|---------|
| Digit | `what(?:'s\| is)\s+the\s+weather\s+for\s+the\s+next\s+(\d+)\s+days` | "What's the weather for the next 3 days" |
| Word | `what(?:'s\| is)\s+the\s+weather\s+for\s+the\s+next\s+(one\|two\|...)\s+days` | "What's the weather for the next seven days" |

Both extract only `forecast_days` (no location), routing to GPS-based weather with multi-day forecast — matching the user's intent.

## Testing

- All `:core:skills:testDebugUnitTest` pass
- New test cases added to `weatherForecastRegexPhrases` parameterized test
- Smoke test passes

Closes #929