### PR TITLE
fix: chat polish for timestamp contrast and stop button spacing

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -1485,7 +1485,7 @@ private fun InputBar(
                                 color = MaterialTheme.colorScheme.errorContainer,
                                 modifier = Modifier
                                     .testTag("chat_cancel_generation")
-                                    .padding(end = 4.dp),
+                                    .padding(end = 10.dp),
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Stop,
@@ -1496,7 +1496,7 @@ private fun InputBar(
                             }
                             } else {
                                 IconButton(
-                                    modifier = Modifier.padding(end = 4.dp),
+                                    modifier = Modifier.padding(end = 10.dp),
                                     onClick = onSend,
                                     enabled = sendEnabled,
                                 ) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -780,7 +780,7 @@ private fun ConversationListItem(
                 else
                     formatTimestamp(conversation.updatedAt),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.outline,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         leadingContent = if (isInSelectionMode) {


### PR DESCRIPTION
Visual/layout-only changes — no behaviour, inference, cancellation, routing, or data changes.

## Changes

### #1196 — Timestamp/date contrast
- **File:** `ConversationListScreen.kt`
- **Change:** `color = MaterialTheme.colorScheme.outline` → `color = MaterialTheme.colorScheme.onSurfaceVariant`
- **Rationale:** `outline` is the lowest-contrast M3 token designed for borders, not text. `onSurfaceVariant` is the correct token for secondary/subtitle text. Improves readability in dark/Jandal fallback theme while keeping timestamps visually subordinate to the conversation title.
- Dynamic Colour mode preserved (theme token, not hard-coded colour).

### #1197 — Stop-inferencing button trailing spacing
- **File:** `ChatScreen.kt`
- **Change:** `padding(end = 4.dp)` → `padding(end = 10.dp)` on both the stop button (Surface) and the send button (IconButton)
- **Rationale:** The stop button was crowding the trailing/right edge of the input bar. 10dp provides safer inset while keeping both buttons aligned across idle/generating states.
- No changes to click handlers, semantics, test tag, content description, or cancellation behaviour.

## Validation
- `./gradlew :feature:chat:compileDebugKotlin` ✅
- All warnings pre-existing
- Manual smoke to follow on dark/Jandal theme: timestamps readable, stop button comfortably placed

Closes #1196
Closes #1197