### PR TITLE
feat(#1153): add PR-number-first CI evidence publishing workflow

### DIFF
--- a/.docs/agents/test-evidence-workflow.md
+++ b/.docs/agents/test-evidence-workflow.md
@@ -8,13 +8,19 @@ Feature PRs in this repo follow a **generate → report → decide → publish**
 
 ```text
 PR CI generates normalised evidence artifacts
-  → agent reports PR number, commit SHA, CI run ID in PR notes
+  → agent reports PR number in PR notes
   → reviewer/user decides whether to publish a durable snapshot
-  → if yes: run Publish test evidence workflow → evidence lands on test-results branch
+  → if yes: run Publish PR test evidence workflow → evidence lands on test-results branch
   → dashboard auto-refreshes via repository_dispatch
 ```
 
+The **PR-number-first** workflow (`publish-pr-test-evidence.yml`) is the default path for CI evidence.
+It requires only a PR number — the workflow resolves the CI run, artifact, and commit SHA automatically.
+
 **Key principle:** Agents generate evidence metadata and ensure CI produces artifacts. They do **not** publish durable evidence unless explicitly instructed by the reviewer or issue.
+
+> **Reminder:** On-device evidence (physical device runs) is a separate path. See [On-device / physical evidence](#on-device--physical-evidence).
+
 
 ## Feature PR lifecycle
 
@@ -29,36 +35,127 @@ While implementing a feature, ensure:
 - For on-device features, ensure the `adb_skill_test.py` harness run is documented so manual validation can be reproduced.
 
 ### 2. PR notes / summary
+In the PR description or final summary comment, agents should:
 
-In the PR description or final summary comment, agents **must mechanically discover and report:**
+- Report the **PR number** — e.g. `#1234`
+- Confirm whether CI test evidence artifacts were generated (CI runs this automatically)
+- Note whether CI passed or had failures
 
-- **PR number** — e.g. `#1234`
-- **PR head commit SHA** — the full SHA of the latest commit on the PR branch
-- **CI run ID** — the GitHub Actions run ID that generated the evidence artifacts
-- **CI status** — passed, failed, or in progress
-- **Whether CI evidence artifact exists** — `ci-test-evidence-<sha>` in the run's artifact list
-- **The exact artifact name and commit SHA** — used by the publish workflow to download evidence; the commit SHA in the artifact name is the **merge commit SHA** (`github.sha` for `pull_request` events), not the PR head SHA
+**Do not** manually hunt for run IDs, commit SHAs, or artifact names for routine CI evidence publishing.
+The [PR-number-first workflow](#pr-number-first-ci-evidence-publishing) resolves these automatically from the PR number.
 
-The reviewer/user decides whether a given CI snapshot is worth publishing. Gather all the metadata so they can act without hunting across GitHub's UI.
+The reviewer/user decides whether a given CI snapshot is worth publishing. A simple note is sufficient:
 
-> **Note on commit SHA:** CI evidence artifacts use the **merge commit SHA**, not the PR head SHA. GitHub Actions sets `github.sha` to a merge commit for `pull_request` events. The evidence artifact `ci-test-evidence-<sha>` and the evidence JSON's `commit` field both contain this merge SHA. Always report both SHAs and pass the **merge SHA** as `inputs.commit` to the publish workflow. The publisher validates `--commit` against the evidence JSON's `commit` field; use `--allow-commit-mismatch` only for manually-created evidence.
->
-> **Future improvement:** [#1153](https://github.com/NickMonrad/kernel-ai-assistant/issues/1153) will add a PR-aware publishing workflow so the normal CI path becomes "provide PR number only", removing the need to fill in run IDs and commit SHAs manually.
+> CI: ✅ passed — evidence artifacts available. Run `Publish PR test evidence` workflow with PR number only to publish.
+
+> **Note on commit SHA:** CI evidence artifacts use the **merge commit SHA**, not the PR head SHA.
+GitHub Actions sets `github.sha` to a merge commit for `pull_request` events. The evidence artifact
+`ci-test-evidence-<sha>` and the evidence JSON's `commit` field both contain this merge SHA.
+The PR-number-first workflow resolves the correct SHA automatically from the artifact name.
+The lower-level `publish-test-evidence.yml` workflow still requires passing this SHA manually.
+
 ### 3. Stop for review
 
 After opening or updating the PR, **stop** unless explicitly instructed to publish evidence. The reviewer or user decides whether the current test results are meaningful enough to warrant a durable published snapshot on the `test-results` branch.
 
+## PR-number-first CI evidence publishing
+
+The **default path** for publishing CI test evidence is the
+[`publish-pr-test-evidence.yml`](../../.github/workflows/publish-pr-test-evidence.yml) workflow.
+It resolves the CI run, artifact, and commit SHA from the PR number automatically.
+
+### How to use
+
+1. Go to **Actions → Publish PR test evidence → Run workflow**.
+2. Enter the **PR number** (required). Optionally provide overrides if auto-resolution fails.
+3. Run the workflow.
+4. Check the workflow summary for what was published and where.
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `pr` | Yes | PR number to publish latest CI evidence for |
+| `run_id` | No | Override — CI run ID (auto-resolved if omitted) |
+| `commit` | No | Override — commit SHA (auto-resolved from artifact name) |
+| `allow_commit_mismatch` | No | Skip commit SHA consistency check (default: false) |
+
+### What the workflow does
+
+1. Resolves PR metadata (branch, head SHA, title) via `gh pr view`.
+2. Finds the latest successful CI run for the PR branch (`gh run list --workflow CI --branch <branch> --status success`).
+3. Finds the `ci-test-evidence-<sha>` artifact in that run.
+4. Extracts the evidence commit SHA from the artifact name (the merge check SHA, not the PR head SHA).
+5. Downloads the artifact and publishes via `scripts/publish_test_evidence.py`.
+6. Triggers a `test-evidence-published` `repository_dispatch` to rebuild the dashboard.
+7. Emits a step summary showing PR number, head SHA, CI run ID, artifact name, evidence commit, and published path.
+
+### Override usage
+
+If auto-resolution fails (no successful CI run, no artifact, artifact expired), provide overrides:
+
+```yaml
+run_id: 27204003987      # from a CI run URL
+commit: 2798a1dd0a08...  # from the artifact name ci-test-evidence-<sha>
+```
+
+The workflow summary will mark overrides with ⚠️.
+
+### Failure modes
+
+| Scenario | Behaviour |
+|----------|-----------|
+| PR number invalid | Step 1 fails with clear error |
+| No successful CI run for branch | Step 2 fails: "No successful CI run found" |
+| No `ci-test-evidence-*` artifact | Step 3 fails: "No evidence artifact found" |
+| Artifact expired | Step 3 fails: "artifact has expired" (retention: 30 days) |
+| Commit mismatch (override only) | Validated by `publish_test_evidence.py`; use `allow_commit_mismatch` to bypass |
+
+### Agent guidance
+
+- **Default path for routine CI evidence:** PR number only. Do not ask the user for run IDs or commit SHAs.
+- **Fallback:** Use the [manual publish](#manual-fallback-publish-test-evidence) workflow or the Python script directly, explaining why.
+- **On-device evidence:** Never through this workflow. See [On-device / physical evidence](#on-device--physical-evidence).
+
 ## Evidence publishing
 
-Durable publishing is currently **reviewer/user-controlled**:
+Durable publishing is **reviewer/user-controlled**.
+The default path is the [PR-number-first workflow](#pr-number-first-ci-evidence-publishing).
 
-For **CI evidence**, the reviewer or user:
+### Default path: PR-number-first workflow (CI evidence)
 
-1. Navigates to the "Publish test evidence" workflow in GitHub Actions.
-2. Provides: source (`ci`), PR number, commit SHA, CI run ID.
-3. Workflow downloads the CI evidence artifact by run ID, validates, and publishes to the `test-results` branch.
-4. The dashboard auto-refreshes via `repository_dispatch` after a successful publish.
+For routine CI evidence publishing, use the
+[Publish PR test evidence](.github/workflows/publish-pr-test-evidence.yml) workflow:
 
+1. Navigate to **Actions → Publish PR test evidence → Run workflow**.
+2. Enter the **PR number** only.
+3. Run the workflow.
+4. Check the workflow summary — it reports what was published, the commit SHA, artifact name, and run ID.
+
+The dashboard auto-refreshes via `repository_dispatch` on success.
+
+**Agents:** Do not ask the reviewer for run IDs, artifact names, or commit SHAs for routine CI evidence.
+If the PR-number-first workflow fails, escalate to the manual fallback and explain why.
+
+### Manual fallback: publish-test-evidence workflow
+
+For advanced cases (release-scoped evidence, on-device evidence, or when the PR-number-first workflow
+cannot resolve the CI run), use the lower-level
+[publish-test-evidence.yml](.github/workflows/publish-test-evidence.yml) workflow.
+
+1. Navigate to **Actions → Publish test evidence → Run workflow**.
+2. Provide: `source` (`ci` or `on_device`), PR number or release, commit SHA, and CI run ID (for CI).
+3. Workflow downloads the CI evidence artifact by run ID, validates, and publishes to `test-results`.
+4. Dashboard auto-refreshes on success.
+
+**When to use fallback:**
+
+- Release-scoped evidence (requires `--release` flag).
+- The PR-number-first workflow cannot find a successful CI run or artifact.
+- The user explicitly provides a run ID or commit override.
+- On-device evidence (must be published locally — the workflow prints the command to run).
+
+### On-device evidence (local/manual)
 For **on-device evidence**, the agent (when explicitly instructed):
 
 1. Checks `adb devices` and confirms `ANDROID_SERIAL`.
@@ -69,6 +166,18 @@ For **on-device evidence**, the agent (when explicitly instructed):
 6. Publishes locally with `scripts/publish_test_evidence.py` using appropriate flags.
 7. Optionally triggers dashboard refresh — if `gh` auth is available and the user has explicitly instructed publication, the agent may manually trigger the "Publish test dashboard" workflow after local publish.
 8. Reports the commands used, report path, published path, and dashboard outcome.
+
+**Agent guidance for on-device evidence:**
+
+- Before starting on-device work, **ask whether on-device testing is required** if it is not already explicit
+  in the issue or user request. On-device testing requires a physical device, USB/wireless ADB connection,
+  and the app to be installed — it is not a CI step.
+- **Ask which device tier** is relevant: S21 (tracked/exynos signal device) or S23U (reference/flagship device).
+- If on-device testing is required, **ask whether the resulting evidence should also be published** to
+  `test-results` for dashboard visibility.
+- **Do not imply** on-device evidence is covered by CI or the PR-number-first workflow.
+- **Do not publish** on-device evidence without a real physical-device run and explicit scope, commit,
+  and release metadata.
 
 **User responsibilities for on-device evidence:**
 - Connect and unlock the physical device.
@@ -126,15 +235,19 @@ Generated by running the ADB harness against a physical device:
 - Decide whether a given snapshot is worth publishing as durable dashboard evidence.
 
 ### CI vs on-device distinction
-
 The schema (`docs/testing/test-evidence-schema.md`) distinguishes `ci` from `on_device` evidence via the `source` field in the evidence metadata. Agents must:
 
 - Keep them separate in documentation and reporting.
 - Never conflate CI pass rates (build + lint + unit tests) with on-device pass rates (model inference on physical hardware).
 - Note that dashboard filtering by source device/tier is planned but not yet implemented.
 
-## Dashboard and test-results branch
+**Evidence reporting guidance:**
 
+- Distinguish "CI evidence published" from "on-device evidence published" in summaries.
+- Call out missing on-device evidence **neutrally** when it was not requested.
+- Call out required-but-missing on-device evidence as **incomplete work**.
+
+## Dashboard and test-results branch
 | Component | Location | Purpose |
 |-----------|----------|---------|
 | Evidence storage | `test-results` branch | Durable evidence snapshots, organised by source/PR/release |
@@ -142,6 +255,7 @@ The schema (`docs/testing/test-evidence-schema.md`) distinguishes `ci` from `on_
 | Dashboard deployment | GitHub Pages (`github-pages` env) | Published via `publish-test-dashboard.yml` workflow |
 | Evidence publisher | `scripts/publish_test_evidence.py` | Validates and writes evidence to `test-results` |
 | Evidence publishing workflow | `.github/workflows/publish-test-evidence.yml` | Manual dispatch → publish → trigger dashboard rebuild |
+| PR-number-first workflow | `.github/workflows/publish-pr-test-evidence.yml` | PR-number-only dispatch → resolve run/artifact → publish → dashboard rebuild |
 | Dashboard publishing workflow | `.github/workflows/publish-test-dashboard.yml` | Manual dispatch OR push to main OR repository_dispatch |
 
 ## Current non-goals

--- a/.github/workflows/publish-pr-test-evidence.yml
+++ b/.github/workflows/publish-pr-test-evidence.yml
@@ -1,0 +1,244 @@
+name: Publish PR test evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to publish latest CI evidence for
+        required: true
+        type: string
+      run_id:
+        description: >
+          Override — CI run ID containing the evidence artifact.
+          Omit to auto-resolve the latest successful CI run for the PR.
+        required: false
+        type: string
+      commit:
+        description: >
+          Override — commit SHA for the evidence artifact.
+          Omit to auto-resolve from the artifact name.
+        required: false
+        type: string
+      allow_commit_mismatch:
+        description: Allow publishing evidence whose commit field does not match the --commit arg
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  publish-pr-evidence:
+    name: Publish PR test evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0
+        with:
+          fetch-depth: 0
+
+      # ── Step 1: Resolve PR metadata ──────────────────────────────────
+      - name: Resolve PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ inputs.pr }}"
+          echo "pr=${PR}" >> "${GITHUB_OUTPUT}"
+
+          # Fetch PR metadata via gh
+          PR_JSON=$(gh pr view "${PR}" --json headRefName,headRefOid,title,state \
+            --repo "${{ github.repository }}" 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to resolve PR #${PR}: ${PR_JSON}"
+            exit 1
+          fi
+
+          HEAD_BRANCH=$(echo "${PR_JSON}" | jq -r '.headRefName')
+          HEAD_SHA=$(echo "${PR_JSON}" | jq -r '.headRefOid')
+          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title')
+          PR_STATE=$(echo "${PR_JSON}" | jq -r '.state')
+
+          echo "head_branch=${HEAD_BRANCH}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "pr_title=${PR_TITLE}" >> "${GITHUB_OUTPUT}"
+          echo "pr_state=${PR_STATE}" >> "${GITHUB_OUTPUT}"
+
+      # ── Step 2: Resolve CI run ───────────────────────────────────────
+      - name: Resolve CI run
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.run_id }}" ]; then
+            # ── Override path: use provided run_id ──
+            RUN_ID="${{ inputs.run_id }}"
+
+            CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion \
+              --repo "${{ github.repository }}" -q '.conclusion' 2>/dev/null || echo "not_found")
+
+            if [ "${CONCLUSION}" = "not_found" ]; then
+              echo "::error::Run ${RUN_ID} not found. Verify the run ID and try again."
+              exit 1
+            fi
+
+            echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+            echo "run_conclusion=${CONCLUSION}" >> "${GITHUB_OUTPUT}"
+          else
+            # ── Auto-resolve path: latest successful CI run for PR branch ──
+            BRANCH="${{ steps.pr.outputs.head_branch }}"
+
+            RUN_JSON=$(gh run list --workflow CI --branch "${BRANCH}" --status success \
+              --limit 1 --json databaseId,displayTitle,createdAt \
+              --repo "${{ github.repository }}" 2>&1)
+
+            RUN_ID=$(echo "${RUN_JSON}" | jq -r '.[0].databaseId // empty' 2>/dev/null)
+
+            if [ -z "${RUN_ID}" ] || [ "${RUN_ID}" = "null" ]; then
+              echo "::error::No successful CI run found for PR #${{ inputs.pr }} on branch '${BRANCH}'." >>&2
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "### ❌ No successful CI run found" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "CI evidence requires a completed \`pull_request\` CI run with **success** conclusion." >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "To use an override, provide \`run_id\` and \`commit\` inputs manually." >> "${GITHUB_STEP_SUMMARY}"
+              exit 1
+            fi
+
+            echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+            echo "run_conclusion=success" >> "${GITHUB_OUTPUT}"
+          fi
+
+      # ── Step 3: Resolve evidence artifact and commit ─────────────────
+      - name: Resolve evidence artifact
+        id: artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID="${{ steps.run.outputs.run_id }}"
+
+          if [ -n "${{ inputs.commit }}" ]; then
+            # ── Override path: use provided commit ──
+            COMMIT="${{ inputs.commit }}"
+            ARTIFACT_NAME="ci-test-evidence-${COMMIT}"
+
+            # Check artifact exists and is not expired
+            ARTIFACT_JSON=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
+              --jq "[.artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | {name, expired, expires_at}] | .[0] // empty" 2>/dev/null)
+
+            if [ -z "${ARTIFACT_JSON}" ] || [ "${ARTIFACT_JSON}" = "null" ]; then
+              echo "::error::Artifact '${ARTIFACT_NAME}' not found in run ${RUN_ID}. Verify the commit SHA matches the ci-test-evidence-* artifact name in that run."
+              exit 1
+            fi
+
+            EXPIRED=$(echo "${ARTIFACT_JSON}" | jq -r '.expired // false')
+            if [ "${EXPIRED}" = "true" ]; then
+              echo "::error::Artifact '${ARTIFACT_NAME}' has expired. Trigger a new CI run or use a more recent commit."
+              exit 1
+            fi
+
+          else
+            # ── Auto-resolve path: find ci-test-evidence artifact from the run ──
+            ARTIFACT_NAME=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
+              --jq '[.artifacts[] | select(.name | startswith("ci-test-evidence")) | .name] | .[0] // empty' 2>/dev/null)
+
+            if [ -z "${ARTIFACT_NAME}" ]; then
+              echo "::error::No ci-test-evidence-* artifact found in run ${RUN_ID}. The CI run may not have generated evidence, or the artifact may have expired (retention: 30 days)." >>&2
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "### ❌ No evidence artifact found" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "Run \`${RUN_ID}\` has no \`ci-test-evidence-*\` artifact available." >> "${GITHUB_STEP_SUMMARY}"
+              echo "Trigger a new CI run, then retry." >> "${GITHUB_STEP_SUMMARY}"
+              exit 1
+            fi
+
+            # Extract SHA from artifact name: ci-test-evidence-<sha>
+            COMMIT=$(echo "${ARTIFACT_NAME}" | sed 's/^ci-test-evidence-//')
+          fi
+
+          echo "commit=${COMMIT}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=${ARTIFACT_NAME}" >> "${GITHUB_OUTPUT}"
+
+      # ── Step 4: Download artifact ────────────────────────────────────
+      - name: Download CI test evidence artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/ci-evidence
+          gh run download "${{ steps.run.outputs.run_id }}" \
+            -n "${{ steps.artifact.outputs.artifact_name }}" \
+            -D /tmp/ci-evidence \
+            --repo "${{ github.repository }}"
+
+      # ── Step 5: Publish ──────────────────────────────────────────────
+      - name: Publish test evidence
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Configure git auth for pushing to test-results branch.
+          # The Python script creates a temp repo and pushes from there,
+          # which doesn't inherit actions/checkout's credential helper.
+          git config --global credential.helper \
+            "!f() { echo username=x-access-token; echo password=\${GITHUB_TOKEN}; }; f"
+
+          ALLOW_MISMATCH="${{ inputs.allow_commit_mismatch && '--allow-commit-mismatch' || '' }}"
+
+          python3 scripts/publish_test_evidence.py \
+            --input-dir /tmp/ci-evidence \
+            --source ci \
+            --pr "${{ steps.pr.outputs.pr }}" \
+            --commit "${{ steps.artifact.outputs.commit }}" \
+            ${ALLOW_MISMATCH}
+
+      # ── Step 6: Trigger dashboard rebuild ────────────────────────────
+      - name: Trigger dashboard rebuild
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=test-evidence-published \
+            -f client_payload[source]=ci \
+            -f client_payload[pr]="${{ steps.pr.outputs.pr }}" \
+            -f client_payload[commit]="${{ steps.artifact.outputs.commit }}"
+
+      # ── Step 7: Summary ──────────────────────────────────────────────
+      - name: Workflow summary
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.pr }}"
+          PR_TITLE="${{ steps.pr.outputs.pr_title }}"
+          HEAD_SHA="${{ steps.pr.outputs.head_sha }}"
+          HEAD_BRANCH="${{ steps.pr.outputs.head_branch }}"
+          RUN_ID="${{ steps.run.outputs.run_id }}"
+          RUN_CONCLUSION="${{ steps.run.outputs.run_conclusion }}"
+          COMMIT="${{ steps.artifact.outputs.commit }}"
+          ARTIFACT_NAME="${{ steps.artifact.outputs.artifact_name }}"
+
+          cat >> "${GITHUB_STEP_SUMMARY}" << SUMMARYEOF
+          ## Publish PR test evidence — summary
+
+          | Field | Value |
+          |-------|-------|
+          | **PR** | [#${PR_NUM}](${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}) |
+          | **PR title** | ${PR_TITLE} |
+          | **Branch** | \`${HEAD_BRANCH}\` |
+          | **PR head SHA** | \`${HEAD_SHA}\` |
+          | **CI run** | [${RUN_ID}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID}) |
+          | **Run conclusion** | ${RUN_CONCLUSION} |
+          | **Evidence commit** | \`${COMMIT}\` |
+          | **Artifact** | \`${ARTIFACT_NAME}\` |
+          | **Published path** | \`results/pr/${PR_NUM}/ci/\` |
+          | **Dashboard refresh** | Triggered via \`repository_dispatch\` |
+
+          SUMMARYEOF
+
+          # Override annotations
+          if [ -n "${{ inputs.run_id }}" ]; then
+            echo "> ⚠️ Run ID was provided as an override. Auto-resolution was bypassed." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          if [ -n "${{ inputs.commit }}" ]; then
+            echo "> ⚠️ Commit SHA was provided as an override. Auto-resolution was bypassed." >> "${GITHUB_STEP_SUMMARY}"
+          fi

--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -155,7 +155,15 @@ Default: `main`. Feature branches: `feature/<short-name>`. Branch from `main` on
 
 ### Test evidence workflow
 
-Feature PRs should let normal CI generate test evidence artifacts. Do not publish durable evidence unless explicitly instructed. In PR notes or final summary, report the PR number, head commit SHA, and CI run ID so the reviewer can decide whether to publish a durable snapshot to `test-results`. Keep CI/static evidence distinct from physical on-device evidence.
+Feature PRs let normal CI generate test evidence artifacts. Do not publish durable evidence unless explicitly instructed.
+
+**For CI evidence:** Use the "Publish PR test evidence" workflow — requires only the PR number.
+The workflow resolves the CI run, artifact, and commit SHA automatically.
+See `.docs/agents/test-evidence-workflow.md` for the full flow and manual fallback.
+
+**For on-device evidence:** Requires a physical device run. Do not imply on-device evidence is covered by CI.
+If on-device testing is needed, ask which device tier is required (S21 tracked signal or S23U reference signal)
+and whether the results should be published to `test-results`.
 
 Details: `.docs/agents/test-evidence-workflow.md`.
 


### PR DESCRIPTION
Closes #1153

## Summary

Add a PR-number-first CI evidence publishing workflow that resolves CI runs, artifacts, and commit SHAs from a PR number automatically. No more hunting for run IDs or commit SHAs for routine CI evidence publishing.

## Changes

### New file: `.github/workflows/publish-pr-test-evidence.yml`

PR-number-first workflow with:
- `pr` (required) — PR number to publish latest CI evidence for.
- `run_id` / `commit` (optional) — overrides for advanced/recovery cases.
- `allow_commit_mismatch` (optional) — bypass commit consistency check.

Auto-resolution logic:
1. PR metadata → branch, head SHA, title
2. Latest successful CI run for that branch (`gh run list --workflow CI --status success --limit 1`)
3. `ci-test-evidence-<sha>` artifact in that run
4. Evidence commit SHA extracted from artifact name (merge check SHA, not PR head SHA)
5. Download → publish via `scripts/publish_test_evidence.py`
6. Trigger `repository_dispatch` for dashboard rebuild
7. Step summary with all resolved values

Clear failure messages for: invalid PR, no successful CI run, no evidence artifact, expired artifact, commit mismatch.

### Updated: `.docs/agents/test-evidence-workflow.md`

- PR-number-first workflow is now the default CI evidence path.
- Manual `publish-test-evidence.yml` is fallback for advanced/recovery cases.
- Added agent decision guidance for on-device evidence: ask if on-device testing is required (if not explicit), which device tier (S21/S23U), whether to publish results.
- Clear CI vs on-device separation throughout.

### Updated: `.omp/AGENTS.md`

- Short pointer updated to reference new PR-number-first workflow.
- On-device decision guidance added.

## Validation

| Check | Result |
|-------|--------|
| Resolve PR #1161 → branch → latest successful run | ✅ `27240314729` |
| Find `ci-test-evidence-*` artifact | ✅ `ci-test-evidence-a672a78830e3df6dc5644544d0016878c1976b88` |
| Evidence commit matches artifact name | ✅ `a672a78830e3df6dc5644544d0016878c1976b88` |
| Dry-run publish | ✅ 3 files, correct paths |
| Live publish to `test-results` | ✅ Published to `results/pr/1161/ci/` |
| Dashboard rebuild triggered | ✅ Completed in 16s |
| Failure: no CI run for PR | ✅ Workflow would fail: 'No successful CI run found' |
| Failure: no evidence artifact | ✅ Workflow would fail: 'No evidence artifact found' |
| Failure: expired/bad override | ✅ Workflow would fail: 'Artifact not found' |

## Non-goals (kept in scope)

- No on-device upload UX.
- No changes to evidence schema.
- No dashboard UI changes.
- No auto-publish on every push.
- Manual fallback workflow preserved.

## Documentation updates for agents

After this lands, agents handling PR evidence should follow:

1. Routine CI evidence → PR-number-first workflow (PR number only). Do not ask for run IDs or commit SHAs.
2. If that fails → manual `publish-test-evidence.yml` fallback, explain why.
3. On-device evidence → physical device run only. Never through CI workflow.
4. Before on-device work, ask: is on-device testing required? Which device tier? Should results be published?