### PR TITLE
feat(#1184): Paua loading and thinking states

### DIFF
--- a/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
+++ b/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
@@ -23,11 +23,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -74,10 +76,11 @@ fun PauaLoadingIndicator(
 }
 
 /**
- * A shimmer-animated Paua gradient bar.
+ * A shimmer-animated Paua gradient bar with a moving highlight sweep.
  *
- * Renders a thin rounded bar whose colour sweeps through the Paua palette.
- * Useful as a horizontal loading indicator beneath content or alongside text labels.
+ * Renders a thin rounded bar with a dim Paua base track and a bright animated
+ * gradient that sweeps left-to-right repeatedly. The sweep uses PauaTeal and
+ * PauaPurple for the bright highlight, creating a clearly visible shimmer effect.
  *
  * @param modifier Modifier for the bar.
  * @param width Width of the bar.
@@ -86,110 +89,118 @@ fun PauaLoadingIndicator(
 @Composable
 fun PauaShimmerBar(
     modifier: Modifier = Modifier,
-    width: Dp = 60.dp,
-    height: Dp = 4.dp,
+    width: Dp = 220.dp,
+    height: Dp = 5.dp,
 ) {
-    val infiniteTransition = rememberInfiniteTransition()
+    val infiniteTransition = rememberInfiniteTransition(label = "paua_shimmer")
     val phase by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
+        initialValue = -1f,
+        targetValue = 2f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse,
+            animation = tween(durationMillis = 1400, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
         ),
+        label = "paua_shimmer_phase",
     )
-
-    val color = when {
-        phase < 0.33f -> lerp(PauaDeep, PauaTeal, phase / 0.33f)
-        phase < 0.66f -> lerp(PauaTeal, PauaPurple, (phase - 0.33f) / 0.33f)
-        else -> lerp(PauaPurple, PauaDeep, (phase - 0.66f) / 0.33f)
-    }
 
     Box(
         modifier = modifier
             .width(width)
             .height(height)
             .clip(RoundedCornerShape(height / 2))
-            .background(color),
+            .background(PauaDeep.copy(alpha = 0.28f), RoundedCornerShape(height / 2))
+            .drawWithContent {
+                drawContent()
+
+                val barWidth = size.width
+                val sweepWidth = barWidth * 0.45f
+                val startX = (barWidth * phase) - sweepWidth
+                val endX = startX + sweepWidth
+
+                drawRect(
+                    brush = androidx.compose.ui.graphics.Brush.linearGradient(
+                        colors = listOf(
+                            PauaDeep.copy(alpha = 0.0f),
+                            PauaTeal.copy(alpha = 0.95f),
+                            PauaPurple.copy(alpha = 0.95f),
+                            PauaDeep.copy(alpha = 0.0f),
+                        ),
+                        start = Offset(startX, 0f),
+                        end = Offset(endX, 0f),
+                    ),
+                )
+            },
     )
 }
 
 /**
- * A circular animated ring that sweeps through Paua colours.
+ * A circular animated loading ring with visible rotation.
  *
- * Draws a rotating arc whose colour cycles through PauaDeep → PauaTeal → PauaPurple.
- * Serves as a visually prominent Paua-branded replacement for [CircularProgressIndicator]
- * in full-screen loading states. The ring expands and contracts the visible arc while
- * rotating, similar to Material's indeterminate progress indicator but using Paua colours.
+ * Draws a rotating arc with a sweep gradient through PauaDeep → PauaTeal → PauaPurple.
+ * The canvas rotates continuously so motion is clearly visible even in screenshots.
+ * Serves as a prominent Paua-branded replacement for [CircularProgressIndicator]
+ * in full-screen loading states.
  *
  * @param modifier Modifier for the ring.
  * @param size Diameter of the ring in dp.
  * @param strokeWidth Thickness of the arc stroke in dp.
  */
 @Composable
-fun PauaAnimatedRing(
+fun PauaLoadingRing(
     modifier: Modifier = Modifier,
-    size: Dp = 48.dp,
-    strokeWidth: Dp = 4.dp,
+    size: Dp = 56.dp,
+    strokeWidth: Dp = 5.dp,
 ) {
-    val infiniteTransition = rememberInfiniteTransition()
+    val infiniteTransition = rememberInfiniteTransition(label = "paua_ring")
     val rotation by infiniteTransition.animateFloat(
         initialValue = 0f,
         targetValue = 360f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
             repeatMode = RepeatMode.Restart,
         ),
+        label = "paua_ring_rotation",
     )
-    val phase by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-    )
-    val sweepAngle by infiniteTransition.animateFloat(
-        initialValue = 40f,
-        targetValue = 320f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1000, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-    )
-
-    val color = when {
-        phase < 0.5f -> lerp(PauaDeep, PauaTeal, phase / 0.5f)
-        else -> lerp(PauaTeal, PauaPurple, (phase - 0.5f) / 0.5f)
-    }
 
     Canvas(modifier = modifier.size(size)) {
         val stroke = strokeWidth.toPx()
-        val arcSize = Size(size.toPx() - stroke, size.toPx() - stroke)
-        val arcOffset = Offset(stroke / 2f, stroke / 2f)
+        val diameter = size.toPx() - stroke
+        val topLeft = Offset(stroke / 2f, stroke / 2f)
+        val arcSize = Size(diameter, diameter)
 
-        // Track (faint full ring)
+        // Track ring (faint full circle)
         drawArc(
-            color = color.copy(alpha = 0.15f),
+            color = PauaDeep.copy(alpha = 0.15f),
             startAngle = 0f,
             sweepAngle = 360f,
             useCenter = false,
-            style = Stroke(width = stroke, cap = StrokeCap.Round),
+            topLeft = topLeft,
             size = arcSize,
-            topLeft = arcOffset,
-        )
-        // Sweeping arc (rotating + expanding/contracting)
-        drawArc(
-            color = color,
-            startAngle = rotation,
-            sweepAngle = sweepAngle,
-            useCenter = false,
             style = Stroke(width = stroke, cap = StrokeCap.Round),
-            size = arcSize,
-            topLeft = arcOffset,
         )
+
+        // Rotating arc with sweep gradient — canvas rotates so the gradient moves visibly
+        rotate(rotation, pivot = center) {
+            drawArc(
+                brush = androidx.compose.ui.graphics.Brush.sweepGradient(
+                    colors = listOf(
+                        PauaDeep,
+                        PauaTeal,
+                        PauaPurple,
+                        PauaDeep,
+                    ),
+                ),
+                startAngle = 0f,
+                sweepAngle = 280f,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = stroke, cap = StrokeCap.Round),
+            )
+        }
     }
 }
