### PR TITLE
fix(#1191): isolate slot-fill state across independent ADB commands

### DIFF
--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -125,6 +125,12 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        // #1191: Clear one-shot ADB extras before reading new intent extras.
+        // When a new `quick_action_input` arrives without `slot_reply_input`, the stale
+        // slot reply value would persist and re-fire the LaunchedEffect in ActionsScreen
+        // if the composable re-enters between independent commands, causing the previous
+        // case's slot reply to overwrite the newly primed pending slot.
+        adbSlotReplyInput.value = null
         intent.getStringExtra("chat_input")?.let { adbChatInput.value = it }
         intent.getStringExtra("quick_action_input")?.takeIf { it.isNotBlank() }?.let {
             val voice = intent.getBooleanExtra("quick_action_is_voice", false)

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -337,4 +337,97 @@ class SlotFillerManagerTest {
         assertFalse(manager.hasPending)
         assertNull(manager.pendingRequest)
     }
+
+    @Test
+    fun `sequential slot completions do not leak values between independent requests`() {
+        // Simulate: complete open_app(app_name=Spotify), then new set_timer(duration_seconds=5min)
+        // The second completion must not inherit app_name from the first.
+
+        // First request: open_app → fill app_name=Spotify
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "open_app",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("app_name", "Which app?"),
+            ),
+        )
+        val firstResult = manager.onUserReply(conversationOne, "Spotify")
+        assertInstanceOf(SlotFillResult.Completed::class.java, firstResult)
+        val completed = firstResult as SlotFillResult.Completed
+        assertEquals("open_app", completed.intentName)
+        assertEquals("Spotify", completed.params["app_name"])
+        assertFalse(manager.hasPending)
+
+        // Second independent request: set_timer → fill duration_seconds=300
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long?"),
+            ),
+        )
+        val secondResult = manager.onUserReply(conversationOne, "5 minutes")
+        assertInstanceOf(SlotFillResult.Completed::class.java, secondResult)
+        val completed2 = secondResult as SlotFillResult.Completed
+        assertEquals("set_timer", completed2.intentName)
+        assertEquals("5 minutes", completed2.params["duration_seconds"])
+        // MUST NOT leak app_name from first request
+        assertNull(completed2.params["app_name"])
+    }
+
+    @Test
+    fun `current reply value wins over stale existing params`() {
+        // existingParams carries a stale value (e.g. app_name=5 minutes from a previous bug),
+        // but the current reply is "Spotify" — the current reply must win.
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "open_app",
+                existingParams = mapOf("app_name" to "5 minutes"),  // stale value
+                missingSlot = SlotSpec("app_name", "Which app?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "Spotify")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("Spotify", completed.params["app_name"])
+    }
+
+    @Test
+    fun `cancel clears all pending state for new independent requests`() {
+        // First: create a pending open_app request
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "open_app",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("app_name", "Which app?"),
+            ),
+        )
+        assertTrue(manager.hasPending)
+
+        // Simulate cancellation — new independent command clears incompatible pending slot state
+        manager.cancel()
+
+        assertFalse(manager.hasPending)
+        assertNull(manager.pendingRequest)
+
+        // New independent request must work fresh
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long?"),
+            ),
+        )
+        assertTrue(manager.hasPending)
+        val result = manager.onUserReply(conversationOne, "300")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("set_timer", completed.intentName)
+        assertEquals("300", completed.params["duration_seconds"])
+    }
 }

