### PR TITLE
feat(#1145): auto-refresh dashboard on evidence publish via repository_dispatch

### DIFF
--- a/.github/workflows/publish-test-dashboard.yml
+++ b/.github/workflows/publish-test-dashboard.yml
@@ -2,6 +2,9 @@ name: Publish test dashboard
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - test-evidence-published
   push:
     branches:
       - main

--- a/.github/workflows/publish-test-evidence.yml
+++ b/.github/workflows/publish-test-evidence.yml
@@ -109,3 +109,16 @@ jobs:
             $RELEASE_ARGS \
             --commit "$COMMIT" \
             $ALLOW_MISMATCH
+
+      - name: Trigger dashboard rebuild
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Dispatching test-evidence-published event to rebuild Pages dashboard..."
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=test-evidence-published \
+            -f client_payload[source]="${{ inputs.source }}" \
+            -f client_payload[pr]="${{ inputs.pr }}" \
+            -f client_payload[release]="${{ inputs.release }}" \
+            -f client_payload[commit]="${{ inputs.commit }}"


### PR DESCRIPTION
Adds reliable auto-refresh of the GitHub Pages test dashboard when new evidence is published to `test-results`.

## How it works

**Publish test evidence → `repository_dispatch` → Publish test dashboard → rebuild → deploy**

### `.github/workflows/publish-test-evidence.yml`

New step `Trigger dashboard rebuild` runs after `Publish test evidence` succeeds:
- Uses `if: success()` — dispatch only fires when the publish step completes
- Sends `repository_dispatch` event with type `test-evidence-published`
- Carries `source`, `pr`, `release`, `commit` in `client_payload`
- Uses existing `GITHUB_TOKEN` (no new permissions needed — `contents: write` already covers dispatch)

If the publish step fails, the dispatch step is skipped automatically (GitActions stops the job and no further steps run). Local/manual publishing continues to require manual dashboard dispatch as before.

### `.github/workflows/publish-test-dashboard.yml`

New trigger:
```yaml
on:
  repository_dispatch:
    types:
      - test-evidence-published
```

Existing `workflow_dispatch` and `push: main` triggers preserved. All other constraints unchanged: SHA-pinned actions, least-privilege Pages permissions, job-scoped `github-pages` environment, `continue-on-error` for missing `test-results` branch.

## Verification

| Scenario | Expected |
|---|---|
| Publish CI evidence → `test-results` updated | Dispatch sent, dashboard rebuilds, Pages deploys |
| Publish CI evidence fails (bad run_id, etc.) | Dispatch NOT sent (step skipped) |
| Manual `workflow_dispatch` on dashboard | Still works as before |
| Push to `main` | Still triggers dashboard rebuild |
| Local evidence publish (outside Actions) | Dashboard NOT auto-refreshed — manual dispatch needed |

## Non-goals

- No charts, gates, PR comments, analytics
- No schema changes
- No GitHub API calls in `scripts/publish_test_evidence.py`
- No `test-results` push trigger

Closes #1145.