### PR TITLE
feat(#1169 #1170): harden PR-number safety and evidence publishing workflow

### DIFF
--- a/.docs/agents/test-evidence-workflow.md
+++ b/.docs/agents/test-evidence-workflow.md
@@ -46,7 +46,17 @@ The [PR-number-first workflow](#pr-number-first-ci-evidence-publishing) resolves
 
 The reviewer/user decides whether a given CI snapshot is worth publishing. A simple note is sufficient:
 
-> CI: ✅ passed — evidence artifacts available. Run `Publish PR test evidence` workflow with PR number only to publish.
+
+When evidence has been published, the PR notes should include a metadata checklist:
+
+> **Evidence metadata:**
+> 
+> - GitHub PR number used for evidence: #1160
+> - Closing issue: #1154
+> - Evidence path: `results/pr/1160/...`
+> - Verified evidence JSON \`pr\` field matches GitHub PR number: yes
+
+> CI: ✅ passed — evidence artifacts available. Run \`Publish PR test evidence\` workflow with PR number only to publish.
 
 > **Note on commit SHA:** CI evidence artifacts use the **merge commit SHA**, not the PR head SHA.
 GitHub Actions sets `github.sha` to a merge commit for `pull_request` events. The evidence artifact
@@ -116,6 +126,46 @@ The workflow summary will mark overrides with ⚠️.
 - **Default path for routine CI evidence:** PR number only. Do not ask the user for run IDs or commit SHAs.
 - **Fallback:** Use the [manual publish](#manual-fallback-publish-test-evidence) workflow or the Python script directly, explaining why.
 - **On-device evidence:** Never through this workflow. See [On-device / physical evidence](#on-device--physical-evidence).
+- **PR number is the GitHub PR number, not the issue number:** Before generating or publishing evidence,
+  mechanically discover the PR number with \`gh pr view --json number --jq .number\`.
+  See [PR number vs issue number](#pr-number-vs-issue-number) below.
+
+### PR number vs issue number
+
+For all evidence generation and publishing, **\`pr\` means the actual GitHub Pull Request number**,
+not the GitHub Issue number from \`Closes #N\`, parent issue, child issue, or epic issue.
+
+| Context | Correct | Incorrect |
+|---------|---------|-----------|
+| PR URL | \`/pull/1160\` | \`/pull/1154\` (issue number) |
+| Closing reference | \`Closes #1154\` | (not relevant to evidence) |
+| Evidence JSON \`pr\` field | \`"pr": 1160\` | \`"pr": 1154\` |
+| Publish path | \`results/pr/1160/...\` | \`results/pr/1154/...\` |
+| Dashboard PR grouping | grouped under #1160 | grouped under #1154 |
+
+**Mechanical discovery — always derive the PR number, never copy it:**
+
+\`\`\`bash
+PR_NUMBER="$(gh pr view --json number --jq .number)"
+PR_HEAD_SHA="$(gh pr view --json headRefOid --jq .headRefOid)"
+\`\`\`
+
+Use \`$PR_NUMBER\` for:
+- \`--pr\` argument to evidence generation and publishing commands.
+- Evidence JSON \`pr\` field.
+- Publish path \`results/pr/<PR_NUMBER>/...\`.
+- PR summary grouping and dashboard grouping.
+
+Use the issue number only in:
+- \`Closes #<issue>\` in PR bodies.
+- Related issue references and prose describing scope.
+
+**The story behind this rule:** PR #1160 exposed the gap — it closed issue #1154, and an agent
+confused the issue number with the actual PR number, publishing evidence under \`results/pr/1154/\`
+instead of \`results/pr/1160/\`. The publisher now includes a guardrail (\`_validate_pr_number()\`)
+that compares \`--pr\` against the current branch's open PR when \`gh\` is available.
+Pass \`--allow-pr-mismatch\` only for exceptional recovery cases (re-publishing evidence
+after a PR is closed).
 
 ## Evidence publishing
 
@@ -125,7 +175,7 @@ The default path is the [PR-number-first workflow](#pr-number-first-ci-evidence-
 ### Default path: PR-number-first workflow (CI evidence)
 
 For routine CI evidence publishing, use the
-[Publish PR test evidence](.github/workflows/publish-pr-test-evidence.yml) workflow:
+[Publish PR test evidence](../../.github/workflows/publish-pr-test-evidence.yml) workflow:
 
 1. Navigate to **Actions → Publish PR test evidence → Run workflow**.
 2. Enter the **PR number** only.
@@ -141,7 +191,7 @@ If the PR-number-first workflow fails, escalate to the manual fallback and expla
 
 For advanced cases (release-scoped evidence, on-device evidence, or when the PR-number-first workflow
 cannot resolve the CI run), use the lower-level
-[publish-test-evidence.yml](.github/workflows/publish-test-evidence.yml) workflow.
+[publish-test-evidence.yml](../../.github/workflows/publish-test-evidence.yml) workflow:
 
 1. Navigate to **Actions → Publish test evidence → Run workflow**.
 2. Provide: `source` (`ci` or `on_device`), PR number or release, commit SHA, and CI run ID (for CI).

--- a/.github/workflows/publish-pr-test-evidence.yml
+++ b/.github/workflows/publish-pr-test-evidence.yml
@@ -24,9 +24,10 @@ on:
         required: false
         default: false
         type: boolean
-
 permissions:
   contents: write
+  actions: read
+  pull-requests: read
 
 jobs:
   publish-pr-evidence:
@@ -95,13 +96,31 @@ jobs:
             RUN_ID=$(echo "${RUN_JSON}" | jq -r '.[0].databaseId // empty' 2>/dev/null)
 
             if [ -z "${RUN_ID}" ] || [ "${RUN_ID}" = "null" ]; then
-              echo "::error::No successful CI run found for PR #${{ inputs.pr }} on branch '${BRANCH}'." >>&2
+              echo "::error::No successful CI run found for PR #${{ inputs.pr }} on branch '${BRANCH}'." >&2
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo "### ❌ No successful CI run found" >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo "CI evidence requires a completed \`pull_request\` CI run with **success** conclusion." >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo "To use an override, provide \`run_id\` and \`commit\` inputs manually." >> "${GITHUB_STEP_SUMMARY}"
+              exit 1
+            fi
+
+            # ── Stale-run guard: check latest run on this branch ──
+            LATEST_RUN_JSON=$(gh run list --workflow CI --branch "${BRANCH}" \
+              --limit 1 --json databaseId,conclusion,createdAt \
+              --repo "${{ github.repository }}" 2>&1)
+            LATEST_RUN_ID=$(echo "${LATEST_RUN_JSON}" | jq -r '.[0].databaseId // empty' 2>/dev/null)
+            LATEST_CONCLUSION=$(echo "${LATEST_RUN_JSON}" | jq -r '.[0].conclusion // "unknown"' 2>/dev/null)
+
+            if [ -n "${LATEST_RUN_ID}" ] && [ "${LATEST_RUN_ID}" != "${RUN_ID}" ] && [ "${LATEST_CONCLUSION}" != "success" ]; then
+              echo "::error::Stale CI run detected: latest run #${LATEST_RUN_ID} for branch '${BRANCH}' is '${LATEST_CONCLUSION}', not successful. Selected run #${RUN_ID} pre-dates this. Provide an explicit \`run_id\` override to publish stale evidence." >&2
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "### ❌ Stale CI run" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "Latest run for branch \`${BRANCH}\` is **#${LATEST_RUN_ID}** (${LATEST_CONCLUSION}), but the selected successful run is **#${RUN_ID}**." >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "To publish evidence from an older run anyway, provide \`run_id\` override." >> "${GITHUB_STEP_SUMMARY}"
               exit 1
             fi
 
@@ -139,11 +158,13 @@ jobs:
 
           else
             # ── Auto-resolve path: find ci-test-evidence artifact from the run ──
-            ARTIFACT_NAME=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
-              --jq '[.artifacts[] | select(.name | startswith("ci-test-evidence")) | .name] | .[0] // empty' 2>/dev/null)
+            ARTIFACT_NAMES=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
+              --jq '[.artifacts[] | select(.name | startswith("ci-test-evidence")) | .name]' 2>/dev/null)
 
-            if [ -z "${ARTIFACT_NAME}" ]; then
-              echo "::error::No ci-test-evidence-* artifact found in run ${RUN_ID}. The CI run may not have generated evidence, or the artifact may have expired (retention: 30 days)." >>&2
+            ARTIFACT_COUNT=$(echo "${ARTIFACT_NAMES}" | jq 'length')
+
+            if [ -z "${ARTIFACT_NAMES}" ] || [ "${ARTIFACT_COUNT}" = "0" ]; then
+              echo "::error::No ci-test-evidence-* artifact found in run ${RUN_ID}. The CI run may not have generated evidence, or the artifact may have expired (retention: 30 days)." >&2
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo "### ❌ No evidence artifact found" >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
@@ -151,6 +172,27 @@ jobs:
               echo "Trigger a new CI run, then retry." >> "${GITHUB_STEP_SUMMARY}"
               exit 1
             fi
+
+            if [ "${ARTIFACT_COUNT}" -gt 1 ]; then
+              # Check whether multiple artifacts share the same SHA
+              UNIQUE_SHAS=$(echo "${ARTIFACT_NAMES}" | jq -r '.[] | sub("^ci-test-evidence-"; "")' | sort -u | wc -l)
+              if [ "${UNIQUE_SHAS}" -gt 1 ]; then
+                echo "::error::Ambiguous: ${ARTIFACT_COUNT} ci-test-evidence-* artifacts with distinct SHAs in run ${RUN_ID}. Use \`run_id\` and \`commit\` overrides to select the correct one." >&2
+                echo "" >> "${GITHUB_STEP_SUMMARY}"
+                echo "### ❌ Ambiguous evidence artifacts" >> "${GITHUB_STEP_SUMMARY}"
+                echo "" >> "${GITHUB_STEP_SUMMARY}"
+                echo "Run \`${RUN_ID}\` has ${ARTIFACT_COUNT} \`ci-test-evidence-*\` artifacts with different SHAs:" >> "${GITHUB_STEP_SUMMARY}"
+                echo "${ARTIFACT_NAMES}" | jq -r '.[]' | while read -r name; do
+                  echo "  - \`${name}\`" >> "${GITHUB_STEP_SUMMARY}"
+                done
+                echo "" >> "${GITHUB_STEP_SUMMARY}"
+                echo "Provide explicit \`run_id\` and \`commit\` overrides to disambiguate." >> "${GITHUB_STEP_SUMMARY}"
+                exit 1
+              fi
+            fi
+
+            # Safe: either exactly one artifact, or multiple with the same SHA
+            ARTIFACT_NAME=$(echo "${ARTIFACT_NAMES}" | jq -r '.[0]')
 
             # Extract SHA from artifact name: ci-test-evidence-<sha>
             COMMIT=$(echo "${ARTIFACT_NAME}" | sed 's/^ci-test-evidence-//')

--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -159,7 +159,11 @@ Feature PRs let normal CI generate test evidence artifacts. Do not publish durab
 
 **For CI evidence:** Use the "Publish PR test evidence" workflow — requires only the PR number.
 The workflow resolves the CI run, artifact, and commit SHA automatically.
-See `.docs/agents/test-evidence-workflow.md` for the full flow and manual fallback.
+See \`.docs/agents/test-evidence-workflow.md\` for the full flow and manual fallback.
+
+> **⚠️ PR number, not issue number:** For evidence publishing, \`--pr\` is always the GitHub Pull Request number,
+> not the issue number from \`Closes #N\`. Derive it mechanically: \`gh pr view --json number --jq .number\`.
+> Publishing under the wrong number misroutes dashboard evidence to the wrong PR.
 
 **For on-device evidence:** Requires a physical device run. Do not imply on-device evidence is covered by CI.
 If on-device testing is needed, ask which device tier is required (S21 tracked signal or S23U reference signal)

--- a/scripts/publish_test_evidence.py
+++ b/scripts/publish_test_evidence.py
@@ -132,8 +132,9 @@ def _check_pr_mismatches(
     * Always compares CLI ``--pr`` against each evidence JSON ``pr`` field.
     * When ``detected_pr`` is provided (from ``gh pr view``), also checks
       CLI ``--pr`` against the live PR as an additional safety measure.
-    * ``None`` evidence PRs (unset field) are ignored — not every evidence
-      file carries a ``pr`` field.
+    * ``None`` evidence PRs (unset or null ``pr`` field) are treated as a
+      mismatch when ``cli_pr`` is set — evidence without a PR number should
+      not be published under a PR scope.
     * ``cli_pr is None`` means release-scoped — no PR validation needed.
     """
     if cli_pr is None:
@@ -142,8 +143,13 @@ def _check_pr_mismatches(
     mismatches: list[str] = []
 
     # 1. Direct comparison: CLI --pr vs each evidence JSON pr field
-    known_evidence_prs = {p for p in evidence_prs if p is not None}
-    for evidence_pr in sorted(known_evidence_prs):
+    #    Including None — evidence without a pr field cannot go under PR scope
+    if None in evidence_prs:
+        mismatches.append(
+            f"Evidence JSON pr field is null/missing but CLI --pr={cli_pr}. "
+            f"All evidence files must have a 'pr' field matching the PR being published."
+        )
+    for evidence_pr in sorted(p for p in evidence_prs if p is not None):
         if evidence_pr != cli_pr:
             mismatches.append(
                 f"Evidence JSON pr={evidence_pr} does not match CLI --pr={cli_pr}. "

--- a/scripts/publish_test_evidence.py
+++ b/scripts/publish_test_evidence.py
@@ -119,57 +119,84 @@ def _detect_current_pr_number() -> int | None:
         pass
 
 
-def _validate_pr_number(cli_pr: int | None, evidence_pr: int | None, allow_mismatch: bool) -> None:
-    """Validate PR number consistency.
+def _check_pr_mismatches(
+    cli_pr: int | None,
+    evidence_prs: set[int | None],
+    detected_pr: int | None,
+) -> list[str]:
+    """Check for PR number mismatches.
 
-    When ``gh`` is available and the current branch has an open PR, checks that
-    the CLI ``--pr`` matches both the detected PR number and the evidence JSON
-    ``pr`` field. Exits with a clear error on mismatch unless ``allow_mismatch``
-    is set.
+    Pure function with no side effects — testable directly. Returns a list of
+    human-readable mismatch descriptions. An empty list means no problems.
+
+    * Always compares CLI ``--pr`` against each evidence JSON ``pr`` field.
+    * When ``detected_pr`` is provided (from ``gh pr view``), also checks
+      CLI ``--pr`` against the live PR as an additional safety measure.
+    * ``None`` evidence PRs (unset field) are ignored — not every evidence
+      file carries a ``pr`` field.
+    * ``cli_pr is None`` means release-scoped — no PR validation needed.
     """
     if cli_pr is None:
-        # Release-scoped evidence — no PR validation needed
-        return
-
-    detected = _detect_current_pr_number()
-    if detected is None:
-        # Cannot detect a PR for the current branch — skip validation
-        # (e.g. main branch, no gh available, or no open PR)
-        return
+        return []
 
     mismatches: list[str] = []
 
-    # Compare CLI --pr against detected current PR
-    if cli_pr != detected:
+    # 1. Direct comparison: CLI --pr vs each evidence JSON pr field
+    known_evidence_prs = {p for p in evidence_prs if p is not None}
+    for evidence_pr in sorted(known_evidence_prs):
+        if evidence_pr != cli_pr:
+            mismatches.append(
+                f"Evidence JSON pr={evidence_pr} does not match CLI --pr={cli_pr}. "
+                f"The evidence 'pr' field must match the PR number being published."
+            )
+
+    # 2. Additional local safety: detected PR from gh (when available)
+    if detected_pr is not None and cli_pr != detected_pr:
         mismatches.append(
-            f"CLI --pr={cli_pr} does not match current GitHub PR #{detected}. "
+            f"CLI --pr={cli_pr} does not match current GitHub PR #{detected_pr}. "
             f"The --pr argument must be the actual Pull Request number, "
             f"not a related issue number from Closes #N."
         )
 
-    # Compare evidence JSON pr against detected current PR
-    if evidence_pr is not None and evidence_pr != detected:
-        mismatches.append(
-            f"Evidence JSON pr={evidence_pr} does not match current GitHub PR #{detected}. "
-            f"The evidence 'pr' field must be the actual Pull Request number."
-        )
+    return mismatches
 
-    if mismatches:
-        if allow_mismatch:
-            for msg in mismatches:
-                print(f"WARNING: PR number mismatch (allowed by --allow-pr-mismatch): {msg}")
-            return
 
-        print("ERROR: PR number mismatch detected:", file=sys.stderr)
+
+def _validate_pr_number(cli_pr: int | None, evidence_prs: set[int | None], allow_mismatch: bool) -> None:
+    """Validate PR number consistency.
+
+    Checks that CLI ``--pr`` matches the evidence JSON ``pr`` field(s) from
+    **all** files — this guardrail always runs, even when ``gh pr view`` is
+    unavailable (e.g. GitHub Actions merge checkout).
+
+    When ``gh`` is available *and* the current branch has an open PR, also
+    checks against the detected PR number as an additional safety measure.
+
+    Exits with a clear error on mismatch unless ``allow_mismatch`` is set.
+    """
+    if cli_pr is None:
+        return
+
+    detected = _detect_current_pr_number()
+    mismatches = _check_pr_mismatches(cli_pr, evidence_prs, detected)
+
+    if not mismatches:
+        return
+
+    if allow_mismatch:
         for msg in mismatches:
-            print(f"  {msg}", file=sys.stderr)
-        print(
-            "Use '--allow-pr-mismatch' only for recovery cases "
-            "(e.g. re-publishing evidence after a PR is closed).",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    return None
+            print(f"WARNING: PR number mismatch (allowed by --allow-pr-mismatch): {msg}")
+        return
+
+    print("ERROR: PR number mismatch detected:", file=sys.stderr)
+    for msg in mismatches:
+        print(f"  {msg}", file=sys.stderr)
+    print(
+        "Use '--allow-pr-mismatch' only for recovery cases "
+        "(e.g. re-publishing evidence after a PR is closed).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 # ── Schema validation (lightweight, no external deps) ──────────────────────────
@@ -696,17 +723,19 @@ def main() -> None:
     # Collect and validate input files
     files = _collect_input_files(args)
 
-    # Find JSON evidence file for validation
+    # Find JSON evidence files for validation
     json_files: list[Path] = [f for f in files if f.suffix == ".json"]
     data: dict | None = None
+    evidence_prs: set[int | None] = set()
     for json_file in json_files:
-        data = _validate_evidence_file(json_file, args)
+        ev_data = _validate_evidence_file(json_file, args)
+        evidence_prs.add(ev_data.get("pr") if ev_data else None)
+        data = ev_data  # Keep last for output path building
 
     # Validate PR number consistency (guard against issue vs PR number confusion)
-    evidence_pr = data.get("pr") if data else None
     _validate_pr_number(
         cli_pr=args.pr,
-        evidence_pr=evidence_pr,
+        evidence_prs=evidence_prs,
         allow_mismatch=args.allow_pr_mismatch,
     )
 

--- a/scripts/publish_test_evidence.py
+++ b/scripts/publish_test_evidence.py
@@ -97,6 +97,80 @@ def _get_remote_url() -> str:
         _DEFAULT_REMOTE_URL = f"https://github.com/{REPO}.git"
     return _DEFAULT_REMOTE_URL
 
+def _detect_current_pr_number() -> int | None:
+    """Detect the current GitHub PR number for the active branch.
+
+    Uses ``gh pr view`` on the repository checkout. Returns None when:
+    - ``gh`` is not installed
+    - The current branch has no open PR
+    - The command times out or fails for any other reason
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number", "--jq", ".number"],
+            capture_output=True, text=True, timeout=5,
+            cwd=HERE,
+        )
+        if result.returncode == 0:
+            text = result.stdout.strip()
+            if text:
+                return int(text)
+    except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+
+def _validate_pr_number(cli_pr: int | None, evidence_pr: int | None, allow_mismatch: bool) -> None:
+    """Validate PR number consistency.
+
+    When ``gh`` is available and the current branch has an open PR, checks that
+    the CLI ``--pr`` matches both the detected PR number and the evidence JSON
+    ``pr`` field. Exits with a clear error on mismatch unless ``allow_mismatch``
+    is set.
+    """
+    if cli_pr is None:
+        # Release-scoped evidence — no PR validation needed
+        return
+
+    detected = _detect_current_pr_number()
+    if detected is None:
+        # Cannot detect a PR for the current branch — skip validation
+        # (e.g. main branch, no gh available, or no open PR)
+        return
+
+    mismatches: list[str] = []
+
+    # Compare CLI --pr against detected current PR
+    if cli_pr != detected:
+        mismatches.append(
+            f"CLI --pr={cli_pr} does not match current GitHub PR #{detected}. "
+            f"The --pr argument must be the actual Pull Request number, "
+            f"not a related issue number from Closes #N."
+        )
+
+    # Compare evidence JSON pr against detected current PR
+    if evidence_pr is not None and evidence_pr != detected:
+        mismatches.append(
+            f"Evidence JSON pr={evidence_pr} does not match current GitHub PR #{detected}. "
+            f"The evidence 'pr' field must be the actual Pull Request number."
+        )
+
+    if mismatches:
+        if allow_mismatch:
+            for msg in mismatches:
+                print(f"WARNING: PR number mismatch (allowed by --allow-pr-mismatch): {msg}")
+            return
+
+        print("ERROR: PR number mismatch detected:", file=sys.stderr)
+        for msg in mismatches:
+            print(f"  {msg}", file=sys.stderr)
+        print(
+            "Use '--allow-pr-mismatch' only for recovery cases "
+            "(e.g. re-publishing evidence after a PR is closed).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return None
+
 
 # ── Schema validation (lightweight, no external deps) ──────────────────────────
 
@@ -336,6 +410,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--allow-commit-mismatch",
         action="store_true",
         help="Skip commit SHA consistency check",
+    )
+    parser.add_argument(
+        "--allow-pr-mismatch",
+        action="store_true",
+        help=(
+            "Skip PR number consistency check with current GitHub PR. "
+            "Only use this for recovery cases (e.g. re-publishing evidence "
+            "after a PR is closed)."
+        ),
     )
 
     args = parser.parse_args(argv)
@@ -618,6 +701,14 @@ def main() -> None:
     data: dict | None = None
     for json_file in json_files:
         data = _validate_evidence_file(json_file, args)
+
+    # Validate PR number consistency (guard against issue vs PR number confusion)
+    evidence_pr = data.get("pr") if data else None
+    _validate_pr_number(
+        cli_pr=args.pr,
+        evidence_pr=evidence_pr,
+        allow_mismatch=args.allow_pr_mismatch,
+    )
 
     # Build output path mapping
     mapping = _build_output_paths(files, args, data)

--- a/scripts/tests/test_publish_pr_validation.py
+++ b/scripts/tests/test_publish_pr_validation.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Tests for PR number validation guardrail in publish_test_evidence.py.
+
+Covers the pure ``_check_pr_mismatches()`` function (no side effects).
+``_validate_pr_number()`` is tested via a lightweight wrapper that captures
+``sys.exit`` — the exit path is the critical behaviour difference between
+``--allow-pr-mismatch`` and its absence.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Import the module-under-test via its file path
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import publish_test_evidence as pte
+
+
+class CheckPrMismatchesTest(unittest.TestCase):
+    """Tests for the pure _check_pr_mismatches() function."""
+
+    # ── Release mode (cli_pr is None) ──────────────────────────────────────
+
+    def test_release_mode_returns_empty(self) -> None:
+        """cli_pr=None (release-scoped) → no mismatches regardless of evidence."""
+        self.assertEqual(pte._check_pr_mismatches(None, {1171}, None), [])
+        self.assertEqual(pte._check_pr_mismatches(None, set(), 1171), [])
+        self.assertEqual(pte._check_pr_mismatches(None, {1154, 1160}, 1171), [])
+
+    # ── No mismatches ──────────────────────────────────────────────────────
+
+    def test_no_evidence_files_ok(self) -> None:
+        """No evidence PRs and no detected PR → empty list."""
+        self.assertEqual(pte._check_pr_mismatches(1171, set(), None), [])
+
+    def test_all_evidence_match(self) -> None:
+        """Single evidence PR matches cli_pr, no detected PR."""
+        self.assertEqual(pte._check_pr_mismatches(1171, {1171}, None), [])
+
+    def test_multiple_evidence_all_match(self) -> None:
+        """Multiple evidence PRs all matching cli_pr."""
+        self.assertEqual(
+            pte._check_pr_mismatches(1171, {1171, 1171, None}, None),
+            [],
+        )
+
+    def test_detected_pr_matches_no_evidence(self) -> None:
+        """detected_pr matches cli_pr, no evidence PRs → ok."""
+        self.assertEqual(pte._check_pr_mismatches(1171, set(), 1171), [])
+
+    def test_everything_matches(self) -> None:
+        """cli_pr, evidence_prs, and detected_pr all agree."""
+        self.assertEqual(
+            pte._check_pr_mismatches(1171, {1171, 1171}, 1171),
+            [],
+        )
+
+    # ── Single mismatch: evidence ──────────────────────────────────────────
+
+    def test_evidence_mismatch(self) -> None:
+        """Single evidence PR differs from cli_pr."""
+        mismatches = pte._check_pr_mismatches(1171, {1154}, None)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("1154", mismatches[0])
+        self.assertIn("1171", mismatches[0])
+
+    def test_evidence_mismatch_with_none_prs(self) -> None:
+        """None evidence PRs are ignored; only the real mismatch surfaces."""
+        mismatches = pte._check_pr_mismatches(1171, {None, 1154, None}, None)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("1154", mismatches[0])
+
+    def test_multiple_evidence_mismatches(self) -> None:
+        """Multiple evidence PRs, none matching cli_pr."""
+        mismatches = pte._check_pr_mismatches(1171, {1154, 1160}, None)
+        self.assertEqual(len(mismatches), 2)
+        self.assertIn("1154", mismatches[0])
+        self.assertIn("1160", mismatches[1])
+
+    def test_mixed_evidence_match_and_mismatch(self) -> None:
+        """Some evidence matches, some doesn't — only mismatches reported."""
+        mismatches = pte._check_pr_mismatches(1171, {1171, 1154}, None)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("1154", mismatches[0])
+
+    # ── Single mismatch: detected PR ───────────────────────────────────────
+
+    def test_detected_pr_mismatch_only(self) -> None:
+        """detected_pr differs from cli_pr, no evidence PR → mismatch."""
+        mismatches = pte._check_pr_mismatches(1171, set(), 1154)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("1171", mismatches[0])
+        self.assertIn("1154", mismatches[0])
+
+    # ── Both mismatches ────────────────────────────────────────────────────
+
+    def test_both_evidence_and_detected_mismatch(self) -> None:
+        """Both evidence PR and detected PR differ from cli_pr."""
+        mismatches = pte._check_pr_mismatches(1171, {1154}, 1160)
+        self.assertEqual(len(mismatches), 2)
+        self.assertIn("1154", mismatches[0])
+        self.assertIn("1160", mismatches[1])
+
+    # ── Edge cases ─────────────────────────────────────────────────────────
+
+    def test_none_evidence_prs_removed(self) -> None:
+        """None entries in evidence_prs set are filtered out."""
+        mismatches = pte._check_pr_mismatches(1171, {None, None}, None)
+        self.assertEqual(mismatches, [])
+
+
+class ValidatePrNumberTest(unittest.TestCase):
+    """Tests for _validate_pr_number() — uses capture to avoid sys.exit.
+
+    We inject a _detect_current_pr_number that returns a known value so the
+    gh-dependent path is deterministic.
+    """
+
+    def setUp(self) -> None:
+        self._orig_detect = pte._detect_current_pr_number
+
+    def tearDown(self) -> None:
+        pte._detect_current_pr_number = self._orig_detect
+        pte._check_pr_mismatches = pte._check_pr_mismatches  # restore
+
+    # ── Success paths ──────────────────────────────────────────────────────
+
+    def test_release_mode_no_validation(self) -> None:
+        """cli_pr=None → returns without checking anything."""
+        pte._detect_current_pr_number = lambda: 999  # would mismatch, but unreachable
+        pte._validate_pr_number(None, {1171}, allow_mismatch=False)
+        # No exception = pass
+
+    def test_no_mismatch_quiet_return(self) -> None:
+        """All evidence PRs match → returns without messages."""
+        pte._detect_current_pr_number = lambda: None
+        pte._validate_pr_number(1171, {1171}, allow_mismatch=False)
+        # No exception = pass
+
+    # ── Mismatch → sys.exit ────────────────────────────────────────────────
+
+    def test_evidence_mismatch_exits(self) -> None:
+        """Evidence PR differs from --pr; allow_mismatch=False → sys.exit(1)."""
+        pte._detect_current_pr_number = lambda: None
+        with self.assertRaises(SystemExit) as ctx:
+            pte._validate_pr_number(1171, {1154}, allow_mismatch=False)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_detected_mismatch_exits(self) -> None:
+        """detected PR differs from --pr; allow_mismatch=False → sys.exit(1)."""
+        pte._detect_current_pr_number = lambda: 1154
+        with self.assertRaises(SystemExit) as ctx:
+            pte._validate_pr_number(1171, {1171}, allow_mismatch=False)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_dual_mismatch_exits(self) -> None:
+        """Both evidence and detected mismatch → sys.exit(1)."""
+        pte._detect_current_pr_number = lambda: 1154
+        with self.assertRaises(SystemExit) as ctx:
+            pte._validate_pr_number(1171, {1160}, allow_mismatch=False)
+        self.assertEqual(ctx.exception.code, 1)
+
+    # ── Mismatch + --allow-pr-mismatch → warning, no exit ──────────────────
+
+    def test_mismatch_allowed_does_not_exit(self) -> None:
+        """allow_mismatch=True → warning printed, no exit."""
+        pte._detect_current_pr_number = lambda: 1154
+        # Should not raise SystemExit
+        pte._validate_pr_number(1171, {1160}, allow_mismatch=True)
+        # No exception = pass
+
+    def test_detected_mismatch_allowed_does_not_exit(self) -> None:
+        """detected mismatch with allow_mismatch → warning, no exit."""
+        pte._detect_current_pr_number = lambda: 1154
+        pte._validate_pr_number(1171, set(), allow_mismatch=True)
+        # No exception = pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_publish_pr_validation.py
+++ b/scripts/tests/test_publish_pr_validation.py
@@ -45,7 +45,7 @@ class CheckPrMismatchesTest(unittest.TestCase):
     def test_multiple_evidence_all_match(self) -> None:
         """Multiple evidence PRs all matching cli_pr."""
         self.assertEqual(
-            pte._check_pr_mismatches(1171, {1171, 1171, None}, None),
+            pte._check_pr_mismatches(1171, {1171, 1171}, None),
             [],
         )
 
@@ -70,10 +70,12 @@ class CheckPrMismatchesTest(unittest.TestCase):
         self.assertIn("1171", mismatches[0])
 
     def test_evidence_mismatch_with_none_prs(self) -> None:
-        """None evidence PRs are ignored; only the real mismatch surfaces."""
+        """None evidence PRs are also mismatches alongside real mismatches."""
         mismatches = pte._check_pr_mismatches(1171, {None, 1154, None}, None)
-        self.assertEqual(len(mismatches), 1)
-        self.assertIn("1154", mismatches[0])
+        self.assertEqual(len(mismatches), 2, "Should report None mismatch + 1154 mismatch")
+        self.assertTrue(any("null/missing" in m and "1171" in m for m in mismatches),
+                        f"Expected null evidence mismatch, got: {mismatches}")
+        self.assertTrue(any("1154" in m for m in mismatches))
 
     def test_multiple_evidence_mismatches(self) -> None:
         """Multiple evidence PRs, none matching cli_pr."""
@@ -104,14 +106,18 @@ class CheckPrMismatchesTest(unittest.TestCase):
         mismatches = pte._check_pr_mismatches(1171, {1154}, 1160)
         self.assertEqual(len(mismatches), 2)
         self.assertIn("1154", mismatches[0])
-        self.assertIn("1160", mismatches[1])
+    def test_null_evidence_mismatch(self) -> None:
+        """None evidence PR with cli_pr set → mismatch reported."""
+        mismatches = pte._check_pr_mismatches(1171, {None}, None)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("null/missing", mismatches[0])
+        self.assertIn("1171", mismatches[0])
 
-    # ── Edge cases ─────────────────────────────────────────────────────────
-
-    def test_none_evidence_prs_removed(self) -> None:
-        """None entries in evidence_prs set are filtered out."""
-        mismatches = pte._check_pr_mismatches(1171, {None, None}, None)
-        self.assertEqual(mismatches, [])
+    def test_null_evidence_with_other_matches(self) -> None:
+        """Mix of matching and null evidence → only null reported as mismatch."""
+        mismatches = pte._check_pr_mismatches(1171, {1171, None, 1171}, None)
+        self.assertEqual(len(mismatches), 1)
+        self.assertIn("null/missing", mismatches[0])
 
 
 class ValidatePrNumberTest(unittest.TestCase):
@@ -164,6 +170,12 @@ class ValidatePrNumberTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             pte._validate_pr_number(1171, {1160}, allow_mismatch=False)
         self.assertEqual(ctx.exception.code, 1)
+    def test_null_evidence_exits(self) -> None:
+        """Null evidence PR with cli_pr; allow_mismatch=False → sys.exit(1)."""
+        pte._detect_current_pr_number = lambda: None
+        with self.assertRaises(SystemExit) as ctx:
+            pte._validate_pr_number(1171, {None}, allow_mismatch=False)
+        self.assertEqual(ctx.exception.code, 1)
 
     # ── Mismatch + --allow-pr-mismatch → warning, no exit ──────────────────
 
@@ -178,6 +190,11 @@ class ValidatePrNumberTest(unittest.TestCase):
         """detected mismatch with allow_mismatch → warning, no exit."""
         pte._detect_current_pr_number = lambda: 1154
         pte._validate_pr_number(1171, set(), allow_mismatch=True)
+        # No exception = pass
+    def test_null_evidence_allowed_does_not_exit(self) -> None:
+        """Null evidence with allow_mismatch → warning, no exit."""
+        pte._detect_current_pr_number = lambda: None
+        pte._validate_pr_number(1171, {None}, allow_mismatch=True)
         # No exception = pass
 
 


### PR DESCRIPTION
Closes #1169
Closes #1170

## Summary

Harden the PR-aware test evidence publishing path so agents can safely use the PR-number-first workflow by default. Combines two related issues into one focused PR.

## Changes

### Issue #1169 — PR number safety

**Review fix: null evidence PR now fails under PR scope:**
Evidence JSON with `"pr": null` is no longer silently ignored when `--pr` is set. Previously, `None` values in `evidence_prs` were filtered out before comparison — evidence that says "not PR-scoped" could be published under `results/pr/<number>/...`. Now `None` is treated as a mismatch: every evidence file must have a matching `pr` field when publishing under a PR scope. `--allow-pr-mismatch` bypasses this check.

**Publisher guardrail (`scripts/publish_test_evidence.py`):**
- Added `--allow-pr-mismatch` flag (opt-out, recovery only).
- Added `_detect_pr_number()` — detects current GitHub PR via `gh pr view` (local-only safety).
- Added `_check_pr_mismatches()` — pure function that always compares every evidence JSON `pr` field against CLI `--pr`. This runs even when `gh pr view` is unavailable (e.g. GitHub Actions merge checkout), closing the original bypass.
- Rewrote `_validate_pr_number()` to call `_check_pr_mismatches()`, using `gh pr view` only as an additional local safety check rather than the sole validation mechanism.
- **Directory mode now validates ALL JSON evidence files**, not just whichever was parsed last. Collects PR numbers from every file and fails if any evidence `pr` mismatches CLI `--pr`.
- `--allow-pr-mismatch` bypasses either mismatch path (evidence-vs-CLI or detected-vs-CLI).

**Tests (`scripts/tests/test_publish_pr_validation.py`):** 23 tests covering:
- Release mode (cli_pr=None → no validation)
- All evidence PRs match → success
- Single and multiple evidence mismatches → error
- `pr: null` with `--pr` → error (NEW — previous gap)
- `pr: null` with `--pr` + `--allow-pr-mismatch` → warning (NEW)
- Detected PR mismatch → error
- Combined evidence + detected mismatches → both reported
- `--allow-pr-mismatch` bypass for all mismatch types

**Agent documentation:**
- Added "PR number vs issue number" section to `.docs/agents/test-evidence-workflow.md` with table, mechanical discovery commands, and story behind the rule.
- Added `.omp/AGENTS.md` high-visibility warning block.
- Added PR evidence metadata checklist for PR bodies.

### Issue #1170 — Workflow hardening

**Shell syntax fix:**
- Replaced `>>&2` with `>&2` in two failure paths (invalid bash syntax → shell error instead of intended error message).

**Workflow permissions tightened:**
- From `contents: write` to `contents: write, actions: read, pull-requests: read`.

**Multiple artifact handling:**
- Auto-resolve path now detects multiple `ci-test-evidence-*` artifacts.
- If multiple distinct SHAs exist, fails with clear ambiguous-artifact error showing all found artifacts.
- If multiple artifacts share the same SHA, picks the first (safe).

**Stale CI run guard:**
- After resolving the latest successful CI run, checks the latest overall run (any status) for the same branch.
- If the latest run is newer and not successful, fails with a stale-run error.
- Override path (`run_id` input) bypasses this check entirely.

**Relative documentation links fixed:**
- `.github/workflows/publish-pr-test-evidence.yml` → `../../.github/workflows/...`
- `.github/workflows/publish-test-evidence.yml` → `../../.github/workflows/...`

## Validation

| Check | Result |
|-------|--------|
| Publisher `py_compile` | ✅ |
| All Python scripts compile | ✅ |
| YAML parses (GH Actions parser) | ✅ |
| `_detect_pr_number()` returns None on `main` | ✅ |
| `_validate_pr_number()` skips for release scope | ✅ |
| `>>&2` → `>&2` (2 occurrences) | ✅ Fixed |
| Permissions: explicit read set | ✅ Set |
| Relative links fixed | ✅ Fixed |
| **Review fix: evidence PR vs CLI --pr (no gh) — match** | ✅ |
| **Review fix: evidence PR vs CLI --pr (no gh) — mismatch → exit 1** | ✅ |
| **Review fix: evidence PR vs CLI --pr — --allow-pr-mismatch bypass** | ✅ |
| **Review fix: directory mode validates ALL JSON files** | ✅ |
| **Review fix: single-file mode mismatch → exit 1** | ✅ |
| **Review fix: pr:null with --pr → exit 1** | ✅ |
| **Review fix: pr:null with --pr + --allow-pr-mismatch → warning** | ✅ |
| **Unit tests (23 tests)** | ✅ All pass |

## Reviewer notes

**Do not merge** without explicit review and approval. This PR is hardening-only — it adds guardrails and safety checks without changing normal UX. The normal path remains PR-number-only for agents.

Previous review requested changes to the guardrail logic: the original implementation only validated when `gh pr view` returned a detected PR, which silently skipped in GitHub Actions (merge checkout). Fixed by extracting a pure comparison function that always runs, with `gh pr view` as an additional check.

Second review requested that `pr: null` evidence fail under PR scope — previously silently ignored. Now treated as a mismatch.

**CI run `#27254048237` is in progress for the current head `4c22a8d7` — wait for it to complete before merging.**