--- a/docs/test-triage/evidence/2026-06-12/issue-1191-s21-safe-smoke-regression.json
+++ b/docs/test-triage/evidence/2026-06-12/issue-1191-s21-safe-smoke-regression.json
@@ -1,0 +1,19 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-12T13-55-03Z",
+  "device": "SM-G991B (S21, Exynos 2100, Mali G78 GPU)",
+  "build": "debug (commit with #1191 fix)",
+  "scenario": "safe-smoke regression — verify #1190 not regressed by #1191 changes",
+  "comparison_to_pre_1191": "Identical to pre-1191 safe-smoke results. #1190 fix (history replay suppression) not regressed.",
+  "results": [
+    {"index": 1, "case_id": "set_an_alarm_for_11pm", "result": "pass", "intent": "set_alarm"},
+    {"index": 2, "case_id": "set_a_timer_for_2_hours", "result": "pass", "intent": "set_timer"},
+    {"index": 3, "case_id": "remember_that_i_prefer_dark_mode", "result": "pass", "intent": "save_memory"},
+    {"index": 4, "case_id": "what_time_is_it", "result": "fail", "intent": "save_memory", "note": "MiniLM classifier warmup timing — same as before, unrelated"},
+    {"index": 5, "case_id": "whats_my_battery_level", "result": "pass", "intent": "get_battery"},
+    {"index": 6, "case_id": "set_an_alarm", "result": "fail", "intent": "open_app", "note": "Model warmup timeout — MiniLM fallback, unrelated to slot-fill state"},
+    {"index": 7, "case_id": "set_a_timer", "result": "fail", "intent": "open_app", "note": "Model warmup timeout — MiniLM fallback, unrelated to slot-fill state"}
+  ],
+  "verdict": "No regression of #1190. Remaining failures are MiniLM/model warmup issues, not state carryover."
+}

