### PR TITLE
docs(#1119): documentation audit — align docs with recent merged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 | DI | Hilt |
 | Persistence | Room |
 | Min SDK | API 35 (Android 15) |
-| Speech-to-Text | Vosk (default), Android SpeechRecognizer (optional) |
-| Text-to-Speech | Android TTS (default), Sherpa Piper/Kokoro (optional) |
+| Speech-to-Text | Sherpa-ONNX (Zipformer default, SenseVoice/Whisper/Paraformer optional) |
+| Text-to-Speech | Sherpa VITS (default), Android TTS (optional), Kokoro (research) |
 
 ## Features
 
@@ -84,6 +84,10 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 💬 **Multi-turn dialog** — expanded confirmation, digression, and slot-filling coverage across more intents (#708, PR #712)
 - ⏰ **Alarms CRUD UI** — create, edit, and toggle alarms directly from the Alarms screen; full CRUD via nav drawer (#479, PR #484)
 - 🗒️ **Lists management upgrades** — rename, pin, sort, edit items, favorites, and due dates (#662)
+- ❄️ **Model Availability UX** — StateBadge with download/size/status indicator, ModelCard with interactive download/retry/delete, gated-model status repo for model management (#1025/#1067, PRs #1028/#1067)
+- 🎤 **Sherpa-ONNX streaming STT family** — selectable Zipformer (default, streaming online), SenseVoice (multilingual offline), Whisper tiny.en (offline), and Paraformer (online) engines in Settings → Voice (#821/#1022, PRs #995/#1044)
+- 🔤 **STT transcript normalisation** — central TranscriptNormaliser with Kiwi phonetic normalisation, unit alias tables, and trailing-punctuation strip; all STT engines route through the shared pipeline (#935/#939/#982/#1017, PR #1070)
+- 🎙️ **"Hey Jandal" wake word** — trained ML model with dual-threshold Sherpa-ONNX verification; integrates with Android Default Assistant (#983/#984, PRs #987/#1000)
 
 ### Coming Soon
 - 🗒️ **Lists — hierarchical items** — nested sub-items within lists *(#928)*
@@ -93,7 +97,6 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - 🧩 **Wasm skill store** — community-extensible plugins with sandboxed execution *(Phase 5)*
 - 🏠 **Home Assistant / Google Home** — smart home control *(Phase 5)*
 - 📱 **8GB device optimisation** — dynamic weight loading/unloading, E2B fallback *(Phase 6)*
-- 🎙️ **"Hey Jandal" wake word** — always-on local detection → instant action routing *(Phase 3F)*
 
 ## Roadmap
 
@@ -113,6 +116,7 @@ consciously parked.
 | Issue | Size | Summary |
 |-------|------|---------|
 | ~~[#915](https://github.com/NickMonrad/kernel-ai-assistant/issues/915)~~ · ~~[#916](https://github.com/NickMonrad/kernel-ai-assistant/issues/916)~~ | L · S | ✓ Toolchain upgrade — AGP 9.0.1 / Gradle 9.1.0 / Kotlin 2.3.21 / Hilt 2.59.2 (PR #1082) |
+| ~~[#1107](https://github.com/NickMonrad/kernel-ai-assistant/issues/1107)~~ · ~~[#1110](https://github.com/NickMonrad/kernel-ai-assistant/issues/1110)~~ | M · S | ✓ llm_tools E2E harness + hardened runtime markers (PRs #1108, #1111) |
 | [#428](https://github.com/NickMonrad/kernel-ai-assistant/issues/428) | M | Memory profiling — peak RAM & concurrent model usage (feeds #430/#432) |
 | [#692](https://github.com/NickMonrad/kernel-ai-assistant/issues/692) | M | Fix inference stalls in Boring AI Mode |
 | [#937](https://github.com/NickMonrad/kernel-ai-assistant/issues/937) · [#957](https://github.com/NickMonrad/kernel-ai-assistant/issues/957) | M · S | Memory + intent-routing correctness bugs |
@@ -152,6 +156,14 @@ consciously parked.
 | [#868](https://github.com/NickMonrad/kernel-ai-assistant/issues/868) | S | Documentation & licence/attribution review |
 | [#441](https://github.com/NickMonrad/kernel-ai-assistant/issues/441) | M | Publish to Play Store — account, signing, listing, policy compliance |
 
+> **Launch validation & evidence:** Launch readiness also requires measurable
+> cross-cutting stability work beyond the feature items above:
+> - ✅ `llm_tools` E2E harness and hardened runtime markers (#1107/#1110, PRs #1108/#1111)
+> - ✅ Orchestration eval framework with golden-corpus regression protection (#1099, PR #1106)
+> - ⬜ GitHub-native test evidence dashboard for CI + on-device result visibility (#1113)
+> - ⬜ S21 Exynos GPU reliability — fixed via PR #1089, ongoing runtime monitoring needed
+> - ⬜ Model/tool-call generation reliability tracking across reference devices
+
 ### 🟡 Post-Launch — fast-follow after publish
 
 - **Memory & data** — cosine-distance vec tables ([#647](https://github.com/NickMonrad/kernel-ai-assistant/issues/647)), anaphoric "remember that" ([#958](https://github.com/NickMonrad/kernel-ai-assistant/issues/958)), low-confidence search filtering ([#959](https://github.com/NickMonrad/kernel-ai-assistant/issues/959)), Artifact entity ([#235](https://github.com/NickMonrad/kernel-ai-assistant/issues/235))
@@ -165,7 +177,7 @@ consciously parked.
 
 - **Phase 4 — Dreaming Engine** ([#705](https://github.com/NickMonrad/kernel-ai-assistant/issues/705)) incl. graph-DB memory research ([#419](https://github.com/NickMonrad/kernel-ai-assistant/issues/419))
 - **Phase 5 — Wasm Runtime + Skill Store** ([#706](https://github.com/NickMonrad/kernel-ai-assistant/issues/706)) incl. MCP integration research ([#944](https://github.com/NickMonrad/kernel-ai-assistant/issues/944))
-- **Phase 6 — Device Optimisation** ([#707](https://github.com/NickMonrad/kernel-ai-assistant/issues/707)) incl. S21 generation failure ([#684](https://github.com/NickMonrad/kernel-ai-assistant/issues/684))
+- **Phase 6 — Device Optimisation** ([#707](https://github.com/NickMonrad/kernel-ai-assistant/issues/707)) incl. 8GB RAM device optimisation
 - **Model experiments** ([#704](https://github.com/NickMonrad/kernel-ai-assistant/issues/704)) — Qwen 3.5 4B/0.8B ([#691](https://github.com/NickMonrad/kernel-ai-assistant/issues/691), [#699](https://github.com/NickMonrad/kernel-ai-assistant/issues/699)), llama.cpp backend ([#702](https://github.com/NickMonrad/kernel-ai-assistant/issues/702))
 - **Alternative STT** — Parakeet CTC ([#700](https://github.com/NickMonrad/kernel-ai-assistant/issues/700)) & whisper.cpp ([#703](https://github.com/NickMonrad/kernel-ai-assistant/issues/703)) — gated on the Sherpa-default decision ([#1008](https://github.com/NickMonrad/kernel-ai-assistant/issues/1008))
 - **Fun / content skills** — joke ([#819](https://github.com/NickMonrad/kernel-ai-assistant/issues/819)), storytelling ([#820](https://github.com/NickMonrad/kernel-ai-assistant/issues/820)), learn-something-new ([#949](https://github.com/NickMonrad/kernel-ai-assistant/issues/949))

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The app operates on a **Brain–Memory–Action** triad using a three-tier Resid
 - ❄️ **Model Availability UX** — StateBadge with download/size/status indicator, ModelCard with interactive download/retry/delete, gated-model status repo for model management (#1025/#1067, PRs #1028/#1067)
 - 🎤 **Sherpa-ONNX streaming STT family** — selectable Zipformer (default, streaming online), SenseVoice (multilingual offline), Whisper tiny.en (offline), and Paraformer (online) engines in Settings → Voice (#821/#1022, PRs #995/#1044)
 - 🔤 **STT transcript normalisation** — central TranscriptNormaliser with Kiwi phonetic normalisation, unit alias tables, and trailing-punctuation strip; all STT engines route through the shared pipeline (#935/#939/#982/#1017, PR #1070)
-- 🎙️ **"Hey Jandal" wake word** — trained ML model with dual-threshold Sherpa-ONNX verification; integrates with Android Default Assistant (#983/#984, PRs #987/#1000)
+- 🎙️ **"Hey Jandal" wake-word infrastructure** — trained ML model and Sherpa-ONNX dual-threshold verification integrated with Android Default Assistant; FP tuning remains tracked separately (#983/#984/#986, PRs #987/#1000)
 
 ### Coming Soon
 - 🗒️ **Lists — hierarchical items** — nested sub-items within lists *(#928)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kernel AI Assistant — Roadmap
 
-> **Last updated:** 2026-05-12 (PR #848 merged: deterministic currency conversion #831; PR #847 merged: homescreen Glance widget #617; PR #845 merged: aye pronunciation fix #843; cooking conversions #827 in progress)
+> **Last updated:** 2026-06-08 (PR #1111 merged: hardened llm_tools assertions; PR #1108 merged: llm_tools E2E harness; PR #1106 merged: orchestration eval framework; PR #1095 merged: Intent Recovery Orchestrator; PR #1089 merged: Exynos S21 GPU fixes; PR #1082 merged: AGP 9/Gradle 9/Kotlin 2.3.21 toolchain upgrade; PR #1070 merged: STT transcript normaliser; PR #1067 merged: Model Availability UX overhaul)
 >
 > This is the living roadmap for Kernel AI. It tracks what's been built, what's next,
 > and what's planned. If you have ideas, [open an issue](https://github.com/NickMonrad/kernel-ai-assistant/issues/new)
@@ -21,10 +21,11 @@
 | **Chat model** | Gemma-4 E-4B / E-2B |
 | **Embeddings** | EmbeddingGemma-300M (SentencePiece + TFLite) |
 | **Intent router (simple)** | `QuickIntentRouter` (Kotlin regex, zero memory, <5ms) |
+| **Intent recovery** | `IntentRecoveryOrchestrator` (deterministic slot extraction, risk-gated execution) |
 | **Intent router (complex)** | Gemma-4 native SDK tool calling (`@Tool`) + constrained decoding |
 | **Vector search** | sqlite-vec 0.1.9 via bundled SQLite 3.49.2 |
 | **Wasm runtime** | Chicory (pure JVM) |
-| **Test device** | Samsung Galaxy S23 Ultra (SD 8 Gen 2, 12GB RAM) |
+| **Test device** | Samsung Galaxy S23 Ultra (SD 8 Gen 2, 12GB RAM); S21 Exynos (Mali GPU, 8GB RAM) |
 
 ---
 
@@ -122,7 +123,7 @@ tri-tiered memory architecture inspired by the
 > and [#708](https://github.com/NickMonrad/kernel-ai-assistant/issues/708).
 > See [GitHub milestone](https://github.com/NickMonrad/kernel-ai-assistant/milestone/3).
 
-### Three-Tier Intent Architecture
+### Three-Tier Intent Architecture (with Intent Recovery)
 
 ```
 User Input (voice/text)
@@ -309,17 +310,19 @@ Lower-priority skill additions — third-party integrations and local utilities.
 | [#727](https://github.com/NickMonrad/kernel-ai-assistant/issues/727) | Chat voice foundation for conversational push-to-talk | ✅ Done — PR #731 | 🟡 Medium |
 | [#728](https://github.com/NickMonrad/kernel-ai-assistant/issues/728) | Chat voice UI/UX and turn-taking controls | ✅ Done — PR #735 | 🟡 Medium |
 | [#741](https://github.com/NickMonrad/kernel-ai-assistant/issues/741) | Chat voice mode switch (one-shot vs back-and-forth) | ✅ Done — PR #744 | 🟡 Medium |
-| [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word — Picovoice Porcupine | ⬜ Pending | 🟡 Medium |
+| [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word — Sherpa-ONNX dual-threshold verification | ✅ Partially — PRs #987, #1000 (infrastructure); FP tuning #986 → 🟡 Post-Launch | 🟡 Medium |
 | [#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64) | Live mode — real-time streaming interaction | ⬜ Pending | 🟢 Low |
 
-**Current state after merged PRs #780, #789, #805, and #818:**
+**Current state after merged PRs #780, #789, #805, #818, #995, #1044, #987, #1000, #1070, and #1067:**
 
 > **Note:** #781 (Semaine emotional styles) is closed — the emotion detection approach was abandoned because Semaine exposes different *speakers*, not emotional variants. Speaker selection (#817) ships all 4 Semaine voices (Prudence/Spike/Obadiah/Poppy) via Settings → Voice, consistent with VCTK. Emotion research folded into #783 (TTS engine/expressiveness).
 
 - Streaming TTS pipeline (`runStreamingPlayback()` two-coroutine producer/consumer), per-message speaker button, verbal stop command, expanded TTS settings, VCTK + Semaine multi-speaker selection, and chat voice push-to-talk are all shipped.
 - Voice quality slice complete: URL colon preservation in `cleanTextForSpeech()`, speech rate clamping, abbreviation-aware sentence splitting, and Sherpa quality evaluation done on Samsung Galaxy S23 Ultra.
 - `autoSpeakEnabled` is now a cached field in `ChatViewModel` — chat auto-speak is fully decoupled from the Quick Actions `spokenResponsesEnabled` toggle.
-- Remaining voice research: Sherpa-ONNX STT + VAD evaluation (#700/#703 + new issue), Kokoro-82M/VoxSherpa (#783, including expressiveness/emotion exploration), Kiwi corpus tuning (#784), VITS noise_scale (#788).
+- **Sherpa-ONNX STT shipped** as the primary STT engine (#821/#1022, PRs #995/#1044): selectable Zipformer (streaming, default), SenseVoice (multilingual), Whisper tiny.en, and Paraformer families via Settings → Voice. All engines pass through the central `TranscriptNormaliser` (#1070) for Kiwi phonetic normalisation, unit alias tables, and trailing-punctuation strip.
+- **"Hey Jandal" wake word infrastructure shipped** (#983/#984, PRs #987/#1000): trained ML model with Sherpa-ONNX dual-threshold verification; integrates with Android Default Assistant. FP-rate tuning tracked as post-launch (#986).
+- Remaining voice research: Kokoro-82M/VoxSherpa (#783, including expressiveness/emotion exploration), Kiwi corpus tuning (#784), VITS noise_scale (#788).
 - Fallback-path issues and the appointment QIR bug ([#773](https://github.com/NickMonrad/kernel-ai-assistant/issues/773)) remain tracked separately.
 
 ---
@@ -523,8 +526,8 @@ File new ideas there — they'll get reviewed and woven into the roadmap.
 | [#59](https://github.com/NickMonrad/kernel-ai-assistant/issues/59) | Settings: show active model/backend/tier | Phase 2 | ✅ Done (#72) |
 | [#60](https://github.com/NickMonrad/kernel-ai-assistant/issues/60) | Model selection: choose E2B/E4B | Phase 2 | ✅ Done (#72) |
 | [#61](https://github.com/NickMonrad/kernel-ai-assistant/issues/61) | Full markdown rendering | Phase 2 | ✅ Done (#63) |
-| [#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64) | Live mode | Phase 3F | ⬜ Pending |
-| [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word | Phase 3F | ⬜ Pending |
+| [#65](https://github.com/NickMonrad/kernel-ai-assistant/issues/65) | "Hey Jandal" wake word — Sherpa-ONNX dual-threshold verification | ✅ Partially — PRs #987, #1000 (infrastructure); FP tuning #986 → 🟡 Post-Launch | 🟡 Medium |
+| [#64](https://github.com/NickMonrad/kernel-ai-assistant/issues/64) | Live mode — real-time streaming interaction | ⬜ Pending | 🟢 Low |
 | [#71](https://github.com/NickMonrad/kernel-ai-assistant/issues/71) | Review UI patterns | Phase 3 | ⬜ Pending |
 | [#78](https://github.com/NickMonrad/kernel-ai-assistant/issues/78) | Copy chat content | Phase 3 | ✅ Done |
 | [#84](https://github.com/NickMonrad/kernel-ai-assistant/issues/84) | Gemma 4 native tool calling | Phase 3 | ✅ Done |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Technical Specification: Jandal AI — Local-First Android AI Assistant
 
-> **Last updated:** 2026-06-01 (PR #1044 Sherpa STT family split — Zipformer, SenseVoice, Whisper tiny.en, Paraformer; offline VAD; wake-word verification isolation)
+> **Last updated:** 2026-06-08 (PR #1111 merged: hardened llm_tools assertions; PR #1108: llm_tools E2E harness; PR #1106: orchestration eval framework; PR #1095: Intent Recovery Orchestrator; PR #1089: Exynos S21 GPU fixes; PR #1082: AGP 9/Gradle 9/Kotlin 2.3.21 toolchain upgrade; PR #1070: STT transcript normaliser; PR #1067: Model Availability UX overhaul)
 >
 > This is the authoritative technical specification for Jandal AI. For feature status and
 > delivery timeline, see [`ROADMAP.md`](./ROADMAP.md).
@@ -1480,7 +1480,7 @@ viewModelScope.launch {
 | JDK | 17 |
 | Min SDK | API 35 (Android 15) |
 | Target SDK | 36 |
-| Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16) |
+| Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16); S21 Exynos (Mali-G78, 8GB RAM) — GPU inference enabled (#1089)|
 
 **Backend note:** Current dev/test guidance assumes the Samsung Galaxy S23 Ultra uses the
 Hexagon NPU path when the required delegate and models are present, with GPU fallback still
@@ -1519,6 +1519,8 @@ When adding dependencies or features that span multiple modules (especially feat
 ./gradlew installDebug               # Build + install on connected device
 ./gradlew :core:inference:test       # Single-module test
 python3 scripts/adb_skill_test.py    # Device routing/profile regression harness
+python3 scripts/adb_skill_test.py --phases llm_tools  # E2E model tool-call generation harness
+python3 scripts/adb_skill_test.py --phases orch       # Intent recovery orchestration eval
 ```
 
 **CI:** Runs lint + unit tests + debug build. No real model inference in CI — `InferenceEngine`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1480,7 +1480,7 @@ viewModelScope.launch {
 | JDK | 17 |
 | Min SDK | API 35 (Android 15) |
 | Target SDK | 36 |
-| Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16); S21 Exynos (Mali-G78, 8GB RAM) — GPU inference enabled (#1089)|
+| Test device | Samsung Galaxy S23 Ultra (Snapdragon 8 Gen 2, 12GB RAM, Android 16); S21 Exynos (Mali-G78, 8GB RAM) — GPU inference enabled (#1089) |
 
 **Backend note:** Current dev/test guidance assumes the Samsung Galaxy S23 Ultra uses the
 Hexagon NPU path when the required delegate and models are present, with GPU fallback still
@@ -1520,7 +1520,6 @@ When adding dependencies or features that span multiple modules (especially feat
 ./gradlew :core:inference:test       # Single-module test
 python3 scripts/adb_skill_test.py    # Device routing/profile regression harness
 python3 scripts/adb_skill_test.py --phases llm_tools  # E2E model tool-call generation harness
-python3 scripts/adb_skill_test.py --phases orch       # Intent recovery orchestration eval
 ```
 
 **CI:** Runs lint + unit tests + debug build. No real model inference in CI — `InferenceEngine`

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -50,7 +50,8 @@ Supported harness phases today:
 11. `llm_tools` — E2E model tool-call generation after LLM fallthrough (3 golden prompts, runtime marker assertions)
 
 Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
-See [`scripts/test-reports/README.md`](../scripts/test-reports/README.md) for the report format.
+
+Detailed report-format documentation, `llm_tools` marker interpretation, on-device result guidance, and CI vs physical-device evidence guidance are tracked in [#1118](https://github.com/NickMonrad/kernel-ai-assistant/issues/1118).
 
 ## What is still planned
 

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -48,7 +48,6 @@ Supported harness phases today:
 9. `misc`
 10. `slot_fill`
 11. `llm_tools` — E2E model tool-call generation after LLM fallthrough (3 golden prompts, runtime marker assertions)
-12. `orch` — Intent recovery orchestration eval (long-run device scenarios)
 
 Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
 See [`scripts/test-reports/README.md`](../scripts/test-reports/README.md) for the report format.

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -47,6 +47,8 @@ Supported harness phases today:
 8. `system`
 9. `misc`
 10. `slot_fill`
+11. `llm_tools` — E2E model tool-call generation after LLM fallthrough (3 golden prompts, runtime marker assertions)
+12. `orch` — Intent recovery orchestration eval (long-run device scenarios)
 
 Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
 See [`scripts/test-reports/README.md`](../scripts/test-reports/README.md) for the report format.


### PR DESCRIPTION
## Documentation audit summary

Reviewed merged PRs since 2026-05-25.

| Area | Recent PRs considered | Documentation updated |
|---|---|---|
| Model/runtime | #1067, #1070, #1082, #1089, #1095, #1106, #1108, #1111 | README / ROADMAP / SPECIFICATION |
| Testing | #1108, #1111, #1106 | README / automated-testing / SPECIFICATION |
| Intent routing | #1095, #1106 | ROADMAP / SPECIFICATION |
| Build/toolchain | #1082 | ROADMAP / SPECIFICATION |
| Voice/STT | #995, #1044, #1070, #987, #1000 | README / ROADMAP / SPECIFICATION |
| Launch readiness / evidence | #1108, #1111, #1113, #1089 | README / ROADMAP |

## Review fixes (round 2)

- **Removed unsupported `--phases orch` documentation** — `orch` is not a valid harness phase name; orchestration test cases live under the `misc` phase as `__orchtest:` prefixed entries.
- **Aligned README wake-word status with ROADMAP** — updated to "infrastructure delivered; FP tuning tracked separately" (matching ROADMAP's "Partially done" status).
- **Removed broken `scripts/test-reports/README.md` link** — replaced with reference to #1118 for detailed testing-docs scope.
- **Deferred detailed report-format / `llm_tools` marker / on-device testing documentation to #1118** — PR #1120 stays focused on the README/ROADMAP/SPECIFICATION audit.
- **Fixed SPECIFICATION markdown table formatting** — added missing space before trailing pipe.

## What changed (original)

### README.md
- **Tech Stack:** STT row updated from Vosk → Sherpa-ONNX (Zipformer default, SenseVoice/Whisper/Paraformer optional); TTS row updated from Android TTS → Sherpa VITS default
- **Delivered features:** Added "Hey Jandal" wake-word infrastructure (partially done, #983/#984/#986, PRs #987/#1000); added Model Availability UX (#1067), Sherpa-ONNX streaming STT family (#995/#1044), STT transcript normalisation (#1070)
- **Coming Soon:** Removed wake word (now delivered at infrastructure level; FP tuning tracked separately via #986)
- **Launch-blocking Slice 1:** Added completed llm_tools E2E harness + hardened assertions (#1107/#1110) as ✓ row
- **Launch-blocking Slice 5:** Added "Launch validation & evidence" callout block listing completed and pending stability/validation work
- **Deferred:** S21 generation failure (#684) removed (fixed via #1089)

### docs/ROADMAP.md
- **Last updated:** 2026-05-12 → 2026-06-08 with PR references
- **Tech Stack:** Added Intent Recovery Orchestrator row; test device includes S21 Exynos
- **Architecture diagram:** Header renamed to "Three-Tier Intent Architecture (with Intent Recovery)"
- **3F Voice:** #65 wake word status updated to Partially (PRs #987/#1000); voice current state updated for Sherpa STT + wake word
- **Ideas & Enhancements:** #65 wake word status updated from Pending to Partially done

### docs/SPECIFICATION.md
- **Last updated:** 2026-06-01 → 2026-06-08
- **Section 8:** Test device includes S21 Exynos with GPU inference (#1089)
- **Section 9:** Added `--phases llm_tools` harness command

### docs/automated-testing.md
- Added `llm_tools` to supported harness phase list (11)
- Replaced stale `scripts/test-reports/README.md` link with reference to #1118 for detailed testing-docs scope

## Validation

- [x] `python3 scripts/adb_skill_test.py --dry-run` → 201 test cases
- [x] `python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools` → 3 test cases
- [x] No broken `scripts/test-reports/README.md` link remains
- [x] No unsupported `orch` harness command documented
- [x] Markdown renders correctly
- [x] Links checked

Closes #1119