### PR TITLE
feat(#1050): NNAPI EP spike for wake word embedding model

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -281,70 +281,66 @@ class OnnxWakeWordDetector @Inject constructor(
         activeAudioRecord = audioRecord
 
 
-        val env = OrtEnvironment.getEnvironment()
-        val cpuOptions = OrtSession.SessionOptions().apply {
-            setIntraOpNumThreads(1)
-        }
-        val embedOptions = OrtSession.SessionOptions().apply {
-            setIntraOpNumThreads(1)
-            runCatching { addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED)) }
-                .onFailure { Log.w(TAG, "WakeWordDetector: NNAPI EP unavailable, using CPU", it) }
-        }
-
-        val melsSession  = runCatching { env.createSession(bytes.melspectrogram, cpuOptions) }
-            .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load melspectrogram.onnx", e); null }
-        val embedSession = runCatching { env.createSession(bytes.embedding, embedOptions) }
-            .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load embedding_model.onnx", e); null }
-        val classSession = runCatching { env.createSession(bytes.classifier, cpuOptions) }
-            .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load hey_jandal.onnx", e); null }
-        if (melsSession == null || embedSession == null || classSession == null) {
-            cpuOptions.close()
-            embedOptions.close()
-            melsSession?.close()
-            embedSession?.close()
-            classSession?.close()
-            audioRecord.release()
-            activeAudioRecord = null
-            running.set(false)
-            return
-        }
-        // Resolve ONNX node names once at startup (avoids hard-coding strings).
-        val melsInputName   = melsSession.inputNames.first()
-        val melsOutputName  = melsSession.outputNames.first()
-        val embedInputName  = embedSession.inputNames.first()
-        val embedOutputName = embedSession.outputNames.first()
-        val classInputName  = classSession.inputNames.first()
-        val classOutputName = classSession.outputNames.first()
-
-        // Pre-allocate all hot-loop buffers — zero heap churn during detection.
-        //
-        // melRing: sliding window of MEL_RING_SIZE rows × MEL_BINS columns, stored flat row-major.
-        // Each 80ms chunk appends MEL_ROWS_PER_CHUNK new rows; the ring slides by that many rows
-        // each step.  Once full, we build the [1, 76, 32, 1] embedding model input from it.
-        val melRing = FloatArray(MEL_RING_SIZE * MEL_BINS)   // [76 × 32]
-        var melRowsFilled = 0
-        var chunkCount = 0
-
-        val embeddingRing = Array(EMBEDDING_FRAMES) { FloatArray(EMBEDDING_DIM) }
-        var embRingHead = 0
-        var embFramesAccumulated = 0
+        // ── Closeable ORT resources (nullable vars so finally covers all paths) ──
+        var cpuOptions: OrtSession.SessionOptions? = null
+        var embedOptions: OrtSession.SessionOptions? = null
+        var melsSession: OrtSession? = null
+        var embedSession: OrtSession? = null
+        var classSession: OrtSession? = null
+        // Diagnostics counters for final log
         var inferenceCount = 0L
-        val chunk    = ShortArray(FRAME_SAMPLES)
-        val framePcm = FloatArray(FRAME_SAMPLES)
-        // windowFlat: [16 × 96] flattened, re-filled in place each classifier call.
-        val windowFlat = FloatArray(EMBEDDING_FRAMES * EMBEDDING_DIM)
-        // embedInput4D: [1, 76, 32, 1] — reshaped mel ring for the embedding model.
-        val embedInput4D = FloatArray(MEL_RING_SIZE * MEL_BINS)
-
-        // PCM ring buffer for STT verification (pre-allocated; only used when verifyWindow != null).
-        val pcmRing     = if (verifyWindow != null) ShortArray(VERIFY_RING_SAMPLES) else ShortArray(0)
-        var pcmRingHead = 0
-        var pcmFilled   = 0
-        var silenceFrames = 0
-        var voicedFrameStreak = 0
-        var minRms = 0.0
         var gatedFramesSkipped = 0L