--- a/docs/test-triage/evidence/2026-06-12/issue-1191-s21-slot-fill-after-fix.json
+++ b/docs/test-triage/evidence/2026-06-12/issue-1191-s21-slot-fill-after-fix.json
@@ -1,0 +1,120 @@
+{
+  "suite": "skills",
+  "status": "complete",
+  "timestamp": "2026-06-12T23-30-00Z",
+  "device": "SM-G991B (S21, Exynos 2100, Mali G78 GPU)",
+  "build": "debug (commit with #1191 fix — adbSlotReplyInput clear + ADB_SLOT_STATE markers)",
+  "scenario": "slot_fill — 6 cases in sequence",
+  "fix_verification": {
+    "root_cause": "adbSlotReplyInput in MainActivity never cleared after consumption. When send_quick_action fires without slot_reply_input, stale value persists. If composable re-enters between ADB commands, LaunchedEffect(adbSlotReply) re-fires with previous case's reply, overwriting newly primed pending slot.",
+    "fix": "Clear adbSlotReplyInput = null at start of onNewIntent() before reading new intent extras. Each independent command starts with clean slot reply state.",
+    "status": "VERIFIED — stale carryover eliminated"
+  },
+  "results": [
+    {
+      "index": 1,
+      "case_id": "set_an_alarm",
+      "message": "set an alarm",
+      "slot_reply": "7am",
+      "actual_intent": "set_alarm",
+      "actual_params": {"time": "7am"},
+      "intent_correct": true,
+      "params_test_expectation": {"hours": "7", "minutes": "0"},
+      "params_test_failure": "Test expects hours/minutes from NativeIntentHandler log marker, but handler only outputs time=7am. Not a product bug — test expectation issue.",
+      "stale_carryover": false,
+      "adb_slot_state": "action=create → reply(time=\"7am\") → complete(final=[time])"
+    },
+    {
+      "index": 2,
+      "case_id": "set_a_timer",
+      "message": "set a timer",
+      "slot_reply": "5 minutes",
+      "actual_intent": "set_timer",
+      "actual_params": {"duration_seconds": "5 minutes"},
+      "intent_correct": true,
+      "params_test_expectation": {"duration_seconds": "300"},
+      "params_test_failure": "Slot-fill returns raw reply text '5 minutes', not parsed 300 seconds. Handler expects integer. Separate design issue from stale carryover.",
+      "stale_carryover": false,
+      "before_fix": "BEFORE FIX: duration_seconds='7am' (stale from case 1's reply)",
+      "after_fix": "AFTER FIX: duration_seconds='5 minutes' (correct slot reply)",
+      "adb_slot_state": "action=create → reply(duration_seconds=\"5 minutes\") → complete(final=[duration_seconds])"
+    },
+    {
+      "index": 3,
+      "case_id": "open_an_app",
+      "message": "open an app",
+      "slot_reply": "Spotify",
+      "actual_intent": "open_app",
+      "actual_params": {"app_name": "Spotify"},
+      "intent_correct": true,
+      "params_correct": true,
+      "test_passed": true,
+      "stale_carryover": false,
+      "before_fix": "BEFORE FIX: app_name='5 minutes' (stale from case 2's reply)",
+      "after_fix": "AFTER FIX: app_name='Spotify' (correct slot reply)",
+      "adb_slot_state": "action=create → reply(app_name=\"Spotify\") → complete(final=[app_name])"
+    },
+    {
+      "index": 4,
+      "case_id": "send_a_message",
+      "message": "send a message",
+      "slot_reply": "Mum",
+      "actual_intent": "send_sms",
+      "actual_params": {"contact": "Mum"},
+      "slot_chain": [
+        {"slot": "contact", "reply": "Mum", "result": "create intent=send_sms missingSlot=message existingSlots=[contact]"}
+      ],
+      "stale_carryover": false,
+      "note": "First slot filled correctly (contact=Mum). Needs second slot (message) but test sends only one reply. Intent is correct.",
+      "before_fix": "BEFORE FIX: contact='Spotify', message='Mum' (stale from case 3's reply)",
+      "after_fix": "AFTER FIX: contact='Mum' (correct), then pending message slot"
+    },
+    {
+      "index": 5,
+      "case_id": "send_an_email",
+      "message": "send an email",
+      "slot_reply": "Nick",
+      "actual_intent": "send_email",
+      "slot_chain": [
+        {"slot": "contact", "reply": "Nick", "result": "create intent=send_email missingSlot=subject existingSlots=[contact]"}
+      ],
+      "stale_carryover": false,
+      "note": "First slot filled correctly (contact=Nick). Needs second slot (subject) but test sends only one reply."
+    },
+    {
+      "index": 6,
+      "case_id": "add_to_my_list",
+      "message": "add to my list",
+      "slot_reply": "eggs",
+      "actual_intent": "add_to_list",
+      "slot_chain": [
+        {"slot": "item", "reply": "eggs", "result": "create intent=add_to_list missingSlot=list_name existingSlots=[item]"}
+      ],
+      "stale_carryover": false,
+      "note": "First slot filled correctly (item=eggs). Needs second slot (list_name) but test sends only one reply."
+    }
+  ],
+  "stale_carryover_summary": {
+    "before_fix": [
+      "Case 2: duration_seconds='7am' (stale from case 1's reply '7am')",
+      "Case 3: app_name='5 minutes' (stale from case 2's reply '5 minutes')",
+      "Case 4: contact='Spotify' (stale from case 3's reply 'Spotify')",
+      "Case 6: item='Nick' (stale from case 5's contact 'Nick')"
+    ],
+    "after_fix": [
+      "Case 2: duration_seconds='5 minutes' (correct slot reply ✅)",
+      "Case 3: app_name='Spotify' (correct slot reply ✅) — TEST PASSES for first time",
+      "Case 4: contact='Mum' (correct slot reply ✅)",
+      "Case 6: item='eggs' (correct slot reply ✅)"
+    ],
+    "verdict": "STALE SLOT REPLY CARRYOVER IS FIXED",
+    "remaining_pattern": "Multi-slot intents (send_sms, send_email, add_to_list) require more than one slot reply but the test harness sends only one. This is a test/fixture limitation, not a state leak."
+  },
+  "diagnostic_markers": {
+    "adb_slot_state": true,
+    "create_events": 6,
+    "reply_events": 6,
+    "complete_events": 3,
+    "cancel_events": 0
+  }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -567,6 +567,7 @@ _error.value = "Phone permission is required for auto-dial. Check Settings → A
     fun onSlotReply(text: String) {
         cancelPendingVoiceSpeech()
         val pending = _pendingSlot.value ?: return
+        Log.d(TAG, "ADB_SLOT_STATE action=reply intent=${pending.request.intentName} slot=${pending.request.missingSlot.name} reply=\"$text\"")
         setSlotReplyAutoRearmArmed(false, "onSlotReply")
         clearExpectedSlotPromptSpeech()
         val normalizedText = if (pending.inputMode == InputMode.Voice) {
@@ -596,7 +597,7 @@ _error.value = "Phone permission is required for auto-dial. Check Settings → A
             )
             return
         }
-
+        Log.d(TAG, "ADB_SLOT_STATE action=complete intent=${pending.request.intentName} finalSlots=${mergedParams.keys}")
         _pendingSlot.value = null
         viewModelScope.launch {
             _uiState.value = UiState.Executing
@@ -635,9 +636,10 @@ _error.value = "Phone permission is required for auto-dial. Check Settings → A
             }
         }
     }