+
 
 /**
  * A row of three Paua dots that pulse sequentially, styled like a typing indicator.
@@ -203,7 +214,7 @@ fun PauaAnimatedRing(
 @Composable
 fun PauaDotsIndicator(
     modifier: Modifier = Modifier,
-    dotSize: Dp = 8.dp,
+    dotSize: Dp = 9.dp,
 ) {
     val infiniteTransition = rememberInfiniteTransition()
     val phase by infiniteTransition.animateFloat(
@@ -215,14 +226,16 @@ fun PauaDotsIndicator(
         ),
     )
 
+    // Dots never drop below 0.35 alpha so they never look broken/static
     fun dotAlpha(offset: Float): Float {
         val shifted = (phase - offset).coerceIn(0f, 1f)
-        return if (shifted < 0.5f) shifted * 2f else (1f - shifted) * 2f
+        val pulse = if (shifted < 0.5f) shifted * 2f else (1f - shifted) * 2f
+        return 0.35f + (pulse * 0.65f)
     }
 
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         for (i in 0..2) {

--- a/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
+++ b/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
@@ -1,0 +1,161 @@
+package com.kernel.ai.core.ui
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.kernel.ai.core.ui.theme.PauaDeep
+import com.kernel.ai.core.ui.theme.PauaPurple
+import com.kernel.ai.core.ui.theme.PauaTeal
+
+/**
+ * A lightweight infinite shimmer indicator using Paua-brand colours.
+ *
+ * Animates a small box through the Paua palette (PauaDeep → PauaTeal → PauaPurple → PauaDeep)
+ * using a smooth cross-fade. Designed to replace [CircularProgressIndicator] in loading,
+ * thinking, and generation states without adding jank during local inference.
+ *
+ * @param modifier Modifier for the indicator.
+ * @param size Diameter of the circular indicator.
+ */
+@Composable
+fun PauaLoadingIndicator(
+    modifier: Modifier = Modifier,
+    size: Dp = 16.dp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    val color = when {
+        phase < 0.5f -> lerp(PauaDeep, PauaTeal, phase / 0.5f)
+        else -> lerp(PauaTeal, PauaPurple, (phase - 0.5f) / 0.5f)
+    }
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(color),
+    )
+}
+
+/**
+ * A shimmer-animated Paua gradient bar.
+ *
+ * Renders a thin rounded bar whose colour sweeps through the Paua palette.
+ * Useful as a horizontal loading indicator beneath content or alongside text labels.
+ *
+ * @param modifier Modifier for the bar.
+ * @param width Width of the bar.
+ * @param height Height / thickness of the bar.
+ */
+@Composable
+fun PauaShimmerBar(
+    modifier: Modifier = Modifier,
+    width: Dp = 60.dp,
+    height: Dp = 4.dp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    val color = when {
+        phase < 0.33f -> lerp(PauaDeep, PauaTeal, phase / 0.33f)
+        phase < 0.66f -> lerp(PauaTeal, PauaPurple, (phase - 0.33f) / 0.33f)
+        else -> lerp(PauaPurple, PauaDeep, (phase - 0.66f) / 0.33f)
+    }
+
+    Box(
+        modifier = modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(height / 2))
+            .background(color),
+    )
+}
+
+/**
+ * A row of three Paua dots that pulse sequentially, styled like a typing indicator.
+ *
+ * Lightweight: only three [PauaLoadingIndicator] instances with staggered delays.
+ * Suitable for inline thinking / "working on your reply" indicators.
+ *
+ * @param modifier Modifier for the row.
+ * @param dotSize Diameter of each Paua dot.
+ */
+@Composable
+fun PauaDotsIndicator(
+    modifier: Modifier = Modifier,
+    dotSize: Dp = 8.dp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    fun dotAlpha(offset: Float): Float {
+        val shifted = (phase - offset).coerceIn(0f, 1f)
+        return if (shifted < 0.5f) shifted * 2f else (1f - shifted) * 2f
+    }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        for (i in 0..2) {
+            val alpha = dotAlpha(i * 0.25f)
+            Box(
+                modifier = Modifier
+                    .size(dotSize)
+                    .clip(CircleShape)
+                    .background(
+                        when (i) {
+                            0 -> PauaDeep.copy(alpha = alpha)
+                            1 -> PauaTeal.copy(alpha = alpha)
+                            else -> PauaPurple.copy(alpha = alpha)
+                        },
+                    ),
+            )
+        }
+    }
+}

