### PR TITLE
docs: Update context-mode section to reference global SYSTEM.md

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -136,9 +136,9 @@ connectedDebugAndroidTest   # requires device
 
 ## context-mode — routing
 
-context-mode is installed globally (MCP tools + native OMP hooks). Full routing rules at `~/.omp/agent/SYSTEM.md`.
+context-mode is installed globally (MCP tools + native OMP hooks). Full routing rules at `~/.omp/agent/SYSTEM.md` (if available).
 
-Key paradigm: **Think in Code** — write `ctx_execute(language, code)` for analysis/count/filter/parse. Only stdout enters context.
+**Fallback (no SYSTEM.md):** Use `ctx_execute(language, code)` for count/filter/parse/transform analysis. Only stdout enters context — keep analysis in code, not raw data. A one-liner replaces 10+ `read`/`bash` calls. Avoid reading large data into context when code can summarise it.
 
 ## Branching & PR standards
 

--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -134,17 +134,11 @@ connectedDebugAndroidTest   # requires device
 
 **Standalone:** `rtk gain` shows token savings. `rtk env` shows filtered env vars. **Hard rule:** If output is >5 lines, use `rtk`.
 
-## context-mode — Think in Code (when available)
+## context-mode — routing
 
-`ctx_execute(language, code)` runs code in a sandbox — only stdout enters context. Use it for analysis (count, filter, parse, transform) instead of reading raw data into context. A one-liner replaces 10+ `read`/`bash` calls.
+context-mode is installed globally (MCP tools + native OMP hooks). Full routing rules at `~/.omp/agent/SYSTEM.md`.
 
-| Instead of | Use | Saves |
-|------------|-----|-------|
-| 10x `read` to count patterns | `ctx_execute("shell", "grep -c ...")` | ~5K tokens |
-| `bash node -e "..."` for analysis | `ctx_execute("javascript", "...")` | Stdout only |
-| `read(<url>)` for content | `ctx_fetch_and_index(url)` → `ctx_search()` | 50-90% |
-
-**Rule:** For data analysis, write code. Don't read data into context — program the analysis.
+Key paradigm: **Think in Code** — write `ctx_execute(language, code)` for analysis/count/filter/parse. Only stdout enters context.
 
 ## Branching & PR standards
 


### PR DESCRIPTION
Trims the aspirational "context-mode — Think in Code (when available)" section in `.omp/AGENTS.md` to a brief reference pointing at the global `~/.omp/agent/SYSTEM.md` for full routing rules. Context-mode is now fully installed (MCP tools + native OMP hooks via `.pi` extension); the routing rules live in the machine-wide SYSTEM.md.

No functional changes — project docs kept accurate.