### PR TITLE
fix(#1005): Honor Magic 8 Pro — STT backend, assistant role button, log export

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -145,9 +145,15 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         backend = startBackend,
                     )
                 } catch (onDeviceEx: Exception) {
-                    // On-device recognizer failed to start (e.g. not installed, OOM). Attempt
-                    // platform recognizer once before giving up entirely.
+                    // On-device recognizer failed to start (e.g. not installed, OOM). Clean up
+                    // any partially-constructed recognizer before retrying with Platform, so we
+                    // don't orphan an instance that could fire stale callbacks.
                     if (startBackend == RecognizerBackend.OnDevice) {
+                        speechRecognizer?.apply {
+                            runCatching { cancel() }
+                            runCatching { destroy() }
+                        }
+                        speechRecognizer = null
                         Log.w(
                             TAG,
                             "On-device recognizer failed to start; retrying with platform backend",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -47,8 +47,8 @@ internal enum class RecognizerBackend {
     Platform,
 }
 
-internal fun initialRecognizerBackend(mode: VoiceCaptureMode): RecognizerBackend =
-    if (mode == VoiceCaptureMode.AlertCommand) RecognizerBackend.Platform else RecognizerBackend.OnDevice
+internal fun initialRecognizerBackend(): RecognizerBackend =
+    RecognizerBackend.OnDevice
 
 internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBackend): Boolean =
     backend == RecognizerBackend.OnDevice
@@ -140,7 +140,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     sessionId = sessionId,
                     mode = mode,
                     availability = availability,
-                    backend = initialRecognizerBackend(mode),
+                    backend = initialRecognizerBackend(),
                 )
                 VoiceInputStartResult.Started
             } catch (e: Exception) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -136,12 +136,33 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 val sessionId = ++nextSessionId
                 currentMode = mode
                 activeSessionId = sessionId
-                startRecognizer(
-                    sessionId = sessionId,
-                    mode = mode,
-                    availability = availability,
-                    backend = initialRecognizerBackend(),
-                )
+                val startBackend = initialRecognizerBackend()
+                try {
+                    startRecognizer(
+                        sessionId = sessionId,
+                        mode = mode,
+                        availability = availability,
+                        backend = startBackend,
+                    )
+                } catch (onDeviceEx: Exception) {
+                    // On-device recognizer failed to start (e.g. not installed, OOM). Attempt
+                    // platform recognizer once before giving up entirely.
+                    if (startBackend == RecognizerBackend.OnDevice) {
+                        Log.w(
+                            TAG,
+                            "On-device recognizer failed to start; retrying with platform backend",
+                            onDeviceEx,
+                        )
+                        startRecognizer(
+                            sessionId = sessionId,
+                            mode = mode,
+                            availability = availability,
+                            backend = RecognizerBackend.Platform,
+                        )
+                    } else {
+                        throw onDeviceEx
+                    }
+                }
                 VoiceInputStartResult.Started
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start Android native voice capture", e)

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -1,6 +1,21 @@
 package com.kernel.ai.core.voice
 