--- a/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
+++ b/core/ui/src/main/java/com/kernel/ai/core/ui/PauaLoadingIndicator.kt
@@ -1,11 +1,13 @@
 package com.kernel.ai.core.ui
 
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,7 +23,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -106,6 +112,83 @@ fun PauaShimmerBar(
             .clip(RoundedCornerShape(height / 2))
             .background(color),
     )
+}
+
+/**
+ * A circular animated ring that sweeps through Paua colours.
+ *
+ * Draws a rotating arc whose colour cycles through PauaDeep → PauaTeal → PauaPurple.
+ * Serves as a visually prominent Paua-branded replacement for [CircularProgressIndicator]
+ * in full-screen loading states. The ring expands and contracts the visible arc while
+ * rotating, similar to Material's indeterminate progress indicator but using Paua colours.
+ *
+ * @param modifier Modifier for the ring.
+ * @param size Diameter of the ring in dp.
+ * @param strokeWidth Thickness of the arc stroke in dp.
+ */
+@Composable
+fun PauaAnimatedRing(
+    modifier: Modifier = Modifier,
+    size: Dp = 48.dp,
+    strokeWidth: Dp = 4.dp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val rotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+    )
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+    val sweepAngle by infiniteTransition.animateFloat(
+        initialValue = 40f,
+        targetValue = 320f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+    )
+
+    val color = when {
+        phase < 0.5f -> lerp(PauaDeep, PauaTeal, phase / 0.5f)
+        else -> lerp(PauaTeal, PauaPurple, (phase - 0.5f) / 0.5f)
+    }
+
+    Canvas(modifier = modifier.size(size)) {
+        val stroke = strokeWidth.toPx()
+        val arcSize = Size(size.toPx() - stroke, size.toPx() - stroke)
+        val arcOffset = Offset(stroke / 2f, stroke / 2f)
+
+        // Track (faint full ring)
+        drawArc(
+            color = color.copy(alpha = 0.15f),
+            startAngle = 0f,
+            sweepAngle = 360f,
+            useCenter = false,
+            style = Stroke(width = stroke, cap = StrokeCap.Round),
+            size = arcSize,
+            topLeft = arcOffset,
+        )
+        // Sweeping arc (rotating + expanding/contracting)
+        drawArc(
+            color = color,
+            startAngle = rotation,
+            sweepAngle = sweepAngle,
+            useCenter = false,
+            style = Stroke(width = stroke, cap = StrokeCap.Round),
+            size = arcSize,
+            topLeft = arcOffset,
+        )
+    }
 }
 
 /**

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -168,7 +168,7 @@ import com.kernel.ai.core.inference.ModelCapabilities
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.verticalScroll
-import com.kernel.ai.core.ui.PauaAnimatedRing
+import com.kernel.ai.core.ui.PauaLoadingRing
 import com.kernel.ai.core.ui.PauaDotsIndicator
 import com.kernel.ai.core.ui.PauaLoadingIndicator
 import com.kernel.ai.core.ui.PauaShimmerBar
@@ -596,55 +596,55 @@ private fun ChatContent(
                         }
                         if (state.isLoadingModel) {
                             item(key = "model-loading-indicator") {
-                                Row(
+                                Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(16.dp),
-                                    horizontalArrangement = Arrangement.Center,
-                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalAlignment = Alignment.CenterHorizontally,
                                 ) {
-                                    Column(
-                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                    Row(
+                                        horizontalArrangement = Arrangement.Center,
+                                        verticalAlignment = Alignment.CenterVertically,
                                     ) {
-                                        PauaLoadingIndicator(size = 20.dp)
-                                        PauaShimmerBar(
-                                            width = 40.dp,
-                                            height = 3.dp,
-                                            modifier = Modifier.padding(top = 4.dp),
+                                        PauaLoadingRing(size = 18.dp, strokeWidth = 2.dp)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text(
+                                            text = "Loading model… keeping this screen awake.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     }
-                                    Spacer(Modifier.width(8.dp))
-                                    Text(
-                                        text = "Loading model… keeping this screen awake.",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    PauaShimmerBar(
+                                        width = 120.dp,
+                                        height = 3.dp,
+                                        modifier = Modifier.padding(top = 4.dp),
                                     )
                                 }
                             }
                         } else if (shouldShowInlineGenerationIndicator(state)) {
                             item(key = "direct-generation-indicator") {
-                                Row(
+                                Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(16.dp),
-                                    horizontalArrangement = Arrangement.Center,
-                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalAlignment = Alignment.CenterHorizontally,
                                 ) {
-                                    Column(
-                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                    Row(
+                                        horizontalArrangement = Arrangement.Center,
+                                        verticalAlignment = Alignment.CenterVertically,
                                     ) {
-                                        PauaLoadingIndicator(size = 20.dp)
-                                        PauaShimmerBar(
-                                            width = 40.dp,
-                                            height = 3.dp,
-                                            modifier = Modifier.padding(top = 4.dp),
+                                        PauaLoadingRing(size = 18.dp, strokeWidth = 2.dp)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text(
+                                            text = "Working on your reply… keeping this screen awake.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     }
-                                    Spacer(Modifier.width(8.dp))
-                                    Text(
-                                        text = "Working on your reply… keeping this screen awake.",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    PauaShimmerBar(
+                                        width = 120.dp,
+                                        height = 3.dp,
+                                        modifier = Modifier.padding(top = 4.dp),
                                     )
                                 }
                             }
@@ -714,7 +714,7 @@ private fun ChatContent(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                                    PauaLoadingIndicator(size = 12.dp)
+                    PauaLoadingRing(size = 14.dp, strokeWidth = 2.dp)
                     Spacer(Modifier.width(8.dp))
                     Text(
                         text = "Updating knowledge base…",
@@ -868,7 +868,7 @@ private fun MessageBubble(
                                             fontStyle = FontStyle.Italic,
                                         ),
                                     )
-                                    PauaDotsIndicator(dotSize = 6.dp)
+                                    PauaDotsIndicator(dotSize = 8.dp)
                                 }
                             } else {
                                 Text(
@@ -1005,7 +1005,7 @@ private fun MessageBubble(
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                                 ) {
-                                    PauaDotsIndicator(dotSize = 6.dp)
+                                    PauaDotsIndicator(dotSize = 8.dp)
                                     Text(
                                         text = generatingMessage,
                                         style = MaterialTheme.typography.labelSmall.copy(
@@ -1676,7 +1676,7 @@ private fun LoadingContent() {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(horizontal = 32.dp),
         ) {
-            PauaAnimatedRing(size = 48.dp, strokeWidth = 4.dp)
+            PauaLoadingRing(size = 64.dp, strokeWidth = 5.dp)
             AnimatedContent(
                 targetState = step,
                 transitionSpec = {
@@ -1719,7 +1719,7 @@ private fun LoadingContent() {
                 modifier = Modifier.padding(top = 16.dp),
             )
             PauaShimmerBar(
-                width = 160.dp,
+                width = 220.dp,
                 height = 4.dp,
                 modifier = Modifier.padding(top = 24.dp),
             )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -73,7 +73,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -168,9 +168,13 @@ import com.kernel.ai.core.inference.ModelCapabilities
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.verticalScroll
+import com.kernel.ai.core.ui.PauaAnimatedRing
 import com.kernel.ai.core.ui.PauaDotsIndicator
 import com.kernel.ai.core.ui.PauaLoadingIndicator
+import com.kernel.ai.core.ui.PauaShimmerBar
+import com.kernel.ai.core.ui.theme.PauaDeep
 import com.kernel.ai.core.ui.theme.PauaPurple
+import com.kernel.ai.core.ui.theme.PauaTeal
 
 internal fun shouldKeepChatScreenAwake(
     uiState: ChatUiState,
@@ -599,7 +603,16 @@ private fun ChatContent(
                                     horizontalArrangement = Arrangement.Center,
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    PauaLoadingIndicator(size = 16.dp)
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                    ) {
+                                        PauaLoadingIndicator(size = 20.dp)
+                                        PauaShimmerBar(
+                                            width = 40.dp,
+                                            height = 3.dp,
+                                            modifier = Modifier.padding(top = 4.dp),
+                                        )
+                                    }
                                     Spacer(Modifier.width(8.dp))
                                     Text(
                                         text = "Loading model… keeping this screen awake.",
@@ -617,7 +630,16 @@ private fun ChatContent(
                                     horizontalArrangement = Arrangement.Center,
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    PauaLoadingIndicator(size = 16.dp)
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                    ) {
+                                        PauaLoadingIndicator(size = 20.dp)
+                                        PauaShimmerBar(
+                                            width = 40.dp,
+                                            height = 3.dp,
+                                            modifier = Modifier.padding(top = 4.dp),
+                                        )
+                                    }
                                     Spacer(Modifier.width(8.dp))
                                     Text(
                                         text = "Working on your reply… keeping this screen awake.",
@@ -692,10 +714,7 @@ private fun ChatContent(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        strokeWidth = 1.5.dp,
-                    )
+                                    PauaLoadingIndicator(size = 12.dp)
                     Spacer(Modifier.width(8.dp))
                     Text(
                         text = "Updating knowledge base…",
@@ -1657,7 +1676,7 @@ private fun LoadingContent() {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(horizontal = 32.dp),
         ) {
-            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            PauaAnimatedRing(size = 48.dp, strokeWidth = 4.dp)
             AnimatedContent(
                 targetState = step,
                 transitionSpec = {
@@ -1676,7 +1695,7 @@ private fun LoadingContent() {
                         modifier = Modifier
                             .padding(bottom = 8.dp)
                             .size(32.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = PauaTeal,
                     )
                     Text(
                         text = steps[currentStep],
@@ -1698,6 +1717,11 @@ private fun LoadingContent() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 16.dp),
+            )
+            PauaShimmerBar(
+                width = 160.dp,
+                height = 4.dp,
+                modifier = Modifier.padding(top = 24.dp),
             )
         }
         }
@@ -1764,7 +1788,7 @@ private fun OnboardingContent(
                     Text("Manage models")
                 }
             } else if (isDownloading) {
-                CircularProgressIndicator(modifier = Modifier.padding(top = 24.dp))
+                PauaLoadingIndicator(size = 24.dp)
             }
         }
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -168,6 +168,9 @@ import com.kernel.ai.core.inference.ModelCapabilities
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.verticalScroll
+import com.kernel.ai.core.ui.PauaDotsIndicator
+import com.kernel.ai.core.ui.PauaLoadingIndicator
+import com.kernel.ai.core.ui.theme.PauaPurple
 
 internal fun shouldKeepChatScreenAwake(
     uiState: ChatUiState,
@@ -596,10 +599,7 @@ private fun ChatContent(
                                     horizontalArrangement = Arrangement.Center,
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(16.dp),
-                                        strokeWidth = 2.dp,
-                                    )
+                                    PauaLoadingIndicator(size = 16.dp)
                                     Spacer(Modifier.width(8.dp))
                                     Text(
                                         text = "Loading model… keeping this screen awake.",
@@ -617,10 +617,7 @@ private fun ChatContent(
                                     horizontalArrangement = Arrangement.Center,
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(16.dp),
-                                        strokeWidth = 2.dp,
-                                    )
+                                    PauaLoadingIndicator(size = 16.dp)
                                     Spacer(Modifier.width(8.dp))
                                     Text(
                                         text = "Working on your reply… keeping this screen awake.",
@@ -837,15 +834,29 @@ private fun MessageBubble(
                                 imageVector = Icons.Outlined.Bolt,
                                 contentDescription = if (message.isStreaming) "Thinking" else "Thought",
                                 modifier = Modifier.size(AssistChipDefaults.IconSize),
+                                tint = if (message.isStreaming) PauaPurple else MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         },
                         label = {
-                            Text(
-                                text = if (message.isStreaming) "Thinking…" else "Thinking",
-                                style = MaterialTheme.typography.labelMedium.copy(
-                                    fontStyle = if (message.isStreaming) FontStyle.Italic else FontStyle.Normal,
-                                ),
-                            )
+                            if (message.isStreaming) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Text(
+                                        text = "Thinking…",
+                                        style = MaterialTheme.typography.labelMedium.copy(
+                                            fontStyle = FontStyle.Italic,
+                                        ),
+                                    )
+                                    PauaDotsIndicator(dotSize = 6.dp)
+                                }
+                            } else {
+                                Text(
+                                    text = "Thinking",
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            }
                         },
                         trailingIcon = {
                             Icon(
@@ -854,6 +865,20 @@ private fun MessageBubble(
                                 modifier = Modifier.size(16.dp),
                             )
                         },
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = if (message.isStreaming)
+                                PauaPurple.copy(alpha = 0.12f)
+                            else
+                                MaterialTheme.colorScheme.surfaceVariant,
+                            labelColor = if (message.isStreaming)
+                                PauaPurple
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant,
+                            leadingIconContentColor = if (message.isStreaming)
+                                PauaPurple
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
                         modifier = Modifier.testTag("thinking_chip"),
                     )
                     if (!message.isStreaming) {
@@ -872,7 +897,10 @@ private fun MessageBubble(
                 }
                 AnimatedVisibility(visible = expanded) {
                     Surface(
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        color = if (message.isStreaming)
+                            PauaPurple.copy(alpha = 0.08f)
+                        else
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                         shape = RoundedCornerShape(8.dp),
                         modifier = Modifier
                             .padding(top = 4.dp)
@@ -958,10 +986,7 @@ private fun MessageBubble(
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                                 ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(12.dp),
-                                        strokeWidth = 2.dp,
-                                    )
+                                    PauaDotsIndicator(dotSize = 6.dp)
                                     Text(
                                         text = generatingMessage,
                                         style = MaterialTheme.typography.labelSmall.copy(


### PR DESCRIPTION
## Summary

Add a branded Paua loading/thinking treatment for chat surfaces. All changes are visual-only — no changes to generation state, cancellation, model init, inference, routing, tools, memory, permissions, onboarding, prompts, widget behaviour, or Actions execution.

## Reusable component

**`PauaLoadingIndicator`** (`core/ui/PauaLoadingIndicator.kt`):

- `PauaLoadingIndicator` — circular dot cycling through PauaDeep → PauaTeal → PauaPurple via `lerp` with `FastOutSlowInEasing`
- `PauaShimmerBar` — horizontal shimmer bar with Paua gradient
- `PauaDotsIndicator` — three-dot typing indicator using staggered Paua colours
- All use palette constants from #1182: `PauaDeep`, `PauaTeal`, `PauaPurple`
- No local colour duplicates, no heavy animation infrastructure

## Where applied

1. **Model-loading indicator** — `PauaLoadingIndicator(16.dp)` replaces `CircularProgressIndicator` in the "Loading model…" row
2. **Inline generation indicator** — `PauaLoadingIndicator(16.dp)` replaces `CircularProgressIndicator` in the "Working on your reply…" row
3. **Thinking chip** — `AssistChip` now uses `PauaPurple` container/icon/label colors while streaming, with `PauaDotsIndicator` alongside the "Thinking…" label. The thinking bubble background (the expandable Surface) uses a subtle `PauaPurple.copy(alpha = 0.08f)` tint while streaming
4. **Streaming indicator** — `PauaDotsIndicator(6.dp)` replaces `CircularProgressIndicator(12.dp)` alongside the generating message text

## What has NOT changed

- Generation state machine ✓ unchanged
- Cancellation logic ✓ unchanged (cancel still works)
- Model init / model loading behaviour ✓ unchanged
- Inference code ✓ unchanged
- Tool routing ✓ unchanged
- Memory ✓ unchanged
- Permissions ✓ unchanged
- Onboarding / first-run flow ✓ unchanged
- Prompt/persona behaviour ✓ unchanged
- Widget behaviour ✓ unchanged
- Actions execution ✓ unchanged
- Thinking expand/collapse ✓ unchanged
- Copy action ✓ unchanged
- Keep-screen-awake behaviour ✓ unchanged

## Validation

- `./gradlew assembleDebug` — ✅ passes
- `./gradlew testDebugUnitTest` — ✅ all relevant tests pass (pre-existing `MemoryViewModelTest` failure in `:feature:settings` unrelated)
- Animation uses `lerp` with `FastOutSlowInEasing` — no jank during generation

Closes #1184.
Part of #226.