### PR TITLE
fix(#1086): cancel viewModelScope in ChatViewModel tests + chore(#1087): upgrade CI actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-test:
@@ -18,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0
 
       # ── Validate repo structure ──────────────────────────────────────
       - name: Check required files exist
@@ -28,16 +26,16 @@ jobs:
 
       # ── Android build ──────────────────────────────────────────────
       - name: Set up JDK 21
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699
 
       - name: Cache Gradle packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ~/.gradle/caches
@@ -49,7 +47,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Sherpa-ONNX AAR
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: third_party/sherpa-onnx
           key: sherpa-onnx-aar-1.13.0
@@ -86,7 +84,7 @@ jobs:
 
       - name: Upload APK
         if: success()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: apk-${{ github.sha }}
           path: app/build/outputs/apk/debug/

--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -9,8 +9,6 @@ on:
         default: '7'
         type: string
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   cleanup:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   delete-preview-release:
     name: Delete PR preview release
@@ -15,7 +12,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Delete pr-N release and tag
         env:

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -29,7 +29,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check triage script
         id: check-script
@@ -52,7 +52,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -104,7 +104,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +116,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,10 +15,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -118,6 +118,7 @@ class ChatViewModelInitTest {
         coEvery { inferenceEngine.resetConversation() } just runs
 
         every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+        every { downloadManager.downloadSources } returns MutableStateFlow(emptyMap())
         every { downloadManager.areRequiredModelsDownloaded() } returns false
         every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
 
@@ -127,7 +128,21 @@ class ChatViewModelInitTest {
             ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L)
         }
         coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
+        every { conversationRepository.observeConversationById(any()) } answers {
+            val id = firstArg<String>()
+            flowOf(ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L))
+        }
 
+        every { authRepository.isAuthenticated } returns MutableStateFlow(false)
+        every { chatPreferences.fontSize } returns flowOf(1)
+        every { chatPreferences.bubbleTheme } returns flowOf("system")
+        every { chatPreferences.userFontColor } returns flowOf(null)
+        every { chatPreferences.assistantFontColor } returns flowOf(null)
+        every { chatPreferences.wallpaperType } returns flowOf("none")
+        every { chatPreferences.wallpaperColor } returns flowOf(null)
+        every { chatPreferences.wallpaperImageUri } returns flowOf(null)
+        every { chatPreferences.copyToolCalls } returns flowOf(false)
+        every { chatPreferences.copyThinking } returns flowOf(false)
         every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
         every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
         every { voiceOutputPreferences.spokenResponsesEnabled } returns MutableStateFlow(false)
@@ -259,7 +274,7 @@ class ChatViewModelInitTest {
         )
 
         advanceUntilIdle()
-        invokeOnCleared(viewModel)
+        clearViewModel(viewModel)
 
         coVerify(exactly = 0) { inferenceEngine.shutdown() }
     }
