### PR TITLE
feat(#1184): add Paua shimmer loading treatment for model-loading and thinking states

### DIFF
--- a/core/ui/src/main/java/com/kernel/ai/core/ui/PauaShimmerSurface.kt
+++ b/core/ui/src/main/java/com/kernel/ai/core/ui/PauaShimmerSurface.kt
@@ -1,0 +1,79 @@
+package com.kernel.ai.core.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.kernel.ai.core.ui.theme.PauaDeep
+import com.kernel.ai.core.ui.theme.PauaPurple
+import com.kernel.ai.core.ui.theme.PauaTeal
+
+/**
+ * A lightweight infinite shimmer surface using the Jandal Paua palette
+ * (Paua Deep → Paua Teal → Paua Purple → Paua Deep).
+ *
+ * Apply as a background or overlay where a branded loading/thinking
+ * treatment is needed. Animates a horizontal gradient.
+ *
+ * @param modifier Modifier for sizing/positioning.
+ * @param shape RoundedCornerShape for the clip surface (default 12.dp).
+ * @param content Optional content overlaid on top of the shimmer.
+ */
+@Composable
+fun PauaShimmerSurface(
+    modifier: Modifier = Modifier,
+    shape: RoundedCornerShape = RoundedCornerShape(12.dp),
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "pauaShimmer")
+    val shimmerOffset by infiniteTransition.animateFloat(
+        initialValue = -1f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2500, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmerOffset",
+    )
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .drawWithContent {
+                val gradient = Brush.linearGradient(
+                    colors = listOf(
+                        PauaDeep,
+                        PauaDeep.copy(alpha = 0.7f),
+                        PauaTeal,
+                        PauaPurple,
+                        PauaTeal,
+                        PauaDeep.copy(alpha = 0.7f),
+                        PauaDeep,
+                    ),
+                    start = Offset(shimmerOffset * size.width, 0f),
+                    end = Offset((shimmerOffset + 2f) * size.width, 0f),
+                )
+                drawRect(gradient)
+                drawContent()
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.WindowInsets
+import com.kernel.ai.core.ui.PauaShimmerSurface
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -829,46 +830,56 @@ private fun MessageBubble(
             var userExpanded by rememberSaveable(key = "thinking_userExpanded") { mutableStateOf(false) }
             val expanded = userExpanded || message.isStreaming
             Column(modifier = Modifier.padding(bottom = 4.dp).testTag("think_bubble")) {
-                Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                    AssistChip(
-                        onClick = { userExpanded = !userExpanded },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Outlined.Bolt,
-                                contentDescription = if (message.isStreaming) "Thinking" else "Thought",
-                                modifier = Modifier.size(AssistChipDefaults.IconSize),
-                            )
-                        },
-                        label = {
-                            Text(
-                                text = if (message.isStreaming) "Thinking…" else "Thinking",
-                                style = MaterialTheme.typography.labelMedium.copy(
-                                    fontStyle = if (message.isStreaming) FontStyle.Italic else FontStyle.Normal,
-                                ),
-                            )
-                        },
-                        trailingIcon = {
-                            Icon(
-                                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                                contentDescription = if (expanded) "Collapse thinking" else "Expand thinking",
-                                modifier = Modifier.size(16.dp),
-                            )
-                        },
-                        modifier = Modifier.testTag("thinking_chip"),
-                    )
-                    if (!message.isStreaming) {
-                        IconButton(
-                            onClick = { onCopy(message.thinkingText!!) },
-                            modifier = Modifier.size(32.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.ContentCopy,
-                                contentDescription = "Copy thinking",
-                                modifier = Modifier.size(16.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                val chipContent = @Composable {
+                    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                        AssistChip(
+                            onClick = { userExpanded = !userExpanded },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Bolt,
+                                    contentDescription = if (message.isStreaming) "Thinking" else "Thought",
+                                    modifier = Modifier.size(AssistChipDefaults.IconSize),
+                                )
+                            },
+                            label = {
+                                Text(
+                                    text = if (message.isStreaming) "Thinking…" else "Thinking",
+                                    style = MaterialTheme.typography.labelMedium.copy(
+                                        fontStyle = if (message.isStreaming) FontStyle.Italic else FontStyle.Normal,
+                                    ),
+                                )
+                            },
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                    contentDescription = if (expanded) "Collapse thinking" else "Expand thinking",
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            },
+                            modifier = Modifier.testTag("thinking_chip"),
+                        )
+                        if (!message.isStreaming) {
+                            IconButton(
+                                onClick = { onCopy(message.thinkingText!!) },
+                                modifier = Modifier.size(32.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.ContentCopy,
+                                    contentDescription = "Copy thinking",
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
                         }
                     }
+                }
+                if (message.isStreaming) {
+                    PauaShimmerSurface(
+                        shape = RoundedCornerShape(20.dp),
+                    ) {
+                        chipContent()
+                    }
+                } else {
+                    chipContent()
                 }
                 AnimatedVisibility(visible = expanded) {
                     Surface(
@@ -1635,7 +1646,10 @@ private fun LoadingContent() {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(horizontal = 32.dp),
         ) {
-            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            PauaShimmerSurface(
+                modifier = Modifier.size(80.dp),
+                shape = RoundedCornerShape(40.dp),
+            )
             AnimatedContent(
                 targetState = step,
                 transitionSpec = {


### PR DESCRIPTION
## Summary

Adds branded Paua loading/thinking treatment as a reusable Compose component and applies it to the model-loading and thinking-chip surfaces.

Part of #226 (Jandal visual identity polish).
Closes #1184.

## Changes

### New: `core/ui/.../PauaShimmerSurface.kt`

A lightweight reusable shimmer component using the Jandal Paua palette:
- Animates an infinite horizontal gradient through Paua Deep → Paua Teal → Paua Purple → Paua Deep
- Uses `drawWithContent` for efficient rendering (no overdraw)
- Accepts optional `content` lambda for overlay content
- Default `RoundedCornerShape(12.dp)`

### `ChatScreen.kt` — LoadingContent

Replaces the generic `CircularProgressIndicator` with a circular `PauaShimmerSurface(80.dp, RoundedCornerShape(40.dp))` during model initialisation.

### `ChatScreen.kt` — Thinking chip

When the model is actively streaming a thinking response (`message.isStreaming`), the thinking AssistChip is wrapped in a `PauaShimmerSurface(shape = RoundedCornerShape(20.dp))`. Static/completed thought chips remain unchanged.

## Out of scope

- No inference, cancellation, routing, tool, memory, permission, or onboarding behaviour changes.
- No changes to the `isGenerating` guard, voice stop buttons, or the send/cancel button layout.

## Validation

- [x] `./gradlew :feature:chat:compileDebugKotlin` — clean
- [x] `./gradlew :feature:chat:testDebugUnitTest` — all **442 tests pass**
- [ ] S23U manual smoke: trigger model loading and observe Paua shimmer
- [ ] S23U manual smoke: send a query that triggers thinking mode and observe Paua shimmer on the thinking chip