+import android.content.Context
+import android.media.AudioManager
+import android.speech.SpeechRecognizer
+import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class NativeAndroidVoiceInputControllerTest {
@@ -57,7 +72,7 @@ class NativeAndroidVoiceInputControllerTest {
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
                 mode = VoiceCaptureMode.Command,
-                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                error = SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = false,
                 sawPartialTranscript = false,
             ),
@@ -67,7 +82,7 @@ class NativeAndroidVoiceInputControllerTest {
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
                 mode = VoiceCaptureMode.Command,
-                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                error = SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = true,
                 sawPartialTranscript = false,
             ),
@@ -77,7 +92,7 @@ class NativeAndroidVoiceInputControllerTest {
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.Platform,
                 mode = VoiceCaptureMode.Command,
-                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                error = SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = false,
                 sawPartialTranscript = false,
             ),
@@ -91,7 +106,7 @@ class NativeAndroidVoiceInputControllerTest {
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
                 mode = VoiceCaptureMode.AlertCommand,
-                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                error = SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = true,
                 sawPartialTranscript = false,
             ),
@@ -101,7 +116,7 @@ class NativeAndroidVoiceInputControllerTest {
             shouldRetryWithPlatformAfterRecognitionError(
                 backend = RecognizerBackend.OnDevice,
                 mode = VoiceCaptureMode.AlertCommand,
-                error = android.speech.SpeechRecognizer.ERROR_NO_MATCH,
+                error = SpeechRecognizer.ERROR_NO_MATCH,
                 heardSpeech = true,
                 sawPartialTranscript = true,
             ),
@@ -126,5 +141,95 @@ class NativeAndroidVoiceInputControllerTest {
 
         assertEquals(false, shouldForceRecognizerLanguage(unknownAvailability))
         assertEquals(true, shouldForceRecognizerLanguage(readyAvailability))
+    }
+}
+
+/**
+ * Integration-level tests for [NativeAndroidVoiceInputController.startListening].
+ *
+ * These tests construct a real controller with a mocked [AndroidNativeRecognitionSupport] so
+ * they exercise the actual dispatch/retry logic rather than just pure helper functions.
+ * Android framework stubs return default values (isReturnDefaultValues = true in build.gradle.kts),
+ * so SpeechRecognizer methods that are not explicitly stubbed are safe no-ops.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NativeAndroidVoiceInputControllerStartListeningTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var context: Context
+    private lateinit var recognitionSupport: AndroidNativeRecognitionSupport
+    private lateinit var controller: NativeAndroidVoiceInputController
+
+    private val availability = createRecognitionAvailability(
+        isRecognitionAvailable = true,
+        isOnDeviceRecognitionAvailable = true,
+        languageTag = "en-AU",
+        languageDisplayName = "English (Australia)",
+        localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        context = mockk(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        every { context.getSystemService(Context.AUDIO_SERVICE) } returns audioManager
+        recognitionSupport = mockk(relaxed = true)
+
+        // getAvailability / getCaptureAvailability both return the ready availability
+        coEvery { recognitionSupport.getAvailability() } returns availability
+        every { recognitionSupport.getCaptureAvailability() } returns availability
+
+        controller = NativeAndroidVoiceInputController(context, recognitionSupport)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `startListening falls back to platform recognizer when on-device start throws`() = runTest {
+        // Arrange: on-device recognizer throws on startListening(); platform recognizer succeeds.
+        val onDeviceRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+
+        every { recognitionSupport.createOnDeviceSpeechRecognizer() } returns onDeviceRecognizer
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returns platformRecognizer
+
+        every { onDeviceRecognizer.startListening(any()) } throws
+            RuntimeException("on-device recognizer unavailable")
+
+        // Act
+        val result = controller.startListening(VoiceCaptureMode.Command)
+
+        // Assert: overall result is Started (platform succeeded)
+        assertEquals(VoiceInputStartResult.Started, result)
+
+        // Platform recognizer was started
+        verify(exactly = 1) { recognitionSupport.createPlatformSpeechRecognizer() }
+        verify(exactly = 1) { platformRecognizer.startListening(any()) }
+
+        // Orphaned on-device recognizer was cleaned up before the retry
+        verify(atLeast = 1) { onDeviceRecognizer.cancel() }
+        verify(atLeast = 1) { onDeviceRecognizer.destroy() }
+    }
+
+    @Test
+    fun `startListening returns Unavailable when both on-device and platform recognizers throw`() = runTest {
+        val onDeviceRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+
+        every { recognitionSupport.createOnDeviceSpeechRecognizer() } returns onDeviceRecognizer
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returns platformRecognizer
+
+        every { onDeviceRecognizer.startListening(any()) } throws RuntimeException("on-device unavailable")
+        every { platformRecognizer.startListening(any()) } throws RuntimeException("platform unavailable")
+
+        val result = controller.startListening(VoiceCaptureMode.Command)
+
+        assertEquals(true, result is VoiceInputStartResult.Unavailable)
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -17,6 +17,16 @@ class NativeAndroidVoiceInputControllerTest {
         assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend())
     }
 
+    @Test
+    fun `initial backend arms the startup-timeout platform fallback`() {
+        // Contract: whichever backend initialRecognizerBackend() chooses, the startup-timeout
+        // safety net must be active so the async fallback fires if the recognizer stalls.
+        // This also covers the sync-throw path added in startListening: both code paths share
+        // the same RecognizerBackend.OnDevice value, so a change to either helper breaks here.
+        val backend = initialRecognizerBackend()
+        assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(backend))
+    }
+
 
     @Test
     fun `sessionResultTimeoutMs shortens alert command watchdog`() {

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -13,10 +13,8 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
-    fun `initialRecognizerBackend starts alert commands on platform`() {
-        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.Command))
-        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.SlotReply))
-        assertEquals(RecognizerBackend.Platform, initialRecognizerBackend(VoiceCaptureMode.AlertCommand))
+    fun `initialRecognizerBackend always starts on device`() {
+        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend())
     }
 
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -109,8 +109,16 @@ class AboutViewModel @Inject constructor(
                         arrayOf("logcat", "-d", "-v", "threadtime", "--pid=$pid", "-t", "500"),
                     )
                     val logText = process.inputStream.bufferedReader().use { it.readText() }
-                    process.errorStream.bufferedReader().use { it.readText() } // drain stderr to avoid deadlock
-                    process.waitFor()
+                    val stderrText = process.errorStream.bufferedReader().use { it.readText() }
+                    val exitCode = process.waitFor()
+                    if (logText.isBlank()) {
+                        val detail = stderrText.trim().ifEmpty { "exit code $exitCode" }
+                        throw Exception(
+                            "No log entries captured ($detail). This device may restrict logcat " +
+                                "access for user apps. Use ADB instead:\n" +
+                                "adb logcat -s KernelAI",
+                        )
+                    }
                     val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS"))
                     val versionName = try {
                         context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "unknown"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -131,10 +131,10 @@ fun VoiceScreen(
             //
             // Samsung One UI: rejects VIS via proprietary RoleControllerService → deep-link
             //   to ACTION_VOICE_INPUT_SETTINGS (assistant sub-page within Default Apps).
-            // Honor MagicOS: createRequestRoleIntent(ROLE_ASSISTANT) returns null or the
-            //   dialog "Set" button is a no-op → fall back to ACTION_MANAGE_DEFAULT_APPS_SETTINGS.
+            // Other OEMs (incl. Honor MagicOS): attempt the standard role dialog first; if
+            //   the intent is null (broken RoleControllerService) fall back to
+            //   ACTION_MANAGE_DEFAULT_APPS_SETTINGS.
             val isSamsung = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
-            val isHonor = Build.MANUFACTURER.equals("honor", ignoreCase = true)
             when {
                 isSamsung -> {
                     try {
@@ -143,16 +143,17 @@ fun VoiceScreen(
                         assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
                     }
                 }
-                isHonor -> {
-                    try {
-                        assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
-                    } catch (_: Exception) {
-                        // No standard default-apps page available — nothing more we can do.
-                    }
-                }
                 else -> {
                     val intent = roleManager?.createRequestRoleIntent(RoleManager.ROLE_ASSISTANT)
-                    if (intent != null) assistantRoleLauncher.launch(intent)
+                    if (intent != null) {
+                        assistantRoleLauncher.launch(intent)
+                    } else {
+                        try {
+                            assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
+                        } catch (_: Exception) {
+                            // No standard default-apps page — nothing more we can do.
+                        }
+                    }
                 }
             }
         },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -124,21 +124,36 @@ fun VoiceScreen(
         uiState = uiState,
         onBack = onBack,
         onRequestAssistantRole = {
-            // Samsung One UI overrides RoleManager.ROLE_ASSISTANT with a proprietary
-            // RoleControllerService that silently rejects third-party VIS packages.
-            // On Samsung we deep-link directly to the assistant chooser page; on all
-            // other OEMs we use the standard role request dialog.
-            if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
-                val settingsIntent = Intent(Settings.ACTION_VOICE_INPUT_SETTINGS)
-                try {
-                    assistantRoleLauncher.launch(settingsIntent)
-                } catch (_: Exception) {
-                    // Fallback: generic default-apps page if the specific page is unavailable
-                    assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
+            // Several OEM RoleControllerService implementations silently reject third-party
+            // VoiceInteractionService packages or return null from createRequestRoleIntent,
+            // making the standard role-request dialog a no-op. For these OEMs we deep-link
+            // directly into the system Default Apps settings page.
+            //
+            // Samsung One UI: rejects VIS via proprietary RoleControllerService → deep-link
+            //   to ACTION_VOICE_INPUT_SETTINGS (assistant sub-page within Default Apps).
+            // Honor MagicOS: createRequestRoleIntent(ROLE_ASSISTANT) returns null or the
+            //   dialog "Set" button is a no-op → fall back to ACTION_MANAGE_DEFAULT_APPS_SETTINGS.
+            val isSamsung = Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+            val isHonor = Build.MANUFACTURER.equals("honor", ignoreCase = true)
+            when {
+                isSamsung -> {
+                    try {
+                        assistantRoleLauncher.launch(Intent(Settings.ACTION_VOICE_INPUT_SETTINGS))
+                    } catch (_: Exception) {
+                        assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
+                    }
                 }
-            } else {
-                val intent = roleManager?.createRequestRoleIntent(RoleManager.ROLE_ASSISTANT)
-                if (intent != null) assistantRoleLauncher.launch(intent)
+                isHonor -> {
+                    try {
+                        assistantRoleLauncher.launch(Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
+                    } catch (_: Exception) {
+                        // No standard default-apps page available — nothing more we can do.
+                    }
+                }
+                else -> {
+                    val intent = roleManager?.createRequestRoleIntent(RoleManager.ROLE_ASSISTANT)
+                    if (intent != null) assistantRoleLauncher.launch(intent)
+                }
             }
         },
         onHeyJandalEnabledChanged = { enabled ->

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
@@ -79,15 +79,27 @@ class AboutViewModelTest {
         cacheDir.deleteRecursively()
     }
 
-    /** Stubs Runtime.getRuntime().exec() to return empty log output, avoiding real logcat calls. */
-    private fun stubRuntime() {
+    /** Stubs Runtime.getRuntime().exec() to return a non-empty log, avoiding real logcat calls. */
+    private fun stubRuntime(logContent: String = "I/KernelAI: test log entry\n") {
         mockkStatic(Runtime::class)
         val mockProcess = mockk<Process>()
         every { Runtime.getRuntime() } returns mockk(relaxed = true) {
             every { exec(any<Array<String>>()) } returns mockProcess
         }
-        every { mockProcess.inputStream } returns "".byteInputStream()
-        every { mockProcess.errorStream } returns "".byteInputStream()
+        every { mockProcess.inputStream } answers { logContent.byteInputStream() }
+        every { mockProcess.errorStream } answers { "".byteInputStream() }
+        every { mockProcess.waitFor() } returns 0
+    }
+
+    /** Stubs logcat to return blank output (simulates Honor MagicOS log-access restriction). */
+    private fun stubRuntimeEmpty(stderrText: String = "") {
+        mockkStatic(Runtime::class)
+        val mockProcess = mockk<Process>()
+        every { Runtime.getRuntime() } returns mockk(relaxed = true) {
+            every { exec(any<Array<String>>()) } returns mockProcess
+        }
+        every { mockProcess.inputStream } answers { "".byteInputStream() }
+        every { mockProcess.errorStream } answers { stderrText.byteInputStream() }
         every { mockProcess.waitFor() } returns 0
     }
 
@@ -197,10 +209,10 @@ class AboutViewModelTest {
         every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
 
         viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-
+        // Loading is set synchronously before the coroutine runs — check before advancing.
         assertTrue(viewModel.uiState.value.exportState is ExportState.Loading)
 
+        testDispatcher.scheduler.advanceUntilIdle()
         testDispatcher.scheduler.advanceTimeBy(1.seconds)
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -239,6 +251,36 @@ class AboutViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(false, viewModel.uiState.value.verboseLogging)
+    }
+
+    @Test
+    fun `exportLogs with blank logcat output sets error state with ADB hint`() = testScope.runTest {
+        // Simulates Honor MagicOS (and similar OEMs) where the OS SELinux policy silently
+        // blocks logcat access for user apps — process exits 0 but stdout is empty.
+        stubRuntimeEmpty()
+
+        viewModel.exportLogs()
+        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+
+        val state = viewModel.uiState.value.exportState
+        assertTrue(state is ExportState.Error, "Expected Error state when logcat returns no output")
+        val message = (state as ExportState.Error).message
+        assertTrue(message.contains("No log entries captured"), "Error should explain empty capture")
+        assertTrue(message.contains("adb logcat"), "Error should include ADB fallback hint")
+    }
+
+    @Test
+    fun `exportLogs with blank logcat includes stderr detail in error message`() = testScope.runTest {
+        stubRuntimeEmpty(stderrText = "read: unexpected EOF!")
+
+        viewModel.exportLogs()
+        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+
+        val state = viewModel.uiState.value.exportState
+        assertTrue(state is ExportState.Error)
+        assertTrue((state as ExportState.Error).message.contains("read: unexpected EOF!"))
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes all five reported issues on Honor Magic 8 Pro (BKQ-N49, MagicOS).

## Fixes

### 1 & 2 — Widget mic / long-press assistant trigger (`NativeAndroidVoiceInputController`)

`initialRecognizerBackend()` returned `RecognizerBackend.Platform` for `AlertCommand` mode. On Honor, the Platform backend (Android native `SpeechRecognizer`) fires `ERROR_CLIENT (5)` synchronously before any audio is captured, silently breaking every entry point that uses `AlertCommand` mode. Fix: always start on `OnDevice`; the existing `shouldRetryWithPlatformAfterStartupTimeout` fallback remains as a safety net.

```diff
-internal fun initialRecognizerBackend(mode: VoiceCaptureMode): RecognizerBackend =
-    if (mode == VoiceCaptureMode.AlertCommand) RecognizerBackend.Platform else RecognizerBackend.OnDevice
+internal fun initialRecognizerBackend(): RecognizerBackend =
+    RecognizerBackend.OnDevice
```

### 3 — Hey Jandal wakeword

Rebased onto `main` to pick up `e969d15e` (wakeword ONNX model files + `OnnxWakeWordDetector`). The backend fix above also applies to the wakeword trigger path.

### 4 — Set default assistant button does nothing (`VoiceScreen`)

`RoleManager.createRequestRoleIntent(ROLE_ASSISTANT)` returns `null` on Honor MagicOS (or produces a dialog whose "Set" button is a no-op), so the existing `if (intent != null)` guard silently skipped the launch. Added a `isHonor` branch (matching the existing Samsung workaround) that deep-links directly to `ACTION_MANAGE_DEFAULT_APPS_SETTINGS`.

### 5 — Log export silently produces empty file (`AboutViewModel`)

Honor MagicOS SELinux policy blocks `logcat` access for user apps: the process exits 0 but stdout is empty. The old code would write an empty file and show the share sheet with no content. Fix: check for blank output, capture stderr for diagnostics, and surface an `ExportState.Error` with the ADB fallback command (`adb logcat -s KernelAI`) instead of sharing an empty file.

## Tests

- `./gradlew :core:voice:testDebugUnitTest` — all pass
- `./gradlew :feature:settings:testDebugUnitTest` — all pass (includes 2 new tests for blank logcat behavior)
- `./gradlew assembleDebug` — clean build

## On-device

Requires reconnecting the Honor device (AUNN025C02000923) for smoke test of all five flows.

Closes #1005