### PR TITLE
fix(#1049): lower wakeword detection threshold from 0.80 to 0.65

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordPreferences.kt
@@ -19,7 +19,7 @@ private const val TAG = "WakeWordPrefs"
 private val Context.wakeWordPrefsDataStore by preferencesDataStore(name = "wake_word_preferences")
 
 /** Detection fires immediately when confidence ≥ this value. */
-const val WAKE_WORD_DEFAULT_THRESHOLD = 0.80f
+const val WAKE_WORD_DEFAULT_THRESHOLD = 0.65f
 
 /**
  * Secondary (lower) threshold for the dual-threshold verification path.


### PR DESCRIPTION
## Problem

The 16-frame embedding window (1.28s) is longer than the "Hey Jandal" wake word (~0.8s). Even after the embedding ring flush fix (PR #1063), the classifier window always contains ~6/16 post-speech silence embeddings, making confidence borderline around 0.80.

## Fix

Lower `WAKE_WORD_DEFAULT_THRESHOLD` from 0.80 → 0.65.

This improves recall for short wake words. The STT verification path (`lowThreshold=0.50`) continues to guard against false positives — any detection in [0.50, 0.65) runs STT to confirm actual speech.

## Change

`core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordPreferences.kt` — one line.

Closes #1049