@@ -306,8 +321,12 @@ class ChatViewModelInitTest {
         coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
         coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
         coVerify(exactly = 0) { ragRepository.indexMessage(any(), any(), any()) }
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals(prompt, state.messages.last().content)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals(prompt, state.messages.last().content)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -431,8 +450,12 @@ class ChatViewModelInitTest {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { conversationRepository.renameConversation("conv-existing", snapshot.displayName) }
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals(snapshot.displayName, state.conversationTitle)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals(snapshot.displayName, state.conversationTitle)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -485,9 +508,13 @@ class ChatViewModelInitTest {
 
         coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
         coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals(1, state.messages.size)
-        assertEquals(prompt, state.messages.last().content)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals(1, state.messages.size)
+            assertEquals(prompt, state.messages.last().content)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -555,9 +582,13 @@ class ChatViewModelInitTest {
 
         coVerify(exactly = 1) { mealPlannerCoordinator.activeSessionReply("conv-existing") }
         coVerify(exactly = 0) { conversationRepository.addMessage("conv-existing", "assistant", prompt, any(), any()) }
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals(4, state.messages.size)
-        assertEquals(prompt, state.messages.last().content)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals(4, state.messages.size)
+            assertEquals(prompt, state.messages.last().content)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -912,8 +943,9 @@ class ChatViewModelInitTest {
         coVerify(exactly = 0) { ragRepository.indexMessage("assistant-fallback-id", any(), any()) }
     }
 
-    private fun invokeOnCleared(viewModel: ChatViewModel) {
-        val method = ChatViewModel::class.java.getDeclaredMethod("onCleared")
+    private fun clearViewModel(viewModel: ChatViewModel) {
+        val method = androidx.lifecycle.ViewModel::class.java
+            .getDeclaredMethod("clear\$lifecycle_viewmodel_release")
         method.isAccessible = true
         method.invoke(viewModel)
     }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -142,6 +142,7 @@ class ChatViewModelVoiceTest {
         coEvery { inferenceEngine.resetConversation() } just runs
 
         every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+        every { downloadManager.downloadSources } returns MutableStateFlow(emptyMap())
         every { downloadManager.areRequiredModelsDownloaded() } returns true
         every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
 
@@ -152,7 +153,21 @@ class ChatViewModelVoiceTest {
         coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
         coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
             listOf("user-msg", "assistant-msg")
+        every { conversationRepository.observeConversationById(any()) } answers {
+            val id = firstArg<String>()
+            flowOf(ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L))
+        }
 
+        every { authRepository.isAuthenticated } returns MutableStateFlow(false)
+        every { chatPreferences.fontSize } returns flowOf(1)
+        every { chatPreferences.bubbleTheme } returns flowOf("system")
+        every { chatPreferences.userFontColor } returns flowOf(null)
+        every { chatPreferences.assistantFontColor } returns flowOf(null)
+        every { chatPreferences.wallpaperType } returns flowOf("none")
+        every { chatPreferences.wallpaperColor } returns flowOf(null)
+        every { chatPreferences.wallpaperImageUri } returns flowOf(null)
+        every { chatPreferences.copyToolCalls } returns flowOf(false)
+        every { chatPreferences.copyThinking } returns flowOf(false)
         every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
         every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
         every { voiceInputController.events } returns voiceInputEvents
@@ -927,9 +942,13 @@ class ChatViewModelVoiceTest {
 
         viewModel.onSmartReplySelected(MealPlannerSuggestion("Generate recipes", "generate recipes"))
 
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals("generate recipes", state.inputText)
-        coVerify(exactly = 0) { conversationRepository.addMessage(any(), any(), any(), any(), any()) }
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals("generate recipes", state.inputText)
+            coVerify(exactly = 0) { conversationRepository.addMessage(any(), any(), any(), any(), any()) }
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -944,8 +963,12 @@ class ChatViewModelVoiceTest {
             MealPlannerSuggestion("Nut free", "nut free", MealPlannerSuggestionComposeMode.APPEND_COMMA),
         )
 
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals("gluten free, nut free", state.inputText)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals("gluten free, nut free", state.inputText)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -958,8 +981,12 @@ class ChatViewModelVoiceTest {
             MealPlannerSuggestion("Chicken", "chicken", MealPlannerSuggestionComposeMode.APPEND_COMMA),
         )
 
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals("beef, chicken", state.inputText)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals("beef, chicken", state.inputText)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
     @Test
@@ -1026,11 +1053,21 @@ class ChatViewModelVoiceTest {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { conversationRepository.renameConversation("conv-existing", snapshot.displayName) }
-        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
-        assertEquals(snapshot.displayName, state.conversationTitle)
+        try {
+            val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+            assertEquals(snapshot.displayName, state.conversationTitle)
+        } finally {
+            clearViewModel(viewModel)
+        }
     }
 
 
+    private fun clearViewModel(viewModel: ChatViewModel) {
+        val method = androidx.lifecycle.ViewModel::class.java
+            .getDeclaredMethod("clear\$lifecycle_viewmodel_release")
+        method.isAccessible = true
+        method.invoke(viewModel)
+    }
     private fun createViewModel(): ChatViewModel = ChatViewModel(savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")), chatPreferences = chatPreferences, authRepository = authRepository,
     inferenceEngine = inferenceEngine,
     downloadManager = downloadManager,


### PR DESCRIPTION
Closes #1086
Closes #1087

## #1086 — Fix 8 UncompletedCoroutinesError test failures

**Root cause:** `viewModel.uiState.first { it is ChatUiState.Ready }` never resolved in 8 tests because `ChatViewModel.baseUiState` is a 7-way `combine` that depends on flows that relaxed mocks never emitted deterministically. Additionally, the old `invokeOnCleared` helper called `onCleared()` which is empty in ViewModel — it never actually cancelled the `viewModelScope`.

**Fixes:**
- Stub missing `baseUiState` dependencies in `setUp()`: `downloadSources`, `observeConversationById`, `isAuthenticated`, `fontSize`
- Replace reflection `onCleared()` call with `ViewModel.clear$lifecycle_viewmodel_release()` (the real teardown)
- Wrap `uiState.first { Ready }` assertions in `try/finally` to guarantee cleanup

## #1087 — Update CI actions to Node 24-native versions

- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var
- actions/checkout @v4 → @v6
- actions/cache @v4.3.0 → @v5.0.5
- actions/setup-java @v4 → @v5.2.0
- actions/upload-artifact @v4.6.2 → @v7.0.1
- android-actions/setup-android @v3.2.2 → @v4.0.1
- actions/github-script @v7 → @v8