### PR TITLE
fix(#1206): robust chat background import and cleanup

### DIFF
--- a/core/memory/src/main/java/com/kernel/ai/core/memory/wallpaper/WallpaperManager.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/wallpaper/WallpaperManager.kt
@@ -1,0 +1,149 @@
+package com.kernel.ai.core.memory.wallpaper
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.net.Uri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages importing, storing, and cleaning up chat wallpaper images in app-private storage.
+ *
+ * Wallpapers are stored under `files/chat_wallpapers/` to decouple wallpaper longevity from
+ * external content-provider URI permissions. The active wallpaper is referenced as an absolute
+ * file path in DataStore preferences.
+ */
+@Singleton
+class WallpaperManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val wallpaperDir: File
+        get() = File(context.filesDir, WALLPAPER_DIR).also { it.mkdirs() }
+
+    /**
+     * Import a wallpaper from an external [sourceUri] into app-private storage.
+     *
+     * Opens the URI via [ContentResolver.openInputStream], validates the content is a decodable
+     * image, and writes a copy to `files/chat_wallpapers/`.
+     *
+     * @return [Result.success] with the absolute file path, or [Result.failure] with the error.
+     */
+    suspend fun importWallpaper(sourceUri: Uri): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            // Validate the source is a readable image
+            val validateResult = validateImageUri(sourceUri)
+            if (validateResult.isFailure) {
+                return@withContext Result.failure(validateResult.exceptionOrNull()!!)
+            }
+
+            // Read the source bytes
+            val bytes = context.contentResolver.openInputStream(sourceUri)?.use { stream ->
+                stream.readBytes()
+            } ?: return@withContext Result.failure(
+                FileNotFoundException("Cannot open $sourceUri"),
+            )
+
+            // Generate a unique filename
+            val ext = guessExtension(bytes) ?: "jpg"
+            val filename = "wallpaper_${System.currentTimeMillis()}_${sourceUri.hashCode()}.$ext"
+            val destFile = File(wallpaperDir, filename)
+
+            destFile.outputStream().use { output ->
+                output.write(bytes)
+            }
+
+            Result.success(destFile.absolutePath)
+        } catch (e: SecurityException) {
+            Result.failure(e)
+        } catch (e: FileNotFoundException) {
+            Result.failure(e)
+        } catch (e: IOException) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Delete a single wallpaper file identified by its absolute path.
+     * Silently ignores missing files or non-wallpaper-directory paths.
+     */
+    fun deleteWallpaper(filePath: String) {
+        val file = File(filePath)
+        if (file.isFile && file.parentFile?.absolutePath == wallpaperDir.absolutePath) {
+            file.delete()
+        }
+    }
+
+    /**
+     * Delete all imported wallpaper files that are not in [activePaths].
+     *
+     * Only deletes files under the app-owned [wallpaperDir]. Never touches external files.
+     */
+    fun deleteUnusedWallpapers(activePaths: Set<String>) {
+        wallpaperDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.absolutePath !in activePaths) {
+                file.delete()
+            }
+        }
+    }
+
+    /**
+     * Returns all imported wallpaper files sorted by modification time (most recent first).
+     */
+    fun getImportedWallpapers(): List<File> {
+        return wallpaperDir.listFiles()
+            ?.filter { it.isFile }
+            ?.sortedByDescending { it.lastModified() }
+            ?: emptyList()
+    }
+
+    /**
+     * Count of wallpaper files currently in app-private storage.
+     */
+    fun getWallpaperCount(): Int = wallpaperDir.listFiles()?.count { it.isFile } ?: 0
+
+    /**
+     * Validate that [uri] points to a decodable image.
+     */
+    private fun validateImageUri(uri: Uri): Result<Unit> {
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { stream ->
+                val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeStream(stream, null, opts)
+                if (opts.outWidth <= 0 || opts.outHeight <= 0) {
+                    return Result.failure(IllegalArgumentException("URI does not point to a valid image"))
+                }
+            } ?: return Result.failure(FileNotFoundException("Cannot open $uri"))
+            Result.success(Unit)
+        } catch (e: SecurityException) {
+            Result.failure(e)
+        } catch (e: FileNotFoundException) {
+            Result.failure(e)
+        } catch (e: IOException) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Guess a file extension from image magic bytes.
+     */
+    private fun guessExtension(bytes: ByteArray): String? {
+        return when {
+            bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() -> "jpg"
+            bytes.size >= 8 && bytes[0] == 0x89.toByte() && bytes[1] == 0x50.toByte() &&
+                bytes[2] == 0x4E.toByte() && bytes[3] == 0x47.toByte() -> "png"
+            bytes.size >= 4 && bytes[0] == 0x52.toByte() && bytes[1] == 0x49.toByte() &&
+                bytes[2] == 0x46.toByte() && bytes[3] == 0x46.toByte() -> "webp"
+            else -> null
+        }
+    }
+
+    private companion object {
+        private const val WALLPAPER_DIR = "chat_wallpapers"
+    }
+}

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/wallpaper/WallpaperManager.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/wallpaper/WallpaperManager.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,35 +32,58 @@ class WallpaperManager @Inject constructor(
      * Import a wallpaper from an external [sourceUri] into app-private storage.
      *
      * Opens the URI via [ContentResolver.openInputStream], validates the content is a decodable
-     * image, and writes a copy to `files/chat_wallpapers/`.
+     * image, and writes a copy to `files/chat_wallpapers/` using bounded streaming copy.
      *
      * @return [Result.success] with the absolute file path, or [Result.failure] with the error.
      */
     suspend fun importWallpaper(sourceUri: Uri): Result<String> = withContext(Dispatchers.IO) {
         try {
-            // Validate the source is a readable image
+            // Validate the source is a readable image (bounds-only decode — no pixel data loaded)
             val validateResult = validateImageUri(sourceUri)
             if (validateResult.isFailure) {
                 return@withContext Result.failure(validateResult.exceptionOrNull()!!)
             }
 
-            // Read the source bytes
-            val bytes = context.contentResolver.openInputStream(sourceUri)?.use { stream ->
-                stream.readBytes()
-            } ?: return@withContext Result.failure(
-                FileNotFoundException("Cannot open $sourceUri"),
-            )
+            val timestamp = System.currentTimeMillis()
+            val hash = sourceUri.hashCode()
+            val tempFile = File(wallpaperDir, "wallpaper_${timestamp}_${hash}.tmp")
 
-            // Generate a unique filename
-            val ext = guessExtension(bytes) ?: "jpg"
-            val filename = "wallpaper_${System.currentTimeMillis()}_${sourceUri.hashCode()}.$ext"
-            val destFile = File(wallpaperDir, filename)
+            try {
+                // Stream-copy with bounded cap
+                val input = context.contentResolver.openInputStream(sourceUri)
+                    ?: return@withContext Result.failure(
+                        FileNotFoundException("Cannot open $sourceUri"),
+                    )
 
-            destFile.outputStream().use { output ->
-                output.write(bytes)
+                input.use { stream ->
+                    tempFile.outputStream().use { output ->
+                        copyBounded(stream, output, MAX_WALLPAPER_IMPORT_BYTES)
+                    }
+                }
+
+                // Validate the copied file is a fully delivered valid image
+                val fileValidate = validateImageFile(tempFile)
+                if (fileValidate.isFailure) {
+                    tempFile.delete()
+                    return@withContext Result.failure(fileValidate.exceptionOrNull()!!)
+                }
+
+                // Guess extension from magic bytes of the copied file
+                val ext = guessExtensionFromFile(tempFile) ?: "jpg"
+                val destFile = File(wallpaperDir, "wallpaper_${timestamp}_${hash}.$ext")
+                if (!tempFile.renameTo(destFile)) {
+                    // Fallback: temp path used as-is (rare on same filesystem)
+                    return@withContext Result.success(tempFile.absolutePath)
+                }
+
+                Result.success(destFile.absolutePath)
+            } catch (e: Exception) {
+                // Delete any partial file on failure
+                if (tempFile.exists()) tempFile.delete()
+                throw e
             }
-
-            Result.success(destFile.absolutePath)
+        } catch (e: WallpaperImportTooLargeException) {
+            Result.failure(e)
         } catch (e: SecurityException) {
             Result.failure(e)
         } catch (e: FileNotFoundException) {
@@ -109,6 +134,7 @@ class WallpaperManager @Inject constructor(
 
     /**
      * Validate that [uri] points to a decodable image.
+     * Uses bounds-only decoding — no pixel data is loaded into memory.
      */
     private fun validateImageUri(uri: Uri): Result<Unit> {
         return try {
@@ -116,7 +142,9 @@ class WallpaperManager @Inject constructor(
                 val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 BitmapFactory.decodeStream(stream, null, opts)
                 if (opts.outWidth <= 0 || opts.outHeight <= 0) {
-                    return Result.failure(IllegalArgumentException("URI does not point to a valid image"))
+                    return Result.failure(
+                        IllegalArgumentException("URI does not point to a valid image"),
+                    )
                 }
             } ?: return Result.failure(FileNotFoundException("Cannot open $uri"))
             Result.success(Unit)
@@ -130,20 +158,88 @@ class WallpaperManager @Inject constructor(
     }
 
     /**
-     * Guess a file extension from image magic bytes.
+     * Validate that [file] is a decodable image using bounds-only decoding.
      */
-    private fun guessExtension(bytes: ByteArray): String? {
+    private fun validateImageFile(file: File): Result<Unit> {
+        return try {
+            val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(file.absolutePath, opts)
+            if (opts.outWidth <= 0 || opts.outHeight <= 0) {
+                return Result.failure(
+                    IllegalArgumentException("Imported file is not a valid image"),
+                )
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Guess a file extension from image magic bytes read from [file].
+     */
+    private fun guessExtensionFromFile(file: File): String? {
+        return try {
+            val bytes = ByteArray(16)
+            file.inputStream().use { stream ->
+                val read = stream.read(bytes)
+                if (read < 2) return null
+                guessExtension(bytes, read)
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Guess a file extension from the first [len] bytes of image data.
+     */
+    private fun guessExtension(bytes: ByteArray, len: Int = bytes.size): String? {
         return when {
-            bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() -> "jpg"
-            bytes.size >= 8 && bytes[0] == 0x89.toByte() && bytes[1] == 0x50.toByte() &&
+            len >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() -> "jpg"
+            len >= 8 && bytes[0] == 0x89.toByte() && bytes[1] == 0x50.toByte() &&
                 bytes[2] == 0x4E.toByte() && bytes[3] == 0x47.toByte() -> "png"
-            bytes.size >= 4 && bytes[0] == 0x52.toByte() && bytes[1] == 0x49.toByte() &&
+            len >= 4 && bytes[0] == 0x52.toByte() && bytes[1] == 0x49.toByte() &&
                 bytes[2] == 0x46.toByte() && bytes[3] == 0x46.toByte() -> "webp"
             else -> null
         }
     }
 
+    /**
+     * Bounded streaming copy from [input] to [output].
+     *
+     * @throws WallpaperImportTooLargeException if data exceeds [maxBytes].
+     * @return total bytes copied.
+     */
+    @Throws(WallpaperImportTooLargeException::class, IOException::class)
+    private fun copyBounded(
+        input: InputStream,
+        output: OutputStream,
+        maxBytes: Long,
+    ): Long {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read == -1) break
+            total += read
+            if (total > maxBytes) {
+                throw WallpaperImportTooLargeException(maxBytes)
+            }
+            output.write(buffer, 0, read)
+        }
+        return total
+    }
+
+    /** Thrown when a wallpaper import exceeds the maximum allowed file size. */
+    private class WallpaperImportTooLargeException(maxBytes: Long) :
+        IOException("Image exceeds maximum import size of ${maxBytes / (1024 * 1024)} MB")
+
     private companion object {
         private const val WALLPAPER_DIR = "chat_wallpapers"
+        /** Maximum allowed size for imported wallpaper files: 25 MB. */
+        private const val MAX_WALLPAPER_IMPORT_BYTES = 25L * 1024L * 1024L
+        /** Transfer buffer size for streaming copy operations. */
+        private const val DEFAULT_BUFFER_SIZE = 8192
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -477,13 +477,7 @@ private fun ChatContent(
         if (state.wallpaperType != "image") return@remember null
         val uriStr = state.wallpaperImageUri ?: return@remember null
         try {
-            val uri = Uri.parse(uriStr)
-            val bitmap = with(context.contentResolver) {
-                openInputStream(uri)?.use { stream ->
-                    val opts = BitmapFactory.Options().apply { inSampleSize = 4 }
-                    BitmapFactory.decodeStream(stream, null, opts)
-                }
-            }
+            val bitmap = wallpaperBitmap(context, uriStr)
             bitmap?.let { BitmapPainter(it.asImageBitmap()) }
         } catch (_: Exception) {
             null
@@ -537,7 +531,9 @@ private fun ChatContent(
             )
         },
     ) { innerPadding ->
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .then(if (wallpaperBackground != null) Modifier.background(wallpaperBackground) else Modifier)) {
             // Wallpaper image behind content
             wallpaperPainter?.let { painter ->
                 Image(
@@ -554,7 +550,6 @@ private fun ChatContent(
                     .imePadding()
                     // InputBar handles nav bar padding when visible; add it here for archived (read-only) view.
                     .then(if (isArchived) Modifier.navigationBarsPadding() else Modifier)
-                    .then(if (wallpaperBackground != null) Modifier.background(wallpaperBackground) else Modifier),
         ) {
             if (isArchived) {
                 Box(
@@ -2073,4 +2068,37 @@ private fun Uri.getFileName(context: android.content.Context): String? {
         }
     }
     return name
+}
+
+/**
+ * Decode a wallpaper bitmap from either an app-private file path or an external content URI.
+ *
+ * - Absolute file paths (starting with "/") are decoded directly via [BitmapFactory.decodeFile].
+ * - Content URIs and other references are decoded via [ContentResolver.openInputStream].
+ *
+ * Returns null if the image cannot be read or decoded.
+ */
+private fun wallpaperBitmap(
+    context: android.content.Context,
+    uriStr: String,
+): android.graphics.Bitmap? {
+    return try {
+        if (uriStr.startsWith("/")) {
+            android.graphics.BitmapFactory.decodeFile(
+                uriStr,
+                android.graphics.BitmapFactory.Options().apply { inSampleSize = 4 },
+            )
+        } else {
+            val uri = android.net.Uri.parse(uriStr)
+            context.contentResolver.openInputStream(uri)?.use { stream ->
+                android.graphics.BitmapFactory.decodeStream(
+                    stream,
+                    null,
+                    android.graphics.BitmapFactory.Options().apply { inSampleSize = 4 },
+                )
+            }
+        }
+    } catch (_: java.lang.Exception) {
+        null
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
@@ -327,7 +327,7 @@ fun ChatPreferencesScreen(
                 "image" -> {
                     wallpaperImageUri?.let { uri ->
                         AsyncImage(
-                            model = toCoilUri(uri),
+                            model = if (uri.startsWith("/")) android.net.Uri.fromFile(java.io.File(uri)) else Uri.parse(uri),
                             contentDescription = "Wallpaper preview",
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -369,42 +369,6 @@ fun ChatPreferencesScreen(
                         .padding(horizontal = 16.dp, vertical = 4.dp),
                 ) {
                     Text("Delete unused image wallpapers (${importedWallpapers.count { !it.isActive }})")
-                }
-            }
-            if (importedWallpapers.size > 1) {
-                Text(
-                    text = "Previously used images",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).padding(top = 12.dp),
-                )
-                importedWallpapers.forEach { wallpaper ->
-                    val isActive = wallpaper.isActive
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp)
-                            .then(
-                                if (!isActive) Modifier.clickable { imagePicker.launch("image/*") } else Modifier
-                            ),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        AsyncImage(
-                            model = toCoilUri(wallpaper.path),
-                            contentDescription = wallpaper.name,
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(RoundedCornerShape(4.dp)),
-                            contentScale = ContentScale.Crop,
-                        )
-                        Text(
-                            text = if (isActive) "${wallpaper.name} (current)" else wallpaper.name,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (isActive) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
                 }
             }
 
@@ -736,17 +700,6 @@ private fun ColorPickerDialog(
     )
 }
 
-/**
- * Convert a stored wallpaper reference (file path or content URI) to a Coil-compatible URI.
- * File paths are wrapped with [android.net.Uri.fromFile] for compatibility.
- */
-private fun toCoilUri(ref: String): Uri {
-    return if (ref.startsWith("/")) {
-        android.net.Uri.fromFile(java.io.File(ref))
-    } else {
-        Uri.parse(ref)
-    }
-}
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -49,6 +51,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -132,6 +135,9 @@ fun ChatPreferencesScreen(
     val copyToolCalls by viewModel.copyToolCalls.collectAsStateWithLifecycle()
     val copyThinking by viewModel.copyThinking.collectAsStateWithLifecycle()
     val useSystemColors by viewModel.useSystemColors.collectAsStateWithLifecycle()
+    val importedWallpapers by viewModel.importedWallpapers.collectAsStateWithLifecycle()
+    val wallpaperImportError by viewModel.wallpaperImportError.collectAsStateWithLifecycle()
+    val migrationRunning by viewModel.migrationRunning.collectAsStateWithLifecycle()
 
     var showRetentionPicker by remember { mutableStateOf(false) }
     var showFontSizePicker by remember { mutableStateOf(false) }
@@ -141,20 +147,21 @@ fun ChatPreferencesScreen(
     var showWallpaperColorPicker by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
 
     val imagePicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
     ) { uri: Uri? ->
         if (uri != null) {
-            // Take persistable permission so the URI survives reboots
-            context.contentResolver.takePersistableUriPermission(
-                uri,
-                android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION,
-            )
-            scope.launch {
-                viewModel.setWallpaperType("image")
-                viewModel.setWallpaperImageUri(uri.toString())
-            }
+            viewModel.importWallpaper(uri)
+        }
+    }
+
+    // Show snackbar on wallpaper import errors
+    LaunchedEffect(wallpaperImportError) {
+        wallpaperImportError?.let { message ->
+            snackbarHostState.showSnackbar(message)
+            viewModel.clearWallpaperImportError()
         }
     }
 
@@ -169,6 +176,7 @@ fun ChatPreferencesScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -319,7 +327,7 @@ fun ChatPreferencesScreen(
                 "image" -> {
                     wallpaperImageUri?.let { uri ->
                         AsyncImage(
-                            model = Uri.parse(uri),
+                            model = toCoilUri(uri),
                             contentDescription = "Wallpaper preview",
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -330,7 +338,73 @@ fun ChatPreferencesScreen(
                             placeholder = null,
                             error = null,
                         )
+                    }
                 }
+            }
+
+            // Wallpaper management (#1206)
+            if (migrationRunning) {
+                Text(
+                    text = "Migrating existing wallpaper…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
+            if (wallpaperType == "image" && wallpaperImageUri != null) {
+                OutlinedButton(
+                    onClick = { viewModel.deleteCurrentWallpaper() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                ) {
+                    Text("Delete current image wallpaper")
+                }
+            }
+            if (importedWallpapers.any { !it.isActive }) {
+                OutlinedButton(
+                    onClick = { viewModel.deleteUnusedWallpapers() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                ) {
+                    Text("Delete unused image wallpapers (${importedWallpapers.count { !it.isActive }})")
+                }
+            }
+            if (importedWallpapers.size > 1) {
+                Text(
+                    text = "Previously used images",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).padding(top = 12.dp),
+                )
+                importedWallpapers.forEach { wallpaper ->
+                    val isActive = wallpaper.isActive
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp)
+                            .then(
+                                if (!isActive) Modifier.clickable { imagePicker.launch("image/*") } else Modifier
+                            ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        AsyncImage(
+                            model = toCoilUri(wallpaper.path),
+                            contentDescription = wallpaper.name,
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                            contentScale = ContentScale.Crop,
+                        )
+                        Text(
+                            text = if (isActive) "${wallpaper.name} (current)" else wallpaper.name,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (isActive) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
                 }
             }
 
@@ -660,6 +734,18 @@ private fun ColorPickerDialog(
         },
         confirmButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
+}
+
+/**
+ * Convert a stored wallpaper reference (file path or content URI) to a Coil-compatible URI.
+ * File paths are wrapped with [android.net.Uri.fromFile] for compatibility.
+ */
+private fun toCoilUri(ref: String): Uri {
+    return if (ref.startsWith("/")) {
+        android.net.Uri.fromFile(java.io.File(ref))
+    } else {
+        Uri.parse(ref)
+    }
 }
 
 @Preview(showBackground = true)

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImage
+import java.io.File
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -372,6 +373,25 @@ fun ChatPreferencesScreen(
                 }
             }
 
+            // ─────── Saved image wallpapers ───────
+            if (importedWallpapers.isNotEmpty()) {
+                SectionHeader("Saved image wallpapers")
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    importedWallpapers.forEach { wallpaper ->
+                        SavedWallpaperThumbnail(
+                            wallpaper = wallpaper,
+                            onClick = { viewModel.selectImportedWallpaper(wallpaper.path) },
+                        )
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
             HorizontalDivider()
 
             // ─────── Conversation Copy (#1024) ───────
@@ -588,6 +608,51 @@ private fun WallpaperTypeButton(
             icon?.invoke()
             if (icon != null) Spacer(Modifier.width(4.dp))
             Text(label)
+        }
+    }
+}
+
+@Composable
+private fun SavedWallpaperThumbnail(
+    wallpaper: ImportedWallpaper,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(80.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .then(
+                if (wallpaper.isActive) {
+                    Modifier.border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp))
+                } else {
+                    Modifier.border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+                }
+            ),
+    ) {
+        AsyncImage(
+            model = Uri.fromFile(File(wallpaper.path)),
+            contentDescription = wallpaper.name,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
+        if (wallpaper.isActive) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(2.dp)
+                    .size(20.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "Active wallpaper",
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.feature.settings
 
 import android.net.Uri
+import java.io.File
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.prefs.ChatPreferences
@@ -155,6 +156,24 @@ class ChatPreferencesViewModel @Inject constructor(
             // Only treat the image as active when the mode is actually "image" (#1206)
             val active = if (currentType == "image" && currentUri != null) setOf(currentUri) else emptySet()
             wallpaperManager.deleteUnusedWallpapers(active)
+            refreshImportedWallpapers()
+        }
+    }
+
+    /**
+     * Select an already-imported wallpaper from app-private storage and activate it.
+     * Does not launch Gallery/Files or re-import the file.
+     */
+    fun selectImportedWallpaper(path: String) {
+        viewModelScope.launch {
+            // Verify the file still exists before activating
+            if (!File(path).exists()) {
+                refreshImportedWallpapers()
+                _wallpaperImportError.value = "Selected wallpaper file was not found"
+                return@launch
+            }
+            chatPreferences.setWallpaperImageUri(path)
+            chatPreferences.setWallpaperType("image")
             refreshImportedWallpapers()
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
@@ -67,7 +67,14 @@ class ChatPreferencesViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "none")
 
     fun setWallpaperType(type: String) {
-        viewModelScope.launch { chatPreferences.setWallpaperType(type) }
+        viewModelScope.launch {
+            chatPreferences.setWallpaperType(type)
+            // Clear the active image reference when switching away from image mode (#1206)
+            if (type != "image") {
+                chatPreferences.setWallpaperImageUri(null)
+            }
+            refreshImportedWallpapers()
+        }
     }
 
     val wallpaperColor: StateFlow<Long?> = chatPreferences.wallpaperColor
@@ -143,8 +150,10 @@ class ChatPreferencesViewModel @Inject constructor(
      */
     fun deleteUnusedWallpapers() {
         viewModelScope.launch {
+            val currentType = chatPreferences.wallpaperType.first()
             val currentUri = chatPreferences.wallpaperImageUri.first()
-            val active = if (currentUri != null) setOf(currentUri) else emptySet()
+            // Only treat the image as active when the mode is actually "image" (#1206)
+            val active = if (currentType == "image" && currentUri != null) setOf(currentUri) else emptySet()
             wallpaperManager.deleteUnusedWallpapers(active)
             refreshImportedWallpapers()
         }
@@ -156,13 +165,15 @@ class ChatPreferencesViewModel @Inject constructor(
 
     private fun refreshImportedWallpapers() {
         viewModelScope.launch {
+            val currentType = chatPreferences.wallpaperType.first()
             val currentUri = chatPreferences.wallpaperImageUri.first()
+            val activeUri = currentUri.takeIf { currentType == "image" }
             val files = wallpaperManager.getImportedWallpapers()
             _importedWallpapers.value = files.map { file ->
                 ImportedWallpaper(
                     path = file.absolutePath,
                     name = file.name,
-                    isActive = file.absolutePath == currentUri,
+                    isActive = file.absolutePath == activeUri,
                     lastModified = file.lastModified(),
                 )
             }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ChatPreferencesViewModel.kt
@@ -1,19 +1,30 @@
 package com.kernel.ai.feature.settings
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.prefs.ChatPreferences
+import com.kernel.ai.core.memory.wallpaper.WallpaperManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/**
+ * ViewModel for Chat Preferences screen.
+ */
 @HiltViewModel
 class ChatPreferencesViewModel @Inject constructor(
     private val chatPreferences: ChatPreferences,
+    private val wallpaperManager: WallpaperManager,
 ) : ViewModel() {
+
+    // ---- Archive ----
 
     val archiveRetentionDays: StateFlow<Int> = chatPreferences.archiveRetentionDays
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 7)
@@ -69,9 +80,124 @@ class ChatPreferencesViewModel @Inject constructor(
     val wallpaperImageUri: StateFlow<String?> = chatPreferences.wallpaperImageUri
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    fun setWallpaperImageUri(uri: String?) {
-        viewModelScope.launch { chatPreferences.setWallpaperImageUri(uri) }
+    // ---- Wallpaper management (#1206) ----
+
+    /** All imported wallpaper files in app-private storage, sorted by recency. */
+    private val _importedWallpapers = MutableStateFlow<List<ImportedWallpaper>>(emptyList())
+    val importedWallpapers: StateFlow<List<ImportedWallpaper>> = _importedWallpapers.asStateFlow()
+
+    /** Error message from the last wallpaper import attempt, or null. */
+    private val _wallpaperImportError = MutableStateFlow<String?>(null)
+    val wallpaperImportError: StateFlow<String?> = _wallpaperImportError.asStateFlow()
+
+    /** True while a legacy external wallpaper URI is being migrated. */
+    private val _migrationRunning = MutableStateFlow(false)
+    val migrationRunning: StateFlow<Boolean> = _migrationRunning.asStateFlow()
+
+    init {
+        // Migrate any legacy external content:// URI into app-private storage
+        migrateLegacyWallpaper()
+        refreshImportedWallpapers()
     }
+
+    /**
+     * Import an image from [uri] (Gallery or Files) into app-private storage and activate it.
+     * Runs import on [Dispatchers.IO]; the composable callback remains lightweight.
+     */
+    fun importWallpaper(uri: Uri) {
+        viewModelScope.launch {
+            val result = wallpaperManager.importWallpaper(uri)
+            result.fold(
+                onSuccess = { path ->
+                    chatPreferences.setWallpaperImageUri(path)
+                    chatPreferences.setWallpaperType("image")
+                    _wallpaperImportError.value = null
+                    refreshImportedWallpapers()
+                },
+                onFailure = { error ->
+                    _wallpaperImportError.value = error.message ?: "Failed to import wallpaper"
+                },
+            )
+        }
+    }
+
+    /**
+     * Delete the currently active imported wallpaper file and reset to default (none).
+     * Only affects app-owned files; never touches the original Gallery/Files source.
+     */
+    fun deleteCurrentWallpaper() {
+        viewModelScope.launch {
+            val currentUri = chatPreferences.wallpaperImageUri.first()
+            if (currentUri != null) {
+                wallpaperManager.deleteWallpaper(currentUri)
+            }
+            chatPreferences.setWallpaperImageUri(null)
+            chatPreferences.setWallpaperType("none")
+            refreshImportedWallpapers()
+        }
+    }
+
+    /**
+     * Delete all imported wallpaper files that are not currently active.
+     * Only affects app-owned files under the wallpaper import directory.
+     */
+    fun deleteUnusedWallpapers() {
+        viewModelScope.launch {
+            val currentUri = chatPreferences.wallpaperImageUri.first()
+            val active = if (currentUri != null) setOf(currentUri) else emptySet()
+            wallpaperManager.deleteUnusedWallpapers(active)
+            refreshImportedWallpapers()
+        }
+    }
+
+    fun clearWallpaperImportError() {
+        _wallpaperImportError.value = null
+    }
+
+    private fun refreshImportedWallpapers() {
+        viewModelScope.launch {
+            val currentUri = chatPreferences.wallpaperImageUri.first()
+            val files = wallpaperManager.getImportedWallpapers()
+            _importedWallpapers.value = files.map { file ->
+                ImportedWallpaper(
+                    path = file.absolutePath,
+                    name = file.name,
+                    isActive = file.absolutePath == currentUri,
+                    lastModified = file.lastModified(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Migrate a legacy external [content://] wallpaper URI into app-private storage.
+     * Called once at init. On failure the active wallpaper is silently reset to default.
+     */
+    private fun migrateLegacyWallpaper() {
+        viewModelScope.launch {
+            val type = chatPreferences.wallpaperType.first()
+            val uri = chatPreferences.wallpaperImageUri.first()
+            if (type != "image" || uri == null || !isExternalContentUri(uri)) return@launch
+
+            _migrationRunning.value = true
+            val result = wallpaperManager.importWallpaper(Uri.parse(uri))
+            result.fold(
+                onSuccess = { path ->
+                    chatPreferences.setWallpaperImageUri(path)
+                    // wallpaperType stays "image"
+                },
+                onFailure = {
+                    // Fall back gracefully — don't crash, don't keep a broken reference
+                    chatPreferences.setWallpaperType("none")
+                    chatPreferences.setWallpaperImageUri(null)
+                },
+            )
+            _migrationRunning.value = false
+        }
+    }
+
+    /** True if [uriStr] is an external content:// URI rather than an app-owned file path. */
+    private fun isExternalContentUri(uriStr: String): Boolean = uriStr.startsWith("content://")
 
     // ---- Conversation copy (#1024) ----
 
@@ -98,3 +224,11 @@ class ChatPreferencesViewModel @Inject constructor(
         viewModelScope.launch { chatPreferences.setUseSystemColors(enabled) }
     }
 }
+
+/** Metadata for an imported wallpaper file in app-private storage. */
+data class ImportedWallpaper(
+    val path: String,
+    val name: String,
+    val isActive: Boolean,
+    val lastModified: Long,
+)


### PR DESCRIPTION
## Problem

Selecting a chat background image from Android Files/DocumentsUI crashes the app because `ActivityResultContracts.GetContent()` does not guarantee a persistable URI grant, but `takePersistableUriPermission()` was called unconditionally. Additionally, storing external `content://` URIs in preferences makes the wallpaper dependent on the external provider staying readable across reboots and provider changes.

The wallpaper colour also had a visual cutoff: it was applied only to the message list Column, not the full chat screen, so the composer/input area displayed a separate dark band.

## Changes

### Image import (new `WallpaperManager` in `:core:memory`)

- `WallpaperManager.importWallpaper(sourceUri)` opens the URI via `ContentResolver.openInputStream()`, validates the bytes are a decodable image, writes a copy to `files/chat_wallpapers/`, and returns the app-private absolute file path
- Import runs on `Dispatchers.IO` — the composable picker callback is lightweight
- Error-handling: `SecurityException`, `FileNotFoundException`, `IOException`, decode failures are all caught; a Snackbar shows the error and the previous background is preserved
- No `takePersistableUriPermission()` call — the app no longer depends on external URI grants for wallpaper longevity

### Wallpaper storage

- `wallpaperImageUri` DataStore key now stores an **app-private absolute file path** (e.g. `/data/data/.../files/chat_wallpapers/wallpaper_xxx.jpg`) instead of an external `content://` URI
- On Chat Preferences open, legacy `content://` wallpaper URIs are automatically migrated to app-private storage. If migration fails, the wallpaper is reset to default (no crash, no stale broken reference)

### Default / Solid / Image mode representation

- The existing three-way `wallpaperType` ("none" / "color" / "image") is unchanged
- Solid colours remain first-class options stored as ARGB longs — never represented as image files
- Default ("none") clears the active custom background without deleting imported image files

### **Fixed: stale `wallpaperImageUri` after mode switch** (#1206 review)

When switching to Default/None or Solid colour, `setWallpaperType()` now **automatically clears `wallpaperImageUri`** (dereferences the active image reference). The imported file is **not deleted** — it becomes eligible for "Delete unused image wallpapers".

- `setWallpaperType("none")` → type = none, image URI cleared
- `setWallpaperType("color")` → type = color, image URI cleared (color picker then sets `wallpaperColor`)
- `setWallpaperType("image")` → type = image, image URI preserved (import path sets URI separately)

### **Fixed: cleanup correctly checks wallpaper mode** (#1206 review)

`deleteUnusedWallpapers()` and `refreshImportedWallpapers()` now only treat the image as **active** when `wallpaperType == "image"`. If the current mode is Default or Solid colour, all imported image files are considered unused and eligible for cleanup.

Rule: `val activeImageUri = wallpaperImageUri.takeIf { wallpaperType == "image" }`

### **Fixed: removed misleading "Previously used images" UI** (#1206 review)

The "Previously used images" section was confusing — tapping items launched the image picker instead of reselecting the displayed image. Replaced with a cleaner, simpler management UI:

- **Choose image** — launches picker
- **Delete current image wallpaper** — visible when mode is Image
- **Delete unused image wallpapers** — visible when unused files exist, shows count

### Background rendering (`ChatScreen.kt`)

- The wallpaper colour background (`Modifier.background(wallpaperBackground)`) was **moved from the inner Column to the root Box** so it covers the full chat screen including the composer/input area
- `wallpaperPainter` now handles both app-private file paths (`BitmapFactory.decodeFile`) and legacy content URIs (`ContentResolver.openInputStream`)
- The InputBar Surface with its tonal elevation sits on top for readability — no abrupt horizontal cutoff

## Validation

- `./gradlew :app:compileDebugKotlin` ✅ (0 errors)
- `./gradlew :feature:settings:test :feature:chat:test` ✅ (all tests pass)

**Required device smoke-testing scenarios:**
1. Start with Default → no image shown
2. Select image from Gallery → image applies and persists
3. Switch to Default → image no longer shown, old image becomes unused
4. Select image again → image applies
5. Switch to Solid colour → colour applies, old image becomes unused
6. Select image from Android Files → no crash, image applies
7. Delete unused image wallpapers → only non-active images deleted
8. Delete current image wallpaper → active image deleted, falls back to Default
9. Solid colours unaffected by image cleanup
10. Restart app → no stale missing-image crashes

Closes #1206