### PR TITLE
feat(#1167): add full-app-flow navigation integration tests

### DIFF
--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -448,10 +448,14 @@ class NavigationFullAppFlowTest {
             selected = currentBaseRoute == route.substringBefore('?'),
             onClick = {
                 scope.launch { drawerState.close() }
+                // Matches production KernelNavHost.navigateToDrawerDestination():
+                //   popUpTo(ROUTE_LIST) { saveState = false }
+                //   launchSingleTop = true
+                //   restoreState = false
                 navController.navigate(route) {
-                    popUpTo(ROUTE_LIST) { saveState = true }
+                    popUpTo(ROUTE_LIST) { saveState = false }
                     launchSingleTop = true
-                    restoreState = true
+                    restoreState = false
                 }
             },
             modifier = Modifier.testTag("faf_drawer_item_${destTag.removePrefix("faf_dest_")}"),

--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -1,0 +1,860 @@
+package com.kernel.ai.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Full app-flow navigation integration tests for the #751 launch navigation model.
+ *
+ * This suite complements [NavigationBackStackRegressionTest] by exercising the real
+ * navigation graph with production composables where practical, rather than using
+ * an isolated harness with stub destinations for every route.
+ *
+ * ## What is tested with real production composables
+ *
+ * - [PrimaryBottomBar] — real bottom navigation bar with production test tags
+ * - [ToolsHubScreen] — real tools hub with production row and menu button test tags
+ * - [ToolsLearnScreen] — real learn screen with production example prompt test tags
+ * - Drawer navigation items — same structure as production [KernelNavHost]
+ * - Route wiring — same route constants and navigation patterns as production
+ *
+ * ## What remains stubbed
+ *
+ * - Conversation list screen — uses `hiltViewModel()` for [ConversationListViewModel]
+ * - Actions screen — uses `hiltViewModel()` for [ActionsViewModel]
+ * - Chat screen — uses `hiltViewModel()` for [ChatViewModel]
+ * - All settings/child screens — use `hiltViewModel()` for their ViewModels
+ * - Learn screen example prompts — **real** [ToolsLearnScreen] with real prompts
+ *
+ * Stubs use test tags distinct from production composables (prefixed `faf_`)
+ * to avoid ambiguity. Navigation routing and back-stack behavior through
+ * the stub destinations is real — only the rendered content differs.
+ *
+ * ## Evidence suite
+ *
+ * Suite name: `navigation_full_app_flow`
+ * Source: `on_device`
+ * Distinct from: `navigation_backstack` (#1154 harness)
+ */
+@RunWith(AndroidJUnit4::class)
+class NavigationFullAppFlowTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /** Captured NavHostController from [KernelNavTestHost] for programmatic navigation. */
+    private var testNavController: NavHostController? = null
+
+    /** Captured DrawerState for programmatic drawer open/close. */
+    private var testDrawerState: DrawerState? = null
+
+    companion object {
+        // Route constants matching KernelNavHost production values
+        private const val ROUTE_LIST = "conversation_list"
+        private const val ROUTE_ACTIONS = "actions"
+        private const val ROUTE_TOOLS = "tools"
+        private const val ROUTE_CHAT = "chat"
+        private const val ARG_INITIAL_QUERY = "initialQuery"
+        private const val ARG_MINIMAL_CONTEXT = "minimalContext"
+        private const val ARG_SPEAK_RESPONSE = "speakResponse"
+        private const val ARG_CONVERSATION_ID = "conversationId"
+        private const val ARG_OPEN_SHEET = "openSheet"
+        private const val ARG_START_VOICE = "startVoice"
+        private const val ARG_WIDGET_QUERY = "widgetQuery"
+        private const val ARG_WIDGET_VOICE = "widgetVoice"
+        private const val ARG_DRAFT_QUERY = "draftQuery"
+
+        // Bottom nav test tags (production PrimaryBottomBar)
+        private const val BOTTOM_NAV_CHATS = "bottom_nav_chats"
+        private const val BOTTOM_NAV_ACTIONS = "bottom_nav_actions"
+        private const val BOTTOM_NAV_TOOLS = "bottom_nav_tools"
+
+        // FAF stub screen test tags (prefixed to distinguish from production)
+        private const val TAG_CHATS_SCREEN = "faf_chats_screen"
+        private const val TAG_CHATS_MENU_BUTTON = "faf_chats_menu_button"
+        private const val TAG_ACTIONS_SCREEN = "faf_actions_screen"
+        private const val TAG_DRAFT_INPUT = "faf_draft_input"
+        private const val TAG_DRAFT_SUBMIT = "faf_draft_submit"
+        private const val TAG_DRAFT_TEXT = "faf_draft_text"
+
+        // Destination stub tags
+        private const val TAG_DEST_LEARN = "faf_dest_learn"
+        private const val TAG_DEST_LISTS = "faf_dest_lists"
+        private const val TAG_DEST_NOTES = "faf_dest_notes"
+        private const val TAG_DEST_MEAL_PLANS = "faf_dest_meal_plans"
+        private const val TAG_DEST_CONVERT = "faf_dest_convert"
+        private const val TAG_DEST_SETTINGS = "faf_dest_settings"
+        private const val TAG_DEST_MODELS = "faf_dest_models"
+        private const val TAG_DEST_PERMISSIONS = "faf_dest_permissions"
+        private const val TAG_DEST_ABOUT = "faf_dest_about"
+        private const val TAG_DEST_MEMORY = "faf_dest_memory"
+        private const val TAG_DEST_VOICE = "faf_dest_voice"
+        private const val TAG_DEST_USER_PROFILE = "faf_dest_user_profile"
+        private const val TAG_DEST_CHAT_PREFERENCES = "faf_dest_chat_preferences"
+        private const val TAG_DEST_CONTACTS = "faf_dest_contacts"
+        private const val TAG_DEST_IMPORTANT_DATES = "faf_dest_important_dates"
+        private const val TAG_DEST_SIDE_PANEL = "faf_dest_side_panel"
+    }
+
+    /** Bottom nav route set (matching production KernelNavHost.BOTTOM_NAV_ROUTES). */
+    private val bottomNavRoutes = setOf(ROUTE_LIST, ROUTE_ACTIONS, ROUTE_TOOLS)
+
+    private fun isBottomNavRoute(route: String?): Boolean =
+        route?.substringBefore('?') in bottomNavRoutes
+
+    data class ToolsRouteEntry(
+        val rowTag: String,
+        val route: String,
+        val destTag: String,
+        val backTag: String,
+        val label: String,
+    )
+
+    private val toolsRoutes = listOf(
+        // Learn uses the real ToolsLearnScreen composable (tag: "tools_learn_screen" with "back_from_tools_learn")
+        ToolsRouteEntry("tools_row_learn", ROUTE_TOOLS_LEARN, "tools_learn_screen", "back_from_tools_learn", "Learn"),
+        ToolsRouteEntry("tools_row_lists", ROUTE_LISTS, TAG_DEST_LISTS, "faf_back_from_${TAG_DEST_LISTS}", "Lists"),
+        ToolsRouteEntry("tools_row_notes", ROUTE_NOTES, TAG_DEST_NOTES, "faf_back_from_${TAG_DEST_NOTES}", "Notes"),
+        ToolsRouteEntry("tools_row_meal_plans", ROUTE_MEAL_PLANS, TAG_DEST_MEAL_PLANS, "faf_back_from_${TAG_DEST_MEAL_PLANS}", "Meal plans"),
+        ToolsRouteEntry("tools_row_convert", ROUTE_CONVERT, TAG_DEST_CONVERT, "faf_back_from_${TAG_DEST_CONVERT}", "Convert"),
+        ToolsRouteEntry("tools_row_settings", ROUTE_SETTINGS, TAG_DEST_SETTINGS, "faf_back_from_${TAG_DEST_SETTINGS}", "Settings"),
+        ToolsRouteEntry(
+            "tools_row_models", buildModelManagementRoute(), TAG_DEST_MODELS, "faf_back_from_${TAG_DEST_MODELS}", "Models",
+        ),
+        ToolsRouteEntry("tools_row_permissions", ROUTE_APP_PERMISSIONS, TAG_DEST_PERMISSIONS, "faf_back_from_${TAG_DEST_PERMISSIONS}", "Permissions"),
+        ToolsRouteEntry("tools_row_about", ROUTE_ABOUT, TAG_DEST_ABOUT, "faf_back_from_${TAG_DEST_ABOUT}", "About"),
+    )
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun assertScreenNotPresent(tag: String) {
+        composeTestRule.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes()
+            .let { nodes ->
+                assertTrue("Expected no node with tag '$tag' in tree", nodes.isEmpty())
+            }
+    }
+
+    private fun assertNodeExists(tag: String) {
+        val nodes = composeTestRule.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        assertTrue("Expected semantics node with tag '$tag' to be present in tree", nodes.isNotEmpty())
+    }
+
+    private fun assertBottomNavSelected(navTag: String) {
+        composeTestRule.onNodeWithTag(navTag).assertIsSelected()
+    }
+
+    private fun assertBottomNavNotSelected(navTag: String) {
+        composeTestRule.onNodeWithTag(navTag).assertIsNotSelected()
+    }
+
+    // ── Production-equivalent navigation host ────────────────────────────────
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun KernelNavTestHost(): NavHostController {
+        val navController = rememberNavController()
+        testNavController = navController
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = navBackStackEntry?.destination?.route
+        val currentBaseRoute = currentRoute?.substringBefore('?')
+        val drawerState = rememberDrawerState(DrawerValue.Closed)
+        testDrawerState = drawerState
+        val scope = rememberCoroutineScope()
+
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            gesturesEnabled = isBottomNavRoute(currentBaseRoute),
+            drawerContent = {
+                ModalDrawerSheet(modifier = Modifier.testTag("faf_drawer_sheet")) {
+                    Text(
+                        "Jandal",
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 16.dp),
+                    )
+                    HorizontalDivider()
+                    Spacer(Modifier.height(4.dp))
+
+                    // Production-equivalent drawer items (same as KernelNavHost)
+                    DrawerItem("Lists", TAG_DEST_LISTS, ROUTE_LISTS, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("Notes", TAG_DEST_NOTES, ROUTE_NOTES, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("Clock", TAG_DEST_SIDE_PANEL, ROUTE_SIDE_PANEL, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("Convert", TAG_DEST_CONVERT, ROUTE_CONVERT, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("Important dates", TAG_DEST_IMPORTANT_DATES, ROUTE_IMPORTANT_DATES, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("People & Contacts", TAG_DEST_CONTACTS, ROUTE_CONTACT_ALIASES, currentBaseRoute, navController, drawerState, scope)
+                    DrawerItem("Meal plans", TAG_DEST_MEAL_PLANS, ROUTE_MEAL_PLANS, currentBaseRoute, navController, drawerState, scope)
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    DrawerItem("Settings", TAG_DEST_SETTINGS, ROUTE_SETTINGS, currentBaseRoute, navController, drawerState, scope)
+                }
+            },
+        ) {
+            Scaffold(
+                bottomBar = {
+                    if (isBottomNavRoute(currentBaseRoute)) {
+                        // Real production PrimaryBottomBar
+                        PrimaryBottomBar(
+                            currentBaseRoute = currentBaseRoute,
+                            onNavigateToRoute = { route ->
+                                navController.navigateToPrimaryRoute(route)
+                            },
+                        )
+                    }
+                },
+            ) { innerPadding ->
+                NavHost(
+                    navController = navController,
+                    startDestination = ROUTE_LIST,
+                    modifier = Modifier.padding(innerPadding),
+                ) {
+                    // ── Chats (stub — ConversationListScreen uses Hilt ViewModel) ──
+                    composable(ROUTE_LIST) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag(TAG_CHATS_SCREEN),
+                        ) {
+                            TopAppBar(
+                                title = { Text("Chats") },
+                                navigationIcon = {
+                                    IconButton(
+                                        onClick = { scope.launch { drawerState.open() } },
+                                        modifier = Modifier.testTag(TAG_CHATS_MENU_BUTTON),
+                                    ) {
+                                        Icon(Icons.Default.Menu, contentDescription = "Menu")
+                                    }
+                                },
+                            )
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text("Chats Screen")
+                            }
+                        }
+                    }
+
+                    // ── Actions (stub — ActionsScreen uses Hilt ViewModel) ──
+                    composable(
+                        route = "$ROUTE_ACTIONS?$ARG_OPEN_SHEET={$ARG_OPEN_SHEET}" +
+                            "&$ARG_START_VOICE={$ARG_START_VOICE}" +
+                            "&$ARG_WIDGET_QUERY={$ARG_WIDGET_QUERY}" +
+                            "&$ARG_WIDGET_VOICE={$ARG_WIDGET_VOICE}" +
+                            "&$ARG_DRAFT_QUERY={$ARG_DRAFT_QUERY}",
+                        arguments = listOf(
+                            navArgument(ARG_OPEN_SHEET) {
+                                type = NavType.BoolType; defaultValue = false
+                            },
+                            navArgument(ARG_START_VOICE) {
+                                type = NavType.BoolType; defaultValue = false
+                            },
+                            navArgument(ARG_WIDGET_QUERY) {
+                                type = NavType.StringType; defaultValue = ""
+                            },
+                            navArgument(ARG_WIDGET_VOICE) {
+                                type = NavType.BoolType; defaultValue = false
+                            },
+                            navArgument(ARG_DRAFT_QUERY) {
+                                type = NavType.StringType; defaultValue = ""
+                            },
+                        ),
+                    ) { backStackEntry ->
+                        @Suppress("UNUSED")
+                        val openSheet = backStackEntry.arguments?.getBoolean(ARG_OPEN_SHEET) ?: false
+                        val draftQuery = backStackEntry.arguments?.getString(ARG_DRAFT_QUERY) ?: ""
+                        ActionsScreenStub(draftQuery = draftQuery)
+                    }
+
+                    // ── Tools (real production composable) ──
+                    composable(ROUTE_TOOLS) {
+                        ToolsHubScreen(
+                            onOpenDrawer = { scope.launch { drawerState.open() } },
+                            onNavigateToRoute = { route ->
+                                navController.navigateToToolsDestination(route)
+                            },
+                        )
+                    }
+
+                    // ── Tools Learn (real production composable) ──
+                    composable(ROUTE_TOOLS_LEARN) {
+                        ToolsLearnScreen(
+                            onBack = { navController.popBackStack() },
+                            onOpenPrompt = { prompt ->
+                                navController.navigate(buildActionsDraftRoute(prompt)) {
+                                    launchSingleTop = true
+                                }
+                            },
+                        )
+                    }
+
+                    // ── Stub destinations for remaining routes ──
+                    composable(ROUTE_SETTINGS) {
+                        DestinationStub("Settings", TAG_DEST_SETTINGS) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_LISTS) {
+                        DestinationStub("Lists", TAG_DEST_LISTS) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_NOTES) {
+                        DestinationStub("Notes", TAG_DEST_NOTES) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_MEAL_PLANS) {
+                        DestinationStub("Meal Plans", TAG_DEST_MEAL_PLANS) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_CONVERT) {
+                        DestinationStub("Convert", TAG_DEST_CONVERT) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_ABOUT) {
+                        DestinationStub("About", TAG_DEST_ABOUT) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_APP_PERMISSIONS) {
+                        DestinationStub("Permissions", TAG_DEST_PERMISSIONS) { navController.popBackStack() }
+                    }
+                    composable(
+                        route = "settings/model_management?scrollTo={scrollTo}",
+                        arguments = listOf(
+                            navArgument("scrollTo") { type = NavType.BoolType; defaultValue = false },
+                        ),
+                    ) {
+                        DestinationStub("Models", TAG_DEST_MODELS) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_MEMORY) {
+                        DestinationStub("Memory", TAG_DEST_MEMORY) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_VOICE) {
+                        DestinationStub("Voice", TAG_DEST_VOICE) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_USER_PROFILE) {
+                        DestinationStub("User Profile", TAG_DEST_USER_PROFILE) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_CHAT_PREFERENCES) {
+                        DestinationStub("Chat Preferences", TAG_DEST_CHAT_PREFERENCES) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_CONTACT_ALIASES) {
+                        DestinationStub("People & Contacts", TAG_DEST_CONTACTS) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_IMPORTANT_DATES) {
+                        DestinationStub("Important Dates", TAG_DEST_IMPORTANT_DATES) { navController.popBackStack() }
+                    }
+                    composable(ROUTE_SIDE_PANEL) {
+                        DestinationStub("Side Panel", TAG_DEST_SIDE_PANEL) { navController.popBackStack() }
+                    }
+                    composable(
+                        route = "$ROUTE_CHAT?$ARG_INITIAL_QUERY={$ARG_INITIAL_QUERY}" +
+                            "&$ARG_MINIMAL_CONTEXT={$ARG_MINIMAL_CONTEXT}" +
+                            "&$ARG_SPEAK_RESPONSE={$ARG_SPEAK_RESPONSE}",
+                        arguments = listOf(
+                            navArgument(ARG_INITIAL_QUERY) {
+                                type = NavType.StringType; defaultValue = ""
+                            },
+                            navArgument(ARG_MINIMAL_CONTEXT) {
+                                type = NavType.BoolType; defaultValue = false
+                            },
+                            navArgument(ARG_SPEAK_RESPONSE) {
+                                type = NavType.BoolType; defaultValue = false
+                            },
+                        ),
+                    ) {
+                        DestinationStub("Chat", "faf_dest_chat") { navController.popBackStack() }
+                    }
+                    composable(
+                        route = "$ROUTE_CHAT/{$ARG_CONVERSATION_ID}",
+                        arguments = listOf(
+                            navArgument(ARG_CONVERSATION_ID) { type = NavType.StringType },
+                        ),
+                    ) {
+                        DestinationStub("Chat Detail", "faf_dest_chat_detail") { navController.popBackStack() }
+                    }
+                }
+            }
+        }
+        return navController
+    }
+
+    // ── Shared composables ───────────────────────────────────────────────────
+
+    @Composable
+    private fun DrawerItem(
+        label: String,
+        destTag: String,
+        route: String,
+        currentBaseRoute: String?,
+        navController: NavHostController,
+        drawerState: DrawerState,
+        scope: kotlinx.coroutines.CoroutineScope,
+    ) {
+        NavigationDrawerItem(
+            label = { Text(label) },
+            selected = currentBaseRoute == route.substringBefore('?'),
+            onClick = {
+                scope.launch { drawerState.close() }
+                navController.navigate(route) {
+                    popUpTo(ROUTE_LIST) { saveState = true }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            },
+            modifier = Modifier.testTag("faf_drawer_item_${destTag.removePrefix("faf_dest_")}"),
+        )
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun DestinationStub(
+        label: String,
+        tag: String,
+        onBack: () -> Unit,
+    ) {
+        Column(modifier = Modifier.fillMaxSize().testTag(tag)) {
+            TopAppBar(
+                title = { Text(label) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("faf_back_from_$tag"),
+                    ) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text("$label Content", modifier = Modifier.testTag("${tag}_content"))
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun ActionsScreenStub(draftQuery: String) {
+        val inputText = remember { mutableStateOf(draftQuery) }
+        val showDraft = remember { mutableStateOf(draftQuery.isNotEmpty()) }
+
+        Column(modifier = Modifier.fillMaxSize().testTag(TAG_ACTIONS_SCREEN)) {
+            TopAppBar(title = { Text("Actions") })
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Actions Screen")
+
+                    if (showDraft.value && draftQuery.isNotEmpty()) {
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            "Draft: $draftQuery",
+                            modifier = Modifier.testTag(TAG_DRAFT_TEXT),
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        androidx.compose.material3.OutlinedTextField(
+                            value = inputText.value,
+                            onValueChange = { inputText.value = it },
+                            placeholder = { Text("What do you want to do?") },
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                                .testTag(TAG_DRAFT_INPUT),
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Button(
+                            onClick = {
+                                showDraft.value = false
+                                inputText.value = ""
+                            },
+                            modifier = Modifier.testTag(TAG_DRAFT_SUBMIT),
+                        ) {
+                            Icon(Icons.Default.Send, contentDescription = "Send")
+                            Text(" Send (test)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Navigation helpers (matching KernelNavHost patterns) ─────────────────
+
+    private fun NavHostController.navigateToPrimaryRoute(route: String) {
+        val currentRoute = currentBackStackEntry?.destination?.route
+        val currentBaseRoute = currentRoute?.substringBefore('?')
+        if (currentBaseRoute == route) return
+        val hasTransientParams = currentRoute?.contains('?') == true
+        navigate(route) {
+            popUpTo(graph.findStartDestination().id) {
+                saveState = !hasTransientParams
+            }
+            launchSingleTop = true
+            restoreState = !hasTransientParams
+        }
+    }
+
+    private fun NavHostController.navigateToToolsDestination(route: String) {
+        val currentBaseRoute = currentBackStackEntry?.destination?.route
+            ?.substringBefore('?')
+        val targetBaseRoute = route.substringBefore('?')
+        if (currentBaseRoute == targetBaseRoute) return
+        navigate(route) { launchSingleTop = true }
+    }
+
+    // ═══════════════════════════ 1. PRIMARY NAVIGATION ═══════════════════════
+
+    @Test
+    fun primaryNavigation_chatsActionsToolsRoundTrip() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_ACTIONS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_CHATS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+    }
+
+    @Test
+    fun primaryNavigation_actionsToolsActions() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_ACTIONS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_ACTIONS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+    }
+
+    @Test
+    fun primaryNavigation_toolsChatsTools() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_CHATS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+        // Verify no stale child screen from a previous navigation
+        assertScreenNotPresent(TAG_DEST_LISTS)
+        assertScreenNotPresent(TAG_DEST_SETTINGS)
+    }
+
+    @Test
+    fun primaryNavigation_repeatedTabTapStable() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Repeated tap of already-selected tab
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+    }
+
+    @Test
+    fun primaryNavigation_noStaleChildScreen() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Navigate to a Tools child
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_row_lists"))
+        composeTestRule.onNodeWithTag("tools_row_lists", useUnmergedTree = true).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_LISTS).assertIsDisplayed()
+
+        // Back to Tools
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_LISTS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertScreenNotPresent(TAG_DEST_LISTS)
+
+        // Switch to Chats, back to Tools — verify no stale state
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_CHATS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertScreenNotPresent(TAG_DEST_LISTS)
+        assertScreenNotPresent(TAG_DEST_SETTINGS)
+    }
+
+    // ═══════════════════════════ 2. TOOLS ROW ROUTING ═══════════════════════
+
+    @Test
+    fun toolsRow_matrixNavigateAndBack() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+
+        for (entry in toolsRoutes) {
+            // Navigate Tools → child → Back → Tools → Chats (reset for next route)
+            composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+            composeTestRule.onNodeWithTag("tools_screen")
+                .performScrollToNode(hasTestTag(entry.rowTag))
+            composeTestRule.onNodeWithTag(entry.rowTag, useUnmergedTree = true).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithTag(entry.destTag).assertIsDisplayed()
+
+            composeTestRule.onNodeWithTag(entry.backTag).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+            // Return to Chats to reset for next route
+            composeTestRule.onNodeWithTag(BOTTOM_NAV_CHATS).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        }
+    }
+
+    // ═══════════════════════════ 3. LEARN → ACTIONS DRAFT FLOW ══════════════
+
+    @Test
+    fun learnToActions_exampleOpensDraftPrefill() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Navigate to real ToolsLearnScreen
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_row_learn"))
+        composeTestRule.onNodeWithTag("tools_row_learn", useUnmergedTree = true).performClick()
+        composeTestRule.waitForIdle()
+
+        // Verify real Learn screen is displayed
+        composeTestRule.onNodeWithTag("tools_learn_screen").assertIsDisplayed()
+
+        // Tap a production example prompt
+        composeTestRule.onNodeWithTag("tools_learn_lists_add_milk", useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // Assert Actions opens with draft prefilled
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_TEXT).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add milk to my shopping list").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_INPUT).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_SUBMIT).assertIsDisplayed()
+    }
+
+    @Test
+    fun learnToActions_dismissDraftThenSwitchTabs() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+
+        // Navigate to Learn → tap example → draft opens
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_row_learn"))
+        composeTestRule.onNodeWithTag("tools_row_learn", useUnmergedTree = true).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_learn_screen").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("tools_learn_lists_add_milk", useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_TEXT).assertIsDisplayed()
+
+        // Dismiss/send clears draft state
+        composeTestRule.onNodeWithTag(TAG_DRAFT_SUBMIT).performClick()
+        composeTestRule.waitForIdle()
+        assertScreenNotPresent(TAG_DRAFT_TEXT)
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+
+        // Navigate to Chats
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_CHATS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+
+        // Navigate to Tools — no stale draft restored
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertScreenNotPresent(TAG_DRAFT_TEXT)
+        assertScreenNotPresent(TAG_ACTIONS_SCREEN)
+    }
+
+    // ═══════════════════════════ 4. DRAWER ENTRY POINTS ══════════════════════
+
+    @Test
+    fun drawer_opensFromToolsViaMenuButton() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Use production menu icon button (real ToolsHubScreen test tag)
+        composeTestRule.onNodeWithTag("tools_menu_button").performClick()
+        composeTestRule.waitForIdle()
+
+        // Production Menu → ModalDrawerSheet (not asserting drawer_sheet from
+        // harness — the drawer opens through the real composable's callback)
+        composeTestRule.onNodeWithTag("faf_drawer_sheet").assertIsDisplayed()
+    }
+
+    @Test
+    fun drawer_opensFromChatsViaMenuButton() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+
+        // Use menu button on Chats stub (production ConversationListScreen has
+        // a matching menu icon — our stub mirrors it with a stable test tag)
+        composeTestRule.onNodeWithTag(TAG_CHATS_MENU_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("faf_drawer_sheet").assertIsDisplayed()
+    }
+
+    @Test
+    fun drawer_navigationBackToTools() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+
+        // Open drawer from Tools via production menu button
+        composeTestRule.onNodeWithTag("tools_menu_button").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("faf_drawer_sheet").assertIsDisplayed()
+
+        // Navigate via drawer to Lists
+        composeTestRule.onNodeWithTag("faf_drawer_item_lists").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_LISTS).assertIsDisplayed()
+
+        // Back returns to Chats (drawer's popUpTo resets to start destination)
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_LISTS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+
+        // Switch to Tools — verify drawer not still open and correct tab selected
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+        // Drawer sheet may remain in the composition even when closed (off-screen);
+        // the important thing is the Tools screen is visible and tab is selected.
+        // No stale drawer content is blocking the UI — verified by tools_screen below.
+    }
+
+    @Test
+    fun drawer_bottomNavStateAfterDrawerNavigation() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+
+        // Open drawer from Tools
+        composeTestRule.onNodeWithTag("tools_menu_button").performClick()
+        composeTestRule.waitForIdle()
+
+        // Navigate via drawer to Settings
+        composeTestRule.onNodeWithTag("faf_drawer_item_settings").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+
+        // Back returns to Chats
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+    }
+}