-
-    /** Silently dismiss the slot-fill sheet with no log entry. */
+    /** Silently dismiss the slot-fill sheet, logging the cancel reason. */
     fun cancelSlotFill() {
+        val pending = _pendingSlot.value
+        Log.d(TAG, "ADB_SLOT_STATE action=cancel intent=${pending?.request?.intentName} reason=cancelSlotFill")
         setSlotReplyAutoRearmArmed(false, "cancelSlotFill")
         clearExpectedSlotPromptSpeech()
         cancelPendingVoiceSlotReplyRestart()
@@ -662,6 +664,11 @@ _error.value = "Phone permission is required for auto-dial. Check Settings → A
         )
         // #790: Reset retry budget whenever a fresh slot is primed.
         slotReplyVoiceRetryCount = 0
+        Log.d(
+            TAG,
+            "ADB_SLOT_STATE action=create intent=$intentName missingSlot=${missingSlot.name}" +
+                " existingSlots=${existingParams.keys}",
+        )
         _pendingSlot.value = PendingSlotState(
             request = PendingSlotRequest(
                 intentName = intentName,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
@@ -340,6 +340,38 @@ class ActionsViewModelTest {
     }
 
     @Test
+    fun `sequential independent slot fills do not leak values`() = runTest(dispatcher) {
+        // Complete open_app with app_name=Spotify
+        viewModel.executeAction("open an app")
+        advanceUntilIdle()
+        assertNotNull(viewModel.pendingSlot.value)
+        assertEquals("app_name", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+
+        viewModel.onSlotReply("Spotify")
+        advanceUntilIdle()
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(1, insertedActions.size)
+        // Use the default run_intent skill (set up in setUp)
+        assertEquals("Spotify", CapturingRunIntentSkill.default.calls[0].arguments["app_name"])
+
+        // Then complete set_timer with duration_seconds
+        CapturingRunIntentSkill.default.reset()
+        insertedActions.clear()
+        viewModel.executeAction("set a timer")
+        advanceUntilIdle()
+        assertNotNull(viewModel.pendingSlot.value)
+        assertEquals("duration_seconds", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+
+        viewModel.onSlotReply("5 minutes")
+        advanceUntilIdle()
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(1, insertedActions.size)
+        // MUST NOT leak app_name from first slot fill
+        assertNull(CapturingRunIntentSkill.default.calls[0].arguments["app_name"])
+        assertEquals("5 minutes", CapturingRunIntentSkill.default.calls[0].arguments["duration_seconds"])
+    }
+
+    @Test
     fun `slot reply execution failure records truthful error state`() = runTest(dispatcher) {
         val failingSkill = CapturingRunIntentSkill { throw IllegalStateException("Dialer exploded") }
         every { skillRegistry.get(any()) } answers {


### PR DESCRIPTION
## Root cause

`adbSlotReplyInput` in `MainActivity` was never cleared after consumption. When a new `quick_action_input` intent arrived (via `send_quick_action`) without a `slot_reply_input` extra, the old slot reply value persisted. If the composable re-entered between independent ADB commands (activity going to background and back), `LaunchedEffect(adbSlotReply)` re-fired `onSlotReply()` with the previous case's reply value, overwriting the newly primed pending slot.

This caused a cascade of stale values:

```
Case 1: "set an alarm" + reply "7am" → time=7am ✅
Case 2: "set a timer" + reply "5 minutes" → duration_seconds=7am ❌ (stale from case 1)
Case 3: "open an app" + reply "Spotify" → app_name=5 minutes ❌ (stale from case 2)
Case 4: "send a message" + reply "Mum" → contact=Spotify ❌ (stale from case 3)
Case 6: "add to my list" + reply "eggs" → item=Nick ❌ (stale from case 5)
```

## Fix

**`MainActivity.onNewIntent()`**: Clear `adbSlotReplyInput = null` at the start of `onNewIntent()`, before reading the new intent's extras. This ensures that every independent command starts with a clean slot reply slate. If the new intent carries a `slot_reply_input` extra (legitimate slot reply), it re-sets the value afterward.

**`ActionsViewModel`**: Added `ADB_SLOT_STATE` diagnostic log markers for the full slot-fill lifecycle: `action=create`, `action=reply`, `action=complete`, `action=cancel`.

## S21 Evidence

| Case | BEFORE fix | AFTER fix | Status |
|------|-----------|-----------|--------|
| 1. set an alarm + "7am" | set_alarm (hours/minutes test mismatch) | set_alarm (same) | 🟡 test expectation issue |
| 2. set a timer + "5 minutes" | **duration_seconds=7am** (STALE) | **duration_seconds=5 minutes** ✅ | ✅ Fixed |
| 3. open an app + "Spotify" | **app_name=5 minutes** (STALE) | **app_name=Spotify** ✅ | ✅ **PASSES first time** |
| 4. send a message + "Mum" | **contact=Spotify** (STALE) | contact=Mum ✅ | ✅ Fixed |
| 6. add to my list + "eggs" | **item=Nick** (STALE) | item=eggs ✅ | ✅ Fixed |

`ADB_SLOT_STATE` markers confirm each slot-fill starts with `existingSlots=[]` — no stale state:

```
action=create intent=set_alarm missingSlot=time existingSlots=[]
action=reply intent=set_alarm slot=time reply="7am"
action=complete intent=set_alarm finalSlots=[time]
action=create intent=open_app missingSlot=app_name existingSlots=[]
action=reply intent=open_app slot=app_name reply="Spotify"
action=complete intent=open_app finalSlots=[app_name]
```

## Remaining issues (separate from #1191)

1. **Case 1 test expectation**: Harness expects `hours` and `minutes` in the NativeIntentHandler log marker, but `setAlarm` only outputs `time=7am`. The alarm IS set correctly internally — this is a test-harness assertion bug, not a product bug.
2. **Case 2 param format**: Slot-fill returns raw text `"5 minutes"` as `duration_seconds`. The NativeIntentHandler expects an integer. Duration parsing in the slot-fill path is a separate design issue.
3. **Multi-slot intents (send_sms, send_email, add_to_list)**: The harness sends only one slot reply per test case, but these intents require 2-3 slots. This is a fixture limitation.
4. **#1192**: Parked-location memory QIR gap remains separate.

## Unit tests added

**SlotFillerManagerTest**:
- `sequential slot completions do not leak values between independent requests`
- `current reply value wins over stale existing params`
- `cancel clears all pending state for new independent requests`

**ActionsViewModelTest**:
- `sequential independent slot fills do not leak values`

## Validation

- `:core:skills:testDebugUnitTest` — ✅ 0 failures
- `:feature:chat:testDebugUnitTest` — ✅ 0 failures
- `python3 -m py_compile scripts/*.py scripts/adb_harness/*.py` — ✅ clean
- S21 slot-fill — stale carryover eliminated, ADB_SLOT_STATE markers confirmed
- S21 safe-smoke — #1190 not regressed (same results as pre-#1191)

## Related

- #1190 (command/model state carryover) — fixed by #1202, not regressed
- #1192 (parked-location memory QIR gap) — remains separate
