### PR TITLE
fix(#1057): fallback thought parser when LiteRT fails to populate channels

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -678,6 +678,8 @@ class LiteRtInferenceEngine @Inject constructor(
         val thinkingEnabledForGeneration = currentConfig?.thinkingEnabled == true
         val thinkingStateMachine = if (thinkingEnabledForGeneration) ThinkingStreamStateMachine() else null
         var thinkingStateMachineActive = false
+        var fallbackThinkingBuffer = StringBuilder()
+        var fallbackInThought = false
 
         val thinkingContext: Map<String, Any> =
             if (thinkingEnabledForGeneration) mapOf("enable_thinking" to true) else emptyMap()
@@ -726,10 +728,48 @@ class LiteRtInferenceEngine @Inject constructor(
 
                     if (raw.contains("<|channel>") && !raw.contains("<channel|>")) {
                         // Partial channel header — skip, content will arrive via channels["thought"].
-                        // Log so any false-positive drops are observable in logcat.
                         Log.d(TAG, "Skipping partial channel header in toString() [len=${raw.length}] — expecting thought delta")
                         return
                     }
+
+                    // Fallback thought parser: when the native LiteRT engine fails to populate
+                    // channels["thought"], the raw text still contains <|think|> / <|/think|>
+                    // markers. Detect them here and split manually.
+                    val thinkOpen = "<|think|>"
+                    val thinkClose = "<|/think|>"
+                    if (thinkingEnabledForGeneration && (fallbackInThought || raw.contains(thinkOpen))) {
+                        if (!fallbackInThought) {
+                            fallbackInThought = true
+                            fallbackThinkingBuffer.append(raw.substringAfter(thinkOpen))
+                        } else {
+                            fallbackThinkingBuffer.append(raw)
+                        }
+                        val buffered = fallbackThinkingBuffer.toString()
+                        val closeIdx = buffered.indexOf(thinkClose)
+                        if (closeIdx >= 0) {
+                            fallbackInThought = false
+                            val thought = buffered.substring(0, closeIdx)
+                            val responseText = raw.substringAfter(thinkClose)
+                            if (thought.isNotBlank()) {
+                                thinkingCharCount += thought.length
+                                Log.w(TAG, "thought_fallback: recovered ${thought.length} chars from raw text " +
+                                    "(LiteRT failed to populate channels)")
+                                trySend(GenerationResult.Thinking(thought.trim()))
+                            }
+                            if (responseText.isNotBlank()) {
+                                if (firstTokenMs < 0) {
+                                    firstTokenMs = System.currentTimeMillis() - start
+                                    Log.i(TAG, "TTFT (Time to First Token): ${firstTokenMs}ms [backend=${_activeBackend.value}]")
+                                }
+                                outputTokenCount++
+                                emittedResponseText.append(responseText)
+                                trySend(GenerationResult.Token(responseText))
+                            }
+                            fallbackThinkingBuffer.clear()
+                        }
+                        return
+                    }
+
                     val stripped = CHANNEL_WRAPPER_RE.replace(raw, "")
                     val text = if (stripped.length != raw.length) stripped.trim() else stripped
                     if (text.isNotEmpty() && !text.startsWith("<ctrl")) {

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -794,6 +794,18 @@ class LiteRtInferenceEngine @Inject constructor(
                     val tokensPerSec = if (generationMs > 0 && outputTokenCount > 0) {
                         outputTokenCount * 1000.0 / generationMs
                     } else 0.0
+                    if (fallbackInThought) {
+                        // Model started a thought block with <|think|> but never closed it
+                        // with <|/think|>. Flush the buffered text as response so the user
+                        // doesn't get a blank response.
+                        val stuck = fallbackThinkingBuffer.toString()
+                        if (stuck.isNotBlank()) {
+                            Log.w(TAG, "thought_fallback: stuck in thought (no <|/think|>) — flushing ${stuck.length} chars as response")
+                            outputTokenCount++
+                            emittedResponseText.append(stuck)
+                            trySend(GenerationResult.Token(stuck))
+                        }
+                    }
                     if (thinkingCharCount > 0) {
                         Log.d("KernelAI", "Thinking tokens: $thinkingCharCount chars")
                     }


### PR DESCRIPTION
Closes #1057

## Root cause
The native LiteRT engine (v0.11.0) sometimes fails to populate `channels["thought"]` in streaming response chunks. When this happens, `Message.toString()` contains ALL text (thinking + response combined) with the `<|think|>...<|/think|>` markers still present, but our existing code path never enters the ThinkingStreamStateMachine because `hasThinkingEvidence` is false.

## Fix
Added a fallback delimiter parser in `LiteRtInferenceEngine.kt:735-771` that detects `<|think|>` / `<|/think|>` markers directly in `message.toString()`. When triggered:

1. Text before `<|/think|>` → `GenerationResult.Thinking` (hidden, stored as `thinkingText`)
2. Text after `<|/think|>` → `GenerationResult.Token` (visible chat content)
3. Handles streaming: buffers partial chunks in `fallbackThinkingBuffer` until close marker arrives

The fallback only activates when:
- `thinkingEnabledForGeneration` is true (model supports thinking mode)
- Channel-based evidence is absent (native engine failed to populate `channels`)
- Raw text contains the delimiters

## Verification
- Build: `./gradlew :core:inference:compileDebugKotlin` — clean
- APK deployed to S23 Ultra (version code 2054)
- On activation, logs: `thought_fallback: recovered N chars from raw text (LiteRT failed to populate channels)`

## Oracle review
- Root cause analysis confirmed by oracle
- Approach A (delimiter-based fallback parser) recommended over heuristic alternatives
- Primary channel path untouched — low regression risk