### PR TITLE
fix(#1046): unify PTT and Loop bloop sound via StartListeningCuePlayer

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -607,17 +607,8 @@ private fun SlotFillBottomSheet(
         ActionsViewModel.VoiceCaptureState.Idle -> null
     }
     val isVoiceReplyActive = slotReplyCaptureState != null
-    val loopListeningCueState = when (slotReplyCaptureState) {
-        is ActionsViewModel.VoiceCaptureState.Preparing -> LoopListeningCueState.Preparing
-        is ActionsViewModel.VoiceCaptureState.Listening -> LoopListeningCueState.Listening
-        is ActionsViewModel.VoiceCaptureState.Processing -> LoopListeningCueState.Processing
-        ActionsViewModel.VoiceCaptureState.Idle, null -> LoopListeningCueState.Idle
-    }
-
-    LoopListeningCueEffect(
-        loopActive = inputMode == InputMode.Voice,
-        captureState = loopListeningCueState,
-    )
+    // LoopListeningCueEffect removed — cue playback is handled by StartListeningCuePlayer
+    // in ActionsViewModel on VoiceInputEvent.ListeningStarted.
 
     LaunchedEffect(promptMessage, inputMode, autoVoiceReplyArmed) {
         Log.d(

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -434,17 +434,8 @@ private fun ChatContent(
     val scope = rememberCoroutineScope()
     var showRenameDialog by rememberSaveable { mutableStateOf(false) }
     var showAttachmentPicker by remember { mutableStateOf(false) }
-    val loopListeningCueState = when (voiceCaptureState) {
-        ChatViewModel.VoiceCaptureState.Idle -> LoopListeningCueState.Idle
-        is ChatViewModel.VoiceCaptureState.Preparing -> LoopListeningCueState.Preparing
-        is ChatViewModel.VoiceCaptureState.Listening -> LoopListeningCueState.Listening
-        is ChatViewModel.VoiceCaptureState.Processing -> LoopListeningCueState.Processing
-    }
-
-    LoopListeningCueEffect(
-        loopActive = voiceMode == ChatViewModel.VoiceMode.BackAndForth,
-        captureState = loopListeningCueState,
-    )
+    // LoopListeningCueEffect removed — cue playback is handled by StartListeningCuePlayer
+    // in ChatViewModel on VoiceInputEvent.ListeningStarted.
 
     // Auto-scroll when a new message is appended, but only if the user is already
     // near the bottom (within 2 items). If they've scrolled up to read history,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -56,6 +56,7 @@ import com.kernel.ai.core.voice.VoiceOutputPreferences
 import com.kernel.ai.core.voice.VoiceOutputResult
 import com.kernel.ai.core.voice.VoiceOutputStreamingSession
 import com.kernel.ai.core.voice.VoiceSpeakRequest
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.google.ai.edge.litertlm.ToolProvider
 import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ChatUiState
@@ -134,6 +135,7 @@ class ChatViewModel @Inject constructor(
     private val jandalPersona: JandalPersona,
     private val nzTruthSeedingService: NzTruthSeedingService,
     private val verboseLoggingPreferenceUseCase: com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase,
+    private val startListeningCuePlayer: StartListeningCuePlayer,
     private val chatPreferences: ChatPreferences,
 ) : ViewModel() {
     private enum class SubmitMode { Text, Voice }
@@ -477,6 +479,7 @@ class ChatViewModel @Inject constructor(
                 when (event) {
                     is VoiceInputEvent.ListeningStarted -> {
                         if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
+                        startListeningCuePlayer.playCue()
                         val currentTranscript = (voiceCaptureState.value as? VoiceCaptureState.Listening)
                             ?.transcript
                             .orEmpty()

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoopListeningCue.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/LoopListeningCue.kt
@@ -1,14 +1,6 @@
 package com.kernel.ai.feature.chat
 
-import android.media.AudioManager
-import android.media.ToneGenerator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 
 internal enum class LoopListeningCueState { Idle, Preparing, Listening, Processing }
 
@@ -26,17 +18,7 @@ internal fun LoopListeningCueEffect(
     loopActive: Boolean,
     captureState: LoopListeningCueState,
 ) {
-    val loopListeningCue = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 65) }
-    var previousState by remember { mutableStateOf(LoopListeningCueState.Idle) }
-
-    DisposableEffect(Unit) {
-        onDispose { loopListeningCue.release() }
-    }
-
-    LaunchedEffect(loopActive, captureState) {
-        if (shouldPlayLoopListeningCue(loopActive, captureState, previousState)) {
-            loopListeningCue.startTone(ToneGenerator.TONE_PROP_BEEP2, 120)
-        }
-        previousState = captureState
-    }
+    // Cue playback is handled by StartListeningCuePlayer in the ViewModel
+    // (ChatViewModel, ActionsViewModel) on VoiceInputEvent.ListeningStarted.
+    // This composable is retained for potential future visual indicators.
 }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -42,6 +42,7 @@ import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
 import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -94,6 +95,7 @@ class ChatViewModelInitTest {
     private val jandalPersona: JandalPersona = mockk(relaxed = true)
     private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
     private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
     private val chatPreferences: com.kernel.ai.core.memory.prefs.ChatPreferences = mockk(relaxed = true)
 
     @BeforeEach
@@ -175,6 +177,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -209,6 +212,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -243,6 +247,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -284,6 +289,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -330,6 +336,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -407,6 +414,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -458,6 +466,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -526,6 +535,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -582,6 +592,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -640,6 +651,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -688,6 +700,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -752,6 +765,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -807,6 +821,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )
@@ -858,6 +873,7 @@ class ChatViewModelInitTest {
         jandalPersona = jandalPersona,
         nzTruthSeedingService = nzTruthSeedingService,
         verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        startListeningCuePlayer = startListeningCuePlayer,
         mealPlanSessionRepository = mealPlanSessionRepository,
         mealPlannerCoordinator = mealPlannerCoordinator,
         )

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -41,6 +41,7 @@ import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
 import com.kernel.ai.core.skills.mealplan.MealPlannerReply
 import com.kernel.ai.core.skills.mealplan.MealPlannerSuggestion
 import com.kernel.ai.core.skills.mealplan.MealPlannerSuggestionComposeMode
+import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceInputEvent
@@ -110,6 +111,7 @@ class ChatViewModelVoiceTest {
     private val jandalPersona: JandalPersona = mockk(relaxed = true)
     private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
     private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
     private val chatPreferences: com.kernel.ai.core.memory.prefs.ChatPreferences = mockk(relaxed = true)
 
     private val voiceInputEvents = MutableSharedFlow<VoiceInputEvent>()
@@ -740,6 +742,7 @@ class ChatViewModelVoiceTest {
     jandalPersona = jandalPersona,
     nzTruthSeedingService = nzTruthSeedingService,
     verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+    startListeningCuePlayer = startListeningCuePlayer,
     mealPlanSessionRepository = mealPlanSessionRepository,
     mealPlannerCoordinator = mealPlannerCoordinator,
 )

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -805,9 +805,34 @@ class ChatViewModelVoiceTest {
 
         voiceInputEvents.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.Command, "cancel"))
         advanceUntilIdle()
-
         assertEquals("", viewModel.getConversationAsText())
-        assertEquals(null, viewModel.voiceMode.value)
+    }
+    @Test
+    fun `ListeningStarted for owned Command session triggers cue player`() = runTest(dispatcher) {
+        val viewModel = createViewModel()
+        coEvery {
+            voiceInputController.startListening(VoiceCaptureMode.Command)
+        } returns VoiceInputStartResult.Started
+        viewModel.startVoiceInput()
+        runCurrent()
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
+        advanceUntilIdle()
+        verify(exactly = 1) { startListeningCuePlayer.playCue() }
+    }
+    @Test
+    fun `ListeningStarted for unowned mode does not trigger cue player`() = runTest(dispatcher) {
+        // ChatViewModel is Idle — it owns nothing. An event from an AlertCommand
+        // session started elsewhere should be silently ignored.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand))
+        advanceUntilIdle()
+        verify(exactly = 0) { startListeningCuePlayer.playCue() }
+    }
+    @Test
+    fun `ListeningStarted for SlotReply does not trigger cue in ChatViewModel`() = runTest(dispatcher) {
+        // ChatViewModel only plays cue for Command mode; SlotReply is handled by ActionsViewModel.
+        voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.SlotReply))
+        advanceUntilIdle()
+        verify(exactly = 0) { startListeningCuePlayer.playCue() }
     }
 
     @Test


### PR DESCRIPTION
## Problem

The PTT (push-to-talk) button in chat never plays the start-listening bloop sound. The `ToneStartListeningCuePlayer` was DI-bound but had zero callers in `ChatViewModel`, while the Loop mode used a completely separate inline `ToneGenerator` with different parameters.

## Fix

- **Inject `StartListeningCuePlayer` into `ChatViewModel`** and call `playCue()` in the `ListeningStarted` event handler — mirroring the existing pattern in `ActionsViewModel` and `WakeWordService`.
- **Remove the inline `ToneGenerator` from `LoopListeningCueEffect`** — its audio role is now fulfilled by the shared singleton.
- **Remove `LoopListeningCueEffect` call sites** from `ChatContent` and `ActionsScreen` — the composable is retained as a no-op for potential future visual indicators.

## Result

Both PTT and Loop modes now share the same bloop sound (`TONE_PROP_BEEP`, 100ms), played at the correct moment — after `onReadyForSpeech` fires, when the microphone is truly open.

## Files changed

| File | Change |
|---|---|
| `ChatViewModel.kt` | Inject `StartListeningCuePlayer`, call `playCue()` on `ListeningStarted` |
| `LoopListeningCue.kt` | Remove inline `ToneGenerator`, keep composable as no-op |
| `ChatScreen.kt` | Remove `LoopListeningCueEffect` call from `ChatContent` |
| `ActionsScreen.kt` | Remove `LoopListeningCueEffect` call from `SlotFillBottomSheet` |
| `ChatViewModelInitTest.kt` | Add `StartListeningCuePlayer` mock to all constructors |
| `ChatViewModelVoiceTest.kt` | Add `StartListeningCuePlayer` mock |

Closes #1046