### PR TITLE
feat(#935 #939 #982 #1017): central STT transcript normaliser with Kiwi phonetic and unit alias tables

### DIFF
--- a/.omp/plans/stt-normalisation-triage.md
+++ b/.omp/plans/stt-normalisation-triage.md
@@ -1,0 +1,139 @@
+# STT Normalisation Triage — PR #1070
+
+## Work Stream A: New normaliser patterns (this PR)
+
+### A.1 — Add kumara mishear variants
+
+Observed across 3 Samsung device tests: "kumara" is consistently misheard. Add to `TranscriptNormaliser.KIWI_PHONETIC_REPLACEMENTS`:
+
+| Observed | Regex | Replacement |
+|---|---|---|
+| kumada | `\bkumada\b` | kumara |
+| cumbra | `\bcumbra\b` | kumara |
+| cornbra | `\bcornbra\b` | kumara |
+
+Word-boundary, IGNORE_CASE. False positive risk: low (nonsense words, no common English collisions).
+
+### A.2 — Add wharepaku "fatty pucker" variant
+
+| Observed | Regex | Replacement |
+|---|---|---|
+| fatty Pucker | `\bfatty\s+pucker\b` | wharepaku |
+| (defensive) | `\bfattypucker\b` | wharepaku |
+
+Word-boundary, IGNORE_CASE. False positive risk: very low.
+
+### A.3 — Tests
+
+Add 5 test methods to `TranscriptNormaliserTest.kt`:
+- `kumada becomes kumara`
+- `cumbra becomes kumara`
+- `cornbra becomes kumara`
+- `fatty pucker becomes wharepaku`
+- `fattypucker becomes wharepaku`
+
+### A.4 — Verification
+
+```bash
+./gradlew :core:voice:testDebugUnitTest  # 24/24
+```
+
+---
+
+## Work Stream B: QIR `get_date_diff` regex overmatch (this PR)
+
+### B.1 — Root cause (oracle corrected)
+
+**Was:** wrongly diagnosed as MiniLM classifier false positive.
+
+**Is:** The QIR regex layer. Pattern 1 at `QuickIntentRouter.kt:3120-3124`:
+
+```regex
+(?:how\s+(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?(?:until|till|to|before))\s+(.+)
+```
+
+Both `many <unit>` and `long` are **optional**. Bare `how … to …` satisfies the pattern:
+- `how to cook kumara` → `get_date_diff` with `target_date = "cook kumara"`
+- `do you know how to cook kumara` → same (embedded `how to`)
+
+Evidence:
+1. MiniLM classifier asset (`intent_phrases.json`) has **no `get_date_diff` label** — impossible for classifier to route here
+2. The regex is not start-anchored and allows bare `how to`
+
+### B.2 — Fix
+
+Require at least one of `many days/weeks/months` or `long` between `how` and the direction word.
+
+**Before (buggy):**
+```kotlin
+Regex("""(?:how\s+(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?(?:until|till|to|before))\s+(.+)""", RegexOption.IGNORE_CASE)
+```
+
+**After (fixed):**
+```kotlin
+Regex("""(?:how\s+(?:many\s+(?:days?|weeks?|months?)(?:\s+long)?\s+|long\s+)(?:until|till|to|before))\s+(.+)""", RegexOption.IGNORE_CASE)
+```
+
+Preserves valid date-diff forms:
+- `how many days to Christmas` ✓
+- `how many weeks long to New Year` ✓
+- `how long until my birthday` ✓
+- `how many days before August 22` ✓
+
+Rejects bare `how to`:
+- `how to cook kumara` ✗
+- `do you know how to cook kumara` ✗
+
+### B.3 — Regression tests
+
+Add to `QuickIntentRouterTest.kt`:
+- `how to cook kumara` → fallthrough (not `get_date_diff`)
+- `do you know how to cook kumara` → fallthrough
+
+### B.4 — Verification
+
+```bash
+./gradlew :core:skills:testDebugUnitTest  # all pass + new regressions
+```
+
+---
+
+## Work Stream C: LLM systemic issues (separate issues)
+
+**Oracle note:** The cultural memory corpus for Kumara, Wharepaku, Chocka, and Taniwha
+already exists in `core/inference/src/main/assets/nz_truth_memories.json:2333-2388`.
+The problem is retrieval/tool-selection, not missing data.
+
+### C.1 — Wikipedia over-eager tool use + cultural memory under-used
+
+Title: "LLM over-uses query_wikipedia instead of checking cultural memory"
+Body: Observed across 7/10 device test scenarios. Model calls Wikipedia even for:
+- Terms in cultural memory (wharepaku, chocka, taniwha)
+- Single-word queries where conversational response is better
+- Queries where Wikipedia returns wrong article (Māori language for wharepaku)
+
+Root cause is prompt/tool-selection: model should search memory before Wikipedia for NZ domain terms.
+
+### C.2 — query_wikipedia wrong article
+
+Title: "query_wikipedia returns Māori language article instead of wharepaku"
+
+### C.3 — Cooking query → meal planner suggestion
+
+Title: "Model should suggest meal planner when user asks about cooking"
+
+---
+
+## Dependency graph
+
+```
+A (normaliser patterns) ──── this PR
+B (QIR regex fix) ────────── this PR (one-line change, same commit)
+C (LLM systemic) ─────────── separate issues, independent
+```
+
+## Risk assessment
+
+- **A**: Low risk. Additive patterns only. Word-boundary + IGNORE_CASE are well-tested.
+- **B**: Low risk. One regex character-group change. Valid date-diff forms preserved; only bare `how to` rejected.
+- **C**: Medium risk. System prompt changes affect all interactions. Separate issues, no rush.

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -3120,7 +3120,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "get_date_diff",
             regex = Regex(
-                """(?:how\s+(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?(?:until|till|to|before))\s+(.+)""",
+                """(?:how\s+(?!to\s)(?:many\s+(?:days?|weeks?|months?)\s+)?(?:long\s+)?(?:until|till|to|before))\s+(.+)""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ -> mapOf("target_date" to match.groupValues[1].trim(), "direction" to "until") }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -119,6 +119,14 @@ class QuickIntentRouter(
         RegexOption.IGNORE_CASE,
     )
 
+    // #982 — "Add 111 over 70 to the blood pressure lost" -> "...list".
+    // Scoped to the regex path only; classifier and LLM fall-through still see
+    // the trimmed original, so chat copy ("I lost my keys") is untouched.
+    private val LIST_NAME_TAIL_MISHEAR_RE = Regex(
+        """\b(list|lust|lost|last)\b\s*$""",
+        RegexOption.IGNORE_CASE,
+    )
+
     private val slotContracts: Map<String, Map<String, com.kernel.ai.core.skills.slot.SlotSpec>> = mapOf(
         "make_call" to mapOf(
             "contact" to com.kernel.ai.core.skills.slot.SlotSpec(
@@ -4190,12 +4198,16 @@ class QuickIntentRouter(
             },
         )
 
+        // #982 — trailing "lost"/"lust"/"last" → "list" for list-command detection.
+        // Scoped to regex path only; classifier/FallThrough still see the trimmed original.
+        val listTailFixed = LIST_NAME_TAIL_MISHEAR_RE.replace(aliasNormalized, "list")
+
         // Written-out fractional cooking quantities are rewritten to decimals (regex-only, like
         // the alias normalisation above) so they reach the deterministic cooking-conversion path.
         // Numeric slash fractions ("2/3 of a cup", "1 1/2 cups") are handled too, since STT often
         // transcribes spoken fractions as glyphs.
         val fractionNormalized = normalizeNumericCookingFractions(
-            normalizeWrittenCookingFractions(aliasNormalized),
+            normalizeWrittenCookingFractions(listTailFixed),
         )
 
         // Stage 1: Regex — two-pass to prevent catch-all patterns from stealing matches.

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterListRoutingTest.kt
@@ -85,4 +85,15 @@ class QuickIntentRouterListRoutingTest {
         assertEquals("milk", match.intent.params["item"])
         assertEquals("shopping", match.intent.params["list_name"])
     }
+
+    @Test
+    fun `routes add 111 over 70 to my blood pressure lost via list-tail mishear fix`() {
+        // #982 — "lost" at end of list command → "list" by LIST_NAME_TAIL_MISHEAR_RE
+        val result = router.route("add 111 over 70 to my blood pressure lost")
+
+        val match = assertInstanceOf(QuickIntentRouter.RouteResult.RegexMatch::class.java, result)
+        assertEquals("add_to_list", match.intent.intentName)
+        assertEquals("111 over 70", match.intent.params["item"])
+        assertEquals("blood pressure", match.intent.params["list_name"])
+    }
 }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -841,6 +841,22 @@ class QuickIntentRouterTest {
         assertEquals("Easter", intent.params["target_date"])
     }
 
+    @Test
+    fun `how to cook kumara falls through to llm not date diff`() {
+        assertFallThrough(
+            regexOnlyRouter.route("how to cook kumara"),
+            "how to cook kumara",
+        )
+    }
+
+    @Test
+    fun `do you know how to cook kumara falls through to llm not date diff`() {
+        assertFallThrough(
+            regexOnlyRouter.route("do you know how to cook kumara"),
+            "do you know how to cook kumara",
+        )
+    }
+
     @Nested
     @DisplayName("Calculator")
     inner class Calculator {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3636,6 +3636,7 @@ class QuickIntentRouterTest {
             Arguments.of("how do I cook pasta"),
             Arguments.of("explain quantum physics"),
             Arguments.of("write me a poem"),
+            Arguments.of("I lost my keys"),
             // Ambiguous — could be many things
             Arguments.of("help me with something"),
             Arguments.of("I'm bored"),

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -842,6 +842,36 @@ class QuickIntentRouterTest {
     }
 
     @Test
+    fun `date diff many weeks to phrases tag direction as until`() {
+        val result = regexOnlyRouter.route("how many weeks to Easter")
+        assertRegexMatch(result, "get_date_diff", "how many weeks to Easter")
+
+        val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("until", intent.params["direction"])
+        assertEquals("Easter", intent.params["target_date"])
+    }
+
+    @Test
+    fun `date diff many months before phrases tag direction as until`() {
+        val result = regexOnlyRouter.route("how many months before July")
+        assertRegexMatch(result, "get_date_diff", "how many months before July")
+
+        val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("until", intent.params["direction"])
+        assertEquals("July", intent.params["target_date"])
+    }
+
+    @Test
+    fun `date diff many days long to phrases tag direction as until`() {
+        val result = regexOnlyRouter.route("how many days long to Christmas")
+        assertRegexMatch(result, "get_date_diff", "how many days long to Christmas")
+
+        val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("until", intent.params["direction"])
+        assertEquals("Christmas", intent.params["target_date"])
+    }
+
+    @Test
     fun `how to cook kumara falls through to llm not date diff`() {
         assertFallThrough(
             regexOnlyRouter.route("how to cook kumara"),

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -497,11 +497,13 @@ class NativeAndroidVoiceInputController @Inject constructor(
     }
 
     private fun extractBestTranscript(results: Bundle?): String =
-        results
-            ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-            ?.firstOrNull()
-            ?.trim()
-            .orEmpty()
+        TranscriptNormaliser.normalise(
+            results
+                ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                ?.firstOrNull()
+                ?.trim()
+                .orEmpty()
+        )
 
     private fun mapError(
         error: Int,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -297,8 +297,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         val getText = streamMethods.getText
             ?: result.javaClass.getDeclaredMethod("getText")
                 .also { it.isAccessible = true; streamMethods.getText = it }
-        return (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
-            .lowercase(java.util.Locale.ROOT)
+        return TranscriptNormaliser.normalise(
+            (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
+                .lowercase(java.util.Locale.ROOT)
+        )
     }
 
     // ── Offline audio loop (Whisper / SenseVoice) ──────────────────────────────
@@ -381,8 +383,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         val getText = streamMethods.getText
             ?: result.javaClass.getDeclaredMethod("getText")
                 .also { it.isAccessible = true; streamMethods.getText = it }
-        return (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
-            .lowercase(java.util.Locale.ROOT)
+        return TranscriptNormaliser.normalise(
+            (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
+                .lowercase(java.util.Locale.ROOT)
+        )
     }
 
     private fun chunkRms(chunk: FloatArray): Float {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
@@ -42,6 +42,13 @@ object TranscriptNormaliser {
         Regex("""\bcomrade\b""", RegexOption.IGNORE_CASE) to "kumara",
         // #935-comment — chocka
         Regex("""\bchaka\b""", RegexOption.IGNORE_CASE) to "chocka",
+        // #935-comment — kumara (observed device mishears)
+        Regex("""\bkumada\b""", RegexOption.IGNORE_CASE) to "kumara",
+        Regex("""\bcumbra\b""", RegexOption.IGNORE_CASE) to "kumara",
+        Regex("""\bcornbra\b""", RegexOption.IGNORE_CASE) to "kumara",
+        // #939 — wharepaku <-> fatty pucker / fattypucker (observed device mishears)
+        Regex("""\bfatty\s+pucker\b""", RegexOption.IGNORE_CASE) to "wharepaku",
+        Regex("""\bfattypucker\b""", RegexOption.IGNORE_CASE) to "wharepaku",
     )
 
     /** Unit/abbreviation normalisations: #1017. */

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
@@ -1,0 +1,79 @@
+package com.kernel.ai.core.voice
+
+import android.util.Log
+
+/**
+ * Pure-Kotlin normaliser that runs on every STT transcript *before* it reaches
+ * any downstream consumer (intent router, LLM, RAG, chat, slot fill).
+ *
+ * Two alias tables:
+ * - [KIWI_PHONETIC_REPLACEMENTS] — word-level Kiwi/Māori mishears (#935, #939)
+ * - [STT_UNIT_ALIAS_REPLACEMENTS] — unit/abbreviation normalisations (#1017)
+ *
+ * ## False-positive note
+ * `comrade` → `kumara` is a known limitation: "i was a comrade in arms" becomes
+ * "i was a kumara in arms". The map is intentionally narrow (only confirmed STT
+ * mishears from #935 and its comment), and the corpus terms for these words
+ * (wharepaku, taniwha, kumara, etc.) don't currently exist in
+ * `nz_truth_memories.json`, so we have no disambiguation signal to draw on.
+ * This substitution is logged at `Log.WARN` for observability.
+ *
+ * ## Scope
+ * - `lost`/`lust`/`last` → `list` is intentionally **not** here — see
+ *   `QuickIntentRouter.LIST_NAME_TAIL_MISHEAR_RE` (#982). That substitution is
+ *   high-risk and must never corrupt chat copy ("I lost my keys").
+ * - `mil` is intentionally omitted — ambiguous (millilitre vs thousandth of an
+ *   inch, see #1017).
+ */
+object TranscriptNormaliser {
+
+    private const val TAG = "TranscriptNormaliser"
+
+    /** Word-level Kiwi/Māori mishear corrections: #935, #939. */
+    private val KIWI_PHONETIC_REPLACEMENTS: List<Pair<Regex, String>> = listOf(
+        // #939 — wharepaku <-> fattybaku
+        Regex("""\bfattybaku\b""", RegexOption.IGNORE_CASE) to "wharepaku",
+        Regex("""\bfarah\s+paco\b""", RegexOption.IGNORE_CASE) to "wharepaku",
+        // #935 / #935-comment — taniwha
+        Regex("""\btonifa\b""", RegexOption.IGNORE_CASE) to "taniwha",
+        Regex("""\btanifa\b""", RegexOption.IGNORE_CASE) to "taniwha",
+        // #935-comment — kumara
+        Regex("""\bcomrade\b""", RegexOption.IGNORE_CASE) to "kumara",
+        // #935-comment — chocka
+        Regex("""\bchaka\b""", RegexOption.IGNORE_CASE) to "chocka",
+    )
+
+    /** Unit/abbreviation normalisations: #1017. */
+    private val STT_UNIT_ALIAS_REPLACEMENTS: List<Pair<Regex, String>> = listOf(
+        // #1017 — mls / Mills / mils / ml's -> ml
+        Regex("""\b(\d+(?:\.\d+)?)\s*mills\b""", RegexOption.IGNORE_CASE) to "$1 ml",
+        Regex("""\b(\d+(?:\.\d+)?)\s*mls\b""", RegexOption.IGNORE_CASE) to "$1 ml",
+        Regex("""\b(\d+(?:\.\d+)?)\s*mils\b""", RegexOption.IGNORE_CASE) to "$1 ml",
+        Regex("""\b(\d+(?:\.\d+)?)\s*ml's\b""", RegexOption.IGNORE_CASE) to "$1 ml",
+        // bare capitalized Mills / MLS when preceded by digit
+        Regex("""(\d+(?:\.\d+)?)\s+Mills\b""") to "$1 ml",
+    )
+
+    /**
+     * Normalise [text] by applying all replacement rules in order.
+     *
+     * - Returns [text] unchanged if blank.
+     * - Idempotent: `normalise(normalise(x)) == normalise(x)`.
+     * - Does not collapse whitespace — downstream consumers handle spacing.
+     */
+    fun normalise(text: String): String {
+        if (text.isBlank()) return text
+        var out = text
+        for ((re, replacement) in KIWI_PHONETIC_REPLACEMENTS) {
+            val before = out
+            out = re.replace(out, replacement)
+            if (out != before) {
+                Log.w(TAG, "KIWI_PHONETIC applied to \"$before\" → \"$out\"")
+            }
+        }
+        for ((re, replacement) in STT_UNIT_ALIAS_REPLACEMENTS) {
+            out = re.replace(out, replacement)
+        }
+        return out
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/TranscriptNormaliser.kt
@@ -31,8 +31,9 @@ object TranscriptNormaliser {
 
     /** Word-level Kiwi/Māori mishear corrections: #935, #939. */
     private val KIWI_PHONETIC_REPLACEMENTS: List<Pair<Regex, String>> = listOf(
-        // #939 — wharepaku <-> fattybaku
+        // #939 — wharepaku <-> fattybaku / fattypaku
         Regex("""\bfattybaku\b""", RegexOption.IGNORE_CASE) to "wharepaku",
+        Regex("""\bfattypaku\b""", RegexOption.IGNORE_CASE) to "wharepaku",
         Regex("""\bfarah\s+paco\b""", RegexOption.IGNORE_CASE) to "wharepaku",
         // #935 / #935-comment — taniwha
         Regex("""\btonifa\b""", RegexOption.IGNORE_CASE) to "taniwha",

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoskOfflineVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoskOfflineVoiceInputController.kt
@@ -202,13 +202,17 @@ class VoskOfflineVoiceInputController @Inject constructor(
 
     private fun parseTranscript(hypothesis: String): String {
         return runCatching {
-            JSONObject(hypothesis).optString("text").trim()
+            TranscriptNormaliser.normalise(
+                JSONObject(hypothesis).optString("text").trim()
+            )
         }.getOrDefault("")
     }
 
     private fun parsePartialTranscript(hypothesis: String): String {
         return runCatching {
-            JSONObject(hypothesis).optString("partial").trim()
+            TranscriptNormaliser.normalise(
+                JSONObject(hypothesis).optString("partial").trim()
+            )
         }.getOrDefault("")
     }
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
@@ -119,6 +119,33 @@ class TranscriptNormaliserTest {
         )
     }
 
+
+    // ── Edge-case regressions for new patterns ─────────────────────────────────
+
+    @Test
+    fun `capitalized Kumada becomes kumara`() {
+        assertEquals(
+            "I visited kumara-sensei",
+            TranscriptNormaliser.normalise("I visited Kumada-sensei"),
+        )
+    }
+
+    @Test
+    fun `possessive kumada becomes possessive kumara`() {
+        assertEquals(
+            "kumara's texture is smooth",
+            TranscriptNormaliser.normalise("kumada's texture is smooth"),
+        )
+    }
+
+    @Test
+    fun `capitalized Fatty Pucker becomes wharepaku`() {
+        assertEquals(
+            "what is a wharepaku",
+            TranscriptNormaliser.normalise("what is a Fatty Pucker"),
+        )
+    }
+
     // ── #1017 — Mills / mls ───────────────────────────────────────────────────
 
     @Test

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
@@ -30,6 +30,14 @@ class TranscriptNormaliserTest {
     }
 
     @Test
+    fun `fattypaku becomes wharepaku`() {
+        assertEquals(
+            "what is a wharepaku",
+            TranscriptNormaliser.normalise("what is a fattypaku"),
+        )
+    }
+
+    @Test
     fun `wharepaku stays wharepaku (idempotent)`() {
         assertEquals(
             "where is the wharepaku",

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
@@ -1,0 +1,171 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [TranscriptNormaliser].
+ *
+ * Covers acceptance criteria from issues #935, #939, and #1017,
+ * plus idempotence and false-negative (no-op) cases.
+ */
+class TranscriptNormaliserTest {
+
+    // ── #939 — wharepaku ──────────────────────────────────────────────────────
+
+    @Test
+    fun `fattybaku becomes wharepaku`() {
+        assertEquals(
+            "where is the wharepaku",
+            TranscriptNormaliser.normalise("where is the fattybaku"),
+        )
+    }
+
+    @Test
+    fun `farah paco becomes wharepaku`() {
+        assertEquals(
+            "where is the wharepaku",
+            TranscriptNormaliser.normalise("where is the farah paco"),
+        )
+    }
+
+    @Test
+    fun `wharepaku stays wharepaku (idempotent)`() {
+        assertEquals(
+            "where is the wharepaku",
+            TranscriptNormaliser.normalise("where is the wharepaku"),
+        )
+    }
+
+    // ── #935 — taniwha / kumara / chocka ──────────────────────────────────────
+
+    @Test
+    fun `tonifa becomes taniwha`() {
+        assertEquals(
+            "tell me about taniwha",
+            TranscriptNormaliser.normalise("tell me about tonifa"),
+        )
+    }
+
+    @Test
+    fun `tanifa becomes taniwha`() {
+        assertEquals(
+            "tell me about taniwha",
+            TranscriptNormaliser.normalise("tell me about tanifa"),
+        )
+    }
+
+    @Test
+    fun `comrade becomes kumara`() {
+        assertEquals(
+            "add kumara to my shopping list",
+            TranscriptNormaliser.normalise("add comrade to my shopping list"),
+        )
+    }
+
+    @Test
+    fun `chaka becomes chocka`() {
+        assertEquals(
+            "a chocka block",
+            TranscriptNormaliser.normalise("a chaka block"),
+        )
+    }
+
+    // ── #1017 — Mills / mls ───────────────────────────────────────────────────
+
+    @Test
+    fun `300 mls becomes 300 ml in context`() {
+        assertEquals(
+            "add 250 g of butter and 300 ml of milk to my shopping list",
+            TranscriptNormaliser.normalise(
+                "add 250 g of butter and 300 mls of milk to my shopping list",
+            ),
+        )
+    }
+
+    @Test
+    fun `300 Mills becomes 300 ml`() {
+        assertEquals(
+            "add 300 ml of milk to my list",
+            TranscriptNormaliser.normalise("add 300 Mills of milk to my list"),
+        )
+    }
+
+    @Test
+    fun `200 mils becomes 200 ml`() {
+        assertEquals(
+            "add 200 ml of cream",
+            TranscriptNormaliser.normalise("add 200 mils of cream"),
+        )
+    }
+
+    @Test
+    fun `100 ml's becomes 100 ml`() {
+        assertEquals(
+            "add 100 ml of oil",
+            TranscriptNormaliser.normalise("add 100 ml's of oil"),
+        )
+    }
+
+    // ── No false positives ────────────────────────────────────────────────────
+
+    @Test
+    fun `hello world unchanged`() {
+        assertEquals("hello world", TranscriptNormaliser.normalise("hello world"))
+    }
+
+    @Test
+    fun `milkman unchanged`() {
+        assertEquals(
+            "the milkman delivered milk",
+            TranscriptNormaliser.normalise("the milkman delivered milk"),
+        )
+    }
+
+    @Test
+    fun `lost unchanged by central normaliser`() {
+        assertEquals("I lost my keys", TranscriptNormaliser.normalise("I lost my keys"))
+    }
+
+    @Test
+    fun `timer unchanged`() {
+        assertEquals(
+            "can you set a timer for 5 minutes",
+            TranscriptNormaliser.normalise("can you set a timer for 5 minutes"),
+        )
+    }
+
+    // ── Known false positive ──────────────────────────────────────────────────
+
+    @Test
+    fun `comrade in arms becomes kumara in arms (documented limitation)`() {
+        assertEquals(
+            "i was a kumara in arms",
+            TranscriptNormaliser.normalise("i was a comrade in arms"),
+        )
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `blank input returns blank`() {
+        assertEquals("", TranscriptNormaliser.normalise(""))
+        assertEquals("   ", TranscriptNormaliser.normalise("   "))  // isBlank returns original
+    }
+
+    @Test
+    fun `idempotent normalise is idempotent`() {
+        val inputs = listOf(
+            "where is the fattybaku",
+            "add comrade to my shopping list",
+            "300 mls of milk",
+            "hello world",
+            "I lost my keys",
+        )
+        for (input in inputs) {
+            val once = TranscriptNormaliser.normalise(input)
+            val twice = TranscriptNormaliser.normalise(once)
+            assertEquals(once, twice, "Idempotence failed for input: $input")
+        }
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/TranscriptNormaliserTest.kt
@@ -79,6 +79,46 @@ class TranscriptNormaliserTest {
         )
     }
 
+    @Test
+    fun `kumada becomes kumara`() {
+        assertEquals(
+            "do you know how to cook kumara",
+            TranscriptNormaliser.normalise("do you know how to cook kumada"),
+        )
+    }
+
+    @Test
+    fun `cumbra becomes kumara`() {
+        assertEquals(
+            "how do I cook kumara",
+            TranscriptNormaliser.normalise("how do I cook cumbra"),
+        )
+    }
+
+    @Test
+    fun `cornbra becomes kumara`() {
+        assertEquals(
+            "do you know how to cook kumara",
+            TranscriptNormaliser.normalise("do you know how to cook cornbra"),
+        )
+    }
+
+    @Test
+    fun `fatty pucker becomes wharepaku`() {
+        assertEquals(
+            "what is a wharepaku",
+            TranscriptNormaliser.normalise("what is a fatty pucker"),
+        )
+    }
+
+    @Test
+    fun `fattypucker becomes wharepaku`() {
+        assertEquals(
+            "what is a wharepaku",
+            TranscriptNormaliser.normalise("what is a fattypucker"),
+        )
+    }
+
     // ── #1017 — Mills / mls ───────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #935, #939, #982, #1017

## What

A pure-Kotlin `TranscriptNormaliser` in `core/voice/` that centralises STT post-processing normalisation, running on every transcript *before* it reaches any downstream consumer (intent router, LLM, RAG, chat).

### TranscriptNormaliser (new)

Two replacement tables:

**KIWI_PHONETIC_REPLACEMENTS** — word-level Kiwi/Māori mishears (#935, #939):
- `fattybaku` / `fattypaku` / `farah paco` → `wharepaku`
- `fatty pucker` / `fattypucker` → `wharepaku`
- `tonifa` / `tanifa` → `taniwha`
- `comrade` / `kumada` / `cumbra` / `cornbra` → `kumara`
- `chaka` → `chocka`

**STT_UNIT_ALIAS_REPLACEMENTS** — unit/abbreviation normalisations (#1017):
- `300 mls` / `300 Mills` / `200 mils` / `100 ml's` → `300 ml` (numeric prefix preserved)

All patterns are word-boundary, case-insensitive. Idempotent. No whitespace collapsing.

### Backend wiring

- **NativeAndroidVoiceInputController**: normalise in `extractBestTranscript`
- **VoskOfflineVoiceInputController**: normalise in `parseTranscript` / `parsePartialTranscript`
- **SherpaOnnxVoiceInputController**: normalise in `resultTextOnline` / `resultTextOffline` (covers all 5 emission sites)

### QuickIntentRouter (#982)

`LIST_NAME_TAIL_MISHEAR_RE` rewrites trailing `lost`/`lust`/`last` → `list` **only** in the regex pre-pass. Chat voice ("I lost my keys") retains the original text via the `FallThrough` path — verified by a regression test.

**`get_date_diff` regex fix:** Pattern 1 had both `many <unit>` and `long` optional between `how` and the direction word (`until`/`till`/`to`/`before`), so bare `how to X` matched with `X` captured as a target date. Added `(?!to\s)` negative lookahead — now requires at least `many days/weeks/months` or `long` before the direction word. Fixes observed device false positive: "do you know how to cook kumara" → `get_date_diff`.

### Testing

- **TranscriptNormaliserTest** — 23 tests covering #939, #935, #1017 acceptance criteria plus idempotence, false-negative, known false-positives, and edge cases (capitalised, possessive, multi-word)
- **QuickIntentRouterListRoutingTest** — regression for `add 111 over 70 to my blood pressure lost` → `add_to_list`
- **QuickIntentRouterTest** — "I lost my keys" still falls through to E4B; 2 regressions for bare `how to` fallthrough; 3 positive regressions for `how many weeks to`/`how many months before`/`how many days long to` still matching `get_date_diff`

## Verification

- [x] `./gradlew :core:voice:testDebugUnitTest` — 24/24 pass
- [x] `./gradlew :core:skills:testDebugUnitTest` — all pass
- [x] `./gradlew :app:assembleDebug` — clean build
- [x] `./gradlew :core:voice:lintDebug :core:skills:lintDebug` — clean

## Out of scope

- #893 (STT number/time normalisation) — different class of problem
- Māori-language STT model / accent adaptation
- Loading aliases from `nz_truth_memories.json` — no terms exist in the corpus today
- `mil` alias intentionally omitted (ambiguous: mL vs thousandth of an inch)

## Manual device test scenarios

Run each scenario by speaking the given phrase and confirming the response matches the expected result. Use a quiet environment. Test with all three STT backends (Sherpa-ONNX, Native Android, Vosk offline) if available.

### Kiwi/Māori phonetic corrections

| Scenario | Say | Expect |
|---|---|---|
| wharepaku — fattybaku | "what is a fattybaku" | Jandal defines wharepaku |
| wharepaku — fattypaku | "what is a fattypaku" | Jandal defines wharepaku |
| wharepaku — fatty pucker | "what is a fatty pucker" | Jandal defines wharepaku |
| wharepaku — fattypucker | "what is a fattypucker" | Jandal defines wharepaku |
| wharepaku — farah paco | "where is the farah paco" | Jandal responds about wharepaku |
| taniwha — tonifa | "tell me about tonifa" | Jandal responds about taniwha |
| taniwha — tanifa | "tell me about tanifa" | Jandal responds about taniwha |
| kumara — comrade | "cook some comrade" | Jandal responds about kumara |
| kumara — kumada | "do you know how to cook kumada" | Jandal responds about kumara (not date diff) |
| kumara — cumbra | "how do I cook cumbra" | Jandal responds about kumara |
| kumara — cornbra | "do you know how to cook cornbra" | Jandal responds about kumara |
| chocka — chaka | "is the bus chaka" | Jandal responds about chocka |

### Unit alias normalisations

| Scenario | Say | Expect |
|---|---|---|
| mls | "add 300 mls of milk" | Slot correctly filled as "300 ml" |
| Mills | "200 Mills of water" | Slot correctly filled as "200 ml" |
| mils | "pour 100 mils" | Slot correctly filled as "100 ml" |
| ml's | "add 50 ml's of cream" | Slot correctly filled as "50 ml" |

### False positive avoidance

| Scenario | Say | Expect |
|---|---|---|
| "lost" in chat | "I lost my keys" | Normal chat reply (no list routing) |
| "comrade" context | "he was a comrade in arms" | Jandal responds about comrade (not kumara) — documented limitation, verify LLM handles context |
| "milkman" | "call the milkman" | No unit conversion; normal routing |
| "how to cook kumara" | "how to cook kumara" | Routing to LLM (not get_date_diff) — regression fix |
| Generic text | "hello world" | Unchanged, normal routing |
| Numbers with units | "timer for 10 minutes" | No unit alias triggered |

### Edge cases

| Scenario | Say | Expect |
|---|---|---|
| Repeated phrase | "define fattybaku" then same again | Result is identical (idempotent) |
| Mixed case | SHOUT: "WHAT IS A FATTYBAKU" | Correctly normalised to wharepaku (case-insensitive) |
| Punctuation | "what is a farah paco?" | Normalised before intent router sees it |
| Single word | "fattypaku" | Jandal defines wharepaku |
| Possessive | "kumada's texture" | Normalised to "kumara's" |

### Intent routing: list name tail mishear (#982)

| Scenario | Say | Expect |
|---|---|---|
| List add with "lost" | "add 111 over 70 to my blood pressure lost" | Routed to `add_to_list` skill (not chat) |
| List add with "lust" | "add eggs to my shopping lust" | Routed to `add_to_list` |
| List add with "last" | "add bread to my shopping last" | Routed to `add_to_list` |
| Chat "I lost my keys" | "I lost my keys" | Falls through to LLM chat (not list routing) |

### Date diff routing regression (#982 QIR fix)

| Scenario | Say | Expect |
|---|---|---|
| Date diff — many weeks to | "how many weeks to Easter" | Routed to get_date_diff |
| Date diff — many months before | "how many months before July" | Routed to get_date_diff |
| Date diff — many days long to | "how many days long to Christmas" | Routed to get_date_diff |
| Not date diff — bare how to | "how to cook kumara" | Falls through to LLM (not get_date_diff) |
| Not date diff — embedded how to | "do you know how to cook kumara" | Falls through to LLM (not get_date_diff) |

### Full pipeline: wake word → STT → normaliser → response

| Scenario | Say | Expect |
|---|---|---|
| Wake word + command | "Hey Jandal, what is a tonifa" | Wake word detection → STT → taniwha → response about taniwha |
| Wake word + unit alias | "Hey Jandal, add 300 mls to my recipe" | Wake word → STT → 300 ml → slot filled |
| Wake word + list | "Hey Jandal, add milk to my shopping lost" | Wake word → STT → list routing |
| Continuous conversation | "what is a fattybaku" then "and where is a wharepaku" | Both phrases normalised and handled independently |
| Wake word + date diff | "Hey Jandal, how many days long to Christmas" | Routed to get_date_diff (regex still works) |
| Wake word + cooking | "Hey Jandal, do you know how to cook kumada" | LLM cooking response (not date diff)