### PR TITLE
fix(lsp): re-enable kotlin-lsp with tracked faketime wrapper

### DIFF
--- a/.omp/bin/kotlin-lsp
+++ b/.omp/bin/kotlin-lsp
@@ -11,7 +11,7 @@
 #
 # Usage:
 #   export KOTLIN_LSP_BIN=/path/to/intellij-server
-#   ./omp/bin/kotlin-lsp --stdio
+#   .omp/bin/kotlin-lsp --stdio
 #
 # Caches:
 #   IDEA_CONFIG_DIR  = ~/.cache/kotlin-lsp/config

--- a/.omp/bin/kotlin-lsp
+++ b/.omp/bin/kotlin-lsp
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ── kotlin-lsp faketime wrapper ──────────────────────────────────────────────
+#
+# JetBrains EAP builds have a hardcoded ~40-day expiry. This wrapper runs the
+# intellij-server binary through libfaketime to bypass the license check.
+# The fake date (2026-04-30) is before the build's expiry boundary.
+#
+# Dependencies:
+#   libfaketime   (Arch/CachyOS: sudo pacman -S libfaketime)
+#   kotlin-lsp    (EAP server binary, installed separately)
+#
+# Usage:
+#   export KOTLIN_LSP_BIN=/path/to/intellij-server
+#   ./omp/bin/kotlin-lsp --stdio
+#
+# Caches:
+#   IDEA_CONFIG_DIR  = ~/.cache/kotlin-lsp/config
+#   IDEA_SYSTEM_DIR  = ~/.cache/kotlin-lsp/system
+#
+# Without these persistent dirs, OMP generates random temp dirs on every
+# launch, forcing a full project-index rebuild (~34s cold, ~5-13s warm).
+# ──────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ── Verify dependencies ──────────────────────────────────────────────────────
+
+if ! command -v faketime &>/dev/null; then
+    echo "ERROR: 'faketime' not found. Install libfaketime:" >&2
+    echo "  Arch/CachyOS: sudo pacman -S libfaketime" >&2
+    echo "  Debian/Ubuntu: sudo apt install faketime" >&2
+    echo "  Fedora: sudo dnf install faketime" >&2
+    exit 1
+fi
+
+# ── Locate the intellij-server binary ────────────────────────────────────────
+# Priority: env var > PATH > well-known install paths
+
+if [ -n "${KOTLIN_LSP_BIN:-}" ]; then
+    SERVER="$KOTLIN_LSP_BIN"
+elif command -v kotlin-lsp-bin &>/dev/null; then
+    SERVER="$(command -v kotlin-lsp-bin)"
+elif [ -x ~/.local/kotlin-lsp/kotlin-server-262.4739.0/bin/intellij-server ]; then
+    SERVER=~/.local/kotlin-lsp/kotlin-server-262.4739.0/bin/intellij-server
+else
+    echo "ERROR: intellij-server not found." >&2
+    echo "  Set KOTLIN_LSP_BIN to the intellij-server path, or" >&2
+    echo "  install the EAP server at ~/.local/kotlin-lsp/." >&2
+    exit 1
+fi
+
+if [ ! -x "$SERVER" ]; then
+    echo "ERROR: Server binary not executable: $SERVER" >&2
+    exit 1
+fi
+
+# ── Persistent cache dirs ─────────────────────────────────────────────────────
+# Speeds up subsequent initializations by preserving the project index.
+export IDEA_CONFIG_DIR="${IDEA_CONFIG_DIR:-$HOME/.cache/kotlin-lsp/config}"
+export IDEA_SYSTEM_DIR="${IDEA_SYSTEM_DIR:-$HOME/.cache/kotlin-lsp/system}"
+mkdir -p "$IDEA_CONFIG_DIR" "$IDEA_SYSTEM_DIR"
+
+# ── Launch with faketime ─────────────────────────────────────────────────────
+# The EAP build expires ~40 days after release. The fake date 2026-04-30 is
+# well within the build's valid window. If a newer EAP build has a different
+# expiry, update this date to a safe value before that build's expiry.
+exec faketime "2026-04-30" "$SERVER" "$@"

--- a/lsp.json
+++ b/lsp.json
@@ -1,6 +1,7 @@
 {
   "kotlin-lsp": {
-    "disabled": true,
+    "command": ".omp/bin/kotlin-lsp",
+    "disabled": false,
     "warmupTimeoutMs": 90000
   }
 }


### PR DESCRIPTION
The JetBrains kotlin-lsp EAP build (LS-262.4739.0) has a hardcoded ~40-day time bomb that expired ~2026-06-05. This PR works around the expiry with a tracked wrapper script using libfaketime.

**Changes:**
- **`.omp/bin/kotlin-lsp`** — new tracked wrapper script that:
  - Fails clearly if `faketime` is not installed, with distro-specific install instructions
  - Locates the `intellij-server` binary via `KOTLIN_LSP_BIN` env var, `PATH`, or `~/.local/kotlin-lsp/`
  - Sets persistent `IDEA_CONFIG_DIR`/`IDEA_SYSTEM_DIR` to `~/.cache/kotlin-lsp/` for fast warm starts (~5-13s instead of cold ~34s)
  - Launches `intellij-server --stdio` through `faketime "2026-04-30"`
  - Documents the EAP time bomb, the fake-date rationale, and required dependency installation
- **`lsp.json`** — sets `"command": ".omp/bin/kotlin-lsp"` and `"disabled": false` so OMP uses the tracked wrapper instead of PATH lookup

**Required dependency:**
```bash
# CachyOS / Arch Linux
sudo pacman -S libfaketime
```

**Scooped from this PR:** all unrelated changes from the previous branch (llm_tools E2E markers in `ChatViewModel.kt`, `adb_skill_test.py` llm_tools harness, `LiteRtInferenceEngine.kt` foreground-service refactors, `issue-1107` research review doc) — those belong in #1111/`feature/1107-llm-tools-harness` and are now removed from this branch.

**Verification:**
- `lsp status` → `kotlin-lsp` active
- `lsp diagnostics` on `.kt` → OK
- `lsp definition` on Kotlin symbol → navigates correctly