### PR TITLE
fix(#1057): fast-open VAD gate for wake word detection

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -384,30 +384,33 @@ class OnnxWakeWordDetector @Inject constructor(
                 // Track the minimum observed RMS for diagnostic logging.
                 if (minRms <= 0.0 || rms < minRms) minRms = rms
 
-                // ── Debounced voice detection ──────────────────────────────────────
-                // Require 3+ consecutive frames with RMS ≥ threshold (240ms) before
-                // treating audio as speech.  A single 80ms transient (door, tap, car
-                // passing) no longer resets the silence timer.
+                // ── Fast-open / slow-close voice detection ───────────────────────
+                // Fast-open: a single frame above threshold immediately resets the
+                // silence counter, un-gating Stage 2/3 so the classifier sees speech
+                // onset within 80ms instead of 240ms.
+                // Slow-close: require 3 consecutive silent frames before the silence
+                // timer starts accumulating, so a single 80ms transient (door, tap,
+                // car passing) doesn't falsely re-enter gated mode.
                 val isFrameVoiced = rms >= silenceRmsThreshold
-                voicedFrameStreak = if (isFrameVoiced) voicedFrameStreak + 1 else 0
-                val voiced = voicedFrameStreak >= 3
-
-                if (voiced) {
+                if (isFrameVoiced) {
+                    // Flush the embedding ring on speech onset after gated silence.
+                    // The ring holds stale silence embeddings from before gating.
+                    // Resetting embFramesAccumulated forces a clean 16-frame refill
+                    // from live audio.  The mel ring slides naturally (Stage 1 runs
+                    // every frame even during gating), so the first speech frame
+                    // already pre-fills it with speech mel data.
+                    // Latency: 80ms + 16-frame ring fill (~1.3s) ≈ ~1.4s.
                     if (wasGated) {
-                        // Flush the embedding ring on speech onset after gated silence.
-                        // The ring holds stale silence embeddings from before gating.
-                        // Resetting embFramesAccumulated forces a clean 16-frame refill
-                        // from live audio.  The mel ring slides naturally (Stage 1 runs
-                        // every frame even during gating), so the debounce frames already
-                        // pre-fill it with speech mel data — no separate mel flush needed.
-                        // Detection latency: 3-frame debounce (~240ms) + 16-frame ring
-                        // fill (~1.3s) ≈ ~1.5s after speech onset.
                         embFramesAccumulated = 0
                         wasGated = false
                     }
                     silenceFrames = 0
+                    voicedFrameStreak = 0
                 } else {
-                    silenceFrames++
+                    voicedFrameStreak++
+                    if (voicedFrameStreak >= 3) {
+                        silenceFrames++
+                    }
                 }
                 // ── Stage 1: mel spectrogram (runs on every frame) ──────────────────
                 // Keeps the mel ring fresh during gated silence so that when speech
@@ -452,8 +455,8 @@ class OnnxWakeWordDetector @Inject constructor(
                 }
                 if (melRowsFilled < MEL_RING_SIZE) continue
 
-                // ── Gating: skip embedding + classifier when silent ─────────────────
-                if (!voiced && silenceFrames > silenceHangoverFrames &&
+                // ── Gating: skip embedding + classifier when confirmed-silent ─────
+                if (silenceFrames > silenceHangoverFrames &&
                     chunkCount % maxSilenceSkipFrames.toLong() != 0L) {
                     gatedFramesSkipped++
                     wasGated = true
@@ -465,9 +468,9 @@ class OnnxWakeWordDetector @Inject constructor(
                         TAG,
                         "WakeWordDetector: alive chunk=$chunkCount rms=${"%.1f".format(rms)} " +
                             "base=${"%.1f".format(minRms)} " +
-                            "thresh=$silenceRmsThreshold voiced=$voiced " +
-                            "melFilled=$melRowsFilled embAcc=$embFramesAccumulated " +
-                            "ongoingSkips=$gatedFramesSkipped",
+                            "thresh=$silenceRmsThreshold isVoiced=$isFrameVoiced " +
+                            "silenceFrames=$silenceFrames melFilled=$melRowsFilled " +
+                            "embAcc=$embFramesAccumulated ongoingSkips=$gatedFramesSkipped",
                     )
                 }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordPreferences.kt
@@ -38,7 +38,7 @@ const val WAKE_WORD_DEFAULT_LOW_THRESHOLD = 0.50f
 const val WAKE_WORD_VERIFY_WINDOW_S = 3
 
 /** RMS threshold below which a frame is treated as silence for wake-word gating. */
-const val WAKE_WORD_DEFAULT_SILENCE_RMS_THRESHOLD = 600f
+const val WAKE_WORD_DEFAULT_SILENCE_RMS_THRESHOLD = 300f
 
 /** Continue full-rate inference this long after the last voiced frame before gating back down. */
 const val WAKE_WORD_DEFAULT_SILENCE_HANGOVER_SECONDS = 5.0f
@@ -50,7 +50,7 @@ const val WAKE_WORD_DEFAULT_SILENCE_REARM_SECONDS = 2.5f
 const val WAKE_WORD_MAX_REPLAY_SECONDS = 3.0f
 
 /** Maximum sustained-silence interval between full inferences while gated down. */
-const val WAKE_WORD_MAX_SILENCE_SKIP_SECONDS = 3.0f
+const val WAKE_WORD_MAX_SILENCE_SKIP_SECONDS = 1.0f
 
 /** Frame size used by the detector loop (80 ms). Shared here for silence-gating defaults. */
 const val WAKE_WORD_FRAME_SAMPLES = 1_280

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordSilenceGateTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordSilenceGateTest.kt
@@ -23,7 +23,7 @@ class WakeWordSilenceGateTest {
     }
 
     @Test
-    fun `default silence skip interval is three seconds`() {
-        assertEquals(38, secondsToFrames(WAKE_WORD_MAX_SILENCE_SKIP_SECONDS))
+    fun `default silence skip interval is one second`() {
+        assertEquals(13, secondsToFrames(WAKE_WORD_MAX_SILENCE_SKIP_SECONDS))
     }
 }


### PR DESCRIPTION
## Problem

Wake word detection is inconsistent — often need to say "hey jandal" 2-3 times. The VAD gate requires 3 consecutive frames (240ms) above RMS threshold before opening, causing the classifier to miss speech onset. During gated silence, inference runs only once every 3 seconds.

## Fix

Three changes to `OnnxWakeWordDetector.kt` + `WakeWordPreferences.kt`:

1. **Fast-open gate**: A single above-threshold frame immediately resets the silence counter, opening the gate in 80ms instead of 240ms
2. **Slow-close**: Silence timer only starts accumulating after 3 consecutive silent frames
3. **Lower VAD threshold**: `silenceRmsThreshold` 600→300 to catch quieter speech at normal distance
4. **Frequent periodic check**: `maxSilenceSkipSeconds` 3.0→1.0 during gated silence

Oracle code review: no correctness issues.

## Test results
- `:core:voice:test` ✓
- `:core:voice:compileDebugKotlin` ✓