### PR TITLE
fix(#1025): Oracle review — optional model workflows, model card fields, gap analysis

### DIFF
--- a/docs/model-availability-gap-analysis.md
+++ b/docs/model-availability-gap-analysis.md
@@ -2,7 +2,7 @@
 
 > **Generated:** 2026-05-30
 > **Scope:** All model-facing screens in `kernel-ai-assistant` reviewed against `docs/model-availability-ux-patterns.md`
-> **Status:** In-progress — initial audit complete, issue creation pending
+> **Status:** Complete — audit, writeup, and issue creation done
 
 ---
 
@@ -77,7 +77,7 @@ The current implementation has a solid foundation for model management but diver
 | Aspect | Current | Guideline | Gap |
 |--------|---------|-----------|-----|
 | Model cards | Two cards (E-2B, E-4B) with settings | Model card pattern | **Partial** — cards show model name and settings but no state badge, no publisher, no capability |
-| State display | None — assumes models are loaded and available | All cards should show current state | **Gap** — no state shown; if a model is unavailable the card just doesn't render |
+| State display | Always loads defaults from repository; no explicit unavailable handling | All cards should show current state | **Gap** — no state shown; defaults are loaded even if model is unavailable
 | Save/Cancel pattern | Screen-level buttons at bottom | N/A | **Aligned** — standard pattern |
 | "Saving…" state | Shown in save button | N/A | **Minor** — loading state on button |
 
@@ -98,7 +98,7 @@ The current implementation has a solid foundation for model management but diver
 | Error state | "Download failed" + Retry button | "Action Required" with single action | **Gap** — Retry is appropriate but label doesn't use guideline state |
 | Gated model (NotDownloaded) | "Sign in to HuggingFace to download" + "Sign in" button | "Action Required" with Sign In | **Aligned** — this is correct |
 | Queued models | Shows "Queued" text | "Preparing" | **Gap** — "Queued" is not a guideline state; should be "Preparing" |
-| No "Preparing" with background indicator | Downloading shows progress bar + Cancel | Background work should show "Preparing" without Cancel | **Gap** — user can cancel required model downloads; should be "Preparing" without cancel |
+| No "Preparing" with background indicator | Downloading shows progress bar only (no Cancel) | Background work should show "Preparing" without Cancel | **Gap** — no "Preparing" state; progress bar shown but without guideline state label
 | "please stay connected to Wi-Fi" | Shown during download | Progressive disclosure | **Minor** — technical detail, acceptable |
 
 **Verdict:** Moderate gaps. The onboarding correctly auto-downloads models and handles gated access, but state labels are raw enum names rather than the guideline states. The "Queued" state is not mapped to "Preparing".
@@ -126,7 +126,7 @@ The current implementation has a solid foundation for model management but diver
 | Aspect | Current | Guideline | Gap |
 |--------|---------|-----------|-----|
 | Required flag | `isRequired = true` | Automatically acquired | **Partial** — shown in Model Management with "Download" button |
-| Auto-download | Not explicitly triggered at app start | Required models should auto-download | **Gap** — no explicit auto-queue for E-2B at startup |
+| Auto-download | Tier-preferred optional models auto-queued by ModelDownloadManager | Required models should auto-download; optional tier-preferred models auto-queue | **Aligned** — tier-preferred optionals are auto-queued via ModelDownloadManager
 | State display | "Downloaded" / "Downloading" / "Error" / "Not downloaded" | Ready / Preparing / Action Required / Unavailable | **Gap** — labels don't match |
 | Cannot be deleted | Not explicitly enforced | Required models should not be deletable | **Aligned** — delete only shown for `!isRequired` |
 | Preferred model option | Yes — selectable in Model Management | Single active model | **Aligned** |
@@ -171,7 +171,7 @@ The current implementation has a solid foundation for model management but diver
 
 | Aspect | Current | Guideline | Gap |
 |--------|---------|-----------|-----|
-| Display in Model Management | Hidden (`showInModelManagement = false`) | Delegated to Voice screen | **Aligned** — but Voice screen has full download management |
+| Display in Model Management | Hidden (`showInModelManagement = false`) | Delegated to Model Management | **Gap** — hidden from Model Management but Voice screen has full download management (contradicts guideline)
 | Download in Voice screen | `SherpaOnnxSttDownloadCard` | Delegated to Model Management | **Critical** — Voice screen should not manage downloads |
 | State labels | `isSherpaOnnxSttDownloaded`, `isSherpaOnnxSttDownloading`, `sherpaOnnxSttError` | Ready / Preparing / Action Required / Unavailable | **Gap** — labels |
 

--- a/docs/model-availability-ux-patterns.md
+++ b/docs/model-availability-ux-patterns.md
@@ -86,6 +86,10 @@ Detailed lifecycle states map to top-level states as follows:
 | Access Approval Required | **Action Required** |
 | Access Denied | **Unavailable** |
 | Provider unavailable / model removed / unsupported device | **Unavailable** |
+| Insufficient storage | **Action Required** |
+| Tier-preferred optional model (auto-queued by hardware tier) | **Preparing** |
+| Not installed (optional, not yet queued) | **Ready** |
+| Ready to Download (optional, available for install) | **Ready** |
 
 This mapping ensures every screen uses the same top-level badge regardless of the underlying cause.
 
@@ -200,7 +204,7 @@ Jandal AI should automatically progress through all stages that do not require u
 ### Automatic Workflow
 
 ```
-Ready to Download → Downloading → Validating → Ready
+Ready → Downloading → Validating → Ready
 ```
 
 Users should not be required to manually trigger these steps.
@@ -209,10 +213,30 @@ Users should not be required to manually trigger these steps.
 
 ```
 Sign In Required → License Acceptance Required → Access Approval Required
-    → Ready to Download → Downloading → Validating → Ready
+    → Ready → Downloading → Validating → Ready
 ```
 
 Jandal AI should automatically continue once the user completes the required action.
+
+### Optional Model Workflow
+
+Optional models follow the same lifecycle, but the initial trigger differs:
+
+```
+Ready (Not installed) → Ready to Download → Downloading → Validating → Ready
+```
+
+For optional models, "Ready to Download" is a visual affordance (e.g. a "Download" button on the card) rather than a separate state badge. The badge remains **Ready**.
+
+Tier-preferred optional models (e.g. E-4B on flagship devices) are auto-queued by the system and follow the automatic workflow above — they show **Preparing** without user action.
+
+### Storage-Blocked Workflow
+
+```
+Preparing → Insufficient Storage (Action Required) → Retry → Downloading → Validating → Ready
+```
+
+When storage runs out during download or validation, the state transitions to **Action Required** with a "Free up space" action.
 
 ---
 
@@ -273,6 +297,8 @@ All models should use a consistent card design.
 - Publisher
 - Capability
 - Current State
+- Requirement Level (Required / Optional) — shown as a chip or label
+- Selection State (Selected / Not selected) — shown as a radio indicator or label
 
 ### Secondary Information
 
@@ -280,6 +306,9 @@ All models should use a consistent card design.
 - Size
 - Version
 - Storage Usage
+
+Requirement Level and Selection State may also appear here if the card design prioritises them
+over the primary section — but they must always be visible on the card.
 
 ### Advanced Information
 


### PR DESCRIPTION
## Summary

Follow-up to #1028 (already merged). Addresses all 3 Oracle review blocking findings:

### Finding 1: Optional model state model under-specified
- Added `Insufficient storage` → **Action Required** mapping
- Added `Tier-preferred optional model` → **Preparing** mapping
- Added `Not installed (optional)` → **Ready** mapping
- Added `Ready to Download` → **Ready** mapping
- Added **Optional Model Workflow** section explaining "Ready to Download" as visual affordance, not a separate state
- Added **Storage-Blocked Workflow** section
- Clarified tier-preferred optional models (e.g. E-4B on flagship) are auto-queued

### Finding 2: Model card spec doesn't satisfy acceptance criteria
- Added **Requirement Level** (Required/Optional) as mandatory primary card info
- Added **Selection State** (Selected/Not selected) as mandatory primary card info
- Added note that these may appear in Secondary Information if card design prioritises them

### Finding 3: Gap analysis has stale/incorrect claims
- Fixed status from "issue creation pending" → "Complete"
- Fixed Model Settings: models always load defaults from repository (don't "just not render")
- Fixed E-4B auto-download: tier-preferred optional models ARE auto-queued via ModelDownloadManager
- Fixed Sherpa STT: hidden from Model Management but Voice screen has download management (contradicts guideline)
- Fixed Onboarding: no Cancel button exists (progress bar only)

## Files changed
- `docs/model-availability-ux-patterns.md` — +35 lines (optional/storage workflows, model card fields)
- `docs/model-availability-gap-analysis.md` — 5 corrections to stale/incorrect claims