--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -58,6 +58,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -135,6 +136,7 @@ class NavigationFullAppFlowTest {
         private const val TAG_CHATS_MENU_BUTTON = "faf_chats_menu_button"
         private const val TAG_ACTIONS_SCREEN = "faf_actions_screen"
         private const val TAG_DRAFT_INPUT = "faf_draft_input"
+        private const val TAG_ACTIONS_MENU_BUTTON = "faf_actions_menu_button"
         private const val TAG_DRAFT_SUBMIT = "faf_draft_submit"
         private const val TAG_DRAFT_TEXT = "faf_draft_text"
 
@@ -323,7 +325,7 @@ class NavigationFullAppFlowTest {
                         @Suppress("UNUSED")
                         val openSheet = backStackEntry.arguments?.getBoolean(ARG_OPEN_SHEET) ?: false
                         val draftQuery = backStackEntry.arguments?.getString(ARG_DRAFT_QUERY) ?: ""
-                        ActionsScreenStub(draftQuery = draftQuery)
+                        ActionsScreenStub(draftQuery = draftQuery, drawerState = drawerState, scope = scope)
                     }
 
                     // ── Tools (real production composable) ──
@@ -489,15 +491,28 @@ class NavigationFullAppFlowTest {
             }
         }
     }
-
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    private fun ActionsScreenStub(draftQuery: String) {
+    private fun ActionsScreenStub(
+        draftQuery: String,
+        drawerState: DrawerState,
+        scope: CoroutineScope,
+    ) {
         val inputText = remember { mutableStateOf(draftQuery) }
         val showDraft = remember { mutableStateOf(draftQuery.isNotEmpty()) }
 
         Column(modifier = Modifier.fillMaxSize().testTag(TAG_ACTIONS_SCREEN)) {
-            TopAppBar(title = { Text("Actions") })
+            TopAppBar(
+                title = { Text("Actions") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { scope.launch { drawerState.open() } },
+                        modifier = Modifier.testTag(TAG_ACTIONS_MENU_BUTTON),
+                    ) {
+                        Icon(Icons.Default.Menu, contentDescription = "Menu")
+                    }
+                },
+            )
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
@@ -860,5 +875,20 @@ class NavigationFullAppFlowTest {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
         assertBottomNavSelected(BOTTOM_NAV_CHATS)
+    }
+
+    @Test
+    fun drawer_opensFromActionsViaMenuButton() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_ACTIONS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+
+        // Use menu button on Actions stub (production ActionsScreen has a matching
+        // menu icon — our stub mirrors it with a stable test tag)
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_MENU_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("faf_drawer_sheet").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
@@ -215,7 +215,7 @@ fun ToolsLearnScreen(
             TopAppBar(
                 title = { Text("Learn what Jandal can do") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("back_from_tools_learn")) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",

--- a/scripts/generate_navigation_test_evidence.py
+++ b/scripts/generate_navigation_test_evidence.py
@@ -391,8 +391,13 @@ def _write_markdown(normalised: dict, path: Path) -> None:
     device = normalised.get("device", {})
     cases = normalised.get("cases", [])
 
+    suite = normalised.get('suite', '')
+    if suite == "navigation_full_app_flow":
+        heading_title = "Navigation Full App Flow"
+    else:
+        heading_title = "Navigation Back-Stack Regression"
     lines: list[str] = [
-        f"# Navigation Back-Stack Regression — PR #{normalised.get('pr', '?')}",
+        f"# {heading_title} — PR #{normalised.get('pr', '?')}",
         "",
         f"**Suite:** `{normalised.get('suite', '')}`",
         f"**Source:** `{normalised.get('source', '')}`",
@@ -411,19 +416,31 @@ def _write_markdown(normalised: dict, path: Path) -> None:
 
     # Group by category
     cat_order = [
+        # Common categories (both suites)
         "tools_row_navigation",
         "tab_switching",
         "parameterised_route",
+        # navigation_full_app_flow categories
+        "primary_navigation",
+        "learn_to_actions_draft",
         "drawer",
+        "drawer_entry_point",
+        # navigation_backstack categories
         "repeated_tap",
         "real_composable",
         "screenshot",
     ]
     cat_labels = {
+        # Common categories (both suites)
         "tools_row_navigation": "Tools Row Navigation",
         "tab_switching": "Tab Switching",
         "parameterised_route": "Parameterised Routes",
+        # navigation_full_app_flow categories
+        "primary_navigation": "Primary Navigation",
+        "learn_to_actions_draft": "Tools Learn to Actions Draft",
         "drawer": "Drawer Transitions",
+        "drawer_entry_point": "Drawer Entry Points",
+        # navigation_backstack categories
         "repeated_tap": "Repeated-Tap / Duplicate Stack",
         "real_composable": "Real Composable",
         "screenshot": "Screenshot Evidence",

--- a/scripts/generate_navigation_test_evidence.py
+++ b/scripts/generate_navigation_test_evidence.py
@@ -65,38 +65,57 @@ REPO = "NickMonrad/kernel-ai-assistant"
 SCHEMA_VERSION = "1.0"
 
 NAVIGATION_CASES: list[dict[str, Any]] = [
+    # ═══════════ navigation_backstack (#1154 harness) ═══════════
     # ── Route matrix (combined test verifying all 16 Tools rows) ──
-    {"name": "toolsRouteMatrix_allRowsNavigateAndBack", "category": "tools_row_navigation"},
+    {"name": "toolsRouteMatrix_allRowsNavigateAndBack", "category": "tools_row_navigation", "suite": "navigation_backstack"},
     # ── Primary tab switching ──
-    {"name": "tabs_chatsActionsTools_roundTrip", "category": "tab_switching"},
-    {"name": "tools_childDestination_back_toTools", "category": "tab_switching"},
-    {"name": "tools_childDestination_actions_thenTools", "category": "tab_switching"},
-    {"name": "tools_childDestination_chats_thenTools", "category": "tab_switching"},
-    {"name": "actions_tools_switching", "category": "tab_switching"},
+    {"name": "tabs_chatsActionsTools_roundTrip", "category": "tab_switching", "suite": "navigation_backstack"},
+    {"name": "tools_childDestination_back_toTools", "category": "tab_switching", "suite": "navigation_backstack"},
+    {"name": "tools_childDestination_actions_thenTools", "category": "tab_switching", "suite": "navigation_backstack"},
+    {"name": "tools_childDestination_chats_thenTools", "category": "tab_switching", "suite": "navigation_backstack"},
+    {"name": "actions_tools_switching", "category": "tab_switching", "suite": "navigation_backstack"},
     # ── Parameterised / transient route tests ──
-    {"name": "actions_draftRoute_dismiss_back_toTools", "category": "parameterised_route"},
-    {"name": "actions_draftRoute_chats_then_tools", "category": "parameterised_route"},
+    {"name": "actions_draftRoute_dismiss_back_toTools", "category": "parameterised_route", "suite": "navigation_backstack"},
+    {"name": "actions_draftRoute_chats_then_tools", "category": "parameterised_route", "suite": "navigation_backstack"},
     # ── Drawer transition tests ──
-    {"name": "drawer_opens_fromTools", "category": "drawer"},
-    {"name": "drawer_navigatesFromTools_predictable_stack", "category": "drawer"},
-    {"name": "drawer_navigatesFromChats", "category": "drawer"},
+    {"name": "drawer_opens_fromTools", "category": "drawer", "suite": "navigation_backstack"},
+    {"name": "drawer_navigatesFromTools_predictable_stack", "category": "drawer", "suite": "navigation_backstack"},
+    {"name": "drawer_navigatesFromChats", "category": "drawer", "suite": "navigation_backstack"},
     # ── Duplicate-stack / repeated-tap tests ──
-    {"name": "repeatedToolsTab_noDuplicateStacks", "category": "repeated_tap"},
-    {"name": "repeatedTabSwitches_noStaleState", "category": "repeated_tap"},
-    {"name": "reopenSameChildDestination_noDuplicateStack", "category": "repeated_tap"},
-    {"name": "repeatedToolsRowTap_noDuplicateStacks", "category": "repeated_tap"},
-    {"name": "toolsLearn_example_dismissActions_returnToTools", "category": "repeated_tap"},
+    {"name": "repeatedToolsTab_noDuplicateStacks", "category": "repeated_tap", "suite": "navigation_backstack"},
+    {"name": "repeatedTabSwitches_noStaleState", "category": "repeated_tap", "suite": "navigation_backstack"},
+    {"name": "reopenSameChildDestination_noDuplicateStack", "category": "repeated_tap", "suite": "navigation_backstack"},
+    {"name": "repeatedToolsRowTap_noDuplicateStacks", "category": "repeated_tap", "suite": "navigation_backstack"},
+    {"name": "toolsLearn_example_dismissActions_returnToTools", "category": "repeated_tap", "suite": "navigation_backstack"},
     # ── Real composable tests ──
-    {"name": "realToolsHubScreen_rendersAllRows", "category": "real_composable"},
-    {"name": "realPrimaryBottomBar_rendersAndNavigates", "category": "real_composable"},
-    {"name": "realToolsHubScreen_toolbarOpensDrawer", "category": "real_composable"},
+    {"name": "realToolsHubScreen_rendersAllRows", "category": "real_composable", "suite": "navigation_backstack"},
+    {"name": "realPrimaryBottomBar_rendersAndNavigates", "category": "real_composable", "suite": "navigation_backstack"},
+    {"name": "realToolsHubScreen_toolbarOpensDrawer", "category": "real_composable", "suite": "navigation_backstack"},
     # ── Screenshot capture tests ──
-    {"name": "captureScreenshot_toolsHub", "category": "screenshot"},
-    {"name": "captureScreenshot_toolsLearnChild", "category": "screenshot"},
-    {"name": "captureScreenshot_toolsChildDestination", "category": "screenshot"},
-    {"name": "captureScreenshot_actionsDraftDismissedBackToTools", "category": "screenshot"},
-    {"name": "captureScreenshot_drawerOpenFromTools", "category": "screenshot"},
-    {"name": "captureScreenshot_afterTabSwitch", "category": "screenshot"},
+    {"name": "captureScreenshot_toolsHub", "category": "screenshot", "suite": "navigation_backstack"},
+    {"name": "captureScreenshot_toolsLearnChild", "category": "screenshot", "suite": "navigation_backstack"},
+    {"name": "captureScreenshot_toolsChildDestination", "category": "screenshot", "suite": "navigation_backstack"},
+    {"name": "captureScreenshot_actionsDraftDismissedBackToTools", "category": "screenshot", "suite": "navigation_backstack"},
+    {"name": "captureScreenshot_drawerOpenFromTools", "category": "screenshot", "suite": "navigation_backstack"},
+    {"name": "captureScreenshot_afterTabSwitch", "category": "screenshot", "suite": "navigation_backstack"},
+
+    # ═══════════ navigation_full_app_flow (#1167 full-app-flow) ═══════════
+    # ── Primary navigation ──
+    {"name": "primaryNavigation_chatsActionsToolsRoundTrip", "category": "primary_navigation", "suite": "navigation_full_app_flow"},
+    {"name": "primaryNavigation_actionsToolsActions", "category": "primary_navigation", "suite": "navigation_full_app_flow"},
+    {"name": "primaryNavigation_toolsChatsTools", "category": "primary_navigation", "suite": "navigation_full_app_flow"},
+    {"name": "primaryNavigation_repeatedTabTapStable", "category": "primary_navigation", "suite": "navigation_full_app_flow"},
+    {"name": "primaryNavigation_noStaleChildScreen", "category": "primary_navigation", "suite": "navigation_full_app_flow"},
+    # ── Tools row routing ──
+    {"name": "toolsRow_matrixNavigateAndBack", "category": "tools_row_navigation", "suite": "navigation_full_app_flow"},
+    # ── Learn → Actions draft prefill ──
+    {"name": "learnToActions_exampleOpensDraftPrefill", "category": "learn_to_actions_draft", "suite": "navigation_full_app_flow"},
+    {"name": "learnToActions_dismissDraftThenSwitchTabs", "category": "learn_to_actions_draft", "suite": "navigation_full_app_flow"},
+    # ── Drawer entry points ──
+    {"name": "drawer_opensFromToolsViaMenuButton", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
+    {"name": "drawer_opensFromChatsViaMenuButton", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
+    {"name": "drawer_navigationBackToTools", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
+    {"name": "drawer_bottomNavStateAfterDrawerNavigation", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
 ]
 
 
@@ -596,9 +615,11 @@ def main() -> None:
         else:
             print(f"WARNING: no test result XMLs found in {args.results_dir}", file=sys.stderr)
 
-    # ── Build cases ──
+    # ── Build cases (filtered by suite) ──
     cases: list[dict[str, Any]] = []
     for case_def in NAVIGATION_CASES:
+        if case_def.get("suite", "navigation_backstack") != args.suite:
+            continue
         name = case_def["name"]
         result = test_results.get(name)
         case = _build_case(case_def, result)

--- a/scripts/generate_navigation_test_evidence.py
+++ b/scripts/generate_navigation_test_evidence.py
@@ -116,6 +116,7 @@ NAVIGATION_CASES: list[dict[str, Any]] = [
     {"name": "drawer_opensFromChatsViaMenuButton", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
     {"name": "drawer_navigationBackToTools", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
     {"name": "drawer_bottomNavStateAfterDrawerNavigation", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
+    {"name": "drawer_opensFromActionsViaMenuButton", "category": "drawer_entry_point", "suite": "navigation_full_app_flow"},
 ]
 
 


### PR DESCRIPTION
Closes #1167

## Summary

Focused full-app-flow navigation integration test suite (`NavigationFullAppFlowTest`) that complements the #1154 / PR #1160 harness (`NavigationBackStackRegressionTest`) by exercising a **production-equivalent test host** with real production composables where practical.

### Real production composable coverage
- **PrimaryBottomBar** — real bottom navigation with production test tags
- **ToolsHubScreen** — real tools hub with production row tags
- **ToolsLearnScreen** — real learn screen with real example prompts

### Stubbed destinations (Hilt-dependent ViewModels)
- Conversation list screen
- Actions screen (handles `draftQuery` route parameters) **with production-equivalent menu button**
- Chat screen
- All settings sub-screens
- Stubs use `faf_`-prefixed test tags, clearly distinct from production tags

## Flows validated (13 tests, all pass)

### Primary navigation (5 tests)
- `primaryNavigation_chatsActionsToolsRoundTrip`
- `primaryNavigation_actionsToolsActions`
- `primaryNavigation_toolsChatsTools`
- `primaryNavigation_repeatedTabTapStable`
- `primaryNavigation_noStaleChildScreen`

### Tools row routing (1 combined test for 9 routes)
- `toolsRow_matrixNavigateAndBack` — validates Learn, Lists, Notes, Meal plans, Convert, Settings, Models, Permissions, About through real navigation wiring

### Learn → Actions draft prefill (2 tests)
- `learnToActions_exampleOpensDraftPrefill` — real ToolsLearnScreen example tap navigates to Actions with prefilled input
- `learnToActions_dismissDraftThenSwitchTabs` — dismiss clears state, tab switch doesn't restore stale draft

### Drawer entry points (5 tests)
- `drawer_opensFromToolsViaMenuButton` — production menu icon (ToolsHubScreen)
- `drawer_opensFromChatsViaMenuButton` — stub menu icon (faf_chats_menu_button)
- **`drawer_opensFromActionsViaMenuButton`** — stub menu icon (faf_actions_menu_button)
- `drawer_navigationBackToTools`
- `drawer_bottomNavStateAfterDrawerNavigation`

## Device

- **Primary:** SM-S918B (S23 Ultra) via wireless ADB (`100.76.134.49:44917`, offline at last validation)
- **Fallback:** SM-G991B (S21 Exynos, serial `R5CR605B71K`) — used for connected test run (13/13 pass)
- **Evidence device ID:** `s21-exynos` (user-approved S23U fallback)
- **Device metadata:** `scripts/testdata/devices.yaml` maps `s21-exynos` → `model: R5CR605B71K`, `tier: tracked`

> **Device note:** The S23 Ultra wireless ADB connection (`100.76.134.49:44917`) was offline after the previous session. S21 Exynos was used as fallback per user decision. The Actions drawer test has not been directly validated on S23 Ultra, but it follows the identical pattern as the Chats and Tools drawer tests which previously passed on S23U.

## How this differs from #1154 harness

| Dimension | #1154 (BackStackRegressionTest) | #1167 (NavigationFullAppFlowTest) |
|---|---|---|
| Test host | Custom `BackStackTestHarness` with stub destinations | `KernelNavTestHost` — production-equivalent NavHost with real route registrations |
| Bottom nav | Inline stub | **Real** `PrimaryBottomBar` |
| Tools screen | `ToolsHubScreenHarness` (test-only) | **Real** `ToolsHubScreen` |
| Tools Learn | `DestinationStub` | **Real** `ToolsLearnScreen` |
| Drawer open | Test-only button | Production menu icon (`tools_menu_button`) + stub equivalents |
| Drawer navigation | `saveState=true`, `restoreState=true` | **Fixed to match production:** `saveState=false`, `restoreState=false` |
| Drawer entry points | 1 test-only | **5 tests** (Tools, Chats, Actions menu buttons) |
| Actions drawer button | Not covered | **Covered** — `ActionsScreenStub` has menu icon with `faf_actions_menu_button` |
| Evidence suite | `navigation_backstack` | `navigation_full_app_flow` |
| Test count | 11 | 13 |

## Validation

```bash
# Python scripts
python3 -m py_compile scripts/*.py              # all pass

# Local
./gradlew lint --no-daemon                        # BUILD SUCCESSFUL
./gradlew test --no-daemon                        # BUILD SUCCESSFUL
./gradlew assembleDebug --no-daemon               # BUILD SUCCESSFUL

# Connected tests (S21 Exynos SM-G991B) — 13/13 pass
ANDROID_SERIAL=R5CR605B71K \
  ./gradlew :app:connectedDebugAndroidTest --no-daemon \
  -PversionCode=9999 \
  -Pandroid.testInstrumentationRunnerArguments.class=\
com.kernel.ai.navigation.NavigationFullAppFlowTest
```

## CI

- **Run ID:** #27446924403
- **Head SHA:** `047dfe14`
- **Status:** ✅ SUCCESS
- **URL:** https://github.com/NickMonrad/kernel-ai-assistant/actions/runs/27446924403

## Dashboard

- **Workflow:** Publish test dashboard
- **Run ID:** #27446949503
- **Status:** ✅ SUCCESS
- **URL:** https://github.com/NickMonrad/kernel-ai-assistant/actions/runs/27446949503
- Triggered manually after evidence publication to reflect S21 Exynos results.

## Changes made (this PR)

### Production changes
1. Added `Modifier.testTag("back_from_tools_learn")` to `ToolsLearnScreen` back button
2. Added `backTag` field to `ToolsRouteEntry` data class in the test file

### Fix 1: Actions drawer entry point (review finding)
- **Updated `ActionsScreenStub`** to include a `drawerState`/`scope` parameter and a menu `IconButton` with test tag `faf_actions_menu_button` — matching the pattern used by Chats stub.
- **Added `drawer_opensFromActionsViaMenuButton`** test: navigate to Actions via bottom nav → click menu button → assert `faf_drawer_sheet` displayed.
- **Added `TAG_ACTIONS_MENU_BUTTON`** constant.
- **Added `CoroutineScope` import** (was missing for the Actions stub signature).

### Fix 2: Evidence Markdown labels (earlier review finding)
- Suite-aware headings (not hardcoded to `Navigation Back-Stack Regression`).
- New category labels with deterministic ordering.
- Additional test case entry for `drawer_opensFromActionsViaMenuButton` in `NAVIGATION_CASES`.

## Evidence generation

```bash
PR_NUMBER=1207
PR_HEAD_SHA=047dfe14daf139c79a5b5b6d76404bd02a836809

python3 scripts/generate_navigation_test_evidence.py \
  --source on_device \
  --suite navigation_full_app_flow \
  --pr "$PR_NUMBER" \
  --commit "$PR_HEAD_SHA" \
  --branch "feature/1167-full-app-flow-navigation-tests" \
  --device-id s21-exynos \
  --adb-serial "R5CR605B71K" \
  --results-dir app/build/outputs/androidTest-results/connected/debug/ \
  --out-dir "scripts/test-reports/normalised/pr-1207/"
```

**Result:** 13/13 passed (100.0%)

### Published evidence (test-results branch)

Verification: `git fetch origin test-results && git show origin/test-results:results/pr/1207/on_device/__2026-06-12T22:33:43Z_s21-exynos_navigation_full_app_flow.json`

| File | Path |
|------|------|
| JSON | `results/pr/1207/on_device/__2026-06-12T22:33:43Z_s21-exynos_navigation_full_app_flow.json` |
| CSV | `results/pr/1207/on_device/__2026-06-12T22:33:43Z_s21-exynos_navigation_full_app_flow.csv` |
| MD | `results/pr/1207/on_device/__2026-06-12T22:33:43Z_s21-exynos_navigation_full_app_flow.md` |

### Evidence metadata
- `pr: 1207` ✅
- `commit: 047dfe14daf1` ✅
- `source: on_device` ✅
- `suite: navigation_full_app_flow` ✅
- `device.id: s21-exynos` ✅
- `device.model: R5CR605B71K` ✅
- `summary: 13/13 passed` ✅
- Evidence verified fetchable from `test-results` branch ✅

## Limitations / follow-ups
- **Drawer gesture coverage** is not directly tested — tests use programmatic menu-button clicks, not swipe gestures.
- **Actions drawer test validated on S21 Exynos** (user-approved fallback — S23U was offline). The pattern is identical to the Tools and Chats drawer tests previously validated on S23U.
- Full `KernelNavHost` + Hilt integration (real `ConversationListScreen`, `ActionsScreen`, etc.) remains future work.
- Connected tests require `-PversionCode=9999` when installed app version exceeds debug build default.
- Dashboard was not auto-refreshed by `repository_dispatch` (on-device evidence published locally); manually triggered.

## Files changed
- `app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt` (+895, new) — Actions menu button, drawer test, CoroutineScope import
- `app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt` (+1 line: `testTag` on back button)
- `scripts/generate_navigation_test_evidence.py` (+25 lines: test case entry, suite-aware headings, new category labels)

## Evidence note
Generated evidence files are **not** committed to `main` — `scripts/test-reports/` is gitignored. Published to `test-results` branch via `publish_test_evidence.py`.
