### PR TITLE
docs(#1118): update testing documentation for ADB, llm_tools, and on-device workflow

### DIFF
--- a/docs/adb-testing.md
+++ b/docs/adb-testing.md
@@ -1,9 +1,11 @@
 # ADB Testing Guide
 
-| Device | Chip | RAM | Backend | Tier |
-|--------|------|-----|---------|------|
-| Samsung Galaxy S23 Ultra | Snapdragon 8 Gen 2 (SM8550) | 12 GB | NPU | FLAGSHIP |
-| Google Pixel 10 | Tensor G5 | 12 GB | GPU | FLAGSHIP |
+| Device | Chip | RAM | Backend | Tier | Role |
+|--------|------|-----|---------|------|------|
+| Samsung Galaxy S23 Ultra | Snapdragon 8 Gen 2 (SM8550) | 12 GB | NPU | FLAGSHIP | Reference device — primary target |
+| Google Pixel 10 | Tensor G5 | 12 GB | GPU | FLAGSHIP | Reference device — GPU-only |
+| Samsung Galaxy S21 (Exynos) | Exynos 2100 | 8 GB | GPU | FLAGSHIP | Tracked reliability signal — see #1089 / #684 |
+| Honor Magic 8 Pro | Snapdragon 8 Elite | 12 GB | NPU | FLAGSHIP | Future tracked / reference candidate |
 
 ---
 
@@ -250,3 +252,23 @@ adb shell monkey -p com.kernel.ai.debug 1
 # Pull a bugreport for CI/issue reporting
 adb bugreport ~/Desktop/kernel-ai-bugreport.zip
 ```
+
+---
+
+## 9. Running the `llm_tools` Harness
+
+The `llm_tools` harness phase validates E2E model tool-call generation (Tier 2 → FallThrough → Tier 3 / Gemma).
+
+```bash
+# Run just the llm_tools phase
+ANDROID_SERIAL=R5CR605B71K python3 scripts/adb_skill_test.py --phases=llm_tools
+
+# Wireless device
+ANDROID_SERIAL=100.76.134.49:44599 python3 scripts/adb_skill_test.py --phases=llm_tools
+
+# Dry run (no device needed)
+python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools
+```
+
+See [`docs/automated-testing.md`](./automated-testing.md) for detailed output format and
+[`docs/testing/llm-tools-harness.md`](./testing/llm-tools-harness.md) for deep reference.

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -47,7 +47,8 @@ Supported harness phases today:
 8. `system`
 9. `misc`
 10. `slot_fill`
-11. `llm_tools` — E2E model tool-call generation after LLM fallthrough (3 golden prompts, runtime marker assertions)
+The `llm_tools` harness is a separate special mode (see below) — it is not one of the ten
+QIR skill-routing phases and is not included in a normal full-suite run.
 
 Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
 
@@ -83,9 +84,9 @@ jq '.results[] | {index, message, expect_intent, actual_intent, intent_passed, p
 # Only failures
 jq '.results[] | select(.status == "fail") | {message, expect_intent, actual_intent, param_failures}' "$latest"
 
-# llm_tools — per-result summary
-jq '.results[] | {name, passed, expected_top_level_tool, actual_top_level_tool, expected_result_mode: "success", actual_result_mode, failures}' "$latest_llm"
-
+```bash
+# llm_tools — per-result summary (mode is embedded in skill_result_marker)
+jq '.results[] | {name, passed, expected_top_level_tool, actual_top_level_tool, route_marker, skill_result_marker, failures}' "$latest_llm"
 # llm_tools — only failures with failure details
 jq '.results[] | select(.passed == false) | {name, expected_top_level_tool, actual_top_level_tool, failures}' "$latest_llm"
 ```
@@ -158,7 +159,8 @@ QIR/classifier deterministic routing and falls through to Gemma. It covers the
 
 **What it validates per case:**
 
-- The query reached Gemma via LLM fallthrough (not QIR match, not classifier match)
+- The harness confirms a `llm_tools_route` marker was emitted and that deterministic
+  QIR/classifier/slot-fill paths did not win before Gemma tool-call generation
 - Gemma generated a native **or** legacy text-format tool call
 - The expected tool was actually called
 - The tool result is observable via `llm_tools_skill_result` marker

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -84,7 +84,6 @@ jq '.results[] | {index, message, expect_intent, actual_intent, intent_passed, p
 # Only failures
 jq '.results[] | select(.status == "fail") | {message, expect_intent, actual_intent, param_failures}' "$latest"
 
-```bash
 # llm_tools — per-result summary (mode is embedded in skill_result_marker)
 jq '.results[] | {name, passed, expected_top_level_tool, actual_top_level_tool, route_marker, skill_result_marker, failures}' "$latest_llm"
 # llm_tools — only failures with failure details

--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -51,7 +51,213 @@ Supported harness phases today:
 
 Reports are written to [`scripts/test-reports/`](../scripts/test-reports/) as JSON artifacts.
 
-Detailed report-format documentation, `llm_tools` marker interpretation, on-device result guidance, and CI vs physical-device evidence guidance are tracked in [#1118](https://github.com/NickMonrad/kernel-ai-assistant/issues/1118).
+### Reports and result inspection
+
+Each run produces a timestamped JSON report:
+
+| Suite | File pattern | Example |
+|-------|-------------|---------|
+| Full QIR skill routing | `<timestamp>_skills.json` | `2026-06-07T01-39-59Z_skills.json` |
+| LLM tool-call generation | `<timestamp>_llm_tools.json` | `2026-06-08T04-28-55Z_llm_tools.json` |
+| Partial in-progress snapshot | `<timestamp>_<suite>_partial.json` | `2026-06-08T04-28-55Z_llm_tools_partial.json` |
+
+The HTML report generator (`scripts/generate_report.py`) automatically converts `skills` JSON
+reports to HTML when present.
+
+**Finding the latest report:**
+
+```bash
+latest=$(ls -t scripts/test-reports/*_skills.json | head -1)
+latest_llm=$(ls -t scripts/test-reports/*_llm_tools.json | head -1)
+```
+
+**Inspecting with `jq`:**
+
+```bash
+# Summary fields
+jq '.summary' "$latest"
+
+# Per-result: passed, intent matching, param detail
+jq '.results[] | {index, message, expect_intent, actual_intent, intent_passed, params_passed, status}' "$latest"
+
+# Only failures
+jq '.results[] | select(.status == "fail") | {message, expect_intent, actual_intent, param_failures}' "$latest"
+
+# llm_tools — per-result summary
+jq '.results[] | {name, passed, expected_top_level_tool, actual_top_level_tool, expected_result_mode: "success", actual_result_mode, failures}' "$latest_llm"
+
+# llm_tools — only failures with failure details
+jq '.results[] | select(.passed == false) | {name, expected_top_level_tool, actual_top_level_tool, failures}' "$latest_llm"
+```
+
+**Report schema (skills suite):**
+
+```json
+{
+  "suite": "skills",
+  "status": "complete",         // or "in_progress" for partial
+  "timestamp": "2026-06-07T01-39-59Z",
+  "elapsed_seconds": 3545.0,
+  "summary": { "total": 199, "passed": 73, "xfail": 5, "failed": 121 },
+  "results": [
+    {
+      "index": 1,
+      "message": "set an alarm for 11pm",
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass"          // "pass", "fail", or "xfail"
+    }
+  ]
+}
+```
+
+**Report schema (llm_tools suite):**
+
+```json
+{
+  "suite": "llm_tools",
+  "status": "complete",
+  "timestamp": "2026-06-08T04-28-55Z",
+  "elapsed_seconds": 0,
+  "summary": { "total": 3, "passed": 2, "failed": 1 },
+  "results": [
+    {
+      "index": 1,
+      "name": "query_wikipedia_natural",
+      "message": "Look up the history of the Battle of Hastings...",
+      "expected_top_level_tool": "query_wikipedia",
+      "actual_top_level_tool": "query_wikipedia",
+      "route_marker": "result=fallthrough ...",
+      "native_tool_marker": null,
+      "legacy_tool_marker": "<|tool_call|>call:query_wikipedia...",
+      "skill_result_marker": "skill={\"name\":\"query_wikipedia\",...}",
+      "message_saved_marker": "id=7e195582-... tool=query_wikipedia",
+      "retry_seen": false,
+      "slot_fill_seen": false,
+      "chip_text": "tool=query_wikipedia",
+      "reply_text": null,
+      "passed": true,
+      "failures": []
+    }
+  ]
+}
+```
+
+### `llm_tools` phase
+
+The `llm_tools` harness phase validates E2E model tool-call generation after the query bypasses
+QIR/classifier deterministic routing and falls through to Gemma. It covers the
+`Tier 2 → FallThrough → Tier 3 (Gemma)` path.
+
+**What it validates per case:**
+
+- The query reached Gemma via LLM fallthrough (not QIR match, not classifier match)
+- Gemma generated a native **or** legacy text-format tool call
+- The expected tool was actually called
+- The tool result is observable via `llm_tools_skill_result` marker
+- The tool call is persisted in chat history
+- A UI chip for the tool call is visible
+- No unexpected hallucination retry path was triggered
+- No unexpected QIR slot-fill path was used
+
+**Run commands:**
+
+```bash
+# Preview without a device
+python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools
+
+# Run on device
+python3 scripts/adb_skill_test.py --phases=llm_tools
+```
+
+**Golden prompts (3 cases):**
+
+| Case | Prompt | Expected tool | Assertions |
+|------|--------|--------------|------------|
+| Wikipedia query | "Look up the history of the Battle of Hastings on Wikipedia for me" | `query_wikipedia` | No regex matching, no classifier, no slot fill, no retry |
+| Memory save | "Here is a lasting fact I want you to know: my preferred dry cleaner is Star Dry Cleaning" | `save_memory` | Same + `content` field present |
+| System info | "Can you inspect this device and summarise its current system status?" | `get_system_info` | Same, no args expected |
+
+### On-device validation
+
+Run the harness against a physical device by setting `ANDROID_SERIAL`:
+
+```bash
+# USB-connected device (serial from `adb devices`)
+ANDROID_SERIAL=R5CR605B71K python3 scripts/adb_skill_test.py --phases=llm_tools
+
+# Wireless device (IP:port from `adb connect`)
+ANDROID_SERIAL=100.76.134.49:44599 python3 scripts/adb_skill_test.py --phases=llm_tools
+```
+
+**Reference and tracked devices:**
+
+| Device | SoC | RAM | Inference backend | Role |
+|--------|-----|-----|-------------------|------|
+| Samsung Galaxy S23 Ultra | Snapdragon 8 Gen 2 (SM8550) | 12 GB | NPU (Adreno GPU fallback) | Reference device — primary target |
+| Samsung Galaxy S21 (Exynos) | Exynos 2100 | 8 GB | GPU | Tracked reliability signal — see #1089 / #684 |
+| Honor Magic 8 Pro | Snapdragon 8 Elite | 12 GB | NPU | Future tracked / reference candidate |
+| Google Pixel 10 | Tensor G5 | 12 GB | GPU | Reference device — GPU-only |
+
+See [`docs/adb-testing.md`](./adb-testing.md) for device setup, USB/wireless debugging, and
+gotcha troubleshooting.
+
+**Expected pass-rate variance:** Model tool-call generation reliability differs across SoCs
+and inference backends. A case that passes on S23 Ultra NPU may fail on S21 Exynos GPU due
+to differences in model output distribution across backends. Track device-specific flakes
+in issues, not by relaxing harness assertions.
+
+### CI vs on-device evidence
+
+| Validation type | What it verifies | Limitations |
+|----------------|-----------------|-------------|
+| `--dry-run` | Phase definitions, test structure, CLI parsing | No device interaction, no model inference |
+| Unit tests (Gradle) | Kotlin logic, routing, parsing | No E2E device behaviour |
+| On-device run | Full E2E model tool-call generation | Requires physical device; results vary by SoC/backend |
+| CI (GitHub Actions) | Build, lint, unit tests | No physical device available — no `--phases=llm_tools` or live ADB tests |
+
+> **CI cannot validate physical-device model/tool-call reliability** unless a self-hosted
+> device runner is added. On-device results must be reported separately from CI results.
+> Model/tool-call generation flakes must not be hidden as harness passes.
+
+Evidence normalisation and a dashboard view (combining CI and on-device runs, tracking
+pass-rate trends per device) are tracked in [#1113](https://github.com/NickMonrad/kernel-ai-assistant/issues/1113).
+
+### Failure interpretation
+
+| Failure pattern | Meaning | Likely cause |
+|---|---|---|
+| No native/legacy tool marker | Model did not call any tool | Model missed the tool-call form in its output |
+| Wrong actual tool | Model called a different tool than expected | Intent confusion from the LLM |
+| Missing `tool_chip_visible` | UI chip for the tool call not found | UI rendering delay, missing chip, or timing issue |
+| Missing `llm_tools_skill_result` | Tool execution result not observed | Result logging missing or routing failure |
+| Wrong result mode | Expected `success` / `direct_reply` / `failure` mismatch | Tool implementation divergence |
+| `NO_MATCH` / conversational response | Model gave plain-text instead of a tool call | Model/tool-call generation miss, not a harness bug |
+| Retry marker present | Unexpected hallucination retry path triggered | Spurious retry from the model |
+| Slot-fill marker present | QIR slot-fill path used instead of LLM tool call | Prompt did not stay on the expected LLM tool-call path |
+
+### Runtime markers
+
+The harness reads structured logcat markers emitted by the app. These are the signals that
+determine pass/fail for `llm_tools` cases:
+
+| Marker | Report field | When it appears | Required to pass |
+|--------|-------------|----------------|:---:|
+| `llm_tools_route:` | `route_marker` | After QIR/classifier — confirms query fell through to Gemma | ✓ |
+| `llm_tools_native_tool:` | `native_tool_marker` | Tool call dispatched via the native SDK tool-call path | one of these ✓ |
+| `llm_tools_legacy_tool:` | `legacy_tool_marker` | Tool call dispatched via legacy Gemma text-format path | one of these ✓ |
+| `llm_tools_skill_result:` | `skill_result_marker` | Tool execution result captured (includes tool name, args, mode, success) | ✓ |
+| `llm_tools_message_toolcall_saved:` | `message_saved_marker` | Tool call message persisted in chat history (UUID + tool name) | ✓ |
+| `tool_chip_visible` (in chip_text) | `chip_text` | UI chip for the tool call is visible on screen | ✓ |
+| `raw_tool_call_retry_succeeded` / `hallucination_retry_succeeded` | `retry_seen` | Unexpected retry path activated | must be `false` |
+| `NeedsSlot` / `ConfirmationFastPath:` | `slot_fill_seen` | QIR slot-fill or confirmation path used | must be `false` |
 
 ## What is still planned
 
@@ -62,3 +268,15 @@ document is wired into a single runnable repo command yet.
 
 Treat this file as the "what exists today" index, and the detailed testing specification as
 the "where we want to grow next" design document.
+
+## Related docs
+
+| Document | Purpose |
+|----------|---------|
+| [`docs/testing/README.md`](./testing/README.md) | Index of all testing documentation |
+| [`docs/testing/llm-tools-harness.md`](./testing/llm-tools-harness.md) | Deep reference for the `llm_tools` harness |
+| [`docs/adb-testing.md`](./adb-testing.md) | Device setup, build & install, logcat filters, benchmarks |
+| [`scripts/adb_skill_test.py`](../scripts/adb_skill_test.py) | The harness script (source of truth for CLI args) |
+| [`scripts/generate_report.py`](../scripts/generate_report.py) | HTML report generator |
+| [#1113](https://github.com/NickMonrad/kernel-ai-assistant/issues/1113) | GitHub-native test evidence dashboard |
+| [#1118](https://github.com/NickMonrad/kernel-ai-assistant/issues/1118) | This documentation update |

--- a/docs/testing/481-outcomes-review.md
+++ b/docs/testing/481-outcomes-review.md
@@ -1,3 +1,7 @@
+> **Status:** Historical audit (2025-07-19). Retained for reference.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational docs and
+> [`docs/testing/README.md`](./README.md) for the testing docs index.
+>
 # Issue #481 — Hallucination Guard: Outcomes Audit
 
 > **Branch:** `feature/519-profile-parser-llm-extraction`  

--- a/docs/testing/PR-72-settings-model-info-selection.md
+++ b/docs/testing/PR-72-settings-model-info-selection.md
@@ -1,3 +1,7 @@
+> **Status:** Historical test plan (PRs #72, #74). Retained for reference.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational docs and
+> [`docs/testing/README.md`](./README.md) for the testing docs index.
+>
 # PR #72/#74 — Settings: Model Info & Selection Manual Test Plan
 
 **Issues:** #59 (show active model info), #60 (manual E2B/E4B selection)

--- a/docs/testing/PR-95-100-101-102-testing.md
+++ b/docs/testing/PR-95-100-101-102-testing.md
@@ -1,3 +1,7 @@
+> **Status:** Historical test plan (PRs #95, #100, #101, #102). Retained for reference.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational docs and
+> [`docs/testing/README.md`](./README.md) for the testing docs index.
+>
 # Device Testing — PRs #95, #100, #101, #102
 
 Install the latest build and run through the test cases below.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,44 @@
+# Testing Documentation
+
+## Current operational docs
+
+| Document | Purpose |
+|----------|---------|
+| [`docs/automated-testing.md`](../automated-testing.md) | Primary operational index — harness commands, supported phases, report inspection, on-device validation, CI vs on-device evidence, failure interpretation |
+| [`docs/adb-testing.md`](../adb-testing.md) | Device setup, build & install, logcat filters, TTFT benchmarking, memory monitoring, wireless debugging |
+| [`docs/testing/llm-tools-harness.md`](./llm-tools-harness.md) | Deep reference for the `llm_tools` harness phase — markers, assertions, troubleshooting |
+
+## Design / specification docs
+
+These documents were written during earlier phases and contain design proposals,
+coverage matrices, or test specifications that are not fully implemented. They are
+retained for reference but may contain stale assumptions.
+
+| Document | Status | Description |
+|----------|--------|-------------|
+| [`automated-test-specification.md`](./automated-test-specification.md) | **Design / Draft** (#427) | Comprehensive test coverage matrix with proposed ADB, UI Automator, and manual tests. Many items predate the current harness structure. |
+| [`nl-test-specification.md`](./nl-test-specification.md) | **Design / Living** | Implementation-agnostic natural-language test cases written without knowledge of regex patterns or routing internals. |
+
+## Historical audits
+
+| Document | Date | Description |
+|----------|------|-------------|
+| [`481-outcomes-review.md`](./481-outcomes-review.md) | 2025-07-19 | Hallucination guard outcomes audit — reviewed QIR param gaps, ChatViewModel C2 guard, NL coverage |
+| [`issue-audit.md`](./issue-audit.md) | 2025-07-18 | Open issues audit — 61 issues reviewed during Sprint 3 |
+
+## PR-specific test plans
+
+These manual test plans were written for specific pull requests and are retained
+as historical documentation only.
+
+| Document | PRs | Description |
+|----------|-----|-------------|
+| [`PR-72-settings-model-info-selection.md`](./PR-72-settings-model-info-selection.md) | #72, #74 | Settings: model info display and manual E-2B/E-4B selection |
+| [`PR-95-100-101-102-testing.md`](./PR-95-100-101-102-testing.md) | #95, #100, #101, #102 | Complex LaTeX rendering, onboarding, system prompt, Gemini Flash fallback |
+
+## Related issues
+
+- [#1118](https://github.com/NickMonrad/kernel-ai-assistant/issues/1118) — This documentation update
+- [#1113](https://github.com/NickMonrad/kernel-ai-assistant/issues/1113) — GitHub-native test evidence dashboard for CI and on-device results
+- [#427](https://github.com/NickMonrad/kernel-ai-assistant/issues/427) — Living test document (comprehensive QA gate)
+- [#1107](https://github.com/NickMonrad/kernel-ai-assistant/issues/1107) — LLM tools harness and `llm_tools` marker logic

--- a/docs/testing/automated-test-specification.md
+++ b/docs/testing/automated-test-specification.md
@@ -3,7 +3,8 @@
 > **Issue ref:** #427 Living Test Document
 > **Harness:** `scripts/adb_skill_test.py`
 > **Date:** 2025-07-17
-> **Status:** Draft — ready for implementation
+> **Status:** Design / Draft — many test cases not yet wired into the current harness.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational docs.
 
 ---
 

--- a/docs/testing/issue-audit.md
+++ b/docs/testing/issue-audit.md
@@ -1,3 +1,7 @@
+> **Status:** Historical audit (2025-07-18). Retained for reference.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational docs and
+> [`docs/testing/README.md`](./README.md) for the testing docs index.
+>
 # Open Issues Audit — NickMonrad/kernel-ai-assistant
 
 > **Date:** 2025-07-18  

--- a/docs/testing/llm-tools-harness.md
+++ b/docs/testing/llm-tools-harness.md
@@ -20,8 +20,8 @@ It does **not** test:
 
 For each of the 3 golden prompts, the harness checks:
 
-1. **Route to Gemma** — the query reached Gemma via LLM fallthrough (`llm_tools_route` marker
-   contains `result=fallthrough`)
+1. **Route to Gemma** — the harness confirms a `llm_tools_route` marker was emitted,
+   indicating the query reached Gemma (via fallthrough from deterministic QIR/classifier paths)
 2. **Tool call generation** — Gemma produced either a native SDK tool call or a legacy
    text-format tool call
 3. **Correct tool** — the expected top-level tool name matches the actual tool called
@@ -59,12 +59,13 @@ Each case expects a specific result mode, encoded in the `llm_tools_skill_result
 
 | Mode | Meaning | Expected for |
 |------|---------|-------------|
-| `success` | Tool executed and returned a result | `query_wikipedia`, `get_system_info` |
-| `direct_reply` | Tool result was streamed directly as a chat reply | `save_memory` |
+| `success` | Tool executed and returned a result | `save_memory` |
+| `direct_reply` | Tool result was streamed directly as a chat reply | `query_wikipedia`, `get_system_info` |
 | `failure` | Tool execution failed | Not expected for golden prompts; seen during development |
 
-The `save_memory` case uses `direct_reply` mode because the memory save operation returns a
-human-readable confirmation rather than structured data.
+The `query_wikipedia` and `get_system_info` cases expect `direct_reply` because the tool
+execution result is streamed directly as a chat reply. The `save_memory` case expects
+`success` because the memory save operation confirms persistence.
 
 ## Report format
 
@@ -95,14 +96,12 @@ ANDROID_SERIAL=R5CR605B71K python3 scripts/adb_skill_test.py --phases=llm_tools
 
 # Dry run (no device needed)
 python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools
-
-# Full suite including llm_tools (llm_tools runs after the QIR phases)
-python3 scripts/adb_skill_test.py --phases=llm_tools
 ```
 
-The `--phases=llm_tools` flag is handled as a special case — it does not run the QIR skill
-phases at all. To run llm_tools alongside QIR phases, run the full harness which includes
-all phases in order; llm_tools is phase 11 (last).
+The `--phases=llm_tools` flag is handled as a special case — it does not run any QIR skill
+phases. `llm_tools` is intentionally separate from the normal QIR/skills phase list because
+it has different data models, runtime markers, model/tool-call assertions, and device
+reliability characteristics.
 
 ## Known model/device flakes
 

--- a/docs/testing/llm-tools-harness.md
+++ b/docs/testing/llm-tools-harness.md
@@ -1,0 +1,153 @@
+# `llm_tools` Harness — Deep Reference
+
+See [`docs/automated-testing.md`](../automated-testing.md) for the operational index, commands,
+and report inspection. This document provides deeper technical detail for contributors working
+with the `llm_tools` harness phase.
+
+## Purpose
+
+The `llm_tools` harness phase validates end-to-end LLM tool-call generation. It tests the
+path where a user query bypasses the deterministic QIR (Tier 2) and classifier routers and
+falls through to Gemma (Tier 3) for reasoning and tool-call generation.
+
+It does **not** test:
+- QIR deterministic routing (that is covered by the main `skills` suite)
+- Classifier zero-shot intent matching
+- Slot filling or confirmation dialogs
+- Hallucination retry paths
+
+## What it validates
+
+For each of the 3 golden prompts, the harness checks:
+
+1. **Route to Gemma** — the query reached Gemma via LLM fallthrough (`llm_tools_route` marker
+   contains `result=fallthrough`)
+2. **Tool call generation** — Gemma produced either a native SDK tool call or a legacy
+   text-format tool call
+3. **Correct tool** — the expected top-level tool name matches the actual tool called
+4. **Result observability** — the tool execution result is logged via `llm_tools_skill_result`
+5. **Message persistence** — the tool call message is saved in chat history
+6. **UI evidence** — a chip for the tool call is visible on screen
+7. **No retry** — no unexpected hallucination retry path was triggered
+8. **No slot fill** — no QIR slot-fill or confirmation path was used
+
+## Golden prompts
+
+| Case | Prompt | Expected tool | Key expectations |
+|------|--------|--------------|------------------|
+| `query_wikipedia_natural` | "Look up the history of the Battle of Hastings on Wikipedia for me" | `query_wikipedia` | `no_regex_match=True`, `no_classifier=True`, `no_slot_fill=True`, `no_retry=True` |
+| `save_memory_durable_fact` | "Here is a lasting fact I want you to know: my preferred dry cleaner is Star Dry Cleaning" | `save_memory` | Same + `content` field must be present and non-empty |
+| `get_system_info_natural` | "Can you inspect this device and summarise its current system status?" | `get_system_info` | Same, no tool arguments expected |
+
+## Runtime markers
+
+These are the structured logcat markers the harness reads. They are emitted by the app code
+(`ChatViewModel`, `NativeIntentHandler`, and the tool-call path).
+
+| Marker | Report field | Format | Example |
+|--------|-------------|--------|---------|
+| `llm_tools_route` | `route_marker` | `result=<value> best_guess=<intent> confidence=<float>` | `result=fallthrough best_guess=null confidence=0.0` |
+| `llm_tools_native_tool` | `native_tool_marker` | Full tool-call JSON | `{"name":"query_wikipedia","arguments":{...}}` |
+| `llm_tools_legacy_tool` | `legacy_tool_marker` | Raw `<\|tool_call\|>` text | `<\|tool_call\|>call:query_wikipedia{query:...}` |
+| `llm_tools_skill_result` | `skill_result_marker` | `skill=... mode=<mode> success=<bool>` | `skill={"name":"query_wikipedia",...} mode=direct_reply success=true` |
+| `llm_tools_message_toolcall_saved` | `message_saved_marker` | `id=<uuid> tool=<name>` | `id=7e195582-... tool=query_wikipedia` |
+| `tool_chip_visible` | `chip_text` | `tool=<name>` | `tool=query_wikipedia` |
+
+## Result mode assertions
+
+Each case expects a specific result mode, encoded in the `llm_tools_skill_result` marker:
+
+| Mode | Meaning | Expected for |
+|------|---------|-------------|
+| `success` | Tool executed and returned a result | `query_wikipedia`, `get_system_info` |
+| `direct_reply` | Tool result was streamed directly as a chat reply | `save_memory` |
+| `failure` | Tool execution failed | Not expected for golden prompts; seen during development |
+
+The `save_memory` case uses `direct_reply` mode because the memory save operation returns a
+human-readable confirmation rather than structured data.
+
+## Report format
+
+See [`docs/automated-testing.md`](../automated-testing.md#reports-and-result-inspection) for
+the full JSON schema.
+
+Key `llm_tools`-specific report fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expected_top_level_tool` | string | The tool the model should call |
+| `actual_top_level_tool` | string or null | The tool the model actually called (null if no call) |
+| `route_marker` | string or null | Raw `llm_tools_route:` log line content |
+| `native_tool_marker` | string or null | Raw native tool-call JSON |
+| `legacy_tool_marker` | string or null | Raw legacy text-format tool call |
+| `skill_result_marker` | string or null | Raw `llm_tools_skill_result:` content |
+| `message_saved_marker` | string or null | Raw `llm_tools_message_toolcall_saved:` content |
+| `retry_seen` | bool | Whether a retry marker was found in logs |
+| `slot_fill_seen` | bool | Whether a slot-fill/confirmation marker was found |
+| `chip_text` | string or null | UI chip text for the tool call |
+| `failures` | array of strings | Descriptive failure messages |
+
+## On-device commands
+
+```bash
+# Run just the llm_tools phase on a specific device
+ANDROID_SERIAL=R5CR605B71K python3 scripts/adb_skill_test.py --phases=llm_tools
+
+# Dry run (no device needed)
+python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools
+
+# Full suite including llm_tools (llm_tools runs after the QIR phases)
+python3 scripts/adb_skill_test.py --phases=llm_tools
+```
+
+The `--phases=llm_tools` flag is handled as a special case — it does not run the QIR skill
+phases at all. To run llm_tools alongside QIR phases, run the full harness which includes
+all phases in order; llm_tools is phase 11 (last).
+
+## Known model/device flakes
+
+These are observed reliability patterns, not harness bugs:
+
+| Case | Device | Failure mode | Frequency | Status |
+|------|--------|-------------|-----------|--------|
+| `save_memory_durable_fact` | S21 Exynos (GPU) | No tool call generated — model returns conversational response | ~50% | Tracked — backend difference |
+| `get_system_info_natural` | S21 Exynos (GPU) | Wrong tool or no tool call | ~30% | Tracked — #1114 |
+| Any `llm_tools` case | Any device (first run after app install) | Route marker not found — app still initialising | First run only | Expected — retry after engine ready |
+
+> Flakes must be tracked in issues, not silenced by relaxing harness assertions.
+
+## Troubleshooting
+
+**All cases fail with "No route marker found"**
+- The app may not have started or the engine may not be ready. Wait for
+  `Engine ready` in logcat before running.
+- Check that the app has the llm_tools marker logging enabled (build after PR #1111).
+
+**All cases fail with "No native-tool or legacy-tool marker found"**
+- Gemma is not producing tool-call output. Check:
+  - Is the model loaded? (`adb logcat -s LiteRtInferenceEngine`)
+  - Is the system prompt including the tool definitions correctly?
+  - Is the query actually falling through to Gemma?
+
+**A single case fails intermittently across runs**
+- Model output is non-deterministic. Run 3 times before reporting a regression.
+- Compare across inference backends (NPU vs GPU) — some backends produce different model
+  output distributions.
+
+**Failures change between `--dry-run` and on-device runs**
+- `--dry-run` only validates test case definitions, not model behaviour. A passing dry-run
+  with a failing on-device run means the test structure is correct but the model is not
+  generating the expected output.
+
+## Code structure
+
+The harness code is in `scripts/adb_skill_test.py`:
+
+- `LLMToolsTestCase` — test case data class (lines ~111–124)
+- `LLMToolsResult` — result data class (lines ~143–162)
+- `run_llm_tools()` — main runner function (lines ~693–944)
+- `save_llm_tools_report()` — JSON report serialisation (lines ~1302–1360)
+- Marker patterns — lines ~44–50
+
+The llm_tools runner is invoked as a separate top-level path in `main()` (line ~2284) when
+`--phases=llm_tools` is passed.

--- a/docs/testing/nl-test-specification.md
+++ b/docs/testing/nl-test-specification.md
@@ -1,5 +1,9 @@
 # Natural Language Test Specification — Jandal AI
 
+> **Status:** Design / Living document. Implementation-agnostic test cases derived from
+> real human speech patterns. Not all cases are wired into the current harness.
+> See [`docs/automated-testing.md`](../automated-testing.md) for current operational coverage.
+>
 > **Purpose:** Implementation-agnostic test cases derived from how real humans speak to voice assistants.
 > Written with zero knowledge of regex patterns, slot names, or routing internals.
 > The implementation must be adapted to pass these tests — not the other way around.


### PR DESCRIPTION
## Summary

Comprehensive testing documentation update addressing issue #1118. Adds `llm_tools` harness documentation, report inspection guidance, on-device validation workflow, CI vs on-device evidence distinction, failure interpretation, runtime markers glossary, a testing-docs index, and historical-doc annotations.

### `docs/automated-testing.md` — major expansion

- **Reports and result inspection** — JSON schemas for both `skills` and `llm_tools` suites, `jq` inspection commands, file naming conventions
- **`llm_tools` phase** — purpose, validation checklist, run commands, golden prompts table
- **On-device validation** — `ANDROID_SERIAL` usage, device table (S23 Ultra reference, S21 Exynos tracked, Honor Magic 8 Pro candidate, Pixel 10 reference)
- **CI vs on-device evidence** — comparison table with explicit "CI cannot validate model/tool-call reliability" callout, reference to #1113
- **Failure interpretation** — 8-row failure-pattern table with likely causes
- **Runtime markers** — glossary of 8 markers with report fields and pass/fail requirements

### New files

- **`docs/testing/README.md`** — Testing documentation index, clearly labelling current operational docs vs design/spec docs vs historical audits vs PR-specific test plans
- **`docs/testing/llm-tools-harness.md`** — Deep reference: purpose, what it validates, golden prompts, runtime markers, result mode assertions, report format, on-device commands, known flakes, troubleshooting guide, code structure map

### Updated files

- **`docs/adb-testing.md`** — Device table expanded to 4 rows with Role column, new section 9 for `llm_tools` harness commands
- **6 historical testing docs** — Added consistent status headers marking each as Design / Historical / Audit with pointers to `docs/automated-testing.md` and `docs/testing/README.md`

### Annotations applied

| Doc | Header added |
|-----|-------------|
| `automated-test-specification.md` | Status: Design / Draft |
| `nl-test-specification.md` | Status: Design / Living document |
| `481-outcomes-review.md` | Status: Historical audit |
| `issue-audit.md` | Status: Historical audit |
| `PR-95-100-101-102-testing.md` | Status: Historical test plan |
| `PR-72-settings-model-info-selection.md` | Status: Historical test plan |

## Validation

- [x] `python3 scripts/adb_skill_test.py --dry-run` → 201 test cases
- [x] `python3 scripts/adb_skill_test.py --dry-run --phases=llm_tools` → 3 test cases
- [x] All internal links in updated docs resolve correctly
- [x] No broken references to `scripts/test-reports/README.md` remain
- [x] All 10 files committed

Closes #1118