### PR TITLE
feat(#1001): handle permission revocation — add App Permissions screen in Settings

### DIFF
--- a/app/src/main/java/com/kernel/ai/assistant/JandalRecognitionService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/JandalRecognitionService.kt
@@ -2,6 +2,8 @@ package com.kernel.ai.assistant
 
 import android.content.Intent
 import android.speech.RecognitionService
+import android.speech.SpeechRecognizer
+import android.util.Log
 
 /**
  * Stub [RecognitionService] required by Android's [AssistantRoleBehavior] eligibility check.
@@ -11,15 +13,18 @@ import android.speech.RecognitionService
  * the role framework logs "unqualified voice interaction service" and immediately reverts the
  * selection to the previous holder.
  *
- * Jandal performs its own speech recognition via Sherpa-ONNX / Whisper (on-device); this
- * service is never actually invoked for recognition. It exists solely to satisfy the system's
- * metadata check at role-grant time.
+ * Jandal performs its own speech recognition via Sherpa-ONNX / Android native STT; this
+ * stub exists solely to satisfy the system's metadata check at role-grant time. When Jandal
+ * is the default assistant, the system may point `voice_recognition_service` at this stub,
+ * so app-owned SpeechRecognizer callers must explicitly bind to a real external recognizer.
  */
+private const val TAG = "KernelAI"
+
 class JandalRecognitionService : RecognitionService() {
 
     override fun onStartListening(recognizerIntent: Intent?, listener: Callback?) {
-        // Jandal does not use the Android SpeechRecognizer API path.
-        listener?.error(android.speech.SpeechRecognizer.ERROR_CLIENT)
+        Log.w(TAG, "JandalRecognitionService invoked unexpectedly")
+        listener?.error(SpeechRecognizer.ERROR_CLIENT)
     }
 
     override fun onCancel(listener: Callback?) = Unit

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -8,6 +8,9 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
 import android.util.Log
 import com.kernel.ai.MainActivity
 import com.kernel.ai.core.voice.SherpaOnnxVoiceInputController
@@ -153,10 +156,13 @@ class WakeWordService : Service() {
                     val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
                     if (startResult !is VoiceInputStartResult.Started) {
                         Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
+                        val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
+                        if (!message.isNullOrBlank()) showWakeWordError(message)
                         break
                     }
-                    // Play the cue only on the first attempt; a silent retry is less jarring.
-                    if (attempt == 1) cuePlayer.playCue()
+                    // Play the cue only on the first attempt; use the audible variant here so
+                    // wake-word capture remains noticeable even in silent/vibrate mode.
+                    if (attempt == 1) cuePlayer.playCue(forceAudible = true)
 
                     val terminalEvent = try {
                         voiceInputController.events
@@ -187,6 +193,12 @@ class WakeWordService : Service() {
                 isHandlingDetection = false
                 rearmDetector()
             }
+        }
+    }
+
+    private fun showWakeWordError(message: String) {
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -27,11 +27,12 @@ import com.kernel.ai.feature.widget.VoiceCommandActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 import javax.inject.Inject
@@ -153,8 +154,14 @@ class WakeWordService : Service() {
                 // is true, so re-arm is always done explicitly at the end of this function.
                 var transcript: String? = null
                 for (attempt in 1..2) {
+                    val terminalEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
+                        voiceInputController.events.first { it is VoiceInputEvent.Transcript
+                              || it is VoiceInputEvent.Error
+                              || it is VoiceInputEvent.ListeningStopped }
+                    }
                     val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
                     if (startResult !is VoiceInputStartResult.Started) {
+                        terminalEventDeferred.cancel()
                         Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
                         val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
                         if (!message.isNullOrBlank()) showWakeWordError(message)
@@ -165,10 +172,7 @@ class WakeWordService : Service() {
                     if (attempt == 1) cuePlayer.playCue(forceAudible = true)
 
                     val terminalEvent = try {
-                        voiceInputController.events
-                            .first { it is VoiceInputEvent.Transcript
-                                  || it is VoiceInputEvent.Error
-                                  || it is VoiceInputEvent.ListeningStopped }
+                        terminalEventDeferred.await()
                     } catch (e: Exception) {
                         Log.w(TAG, "WakeWordService: transcript collection failed (attempt $attempt)", e)
                         break
@@ -178,6 +182,10 @@ class WakeWordService : Service() {
                     if (!text.isNullOrBlank()) {
                         transcript = text
                         break
+                    }
+                    val errorMessage = (terminalEvent as? VoiceInputEvent.Error)?.message
+                    if (!errorMessage.isNullOrBlank() && attempt == 2) {
+                        showWakeWordError(errorMessage)
                     }
                     Log.w(TAG, "WakeWordService: no transcript on attempt $attempt ($terminalEvent)" +
                         if (attempt < 2) " — retrying" else "")

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -154,28 +154,56 @@ class WakeWordService : Service() {
                 // is true, so re-arm is always done explicitly at the end of this function.
                 var transcript: String? = null
                 for (attempt in 1..2) {
+                    val startupEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
+                        voiceInputController.events.first {
+                            it is VoiceInputEvent.ListeningStarted
+                                || it is VoiceInputEvent.Transcript
+                                || it is VoiceInputEvent.Error
+                                || it is VoiceInputEvent.ListeningStopped
+                        }
+                    }
                     val terminalEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
-                        voiceInputController.events.first { it is VoiceInputEvent.Transcript
-                              || it is VoiceInputEvent.Error
-                              || it is VoiceInputEvent.ListeningStopped }
+                        voiceInputController.events.first {
+                            it is VoiceInputEvent.Transcript
+                                || it is VoiceInputEvent.Error
+                                || it is VoiceInputEvent.ListeningStopped
+                        }
                     }
                     val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
                     if (startResult !is VoiceInputStartResult.Started) {
+                        startupEventDeferred.cancel()
                         terminalEventDeferred.cancel()
                         Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
                         val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
                         if (!message.isNullOrBlank()) showWakeWordError(message)
                         break
                     }
-                    // Play the cue only on the first attempt; use the audible variant here so
-                    // wake-word capture remains noticeable even in silent/vibrate mode.
-                    if (attempt == 1) cuePlayer.playCue(forceAudible = true)
 
-                    val terminalEvent = try {
-                        terminalEventDeferred.await()
+                    val startupEvent = try {
+                        startupEventDeferred.await()
                     } catch (e: Exception) {
-                        Log.w(TAG, "WakeWordService: transcript collection failed (attempt $attempt)", e)
+                        terminalEventDeferred.cancel()
+                        Log.w(TAG, "WakeWordService: startup event collection failed (attempt $attempt)", e)
                         break
+                    }
+
+                    val terminalEvent = when (startupEvent) {
+                        is VoiceInputEvent.ListeningStarted -> {
+                            // Play the cue only after the recognizer reports it is actually ready
+                            // for speech, so users can start speaking on the bloop without losing
+                            // the start of the command on slower devices.
+                            if (attempt == 1) cuePlayer.playCue(forceAudible = true)
+                            try {
+                                terminalEventDeferred.await()
+                            } catch (e: Exception) {
+                                Log.w(TAG, "WakeWordService: transcript collection failed (attempt $attempt)", e)
+                                break
+                            }
+                        }
+                        else -> {
+                            terminalEventDeferred.cancel()
+                            startupEvent
+                        }
                     }
 
                     val text = (terminalEvent as? VoiceInputEvent.Transcript)?.text

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -44,6 +44,7 @@ import com.kernel.ai.feature.chat.ActionsScreen
 import com.kernel.ai.feature.chat.ChatScreen
 import com.kernel.ai.feature.chat.ConversationListScreen
 import com.kernel.ai.feature.convert.ConvertScreen
+import com.kernel.ai.feature.settings.AppPermissionsScreen
 import com.kernel.ai.feature.settings.AboutScreen
 import com.kernel.ai.feature.settings.ContactAliasesScreen
 import com.kernel.ai.feature.settings.ImportantDatesScreen
@@ -78,6 +79,7 @@ private const val ROUTE_MODEL_SETTINGS = "settings/model_settings"
 private const val ROUTE_MODEL_MANAGEMENT = "settings/model_management?scrollTo={scrollTo}"
 private const val ARG_SCROLL_TO = "scrollTo"
 private const val ROUTE_ABOUT = "settings/about"
+private const val ROUTE_APP_PERMISSIONS = "settings/app_permissions"
 private const val ROUTE_CHAT_PREFERENCES = "settings/chat_preferences"
 private const val ROUTE_CONTACT_ALIASES = "settings/contact_aliases"
 private const val ROUTE_SCHEDULED_ALARMS = "settings/scheduled_alarms"
@@ -525,6 +527,9 @@ fun KernelNavHost(
                         onNavigateToAbout = {
                             navController.navigate(ROUTE_ABOUT)
                         },
+                        onNavigateToAppPermissions = {
+                            navController.navigate(ROUTE_APP_PERMISSIONS)
+                        },
                     )
                 }
 
@@ -625,6 +630,12 @@ fun KernelNavHost(
                         buildType = com.kernel.ai.BuildConfig.BUILD_TYPE,
                         gitSha = com.kernel.ai.BuildConfig.GIT_SHA,
                         buildTimestamp = com.kernel.ai.BuildConfig.BUILD_TIMESTAMP,
+                    )
+                }
+
+                composable(ROUTE_APP_PERMISSIONS) {
+                    AppPermissionsScreen(
+                        onBack = { navController.popBackStack() },
                     )
                 }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -61,7 +61,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 private const val TAG = "KernelAI"
-private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
+private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial. Check Settings → App Permissions to grant it."
 
 interface ClockAlertController {
     fun dismissActiveTimerAlerts(): Boolean

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupport.kt
@@ -1,7 +1,11 @@
 package com.kernel.ai.core.voice
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import android.speech.RecognitionService
 import android.speech.RecognitionSupport
 import android.speech.RecognitionSupportCallback
 import android.speech.RecognizerIntent
@@ -21,6 +25,9 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 
 private const val TAG = "NativeVoiceInput"
+private const val VOICE_RECOGNITION_SERVICE_SETTING = "voice_recognition_service"
+private const val NO_EXTERNAL_RECOGNIZER_MESSAGE =
+    "Android speech recognition is unavailable because no external recognition service is configured on this device."
 
 data class AndroidNativeRecognitionAvailability(
     val isRecognitionAvailable: Boolean,
@@ -59,10 +66,54 @@ enum class AndroidNativeRecognitionLocaleStatus {
     Unknown,
 }
 
+private data class ParsedRecognitionComponent(
+    val packageName: String,
+    val className: String,
+) {
+    fun flatten(): String = "$packageName/$className"
+}
+
 private data class LocaleSupportCache(
     val languageTag: String,
     val localeStatus: AndroidNativeRecognitionLocaleStatus,
 )
+internal fun selectPlatformRecognitionService(
+    configuredService: String?,
+    availableServices: List<String>,
+    selfPackageName: String,
+): String? {
+    fun parse(componentName: String): ParsedRecognitionComponent? {
+        val slash = componentName.indexOf('/')
+        if (slash <= 0 || slash == componentName.lastIndex) return null
+        val packageName = componentName.substring(0, slash)
+        val rawClassName = componentName.substring(slash + 1)
+        if (packageName.isBlank() || rawClassName.isBlank()) return null
+        val className = when {
+            rawClassName.startsWith('.') -> "$packageName$rawClassName"
+            '.' in rawClassName -> rawClassName
+            else -> "$packageName.$rawClassName"
+        }
+        return ParsedRecognitionComponent(packageName = packageName, className = className)
+    }
+
+    val availableComponents = availableServices.mapNotNull { raw ->
+        parse(raw)?.let { component -> raw to component }
+    }
+    val externalComponents = availableComponents.filter { (_, component) ->
+        component.packageName != selfPackageName
+    }
+    val configuredExternalComponent = configuredService
+        ?.let(::parse)
+        ?.takeIf { it.packageName != selfPackageName }
+
+    return when {
+        externalComponents.isEmpty() -> null
+        configuredExternalComponent == null -> externalComponents.first().second.flatten()
+        externalComponents.any { (_, component) -> component == configuredExternalComponent } ->
+            configuredExternalComponent.flatten()
+        else -> externalComponents.first().second.flatten()
+    }
+}
 
 
 @Singleton
@@ -143,9 +194,39 @@ class AndroidNativeRecognitionSupport @Inject constructor(
 
     fun createOnDeviceSpeechRecognizer(): SpeechRecognizer =
         SpeechRecognizer.createOnDeviceSpeechRecognizer(context)
-
-    fun createPlatformSpeechRecognizer(): SpeechRecognizer =
-        SpeechRecognizer.createSpeechRecognizer(context)
+    fun createPlatformSpeechRecognizer(): SpeechRecognizer {
+        val configuredService = Settings.Secure.getString(
+            context.contentResolver,
+            VOICE_RECOGNITION_SERVICE_SETTING,
+        )?.takeIf { it.isNotBlank() }
+        val availableServices = context.packageManager.queryIntentServices(
+            Intent(RecognitionService.SERVICE_INTERFACE),
+            PackageManager.ResolveInfoFlags.of(0),
+        ).mapNotNull { resolveInfo ->
+            resolveInfo.serviceInfo?.let { serviceInfo ->
+                ComponentName(serviceInfo.packageName, serviceInfo.name).flattenToShortString()
+            }
+        }
+        val selectedService = selectPlatformRecognitionService(
+            configuredService = configuredService,
+            availableServices = availableServices,
+            selfPackageName = context.packageName,
+        )
+        Log.i(
+            TAG,
+            "Platform recognition service selection: configured=$configuredService " +
+                "available=$availableServices selected=$selectedService",
+        )
+        val selectedComponent = selectedService?.let(ComponentName::unflattenFromString)
+        if (selectedComponent == null) {
+            Log.w(
+                TAG,
+                "No external platform recognition service available: configured=$configuredService available=$availableServices",
+            )
+            throw IllegalStateException(NO_EXTERNAL_RECOGNIZER_MESSAGE)
+        }
+        return SpeechRecognizer.createSpeechRecognizer(context, selectedComponent)
+    }
 
     private suspend fun checkLocaleSupport(languageTag: String): AndroidNativeRecognitionLocaleStatus {
         // Run in an independent scope so the RecognitionSupportCallback closure
@@ -225,6 +306,7 @@ class AndroidNativeRecognitionSupport @Inject constructor(
         }
     }
 }
+
 
 internal fun createRecognitionAvailability(
     isRecognitionAvailable: Boolean,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -79,6 +79,13 @@ internal fun shouldRetryWithPlatformAfterWatchdogTimeout(
     sawPartialTranscript: Boolean,
 ): Boolean = backend == RecognizerBackend.OnDevice && !sawPartialTranscript
 
+internal fun honorAndroidNativeBlockingReason(manufacturer: String?): String? =
+    if (manufacturer?.equals("honor", ignoreCase = true) == true) {
+        "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice."
+    } else {
+        null
+    }
+
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -109,11 +116,17 @@ class NativeAndroidVoiceInputController @Inject constructor(
     @Volatile
     private var startupFallbackJob: Job? = null
 
+
     private var nextSessionId: Long = 0L
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
+            honorAndroidNativeBlockingReason(Build.MANUFACTURER)?.let { reason ->
+                Log.w(TAG, "Blocking Android native STT start on Honor: mode=$mode reason=$reason")
+                return@withContext VoiceInputStartResult.Unavailable(reason)
+            }
+
 
             val availability = if (shouldUseCachedCaptureAvailability(mode)) {
                 recognitionSupport.getCaptureAvailability()

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -79,12 +79,6 @@ internal fun shouldRetryWithPlatformAfterWatchdogTimeout(
     sawPartialTranscript: Boolean,
 ): Boolean = backend == RecognizerBackend.OnDevice && !sawPartialTranscript
 
-internal fun honorAndroidNativeBlockingReason(manufacturer: String?): String? =
-    if (manufacturer?.equals("honor", ignoreCase = true) == true) {
-        "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice."
-    } else {
-        null
-    }
 
 @Singleton
 class NativeAndroidVoiceInputController @Inject constructor(
@@ -122,10 +116,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         return withContext(Dispatchers.Main.immediate) {
             stopListeningInternal(emitStopped = false)
-            honorAndroidNativeBlockingReason(Build.MANUFACTURER)?.let { reason ->
-                Log.w(TAG, "Blocking Android native STT start on Honor: mode=$mode reason=$reason")
-                return@withContext VoiceInputStartResult.Unavailable(reason)
-            }
 
 
             val availability = if (shouldUseCachedCaptureAvailability(mode)) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -26,10 +26,17 @@ import kotlinx.coroutines.withContext
 private const val TAG = "NativeVoiceInput"
 private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
 private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
-private const val ALERT_SESSION_RESULT_TIMEOUT_MS = 2_500L
+private const val ALERT_SESSION_SILENCE_TIMEOUT_MS = 2_500L
 
-internal fun sessionResultTimeoutMs(mode: VoiceCaptureMode): Long =
-    if (mode == VoiceCaptureMode.AlertCommand) ALERT_SESSION_RESULT_TIMEOUT_MS else SESSION_RESULT_TIMEOUT_MS
+internal fun sessionResultTimeoutMs(
+    mode: VoiceCaptureMode,
+    hasSpeechProgress: Boolean = false,
+): Long =
+    if (mode == VoiceCaptureMode.AlertCommand && !hasSpeechProgress) {
+        ALERT_SESSION_SILENCE_TIMEOUT_MS
+    } else {
+        SESSION_RESULT_TIMEOUT_MS
+    }
 
 
 
@@ -47,8 +54,16 @@ internal enum class RecognizerBackend {
     Platform,
 }
 
-internal fun initialRecognizerBackend(): RecognizerBackend =
-    RecognizerBackend.OnDevice
+internal fun initialRecognizerBackend(mode: VoiceCaptureMode): RecognizerBackend =
+    if (mode == VoiceCaptureMode.AlertCommand) {
+        // Wake-word / alert flows are cue-driven. Starting on-device first can report ready,
+        // play the cue, then silently fall back to platform seconds later on some devices
+        // (observed on S23). Start directly on the vetted platform recognizer for alert
+        // commands so the cue aligns with the backend that will actually capture speech.
+        RecognizerBackend.Platform
+    } else {
+        RecognizerBackend.OnDevice
+    }
 
 internal fun shouldRetryWithPlatformAfterStartupTimeout(backend: RecognizerBackend): Boolean =
     backend == RecognizerBackend.OnDevice
@@ -139,7 +154,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 val sessionId = ++nextSessionId
                 currentMode = mode
                 activeSessionId = sessionId
-                val startBackend = initialRecognizerBackend()
+                val startBackend = initialRecognizerBackend(mode)
                 try {
                     startRecognizer(
                         sessionId = sessionId,
@@ -147,7 +162,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         availability = availability,
                         backend = startBackend,
                     )
-                } catch (onDeviceEx: Exception) {
+                } catch (startEx: Exception) {
                     // On-device recognizer failed to start (e.g. not installed, OOM). Clean up
                     // any partially-constructed recognizer before retrying with Platform, so we
                     // don't orphan an instance that could fire stale callbacks.
@@ -160,7 +175,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         Log.w(
                             TAG,
                             "On-device recognizer failed to start; retrying with platform backend",
-                            onDeviceEx,
+                            startEx,
                         )
                         startRecognizer(
                             sessionId = sessionId,
@@ -169,7 +184,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                             backend = RecognizerBackend.Platform,
                         )
                     } else {
-                        throw onDeviceEx
+                        throw startEx
                     }
                 }
                 VoiceInputStartResult.Started
@@ -328,7 +343,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         private fun resetSessionWatchdog() {
             sessionWatchdogJob?.cancel()
             sessionWatchdogJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
-                delay(sessionResultTimeoutMs(mode))
+                delay(sessionResultTimeoutMs(mode, hasSpeechProgress = heardSpeech || sawPartialTranscript))
                 if (sessionCompleted || activeSessionId != sessionId) return@launch
                 if (
                     shouldRetryWithPlatformAfterWatchdogTimeout(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
@@ -5,9 +5,10 @@ import javax.inject.Singleton
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapLatest
-
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class SelectableVoiceInputController @Inject constructor(
@@ -19,8 +20,14 @@ class SelectableVoiceInputController @Inject constructor(
 
     private val activeController = MutableStateFlow<VoiceInputController>(voskOfflineVoiceInputController)
 
-    override val events: Flow<VoiceInputEvent> = activeController.flatMapLatest { controller ->
-        controller.events
+    override val events: Flow<VoiceInputEvent> = merge(
+        voskOfflineVoiceInputController.events.map { event -> voskOfflineVoiceInputController to event },
+        nativeAndroidVoiceInputController.events.map { event -> nativeAndroidVoiceInputController to event },
+        sherpaOnnxVoiceInputController.events.map { event -> sherpaOnnxVoiceInputController to event },
+    ).filter { (controller, _) ->
+        controller === activeController.value
+    }.map { (_, event) ->
+        event
     }
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/StartListeningCuePlayer.kt
@@ -9,7 +9,7 @@ package com.kernel.ai.core.voice
  * is truly open, not on button-press alone.
  */
 interface StartListeningCuePlayer {
-    fun playCue()
+    fun playCue(forceAudible: Boolean = false)
 
     /**
      * Releases any native audio resources held by this player.

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/ToneStartListeningCuePlayer.kt
@@ -8,59 +8,63 @@ import javax.inject.Singleton
 
 private const val TAG = "KernelAI"
 private const val CUE_VOLUME_PERCENT = 60
+private const val DEFAULT_CUE_STREAM = AudioManager.STREAM_MUSIC
+private const val AUDIBLE_CUE_STREAM = AudioManager.STREAM_ALARM
 private const val CUE_DURATION_MS = 100
 
 /**
- * Plays a brief, non-jarring beep via [ToneGenerator] when the microphone
- * becomes ready for speech.
+ * Plays a brief, non-jarring beep when the microphone becomes ready for speech.
  *
- * Uses [ToneGenerator.TONE_PROP_BEEP] on [AudioManager.STREAM_MUSIC] at 60%
- * volume for a 100 ms duration — a short, clean UI earcon that mirrors the
- * convention used by [LoopListeningCue].
+ * Default playback uses [AudioManager.STREAM_MUSIC] so in-app manual mic cues respect the
+ * user's normal media/silent settings. Wake-word capture can request [forceAudible] to route
+ * the cue through [AudioManager.STREAM_ALARM], keeping the earcon audible even when the device
+ * is in silent or vibrate mode.
  */
 @Singleton
 class ToneStartListeningCuePlayer @Inject constructor() : StartListeningCuePlayer {
 
-    /**
-     * Held for process lifetime as a @Singleton. [release] can be called to free the native
-     * AudioTrack if the audio system enters a bad state — it is not called automatically on
-     * ViewModel teardown because this singleton outlives any single ViewModel.
-     */
-    private var toneGeneratorInstance: ToneGenerator? = null
-    private val toneGenerator: ToneGenerator?
-        get() {
-            if (toneGeneratorInstance == null) {
-                toneGeneratorInstance = try {
-                    ToneGenerator(AudioManager.STREAM_MUSIC, CUE_VOLUME_PERCENT)
-                } catch (e: RuntimeException) {
-                    Log.w(TAG, "ToneStartListeningCuePlayer: failed to create ToneGenerator", e)
-                    null
-                }
-            }
-            return toneGeneratorInstance
-        }
+    private var defaultToneGeneratorInstance: ToneGenerator? = null
+    private var audibleToneGeneratorInstance: ToneGenerator? = null
 
-    override fun playCue() {
+    private fun toneGenerator(forceAudible: Boolean): ToneGenerator? {
+        val existing = if (forceAudible) audibleToneGeneratorInstance else defaultToneGeneratorInstance
+        if (existing != null) return existing
+
+        val stream = if (forceAudible) AUDIBLE_CUE_STREAM else DEFAULT_CUE_STREAM
+        val created = try {
+            ToneGenerator(stream, CUE_VOLUME_PERCENT)
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "ToneStartListeningCuePlayer: failed to create ToneGenerator", e)
+            null
+        }
+        if (forceAudible) {
+            audibleToneGeneratorInstance = created
+        } else {
+            defaultToneGeneratorInstance = created
+        }
+        return created
+    }
+
+    override fun playCue(forceAudible: Boolean) {
         try {
-            toneGenerator?.startTone(ToneGenerator.TONE_PROP_BEEP, CUE_DURATION_MS)
+            toneGenerator(forceAudible)?.startTone(ToneGenerator.TONE_PROP_BEEP, CUE_DURATION_MS)
         } catch (e: RuntimeException) {
             Log.w(TAG, "ToneStartListeningCuePlayer: failed to play cue", e)
         }
     }
 
-    /**
-     * Releases the native [ToneGenerator] AudioTrack resource and resets the internal reference
-     * so that the next [playCue] call will recreate it.
-     *
-     * Call this when the audio system enters a bad state and needs to be reset.
-     */
     override fun release() {
-        try {
-            toneGeneratorInstance?.release()
-        } catch (e: RuntimeException) {
-            Log.w(TAG, "ToneStartListeningCuePlayer: failed to release ToneGenerator", e)
-        } finally {
-            toneGeneratorInstance = null
+        fun releaseInstance(instance: ToneGenerator?) {
+            try {
+                instance?.release()
+            } catch (e: RuntimeException) {
+                Log.w(TAG, "ToneStartListeningCuePlayer: failed to release ToneGenerator", e)
+            }
         }
+
+        releaseInstance(defaultToneGeneratorInstance)
+        releaseInstance(audibleToneGeneratorInstance)
+        defaultToneGeneratorInstance = null
+        audibleToneGeneratorInstance = null
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AndroidNativeRecognitionSupportTest.kt
@@ -122,4 +122,96 @@ class AndroidNativeRecognitionSupportTest {
         assertNull(availability.blockingReason)
         assertNull(availability.warningMessage)
     }
+
+    @Test
+    fun `selectPlatformRecognitionService prefers configured external service`() {
+        val configured = "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService"
+        val available = listOf(
+            "com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService",
+            "com.google.android.as/com.google.android.as.AiAiSpeechRecognitionService",
+            configured,
+        )
+
+        assertEquals(
+            configured,
+            selectPlatformRecognitionService(
+                configuredService = configured,
+                availableServices = available,
+                selfPackageName = "com.kernel.ai.debug",
+            ),
+        )
+    }
+
+    @Test
+    fun `selectPlatformRecognitionService skips self package when configured service is self`() {
+        val selected = selectPlatformRecognitionService(
+            configuredService = "com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService",
+            availableServices = listOf(
+                "com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService",
+                "com.google.android.as/com.google.android.as.AiAiSpeechRecognitionService",
+            ),
+            selfPackageName = "com.kernel.ai.debug",
+        )
+
+        assertEquals(
+            "com.google.android.as/com.google.android.as.AiAiSpeechRecognitionService",
+            selected,
+        )
+    }
+
+    @Test
+    fun `selectPlatformRecognitionService returns null when only self service is available`() {
+        val selected = selectPlatformRecognitionService(
+            configuredService = "com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService",
+            availableServices = listOf("com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService"),
+            selfPackageName = "com.kernel.ai.debug",
+        )
+
+        assertEquals(null, selected)
+    }
+
+    @Test
+    fun `selectPlatformRecognitionService prefers queryable external service over stale configured service`() {
+        val selected = selectPlatformRecognitionService(
+            configuredService = "com.stale.engine/com.stale.engine.OldRecognitionService",
+            availableServices = listOf(
+                "com.kernel.ai.debug/com.kernel.ai.assistant.JandalRecognitionService",
+                "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService",
+            ),
+            selfPackageName = "com.kernel.ai.debug",
+        )
+
+        assertEquals(
+            "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService",
+            selected,
+        )
+    }
+
+    @Test
+    fun `selectPlatformRecognitionService returns null when configured external service is not queryable`() {
+        val selected = selectPlatformRecognitionService(
+            configuredService = "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService",
+            availableServices = emptyList(),
+            selfPackageName = "com.kernel.ai.debug",
+        )
+
+        assertEquals(null, selected)
+    }
+
+    @Test
+    fun `selectPlatformRecognitionService matches configured service across short and full forms`() {
+        val selected = selectPlatformRecognitionService(
+            configuredService = "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService",
+            availableServices = listOf(
+                "com.other.engine/.OtherRecognitionService",
+                "com.google.android.tts/.GoogleTTSRecognitionService",
+            ),
+            selfPackageName = "com.kernel.ai.debug",
+        )
+
+        assertEquals(
+            "com.google.android.tts/com.google.android.tts.GoogleTTSRecognitionService",
+            selected,
+        )
+    }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -28,26 +28,26 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
-    fun `initialRecognizerBackend always starts on device`() {
-        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend())
+    fun `initialRecognizerBackend starts alert commands on platform and other modes on device`() {
+        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.Command))
+        assertEquals(RecognizerBackend.OnDevice, initialRecognizerBackend(VoiceCaptureMode.SlotReply))
+        assertEquals(RecognizerBackend.Platform, initialRecognizerBackend(VoiceCaptureMode.AlertCommand))
     }
 
     @Test
-    fun `initial backend arms the startup-timeout platform fallback`() {
-        // Contract: whichever backend initialRecognizerBackend() chooses, the startup-timeout
-        // safety net must be active so the async fallback fires if the recognizer stalls.
-        // This also covers the sync-throw path added in startListening: both code paths share
-        // the same RecognizerBackend.OnDevice value, so a change to either helper breaks here.
-        val backend = initialRecognizerBackend()
-        assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(backend))
+    fun `only on-device initial backend arms startup-timeout platform fallback`() {
+        assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(initialRecognizerBackend(VoiceCaptureMode.Command)))
+        assertEquals(true, shouldRetryWithPlatformAfterStartupTimeout(initialRecognizerBackend(VoiceCaptureMode.SlotReply)))
+        assertEquals(false, shouldRetryWithPlatformAfterStartupTimeout(initialRecognizerBackend(VoiceCaptureMode.AlertCommand)))
     }
 
 
     @Test
-    fun `sessionResultTimeoutMs shortens alert command watchdog`() {
+    fun `sessionResultTimeoutMs keeps alert pre-speech timeout short but allows more time after progress`() {
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.Command))
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.SlotReply))
         assertEquals(2_500L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand))
+        assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand, hasSpeechProgress = true))
     }
 
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -123,18 +123,6 @@ class NativeAndroidVoiceInputControllerTest {
         )
     }
 
-    @Test
-    fun `honorAndroidNativeBlockingReason is null for non-Honor devices`() {
-        assertEquals(null, honorAndroidNativeBlockingReason("google"))
-    }
-
-    @Test
-    fun `honorAndroidNativeBlockingReason instructs Honor users to switch engines`() {
-        assertEquals(
-            "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice.",
-            honorAndroidNativeBlockingReason("HONOR"),
-        )
-    }
 
     @Test
     fun `shouldForceRecognizerLanguage only forces verified locale`() {

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -124,6 +124,19 @@ class NativeAndroidVoiceInputControllerTest {
     }
 
     @Test
+    fun `honorAndroidNativeBlockingReason is null for non-Honor devices`() {
+        assertEquals(null, honorAndroidNativeBlockingReason("google"))
+    }
+
+    @Test
+    fun `honorAndroidNativeBlockingReason instructs Honor users to switch engines`() {
+        assertEquals(
+            "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice.",
+            honorAndroidNativeBlockingReason("HONOR"),
+        )
+    }
+
+    @Test
     fun `shouldForceRecognizerLanguage only forces verified locale`() {
         val unknownAvailability = createRecognitionAvailability(
             isRecognitionAvailable = true,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
@@ -61,6 +61,53 @@ class SelectableVoiceInputControllerTest {
     }
 
     @Test
+    fun `events receive synchronous startup error from newly selected controller`() = runTest(dispatcher) {
+        val selectedEngine = MutableStateFlow(VoiceInputEngine.AndroidNative)
+        val voskEvents = MutableSharedFlow<VoiceInputEvent>()
+        val nativeEvents = MutableSharedFlow<VoiceInputEvent>()
+        val received = mutableListOf<VoiceInputEvent>()
+        every { voiceInputPreferences.selectedEngine } returns selectedEngine
+        every { voskOfflineVoiceInputController.events } returns voskEvents
+        every { nativeAndroidVoiceInputController.events } returns nativeEvents
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+        every { sherpaOnnxVoiceInputController.stopListening() } just runs
+        coEvery { nativeAndroidVoiceInputController.startListening(VoiceCaptureMode.Command) } coAnswers {
+            nativeEvents.emit(
+                VoiceInputEvent.Error(
+                    mode = VoiceCaptureMode.Command,
+                    message = "startup failed",
+                ),
+            )
+            VoiceInputStartResult.Started
+        }
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+        val collectJob = launch { controller.events.collect { received += it } }
+        advanceUntilIdle()
+
+        controller.startListening(VoiceCaptureMode.Command)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(
+                VoiceInputEvent.Error(
+                    mode = VoiceCaptureMode.Command,
+                    message = "startup failed",
+                ),
+            ),
+            received,
+        )
+        collectJob.cancel()
+    }
+
+    @Test
     fun `stopListening stops both controllers to avoid orphaned sessions`() = runTest(dispatcher) {
         every { voiceInputPreferences.selectedEngine } returns MutableStateFlow(VoiceInputEngine.Vosk)
         every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -41,7 +41,7 @@ private const val TAG = "KernelAI"
 private const val SLOT_REPLY_REARM_DELAY_MS = 350L
 private const val VOICE_REPLY_TTS_DELAY_MS = 150L
 private const val VOICE_COMMAND_DUPLICATE_WINDOW_MS = 2_000L
-private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial."
+private const val PHONE_PERMISSION_REQUIRED_ERROR = "Phone permission is required for auto-dial. Check Settings → App Permissions to grant it."
 private const val SLOT_REPLY_MAX_VOICE_RETRIES = 2
 private const val COMMAND_MAX_VOICE_RETRIES = 1
 private val VOICE_ESCAPE_PHRASES = setOf("stop", "cancel", "stop that")
@@ -444,7 +444,7 @@ class ActionsViewModel @Inject constructor(
 
     fun onPhonePermissionDenied() {
         pendingPhonePermissionAction = null
-        _error.value = "Phone permission is required for auto-dial."
+_error.value = "Phone permission is required for auto-dial. Check Settings → App Permissions to grant it."
     }
 
     /**

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1033,7 +1033,7 @@ class ActionsViewModelVoiceTest {
         every { runIntentSkill.description } returns "Run intent"
         every { runIntentSkill.schema } returns SkillSchema()
         coEvery { runIntentSkill.execute(any()) } returnsMany listOf(
-            SkillResult.Failure("make_call", "Phone permission is required for auto-dial."),
+SkillResult.Failure("make_call", "Phone permission is required for auto-dial. Check Settings → App Permissions to grant it."),
             SkillResult.Success("Calling susan monrad"),
         )
 
@@ -1048,7 +1048,7 @@ class ActionsViewModelVoiceTest {
             quickActionDao.insert(
                 match {
                     it.skillName == "make_call" &&
-                        it.resultText == "Phone permission is required for auto-dial." &&
+it.resultText == "Phone permission is required for auto-dial. Check Settings → App Permissions to grant it." &&
                         !it.isSuccess
                 }
             )

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
@@ -87,7 +87,7 @@ fun AppPermissionsScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = "These are the permissions Jandal uses. Tap any revoked permission to grant it.",
+                text = "These are the permissions Jandal uses. Tap any revoked permission to open the right system settings page.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -112,7 +112,7 @@ fun AppPermissionsScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = "Tip: If you see revoked permissions, tap the row to open App info and toggle them on.",
+                text = "Tip: Revoked runtime permissions open App info. Revoked special-access items open their dedicated system settings page.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -131,9 +131,10 @@ private fun PermissionRow(
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable {
-                if (!item.isGranted) onFix()
-            },
+            .clickable(
+                enabled = !item.isGranted,
+                onClick = onFix,
+            ),
         headlineContent = {
             Text(
                 text = item.label,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
@@ -25,12 +25,15 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,7 +41,19 @@ fun AppPermissionsScreen(
     onBack: () -> Unit = {},
     viewModel: AppPermissionsViewModel = hiltViewModel(),
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsState()
+
+    // Auto-refresh when returning from system settings (e.g. after toggling permissions)
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refresh()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Scaffold(
         topBar = {
@@ -102,7 +117,6 @@ fun AppPermissionsScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
-
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
@@ -1,0 +1,153 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppPermissionsScreen(
+    onBack: () -> Unit = {},
+    viewModel: AppPermissionsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("App Permissions") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { viewModel.refresh() }) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = "Refresh",
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
+                        Text("Refresh")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                text = "These are the permissions Jandal uses. Tap any revoked permission to grant it.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            uiState.permissions.forEach { perm ->
+                PermissionRow(
+                    item = perm,
+                    onFix = {
+                        if (perm.isSpecial) {
+                            viewModel.openSpecialPermissionSettings(perm.permission)
+                        } else {
+                            viewModel.openAppInfoSettings()
+                        }
+                    },
+                )
+                HorizontalDivider()
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Tip: If you see revoked permissions, tap the row to open App info and toggle them on.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+        }
+    }
+}
+
+@Composable
+private fun PermissionRow(
+    item: AppPermissionItem,
+    onFix: () -> Unit,
+) {
+    val tint = if (item.isGranted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                if (!item.isGranted) onFix()
+            },
+        headlineContent = {
+            Text(
+                text = item.label,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = item.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        trailingContent = {
+            Icon(
+                imageVector = if (item.isGranted) Icons.Default.Check else Icons.Default.Close,
+                contentDescription = if (item.isGranted) "Granted" else "Not granted",
+                tint = tint,
+            )
+        },
+        overlineContent = {
+            if (item.isSpecial) {
+                Text(
+                    text = "Special access",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
@@ -1,0 +1,160 @@
+package com.kernel.ai.feature.settings
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Represents a single runtime permission whose grant status the user can inspect and act on.
+ *
+ * @param label        Human-readable name shown in the UI.
+ * @param description  What the permission is used for in this app.
+ * @param permission   The [Manifest.permission] constant value.
+ * @param isGranted    Current grant state as of the last refresh.
+ * @param isSpecial    If true, this is a special-access permission (like DND/write settings)
+ *                     managed through a system settings intent rather than a runtime request.
+ */
+data class AppPermissionItem(
+    val label: String,
+    val description: String,
+    val permission: String,
+    val isGranted: Boolean = false,
+    val isSpecial: Boolean = false,
+)
+
+data class AppPermissionsUiState(
+    val permissions: List<AppPermissionItem> = emptyList(),
+)
+
+@HiltViewModel
+class AppPermissionsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AppPermissionsUiState())
+    val uiState: StateFlow<AppPermissionsUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = AppPermissionsUiState(
+                permissions = buildPermissionList(),
+            )
+        }
+    }
+
+    /** Opens the system App-info page for this app so the user can toggle runtime permissions. */
+    fun openAppInfoSettings() {
+        val intent = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", context.packageName, null),
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+
+    /** Opens a specific system settings panel for a special-access permission. */
+    fun openSpecialPermissionSettings(permission: String) {
+        val intent = when (permission) {
+            Manifest.permission.ACCESS_NOTIFICATION_POLICY ->
+                Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+            Manifest.permission.WRITE_SETTINGS ->
+                Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                }
+            else -> null
+        }
+        if (intent != null) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } else {
+            openAppInfoSettings()
+        }
+    }
+
+    private fun buildPermissionList(): List<AppPermissionItem> {
+
+        // Runtime permissions that the app actually uses and can be revoked.
+        // Each entry maps to the skill/feature that depends on it.
+        val knownPermissions = listOf(
+            AppPermissionItem(
+                label = "Phone",
+                description = "Hands-free calling via make_call and voicemail",
+                permission = Manifest.permission.CALL_PHONE,
+            ),
+            AppPermissionItem(
+                label = "Microphone",
+                description = "Voice input for Quick Actions and Hey Jandal",
+                permission = Manifest.permission.RECORD_AUDIO,
+            ),
+            AppPermissionItem(
+                label = "Notifications",
+                description = "Alarm, timer and download notifications",
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+            ),
+            AppPermissionItem(
+                label = "Location",
+                description = "GPS-based weather lookup",
+                permission = Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+            AppPermissionItem(
+                label = "Contacts",
+                description = "Call, SMS and email by contact name",
+                permission = Manifest.permission.READ_CONTACTS,
+            ),
+            AppPermissionItem(
+                label = "Calendar",
+                description = "Synced birthday reminders",
+                permission = Manifest.permission.READ_CALENDAR,
+            ),
+        )
+
+        // Special-access permissions — granted via system settings, not runtime request.
+        val specialPermissions = listOfNotNull(
+            AppPermissionItem(
+                label = "Do Not Disturb",
+                description = "Toggle DND mode on/off",
+                permission = Manifest.permission.ACCESS_NOTIFICATION_POLICY,
+                isGranted = checkNotificationPolicyAccess(),
+                isSpecial = true,
+            ),
+            // WRITE_SETTINGS — brightness control; usually auto-granted on Samsung devices,
+            // but included for completeness on devices that deny it.
+            AppPermissionItem(
+                label = "Modify system settings",
+                description = "Change screen brightness",
+                permission = Manifest.permission.WRITE_SETTINGS,
+                isGranted = Settings.System.canWrite(context),
+                isSpecial = true,
+            ),
+        ).filter { !it.isGranted }
+
+        return knownPermissions.map { perm ->
+            perm.copy(
+                isGranted = ContextCompat.checkSelfPermission(context, perm.permission)
+                    == PackageManager.PERMISSION_GRANTED,
+            )
+        } + specialPermissions
+    }
+
+    private fun checkNotificationPolicyAccess(): Boolean {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE)
+                as? android.app.NotificationManager ?: return false
+        return nm.isNotificationPolicyAccessGranted
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
@@ -125,7 +125,7 @@ class AppPermissionsViewModel @Inject constructor(
         )
 
         // Special-access permissions — granted via system settings, not runtime request.
-        val specialPermissions = listOfNotNull(
+        val specialPermissions = listOf(
             AppPermissionItem(
                 label = "Do Not Disturb",
                 description = "Toggle DND mode on/off",
@@ -142,7 +142,7 @@ class AppPermissionsViewModel @Inject constructor(
                 isGranted = Settings.System.canWrite(context),
                 isSpecial = true,
             ),
-        ).filter { !it.isGranted }
+        )
 
         return knownPermissions.map { perm ->
             perm.copy(

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Tune
@@ -61,6 +62,7 @@ fun SettingsScreen(
     onNavigateToModelManagement: (preferred: Boolean) -> Unit = {},
     onNavigateToChatPreferences: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
+    onNavigateToAppPermissions: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -222,6 +224,17 @@ fun SettingsScreen(
                 headlineContent = { Text("Chat Preferences") },
                 supportingContent = { Text("Font size, bubble theme, colours, wallpaper") },
                 leadingContent = { Icon(Icons.Default.Forum, contentDescription = null) },
+                trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
+            )
+            HorizontalDivider()
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onNavigateToAppPermissions() },
+                headlineContent = { Text("App Permissions") },
+                supportingContent = { Text("View and grant required permissions") },
+                leadingContent = { Icon(Icons.Default.Security, contentDescription = null) },
                 trailingContent = { Icon(Icons.Default.ChevronRight, contentDescription = null) },
             )
             HorizontalDivider()

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -124,11 +124,14 @@ fun VoiceScreen(
         uiState = uiState,
         onBack = onBack,
         onRequestAssistantRole = {
-            // Samsung One UI overrides RoleManager.ROLE_ASSISTANT with a proprietary
-            // RoleControllerService that silently rejects third-party VIS packages.
-            // On Samsung we deep-link directly to the assistant chooser page; on all
-            // other OEMs we use the standard role request dialog.
-            if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
+            // Samsung One UI and Honor Magic OS both override RoleManager.ROLE_ASSISTANT
+            // with proprietary RoleControllerServices that silently reject third-party VIS
+            // packages. On these OEMs we deep-link directly to the assistant chooser page;
+            // on all other OEMs we use the standard role request dialog.
+            val manufacturer = Build.MANUFACTURER
+            if (manufacturer.equals("samsung", ignoreCase = true) ||
+                manufacturer.equals("honor", ignoreCase = true)
+            ) {
                 val settingsIntent = Intent(Settings.ACTION_VOICE_INPUT_SETTINGS)
                 try {
                     assistantRoleLauncher.launch(settingsIntent)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -1,9 +1,11 @@
 package com.kernel.ai.feature.settings
 
+import android.os.Build
 import androidx.lifecycle.ViewModel
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
 import com.kernel.ai.core.voice.SherpaKokoroVoice
 import com.kernel.ai.core.voice.SherpaPiperVoice
 import com.kernel.ai.core.voice.SherpaVoicePackDownloadManager
@@ -87,6 +89,16 @@ data class VoiceUiState(
     /** Non-null when a download attempt failed. */
     val sherpaOnnxSttError: String? = null,
 )
+internal fun resolveAndroidNativeAvailabilityMessage(
+    availability: AndroidNativeRecognitionAvailability,
+    manufacturer: String?,
+): String? =
+    if (manufacturer?.equals("honor", ignoreCase = true) == true) {
+        "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice."
+    } else {
+        availability.warningMessage
+    }
+
 
 @HiltViewModel
 class VoiceViewModel @Inject constructor(
@@ -106,9 +118,13 @@ class VoiceViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val availability = androidNativeRecognitionSupport.getAvailability()
+            val nativeWarning = resolveAndroidNativeAvailabilityMessage(
+                availability = availability,
+                manufacturer = Build.MANUFACTURER,
+            )
             _uiState.update {
                 it.copy(
-                    androidNativeAvailabilityMessage = availability.warningMessage,
+                    androidNativeAvailabilityMessage = nativeWarning,
                     androidNativeLanguageSummary = availability.languageSummary,
                 )
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -1,6 +1,5 @@
 package com.kernel.ai.feature.settings
 
-import android.os.Build
 import androidx.lifecycle.ViewModel
 import android.content.Context
 import androidx.lifecycle.viewModelScope
@@ -91,13 +90,7 @@ data class VoiceUiState(
 )
 internal fun resolveAndroidNativeAvailabilityMessage(
     availability: AndroidNativeRecognitionAvailability,
-    manufacturer: String?,
-): String? =
-    if (manufacturer?.equals("honor", ignoreCase = true) == true) {
-        "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice."
-    } else {
-        availability.warningMessage
-    }
+): String? = availability.warningMessage
 
 
 @HiltViewModel
@@ -118,10 +111,7 @@ class VoiceViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val availability = androidNativeRecognitionSupport.getAvailability()
-            val nativeWarning = resolveAndroidNativeAvailabilityMessage(
-                availability = availability,
-                manufacturer = Build.MANUFACTURER,
-            )
+            val nativeWarning = resolveAndroidNativeAvailabilityMessage(availability)
             _uiState.update {
                 it.copy(
                     androidNativeAvailabilityMessage = nativeWarning,

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -265,7 +265,7 @@ class VoiceViewModelTest {
     }
 
     @Test
-    fun `resolveAndroidNativeAvailabilityMessage keeps platform warning on non-Honor`() {
+    fun `resolveAndroidNativeAvailabilityMessage returns platform warning`() {
         val availability = AndroidNativeRecognitionAvailability(
             isRecognitionAvailable = true,
             isOnDeviceRecognitionAvailable = false,
@@ -276,23 +276,7 @@ class VoiceViewModelTest {
 
         assertEquals(
             "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input.",
-            resolveAndroidNativeAvailabilityMessage(availability, manufacturer = "google"),
-        )
-    }
-
-    @Test
-    fun `resolveAndroidNativeAvailabilityMessage shows Honor fallback warning on Honor`() {
-        val availability = AndroidNativeRecognitionAvailability(
-            isRecognitionAvailable = true,
-            isOnDeviceRecognitionAvailable = true,
-            languageTag = "en-AU",
-            languageDisplayName = "English (Australia)",
-            localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
-        )
-
-        assertEquals(
-            "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice.",
-            resolveAndroidNativeAvailabilityMessage(availability, manufacturer = "HONOR"),
+            resolveAndroidNativeAvailabilityMessage(availability),
         )
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.settings
 
+import android.content.Context
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.inference.download.KernelModel
 import com.kernel.ai.core.inference.download.ModelDownloadManager
@@ -46,6 +47,7 @@ class VoiceViewModelTest {
     private val wakeWordPreferences: WakeWordPreferences = mockk(relaxed = true)
     private val wakeWordDetector: WakeWordDetector = mockk()
     private val modelDownloadManager: ModelDownloadManager = mockk()
+    private val context: Context = mockk(relaxed = true)
     private val heyJandalEnabled = MutableStateFlow(false)
     private val wakeWordThreshold = MutableStateFlow(0.80f)
     private val selectedInputEngine = MutableStateFlow(VoiceInputEngine.Vosk)
@@ -137,6 +139,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            context,
         )
     }
 
@@ -193,6 +196,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -221,6 +225,7 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -249,12 +254,45 @@ class VoiceViewModelTest {
             wakeWordPreferences,
             wakeWordDetector,
             modelDownloadManager,
+            context,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             "Android native speech recognition could not verify on-device support for English (New Zealand) on this device. It may fail unless that language is supported and installed locally.",
             viewModel.uiState.value.androidNativeAvailabilityMessage,
+        )
+    }
+
+    @Test
+    fun `resolveAndroidNativeAvailabilityMessage keeps platform warning on non-Honor`() {
+        val availability = AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = false,
+            languageTag = "en-US",
+            languageDisplayName = "English (United States)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.Unknown,
+        )
+
+        assertEquals(
+            "On-device Android speech recognition is unavailable for the current setup. Install the required language pack or keep using Vosk for guaranteed local voice input.",
+            resolveAndroidNativeAvailabilityMessage(availability, manufacturer = "google"),
+        )
+    }
+
+    @Test
+    fun `resolveAndroidNativeAvailabilityMessage shows Honor fallback warning on Honor`() {
+        val availability = AndroidNativeRecognitionAvailability(
+            isRecognitionAvailable = true,
+            isOnDeviceRecognitionAvailable = true,
+            languageTag = "en-AU",
+            languageDisplayName = "English (Australia)",
+            localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
+        )
+
+        assertEquals(
+            "Android native speech recognition is failing on this device. Switch to Sherpa-ONNX or Vosk in Settings → Voice.",
+            resolveAndroidNativeAvailabilityMessage(availability, manufacturer = "HONOR"),
         )
     }
 

--- a/feature/widget/src/main/java/com/kernel/ai/feature/widget/VoiceCommandActivity.kt
+++ b/feature/widget/src/main/java/com/kernel/ai/feature/widget/VoiceCommandActivity.kt
@@ -55,8 +55,8 @@ import com.kernel.ai.core.voice.VoiceInputStartResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -295,9 +295,16 @@ class VoiceCommandActivity : ComponentActivity() {
 
         var retryAttempted = false
         lifecycleScope.launch {
-            voiceInputController.events
-                .onStart { voiceInputController.startListening(VoiceCaptureMode.AlertCommand) }
-                .collect { event ->
+            suspend fun showUnavailableAndFinish(message: String) {
+                val errorText = message.ifBlank { "Voice commands are unavailable right now." }
+                Log.w(TAG, "VoiceCommandActivity: voice unavailable — $errorText")
+                partialText = errorText
+                delay(2_000)
+                if (!isFinishing) finish()
+            }
+
+            val eventCollectorJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                voiceInputController.events.collect { event ->
                     when (event) {
                         is VoiceInputEvent.PartialTranscript -> {
                             partialText = event.text
@@ -309,12 +316,13 @@ class VoiceCommandActivity : ComponentActivity() {
                                 navigator.navigateToActions(this@VoiceCommandActivity, transcript, isVoice = true)
                                 finish()
                             } else if (!retryAttempted) {
-                                // #790: blank transcript — retry once.
                                 retryAttempted = true
                                 partialText = ""
                                 Log.d(TAG, "VoiceCommandActivity: blank transcript — retrying")
-                                val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
-                                if (result !is VoiceInputStartResult.Started) finish()
+                                when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
+                                    is VoiceInputStartResult.Started -> Unit
+                                    is VoiceInputStartResult.Unavailable -> showUnavailableAndFinish(result.message)
+                                }
                             } else {
                                 finish()
                             }
@@ -322,19 +330,29 @@ class VoiceCommandActivity : ComponentActivity() {
                         is VoiceInputEvent.Error -> {
                             Log.w(TAG, "VoiceCommandActivity: voice error — ${event.message}")
                             if (!retryAttempted) {
-                                // #790: retry once on error before closing.
                                 retryAttempted = true
                                 partialText = ""
                                 Log.d(TAG, "VoiceCommandActivity: retrying after error")
-                                val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
-                                if (result !is VoiceInputStartResult.Started) finish()
+                                when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
+                                    is VoiceInputStartResult.Started -> Unit
+                                    is VoiceInputStartResult.Unavailable -> showUnavailableAndFinish(result.message)
+                                }
                             } else {
-                                finish()
+                                showUnavailableAndFinish(event.message)
                             }
                         }
                         else -> Unit
                     }
                 }
+            }
+
+            when (val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
+                is VoiceInputStartResult.Started -> Unit
+                is VoiceInputStartResult.Unavailable -> {
+                    eventCollectorJob.cancel()
+                    showUnavailableAndFinish(startResult.message)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1001

## What

A dedicated **App Permissions** screen in Settings that lists every runtime permission the app declares, shows grant/deny status, and provides a one-tap "fix" action that opens the right system settings panel.

Also improves the "Phone permission required" error message so it tells the user where to go to fix it.

## Changes

**New files:**
- `AppPermissionsViewModel.kt` — enumerates all runtime permissions (`CALL_PHONE`, `RECORD_AUDIO`, `POST_NOTIFICATIONS`, `ACCESS_COARSE_LOCATION`, `READ_CONTACTS`, `READ_CALENDAR`) plus special-access permissions (DND). Checks grant state on init and provides deep-link intents to `ACTION_APPLICATION_DETAILS_SETTINGS` or the specific special-access panel.
- `AppPermissionsScreen.kt` — scrollable Compose list with permission name, description, green/red status icon, and tap-to-fix. Includes refresh button and tip text.

**Modified files:**
- `KernelNavHost.kt` — registers `settings/app_permissions` route with navigation callback
- `SettingsScreen.kt` — adds "App Permissions" ListItem in the "App" section (Security icon)
- `NativeIntentHandler.kt` — updated `PHONE_PERMISSION_REQUIRED_ERROR` to include "Check Settings → App Permissions to grant it."
- `ActionsViewModel.kt` — synced local `PHONE_PERMISSION_REQUIRED_ERROR` constant and `onPhonePermissionDenied()` error string
- `ActionsViewModelVoiceTest.kt` — updated test string literals

## Verification
- [x] `:core:skills:testDebugUnitTest` — pass
- [x] `:feature:chat:testDebugUnitTest` — 377 tests, 1 pre-existing failure (LaTeX nesting, unrelated)
- [x] `:app:assembleDebug` — builds clean