+        var minRms = 0.0
+
         try {
+            val env = OrtEnvironment.getEnvironment()
+            cpuOptions = OrtSession.SessionOptions().apply {
+                setIntraOpNumThreads(1)
+            }
+            embedOptions = OrtSession.SessionOptions().apply {
+                setIntraOpNumThreads(1)
+                runCatching { addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED)) }
+                    .onFailure { Log.w(TAG, "WakeWordDetector: NNAPI EP unavailable, using CPU", it) }
+            }
+
+            melsSession = runCatching { env.createSession(bytes.melspectrogram, cpuOptions!!) }
+                .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load melspectrogram.onnx", e); null }
+            embedSession = runCatching { env.createSession(bytes.embedding, embedOptions!!) }
+                .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load embedding_model.onnx", e); null }
+            classSession = runCatching { env.createSession(bytes.classifier, cpuOptions!!) }
+                .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load hey_jandal.onnx", e); null }
+
+            if (melsSession == null || embedSession == null || classSession == null) {
+                Log.e(TAG, "WakeWordDetector: one or more ONNX sessions failed to load")
+                return
+            }
+
+            // Resolve ONNX node names once at startup.
+            val melsInputName   = melsSession.inputNames.first()
+            val melsOutputName  = melsSession.outputNames.first()
+            val embedInputName  = embedSession.inputNames.first()
+            val embedOutputName = embedSession.outputNames.first()
+            val classInputName  = classSession.inputNames.first()
+            val classOutputName = classSession.outputNames.first()
+
+            // Pre-allocate all hot-loop buffers — zero heap churn during detection.
+            val melRing = FloatArray(MEL_RING_SIZE * MEL_BINS)
+            var melRowsFilled = 0
+            var chunkCount = 0
+
+            val embeddingRing = Array(EMBEDDING_FRAMES) { FloatArray(EMBEDDING_DIM) }
+            var embRingHead = 0
+            var embFramesAccumulated = 0
+            val chunk    = ShortArray(FRAME_SAMPLES)
+            val framePcm = FloatArray(FRAME_SAMPLES)
+            val windowFlat = FloatArray(EMBEDDING_FRAMES * EMBEDDING_DIM)
+            val embedInput4D = FloatArray(MEL_RING_SIZE * MEL_BINS)
+
+            val pcmRing     = if (verifyWindow != null) ShortArray(VERIFY_RING_SAMPLES) else ShortArray(0)
+            var pcmRingHead = 0
+            var pcmFilled   = 0
+            var silenceFrames = 0
+            var voicedFrameStreak = 0
 
             audioRecord.startRecording()
             Log.d(TAG, "WakeWordDetector: recording started")
@@ -536,27 +532,26 @@ class OnnxWakeWordDetector @Inject constructor(
                         }
                     }
 
-                    // Below all thresholds — ignore.
                     else -> Unit
                 }
             }
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
         } catch (e: Exception) {
-            Log.e(TAG, "WakeWordDetector: error in detection loop", e)
+            Log.e(TAG, "WakeWordDetector: fatal error", e)
         } finally {
             activeAudioRecord = null
             runCatching { audioRecord.stop() }
             audioRecord.release()
-            melsSession.close()
-            embedSession.close()
-            classSession.close()
-            cpuOptions.close()
-            embedOptions.close()
+            melsSession?.close()
+            embedSession?.close()
+            classSession?.close()
+            cpuOptions?.close()
+            embedOptions?.close()
+            running.set(false)
             Log.d(TAG, "WakeWordDetector: detection loop exited — " +
                 "inferences=$inferenceCount gatedSkips=$gatedFramesSkipped " +
                 "finalMinRms=${"%.1f".format(minRms)}")
-            running.set(false)
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -314,6 +314,8 @@ class OnnxWakeWordDetector @Inject constructor(
                 Log.e(TAG, "WakeWordDetector: one or more ONNX sessions failed to load")
                 return
             }
+            Log.i(TAG, "WakeWordDetector: models loaded (embedding: NNAPI CPU_DISABLED, mel+classifier: CPU)")
+
 
             // Resolve ONNX node names once at startup.
             val melsInputName   = melsSession.inputNames.first()

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -287,7 +287,8 @@ class OnnxWakeWordDetector @Inject constructor(
         }
         val embedOptions = OrtSession.SessionOptions().apply {
             setIntraOpNumThreads(1)
-            addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED))
+            runCatching { addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED)) }
+                .onFailure { Log.w(TAG, "WakeWordDetector: NNAPI EP unavailable, using CPU", it) }
         }
 
         val melsSession  = runCatching { env.createSession(bytes.melspectrogram, cpuOptions) }
