### PR TITLE
feat(#1025): model availability UX patterns

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -1,4 +1,4 @@
-# Kernel AI Assistant — Agent Context
+# Jandal AI Assistant — Agent Context
 
 Android-native, local-first AI assistant. All inference on-device via LiteRT. Kotlin host; Wasm guest-only.
 

--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -204,7 +204,7 @@ Load these only when relevant:
 - `.docs/agents/decision-heuristics.md` — when multiple valid approaches exist
 - `.docs/agents/failure-handling.md` — blockers, escalation, progress reporting
 - `.docs/agents/repo-map.md` — key file index by area
-- `docs/UX_PATTERNS.md` — canonical UI/UX patterns for lists, navigation, settings, Compose (read before any new screen)
+- `docs/UX_PATTERNS.md` — canonical UI/UX patterns for lists, navigation, settings, Compose (read before any new screen); for model-facing screens also read [`docs/model-availability-ux-patterns.md`](../docs/model-availability-ux-patterns.md)
 
 ## Phase status
 

--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -310,9 +310,12 @@ The model availability patterns govern:
 - All model cards, model lists, and model selection screens
 - Download, validation, and repair flows
 - Provider sign-in, license acceptance, and gated-access workflows
-- Voice Settings model display (Voice Settings delegates download/auth/licensing to Model Management)
+- Voice Preferences model display (delegates download/auth/licensing to Model Management)
+- Assistant Settings model configuration
+- Agent Configuration model selection
 - The four top-level states: **Ready**, **Preparing**, **Action Required**, **Unavailable**
 
-When building any screen that surfaces models — whether in Settings, Voice Preferences, or a
-dedicated Model Management screen — read [`model-availability-ux-patterns.md`](./model-availability-ux-patterns.md)
-first. Do not invent parallel model states or action labels.
+When building any screen that surfaces models — whether in Settings, Voice Preferences, Assistant Settings,
+Agent Configuration, or a dedicated Model Management screen — read
+[`model-availability-ux-patterns.md`](./model-availability-ux-patterns.md) first.
+Do not invent parallel model states or action labels.

--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -7,6 +7,7 @@
 >
 > This document describes **how things are built**, not what is planned. For feature status see
 > [`ROADMAP.md`](./ROADMAP.md). For technical architecture see [`SPECIFICATION.md`](./SPECIFICATION.md).
+> For model availability and acquisition patterns, see [`model-availability-ux-patterns.md`](./model-availability-ux-patterns.md).
 
 ---
 
@@ -296,3 +297,22 @@ Before raising a PR for any new feature that adds a list/collection screen, veri
 - [ ] Search (if applicable): LIKE with NULL guard and escaped wildcards
 - [ ] Confirmation dialogs for all destructive actions
 - [ ] Touch targets ≥ 48dp
+
+---
+
+## 14. Model Availability (Cross-Reference)
+
+Model discovery, acquisition, selection, and lifecycle management follow a separate, dedicated
+pattern document: **[`model-availability-ux-patterns.md`](./model-availability-ux-patterns.md)**.
+
+The model availability patterns govern:
+
+- All model cards, model lists, and model selection screens
+- Download, validation, and repair flows
+- Provider sign-in, license acceptance, and gated-access workflows
+- Voice Settings model display (Voice Settings delegates download/auth/licensing to Model Management)
+- The four top-level states: **Ready**, **Preparing**, **Action Required**, **Unavailable**
+
+When building any screen that surfaces models — whether in Settings, Voice Preferences, or a
+dedicated Model Management screen — read [`model-availability-ux-patterns.md`](./model-availability-ux-patterns.md)
+first. Do not invent parallel model states or action labels.

--- a/docs/model-availability-gap-analysis.md
+++ b/docs/model-availability-gap-analysis.md
@@ -228,18 +228,17 @@ The current implementation has a solid foundation for model management but diver
 
 Based on the gaps above, the following issues should be created (see Issue Creation section for details):
 
-| Issue | Severity | Scope |
 |-------|----------|-------|
-| #1026 | Critical | Introduce canonical 4-state badge system |
-| #1027 | Critical | Remove "Download" button for required models |
-| #1028 | Critical | Delegate voice pack downloads to Model Management |
-| #1029 | High | Add "Preparing" state for auto-queue/background work |
-| #1030 | High | Map all state labels to guideline states |
-| #1031 | High | Add approval pending workflow for gated models |
-| #1032 | Medium | Integrate HF auth into model card workflow |
-| #1033 | Medium | Add model availability overview to Settings |
-| #1034 | Medium | Show state on Model Settings screen |
-| #1035 | Low | Hide deprecated models from Model Management |
-| #1036 | Low | Consolidate Error state to single action |
-| #1037 | Low | Standardize wake word unavailable state |
-| #1038 | Low | Group SentencePiece with EmbeddingGemma |
+| #1029 | Critical | Introduce canonical 4-state badge system |
+| #1030 | Critical | Remove "Download" button for required models |
+| #1031 | Critical | Delegate voice pack downloads to Model Management |
+| #1032 | High | Add "Preparing" state for auto-queue/background work |
+| #1033 | High | Map all state labels to guideline states |
+| #1034 | High | Add approval pending workflow for gated models |
+| #1035 | Medium | Integrate HF auth into model card workflow |
+| #1036 | Medium | Add model availability overview to Settings |
+| #1037 | Medium | Show state on Model Settings screen |
+| #1038 | Low | Hide deprecated models from Model Management |
+| #1039 | Low | Consolidate Error state to single action |
+| #1040 | Low | Standardize wake word unavailable state |
+| #1041 | Low | Group SentencePiece with EmbeddingGemma |

--- a/docs/model-availability-gap-analysis.md
+++ b/docs/model-availability-gap-analysis.md
@@ -1,0 +1,245 @@
+# Model Availability — UX Gap Analysis
+
+> **Generated:** 2026-05-30
+> **Scope:** All model-facing screens in `kernel-ai-assistant` reviewed against `docs/model-availability-ux-patterns.md`
+> **Status:** In-progress — initial audit complete, issue creation pending
+
+---
+
+## Executive Summary
+
+The current implementation has a solid foundation for model management but diverges from the new guidelines in several key areas:
+
+1. **State labels are inconsistent** — the app uses `Downloaded`, `Downloading`, `Error`, `Not downloaded` while the guidelines define `Ready`, `Preparing`, `Action Required`, `Unavailable`.
+2. **"Download" is still a primary action** — required models show a "Download" button in Model Management, contradicting the principle that required models should be acquired automatically.
+3. **No explicit required/optional distinction for users** — while the enum has `isRequired`, the UI shows it as a "Required"/"Optional" chip but doesn't change behaviour accordingly.
+4. **Voice settings duplicates download management** — Voice screen has its own download rows, progress bars, and cancel/delete controls, which the guidelines say should be delegated to Model Management.
+5. **No "Preparing" state** — there is no background-indicator state where the app is working without user action. Downloading is shown but with a "Download"/"Cancel" action visible.
+6. **No approval pending state** — the code handles licence-required errors but has no workflow for gated-access approval requests.
+
+---
+
+## Screen-by-Screen Review
+
+### 1. Model Management Screen (`ModelManagementScreen.kt`)
+
+**What it does:** Generic model inventory with download, cancel, update, delete, licence review, sign-in, and preferred model selection.
+
+**Current state labels:** `Downloaded`, `Downloading`, `Error`, `Not downloaded`, `Built-in`
+
+**Guideline state labels:** `Ready`, `Preparing`, `Action Required`, `Unavailable`
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Top-level state badge | None (raw state labels in supporting text) | Consistent 4-state badge per card | **Missing** — no visible state badge; states shown only in supporting text |
+| "Download" button for required models | Yes — `Text("Download")` shown for all `NotDownloaded` | Should not appear for required models | **Critical** — required models show "Download" button alongside optional ones |
+| Required/Optional chip | Yes — SuggestionChip with "Required"/"Optional" | Yes — but should also change behaviour | **Partial** — chip exists but doesn't affect UI treatment |
+| Download progress display | LinearProgressIndicator + percentage + MB/s + ETA | "Preparing" with progress | **Partial** — progress shown but labelled as a "Download" action |
+| Error handling | Shows error message + "Retry" + "Accept licence" | "Action Required" with single primary action | **Gap** — two buttons shown (Accept licence, Retry); should be one primary action |
+| Gated model lock icon | Yes — orange lock icon | N/A (gated handled via Action Required) | **Minor** — lock icon is redundant when Action Required state is shown |
+| HuggingFace sign-in | Separate section above models | Integrated into access workflow | **Gap** — HF auth is a separate section rather than part of the model card workflow |
+| Update button | Shown for downloaded non-bundled models | Not explicitly covered | **Minor** — "Update" is a valid action for optional models |
+| Delete button | Shown for downloaded non-required models | Yes — optional models may be removed | **Aligned** |
+| Preferred model selection | Radio list below model rows | Separate from acquisition | **Aligned** — selection is independent of download |
+| No "Preparing" state for auto-queue | Downloading shows immediately with Cancel | Background work should show "Preparing" without user action | **Gap** — no distinction between "user initiated download" and "app auto-downloading" |
+
+**Verdict:** Moderate gaps. The biggest issue is that required models are treated identically to optional models in the download row — both show "Download" buttons. The state language is also inconsistent with the guideline.
+
+---
+
+### 2. Voice Preferences Screen (`VoiceScreen.kt`)
+
+**What it does:** Voice configuration — Hey Jandal, wake word, STT engine selection, TTS engine selection, voice pack downloads, speaker selection.
+
+**Current state labels:** `Downloaded and ready`, `Downloading`, `Download failed`, `Not downloaded`, `Selected voice`, `Currently active`, `Download required before use`, `Wake word model not yet available`, `Ready`
+
+**Guideline principle:** Voice Settings should display models and availability, allow selection, but delegate download/auth/licensing to Model Management.
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Voice pack download rows | Yes — `SherpaVoiceRow` and `KokoroVoiceRow` with Download/Cancel/Delete | Delegated to Model Management | **Critical** — Voice screen has full download management |
+| STT download card | `SherpaOnnxSttDownloadCard` with Download/Cancel/Delete | Delegated to Model Management | **Critical** — STT download is in Voice screen |
+| State labels | Mix of `Downloaded and ready`, `Downloading`, `Download failed`, `Not downloaded` | `Ready`, `Preparing`, `Action Required`, `Unavailable` | **Gap** — labels don't match guideline states |
+| "Download required before use" text | Shown as error-text for STT engine | "Action Required" with single action button | **Gap** — just text, no actionable button |
+| Assistant role request | Separate flow in `onRequestAssistantRole` | Not explicitly covered | **Minor** — assistant role is a platform permission, not a model availability concern |
+| Wake word "not yet available" | Shows info text, disables toggle | "Unavailable" state | **Gap** — should use standard Unavailable state pattern |
+| Voice selection when not downloaded | Disabled radio + "not downloaded" text | Selection should be independent of acquisition | **Aligned** — radio is disabled when not downloaded |
+| Speaker selectors | Inlined below selected voice | N/A | **Aligned** — speaker selection is a voice-specific concern |
+
+**Verdict:** Major gap. Voice screen is a download manager in practice, which directly contradicts the guideline. This is the largest area of divergence.
+
+---
+
+### 3. Model Settings Screen (`ModelSettingsScreen.kt`)
+
+**What it does:** Per-model inference parameter tuning (context window, temperature, top-P, top-K, thinking mode, speculative decoding) for Gemma 4 E-2B and E-4B.
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Model cards | Two cards (E-2B, E-4B) with settings | Model card pattern | **Partial** — cards show model name and settings but no state badge, no publisher, no capability |
+| State display | None — assumes models are loaded and available | All cards should show current state | **Gap** — no state shown; if a model is unavailable the card just doesn't render |
+| Save/Cancel pattern | Screen-level buttons at bottom | N/A | **Aligned** — standard pattern |
+| "Saving…" state | Shown in save button | N/A | **Minor** — loading state on button |
+
+**Verdict:** Minor gaps. The model settings screen is a secondary screen (accessed after model is available), so the absence of state badges is acceptable. But it should at least show "Unavailable" if a model is not downloaded.
+
+---
+
+### 4. Chat Screen — Onboarding (`ChatScreen.kt`, `OnboardingContent`)
+
+**What it does:** First-run model download/progress screen shown before chat is accessible.
+
+**Current state labels:** `✓ Ready`, `Error`, `Queued`, `Downloading` (with % and MB/s), `Sign in to HuggingFace to download`
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Welcome screen | "Kia ora, welcome to Jandal" + model progress | Frictionless first run | **Aligned** — models auto-download on first run |
+| Per-model progress rows | `ModelProgressRow` with progress bar + status | "Preparing" with progress | **Partial** — shows progress but labels are raw state names not guideline states |
+| Error state | "Download failed" + Retry button | "Action Required" with single action | **Gap** — Retry is appropriate but label doesn't use guideline state |
+| Gated model (NotDownloaded) | "Sign in to HuggingFace to download" + "Sign in" button | "Action Required" with Sign In | **Aligned** — this is correct |
+| Queued models | Shows "Queued" text | "Preparing" | **Gap** — "Queued" is not a guideline state; should be "Preparing" |
+| No "Preparing" with background indicator | Downloading shows progress bar + Cancel | Background work should show "Preparing" without Cancel | **Gap** — user can cancel required model downloads; should be "Preparing" without cancel |
+| "please stay connected to Wi-Fi" | Shown during download | Progressive disclosure | **Minor** — technical detail, acceptable |
+
+**Verdict:** Moderate gaps. The onboarding correctly auto-downloads models and handles gated access, but state labels are raw enum names rather than the guideline states. The "Queued" state is not mapped to "Preparing".
+
+---
+
+### 5. Settings Screen (`SettingsScreen.kt`)
+
+**What it does:** Settings hub — Models section with preferred model row, Model Management link, Model Settings link, HuggingFace account row. Voice and Memory links.
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Preferred model row | Shows model name + backend + tier | Shows current state | **Gap** — no state badge; just text |
+| HuggingFace account row | Separate section with sign-in/sign-out | Integrated into model card workflow | **Gap** — auth is separate from model acquisition |
+| No model availability overview | No summary of which models are ready/missing | Users should always know model status | **Gap** — Settings doesn't show model availability at a glance |
+
+**Verdict:** Minor gaps. The Settings screen is a navigation hub; it should at least show a status indicator for the preferred model.
+
+---
+
+## Model-by-Model Review
+
+### Gemma 4 E-2B (Required)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Required flag | `isRequired = true` | Automatically acquired | **Partial** — shown in Model Management with "Download" button |
+| Auto-download | Not explicitly triggered at app start | Required models should auto-download | **Gap** — no explicit auto-queue for E-2B at startup |
+| State display | "Downloaded" / "Downloading" / "Error" / "Not downloaded" | Ready / Preparing / Action Required / Unavailable | **Gap** — labels don't match |
+| Cannot be deleted | Not explicitly enforced | Required models should not be deletable | **Aligned** — delete only shown for `!isRequired` |
+| Preferred model option | Yes — selectable in Model Management | Single active model | **Aligned** |
+
+### Gemma 4 E-4B (Optional)
+
+| Aspect | Current | Guideline | Guideline | Gap |
+|--------|---------|-----------|-----------|-----|
+| Required flag | `isRequired = false` | User chooses | **Aligned** |
+| Auto-download | Not triggered | User chooses | **Aligned** |
+| Download button | Shown for all NotDownloaded | Should not show for required; OK for optional | **Aligned** |
+| Delete button | Shown when downloaded | User may remove | **Aligned** |
+| State labels | Same as E-2B | Ready / Preparing / Action Required / Unavailable | **Gap** — labels |
+
+### EmbeddingGemma 300M (Required)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Required flag | `isRequired = true` | Automatically acquired | **Partial** — gated, requires HF auth first |
+| Gated | Yes — `isGated = true` | Access workflow | **Aligned** — Error state shows "Accept licence" |
+| Auto-download | Downloaded alongside E-2B during onboarding | Required models auto-acquire | **Aligned** |
+| State labels | Same as other models | Ready / Preparing / Action Required / Unavailable | **Gap** — labels |
+| SentencePiece tokenizer | Separate model entry, `isRequired = true` | System-managed | **Minor** — shown as separate model in Model Management |
+
+### MiniLM-L6 Intent Classifier (Bundled)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Required flag | `isRequired = false` | N/A (bundled) | **Minor** — bundled models should be clearly marked as such |
+| Bundled | `isBundled = true` | Clearly identified as system-managed | **Aligned** — shows "Built-in" chip |
+| Download controls | None | Should not appear | **Aligned** |
+| Display in Model Management | Yes | User awareness | **Aligned** |
+
+### FunctionGemma-270M (Deprecated)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Status | Deprecated, not loaded | N/A | **Minor** — should be removed or hidden from Model Management |
+| In KernelModel enum | Not present (was removed) | N/A | **Aligned** |
+
+### Sherpa STT Models (Optional, `showInModelManagement = false`)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Display in Model Management | Hidden (`showInModelManagement = false`) | Delegated to Voice screen | **Aligned** — but Voice screen has full download management |
+| Download in Voice screen | `SherpaOnnxSttDownloadCard` | Delegated to Model Management | **Critical** — Voice screen should not manage downloads |
+| State labels | `isSherpaOnnxSttDownloaded`, `isSherpaOnnxSttDownloading`, `sherpaOnnxSttError` | Ready / Preparing / Action Required / Unavailable | **Gap** — labels |
+
+### Sherpa Piper / Kokoro Voice Packs (Optional)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Download in Voice screen | `SherpaVoiceRow` / `KokoroVoiceRow` | Delegated to Model Management | **Critical** — Voice screen has full download management |
+| State labels | `VoicePackDownloadState.Downloaded`, `Downloading`, `Failed`, `NotDownloaded` | Ready / Preparing / Action Required / Unavailable | **Gap** — labels |
+| Delete | Shown for downloaded voices | User may remove | **Aligned** |
+| Download/Cancel | Shown in row | Delegated | **Critical** |
+
+### Wake Word Model (Not yet available)
+
+| Aspect | Current | Guideline | Gap |
+|--------|---------|-----------|-----|
+| Availability | "Wake word model not yet available — model training in progress (#984)" | Unavailable with explanation | **Partial** — shows explanation but uses custom text, not standard Unavailable state |
+| Toggle behavior | Disabled when unavailable | N/A | **Aligned** |
+
+---
+
+## Gap Summary by Severity
+
+### Critical (must fix before guideline adoption)
+
+1. **Voice screen is a download manager** — `VoiceScreen.kt` has full download/cancel/delete for STT and voice packs. Per guidelines, this should be delegated to Model Management.
+2. **Required models show "Download" button** — Model Management shows "Download" for all `NotDownloaded` models including required ones. Required models should show "Preparing" or "Ready" without a Download action.
+3. **No state badge system** — no screen shows the four canonical states (Ready, Preparing, Action Required, Unavailable) as consistent badges.
+
+### High (should fix for guideline compliance)
+
+4. **State labels inconsistent** — app uses `Downloaded`, `Downloading`, `Error`, `Not downloaded`, `Built-in` instead of `Ready`, `Preparing`, `Action Required`, `Unavailable`.
+5. **No "Preparing" state** — no distinction between "user initiated download" and "app auto-downloading". Both show progress bar + Cancel button.
+6. **No approval pending state** — no workflow for gated-access requests awaiting review.
+7. **"Queued" state not mapped** — chat onboarding shows "Queued" for models waiting to download; should be "Preparing".
+
+### Medium (improvement)
+
+8. **HuggingFace auth is separate** — HF sign-in is a separate section, not integrated into the model card access workflow.
+9. **Settings screen has no model availability overview** — no at-a-glance status of which models are ready/missing.
+10. **Model Settings screen has no state** — model cards don't show state; they just don't render if unavailable.
+11. **FunctionGemma-270M deprecated** — should be hidden from Model Management.
+12. **Two buttons on Error state** — Model Management shows both "Accept licence" and "Retry" on error; guideline says one primary action only.
+
+### Low (cosmetic/alignment)
+
+13. **Lock icon redundant** — gated model lock icon shown alongside Action Required state.
+14. **Wake word unavailable uses custom text** — not using standard Unavailable state pattern.
+15. **SentencePiece tokenizer shown separately** — should be grouped with EmbeddingGemma.
+
+---
+
+## Recommended Issue Breakdown
+
+Based on the gaps above, the following issues should be created (see Issue Creation section for details):
+
+| Issue | Severity | Scope |
+|-------|----------|-------|
+| #1026 | Critical | Introduce canonical 4-state badge system |
+| #1027 | Critical | Remove "Download" button for required models |
+| #1028 | Critical | Delegate voice pack downloads to Model Management |
+| #1029 | High | Add "Preparing" state for auto-queue/background work |
+| #1030 | High | Map all state labels to guideline states |
+| #1031 | High | Add approval pending workflow for gated models |
+| #1032 | Medium | Integrate HF auth into model card workflow |
+| #1033 | Medium | Add model availability overview to Settings |
+| #1034 | Medium | Show state on Model Settings screen |
+| #1035 | Low | Hide deprecated models from Model Management |
+| #1036 | Low | Consolidate Error state to single action |
+| #1037 | Low | Standardize wake word unavailable state |
+| #1038 | Low | Group SentencePiece with EmbeddingGemma |

--- a/docs/model-availability-ux-patterns.md
+++ b/docs/model-availability-ux-patterns.md
@@ -7,6 +7,9 @@
 > This document describes **how things should work**, not what is currently implemented.
 > For feature status see [`ROADMAP.md`](./ROADMAP.md). For technical architecture see
 > [`SPECIFICATION.md`](./SPECIFICATION.md).
+>
+> **Applies to:** Model Management, Voice Settings, Assistant Settings, Agent Configuration,
+> and all future model-enabled features.
 
 ---
 
@@ -71,6 +74,20 @@ The same labels should be used throughout the application. Top-level model state
 | **Preparing** | Kernel AI is performing background work |
 | **Action Required** | User must complete an action |
 | **Unavailable** | Model cannot currently be used |
+
+Detailed lifecycle states map to top-level states as follows:
+
+| Detailed state | Top-level state |
+|---|---|
+| Downloading, updating, validating, repairing | **Preparing** |
+| Approval Pending (awaiting review) | **Preparing** |
+| Authentication Required | **Action Required** |
+| License Acceptance Required | **Action Required** |
+| Access Approval Required | **Action Required** |
+| Access Denied | **Unavailable** |
+| Provider unavailable / model removed / unsupported device | **Unavailable** |
+
+This mapping ensures every screen uses the same top-level badge regardless of the underlying cause.
 
 Detailed lifecycle states appear only when additional information is needed.
 
@@ -272,11 +289,13 @@ Examples: Quantisation, Context Length, Runtime, Last Validation Date, Technical
 
 ### Primary Action
 
-One action only.
+One action only — displayed on the card itself.
 
 Examples: Sign In, Review License, Request Access, Select Model, Retry.
 
 The primary action should always represent the next required step.
+
+Secondary actions (Accept License, Open Provider Page, Request Again) are available *after* the primary action opens the relevant flow — not as a second button on the card. For example: the card shows "Review License"; inside the license review screen, the user can "Accept License".
 
 ---
 
@@ -312,9 +331,9 @@ Kernel AI should never silently switch models.
 
 ## Screen Responsibilities
 
-### Voice Settings
+### Voice Preferences
 
-Voice Settings is not a download manager.
+Voice Preferences is not a download manager.
 
 **Should:**
 

--- a/docs/model-availability-ux-patterns.md
+++ b/docs/model-availability-ux-patterns.md
@@ -1,0 +1,364 @@
+# Model Availability UX Patterns
+
+> **Purpose:** This is the canonical reference for user experience patterns around model discovery,
+> acquisition, access, selection, and lifecycle management within Kernel AI.
+> Before implementing any screen or flow related to models, read this document first.
+>
+> This document describes **how things should work**, not what is currently implemented.
+> For feature status see [`ROADMAP.md`](./ROADMAP.md). For technical architecture see
+> [`SPECIFICATION.md`](./SPECIFICATION.md).
+
+---
+
+## Core UX Principle
+
+**Users Want an Assistant, Not a Model Manager.**
+
+Kernel AI should automatically perform any action that can be completed without user intervention.
+Users should only be interrupted when human action is genuinely required.
+
+### Automatic (no user action needed)
+
+- Downloading required models
+- Downloading model updates
+- Validating downloads
+- Repairing corrupted downloads
+- Selecting default models during onboarding
+
+### User Action Required
+
+- Signing in to a provider
+- Accepting a license agreement
+- Requesting access to gated models
+- Purchasing a model
+- Resolving insufficient storage
+
+---
+
+## Design Principles
+
+### Frictionless First Run
+
+A new user should be able to install Kernel AI and begin interacting with the assistant without
+manually downloading required models. Required models should automatically begin acquisition during
+onboarding.
+
+### Progressive Disclosure
+
+Most users care about:
+
+1. Is it available?
+2. Can I use it?
+3. What do I need to do next?
+
+Technical details should be available but secondary.
+
+### Action-Oriented UX
+
+The primary action should always represent the next required step.
+
+Examples: Sign In, Review License, Request Access, Retry, Select Model.
+
+Never show multiple competing primary actions.
+
+### Consistent State Language
+
+The same labels should be used throughout the application. Top-level model states:
+
+| State | Meaning |
+|---|---|
+| **Ready** | Model is fully available |
+| **Preparing** | Kernel AI is performing background work |
+| **Action Required** | User must complete an action |
+| **Unavailable** | Model cannot currently be used |
+
+Detailed lifecycle states appear only when additional information is needed.
+
+---
+
+## Model Sources
+
+Kernel AI supports multiple model providers.
+
+Examples: Hugging Face, Google AI Edge, Ollama Registry, Local Import, Custom URL.
+
+Provider-specific requirements should integrate into the common Kernel AI access workflow. The user
+experience should remain consistent regardless of provider.
+
+---
+
+## Required vs Optional Models
+
+### Required Models
+
+Required models are necessary for core application functionality.
+
+Examples:
+
+- Default assistant model
+- Default speech-to-text model
+- Default text-to-speech model
+
+**Behaviour:**
+
+- Automatically acquired
+- Automatically updated
+- Automatically validated
+- Clearly identified as system-managed
+
+Users should not need to manually download required models.
+
+### Optional Models
+
+Optional models provide additional functionality.
+
+Examples:
+
+- Alternative chat models
+- Coding models
+- Experimental models
+- Large premium models
+
+**Behaviour:**
+
+- User chooses whether to install
+- User controls storage usage
+- User may remove at any time
+
+---
+
+## User-Facing Availability States
+
+### Ready
+
+**Description:** The model is fully available and can be used immediately.
+
+**Examples:** Download complete, validation complete, access requirements satisfied.
+
+### Preparing
+
+**Description:** Kernel AI is performing background work to make the model available.
+
+**Examples:** Downloading, updating, validating, repairing. The user should not need to take action.
+
+**Example surface:**
+
+```
+Llama 4 Scout
+Preparing
+Downloading 62%
+```
+
+### Action Required
+
+**Description:** Kernel AI cannot proceed until the user completes a required action.
+
+**Examples:** Sign in to provider, accept license, request access, resolve storage issue.
+
+The required action should be clearly explained with a single primary action button.
+
+**Example surface:**
+
+```
+Voice Model
+Action Required
+Sign in to Hugging Face to continue.
+[Sign In]
+```
+
+### Unavailable
+
+**Description:** The model cannot currently be used.
+
+**Examples:** Access denied, provider unavailable, model removed by publisher, unsupported device.
+
+A clear explanation should always be provided.
+
+---
+
+## Access Workflow
+
+Kernel AI should automatically progress through all stages that do not require user interaction.
+
+### Automatic Workflow
+
+```
+Ready to Download → Downloading → Validating → Ready
+```
+
+Users should not be required to manually trigger these steps.
+
+### User Intervention Workflow
+
+```
+Sign In Required → License Acceptance Required → Access Approval Required
+    → Ready to Download → Downloading → Validating → Ready
+```
+
+Kernel AI should automatically continue once the user completes the required action.
+
+---
+
+## Provider Requirements
+
+### Authentication Required
+
+**Description:** The provider requires user authentication.
+
+**Examples:** Hugging Face gated repositories, commercial providers.
+
+**Primary Action:** Sign In
+
+### License Acceptance Required
+
+**Description:** The user must review and accept licensing terms.
+
+**Examples:** Llama Community License, Gemma License, OpenRAIL.
+
+**Primary Action:** Review License
+**Secondary Action:** Accept License
+
+The license name should always be visible.
+
+### Access Approval Required
+
+**Description:** The provider requires approval before access is granted.
+
+**Examples:** Gated Hugging Face models, research models, commercially restricted models.
+
+**Primary Action:** Request Access
+**Secondary Action:** Open Provider Page
+
+### Approval Pending
+
+**Description:** An access request has been submitted and is awaiting review.
+
+**Primary Action:** Check Status
+
+Kernel AI should periodically recheck approval status automatically.
+
+### Access Denied
+
+**Description:** The provider has rejected the access request.
+
+**Primary Action:** View Details
+**Secondary Action:** Request Again (when supported by the provider)
+
+---
+
+## Model Card Pattern
+
+All models should use a consistent card design.
+
+### Primary Information
+
+- Model Name
+- Publisher
+- Capability
+- Current State
+
+### Secondary Information
+
+- Provider
+- Size
+- Version
+- Storage Usage
+
+### Advanced Information
+
+Collapsed by default.
+
+Examples: Quantisation, Context Length, Runtime, Last Validation Date, Technical Metadata.
+
+### Primary Action
+
+One action only.
+
+Examples: Sign In, Review License, Request Access, Select Model, Retry.
+
+The primary action should always represent the next required step.
+
+---
+
+## Model Selection
+
+Model selection and model acquisition are separate concerns.
+
+- **Acquisition** determines whether a model is available.
+- **Selection** determines which available model is used.
+
+These workflows should remain independent.
+
+### Single Active Model
+
+Most capabilities should have one active model.
+
+Examples: Chat, Voice, Embeddings.
+
+Selecting a model should never trigger licensing or authentication workflows. Those requirements
+should already be resolved before selection becomes available.
+
+### Missing Selected Models
+
+If a selected model becomes unavailable:
+
+- Preserve the selection reference
+- Display unavailable status
+- Prompt the user to restore or replace the model
+
+Kernel AI should never silently switch models.
+
+---
+
+## Screen Responsibilities
+
+### Voice Settings
+
+Voice Settings is not a download manager.
+
+**Should:**
+
+- Display voice-capable models
+- Display availability status
+- Allow selection
+
+**Should not** implement separate:
+
+- Download workflows
+- Authentication workflows
+- Licensing workflows
+- Access workflows
+
+These are shared platform concerns handled by Model Management.
+
+### Model Management
+
+Model Management is the authoritative interface for model administration.
+
+**Responsibilities:**
+
+- Discover models
+- Manage providers
+- Manage authentication
+- Review licenses
+- Request gated access
+- Manage storage
+- Remove models
+- Update models
+
+---
+
+## Acceptance Criteria
+
+A user should always be able to answer:
+
+1. Can I use this model right now?
+2. If not, what is blocking me?
+3. What do I need to do next?
+4. Is Kernel AI already working on it?
+5. Is this model required or optional?
+6. Is this model selected?
+7. Which provider supplies this model?
+8. Are there licensing or access restrictions?
+
+If these questions cannot be answered immediately from the UI, the design should be reconsidered.

--- a/docs/model-availability-ux-patterns.md
+++ b/docs/model-availability-ux-patterns.md
@@ -1,7 +1,7 @@
 # Model Availability UX Patterns
 
 > **Purpose:** This is the canonical reference for user experience patterns around model discovery,
-> acquisition, access, selection, and lifecycle management within Kernel AI.
+> acquisition, access, selection, and lifecycle management within Jandal AI.
 > Before implementing any screen or flow related to models, read this document first.
 >
 > This document describes **how things should work**, not what is currently implemented.
@@ -17,7 +17,7 @@
 
 **Users Want an Assistant, Not a Model Manager.**
 
-Kernel AI should automatically perform any action that can be completed without user intervention.
+Jandal AI should automatically perform any action that can be completed without user intervention.
 Users should only be interrupted when human action is genuinely required.
 
 ### Automatic (no user action needed)
@@ -42,7 +42,7 @@ Users should only be interrupted when human action is genuinely required.
 
 ### Frictionless First Run
 
-A new user should be able to install Kernel AI and begin interacting with the assistant without
+A new user should be able to install Jandal AI and begin interacting with the assistant without
 manually downloading required models. Required models should automatically begin acquisition during
 onboarding.
 
@@ -71,7 +71,7 @@ The same labels should be used throughout the application. Top-level model state
 | State | Meaning |
 |---|---|
 | **Ready** | Model is fully available |
-| **Preparing** | Kernel AI is performing background work |
+| **Preparing** | Jandal AI is performing background work |
 | **Action Required** | User must complete an action |
 | **Unavailable** | Model cannot currently be used |
 
@@ -95,11 +95,11 @@ Detailed lifecycle states appear only when additional information is needed.
 
 ## Model Sources
 
-Kernel AI supports multiple model providers.
+Jandal AI supports multiple model providers.
 
 Examples: Hugging Face, Google AI Edge, Ollama Registry, Local Import, Custom URL.
 
-Provider-specific requirements should integrate into the common Kernel AI access workflow. The user
+Provider-specific requirements should integrate into the common Jandal AI access workflow. The user
 experience should remain consistent regardless of provider.
 
 ---
@@ -154,7 +154,7 @@ Examples:
 
 ### Preparing
 
-**Description:** Kernel AI is performing background work to make the model available.
+**Description:** Jandal AI is performing background work to make the model available.
 
 **Examples:** Downloading, updating, validating, repairing. The user should not need to take action.
 
@@ -168,7 +168,7 @@ Downloading 62%
 
 ### Action Required
 
-**Description:** Kernel AI cannot proceed until the user completes a required action.
+**Description:** Jandal AI cannot proceed until the user completes a required action.
 
 **Examples:** Sign in to provider, accept license, request access, resolve storage issue.
 
@@ -195,7 +195,7 @@ A clear explanation should always be provided.
 
 ## Access Workflow
 
-Kernel AI should automatically progress through all stages that do not require user interaction.
+Jandal AI should automatically progress through all stages that do not require user interaction.
 
 ### Automatic Workflow
 
@@ -212,7 +212,7 @@ Sign In Required → License Acceptance Required → Access Approval Required
     → Ready to Download → Downloading → Validating → Ready
 ```
 
-Kernel AI should automatically continue once the user completes the required action.
+Jandal AI should automatically continue once the user completes the required action.
 
 ---
 
@@ -252,7 +252,7 @@ The license name should always be visible.
 
 **Primary Action:** Check Status
 
-Kernel AI should periodically recheck approval status automatically.
+Jandal AI should periodically recheck approval status automatically.
 
 ### Access Denied
 
@@ -325,7 +325,7 @@ If a selected model becomes unavailable:
 - Display unavailable status
 - Prompt the user to restore or replace the model
 
-Kernel AI should never silently switch models.
+Jandal AI should never silently switch models.
 
 ---
 
@@ -374,7 +374,7 @@ A user should always be able to answer:
 1. Can I use this model right now?
 2. If not, what is blocking me?
 3. What do I need to do next?
-4. Is Kernel AI already working on it?
+4. Is Jandal AI already working on it?
 5. Is this model required or optional?
 6. Is this model selected?
 7. Which provider supplies this model?


### PR DESCRIPTION
## Summary

Addresses #1025 — creates a dedicated UX pattern document for model discovery, acquisition, access, selection, and lifecycle management.

## Changes

- **`docs/model-availability-ux-patterns.md`** — new document covering:
  - Core principle: users want an assistant, not a model manager
  - Automatic vs. user-action-required workflows
  - Four top-level states: Ready, Preparing, Action Required, Unavailable
  - "Download" removed as a primary action for required models
  - Provider requirements: authentication, license acceptance, access approval, approval pending, access denied
  - Model card pattern (primary/secondary/advanced info + single primary action)
  - Model selection vs. acquisition separation
  - Screen responsibilities (Voice Settings delegates to Model Management)
  - 8-question acceptance criteria for any model-facing UI

- **`docs/UX_PATTERNS.md`** — updated:
  - Purpose block now references the new model availability doc
  - Section 14 (Model Availability Cross-Reference) lists what the model availability doc governs and instructs readers to consult it before building any model-facing screen

## Big shift from previous approach

"Download" disappears as a primary user action for required models. The dominant UX becomes **Ready → Preparing → Action Required**, which is closer to how users actually think about getting an assistant working.