### PR TITLE
feat(#1058): standalone convertCurrency tool with ECB-backed rates

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/KernelAIToolSet.kt
@@ -161,6 +161,27 @@ class KernelAIToolSet @Inject constructor(
         return result
     }
 
+    @Tool(description = "Convert an amount between currencies using latest ECB-backed exchange rates. Use for any currency conversion like 'how much is 100 AUD in INR' or 'convert 50 USD to NZD'. NOT for unit conversion (use runIntent with convert_units for that).")
+    fun convertCurrency(
+        @ToolParam(description = "The amount to convert, as a number (e.g. '100', '50.75')") amount: String,
+        @ToolParam(description = "Source currency code or full name (e.g. 'AUD', 'USD', 'Australian dollars')") fromCurrency: String,
+        @ToolParam(description = "Target currency code or full name (e.g. 'INR', 'NZD', 'Indian rupees')") toCurrency: String,
+    ): Map<String, String> {
+        toolCalledInThisTurn = true
+        setLastToolCall("convert_currency", """{"amount":"$amount","from_currency":"$fromCurrency","to_currency":"$toCurrency"}""")
+        Log.d(TAG, "ToolSet: convertCurrency(amount=$amount, from=$fromCurrency, to=$toCurrency)")
+
+        val args = mapOf(
+            "amount" to amount,
+            "from_currency" to fromCurrency,
+            "to_currency" to toCurrency,
+        )
+
+        val result = executeSkill("convert_currency", args)
+        lastToolResult = result["result"] ?: result["error"]
+        return result
+    }
+
     @Tool(description = "Get current weather or a multi-day forecast (pass forecastDays=1-7 for forecast). ONLY for weather queries. NOT for date, time, or general knowledge.")
     fun getWeather(
         @ToolParam(description = "Optional location/city name. Leave blank for device GPS location.") location: String,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/SkillsModule.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.skills
 import com.google.ai.edge.litertlm.ToolProvider
 import com.google.ai.edge.litertlm.tool
 import com.kernel.ai.core.skills.natives.GetSystemInfoSkill
+import com.kernel.ai.core.skills.natives.ConvertCurrencySkill
 import com.kernel.ai.core.skills.natives.GetWeatherSkill
 import com.kernel.ai.core.skills.natives.GetWeatherUnifiedSkill
 import com.kernel.ai.core.skills.natives.SaveMemorySkill
@@ -58,6 +59,10 @@ abstract class SkillsModule {
     @Binds
     @IntoSet
     abstract fun bindMealPlannerSkill(skill: MealPlannerSkill): Skill
+
+    @Binds
+    @IntoSet
+    abstract fun bindConvertCurrencySkill(skill: ConvertCurrencySkill): Skill
 
     /** Bind MiniLMIntentClassifier as the IntentClassifier for QuickIntentRouter. */
     @Binds

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/ConvertCurrencySkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/ConvertCurrencySkill.kt
@@ -1,0 +1,89 @@
+package com.kernel.ai.core.skills.natives
+
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillParameter
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import kotlinx.coroutines.CancellationException
+import java.math.RoundingMode
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Standalone currency conversion skill exposing [CurrencyConversionService] as a
+ * first-class model tool. The service fetches latest ECB-backed rates via the
+ * Frankfurter API and resolves natural-language currency names to ISO codes.
+ */
+@Singleton
+class ConvertCurrencySkill @Inject constructor(
+    private val currencyConversionService: CurrencyConversionService,
+) : Skill {
+
+    override val name = "convert_currency"
+    override val description =
+        "Convert an amount between currencies using latest ECB-backed exchange rates. " +
+        "Use for any currency conversion like 'how much is X in Y' or 'convert X AUD to INR'. " +
+        "Pass currency codes (AUD, USD, INR, NZD) or full names (Australian dollars, Indian rupees)."
+
+    override val schema = SkillSchema(
+        parameters = mapOf(
+            "amount" to SkillParameter(
+                type = "string",
+                description = "The amount to convert, as a decimal string (e.g. '100', '50.75')",
+            ),
+            "from_currency" to SkillParameter(
+                type = "string",
+                description = "Source currency code (e.g. AUD, NZD, USD, EUR) or full name (Australian dollars)",
+            ),
+            "to_currency" to SkillParameter(
+                type = "string",
+                description = "Target currency code (e.g. INR, JPY, NZD) or full name (Indian rupees, Japanese yen)",
+            ),
+        ),
+        required = listOf("amount", "from_currency", "to_currency"),
+    )
+
+    override suspend fun execute(call: SkillCall): SkillResult {
+        val amountRaw = call.arguments["amount"]?.trim()
+            ?: return SkillResult.Failure(name, "No currency amount provided")
+        val fromCurrencyRaw = call.arguments["from_currency"]?.trim()
+            ?: return SkillResult.Failure(name, "No source currency provided")
+        val toCurrencyRaw = call.arguments["to_currency"]?.trim()
+            ?: return SkillResult.Failure(name, "No target currency provided")
+
+        return try {
+            val result = currencyConversionService.convert(
+                amountRaw = amountRaw,
+                fromCurrencyRaw = fromCurrencyRaw,
+                toCurrencyRaw = toCurrencyRaw,
+            )
+
+            if (result.fromCurrency.code == result.toCurrency.code) {
+                return SkillResult.DirectReply(
+                    "${result.inputAmount.toPlainString()} ${result.fromCurrency.code} is ${result.outputAmount.toPlainString()} ${result.toCurrency.code}.",
+                )
+            }
+
+            val roundedAmount = result.outputAmount.setScale(2, RoundingMode.HALF_UP).stripTrailingZeros()
+            val roundedRate = result.rate.setScale(4, RoundingMode.HALF_UP).stripTrailingZeros()
+            val spokenDate = result.rateDate.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))
+            val content = "${result.inputAmount.toPlainString()} ${result.fromCurrency.code} converts to approximately ${roundedAmount.toPlainString()} ${result.toCurrency.code}. " +
+                "1 ${result.fromCurrency.code} = ${roundedRate.toPlainString()} ${result.toCurrency.code}. " +
+                "This uses the latest ${result.sourceLabel} from ${result.rateDate}. " +
+                "Exchange rates are not real-time and may have moved since then."
+            val spokenSummary = "${result.inputAmount.toPlainString()} ${result.fromCurrency.code} converts to approximately ${roundedAmount.toPlainString()} ${result.toCurrency.code} at the $spokenDate ${result.sourceLabel}."
+            SkillResult.DirectReply(content, spokenSummary = spokenSummary)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val errorMessage = when (e) {
+                is IllegalArgumentException -> e.message
+                else -> "Currency rates are unavailable right now. I can't do a truthful conversion offline."
+            }
+            SkillResult.Failure(name, errorMessage ?: "Could not convert currency")
+        }
+    }
+}


### PR DESCRIPTION
Closes #1058

## Problem
The model couldn't find a currency converter tool. The infrastructure was fully built (`CurrencyConversionService`, `NativeIntentHandler.convertCurrency()`, regex routing), but `convert_currency` was buried in `run_intent`'s 50+ value enum. `SkillRegistry.buildNativeDeclarations()` truncates descriptions at 80 chars — "currency conversion" appeared after ~150 chars and was invisible to the model.

## Fix
Added `convertCurrency` as a **first-class standalone tool** the model can call directly:

1. **`ConvertCurrencySkill`** — implements `Skill`, delegates to `CurrencyConversionService` (Frankfurter API, ECB-backed rates). Returns formatted results with rate, date, and source disclaimer.

2. **`@Tool convertCurrency(amount, fromCurrency, toCurrency)`** — registered in `KernelAIToolSet`, takes three string params. The model now sees `convert_currency` as a top-level tool alongside `get_weather`, `query_wikipedia`, etc.

3. **Hilt registration** — `@Binds @IntoSet` in `SkillsModule`.

## Example
```
User: convert 100 aud to inr
Model: → convertCurrency(amount="100", fromCurrency="AUD", toCurrency="INR")
Tool:  "100 AUD converts to approximately 5472.50 INR. 1 AUD = 54.7250 INR. 
        This uses the latest ECB rate from 2026-06-01."
```

## What's unchanged
- `run_intent(intentName="convert_currency", ...)` still works for regex-routed intents
- `NativeIntentHandler.convertCurrency()` is unchanged (private, used by run_intent path)
- `CurrencyConversionService` is unchanged (shared between both paths)

## Files
- `core/skills/natives/ConvertCurrencySkill.kt` — new (89 lines)
- `core/skills/KernelAIToolSet.kt` — +21 lines (@Tool method)
- `core/skills/SkillsModule.kt` — +5 lines (Hilt binding)