@@ -342,11 +343,10 @@ class OnnxWakeWordDetector @Inject constructor(
         var voicedFrameStreak = 0
         var minRms = 0.0
         var gatedFramesSkipped = 0L
-
         try {
+
             audioRecord.startRecording()
             Log.d(TAG, "WakeWordDetector: recording started")
-
             while (running.get() && !Thread.currentThread().isInterrupted) {
                 // Read exactly one 80ms frame; abort if AudioRecord signals an error.
                 var totalRead = 0
@@ -555,6 +555,7 @@ class OnnxWakeWordDetector @Inject constructor(
             Log.d(TAG, "WakeWordDetector: detection loop exited — " +
                 "inferences=$inferenceCount gatedSkips=$gatedFramesSkipped " +
                 "finalMinRms=${"%.1f".format(minRms)}")
+            running.set(false)
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -12,6 +12,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.nio.FloatBuffer
+import ai.onnxruntime.providers.NNAPIFlags
+import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -280,19 +282,23 @@ class OnnxWakeWordDetector @Inject constructor(
 
 
         val env = OrtEnvironment.getEnvironment()
-        val sessionOptions = OrtSession.SessionOptions().apply {
+        val cpuOptions = OrtSession.SessionOptions().apply {
             setIntraOpNumThreads(1)
         }
+        val embedOptions = OrtSession.SessionOptions().apply {
+            setIntraOpNumThreads(1)
+            addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED))
+        }
 
-        val melsSession  = runCatching { env.createSession(bytes.melspectrogram, sessionOptions) }
+        val melsSession  = runCatching { env.createSession(bytes.melspectrogram, cpuOptions) }
             .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load melspectrogram.onnx", e); null }
-        val embedSession = runCatching { env.createSession(bytes.embedding, sessionOptions) }
+        val embedSession = runCatching { env.createSession(bytes.embedding, embedOptions) }
             .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load embedding_model.onnx", e); null }
-        val classSession = runCatching { env.createSession(bytes.classifier, sessionOptions) }
+        val classSession = runCatching { env.createSession(bytes.classifier, cpuOptions) }
             .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load hey_jandal.onnx", e); null }
-
         if (melsSession == null || embedSession == null || classSession == null) {
-            sessionOptions.close()
+            cpuOptions.close()
+            embedOptions.close()
             melsSession?.close()
             embedSession?.close()
             classSession?.close()
@@ -300,7 +306,6 @@ class OnnxWakeWordDetector @Inject constructor(
             running.set(false)
             return
         }
-
         // Resolve ONNX node names once at startup (avoids hard-coding strings).
         val melsInputName   = melsSession.inputNames.first()
         val melsOutputName  = melsSession.outputNames.first()
@@ -545,8 +550,8 @@ class OnnxWakeWordDetector @Inject constructor(
             melsSession.close()
             embedSession.close()
             classSession.close()
-            sessionOptions.close()
-            running.set(false)
+            cpuOptions.close()
+            embedOptions.close()
             Log.d(TAG, "WakeWordDetector: detection loop exited — " +
                 "inferences=$inferenceCount gatedSkips=$gatedFramesSkipped " +
                 "finalMinRms=${"%.1f".format(minRms)}")

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -304,6 +304,7 @@ class OnnxWakeWordDetector @Inject constructor(
             embedSession?.close()
             classSession?.close()
             audioRecord.release()
+            activeAudioRecord = null
             running.set(false)
             return
         }


### PR DESCRIPTION
## What

Add NNAPI Execution Provider (with `CPU_DISABLED` flag) to the embedding model session only. Also splits `SessionOptions` into per-model instances as shared prep work for QNN EP (#1052).

Closes #1050.

## Changes

`core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt`

- Split shared `sessionOptions` into `cpuOptions` (mel + classifier, CPU-only) and `embedOptions` (embedding, NNAPI)
- `embedOptions` uses `addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED))` — prevents silent fallback to nnapi-reference CPU
- Imports: `ai.onnxruntime.providers.NNAPIFlags` + `java.util.EnumSet`
- Cleanup path closes both option objects

## Scope

**Embedding model only** (35MB). Mel (170KB) and classifier (205KB) stay on CPU — they're tiny, run every 80ms, and NNAPI overhead would swamp any gain.

## Testing

- [x] Compiles (`./gradlew :core:voice:compileDebugKotlin` — clean)
- [ ] Deploy to S23 Ultra and verify session creation
- [ ] Wake word trigger test
- [ ] 30-min batterystats measurement

## Follow-up

The session-options split means QNN (#1052) is a one-line swap on the embedding options.

/cc @lokhor