### PR TITLE
refactor(#1023): extract containsWakePhrase, resolve wake model from selected engine

### DIFF
--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -13,8 +13,7 @@ import android.os.Looper
 import android.widget.Toast
 import android.util.Log
 import com.kernel.ai.MainActivity
-import com.kernel.ai.core.voice.SherpaOnnxVoiceInputController
-import com.kernel.ai.core.voice.SherpaOnnxVoiceInputController.Companion.containsWakePhrase
+import com.kernel.ai.core.voice.containsWakePhrase
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
@@ -77,8 +76,6 @@ class WakeWordService : Service() {
     @Inject lateinit var wakeWordDetector: WakeWordDetector
     @Inject lateinit var voiceInputController: VoiceInputController
     @Inject lateinit var cuePlayer: StartListeningCuePlayer
-
-    @Inject lateinit var sherpaOnnxVoiceInputController: SherpaOnnxVoiceInputController
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var eventCollectorJob: Job? = null
 
@@ -247,7 +244,7 @@ class WakeWordService : Service() {
             verifyWindow = { pcm ->
                 try {
                     kotlinx.coroutines.runBlocking {
-                        sherpaOnnxVoiceInputController.transcribeBlocking(pcm).containsWakePhrase()
+                        voiceInputController.transcribeBlocking(pcm)?.containsWakePhrase() ?: false
                     }
                 } catch (e: Exception) {
                     Log.w(TAG, "WakeWordService: wake word verification failed", e)

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -60,16 +60,6 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         private const val OFFLINE_SPEECH_RMS_THRESHOLD = 0.02f
         private const val OFFLINE_TRAILING_SILENCE_FRAMES = 25 // 2.5 s — tolerate natural speech pauses
         private const val PKG = "com.k2fsa.sherpa.onnx"
-        /**
-         * Returns true when [this] transcript contains a recognisable form of "Hey Jandal".
-         *
-         * Matches across common ASR error modes (Handel/Handal/Jandel) and normalises case.
-         */
-        fun String.containsWakePhrase(): Boolean {
-            val lower = lowercase()
-            val namePattern = Regex("""\b(?:hey|a)\s*(?:jandal|jandel|handel|handal|hando)\b""")
-            return namePattern.containsMatchIn(lower)
-        }
     }
 
     // ── Reflected recogniser state ─────────────────────────────────────────────
@@ -402,10 +392,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         return kotlin.math.sqrt(sum / chunk.size).toFloat()
     }
 
-    suspend fun transcribeBlocking(pcm: ShortArray): String {
-        if (pcm.isEmpty()) return ""
+    override suspend fun transcribeBlocking(pcm: ShortArray): String? {
+        if (pcm.isEmpty()) return null
         val spec = SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
-        val (rec, methods) = ensureWakeRecognizerBlocking(spec) ?: return ""
+        val (rec, methods) = ensureWakeRecognizerBlocking(spec) ?: return null
         val stream = methods.createStream.invoke(rec, "")
         return try {
             val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
@@ -420,7 +410,7 @@ class SherpaOnnxVoiceInputController @Inject constructor(
             resultTextFromWakeMethods(rec, stream, methods)
         } catch (e: Exception) {
             Log.e(TAG, "transcribeBlocking failed", e)
-            ""
+            null
         } finally {
             runCatching { methods.streamRelease.invoke(stream) }
         }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -77,10 +77,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     private val offlineMethods = OfflineMethods()
 
     /**
-     * Dedicated Zipformer recognizer for wake-word verification.
-     * Lives independently from [recognizer] — never released or replaced by
-     * the interactive STT session, so [transcribeBlocking] is safe to call
-     * concurrently with [startListening]/[stopListening].
+     * Dedicated online recognizer for wake-word verification — loads a separate
+     * instance of the user's selected online STT model (Zipformer or Paraformer)
+     * so [transcribeBlocking] can run concurrently with [startListening]/[stopListening].
+     * For offline models (SenseVoice, Whisper), falls back to Zipformer.
      */
     private val wakeRecognizerMutex = Mutex()
     @Volatile private var wakeRecognizer: Any? = null
@@ -394,7 +394,9 @@ class SherpaOnnxVoiceInputController @Inject constructor(
 
     override suspend fun transcribeBlocking(pcm: ShortArray): String? {
         if (pcm.isEmpty()) return null
-        val spec = SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
+        val userSpec = resolveSpec()
+        val spec = if (userSpec.recognizerKind == SherpaSttModelSpec.RecognizerKind.Online) userSpec
+                   else SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
         val (rec, methods) = ensureWakeRecognizerBlocking(spec) ?: return null
         val stream = methods.createStream.invoke(rec, "")
         return try {
@@ -417,7 +419,7 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     }
 
     /**
-     * Ensures a dedicated Zipformer recognizer exists for wake-word verification.
+     * Ensures a dedicated online recognizer exists for wake-word verification.
      * Uses its own mutex and dedicated method handles so the interactive STT recognizer
      * can be reinitialized independently.
      */
@@ -431,8 +433,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
             if (wakeRecognizer != null && wakeSpecValid && wakeSpecEngine == spec.engine && wakeMethods != null) {
                 return@withLock wakeRecognizer!! to wakeMethods!!
             }
+            // Release old recognizer when engine changes to avoid native memory leak.
+            releaseWakeRecognizer()
             if (!isSpecAvailable(spec)) {
-                Log.w(TAG, "Wake-word Zipformer model files missing")
+                Log.w(TAG, "Wake-word STT model files missing for ${spec.engine}")
                 return@withLock null
             }
             try {
@@ -453,8 +457,6 @@ class SherpaOnnxVoiceInputController @Inject constructor(
             }
         }
     }
-
-    // ── AudioRecord helpers ────────────────────────────────────────────────────
 
     private fun createAudioRecord(): AudioRecord? {
         val minBuf = AudioRecord.getMinBufferSize(
@@ -610,6 +612,21 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         onlineMethods.reset = null
         offlineMethods.decode = null
         offlineMethods.getResult = null
+    }
+
+    /**
+     * Releases the dedicated wake-word recognizer and clears its cached method handles.
+     */
+    private fun releaseWakeRecognizer() {
+        if (wakeRecognizer != null) {
+            try {
+                wakeRecognizer!!.javaClass.getDeclaredMethod("release").invoke(wakeRecognizer)
+            } catch (_: Exception) {}
+            wakeRecognizer = null
+            wakeMethods = null
+            wakeSpecEngine = null
+            wakeSpecValid = false
+        }
     }
 
     /**

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaSttModelSpec.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaSttModelSpec.kt
@@ -105,8 +105,9 @@ data class SherpaSttModelSpec(
         fun forEngine(engine: VoiceInputEngine): SherpaSttModelSpec? = ALL[engine]
 
         /**
-         * Returns the default spec used for wake-word verification.
-         * Uses Zipformer since it is the original/supported streaming model.
+         * Default spec used as fallback when the user's selected STT engine is an
+         * offline-only model (SenseVoice or Whisper) that cannot be used for
+         * streaming wake-word verification.
          */
         val WAKE_VERIFICATION_DEFAULT: SherpaSttModelSpec get() = ZIPFORMER
     }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
@@ -22,4 +22,16 @@ interface VoiceInputController {
     suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult
 
     fun stopListening()
+
+    /**
+     * Transcribes [pcm] audio data synchronously and returns the transcript,
+     * or `null` when the engine does not support wake-word verification or
+     * transcription fails.
+     *
+     * Engines that need to perform async work (e.g. awaiting a mutex) can
+     * override this as `suspend` — callers in coroutine-unsafe contexts
+     * (e.g. [WakeWordService]'s verifyWindow) must wrap the call in
+     * [kotlinx.coroutines.runBlocking] when calling a [suspend] override.
+     */
+    suspend fun transcribeBlocking(pcm: ShortArray): String? = null
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordUtils.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordUtils.kt
@@ -1,0 +1,12 @@
+package com.kernel.ai.core.voice
+
+/**
+ * Returns true when [this] transcript contains a recognisable form of "Hey Jandal".
+ *
+ * Matches across common ASR error modes (Handel/Handal/Jandel) and normalises case.
+ */
+fun String.containsWakePhrase(): Boolean {
+    val lower = lowercase()
+    val namePattern = Regex("""\b(?:hey|a)\s*(?:jandal|jandel|handel|handal|hando)\b""")
+    return namePattern.containsMatchIn(lower)
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
@@ -3,7 +3,6 @@ package com.kernel.ai.core.voice
 import android.content.Context
 import android.media.AudioManager
 import kotlinx.coroutines.flow.MutableStateFlow
-import com.kernel.ai.core.voice.SherpaOnnxVoiceInputController.Companion.containsWakePhrase
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -78,47 +77,6 @@ class SherpaOnnxVoiceInputControllerTest {
         val result = controller.startListening(VoiceCaptureMode.Command)
 
         assertInstanceOf(VoiceInputStartResult.Unavailable::class.java, result)
-    }
-
-    // ── containsWakePhrase ─────────────────────────────────────────────────────
-
-    @Test
-    fun `containsWakePhrase matches Hey Jandal`() {
-        assertTrue("Hey Jandal".containsWakePhrase())
-        assertTrue("hey jandal".containsWakePhrase())
-        assertTrue("HEY JANDAL".containsWakePhrase())
-    }
-
-    @Test
-    fun `containsWakePhrase matches ASR variants`() {
-        assertTrue("a jandel".containsWakePhrase())
-        assertTrue("hey handel".containsWakePhrase())
-        assertTrue("Hey Handal".containsWakePhrase())
-        assertTrue("a hando".containsWakePhrase())
-    }
-
-    @Test
-    fun `containsWakePhrase rejects non-matches`() {
-        assertFalse("hello world".containsWakePhrase())
-        assertFalse("hey there".containsWakePhrase())
-        assertFalse("jandal".containsWakePhrase())
-        assertFalse("".containsWakePhrase())
-    }
-
-    @Test
-    fun `containsWakePhrase matches without whitespace`() {
-        // \s* allows zero whitespace between particles
-        assertTrue("heyjandal".containsWakePhrase())
-        assertTrue("heyjandel".containsWakePhrase())
-    }
-
-    @Test
-    fun `containsWakePhrase rejects embedded substrings`() {
-        // \b word boundaries prevent matching inside larger words
-        assertFalse("they jandal".containsWakePhrase())
-        assertFalse("hey jandalish".containsWakePhrase())
-        assertTrue("oh heyjandal who".containsWakePhrase())
-        assertTrue("say hey jandal now".containsWakePhrase())
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordUtilsTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordUtilsTest.kt
@@ -1,0 +1,49 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WakeWordUtilsTest {
+
+    // ── containsWakePhrase ─────────────────────────────────────────────────────
+
+    @Test
+    fun `containsWakePhrase matches Hey Jandal`() {
+        assertTrue("Hey Jandal".containsWakePhrase())
+        assertTrue("hey jandal".containsWakePhrase())
+        assertTrue("HEY JANDAL".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase matches ASR variants`() {
+        assertTrue("a jandel".containsWakePhrase())
+        assertTrue("hey handel".containsWakePhrase())
+        assertTrue("Hey Handal".containsWakePhrase())
+        assertTrue("a hando".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase rejects non-matches`() {
+        assertFalse("hello world".containsWakePhrase())
+        assertFalse("hey there".containsWakePhrase())
+        assertFalse("jandal".containsWakePhrase())
+        assertFalse("".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase matches without whitespace`() {
+        // \s* allows zero whitespace between particles
+        assertTrue("heyjandal".containsWakePhrase())
+        assertTrue("heyjandel".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase rejects embedded substrings`() {
+        // \b word boundaries prevent matching inside larger words
+        assertFalse("they jandal".containsWakePhrase())
+        assertFalse("hey jandalish".containsWakePhrase())
+        assertTrue("oh heyjandal who".containsWakePhrase())
+        assertTrue("say hey jandal now".containsWakePhrase())
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1116,7 +1116,7 @@ on-device via the Sherpa-ONNX AAR; access is through reflection (no compile-time
 
 | Engine | Mode | Size | Latency | Quality Notes |
 |--------|------|------|---------|---------------|
-| **Zipformer** (default) | Streaming (online) | ~72 MB | ~200ms end-of-speech | Best NZ English accuracy; also used for wake-word verification via dedicated isolated recognizer |
+| **Zipformer** (default) | Streaming (online) | ~72 MB | ~200ms end-of-speech | Best NZ English accuracy; also used as fallback for wake-word verification when the selected engine is offline-only |
 | **SenseVoice** | Offline (final only) | ~100 MB | ~500ms after stop | Good multilingual coverage (ZH/EN/JA/KO/YUE); gated HF downloads from `csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17` |
 | **Whisper tiny.en** | Offline (final only) | ~117 MB | ~1s after stop | Strong single-shot accuracy; pauses until speech ends or timeout |
 | **Paraformer** | Streaming (online) | ~226 MB | ~200ms | Continuous decoding; largest footprint |
@@ -1135,12 +1135,12 @@ normalisation pipeline:
   is handled by the punctuation-strip rule above
 - Zipformer produces live partial results; SenseVoice and Whisper emit one final result
 
-**Wake-word verification:** Zipformer is the designated wake-word verification engine.
-`WakeWordService` uses a dedicated Zipformer recognizer instance with its own mutex and
-method-handle cache, fully isolated from the interactive STT recognizer. This prevents
-races between wake-word verification and concurrent recognizer reinitialisation.
-
-**Architecture:**
+**Wake-word verification:** The wake-word verification engine follows the user's selected
+STT engine when it is an online recognizer (Zipformer or Paraformer). When the selected
+engine is offline-only (SenseVoice or Whisper), verification falls back to Zipformer.
+`SherpaOnnxVoiceInputController` maintains a dedicated recognizer instance with its own
+mutex and method-handle cache, fully isolated from the interactive STT recognizer, so
+[transcribeBlocking] can run concurrently with [startListening]/[stopListening].
 - `VoiceInputEngine` enum maps engine selection (`SherpaZipformer` / `SherpaSenseVoice` / `SherpaWhisper` / `SherpaParaformer`) with `isSherpaFamily` classifiers and storage backward-compatibility (`"SherpaOnnx"` → `SherpaZipformer`)
 - `SherpaSttModelSpec` data class maps each engine to its file paths, Sherpa class names, and `RecognizerKind` (Online / Offline)
 - `SherpaOnnxVoiceInputController` creates recognizer instances via reflection, caching method handles per recognizer kind

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -240,8 +241,8 @@ class VoiceViewModel @Inject constructor(
             wakeWordPreferences.heyJandalEnabled.collect { enabled ->
                 _uiState.update { it.copy(heyJandalEnabled = enabled) }
                 if (enabled) {
-                    // Ensure Zipformer is downloaded for wake-word verification.
-                    downloadSherpaStt(VoiceInputEngine.SherpaZipformer)
+                    // Ensure the selected online STT model is downloaded for wake-word verification.
+                    downloadSherpaStt(resolveWakeEngineForDownload())
                 }
             }
         }
@@ -318,6 +319,18 @@ class VoiceViewModel @Inject constructor(
     fun downloadSherpaStt(engine: VoiceInputEngine) {
         val spec = SherpaSttModelSpec.forEngine(engine) ?: return
         modelsForSpec(spec).forEach { modelDownloadManager.startDownload(it) }
+    }
+
+    /**
+     * Resolves the STT engine whose model files should be downloaded for wake-word
+     * verification. Uses the user's selected engine if it's an online recognizer
+     * (Zipformer or Paraformer), otherwise falls back to Zipformer.
+     */
+    private suspend fun resolveWakeEngineForDownload(): VoiceInputEngine {
+        val engine = voiceInputPreferences.selectedEngine.first()
+        val spec = SherpaSttModelSpec.forEngine(engine)
+        return if (spec?.recognizerKind == SherpaSttModelSpec.RecognizerKind.Online) engine
+               else VoiceInputEngine.SherpaZipformer
     }
 
     fun cancelSherpaSttDownload(engine: VoiceInputEngine) {
@@ -468,7 +481,7 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             wakeWordPreferences.setHeyJandalEnabled(enabled)
             if (enabled) {
-                downloadSherpaStt(VoiceInputEngine.SherpaZipformer)
+                downloadSherpaStt(resolveWakeEngineForDownload())
             }
         }
     }


### PR DESCRIPTION
## Summary

Pure refactor — no behavioural changes. Extracts `containsWakePhrase()` from `SherpaOnnxVoiceInputController.Companion` into a shared top-level utility and promotes `transcribeBlocking()` to the `VoiceInputController` interface. Additionally, the wake-word verification engine now follows the user's selected online STT model instead of always using Zipformer.

## Changes — Round 1: Extraction

| File | Change |
|---|---|
| `core/voice/.../WakeWordUtils.kt` (new) | Top-level `fun String.containsWakePhrase()` — same regex, public visibility |
| `core/voice/.../VoiceInputController.kt` | Adds `suspend fun transcribeBlocking(pcm: ShortArray): String? = null` with doc comment |
| `core/voice/.../SherpaOnnxVoiceInputController.kt` | Removes companion `containsWakePhrase`; changes `transcribeBlocking` to `override suspend fun ... String?` (null on failure) |
| `app/.../WakeWordService.kt` | Calls `voiceInputController.transcribeBlocking(pcm)?.containsWakePhrase() ?: false` instead of hardcoded Sherpa field; drops unused injection |
| `core/voice/.../SherpaOnnxVoiceInputControllerTest.kt` | Removes the 5 `containsWakePhrase` tests + stale import |
| `core/voice/.../WakeWordUtilsTest.kt` (new) | Same 5 test cases against top-level function, MockK-free |

## Changes — Round 2: Model selection for wake verification

`transcribeBlocking()` previously hardcoded `SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT` (Zipformer). It now resolves the user's selected engine and uses it when it's an online recognizer (Zipformer/Paraformer), falling back to Zipformer for offline-only models (SenseVoice/Whisper).

| File | Change |
|---|---|
| `core/voice/.../SherpaOnnxVoiceInputController.kt` | `transcribeBlocking` → `resolveSpec()` + Online check; added `releaseWakeRecognizer()` to prevent native memory leak on engine switch; `ensureWakeRecognizerBlocking` doc/log updated |
| `feature/settings/.../VoiceViewModel.kt` | Added `resolveWakeEngineForDownload()` helper; both download sites use it instead of hardcoding `SherpaZipformer` |
| `core/voice/.../SherpaSttModelSpec.kt` | `WAKE_VERIFICATION_DEFAULT` doc updated to reflect fallback role |
| `docs/SPECIFICATION.md` | Zipformer table row and wake-word verification section updated |

## Behaviour matrix

| Selected engine | Wake verification model |
|---|---|
| Zipformer | Zipformer (same model, separate instance) |
| Paraformer | Paraformer (same model, separate instance) |
| SenseVoice | Zipformer (fallback — offline-only) |
| Whisper | Zipformer (fallback — offline-only) |

## Verification
- `:core:voice:test` ✓
- `:app:testDebugUnitTest` ✓
- `assembleDebug` ✓
- No stale references to `SherpaOnnxVoiceInputController.Companion.containsWakePhrase` or the removed field

Closes #1023