### PR TITLE
docs(#1186): add S21-first ADB QIR triage report

### DIFF
--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `6d463236` — triage evidence + review fixes applied (updated with post-permission rerun and S23U comparison) |
+| Latest commit | `faad35eb` — add post-permission S21 rerun evidence, S23U comparison, follow-up issue tracking |
 
 ## Device Preconditions
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -1,0 +1,274 @@
+# ADB S21 QIR/Router Triage Report — 2026-06-11
+
+## Meta
+
+| Field | Value |
+|---|---|
+| Issue | [#1186 — Prioritise S21 QIR triage after harness observability fix](https://github.com/NickMonrad/kernel-ai-assistant/issues/1186) |
+| PR | [docs(#1186): add S21-first ADB QIR triage report](https://github.com/NickMonrad/kernel-ai-assistant/pull/1187) |
+| Date | 2026-06-11 |
+| Commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
+| Harness fix | PR [#1181](https://github.com/NickMonrad/kernel-ai-assistant/pull/1181) — merged, fixed ADB-TLS logcat corruption and multi-word shell quoting |
+
+## Device Preconditions
+
+| Field | Value |
+|---|---|
+| Serial | `R5CR605B71K` |
+| Model | SM-G991B (Samsung Galaxy S21, Exynos) |
+| Android | 15 (API 35) — SDK target 36 |
+| USB connection | ✅ `device` |
+| App package | `com.kernel.ai.debug` v0.1.0 (code 1) |
+| Screen unlocked | ✅ (timeout extended to 30 min) |
+| Oracle preflight | ✅ passed (fresh-probe bounded marker) |
+| Stream health | ✅ passed |
+| Model warmup | ✅ `ready` (one run), ⚠ `timeout` (other runs — model not ready within 120s) |
+| Pre-#1181 evidence | 🚫 **All invalid** — universal false NO_MATCH from broken logcat pipeline |
+
+## Commands Run
+
+```bash
+# Phase 0 — dry-run selectors
+python3 scripts/adb_skill_test.py --dry-run --tags safe_smoke --exclude-tags destructive,device_state
+python3 scripts/adb_skill_test.py --dry-run --tags deterministic_core --exclude-tags destructive,device_state
+python3 scripts/adb_skill_test.py --dry-run --categories slot_fill --exclude-tags destructive,device_state
+
+# Phase 1 — device metadata
+adb -s R5CR605B71K shell getprop ro.product.model
+adb -s R5CR605B71K shell getprop ro.build.version.release
+adb -s R5CR605B71K shell dumpsys package com.kernel.ai.debug | grep -E "versionName|versionCode|debuggable"
+
+# Phase 2 — harness trust check (safe_smoke)
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
+  python3 scripts/adb_skill_test.py --tags safe_smoke --exclude-tags destructive,device_state
+
+# Phase 3a — deterministic core
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
+  python3 scripts/adb_skill_test.py --tags deterministic_core --exclude-tags destructive,device_state
+
+# Phase 3b — slot_fill
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
+  python3 scripts/adb_skill_test.py --categories slot_fill --exclude-tags destructive,device_state
+```
+
+## Bug Fix Applied During Triage
+
+During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_add_to_list`) due to an `AttributeError` in `models.py: _observed_expected_failure()` — the function referenced `r.expect_log_contains` which was not a field on `TestResult`. Fixed in:
+
+- Added `expect_log_contains: str | None = None` to `TestResult` dataclass (models.py)
+- Added `expect_log_contains=tc.expect_log_contains` to TestResult construction (runners.py)
+
+## Results Summary
+
+### safe_smoke (7 tests)
+
+| Result | Count |
+|---|---|
+| ✅ Pass | 4 |
+| ❌ Fail | 3 |
+| ⏭ Xfail | 0 |
+
+**Evidence:** `scripts/test-reports/2026-06-11T20-55-18Z_skills.json`
+
+| # | Prompt | Expected | Actual | Bucket |
+|---|---|---|---|---|
+| 1 | "set an alarm for 11pm" | set_alarm | set_alarm ✅ | — |
+| 2 | "set a timer for 2 hours" | set_timer | set_timer ✅ | — |
+| 3 | "remember that I prefer dark mode" | save_memory | save_memory ✅ | — |
+| 4 | "what time is it" | get_time | **save_memory** ❌ | wrong_tool |
+| 5 | "what's my battery level" | get_battery | get_battery ✅ | — |
+| 6 | "set an alarm" | set_alarm | **get_battery** ❌ | wrong_tool |
+| 7 | "set a timer" | set_timer | set_timer (params: got '7am') ❌ | slot_fill_issue |
+
+### deterministic_core (76 tests)
+
+| Result | Count |
+|---|---|
+| ✅ Pass | 25 |
+| ❌ Fail | 46 |
+| ⏭ Xfail | 5 |
+
+**Evidence:** `scripts/test-reports/2026-06-11T22-11-20Z_skills.json`
+
+### slot_fill (6 tests)
+
+| Result | Count |
+|---|---|
+| ✅ Pass | 0 |
+| ❌ Fail | 6 |
+| ⏭ Xfail | 0 |
+
+**Evidence:** `scripts/test-reports/2026-06-11T22-17-41Z_skills.json`
+
+## Failure Classification by Root-Cause Bucket
+
+### 1. Model "Stuck Mode" / Inference Cascade Failure — 38/46 core fails
+
+The deterministic_core run reveals the model returns the **same intent** for long consecutive blocks:
+
+| Block | Tests | Dominant Intent | Expected Intents | Count |
+|---|---|---|---|---|
+| 1–7 | alarm set/reminder | `add_to_list` | set_alarm, add_reminder | 7 |
+| 8–27 | alarm/timer/cancel | `set_alarm` | add_reminder, cancel_alarm, set_timer, cancel_timer, list_timers, cancel_timer_named | 20 |
+| 28–32 | timer named/remaining | `cancel_alarm` | cancel_timer_named, get_timer_remaining | 5 |
+| 33–39 | timer remaining/weather | `set_timer` | get_timer_remaining, get_weather | 7 |
+| 40–44 | lists/weather | `cancel_timer` | add_to_list, bulk_add_to_list, get_weather | 5 |
+
+After test 46 (45 minutes into the run), the lists phase from case 47 onward mostly passes (18/23 pass) and smart_home passes perfectly (5/5), memory mostly passes (2/3).
+
+**Assessment:** The model appears to require a clean cold-start inference per test or a model-reset between phases. When tests run back-to-back, the inference engine enters a stuck state where it returns the last-used or an incorrect dominant intent. This is likely a model inference reliability / session management issue rather than a routing logic bug.
+
+**Bucket:** `android_platform_constraint` (inference stall) / `unknown_needs_manual_review`
+
+### 2. Location permission not configured — 7/46 core fails
+
+All 7 weather tests fail with `location_or_permission_missing`:
+
+| # | Prompt | Expected | Actual |
+|---|---|---|---|
+| 34–40 | "what's the weather in Auckland" etc | get_weather | set_timer / cancel_timer |
+
+**Assessment:** Location permission needs to be granted or mock location provider configured on the device. These are not QIR issues.
+
+**Bucket:** `device_precondition_issue`
+
+### 3. Slot-fill extraction failures — 6/6 slot_fill fails
+
+All 6 slot_fill tests fail. Key observations:
+
+- "set an alarm" → correct intent `set_alarm` but **empty** params (missing hours, minutes)
+- "set a timer" → **wrong intent** `cancel_timer`
+- "open an app" → correct intent `open_app` but param = `'5 minutes'` (pipelines slot-fill response from wrong context)
+- "send a message" → **wrong intent** `open_app`
+- "send an email" → **wrong intent** `open_app`
+- "add to my list" → correct intent `add_to_list` but param = `'sunscreen'` (from previous test context)
+
+**Assessment:** The slot-fill conversation flow appears contaminated by prior test context. When the app asks "Which app?" and user responds "Spotify", the slot extractor returns values from unrelated earlier conversations. This may be a model session persistence issue (KV cache not cleared between tests) or a slot-fill pipeline bug.
+
+**Bucket:** `slot_fill_issue` / `native_tool_handler_issue`
+
+### 4. Wrong tool on first test after phase change — 3/76 safe_smoke fails
+
+In the safe_smoke run (which had fresh app warmup), case 4 "what time is it" → `save_memory` and case 6 "set an alarm" (slot fill) → `get_battery`. These are not consecutive-context contamination since the run starts fresh.
+
+**Assessment:** Real QIR router misclassifications on the S21.
+
+**Bucket:** `minilm_classifier_miss` / `qir_regex_miss`
+
+### 5. Param extraction: "set a timer" → expects '300' but got '7am' — appearing in multiple runs
+
+In both safe_smoke (case 7) and slot_fill (case 2), the prompt "set a timer" with slot reply "5 minutes" produces `duration_seconds='7am'` instead of `'300'`. The value '7am' appears repeatedly, suggesting alarm context contamination.
+
+**Bucket:** `slot_fill_issue`
+
+### 6. save_memory → save_important_date — 1/76 core fail
+
+Case 76 "remember that I parked on level 3" → `save_important_date` (expected `save_memory`). This is a novel intent classifier routing that treats location-specific memory as an important date.
+
+**Bucket:** `qir_regex_miss` (QIR regex for save_memory didn't match, MiniLM classified as save_important_date)
+
+## Standing
+
+### Invalidated pre-#1181 evidence
+
+All `NO_MATCH` / `regex_or_qir_miss` failures from earlier S21 and S23U runs (before PR #1181 merge at commit `13833fac`) are **invalid**. The logcat pipeline corruption (`adb logcat -c` on ADB-TLS) caused universal false negatives.
+
+### Harness trustworthiness
+
+The harness is now trustworthy:
+- ✅ Oracle uses fresh-probe-bounded logcat capture
+- ✅ Stream health check verifies persistent stream delivers lines
+- ✅ All failures carry concrete intent/param mismatch labels, not NO_MATCH
+- ✅ py_compile and dry-run selectors all pass
+
+### Harness bug found and fixed during triage
+
+- Fixed `AttributeError: 'TestResult' object has no attribute 'expect_log_contains'` in `models.py: _observed_expected_failure()`
+
+## Proposed Follow-Up Issues
+
+### Draft 1: Model inference reliability — cascade failure under sequential test load
+
+**Title:** Model returns same dominant intent for consecutive ADB harness test cases
+
+**Body:**
+```
+The S21 Exynos inference engine exhibits a "stuck mode" behaviour where the same
+intent (e.g. `add_to_list` or `set_alarm`) is returned for 5–20 consecutive test
+cases regardless of the prompt. This occurs approximately 45 minutes into a
+deterministic_core run and eventually resolves after ~2 phases.
+
+Affected: ~38/76 deterministic_core test cases
+
+Proposed investigation:
+1. Add a model-reset or per-test force-stop to the harness to test whether clean
+   inference state per case resolves the issue.
+2. Log LiteRT inference time per case to identify when the model is stalling.
+3. Check whether `InferenceLoadingService` `ForegroundServiceStartNotAllowedException`
+   correlates with stuck-mode phases.
+```
+
+### Draft 2: Slot-fill extraction contamination
+
+**Title:** Slot-fill extractor returns values from unrelated prior context
+
+**Body:**
+```
+When the slot-fill flow asks "Which app?" and user responds "Spotify", the
+parameter extractor sometimes returns '5 minutes' or '7am' instead of 'Spotify'.
+
+Affected: all 6 slot_fill tests (including "set a timer" → duration '7am')
+
+Proposed investigation:
+1. Check whether KV cache is cleared between slot-fill turns.
+2. Check whether the conversation history from prior test cases leaks into the
+   slot extractor prompt.
+```
+
+### Draft 3: Location permission not granted on S21
+
+**Title:** Weather tests fail with location_or_permission_missing on S21
+
+**Body:**
+```
+All 7 weather tests fail with location_or_permission_missing because the S21
+device does not have location permission granted or a mock location provider
+configured.
+
+Fix: Add location permission grant to device precondition setup, or configure
+a mock location provider for the weather fixture.
+```
+
+### Draft 4: save_memory → save_important_date QIR gap
+
+**Title:** "remember that I parked on level 3" routes to save_important_date instead of save_memory
+
+**Body:**
+```
+When the prompt contains both a memory verb ("remember") and a location
+("level 3"), the QIR router selects save_important_date over save_memory.
+
+Affected: case id:remember_that_i_parked_on_level_3
+
+Proposed fix: Adjust QIR regex patterns to prefer save_memory when the prompt
+starts with "remember that I ..." regardless of location nouns.
+```
+
+## Recommended Next Action
+
+1. **Fix the `models.py` harness crash** — ✅ already done in this session
+2. **Investigate model stuck-mode** — highest impact, affects 50%+ of deterministic tests on S21
+3. **Fix slot-fill contamination** — affects all slot-fill coverage
+4. **Configure location permission** — unblocks 7 weather tests
+5. **Do not create QIR/router issues from pre-#1181 data** — all that evidence is invalid
+
+## Evidence Files
+
+| Path | Size | Description |
+|---|---|---|
+| `scripts/test-reports/2026-06-11T20-55-18Z_skills.json` | ~4 KB | safe_smoke results |
+| `scripts/test-reports/2026-06-11T22-11-20Z_skills.json` | ~12 KB | deterministic_core results |
+| `scripts/test-reports/2026-06-11T22-17-41Z_skills.json` | ~3 KB | slot_fill results |
+| `/home/lokhor/.local/share/rtk/tee/1781211323_test.log` | ~2 KB | safe_smoke raw log |
+| `/home/lokhor/.local/share/rtk/tee/1781215886_test.log` | ~9 KB | deterministic_core raw log |
+| `/home/lokhor/.local/share/rtk/tee/1781216267_test.log` | ~1 KB | slot_fill raw log |

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `d83080f8` — report + harness crash fix |
+| Latest commit | `dbb0d53b` — triage evidence + review fixes applied |
 
 ## Device Preconditions
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `faad35eb` — add post-permission S21 rerun evidence, S23U comparison, follow-up issue tracking |
+| Latest commit | `5c1b205e` — add post-permission S21 rerun evidence, S23U comparison, follow-up issue tracking |
 
 ## Device Preconditions
 
@@ -230,22 +230,22 @@ ANDROID_SERIAL=100.76.134.49:36991 ADB_WAIT_SECONDS=20 python3 scripts/adb_skill
 | 1 | "set an alarm for 11pm" | `set_alarm` | `set_alarm` ✅ | |
 | 2 | "set a timer for 2 hours" | `set_timer` | `timer` (wrong tool) | `timer` is not a recognised intent |
 | 3 | "remember that I prefer dark mode" | `save_memory` | `save_memory` ✅ | |
-| 4 | "what time is it" | `get_time` | `save_memory` | No memory content leak — just wrong intent |
+| 4 | "what time is it" | `get_time` | `save_memory` | Content `I prefer dark mode` leaked from case 3 |
 | 5 | "what's my battery level" | `get_battery` | `get_battery` ✅ | |
 | 6 | "set an alarm" (slot) | `set_alarm` | `set_timer` | Slot-fill starts with wrong intent |
-| 7 | "set a timer" (slot) | `set_timer` | `save_memory` | Slot-fill cascade continues |
+| 7 | "set a timer" (slot) | `set_timer` | `save_memory` | Content `I prefer dark mode` leaked from case 3 persists |
 
 ### Key findings
 
 | Issue | S21 (USB, post-fix) | S23U (TCP) | Reproduces? |
 |---|---|---|---|
-| Stuck-mode / state carryover | 3-case blocks in alarm_timer | Cases 2→3→4 show intent drift but NOT the memory-content leak pattern | **Yes, different shape** |
-| Memory content leak (case 3→4) | Original: literal content leak. Post-fix: both stuck on `set_timer` | Case 4 → `save_memory` but **without** case 3's literal content | **Partially** — intent carryover yes, content leak not reproduced on S23U |
+| Stuck-mode / state carryover | 3-case blocks in alarm_timer | Cases 2→3→4 show intent drift with content carryover | **Yes** — same pattern, S23U also leaks content through multiple cases |
+| Memory content leak (case 3→4) | Original: literal content leak. Post-fix: both stuck on `set_timer` | Case 4 → `save_memory` **with** case 3's literal content (`I prefer dark mode`); case 7 also contaminated | **Yes** — fully reproducible on S23U |
 | Slot-fill contamination | All 6 fail, param values cross cases | Cases 6–7 wrong intent at phase start | **Yes** — wrong intent at slot-fill entry |
-| `save_memory → save_important_date` | Clean model state, confirmed QIR gap | Not tested (outside safe_smoke slice) | **Pending** — needs targeted case run |
+| `save_memory → save_important_date` | Clean model state, confirmed QIR gap | Not tested (outside safe_smoke slice) | **Confirmed on S21; not tested on S23U** |
 | Weather routing | ✅ 7/7 pass (clean weather-only) | Not tested | Not tested on S23U |
 
-The S23U failure distribution is different from the S21 (case 2 → `timer` instead of `set_alarm`, case 4 → `save_memory` without content leak), suggesting device/model warmup timing influences the exact stuck pattern. However, slot-fill entry failures reproduce the same cross-test contamination pattern.
+The S23U failure distribution is different from the S21 (case 2 → `timer` instead of `set_alarm`), but the memory content leak pattern is the same: case 3's `"I prefer dark mode"` spills into cases 4 and 7. Slot-fill entry failures reproduce the same cross-test contamination pattern. Device/model warmup timing influences the exact stuck intent but state carryover is cross-device.
 
 **Evidence:** [`docs/test-triage/evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json`](evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json)
 
@@ -421,7 +421,7 @@ All follow-up work from this triage is tracked under the [epic #1189](https://gi
 
 **Notes:**
 - #1190 and #1191 are the highest priority — they account for the majority of observed failures and block meaningful slot-fill coverage.
-- #1192 is a focused QIR/classifier routing fix for a single identifiable gap. Confirmed reproducible even in clean model state on both S21 and S23U.
+- #1192 is a focused QIR/classifier routing fix for a single identifiable gap. Confirmed reproducible on S21 in clean model state; not yet tested on S23U (outside safe_smoke slice).
 - #1193 was originally opened to determine whether weather failures were location-permission issues or stuck-mode confounders. The post-permission rerun (weather-only: 7/7 pass) confirms they are **not** a permission bug. Closing #1193 with no action needed.
 - #1194 tracks the evidence/report updates in this PR.
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `5c1b205e` — add post-permission S21 rerun evidence, S23U comparison, follow-up issue tracking |
+| Latest commit | `e148e6ee` — fix S23U content leak conclusion, #1192 scope, and commit hash |
 
 ## Device Preconditions
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `dbb0d53b` — triage evidence + review fixes applied |
+| Latest commit | `6d463236` — triage evidence + review fixes applied (updated with post-permission rerun and S23U comparison) |
 
 ## Device Preconditions
 
@@ -130,6 +130,124 @@ During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_a
 | 4 | "send a message" | `send_sms` | `open_app` | `field_mismatch` | Wrong intent + leaked params from case 3 |
 | 5 | "send an email" | `send_email` | `open_app` | `field_mismatch` | Wrong intent + leaked params from case 3 |
 | 6 | "add to my list" | `add_to_list` | `add_to_list` ✅ (params: `eggs → sunscreen`) | `field_mismatch` | Correct intent, param value from prior case context |
+
+
+## Post-Permission S21 Rerun (2026-06-11)
+
+After the initial triage, the user fixed location permissions on the S21. All three original suites were re-run
+and a focused weather-only phase was added to determine whether weather failures were a permission issue or
+stuck-mode confounded. The weather-only run confirmed weather routing works correctly; the deterministic_core
+showed dramatic improvement.
+
+### Commands run
+
+```shell
+| Android | 15 (API 35) |
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 python3 scripts/adb_skill_test.py --phases weather
+
+# Post-permission safe_smoke
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 python3 scripts/adb_skill_test.py \
+  --tags safe_smoke --exclude-tags destructive,device_state
+
+# Post-permission deterministic_core
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 python3 scripts/adb_skill_test.py \
+  --tags deterministic_core --exclude-tags destructive,device_state
+
+# Post-permission slot_fill
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 python3 scripts/adb_skill_test.py \
+  --categories slot_fill --exclude-tags destructive,device_state
+```
+
+### Device metadata
+
+| Field | Value |
+|---|---|
+| Serial | `R5CR605B71K` |
+| Model | SM-G991B (Samsung Galaxy S21, Exynos) |
+| Android | 15 (API 35) |
+| Connection | USB |
+| Permissions | **Fixed** — location and notification permissions reconfigured between runs |
+| Oracle preflight | ✅ passed |
+
+### Results: before vs after permission fix
+
+| Suite | Before (2026-06-11 original) | After (2026-06-11 post-permission) | Δ |
+|---|---|---|---|
+| **weather-only** | — (not run separately) | **7/7 pass** ✅ | Weather routing confirmed working |
+| **safe_smoke** | 4 pass / 3 fail | 3 pass / 4 fail | −1 pass — failure pattern shifted but no longer leaks memory content |
+| **deterministic_core** | **25 pass / 46 fail / 5 xfail** | **58 pass / 13 fail / 5 xfail** | **+33 pass, −33 fail** |
+| **slot_fill** | 0 pass / 6 fail | 0 pass / 6 fail | Unchanged |
+
+**Key comparisons:**
+
+1. **Weather routing works correctly.** Weather-only isolated run: **7/7 pass** as `get_weather`. In the sequential deterministic_core, the first 4 weather cases (34–37) fall in the stuck-mode `get_timer_remaining` block from the preceding timer phase → fail. Cases 38–40 (after model recovers) → all pass as `get_weather`. **Conclusions:** The permission fix was effective. Weather is not a location-permission bug. The 4 remaining failures are stuck-mode-confounded.
+
+2. **Model stuck-mode blocks are shorter but still present.** Before: 38/46 failures from stuck-mode cascades of 5–20 consecutive cases. After: stuck-mode blocks of 3–6 cases. The alarm_timer phase dropped from 33 fails → 6 fails (27 pass). The model recovers faster but still exhibits state carryover.
+
+3. **"what time is it" — state carryover pattern changed.** In the original run, case 3 (`save_memory {"I prefer dark mode"}`) leaked its content into case 4. In the post-fix run, both cases 3 and 4 returned `set_timer` (stuck on case 2's intent) — a different pattern but still state carryover.
+
+4. **Slot-fill contamination is fully reproducible.** All 6 slot_fill cases fail post-fix, with the same contamination pattern: `"5 minutes"` from case 1 leaks into case 3's `app_name`, and `"bread and butter"` from deterministic_core leaks across runs into slot_fill case 6. This is a real, reproducible issue independent of device state.
+
+5. **`save_memory → save_important_date` is a real QIR gap.** Case 76 "remember that I parked on level 3" still routes to `save_important_date` in clean model state. Confirmed reproducible independent of permission configuration.
+
+### Evidence files
+
+| Path | Description |
+|---|---|
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-safe-smoke-skills.json` | Post-permission safe_smoke 7-test results |
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-deterministic-core-skills.json` | Post-permission deterministic_core 76-test results |
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-slot-fill-skills.json` | Post-permission slot_fill 6-test results |
+| `docs/test-triage/evidence/2026-06-11/s21-weather-only-skills.json` | Weather-only focused validation 7-test results |
+
+## S23U Focused Comparison
+
+The S23 Ultra (SM-S918B) is the user's daily driver. Only a minimal `safe_smoke` comparison slice was run
+to check whether the same failure patterns reproduce on a different device tier.
+
+### Command run
+
+```shell
+ANDROID_SERIAL=100.76.134.49:36991 ADB_WAIT_SECONDS=20 python3 scripts/adb_skill_test.py \
+  --tags safe_smoke --exclude-tags destructive,device_state
+```
+
+### Device metadata
+
+| Field | Value |
+|---|---|
+| Serial | `100.76.134.49:36991` (wireless ADB) |
+| Model | SM-S918B (Samsung Galaxy S23 Ultra, Snapdragon) |
+| Android | 15 (API 36) |
+| Connection | TCP/IP wireless |
+| App | `com.kernel.ai.debug` (already installed, no reinstall) |
+| Oracle preflight | ✅ passed |
+| Model warmup | ✅ `ready` (first probe) |
+
+### Safe_smoke result: 3/7 pass
+
+| # | Prompt | Expected | Actual | Notes |
+|---|---|---|---|---|
+| 1 | "set an alarm for 11pm" | `set_alarm` | `set_alarm` ✅ | |
+| 2 | "set a timer for 2 hours" | `set_timer` | `timer` (wrong tool) | `timer` is not a recognised intent |
+| 3 | "remember that I prefer dark mode" | `save_memory` | `save_memory` ✅ | |
+| 4 | "what time is it" | `get_time` | `save_memory` | No memory content leak — just wrong intent |
+| 5 | "what's my battery level" | `get_battery` | `get_battery` ✅ | |
+| 6 | "set an alarm" (slot) | `set_alarm` | `set_timer` | Slot-fill starts with wrong intent |
+| 7 | "set a timer" (slot) | `set_timer` | `save_memory` | Slot-fill cascade continues |
+
+### Key findings
+
+| Issue | S21 (USB, post-fix) | S23U (TCP) | Reproduces? |
+|---|---|---|---|
+| Stuck-mode / state carryover | 3-case blocks in alarm_timer | Cases 2→3→4 show intent drift but NOT the memory-content leak pattern | **Yes, different shape** |
+| Memory content leak (case 3→4) | Original: literal content leak. Post-fix: both stuck on `set_timer` | Case 4 → `save_memory` but **without** case 3's literal content | **Partially** — intent carryover yes, content leak not reproduced on S23U |
+| Slot-fill contamination | All 6 fail, param values cross cases | Cases 6–7 wrong intent at phase start | **Yes** — wrong intent at slot-fill entry |
+| `save_memory → save_important_date` | Clean model state, confirmed QIR gap | Not tested (outside safe_smoke slice) | **Pending** — needs targeted case run |
+| Weather routing | ✅ 7/7 pass (clean weather-only) | Not tested | Not tested on S23U |
+
+The S23U failure distribution is different from the S21 (case 2 → `timer` instead of `set_alarm`, case 4 → `save_memory` without content leak), suggesting device/model warmup timing influences the exact stuck pattern. However, slot-fill entry failures reproduce the same cross-test contamination pattern.
+
+**Evidence:** [`docs/test-triage/evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json`](evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json)
 
 ## Failure Classification by Root-Cause Bucket
 
@@ -253,22 +371,15 @@ Proposed investigation:
 Affects: All 6 slot_fill tests.
 ```
 
-### Draft 3: Validate S21 weather/location fixture with clean fixed-harness run
+### Draft 3: Validate S21 weather/location fixture with clean fixed-harness run — ✅ CLOSED
 
-```
-All 7 weather tests occurred during the stuck-mode cascade (actual intents:
-set_timer/cancel_timer). No runtime evidence of a permission denial was captured.
+**Completed:** Weather-only rerun (2026-06-11, post-permission fix) — **7/7 pass**, all returning `get_weather`.
 
-Run a focused weather-only test slice with model in a known-clean state
-to determine whether location permission is actually missing on S21.
+**Conclusion:** No location-permission bug exists. All 7 weather failures in the original run were stuck-mode-confounded
+(occurred during the `set_timer`/`cancel_timer` cascade). Weather routing works correctly when the model is not stuck.
+See the [Post-permission S21 rerun](#post-permission-s21-rerun) section for before/after comparison.
 
-If location_or_permission_missing persists in a clean run with weather cases:
-- Add log excerpts showing the permission/location failure.
-- Create a fixture issue to grant location permission or configure mock location.
-
-If weather tests pass in a clean run:
-- Close without action; the stuck-mode was the sole cause.
-```
+No action needed for #1193 — close as not a bug.
 
 ### Draft 4: QIR: remember parked location routes to save_important_date instead of save_memory
 
@@ -290,16 +401,39 @@ Affected: case id: remember_that_i_parked_on_level_3
 ## Recommended Next Actions
 
 1. **Fix the harness crash** — ✅ `expect_log_contains` field added and committed.
-2. **Investigate model stuck-mode/state carryover** — highest impact, conflates ~80% of observed failures across every test slice.
-3. **Fix slot-fill context contamination** — blocks all slot-fill coverage.
-4. **Run weather-only validation** — determine whether location permission is actually missing before creating a fixture issue.
+2. **Investigate model stuck-mode/state carryover** — highest impact, conflates ~80% of observed failures across every test slice. [#1190](https://github.com/NickMonrad/kernel-ai-assistant/issues/1190)
+3. **Fix slot-fill context contamination** — blocks all slot-fill coverage. [#1191](https://github.com/NickMonrad/kernel-ai-assistant/issues/1191)
+4. **Weather validation** — ✅ **Done.** Weather-only rerun after permission fix: **7/7 pass**. Weather routing works correctly. No location-permission bug exists; all original failures were stuck-mode-confounded. See [post-permission section](#post-permission-s21-rerun).
 5. **Do not create QIR/router issues from pre-#1181 data** — all that evidence is invalid.
-6. **Do not create QIR/router issues from stuck-mode-confounded failures** — only the `save_memory → save_important_date` case and lists `field_mismatch` cases occurred during known-clean model state.
+6. **Do not create QIR/router issues from stuck-mode-confounded failures** — only the `save_memory → save_important_date` case and lists `field_mismatch` cases occurred during known-clean model state. [#1192](https://github.com/NickMonrad/kernel-ai-assistant/issues/1192)
+
+## Follow-Up Issue Tracking
+
+All follow-up work from this triage is tracked under the [epic #1189](https://github.com/NickMonrad/kernel-ai-assistant/issues/1189).
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| [#1190](https://github.com/NickMonrad/kernel-ai-assistant/issues/1190) | Command/model state carryover (stuck-mode) | **Highest** — conflates ~80% of failures | Open |
+| [#1191](https://github.com/NickMonrad/kernel-ai-assistant/issues/1191) | Slot-fill context contamination | **High** — blocks all slot-fill coverage | Open |
+| [#1192](https://github.com/NickMonrad/kernel-ai-assistant/issues/1192) | Parked-location memory QIR gap | Medium — focused classifier fix | Open |
+| [#1193](https://github.com/NickMonrad/kernel-ai-assistant/issues/1193) | Weather/location clean validation | Low — validation only (see post-permission rerun results) | **Done — clean weather pass, no fix needed** |
+| [#1194](https://github.com/NickMonrad/kernel-ai-assistant/issues/1194) | Evidence/report update (this work) | — | **In progress** |
+
+**Notes:**
+- #1190 and #1191 are the highest priority — they account for the majority of observed failures and block meaningful slot-fill coverage.
+- #1192 is a focused QIR/classifier routing fix for a single identifiable gap. Confirmed reproducible even in clean model state on both S21 and S23U.
+- #1193 was originally opened to determine whether weather failures were location-permission issues or stuck-mode confounders. The post-permission rerun (weather-only: 7/7 pass) confirms they are **not** a permission bug. Closing #1193 with no action needed.
+- #1194 tracks the evidence/report updates in this PR.
 
 ## Evidence Files (Committed)
 
 | Path | Description |
 |---|---|
-| `docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json` | safe_smoke 7-test results (raw JSON) |
-| `docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json` | deterministic_core 76-test results (raw JSON) |
-| `docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json` | slot_fill 6-test results (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json` | safe_smoke 7-test results — **pre-permission-fix baseline** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json` | deterministic_core 76-test results — **pre-permission-fix baseline** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json` | slot_fill 6-test results — **pre-permission-fix baseline** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-safe-smoke-skills.json` | safe_smoke 7-test results — **post-permission rerun** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-deterministic-core-skills.json` | deterministic_core 76-test results — **post-permission rerun** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-post-permission-slot-fill-skills.json` | slot_fill 6-test results — **post-permission rerun** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-weather-only-skills.json` | weather-only 7-test focused validation — **post-permission** (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json` | S23U safe_smoke 7-test comparison (raw JSON) |

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Latest commit | `e148e6ee` — fix S23U content leak conclusion, #1192 scope, and commit hash |
+| Evidence baseline commit | `d83080f8` — initial report + S21 evidence set (pre-permission safe_smoke, deterministic_core, slot_fill); subsequent evidence updates: `faad35eb` (post-permission rerun, S23U comparison) |
 
 ## Device Preconditions
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -25,7 +25,7 @@
 | Date | 2026-06-11 |
 | Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
 | Branch | `issue/1186-s21-qir-triage` |
-| Evidence baseline commit | `d83080f8` — initial report + S21 evidence set (pre-permission safe_smoke, deterministic_core, slot_fill); subsequent evidence updates: `faad35eb` (post-permission rerun, S23U comparison) |
+| Evidence baseline commit | [`d83080f8`](https://github.com/NickMonrad/kernel-ai-assistant/tree/d83080f8) — initial report + S21 evidence set (pre-permission safe_smoke, deterministic_core, slot_fill); subsequent evidence updates: `faad35eb` (post-permission rerun, S23U comparison)
 
 ## Device Preconditions
 

--- a/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
+++ b/docs/test-triage/adb-s21-qir-triage-2026-06-11.md
@@ -2,13 +2,30 @@
 
 ## Meta
 
+### Issue lineage
+
+| Stage | Link |
+|---|---|
+| Originating triage issue | [#1180 — Targeted ADB failure triage and root-cause follow-ups](https://github.com/NickMonrad/kernel-ai-assistant/issues/1180) |
+| Continuation issue | [#1186 — Continue/Prioritise S21 QIR triage after harness observability fix](https://github.com/NickMonrad/kernel-ai-assistant/issues/1186) |
+| Harness fix | [#1181](https://github.com/NickMonrad/kernel-ai-assistant/pull/1181) — merged |
+| This PR (evidence/report) | [#1188](https://github.com/NickMonrad/kernel-ai-assistant/pull/1188) |
+
+**Lineage in prose:**
+
+#1180 created the need for targeted root-cause triage.
+#1181 fixed the harness observability blocker that made earlier evidence untrustworthy.
+#1186 carries the remaining S21-first triage workflow forward.
+#1188 records the first S21-focused triage evidence/report.
+
+### Test metadata
+
 | Field | Value |
 |---|---|
-| Issue | [#1186 — Prioritise S21 QIR triage after harness observability fix](https://github.com/NickMonrad/kernel-ai-assistant/issues/1186) |
-| PR | [docs(#1186): add S21-first ADB QIR triage report](https://github.com/NickMonrad/kernel-ai-assistant/pull/1187) |
 | Date | 2026-06-11 |
-| Commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
-| Harness fix | PR [#1181](https://github.com/NickMonrad/kernel-ai-assistant/pull/1181) — merged, fixed ADB-TLS logcat corruption and multi-word shell quoting |
+| Base commit | [`13833fac`](https://github.com/NickMonrad/kernel-ai-assistant/tree/13833fac) — `fix(#1180): remove adb logcat -c, add oracle preflight check (#1181)` |
+| Branch | `issue/1186-s21-qir-triage` |
+| Latest commit | `d83080f8` — report + harness crash fix |
 
 ## Device Preconditions
 
@@ -25,42 +42,29 @@
 | Model warmup | ✅ `ready` (one run), ⚠ `timeout` (other runs — model not ready within 120s) |
 | Pre-#1181 evidence | 🚫 **All invalid** — universal false NO_MATCH from broken logcat pipeline |
 
-## Commands Run
+## Harness Trustworthiness vs S21 Model Reliability
 
-```bash
-# Phase 0 — dry-run selectors
-python3 scripts/adb_skill_test.py --dry-run --tags safe_smoke --exclude-tags destructive,device_state
-python3 scripts/adb_skill_test.py --dry-run --tags deterministic_core --exclude-tags destructive,device_state
-python3 scripts/adb_skill_test.py --dry-run --categories slot_fill --exclude-tags destructive,device_state
+**Important distinction:**
 
-# Phase 1 — device metadata
-adb -s R5CR605B71K shell getprop ro.product.model
-adb -s R5CR605B71K shell getprop ro.build.version.release
-adb -s R5CR605B71K shell dumpsys package com.kernel.ai.debug | grep -E "versionName|versionCode|debuggable"
+- **Harness observability is fixed.** Oracle and stream health checks pass consistently. All failures carry concrete intent/param mismatch labels — no universal NO_MATCH.
+- **S21 model readiness is still a confounder.** Model warmup times out in some runs. The inference engine exhibits stuck-mode behaviour during long sequential test runs.
 
-# Phase 2 — harness trust check (safe_smoke)
-ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
-  python3 scripts/adb_skill_test.py --tags safe_smoke --exclude-tags destructive,device_state
+This means: the harness can be trusted to *report accurately*. But failures observed during a stuck-mode cascade or warmup timeout should not automatically be treated as QIR/router bugs without a clean rerun.
 
-# Phase 3a — deterministic core
-ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
-  python3 scripts/adb_skill_test.py --tags deterministic_core --exclude-tags destructive,device_state
-
-# Phase 3b — slot_fill
-ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
-  python3 scripts/adb_skill_test.py --categories slot_fill --exclude-tags destructive,device_state
-```
+Only failures observed during a known-clean model state (fresh warmup, correct intent returned for surrounding cases) should be used to raise product-routing issues.
 
 ## Bug Fix Applied During Triage
 
-During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_add_to_list`) due to an `AttributeError` in `models.py: _observed_expected_failure()` — the function referenced `r.expect_log_contains` which was not a field on `TestResult`. Fixed in:
+During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_add_to_list`) with an `AttributeError` in `models.py: _observed_expected_failure()` — the function referenced `r.expect_log_contains` which was not a field on `TestResult`. Fixed in commit `d83080f8`:
 
 - Added `expect_log_contains: str | None = None` to `TestResult` dataclass (models.py)
 - Added `expect_log_contains=tc.expect_log_contains` to TestResult construction (runners.py)
 
+**Validation:** `python3 -m py_compile scripts/adb_skill_test.py scripts/adb_harness/*.py` — clean.
+
 ## Results Summary
 
-### safe_smoke (7 tests)
+### safe_smoke — 7 tests (fresh warmup, straightforward prompts)
 
 | Result | Count |
 |---|---|
@@ -68,19 +72,19 @@ During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_a
 | ❌ Fail | 3 |
 | ⏭ Xfail | 0 |
 
-**Evidence:** `scripts/test-reports/2026-06-11T20-55-18Z_skills.json`
+**Evidence:** [`docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json`](evidence/2026-06-11/s21-safe-smoke-skills.json)
 
-| # | Prompt | Expected | Actual | Bucket |
-|---|---|---|---|---|
-| 1 | "set an alarm for 11pm" | set_alarm | set_alarm ✅ | — |
-| 2 | "set a timer for 2 hours" | set_timer | set_timer ✅ | — |
-| 3 | "remember that I prefer dark mode" | save_memory | save_memory ✅ | — |
-| 4 | "what time is it" | get_time | **save_memory** ❌ | wrong_tool |
-| 5 | "what's my battery level" | get_battery | get_battery ✅ | — |
-| 6 | "set an alarm" | set_alarm | **get_battery** ❌ | wrong_tool |
-| 7 | "set a timer" | set_timer | set_timer (params: got '7am') ❌ | slot_fill_issue |
+| # | Prompt | Expected | Actual | Failure | Notes |
+|---|---|---|---|---|---|
+| 1 | "set an alarm for 11pm" | `set_alarm` | `set_alarm` ✅ | — | |
+| 2 | "set a timer for 2 hours" | `set_timer` | `set_timer` ✅ | — | |
+| 3 | "remember that I prefer dark mode" | `save_memory` | `save_memory` ✅ | — | |
+| 4 | "what time is it" | `get_time` | `save_memory` | `wrong_tool` | actual params = `{content: "I prefer dark mode"}` — **case 3 content leaked into case 4** |
+| 5 | "what's my battery level" | `get_battery` | `get_battery` ✅ | — | |
+| 6 | "set an alarm" | `set_alarm` | `get_battery` | `field_mismatch` | wrong intent at slot_fill phase start |
+| 7 | "set a timer" | `set_timer` | `set_timer` (params: `7am`) | `field_mismatch` | correct intent, wrong duration param |
 
-### deterministic_core (76 tests)
+### deterministic_core — 76 tests (sequential, 4 phases)
 
 | Result | Count |
 |---|---|
@@ -88,9 +92,27 @@ During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_a
 | ❌ Fail | 46 |
 | ⏭ Xfail | 5 |
 
-**Evidence:** `scripts/test-reports/2026-06-11T22-11-20Z_skills.json`
+**Evidence:** [`docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json`](evidence/2026-06-11/s21-deterministic-core-skills.json)
 
-### slot_fill (6 tests)
+**Per-phase breakdown:**
+
+| Phase | Pass | Fail | Xfail | Total | Notes |
+|---|---|---|---|---|---|
+| alarm_timer | 0 | 33 | 0 | 33 | All stuck-mode cascade |
+| weather | 0 | 7 | 0 | 7 | All stuck-mode cascade (see below) |
+| lists | 18 | 5 | 5 | 28 | 4 wrong_tool, 5 field_mismatch, 5 xfail |
+| smart_home | 5 | 0 | 0 | 5 | Perfect pass |
+| memory | 2 | 1 | 0 | 3 | 1 wrong_tool (save_important_date) |
+
+**Failure buckets:**
+
+| Bucket | Count | Where |
+|---|---|---|
+| `wrong_tool` | 35 | alarm_timer (33), lists (1), memory (1) |
+| `location_or_permission_missing` | 7 | weather (all — tag-based, see analysis below) |
+| `field_mismatch` | 4 | lists (all — correct intent, wrong params) |
+
+### slot_fill — 6 tests (slot-fill conversation flow)
 
 | Result | Count |
 |---|---|
@@ -98,177 +120,186 @@ During the deterministic_core run, the harness crashed at case 43 (xfail `bulk_a
 | ❌ Fail | 6 |
 | ⏭ Xfail | 0 |
 
-**Evidence:** `scripts/test-reports/2026-06-11T22-17-41Z_skills.json`
+**Evidence:** [`docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json`](evidence/2026-06-11/s21-slot-fill-skills.json)
+
+| # | Prompt | Expected | Actual | Failure | Notes |
+|---|---|---|---|---|---|
+| 1 | "set an alarm" | `set_alarm` | `set_alarm` ✅ (params: `time=5 minutes`) | `field_mismatch` | Correct intent, wrong param value from prior context |
+| 2 | "set a timer" | `set_timer` | `cancel_timer` | `field_mismatch` | Wrong intent at slot-fill phase start |
+| 3 | "open an app" | `open_app` | `open_app` ✅ (params: `Spotify → 5 minutes`) | `field_mismatch` | Param value from case 1 ("5 minutes") leaked in |
+| 4 | "send a message" | `send_sms` | `open_app` | `field_mismatch` | Wrong intent + leaked params from case 3 |
+| 5 | "send an email" | `send_email` | `open_app` | `field_mismatch` | Wrong intent + leaked params from case 3 |
+| 6 | "add to my list" | `add_to_list` | `add_to_list` ✅ (params: `eggs → sunscreen`) | `field_mismatch` | Correct intent, param value from prior case context |
 
 ## Failure Classification by Root-Cause Bucket
 
-### 1. Model "Stuck Mode" / Inference Cascade Failure — 38/46 core fails
+### 1. Model State Carryover / "Stuck Mode" — 38/46 core fails + confounds others
 
 The deterministic_core run reveals the model returns the **same intent** for long consecutive blocks:
 
-| Block | Tests | Dominant Intent | Expected Intents | Count |
-|---|---|---|---|---|
-| 1–7 | alarm set/reminder | `add_to_list` | set_alarm, add_reminder | 7 |
-| 8–27 | alarm/timer/cancel | `set_alarm` | add_reminder, cancel_alarm, set_timer, cancel_timer, list_timers, cancel_timer_named | 20 |
-| 28–32 | timer named/remaining | `cancel_alarm` | cancel_timer_named, get_timer_remaining | 5 |
-| 33–39 | timer remaining/weather | `set_timer` | get_timer_remaining, get_weather | 7 |
-| 40–44 | lists/weather | `cancel_timer` | add_to_list, bulk_add_to_list, get_weather | 5 |
-
-After test 46 (45 minutes into the run), the lists phase from case 47 onward mostly passes (18/23 pass) and smart_home passes perfectly (5/5), memory mostly passes (2/3).
-
-**Assessment:** The model appears to require a clean cold-start inference per test or a model-reset between phases. When tests run back-to-back, the inference engine enters a stuck state where it returns the last-used or an incorrect dominant intent. This is likely a model inference reliability / session management issue rather than a routing logic bug.
-
-**Bucket:** `android_platform_constraint` (inference stall) / `unknown_needs_manual_review`
-
-### 2. Location permission not configured — 7/46 core fails
-
-All 7 weather tests fail with `location_or_permission_missing`:
-
-| # | Prompt | Expected | Actual |
+| Cases | Time | Dominant Intent | Expected Intents |
 |---|---|---|---|
-| 34–40 | "what's the weather in Auckland" etc | get_weather | set_timer / cancel_timer |
+| 1–7 | ~0–4 min | `add_to_list` | set_alarm, add_reminder |
+| 8–27 | ~4–13 min | `set_alarm` | add_reminder, cancel_alarm, set_timer, cancel_timer, list_timers |
+| 28–32 | ~13–19 min | `cancel_alarm` | cancel_timer_named, get_timer_remaining |
+| 33–39 | ~19–25 min | `set_timer` | get_timer_remaining, get_weather |
+| 40–44 | ~25–30 min | `cancel_timer` | add_to_list, bulk_add_to_list, get_weather |
+| 45–46 | ~30–32 min | `cancel_timer_named` | add_to_list, get_weather |
 
-**Assessment:** Location permission needs to be granted or mock location provider configured on the device. These are not QIR issues.
+After case 46 (~32 min), the model recovered and the lists phase mostly passed (18/23 pass including 5 xfail), and smart_home passed perfectly (5/5).
 
-**Bucket:** `device_precondition_issue`
+**Key finding:** safe_smoke case 4 also shows state carryover: "what time is it" returned `save_memory` with the *literal content* `{content: "I prefer dark mode"}` — which was the memory content from case 3. This occurred during a **fresh app warmup**, not a long run. This means the LiteRT session/KV cache is persisting inference results across test cases even on a short run.
 
-### 3. Slot-fill extraction failures — 6/6 slot_fill fails
+**Assessment:** The model inference state is not being properly isolated between sequential invocations. This is the highest-priority issue — it conflates ~80% of observed failures.
 
-All 6 slot_fill tests fail. Key observations:
+**Bucket:** `model_state_carryover` / `liteRt_session_isolation`
 
-- "set an alarm" → correct intent `set_alarm` but **empty** params (missing hours, minutes)
-- "set a timer" → **wrong intent** `cancel_timer`
-- "open an app" → correct intent `open_app` but param = `'5 minutes'` (pipelines slot-fill response from wrong context)
-- "send a message" → **wrong intent** `open_app`
-- "send an email" → **wrong intent** `open_app`
-- "add to my list" → correct intent `add_to_list` but param = `'sunscreen'` (from previous test context)
+**Evidence line:** safe_smoke case 4 actual params show case 3's memory content leaked into a `get_time` query.
 
-**Assessment:** The slot-fill conversation flow appears contaminated by prior test context. When the app asks "Which app?" and user responds "Spotify", the slot extractor returns values from unrelated earlier conversations. This may be a model session persistence issue (KV cache not cleared between tests) or a slot-fill pipeline bug.
+### 2. Slot-fill Context Contamination — 6/6 slot_fill fails + 2/3 safe_smoke fails
 
-**Bucket:** `slot_fill_issue` / `native_tool_handler_issue`
+All 6 slot_fill tests fail with clear evidence of cross-test context leakage:
 
-### 4. Wrong tool on first test after phase change — 3/76 safe_smoke fails
+- Cases 1→3→4→5: param value `'5 minutes'` from case 1's time input propagates through cases 3, 4, and 5 as `app_name`.
+- Case 6: param value `'sunscreen'` comes from prior test context, not the current prompt.
+- Cases 2, 4, 5: wrong intent at phase start, suggesting even the classifier is affected by accumulated state.
 
-In the safe_smoke run (which had fresh app warmup), case 4 "what time is it" → `save_memory` and case 6 "set an alarm" (slot fill) → `get_battery`. These are not consecutive-context contamination since the run starts fresh.
+**Assessment:** The slot-fill conversation flow carries state across ADB test invocations. When the app asks "Which app?" and the harness types "Spotify", the slot extractor returns values from unrelated earlier conversations. This may be a model session persistence issue (KV cache not cleared between slot-fill turns) or a slot-fill pipeline bug.
 
-**Assessment:** Real QIR router misclassifications on the S21.
+**Bucket:** `slot_fill_context_leak`
 
-**Bucket:** `minilm_classifier_miss` / `qir_regex_miss`
+### 3. Weather failures — confounded by stuck-mode cascade (needs clean rerun)
 
-### 5. Param extraction: "set a timer" → expects '300' but got '7am' — appearing in multiple runs
+All 7 weather tests occurred during the stuck-mode cascade (cases 33–40, actual intents `set_timer`/`cancel_timer`). The harness tags these with `location_or_permission_missing` because the test case fixture metadata includes `location_context`, but **no runtime log evidence from this run proves a permission denial**.
 
-In both safe_smoke (case 7) and slot_fill (case 2), the prompt "set a timer" with slot reply "5 minutes" produces `duration_seconds='7am'` instead of `'300'`. The value '7am' appears repeatedly, suggesting alarm context contamination.
+The observed actual intents (`set_timer`/`cancel_timer`) are consistent with the stuck-mode cascade active at that point in the run (cases 33–39 were in the `set_timer` block, case 40 was `cancel_timer`).
 
-**Bucket:** `slot_fill_issue`
+**Assessment:** These failures should NOT yet be classified as location-permission issues. A clean focused weather-only rerun (single phase, known-clean model state) is required before raising a location-permission follow-up issue.
 
-### 6. save_memory → save_important_date — 1/76 core fail
+**Reclassification:** `confounded_by_stuck_mode` — not yet `device_precondition_issue`.
 
-Case 76 "remember that I parked on level 3" → `save_important_date` (expected `save_memory`). This is a novel intent classifier routing that treats location-specific memory as an important date.
+### 4. QIR: save_memory → save_important_date — 1/76 isolated failure
 
-**Bucket:** `qir_regex_miss` (QIR regex for save_memory didn't match, MiniLM classified as save_important_date)
+Case 76 "remember that I parked on level 3" → `save_important_date` (expected `save_memory`). This occurred during a known-clean model state (after the stuck-mode resolved), and the intent is plausible — the model treated location-specific memory as an important date event.
+
+**Assessment:** Appears to be a real QIR routing gap. The MiniLM classifier may be choosing `save_important_date` over `save_memory` when the prompt contains location nouns.
+
+**Bucket:** `qir_gap`
+
+### 5. Lists field_mismatch — 4/76 param extraction failures
+
+Cases 63, 65, 66, 68 in the lists phase (known-clean model state) have correct intents but wrong/missing params. These are real extraction failures after the stuck-mode resolved.
+
+**Assessment:** Real param extraction gaps in the lists phase, but affected by context contamination.
+
+**Bucket:** `param_extraction_gap`
 
 ## Standing
 
 ### Invalidated pre-#1181 evidence
-
 All `NO_MATCH` / `regex_or_qir_miss` failures from earlier S21 and S23U runs (before PR #1181 merge at commit `13833fac`) are **invalid**. The logcat pipeline corruption (`adb logcat -c` on ADB-TLS) caused universal false negatives.
 
 ### Harness trustworthiness
-
-The harness is now trustworthy:
 - ✅ Oracle uses fresh-probe-bounded logcat capture
 - ✅ Stream health check verifies persistent stream delivers lines
-- ✅ All failures carry concrete intent/param mismatch labels, not NO_MATCH
-- ✅ py_compile and dry-run selectors all pass
+- ✅ All failures carry concrete intent/param mismatch labels (0 NO_MATCH across 89 test cases)
+- ✅ `py_compile` and dry-run selectors all pass
+
+### S21 model readiness
+- Warmup `ready` in one run, `timeout` in others
+- Stuck-mode cascade observed in the first ~30 min of deterministic_core
+- State carryover observed even in safe_smoke (7-case fresh run)
 
 ### Harness bug found and fixed during triage
-
 - Fixed `AttributeError: 'TestResult' object has no attribute 'expect_log_contains'` in `models.py: _observed_expected_failure()`
 
-## Proposed Follow-Up Issues
+## Proposed Follow-Up Issues (Drafts for Review)
 
-### Draft 1: Model inference reliability — cascade failure under sequential test load
+### Draft 1: Investigate S21 model stuck-mode / state carryover during sequential ADB intent tests
 
-**Title:** Model returns same dominant intent for consecutive ADB harness test cases
-
-**Body:**
 ```
-The S21 Exynos inference engine exhibits a "stuck mode" behaviour where the same
-intent (e.g. `add_to_list` or `set_alarm`) is returned for 5–20 consecutive test
-cases regardless of the prompt. This occurs approximately 45 minutes into a
-deterministic_core run and eventually resolves after ~2 phases.
+Evidence: safe_smoke case 4 returns the literal memory content from case 3
+("I prefer dark mode") when asked "what time is it". Deterministic_core shows
+5-20 consecutive cases returning the same wrong intent.
 
-Affected: ~38/76 deterministic_core test cases
+The model inference state appears to persist across harness invocations.
+This is the highest-priority issue — it conflates ~80% of observed failures.
 
 Proposed investigation:
-1. Add a model-reset or per-test force-stop to the harness to test whether clean
-   inference state per case resolves the issue.
-2. Log LiteRT inference time per case to identify when the model is stalling.
-3. Check whether `InferenceLoadingService` `ForegroundServiceStartNotAllowedException`
+1. Check whether LiteRT session is created fresh per test or reused.
+2. Log LiteRT inference handles/session IDs per case to detect reuse.
+3. Add a force-stop or model-reset between test phases to test isolation.
+4. Check whether InferenceLoadingService ForegroundServiceStartNotAllowedException
    correlates with stuck-mode phases.
+5. Verify KV cache clearing between inference calls.
+
+Affects: ~38/76 deterministic_core cases, 2/3 safe_smoke failures, confounds weather/slot_fill results.
 ```
 
-### Draft 2: Slot-fill extraction contamination
+### Draft 2: Investigate slot-fill context contamination across ADB test cases
 
-**Title:** Slot-fill extractor returns values from unrelated prior context
-
-**Body:**
 ```
-When the slot-fill flow asks "Which app?" and user responds "Spotify", the
-parameter extractor sometimes returns '5 minutes' or '7am' instead of 'Spotify'.
+Evidence: "5 minutes" from slot_fill case 1 propagates as app_name into cases
+3, 4, and 5. Memory content from case 3 leaks into case 4 of safe_smoke.
+"sunscreen" from unknown prior context appears as the item in slot_fill case 6.
 
-Affected: all 6 slot_fill tests (including "set a timer" → duration '7am')
+The slot-fill conversation flow is not isolating state between test invocations.
 
 Proposed investigation:
-1. Check whether KV cache is cleared between slot-fill turns.
-2. Check whether the conversation history from prior test cases leaks into the
-   slot extractor prompt.
+1. Check KV cache state across slot-fill turns.
+2. Verify that the conversation history is reset between harness test cases.
+3. Check whether the slot extractor prompt includes stale prior turns.
+
+Affects: All 6 slot_fill tests.
 ```
 
-### Draft 3: Location permission not granted on S21
+### Draft 3: Validate S21 weather/location fixture with clean fixed-harness run
 
-**Title:** Weather tests fail with location_or_permission_missing on S21
-
-**Body:**
 ```
-All 7 weather tests fail with location_or_permission_missing because the S21
-device does not have location permission granted or a mock location provider
-configured.
+All 7 weather tests occurred during the stuck-mode cascade (actual intents:
+set_timer/cancel_timer). No runtime evidence of a permission denial was captured.
 
-Fix: Add location permission grant to device precondition setup, or configure
-a mock location provider for the weather fixture.
-```
+Run a focused weather-only test slice with model in a known-clean state
+to determine whether location permission is actually missing on S21.
 
-### Draft 4: save_memory → save_important_date QIR gap
+If location_or_permission_missing persists in a clean run with weather cases:
+- Add log excerpts showing the permission/location failure.
+- Create a fixture issue to grant location permission or configure mock location.
 
-**Title:** "remember that I parked on level 3" routes to save_important_date instead of save_memory
-
-**Body:**
-```
-When the prompt contains both a memory verb ("remember") and a location
-("level 3"), the QIR router selects save_important_date over save_memory.
-
-Affected: case id:remember_that_i_parked_on_level_3
-
-Proposed fix: Adjust QIR regex patterns to prefer save_memory when the prompt
-starts with "remember that I ..." regardless of location nouns.
+If weather tests pass in a clean run:
+- Close without action; the stuck-mode was the sole cause.
 ```
 
-## Recommended Next Action
+### Draft 4: QIR: remember parked location routes to save_important_date instead of save_memory
 
-1. **Fix the `models.py` harness crash** — ✅ already done in this session
-2. **Investigate model stuck-mode** — highest impact, affects 50%+ of deterministic tests on S21
-3. **Fix slot-fill contamination** — affects all slot-fill coverage
-4. **Configure location permission** — unblocks 7 weather tests
-5. **Do not create QIR/router issues from pre-#1181 data** — all that evidence is invalid
+```
+Prompt: "remember that I parked on level 3"
+Expected: save_memory
+Actual: save_important_date
 
-## Evidence Files
+The MiniLM classifier routes to save_important_date when the prompt contains
+both a memory verb ("remember") and a location noun ("level 3").
 
-| Path | Size | Description |
-|---|---|---|
-| `scripts/test-reports/2026-06-11T20-55-18Z_skills.json` | ~4 KB | safe_smoke results |
-| `scripts/test-reports/2026-06-11T22-11-20Z_skills.json` | ~12 KB | deterministic_core results |
-| `scripts/test-reports/2026-06-11T22-17-41Z_skills.json` | ~3 KB | slot_fill results |
-| `/home/lokhor/.local/share/rtk/tee/1781211323_test.log` | ~2 KB | safe_smoke raw log |
-| `/home/lokhor/.local/share/rtk/tee/1781215886_test.log` | ~9 KB | deterministic_core raw log |
-| `/home/lokhor/.local/share/rtk/tee/1781216267_test.log` | ~1 KB | slot_fill raw log |
+Proposed fix: Adjust QIR regex patterns or MiniLM training to prefer
+save_memory when the prompt starts with "remember that I ..."
+regardless of location nouns.
+
+Affected: case id: remember_that_i_parked_on_level_3
+```
+
+## Recommended Next Actions
+
+1. **Fix the harness crash** — ✅ `expect_log_contains` field added and committed.
+2. **Investigate model stuck-mode/state carryover** — highest impact, conflates ~80% of observed failures across every test slice.
+3. **Fix slot-fill context contamination** — blocks all slot-fill coverage.
+4. **Run weather-only validation** — determine whether location permission is actually missing before creating a fixture issue.
+5. **Do not create QIR/router issues from pre-#1181 data** — all that evidence is invalid.
+6. **Do not create QIR/router issues from stuck-mode-confounded failures** — only the `save_memory → save_important_date` case and lists `field_mismatch` cases occurred during known-clean model state.
+
+## Evidence Files (Committed)
+
+| Path | Description |
+|---|---|
+| `docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json` | safe_smoke 7-test results (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json` | deterministic_core 76-test results (raw JSON) |
+| `docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json` | slot_fill 6-test results (raw JSON) |

--- a/docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-deterministic-core-skills.json
@@ -1,0 +1,2123 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-11T22-11-20Z",
+  "elapsed_seconds": 2560.4,
+  "summary": {
+    "total": 76,
+    "passed": 25,
+    "xfail": 5,
+    "xpass": 0,
+    "failed": 46
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm_for_11pm",
+      "message": "set an alarm for 11pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 2,
+      "case_id": "wake_me_up_at_1130",
+      "message": "wake me up at 11:30",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 3,
+      "case_id": "set_an_alarm_for_tomorrow_at_9am",
+      "message": "set an alarm for tomorrow at 9am",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 4,
+      "case_id": "alarm_1130pm",
+      "message": "alarm 11:30pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 5,
+      "case_id": "can_you_wake_me_at_1130",
+      "message": "can you wake me at 11:30",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 6,
+      "case_id": "i_need_an_alarm_for_11_tonight",
+      "message": "I need an alarm for 11 tonight",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 7,
+      "case_id": "remind_me_to_call_the_dentist_monday",
+      "message": "remind me to call the dentist Monday",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 8,
+      "case_id": "remind_me_at_9am_monday_to_call_the_dentist",
+      "message": "remind me at 9am Monday to call the dentist",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 9,
+      "case_id": "remind_me_to_pick_up_dry_cleaning_tomorrow_evening",
+      "message": "remind me to pick up dry cleaning tomorrow evening",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 10,
+      "case_id": "cancel_my_11pm_alarm",
+      "message": "cancel my 11pm alarm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 11,
+      "case_id": "turn_off_all_my_alarms",
+      "message": "turn off all my alarms",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 12,
+      "case_id": "delete_my_alarm",
+      "message": "delete my alarm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 13,
+      "case_id": "get_rid_of_all_alarms",
+      "message": "get rid of all alarms",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 14,
+      "case_id": "set_a_timer_for_2_hours",
+      "message": "set a timer for 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 15,
+      "case_id": "start_a_2_hour_timer",
+      "message": "start a 2 hour timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 16,
+      "case_id": "timer_2_hours",
+      "message": "timer 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 17,
+      "case_id": "start_a_3_hour_timer",
+      "message": "start a 3 hour timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 18,
+      "case_id": "countdown_2_hours",
+      "message": "countdown 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 19,
+      "case_id": "cancel_the_timer",
+      "message": "cancel the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 20,
+      "case_id": "stop_the_timer",
+      "message": "stop the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 21,
+      "case_id": "turn_off_the_timer",
+      "message": "turn off the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 22,
+      "case_id": "dismiss_the_timer",
+      "message": "dismiss the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 23,
+      "case_id": "what_timers_do_i_have",
+      "message": "what timers do I have",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 24,
+      "case_id": "show_my_timers",
+      "message": "show my timers",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 25,
+      "case_id": "how_many_timers_are_running",
+      "message": "how many timers are running",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 26,
+      "case_id": "list_timers",
+      "message": "list timers",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 27,
+      "case_id": "cancel_the_pasta_timer",
+      "message": "cancel the pasta timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"time\": \"9:0\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 28,
+      "case_id": "cancel_the_10_minute_timer",
+      "message": "cancel the 10 minute timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 29,
+      "case_id": "stop_the_egg_timer",
+      "message": "stop the egg timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 30,
+      "case_id": "dismiss_the_laundry_timer",
+      "message": "dismiss the laundry timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 31,
+      "case_id": "how_long_left_on_my_timer",
+      "message": "how long left on my timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 32,
+      "case_id": "how_much_time_is_left_on_the_pasta_timer",
+      "message": "how much time is left on the pasta timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 33,
+      "case_id": "how_long_until_the_timer_goes_off",
+      "message": "how long until the timer goes off",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 34,
+      "case_id": "whats_the_weather_in_auckland",
+      "message": "what's the weather in Auckland",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 35,
+      "case_id": "will_it_rain_today",
+      "message": "will it rain today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 36,
+      "case_id": "how_hot_is_it_outside",
+      "message": "how hot is it outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 37,
+      "case_id": "do_i_need_an_umbrella_today",
+      "message": "do I need an umbrella today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 38,
+      "case_id": "whats_it_like_outside",
+      "message": "what's it like outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 39,
+      "case_id": "is_it_gonna_rain_tomorrow",
+      "message": "is it gonna rain tomorrow",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 40,
+      "case_id": "temperature_in_wellington",
+      "message": "temperature in Wellington",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 41,
+      "case_id": "add_milk_to_my_shopping_list",
+      "message": "add milk to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "cancel_timer",
+      "expect_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param item",
+        "Missing param list_name"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 42,
+      "case_id": "put_eggs_on_the_grocery_list",
+      "message": "put eggs on the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "cancel_timer",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param item",
+        "Missing param list_name"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 43,
+      "case_id": "add_bread_and_butter_v1",
+      "message": "add bread and butter to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 44,
+      "case_id": "chuck_milk_on_the_list",
+      "message": "chuck milk on the list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "cancel_timer",
+      "expect_params": {
+        "item": "milk"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param item"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 45,
+      "case_id": "chuck_eggs_on_the_grocery_list",
+      "message": "chuck eggs on the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param item",
+        "Missing param list_name"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 46,
+      "case_id": "pop_coffee_on_my_list",
+      "message": "pop coffee on my list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 47,
+      "case_id": "put_sunscreen_on_the_holiday_list",
+      "message": "put sunscreen on the holiday list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "sunscreen",
+        "list_name": "holiday"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 48,
+      "case_id": "show_my_todo_list",
+      "message": "show my todo list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": {
+        "list_name": "todo"
+      },
+      "actual_params": {
+        "list_name": "todo"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 49,
+      "case_id": "whats_on_my_shopping_list",
+      "message": "what's on my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": {
+        "list_name": "shopping"
+      },
+      "actual_params": {
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 50,
+      "case_id": "what_do_i_need_to_get_from_the_shops",
+      "message": "what do I need to get from the shops",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 51,
+      "case_id": "whats_on_my_grocery_list",
+      "message": "what's on my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 52,
+      "case_id": "show_me_the_shopping_list",
+      "message": "show me the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 53,
+      "case_id": "read_out_my_holiday_list",
+      "message": "read out my holiday list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "holiday"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 54,
+      "case_id": "read_me_my_grocery_list",
+      "message": "read me my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "me my grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 55,
+      "case_id": "remove_milk_from_my_shopping_list",
+      "message": "remove milk from my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "actual_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 56,
+      "case_id": "delete_eggs_from_the_grocery_list",
+      "message": "delete eggs from the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 57,
+      "case_id": "take_milk_off_the_shopping_list",
+      "message": "take milk off the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 58,
+      "case_id": "cross_milk_off_the_shopping_list",
+      "message": "cross milk off the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 59,
+      "case_id": "ive_got_bread_take_it_off_the_list",
+      "message": "I've got bread, take it off the list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "it",
+        "list_name": "the"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 60,
+      "case_id": "strike_eggs_off_my_grocery_list",
+      "message": "strike eggs off my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "it",
+        "list_name": "the"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 61,
+      "case_id": "create_a_list_called_groceries",
+      "message": "create a list called groceries",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": {
+        "list_name": "groceries"
+      },
+      "actual_params": {
+        "list_name": "groceries"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 62,
+      "case_id": "make_a_new_list_called_holiday_packing",
+      "message": "make a new list called holiday packing",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": {
+        "list_name": "holiday packing"
+      },
+      "actual_params": {
+        "list_name": "holiday packing"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 63,
+      "case_id": "add_eggs_milk_and_bread_to_my_shopping_list",
+      "message": "add eggs, milk, and bread to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 64,
+      "case_id": "make_me_a_list_for_camping",
+      "message": "make me a list for camping",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "me a"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 65,
+      "case_id": "create_a_new_list_called_work_tasks",
+      "message": "create a new list called work tasks",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "work tasks"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 66,
+      "case_id": "add_eggs_milk_and_bread_to_the_shopping_list",
+      "message": "add eggs, milk, and bread to the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "work tasks"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 67,
+      "case_id": "put_tortilla_chips_beef_mince_and_kidney_beans_on",
+      "message": "put tortilla chips, beef mince, and kidney beans on my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "tortilla chips",
+        "list_name": "grocery"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 68,
+      "case_id": "add_these_items_to_my_list_apples_bananas_oranges",
+      "message": "add these items to my list: apples, bananas, oranges",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "these items to my"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 69,
+      "case_id": "turn_on_the_living_room_lights",
+      "message": "turn on the living room lights",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "living room lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 70,
+      "case_id": "lights_on",
+      "message": "lights on",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 71,
+      "case_id": "turn_on_the_heater",
+      "message": "turn on the heater",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "heater"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 72,
+      "case_id": "switch_off_the_bedroom_lamp",
+      "message": "switch off the bedroom lamp",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_off",
+      "actual_intent": "smart_home_off",
+      "expect_params": null,
+      "actual_params": {
+        "device": "bedroom lamp"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 73,
+      "case_id": "kill_the_lights",
+      "message": "kill the lights",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_off",
+      "actual_intent": "smart_home_off",
+      "expect_params": null,
+      "actual_params": {
+        "device": "lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 74,
+      "case_id": "remember_that_i_usually_meet_sarah_on_tuesdays",
+      "message": "remember that I usually meet Sarah on Tuesdays",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I usually meet Sarah on Tuesdays"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 75,
+      "case_id": "remember_that_i_prefer_dark_mode",
+      "message": "remember that I prefer dark mode",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 76,
+      "case_id": "remember_that_i_parked_on_level_3",
+      "message": "remember that I parked on level 3",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_important_date",
+      "expect_params": null,
+      "actual_params": {
+        "label": "I parked",
+        "date": "level 3"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-post-permission-deterministic-core-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-post-permission-deterministic-core-skills.json
@@ -1,0 +1,2117 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-12T00-16-30Z",
+  "elapsed_seconds": 2555.6,
+  "summary": {
+    "total": 76,
+    "passed": 58,
+    "xfail": 5,
+    "xpass": 0,
+    "failed": 13
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm_for_11pm",
+      "message": "set an alarm for 11pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "time": "eggs"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 2,
+      "case_id": "wake_me_up_at_1130",
+      "message": "wake me up at 11:30",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "11",
+        "minutes": "30",
+        "time": "11:30"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 3,
+      "case_id": "set_an_alarm_for_tomorrow_at_9am",
+      "message": "set an alarm for tomorrow at 9am",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "9",
+        "minutes": "0",
+        "time": "9:00",
+        "day": "tomorrow"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 4,
+      "case_id": "alarm_1130pm",
+      "message": "alarm 11:30pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "23",
+        "minutes": "30",
+        "time": "23:30"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 5,
+      "case_id": "can_you_wake_me_at_1130",
+      "message": "can you wake me at 11:30",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "23",
+        "minutes": "30",
+        "time": "23:30"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 6,
+      "case_id": "i_need_an_alarm_for_11_tonight",
+      "message": "I need an alarm for 11 tonight",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "11",
+        "minutes": "0",
+        "time": "11:00"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 7,
+      "case_id": "remind_me_to_call_the_dentist_monday",
+      "message": "remind me to call the dentist Monday",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "11",
+        "minutes": "0",
+        "time": "11:00"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 8,
+      "case_id": "remind_me_at_9am_monday_to_call_the_dentist",
+      "message": "remind me at 9am Monday to call the dentist",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"day\": \"Monday\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 9,
+      "case_id": "remind_me_to_pick_up_dry_cleaning_tomorrow_evening",
+      "message": "remind me to pick up dry cleaning tomorrow evening",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_reminder",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"day\": \"Monday\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 10,
+      "case_id": "cancel_my_11pm_alarm",
+      "message": "cancel my 11pm alarm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 11,
+      "case_id": "turn_off_all_my_alarms",
+      "message": "turn off all my alarms",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 12,
+      "case_id": "delete_my_alarm",
+      "message": "delete my alarm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 13,
+      "case_id": "get_rid_of_all_alarms",
+      "message": "get rid of all alarms",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_alarm",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 14,
+      "case_id": "set_a_timer_for_2_hours",
+      "message": "set a timer for 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 15,
+      "case_id": "start_a_2_hour_timer",
+      "message": "start a 2 hour timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 16,
+      "case_id": "timer_2_hours",
+      "message": "timer 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "cancel_alarm",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 17,
+      "case_id": "start_a_3_hour_timer",
+      "message": "start a 3 hour timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 18,
+      "case_id": "countdown_2_hours",
+      "message": "countdown 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "10800"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 19,
+      "case_id": "cancel_the_timer",
+      "message": "cancel the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 20,
+      "case_id": "stop_the_timer",
+      "message": "stop the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 21,
+      "case_id": "turn_off_the_timer",
+      "message": "turn off the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 22,
+      "case_id": "dismiss_the_timer",
+      "message": "dismiss the timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 23,
+      "case_id": "what_timers_do_i_have",
+      "message": "what timers do I have",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "list_timers",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 24,
+      "case_id": "show_my_timers",
+      "message": "show my timers",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "list_timers",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 25,
+      "case_id": "how_many_timers_are_running",
+      "message": "how many timers are running",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "list_timers",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 26,
+      "case_id": "list_timers",
+      "message": "list timers",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "list_timers",
+      "actual_intent": "list_timers",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 27,
+      "case_id": "cancel_the_pasta_timer",
+      "message": "cancel the pasta timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 28,
+      "case_id": "cancel_the_10_minute_timer",
+      "message": "cancel the 10 minute timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": null,
+      "actual_params": {
+        "name": "10 minute"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 29,
+      "case_id": "stop_the_egg_timer",
+      "message": "stop the egg timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": null,
+      "actual_params": {
+        "name": "egg"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 30,
+      "case_id": "dismiss_the_laundry_timer",
+      "message": "dismiss the laundry timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "cancel_timer_named",
+      "actual_intent": "cancel_timer_named",
+      "expect_params": null,
+      "actual_params": {
+        "name": "laundry"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 31,
+      "case_id": "how_long_left_on_my_timer",
+      "message": "how long left on my timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 32,
+      "case_id": "how_much_time_is_left_on_the_pasta_timer",
+      "message": "how much time is left on the pasta timer",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 33,
+      "case_id": "how_long_until_the_timer_goes_off",
+      "message": "how long until the timer goes off",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_timer_remaining",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 34,
+      "case_id": "whats_the_weather_in_auckland",
+      "message": "what's the weather in Auckland",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 35,
+      "case_id": "will_it_rain_today",
+      "message": "will it rain today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 36,
+      "case_id": "how_hot_is_it_outside",
+      "message": "how hot is it outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 37,
+      "case_id": "do_i_need_an_umbrella_today",
+      "message": "do I need an umbrella today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_timer_remaining",
+      "expect_params": null,
+      "actual_params": {
+        "name": "pasta"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "fail",
+      "failure_bucket": "location_or_permission_missing"
+    },
+    {
+      "index": 38,
+      "case_id": "whats_it_like_outside",
+      "message": "what's it like outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "location": "Auckland"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 39,
+      "case_id": "is_it_gonna_rain_tomorrow",
+      "message": "is it gonna rain tomorrow",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "location": "Auckland"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 40,
+      "case_id": "temperature_in_wellington",
+      "message": "temperature in Wellington",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "location": "Auckland"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 41,
+      "case_id": "add_milk_to_my_shopping_list",
+      "message": "add milk to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "actual_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 42,
+      "case_id": "put_eggs_on_the_grocery_list",
+      "message": "put eggs on the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 43,
+      "case_id": "add_bread_and_butter_v1",
+      "message": "add bread and butter to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 44,
+      "case_id": "chuck_milk_on_the_list",
+      "message": "chuck milk on the list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "milk"
+      },
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'item': expected 'milk', got 'bread and butter'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 45,
+      "case_id": "chuck_eggs_on_the_grocery_list",
+      "message": "chuck eggs on the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'item': expected 'eggs', got 'bread and butter'",
+        "Param 'list_name': expected 'grocery', got 'shopping'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 46,
+      "case_id": "pop_coffee_on_my_list",
+      "message": "pop coffee on my list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 47,
+      "case_id": "put_sunscreen_on_the_holiday_list",
+      "message": "put sunscreen on the holiday list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "sunscreen",
+        "list_name": "holiday"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 48,
+      "case_id": "show_my_todo_list",
+      "message": "show my todo list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": {
+        "list_name": "todo"
+      },
+      "actual_params": {
+        "list_name": "todo"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 49,
+      "case_id": "whats_on_my_shopping_list",
+      "message": "what's on my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": {
+        "list_name": "shopping"
+      },
+      "actual_params": {
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 50,
+      "case_id": "what_do_i_need_to_get_from_the_shops",
+      "message": "what do I need to get from the shops",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 51,
+      "case_id": "whats_on_my_grocery_list",
+      "message": "what's on my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 52,
+      "case_id": "show_me_the_shopping_list",
+      "message": "show me the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 53,
+      "case_id": "read_out_my_holiday_list",
+      "message": "read out my holiday list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "holiday"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 54,
+      "case_id": "read_me_my_grocery_list",
+      "message": "read me my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "get_list_items",
+      "actual_intent": "get_list_items",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "me my grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 55,
+      "case_id": "remove_milk_from_my_shopping_list",
+      "message": "remove milk from my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "actual_params": {
+        "item": "milk",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 56,
+      "case_id": "delete_eggs_from_the_grocery_list",
+      "message": "delete eggs from the grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 57,
+      "case_id": "take_milk_off_the_shopping_list",
+      "message": "take milk off the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 58,
+      "case_id": "cross_milk_off_the_shopping_list",
+      "message": "cross milk off the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "grocery"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 59,
+      "case_id": "ive_got_bread_take_it_off_the_list",
+      "message": "I've got bread, take it off the list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "it",
+        "list_name": "the"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 60,
+      "case_id": "strike_eggs_off_my_grocery_list",
+      "message": "strike eggs off my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "remove_from_list",
+      "actual_intent": "remove_from_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "it",
+        "list_name": "the"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 61,
+      "case_id": "create_a_list_called_groceries",
+      "message": "create a list called groceries",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": {
+        "list_name": "groceries"
+      },
+      "actual_params": {
+        "list_name": "groceries"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 62,
+      "case_id": "make_a_new_list_called_holiday_packing",
+      "message": "make a new list called holiday packing",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": {
+        "list_name": "holiday packing"
+      },
+      "actual_params": {
+        "list_name": "holiday packing"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 63,
+      "case_id": "add_eggs_milk_and_bread_to_my_shopping_list",
+      "message": "add eggs, milk, and bread to my shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "eggs",
+        "list_name": "shopping"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 64,
+      "case_id": "make_me_a_list_for_camping",
+      "message": "make me a list for camping",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "me a"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 65,
+      "case_id": "create_a_new_list_called_work_tasks",
+      "message": "create a new list called work tasks",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "create_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "work tasks"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 66,
+      "case_id": "add_eggs_milk_and_bread_to_the_shopping_list",
+      "message": "add eggs, milk, and bread to the shopping list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "work tasks"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 67,
+      "case_id": "put_tortilla_chips_beef_mince_and_kidney_beans_on",
+      "message": "put tortilla chips, beef mince, and kidney beans on my grocery list",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": null,
+      "actual_params": {
+        "item": "tortilla chips",
+        "list_name": "grocery"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 68,
+      "case_id": "add_these_items_to_my_list_apples_bananas_oranges",
+      "message": "add these items to my list: apples, bananas, oranges",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "bulk_add_to_list",
+      "actual_intent": "create_list",
+      "expect_params": null,
+      "actual_params": {
+        "list_name": "these items to my"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": true,
+      "xfail_reason": "unsupported_feature: multi-item add_to_list not yet implemented (QIR extractor gap)",
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "lists",
+      "status": "xfail",
+      "failure_bucket": "unsupported_feature"
+    },
+    {
+      "index": 69,
+      "case_id": "turn_on_the_living_room_lights",
+      "message": "turn on the living room lights",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "living room lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 70,
+      "case_id": "lights_on",
+      "message": "lights on",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 71,
+      "case_id": "turn_on_the_heater",
+      "message": "turn on the heater",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_on",
+      "actual_intent": "smart_home_on",
+      "expect_params": null,
+      "actual_params": {
+        "device": "heater"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 72,
+      "case_id": "switch_off_the_bedroom_lamp",
+      "message": "switch off the bedroom lamp",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_off",
+      "actual_intent": "smart_home_off",
+      "expect_params": null,
+      "actual_params": {
+        "device": "bedroom lamp"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 73,
+      "case_id": "kill_the_lights",
+      "message": "kill the lights",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "smart_home_off",
+      "actual_intent": "smart_home_off",
+      "expect_params": null,
+      "actual_params": {
+        "device": "lights"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "smart_home",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 74,
+      "case_id": "remember_that_i_usually_meet_sarah_on_tuesdays",
+      "message": "remember that I usually meet Sarah on Tuesdays",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I usually meet Sarah on Tuesdays"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 75,
+      "case_id": "remember_that_i_prefer_dark_mode",
+      "message": "remember that I prefer dark mode",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 76,
+      "case_id": "remember_that_i_parked_on_level_3",
+      "message": "remember that I parked on level 3",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_important_date",
+      "expect_params": null,
+      "actual_params": {
+        "label": "I parked",
+        "date": "level 3"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-post-permission-safe-smoke-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-post-permission-safe-smoke-skills.json
@@ -1,0 +1,233 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-11T23-28-39Z",
+  "elapsed_seconds": 165.3,
+  "summary": {
+    "total": 7,
+    "passed": 3,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 4
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm_for_11pm",
+      "message": "set an alarm for 11pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "23",
+        "minutes": "0",
+        "time": "23:00"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer_for_2_hours",
+      "message": "set a timer for 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "7200"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 3,
+      "case_id": "remember_that_i_prefer_dark_mode",
+      "message": "remember that I prefer dark mode",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "7200"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 4,
+      "case_id": "what_time_is_it",
+      "message": "what time is it",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_time",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "7200"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 5,
+      "case_id": "whats_my_battery_level",
+      "message": "what's my battery level",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_battery",
+      "actual_intent": "get_battery",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 6,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "hours": "7",
+        "minutes": "0"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param hours",
+        "Missing param minutes"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 7,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "get_weather",
+      "expect_params": {
+        "duration_seconds": "300"
+      },
+      "actual_params": {
+        "location": "Wellington"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param duration_seconds"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-post-permission-slot-fill-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-post-permission-slot-fill-skills.json
@@ -1,0 +1,215 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-12T00-22-42Z",
+  "elapsed_seconds": 59.8,
+  "summary": {
+    "total": 6,
+    "passed": 0,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 6
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": {
+        "hours": "7",
+        "minutes": "0"
+      },
+      "actual_params": {
+        "time": "5 minutes"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param hours",
+        "Missing param minutes"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": {
+        "duration_seconds": "300"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param duration_seconds"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 3,
+      "case_id": "open_an_app",
+      "message": "open an app",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required"
+      ],
+      "fixture": "apps:spotify_installed",
+      "expect_intent": "open_app",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "app_name": "Spotify"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'app_name': expected 'Spotify', got '5 minutes'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 4,
+      "case_id": "send_a_message",
+      "message": "send a message",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required",
+        "contact_fixture_required",
+        "ambiguous"
+      ],
+      "fixture": "contacts:family_seed",
+      "expect_intent": "send_sms",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "contact": "Mum"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param contact"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 5,
+      "case_id": "send_an_email",
+      "message": "send an email",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required",
+        "contact_fixture_required",
+        "ambiguous"
+      ],
+      "fixture": "contacts:email_contact_seed",
+      "expect_intent": "send_email",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "contact": "Nick"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param contact"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 6,
+      "case_id": "add_to_my_list",
+      "message": "add to my list",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "eggs"
+      },
+      "actual_params": {
+        "item": "bread and butter",
+        "list_name": "shopping"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'item': expected 'eggs', got 'bread and butter'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-safe-smoke-skills.json
@@ -1,0 +1,231 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-11T20-55-18Z",
+  "elapsed_seconds": 168.8,
+  "summary": {
+    "total": 7,
+    "passed": 4,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 3
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm_for_11pm",
+      "message": "set an alarm for 11pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "23",
+        "minutes": "0",
+        "time": "23:00"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer_for_2_hours",
+      "message": "set a timer for 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_timer",
+      "expect_params": null,
+      "actual_params": {
+        "duration_seconds": "7200"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 3,
+      "case_id": "remember_that_i_prefer_dark_mode",
+      "message": "remember that I prefer dark mode",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 4,
+      "case_id": "what_time_is_it",
+      "message": "what time is it",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_time",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 5,
+      "case_id": "whats_my_battery_level",
+      "message": "what's my battery level",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_battery",
+      "actual_intent": "get_battery",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 6,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "get_battery",
+      "expect_params": {
+        "hours": "7",
+        "minutes": "0"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param hours",
+        "Missing param minutes"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 7,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "set_timer",
+      "expect_params": {
+        "duration_seconds": "300"
+      },
+      "actual_params": {
+        "duration_seconds": "7am"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'duration_seconds': expected '300', got '7am'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-slot-fill-skills.json
@@ -1,0 +1,215 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-11T22-17-41Z",
+  "elapsed_seconds": 59.5,
+  "summary": {
+    "total": 6,
+    "passed": 0,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 6
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": {
+        "hours": "7",
+        "minutes": "0"
+      },
+      "actual_params": {
+        "time": "5 minutes"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param hours",
+        "Missing param minutes"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "cancel_timer",
+      "expect_params": {
+        "duration_seconds": "300"
+      },
+      "actual_params": {},
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param duration_seconds"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 3,
+      "case_id": "open_an_app",
+      "message": "open an app",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required"
+      ],
+      "fixture": "apps:spotify_installed",
+      "expect_intent": "open_app",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "app_name": "Spotify"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'app_name': expected 'Spotify', got '5 minutes'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 4,
+      "case_id": "send_a_message",
+      "message": "send a message",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required",
+        "contact_fixture_required",
+        "ambiguous"
+      ],
+      "fixture": "contacts:family_seed",
+      "expect_intent": "send_sms",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "contact": "Mum"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param contact"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 5,
+      "case_id": "send_an_email",
+      "message": "send an email",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "fixture_required",
+        "contact_fixture_required",
+        "ambiguous"
+      ],
+      "fixture": "contacts:email_contact_seed",
+      "expect_intent": "send_email",
+      "actual_intent": "open_app",
+      "expect_params": {
+        "contact": "Nick"
+      },
+      "actual_params": {
+        "app_name": "5 minutes"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param contact"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 6,
+      "case_id": "add_to_my_list",
+      "message": "add to my list",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill"
+      ],
+      "fixture": null,
+      "expect_intent": "add_to_list",
+      "actual_intent": "add_to_list",
+      "expect_params": {
+        "item": "eggs"
+      },
+      "actual_params": {
+        "item": "sunscreen",
+        "list_name": "holiday"
+      },
+      "intent_passed": true,
+      "params_passed": false,
+      "param_failures": [
+        "Param 'item': expected 'eggs', got 'sunscreen'"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s21-weather-only-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s21-weather-only-skills.json
@@ -1,0 +1,210 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-11T23-20-37Z",
+  "elapsed_seconds": 225.3,
+  "summary": {
+    "total": 7,
+    "passed": 7,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 0
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "whats_the_weather_in_auckland",
+      "message": "what's the weather in Auckland",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "location": "Auckland"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 2,
+      "case_id": "will_it_rain_today",
+      "message": "will it rain today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 3,
+      "case_id": "how_hot_is_it_outside",
+      "message": "how hot is it outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 4,
+      "case_id": "do_i_need_an_umbrella_today",
+      "message": "do I need an umbrella today",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 5,
+      "case_id": "whats_it_like_outside",
+      "message": "what's it like outside",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 6,
+      "case_id": "is_it_gonna_rain_tomorrow",
+      "message": "is it gonna rain tomorrow",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "day": "tomorrow"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 7,
+      "case_id": "temperature_in_wellington",
+      "message": "temperature in Wellington",
+      "category": "fixture",
+      "tags": [
+        "deterministic_core",
+        "fixture_required",
+        "location_context"
+      ],
+      "fixture": null,
+      "expect_intent": "get_weather",
+      "actual_intent": "get_weather",
+      "expect_params": null,
+      "actual_params": {
+        "location": "Wellington"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "weather",
+      "status": "pass",
+      "failure_bucket": null
+    }
+  ]
+}

--- a/docs/test-triage/evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json
+++ b/docs/test-triage/evidence/2026-06-11/s23u-comparison-safe-smoke-skills.json
@@ -1,0 +1,233 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-12T01-02-21Z",
+  "elapsed_seconds": 175.5,
+  "summary": {
+    "total": 7,
+    "passed": 3,
+    "xfail": 0,
+    "xpass": 0,
+    "failed": 4
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm_for_11pm",
+      "message": "set an alarm for 11pm",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_alarm",
+      "expect_params": null,
+      "actual_params": {
+        "hours": "23",
+        "minutes": "0",
+        "time": "23:00"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer_for_2_hours",
+      "message": "set a timer for 2 hours",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "timer",
+      "expect_params": null,
+      "actual_params": {
+        "parameters": "{\"duration\": \"2 hours\""
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "alarm_timer",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 3,
+      "case_id": "remember_that_i_prefer_dark_mode",
+      "message": "remember that I prefer dark mode",
+      "category": "deterministic",
+      "tags": [
+        "deterministic_core",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "save_memory",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "memory",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 4,
+      "case_id": "what_time_is_it",
+      "message": "what time is it",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_time",
+      "actual_intent": "save_memory",
+      "expect_params": null,
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": false,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "fail",
+      "failure_bucket": "wrong_tool"
+    },
+    {
+      "index": 5,
+      "case_id": "whats_my_battery_level",
+      "message": "what's my battery level",
+      "category": "deterministic",
+      "tags": [
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "get_battery",
+      "actual_intent": "get_battery",
+      "expect_params": null,
+      "actual_params": {},
+      "intent_passed": true,
+      "params_passed": true,
+      "param_failures": [],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "system",
+      "status": "pass",
+      "failure_bucket": null
+    },
+    {
+      "index": 6,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_alarm",
+      "actual_intent": "set_timer",
+      "expect_params": {
+        "hours": "7",
+        "minutes": "0"
+      },
+      "actual_params": {
+        "duration_seconds": "7200"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param hours",
+        "Missing param minutes"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    },
+    {
+      "index": 7,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "category": "slot_fill",
+      "tags": [
+        "slot_fill",
+        "safe_smoke",
+        "s21_usb_safe",
+        "s23u_tcp_safe"
+      ],
+      "fixture": null,
+      "expect_intent": "set_timer",
+      "actual_intent": "save_memory",
+      "expect_params": {
+        "duration_seconds": "300"
+      },
+      "actual_params": {
+        "content": "I prefer dark mode"
+      },
+      "intent_passed": false,
+      "params_passed": false,
+      "param_failures": [
+        "Missing param duration_seconds"
+      ],
+      "xfail": false,
+      "xfail_reason": null,
+      "reply_warn": null,
+      "log_check_warn": null,
+      "first_turn_warn": null,
+      "phase": "slot_fill",
+      "status": "fail",
+      "failure_bucket": "field_mismatch"
+    }
+  ]
+}

--- a/scripts/adb_harness/models.py
+++ b/scripts/adb_harness/models.py
@@ -95,6 +95,7 @@ class TestResult:
     xfail_reason: str | None = None
     status: str = ""
     failure_bucket: str | None = None
+    expect_log_contains: str | None = None
 
 
 def is_clean_pass(r: TestResult) -> bool:

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -840,6 +840,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
                 tags=list(tc.tags),
                 fixture=tc.fixture,
                 xfail_reason=tc.xfail_reason,
+                expect_log_contains=tc.expect_log_contains,
             )
             result.status = derive_status(result)
             result.failure_bucket = derive_failure_bucket(result)


### PR DESCRIPTION
## Summary

S21-first targeted ADB triage after the harness observability fix (PR #1181). Generates trustworthy evidence and classifies real root causes. Updated with **post-permission S21 rerun** and **S23U focused comparison**.

## Changes

### Harness bugfix
- Fixed `AttributeError: 'TestResult' object has no attribute 'expect_log_contains'` — added the missing field to the `TestResult` dataclass and wired it through construction.

### Report
- `docs/test-triage/adb-s21-qir-triage-2026-06-11.md`
- Commands, device metadata, oracle/stream health, result counts by slice, failure root-cause buckets, pre-#1181 evidence invalidation statement, and 4 draft follow-up issues.
- **New:** Post-permission S21 rerun section — before vs after comparison table, key findings, weather validation (7/7 pass), slot-fill confirmation.
- **New:** S23U focused comparison section — safe_smoke on S23 Ultra (wireless), cross-device failure comparison table.
- **New:** Follow-up issue tracking section — links to #1189-#1194 with priority and status.
- Evidence JSON files committed under `docs/test-triage/evidence/2026-06-11/`:
  - Original pre-permission baselines: safe_smoke, deterministic_core, slot_fill
  - Post-permission reruns: safe_smoke, deterministic_core, slot_fill
  - Weather-only focused validation
  - S23U comparison: safe_smoke

### Root-cause classification (updated)

| Bucket | Count | Root cause | Status |
|---|---|---|---|
| Model stuck-mode / inference cascade | 38/76 core (original); ~6/13 post-fix | Model returns same intent for consecutive tests | Open — #1190 |
| Weather (stuck-mode confounded) | 7/76 core → proven not a permission bug | Stuck-mode cascade — weather-only rerun proves routing works | **Closed — not a bug** |
| Slot-fill context contamination | 6/6 slot_fill (both runs) | Prior context contaminates slot extraction | Open — #1191 |
| QIR classification gap | 1/76 core | save_memory → save_important_date misrouting | Open — #1192 |

The weather bucket was originally labelled as a location-permission issue but all 7 cases occurred during the stuck-mode cascade. Post-permission weather-only rerun: **7/7 pass as get_weather**. No location-permission bug exists.

### Before vs after permission fix (S21)

| Suite | Before | After | Δ |
|---|---|---|---|
| deterministic_core | 25 pass / 46 fail / 5 xfail | **58 pass / 13 fail / 5 xfail** | **+33 pass** |

### S23U safe_smoke comparison
- S23U (SM-S918B, wireless): 3/7 pass
- Different failure distribution than S21 (case 2 → `timer` instead of `set_alarm`)
- Memory content leak **reproduces on S23U** — case 3's `"I prefer dark mode"` spills into cases 4 and 7, same pattern as S21
- Slot-fill entry failures reproduce the same cross-test contamination pattern

### Pre-#1181 evidence
All previous `NO_MATCH` / `regex_or_qir_miss` evidence is **invalid** due to ADB-TLS logcat corruption. No QIR/router issues should be created from that data.

### Follow-up issues
- Epic: [#1189](https://github.com/NickMonrad/kernel-ai-assistant/issues/1189)
- State carryover: [#1190](https://github.com/NickMonrad/kernel-ai-assistant/issues/1190)
- Slot-fill contamination: [#1191](https://github.com/NickMonrad/kernel-ai-assistant/issues/1191)
- Parked-location QIR gap: [#1192](https://github.com/NickMonrad/kernel-ai-assistant/issues/1192)
- Weather validation: [#1193](https://github.com/NickMonrad/kernel-ai-assistant/issues/1193) — **resolved, no fix needed**
- Evidence update: [#1194](https://github.com/NickMonrad/kernel-ai-assistant/issues/1194)

This PR is docs/evidence-only and is intended to be merged as the durable #1186 evidence/report baseline. Implementation work is tracked separately in #1190, #1191, and #1192.