### PR TITLE
fix(#1146): allow missing test-results branch in dashboard workflow

### DIFF
--- a/.github/workflows/publish-test-dashboard.yml
+++ b/.github/workflows/publish-test-dashboard.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Checkout test-results
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0
+        continue-on-error: true
         with:
           ref: test-results
           path: test-results
@@ -34,6 +35,7 @@ jobs:
       - name: Ensure test-results checkout
         run: |
           if [ ! -d test-results/results ]; then
+            rm -rf test-results
             mkdir -p test-results/results
             echo "::warning::test-results branch not found or empty; using empty results"
           fi


### PR DESCRIPTION
When the `test-results` branch does not exist (fresh repository), the `Checkout test-results` step fails and the entire job is skipped before the empty-results fallback can run. The workflow intended to handle this gracefully but the checkout failure halted execution first.

## Changes to `.github/workflows/publish-test-dashboard.yml`

1. **`continue-on-error: true`** on the `Checkout test-results` step — allows the checkout to fail without aborting the job.
2. **`rm -rf test-results`** in the ensure step — cleans up any partial state left by the failed checkout (`actions/checkout` may create the path before failing), then creates the empty `results/` directory and emits a warning.

All other constraints preserved:
- SHA-pinned actions
- Least-privilege Pages permissions (`contents: read`, `pages: write`, `id-token: write`)
- Job-scoped `github-pages` environment
- No `_site` committed

## Verification

| Scenario | Expected |
|---|---|
| `test-results` branch missing | Checkout fails (continue-on-error), ensure step creates empty results, dashboard builds with "No evidence yet" |
| `test-results/results` empty | Ensure step detects missing dir, creates empty one, dashboard shows empty state |
| `test-results/results` has evidence | Ensure step skips, dashboard shows data — unchanged behavior |

Closes #1146.