### PR TITLE
feat(#1210 #1211): add Settings cog to primary tabs and Tools search/filtering

### DIFF
--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -997,12 +998,14 @@ class NavigationFullAppFlowTest {
         composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
         assertNodeExists("faf_back_from_${TAG_DEST_SETTINGS}")
 
-        // Second tap — should not create a duplicate Settings entry (launchSingleTop)
-        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        // Simulate second rapid tap via navController (cog is on Chats, not visible now)
+        composeTestRule.runOnUiThread {
+            testNavController?.navigate(ROUTE_SETTINGS) { launchSingleTop = true }
+        }
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
 
-        // One back should return to Chats (not a second Settings entry)
+        // One back should return to Chats — not a second Settings entry
         composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
@@ -1021,10 +1024,16 @@ class NavigationFullAppFlowTest {
         // Search field is present
         composeTestRule.onNodeWithTag("tools_search_field").assertIsDisplayed()
 
-        // Full grouped layout rows are visible
+        // Full grouped layout rows are visible (scroll to find below-fold sections)
         composeTestRule.onNodeWithTag("tools_row_learn", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_lists", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_screen").performScrollToNode(
+            hasTestTag("tools_group_productivity")
+        )
         composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_screen").performScrollToNode(
+            hasTestTag("tools_group_app_setup")
+        )
         composeTestRule.onNodeWithTag("tools_group_app_setup").assertIsDisplayed()
     }
 
@@ -1109,6 +1118,9 @@ class NavigationFullAppFlowTest {
 
         // Full layout restored
         composeTestRule.onNodeWithTag("tools_row_lists", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_screen").performScrollToNode(
+            hasTestTag("tools_group_productivity")
+        )
         composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
     }
 

--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -987,7 +987,7 @@ class NavigationFullAppFlowTest {
     }
 
     @Test
-    fun settingsCog_repeatedTapNoDuplicate() {
+    fun settingsCog_launchSingleTopPreventsDuplicateSettingsDestination() {
         composeTestRule.setContent { KernelNavTestHost() }
         composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
         assertBottomNavSelected(BOTTOM_NAV_CHATS)
@@ -1066,6 +1066,26 @@ class NavigationFullAppFlowTest {
 
         // Clock matches via keyword "timer"
         composeTestRule.onNodeWithTag("tools_search_result_clock").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_matchesModelsAndNavigates() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Search for "models" or related keyword
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("gemma")
+        composeTestRule.waitForIdle()
+
+        // Models result appears
+        composeTestRule.onNodeWithTag("tools_search_result_models").assertIsDisplayed()
+
+        // Tap navigates to Model Management
+        composeTestRule.onNodeWithTag("tools_search_result_models").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_MODELS).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/NavigationFullAppFlowTest.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextClearance
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -139,6 +141,7 @@ class NavigationFullAppFlowTest {
         private const val TAG_ACTIONS_MENU_BUTTON = "faf_actions_menu_button"
         private const val TAG_DRAFT_SUBMIT = "faf_draft_submit"
         private const val TAG_DRAFT_TEXT = "faf_draft_text"
+        private const val TAG_SETTINGS_BUTTON = "top_bar_settings_button"
 
         // Destination stub tags
         private const val TAG_DEST_LEARN = "faf_dest_learn"
@@ -287,6 +290,14 @@ class NavigationFullAppFlowTest {
                                         Icon(Icons.Default.Menu, contentDescription = "Menu")
                                     }
                                 },
+                                actions = {
+                                    IconButton(
+                                        onClick = { navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true } },
+                                        modifier = Modifier.testTag(TAG_SETTINGS_BUTTON),
+                                    ) {
+                                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                                    }
+                                },
                             )
                             Box(
                                 modifier = Modifier.fillMaxSize(),
@@ -325,7 +336,12 @@ class NavigationFullAppFlowTest {
                         @Suppress("UNUSED")
                         val openSheet = backStackEntry.arguments?.getBoolean(ARG_OPEN_SHEET) ?: false
                         val draftQuery = backStackEntry.arguments?.getString(ARG_DRAFT_QUERY) ?: ""
-                        ActionsScreenStub(draftQuery = draftQuery, drawerState = drawerState, scope = scope)
+                        ActionsScreenStub(
+                            draftQuery = draftQuery,
+                            drawerState = drawerState,
+                            scope = scope,
+                            onNavigateToSettings = { navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true } },
+                        )
                     }
 
                     // ── Tools (real production composable) ──
@@ -334,6 +350,14 @@ class NavigationFullAppFlowTest {
                             onOpenDrawer = { scope.launch { drawerState.open() } },
                             onNavigateToRoute = { route ->
                                 navController.navigateToToolsDestination(route)
+                            },
+                            onNavigateToSettings = {
+                                navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true }
+                            },
+                            onOpenPrompt = { prompt ->
+                                navController.navigate(buildActionsDraftRoute(prompt)) {
+                                    launchSingleTop = true
+                                }
                             },
                         )
                     }
@@ -497,6 +521,7 @@ class NavigationFullAppFlowTest {
         draftQuery: String,
         drawerState: DrawerState,
         scope: CoroutineScope,
+        onNavigateToSettings: () -> Unit = {},
     ) {
         val inputText = remember { mutableStateOf(draftQuery) }
         val showDraft = remember { mutableStateOf(draftQuery.isNotEmpty()) }
@@ -510,6 +535,14 @@ class NavigationFullAppFlowTest {
                         modifier = Modifier.testTag(TAG_ACTIONS_MENU_BUTTON),
                     ) {
                         Icon(Icons.Default.Menu, contentDescription = "Menu")
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = onNavigateToSettings,
+                        modifier = Modifier.testTag(TAG_SETTINGS_BUTTON),
+                    ) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
                     }
                 },
             )
@@ -890,5 +923,218 @@ class NavigationFullAppFlowTest {
         composeTestRule.onNodeWithTag(TAG_ACTIONS_MENU_BUTTON).performClick()
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("faf_drawer_sheet").assertIsDisplayed()
+    }
+
+    // ═══════════════════════════ 5. SETTINGS COG ENTRY POINTS ═══════════════
+
+    @Test
+    fun settingsCog_chatsToSettingsBackToChats() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+
+        // Tap Settings cog from Chats
+        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+
+        // Back returns to Chats (not reset to conversation_list)
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+    }
+
+    @Test
+    fun settingsCog_actionsToSettingsBackToActions() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_ACTIONS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+
+        // Tap Settings cog from Actions
+        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+
+        // Back returns to Actions
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_ACTIONS)
+    }
+
+    @Test
+    fun settingsCog_toolsToSettingsBackToTools() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+
+        // Tap Settings cog from Tools (real production TopAppBar)
+        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+
+        // Back returns to Tools
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_TOOLS)
+    }
+
+    @Test
+    fun settingsCog_repeatedTapNoDuplicate() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+
+        // First tap — opens Settings
+        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+        assertNodeExists("faf_back_from_${TAG_DEST_SETTINGS}")
+
+        // Second tap — should not create a duplicate Settings entry (launchSingleTop)
+        composeTestRule.onNodeWithTag(TAG_SETTINGS_BUTTON).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_DEST_SETTINGS).assertIsDisplayed()
+
+        // One back should return to Chats (not a second Settings entry)
+        composeTestRule.onNodeWithTag("faf_back_from_${TAG_DEST_SETTINGS}").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(TAG_CHATS_SCREEN).assertIsDisplayed()
+        assertBottomNavSelected(BOTTOM_NAV_CHATS)
+    }
+
+    // ═══════════════════════════ 6. TOOLS SEARCH ═════════════════════════════
+
+    @Test
+    fun search_emptyShowsGroupedLayout() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Search field is present
+        composeTestRule.onNodeWithTag("tools_search_field").assertIsDisplayed()
+
+        // Full grouped layout rows are visible
+        composeTestRule.onNodeWithTag("tools_row_learn", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_row_lists", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_app_setup").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_matchesDestinationByTitle() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Type a destination title
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("Convert")
+        composeTestRule.waitForIdle()
+
+        // Result row appears
+        composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_matchesDestinationByKeyword() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Type a keyword (not in the title directly)
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("timer")
+        composeTestRule.waitForIdle()
+
+        // Clock matches via keyword "timer"
+        composeTestRule.onNodeWithTag("tools_search_result_clock").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_matchesExamplePrompt() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Type text found in an example prompt
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("shopping list")
+        composeTestRule.waitForIdle()
+
+        // Example prompt section header appears
+        composeTestRule.onNodeWithTag("tools_search_examples_header").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_noResultsState() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Type something that won't match anything
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("xyzzy_nonexistent")
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("tools_search_no_results").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_clearRestoresLayout() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Type a query
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("Convert")
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
+
+        // Clear via trailing icon
+        composeTestRule.onNodeWithTag("tools_search_field").performClick()
+        composeTestRule.waitForIdle()
+        // Use semantic clear — set text to empty
+        composeTestRule.onNodeWithTag("tools_search_field").performTextClearance()
+        composeTestRule.waitForIdle()
+
+        // Full layout restored
+        composeTestRule.onNodeWithTag("tools_row_lists", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_tappedExampleOpensDraftOnly() {
+        composeTestRule.setContent { KernelNavTestHost() }
+        composeTestRule.onNodeWithTag(BOTTOM_NAV_TOOLS).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("tools_screen").assertIsDisplayed()
+
+        // Search for a known example
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("Add milk")
+        composeTestRule.waitForIdle()
+
+        // Tap the example result
+        composeTestRule.onNodeWithTag("tools_search_example_lists_add_milk", useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // Actions opens with draft prefilled (same as learn flow)
+        composeTestRule.onNodeWithTag(TAG_ACTIONS_SCREEN).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_TEXT).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add milk to my shopping list").assertIsDisplayed()
+
+        // No auto-execution: draft UI present but no side effect
+        composeTestRule.onNodeWithTag(TAG_DRAFT_INPUT).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(TAG_DRAFT_SUBMIT).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -430,6 +430,9 @@ fun KernelNavHost(
                             onOpenDrawer = {
                                 coroutineScope.launch { drawerState.open() }
                             },
+                            onNavigateToSettings = {
+                                navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true }
+                            },
                         )
                     }
                 }
@@ -514,6 +517,9 @@ fun KernelNavHost(
                             },
                             onOpenDrawer = {
                                 coroutineScope.launch { drawerState.open() }
+                            },
+                            onNavigateToSettings = {
+                                navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true }
                             },
                         )
                     }
@@ -808,6 +814,14 @@ fun KernelNavHost(
                             },
                             onNavigateToRoute = { route ->
                                 navController.navigateToToolsDestination(route)
+                            },
+                            onNavigateToSettings = {
+                                navController.navigate(ROUTE_SETTINGS) { launchSingleTop = true }
+                            },
+                            onOpenPrompt = { prompt ->
+                                navController.navigate(buildActionsDraftRoute(prompt)) {
+                                    launchSingleTop = true
+                                }
                             },
                         )
                     }

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
@@ -1,6 +1,15 @@
 package com.kernel.ai.navigation
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -43,12 +52,104 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 
+/**
+ * Search metadata for a Tools destination row.
+ */
+private data class ToolSearchEntry(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val category: String,
+    val keywords: List<String> = emptyList(),
+)
+
+/**
+ * Search metadata for a Learn example prompt.
+ */
+private data class ExampleSearchEntry(
+    val sectionTitle: String,
+    val id: String,
+    val label: String,
+    val prompt: String,
+)
+
+/** All Tools destinations as searchable entries. */
+private val allToolSearchEntries = listOf(
+    ToolSearchEntry("learn", "Learn what Jandal can do", "Example prompts for actions, planning, weather, maps, media, and more", "Learn",
+        keywords = listOf("examples", "prompts", "tutorial", "guide", "help", "ideas")),
+    ToolSearchEntry("lists", "Lists", "Shopping, tasks, and reusable lists", "Productivity",
+        keywords = listOf("shopping", "tasks", "grocery", "checklist", "todo")),
+    ToolSearchEntry("notes", "Notes", "Quick notes and saved thoughts", "Productivity",
+        keywords = listOf("memo", "reminder", "thoughts", "write")),
+    ToolSearchEntry("meal_plans", "Meal plans", "Plan meals and generate shopping ideas", "Productivity",
+        keywords = listOf("meal planning", "dinner", "recipes", "grocery", "food")),
+    ToolSearchEntry("clock", "Clock", "Alarms, timers, stopwatch, and world clock", "Time & planning",
+        keywords = listOf("timer", "alarm", "stopwatch", "time")),
+    ToolSearchEntry("important_dates", "Important dates", "Birthdays, anniversaries, and recurring dates", "Time & planning",
+        keywords = listOf("birthday", "anniversary", "recurring", "reminder")),
+    ToolSearchEntry("people_contacts", "People & Contacts", "Contact aliases and people Jandal can recognise", "People",
+        keywords = listOf("contacts", "people", "aliases", "address book")),
+    ToolSearchEntry("convert", "Convert", "Units, currency, and quick calculations", "Utilities",
+        keywords = listOf("unit", "currency", "measurement", "cooking", "calculate")),
+    ToolSearchEntry("user_profile", "User Profile", "Tell Jandal about yourself", "Personalisation",
+        keywords = listOf("profile", "name", "about me", "preferences")),
+    ToolSearchEntry("memory", "Memory", "Manage stored memories", "Personalisation",
+        keywords = listOf("remember", "memories", "storage")),
+    ToolSearchEntry("voice", "Voice", "Speech and spoken response settings", "Personalisation",
+        keywords = listOf("speech", "tts", "stt", "spoken", "audio")),
+    ToolSearchEntry("chat_preferences", "Chat Preferences", "Archive, themes, wallpaper, and copy options", "Personalisation",
+        keywords = listOf("archive", "theme", "wallpaper", "copy", "chat")),
+    ToolSearchEntry("settings", "Settings", "App preferences and configuration", "App setup",
+        keywords = listOf("preferences", "configuration", "options")),
+    ToolSearchEntry("models", "Models", "Downloads, availability, and inference preferences", "App setup",
+        keywords = listOf("ai", "llm", "download", "inference", "gemma")),
+    ToolSearchEntry("permissions", "Permissions", "Review Android permissions used by Jandal", "App setup",
+        keywords = listOf("android", "privacy", "security", "access")),
+    ToolSearchEntry("about", "About", "Build info and debug tools", "App setup",
+        keywords = listOf("version", "build", "debug", "info", "licence")),
+)
+
+/** All Learn example prompts as flat searchable entries. */
+private val allExampleSearchEntries: List<ExampleSearchEntry> by lazy {
+    allExampleSections.flatMap { section ->
+        (section.defaultExamples + section.moreExamples).map { prompt ->
+            ExampleSearchEntry(
+                sectionTitle = section.title,
+                id = prompt.id.removePrefix("tools_learn_"),
+                label = prompt.label,
+                prompt = prompt.prompt,
+            )
+        }
+    }
+}
+
+/** Check whether any field in this entry matches [query]. */
+private fun ToolSearchEntry.matchesQuery(query: String): Boolean {
+    val q = query.lowercase().trim()
+    return title.lowercase().contains(q) ||
+        subtitle.lowercase().contains(q) ||
+        category.lowercase().contains(q) ||
+        keywords.any { it.lowercase().contains(q) }
+}
+
+/** Check whether this example entry matches [query]. */
+private fun ExampleSearchEntry.matchesQuery(query: String): Boolean {
+    val q = query.lowercase().trim()
+    return label.lowercase().contains(q) ||
+        prompt.lowercase().contains(q) ||
+        sectionTitle.lowercase().contains(q)
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ToolsHubScreen(
     onOpenDrawer: () -> Unit,
     onNavigateToRoute: (route: String) -> Unit,
+    onNavigateToSettings: () -> Unit = {},
+    onOpenPrompt: (prompt: String) -> Unit = {},
 ) {
+    var searchQuery by remember { mutableStateOf("") }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -56,6 +157,11 @@ fun ToolsHubScreen(
                 navigationIcon = {
                     IconButton(onClick = onOpenDrawer, modifier = Modifier.testTag("tools_menu_button")) {
                         Icon(Icons.Default.Menu, contentDescription = "Menu")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onNavigateToSettings, modifier = Modifier.testTag("top_bar_settings_button")) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
                     }
                 },
             )
@@ -68,194 +174,331 @@ fun ToolsHubScreen(
                 .verticalScroll(rememberScrollState())
                 .testTag("tools_screen"),
         ) {
-            ToolsListItem(
-                testTag = "tools_row_learn",
-                icon = Icons.AutoMirrored.Filled.MenuBook,
-                title = "Learn what Jandal can do",
-                subtitle = "Example prompts for actions, planning, weather, maps, media, and more",
-                onClick = { onNavigateToRoute(ROUTE_TOOLS_LEARN) },
-            )
-            HorizontalDivider()
-
-            Text(
-                text = "Productivity",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
+            // ── Search field ────────────────────────────────────────────────
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = { Text("Search tools…") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = if (searchQuery.isNotEmpty()) {
+                    {
+                        IconButton(onClick = { searchQuery = "" }) {
+                            Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                        }
+                    }
+                } else {
+                    null
+                },
+                singleLine = true,
                 modifier = Modifier
+                    .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_productivity"),
+                    .testTag("tools_search_field"),
             )
-            ToolsListItem(
-                testTag = "tools_row_lists",
-                icon = Icons.Default.Checklist,
-                title = "Lists",
-                subtitle = "Shopping, tasks, and reusable lists",
-                onClick = { onNavigateToRoute(ROUTE_LISTS) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_notes",
-                icon = Icons.Default.Note,
-                title = "Notes",
-                subtitle = "Quick notes and saved thoughts",
-                onClick = { onNavigateToRoute(ROUTE_NOTES) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_meal_plans",
-                icon = Icons.Default.Bookmarks,
-                title = "Meal plans",
-                subtitle = "Plan meals and generate shopping ideas",
-                onClick = { onNavigateToRoute(ROUTE_MEAL_PLANS) },
-            )
-            HorizontalDivider()
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Time & planning",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_time_planning"),
-            )
-            ToolsListItem(
-                testTag = "tools_row_clock",
-                icon = Icons.Default.Timer,
-                title = "Clock",
-                subtitle = "Alarms, timers, stopwatch, and world clock",
-                onClick = { onNavigateToRoute(ROUTE_SIDE_PANEL) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_important_dates",
-                icon = Icons.Default.Event,
-                title = "Important dates",
-                subtitle = "Birthdays, anniversaries, and recurring dates",
-                onClick = { onNavigateToRoute(ROUTE_IMPORTANT_DATES) },
-            )
-            HorizontalDivider()
+            if (searchQuery.isBlank()) {
+                // ── Full grouped layout ──────────────────────────────────────
+                ToolsListItem(
+                    testTag = "tools_row_learn",
+                    icon = Icons.AutoMirrored.Filled.MenuBook,
+                    title = "Learn what Jandal can do",
+                    subtitle = "Example prompts for actions, planning, weather, maps, media, and more",
+                    onClick = { onNavigateToRoute(ROUTE_TOOLS_LEARN) },
+                )
+                HorizontalDivider()
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "People",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_people"),
-            )
-            ToolsListItem(
-                testTag = "tools_row_people_contacts",
-                icon = Icons.Default.People,
-                title = "People & Contacts",
-                subtitle = "Contact aliases and people Jandal can recognise",
-                onClick = { onNavigateToRoute(ROUTE_CONTACT_ALIASES) },
-            )
-            HorizontalDivider()
+                Text(
+                    text = "Productivity",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_productivity"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_lists",
+                    icon = Icons.Default.Checklist,
+                    title = "Lists",
+                    subtitle = "Shopping, tasks, and reusable lists",
+                    onClick = { onNavigateToRoute(ROUTE_LISTS) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_notes",
+                    icon = Icons.Default.Note,
+                    title = "Notes",
+                    subtitle = "Quick notes and saved thoughts",
+                    onClick = { onNavigateToRoute(ROUTE_NOTES) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_meal_plans",
+                    icon = Icons.Default.Bookmarks,
+                    title = "Meal plans",
+                    subtitle = "Plan meals and generate shopping ideas",
+                    onClick = { onNavigateToRoute(ROUTE_MEAL_PLANS) },
+                )
+                HorizontalDivider()
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Utilities",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_utilities"),
-            )
-            ToolsListItem(
-                testTag = "tools_row_convert",
-                icon = Icons.Default.Calculate,
-                title = "Convert",
-                subtitle = "Units, currency, and quick calculations",
-                onClick = { onNavigateToRoute(ROUTE_CONVERT) },
-            )
-            HorizontalDivider()
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Time & planning",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_time_planning"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_clock",
+                    icon = Icons.Default.Timer,
+                    title = "Clock",
+                    subtitle = "Alarms, timers, stopwatch, and world clock",
+                    onClick = { onNavigateToRoute(ROUTE_SIDE_PANEL) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_important_dates",
+                    icon = Icons.Default.Event,
+                    title = "Important dates",
+                    subtitle = "Birthdays, anniversaries, and recurring dates",
+                    onClick = { onNavigateToRoute(ROUTE_IMPORTANT_DATES) },
+                )
+                HorizontalDivider()
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Personalisation",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_personalisation"),
-            )
-            ToolsListItem(
-                testTag = "tools_row_user_profile",
-                icon = Icons.Default.Person,
-                title = "User Profile",
-                subtitle = "Tell Jandal about yourself",
-                onClick = { onNavigateToRoute(ROUTE_USER_PROFILE) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_memory",
-                icon = Icons.Default.Bookmarks,
-                title = "Memory",
-                subtitle = "Manage stored memories",
-                onClick = { onNavigateToRoute(ROUTE_MEMORY) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_voice",
-                icon = Icons.Default.Tune,
-                title = "Voice",
-                subtitle = "Speech and spoken response settings",
-                onClick = { onNavigateToRoute(ROUTE_VOICE) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_chat_preferences",
-                icon = Icons.Default.Forum,
-                title = "Chat Preferences",
-                subtitle = "Archive, themes, wallpaper, and copy options",
-                onClick = { onNavigateToRoute(ROUTE_CHAT_PREFERENCES) },
-            )
-            HorizontalDivider()
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "People",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_people"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_people_contacts",
+                    icon = Icons.Default.People,
+                    title = "People & Contacts",
+                    subtitle = "Contact aliases and people Jandal can recognise",
+                    onClick = { onNavigateToRoute(ROUTE_CONTACT_ALIASES) },
+                )
+                HorizontalDivider()
 
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "App setup",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .testTag("tools_group_app_setup"),
-            )
-            ToolsListItem(
-                testTag = "tools_row_settings",
-                icon = Icons.Default.Settings,
-                title = "Settings",
-                subtitle = "App preferences and configuration",
-                onClick = { onNavigateToRoute(ROUTE_SETTINGS) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_models",
-                icon = Icons.Default.SmartToy,
-                title = "Models",
-                subtitle = "Downloads, availability, and inference preferences",
-                onClick = { onNavigateToRoute(buildModelManagementRoute()) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_permissions",
-                icon = Icons.Default.Security,
-                title = "Permissions",
-                subtitle = "Review Android permissions used by Jandal",
-                onClick = { onNavigateToRoute(ROUTE_APP_PERMISSIONS) },
-            )
-            HorizontalDivider()
-            ToolsListItem(
-                testTag = "tools_row_about",
-                icon = Icons.Default.Info,
-                title = "About",
-                subtitle = "Build info and debug tools",
-                onClick = { onNavigateToRoute(ROUTE_ABOUT) },
-            )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Utilities",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_utilities"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_convert",
+                    icon = Icons.Default.Calculate,
+                    title = "Convert",
+                    subtitle = "Units, currency, and quick calculations",
+                    onClick = { onNavigateToRoute(ROUTE_CONVERT) },
+                )
+                HorizontalDivider()
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Personalisation",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_personalisation"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_user_profile",
+                    icon = Icons.Default.Person,
+                    title = "User Profile",
+                    subtitle = "Tell Jandal about yourself",
+                    onClick = { onNavigateToRoute(ROUTE_USER_PROFILE) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_memory",
+                    icon = Icons.Default.Bookmarks,
+                    title = "Memory",
+                    subtitle = "Manage stored memories",
+                    onClick = { onNavigateToRoute(ROUTE_MEMORY) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_voice",
+                    icon = Icons.Default.Tune,
+                    title = "Voice",
+                    subtitle = "Speech and spoken response settings",
+                    onClick = { onNavigateToRoute(ROUTE_VOICE) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_chat_preferences",
+                    icon = Icons.Default.Forum,
+                    title = "Chat Preferences",
+                    subtitle = "Archive, themes, wallpaper, and copy options",
+                    onClick = { onNavigateToRoute(ROUTE_CHAT_PREFERENCES) },
+                )
+                HorizontalDivider()
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "App setup",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("tools_group_app_setup"),
+                )
+                ToolsListItem(
+                    testTag = "tools_row_settings",
+                    icon = Icons.Default.Settings,
+                    title = "Settings",
+                    subtitle = "App preferences and configuration",
+                    onClick = { onNavigateToRoute(ROUTE_SETTINGS) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_models",
+                    icon = Icons.Default.SmartToy,
+                    title = "Models",
+                    subtitle = "Downloads, availability, and inference preferences",
+                    onClick = { onNavigateToRoute(buildModelManagementRoute()) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_permissions",
+                    icon = Icons.Default.Security,
+                    title = "Permissions",
+                    subtitle = "Review Android permissions used by Jandal",
+                    onClick = { onNavigateToRoute(ROUTE_APP_PERMISSIONS) },
+                )
+                HorizontalDivider()
+                ToolsListItem(
+                    testTag = "tools_row_about",
+                    icon = Icons.Default.Info,
+                    title = "About",
+                    subtitle = "Build info and debug tools",
+                    onClick = { onNavigateToRoute(ROUTE_ABOUT) },
+                )
+            } else {
+                // ── Search results ───────────────────────────────────────────
+                val matchedDestinations = allToolSearchEntries.filter { it.matchesQuery(searchQuery) }
+                val matchedExamples = allExampleSearchEntries.filter { it.matchesQuery(searchQuery) }
+
+                if (matchedDestinations.isEmpty() && matchedExamples.isEmpty()) {
+                    Text(
+                        text = "No results found",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .padding(32.dp)
+                            .testTag("tools_search_no_results"),
+                    )
+                } else {
+                    if (matchedDestinations.isNotEmpty()) {
+                        Text(
+                            text = "Tools",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .testTag("tools_search_results_header"),
+                        )
+                        matchedDestinations.forEach { entry ->
+                            ToolsListItem(
+                                testTag = "tools_search_result_${entry.id}",
+                                icon = iconForEntryId(entry.id),
+                                title = entry.title,
+                                subtitle = entry.subtitle,
+                                onClick = {
+                                    val route = routeForEntryId(entry.id)
+                                    if (route != null) {
+                                        onNavigateToRoute(route)
+                                    } else if (entry.id == "learn") {
+                                        onNavigateToRoute(ROUTE_TOOLS_LEARN)
+                                    }
+                                },
+                            )
+                            if (entry != matchedDestinations.last()) {
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                    if (matchedExamples.isNotEmpty()) {
+                        if (matchedDestinations.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            HorizontalDivider()
+                        }
+                        Text(
+                            text = "Example prompts",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .testTag("tools_search_examples_header"),
+                        )
+                        matchedExamples.forEach { entry ->
+                            ToolsListItem(
+                                testTag = "tools_search_example_${entry.id}",
+                                icon = iconForEntryId(entry.id.substringBefore("_")),
+                                title = entry.label,
+                                subtitle = entry.sectionTitle,
+                                onClick = { onOpenPrompt(entry.prompt) },
+                            )
+                            if (entry != matchedExamples.last()) {
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
+}
+
+/** Map a Tools entry ID to an icon for search results. */
+private fun iconForEntryId(id: String): ImageVector = when (id) {
+    "learn" -> Icons.AutoMirrored.Filled.MenuBook
+    "lists" -> Icons.Default.Checklist
+    "notes" -> Icons.Default.Note
+    "meal_plans" -> Icons.Default.Bookmarks
+    "clock" -> Icons.Default.Timer
+    "important_dates" -> Icons.Default.Event
+    "people_contacts" -> Icons.Default.People
+    "convert" -> Icons.Default.Calculate
+    "user_profile" -> Icons.Default.Person
+    "memory" -> Icons.Default.Bookmarks
+    "voice" -> Icons.Default.Tune
+    "chat_preferences" -> Icons.Default.Forum
+    "settings" -> Icons.Default.Settings
+    "models" -> Icons.Default.SmartToy
+    "permissions" -> Icons.Default.Security
+    "about" -> Icons.Default.Info
+    else -> Icons.AutoMirrored.Filled.MenuBook
+}
+
+/** Map a Tools entry ID to its navigation route, or null for special destinations. */
+private fun routeForEntryId(id: String): String? = when (id) {
+    "lists" -> ROUTE_LISTS
+    "notes" -> ROUTE_NOTES
+    "meal_plans" -> ROUTE_MEAL_PLANS
+    "clock" -> ROUTE_SIDE_PANEL
+    "important_dates" -> ROUTE_IMPORTANT_DATES
+    "people_contacts" -> ROUTE_CONTACT_ALIASES
+    "convert" -> ROUTE_CONVERT
+    "user_profile" -> ROUTE_USER_PROFILE
+    "memory" -> ROUTE_MEMORY
+    "voice" -> ROUTE_VOICE
+    "chat_preferences" -> ROUTE_CHAT_PREFERENCES
+    "settings" -> ROUTE_SETTINGS
+    "models" -> null // handled via buildModelManagementRoute()
+    "permissions" -> ROUTE_APP_PERMISSIONS
+    "about" -> ROUTE_ABOUT
+    else -> null
 }
 
 @Composable

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
@@ -495,7 +495,7 @@ private fun routeForEntryId(id: String): String? = when (id) {
     "voice" -> ROUTE_VOICE
     "chat_preferences" -> ROUTE_CHAT_PREFERENCES
     "settings" -> ROUTE_SETTINGS
-    "models" -> null // handled via buildModelManagementRoute()
+    "models" -> buildModelManagementRoute()
     "permissions" -> ROUTE_APP_PERMISSIONS
     "about" -> ROUTE_ABOUT
     else -> null

--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -118,8 +118,41 @@ not invent new model state labels, badges, provider access flows, download actio
 actions, or model-selection language. Model Management remains the authoritative interface for
 model administration.
 
-Tools search is deferred for the first implementation slice. Do not require a search bar yet.
-However, represent Tools entries in a search-friendly data model so search can be added later
+### 1.2a Settings cog on primary tabs
+
+Settings is globally reachable from the top app bar of all three primary tabs (Chats, Actions, Tools)
+via a dedicated Settings cog icon (Icons.Default.Settings) with content description "Settings".
+
+The cog appears in the top app bar's `actions` slot, preserving the hamburger/drawer affordance
+on the left (navigationIcon slot). The Tools Settings row and the drawer Settings entry remain
+functional alongside the cog.
+
+Opening Settings from the cog behaves as a child destination from the current tab:
+
+```text
+Chats → Settings → Back → Chats
+Actions → Settings → Back → Actions
+Tools → Settings → Back → Tools
+```
+
+Use `launchSingleTop = true` to prevent duplicate Settings destinations on repeated cog taps.
+A stable test tag `top_bar_settings_button` is available for all three tabs.
+
+### 1.2b Tools search
+
+The Tools hub includes a local, deterministic search field for filtering tool destinations and
+Learn example prompts. No model inference or server/semantic search is used.
+
+- Empty query preserves the full grouped Tools layout.
+- Non-empty query filters tool destinations (by title, subtitle, category, and keywords) and
+  example prompts (by label, prompt text, and section title).
+- Search results are displayed under clear "Tools" and "Example prompts" section headers.
+- A clear button appears when search text is entered.
+- A "No results found" state appears when no matches exist.
+- Example prompts selected from search results open Actions as a draft/prefill only — they
+  do not auto-execute. The user must tap Send to execute.
+- Search uses case-insensitive substring matching.
+
 without rewriting the screen. Future-friendly entry metadata should include:
 
 - title

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Error
@@ -111,6 +112,7 @@ fun ActionsScreen(
     onInitialQueryConsumed: () -> Unit = {},
     onNavigateToChat: (query: String, speakResponse: Boolean) -> Unit = { _, _ -> },
     onNewConversation: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     viewModel: ActionsViewModel = hiltViewModel(),
 ) {
@@ -295,6 +297,9 @@ fun ActionsScreen(
                         IconButton(onClick = { showClearConfirmation = true }) {
                             Icon(Icons.Default.Delete, contentDescription = "Clear history")
                         }
+                    }
+                    IconButton(onClick = onNavigateToSettings, modifier = Modifier.testTag("top_bar_settings_button")) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
                     }
                 },
             )

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ConversationListScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -69,6 +70,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -87,6 +89,7 @@ fun ConversationListScreen(
     onNavigateToActions: () -> Unit = {},
     onNavigateToVoiceActions: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     viewModel: ConversationListViewModel = hiltViewModel(),
 ) {
     val conversations by viewModel.conversations.collectAsStateWithLifecycle()
@@ -207,6 +210,9 @@ fun ConversationListScreen(
                                     },
                                 )
                             }
+                        }
+                        IconButton(onClick = onNavigateToSettings, modifier = Modifier.testTag("top_bar_settings_button")) {
+                            Icon(Icons.Default.Settings, contentDescription = "Settings")
                         }
                     },
                 )


### PR DESCRIPTION
Closes #1210
Closes #1211

## #1210 Settings cog

Added a dedicated Settings cog (`Icons.Default.Settings`) to the top app bar of all three primary tabs:

- **Chats** (ConversationListScreen) — `actions` slot with test tag `top_bar_settings_button`
- **Actions** (ActionsScreen) — `actions` slot after the Clear history button
- **Tools** (ToolsHubScreen) — new `actions` slot

### Navigation behaviour

Settings opened from the cog acts as a child destination from the current tab:

```text
Chats → Settings → Back → Chats
Actions → Settings → Back → Actions
Tools → Settings → Back → Tools
```

Uses `launchSingleTop = true` to prevent duplicate Settings on repeated taps.

### Existing paths preserved
- Tools Settings row remains functional
- Drawer Settings entry remains functional
- Overflow menus with non-settings actions (archive toggle) remain

### Tests added (4)
- `settingsCog_chatsToSettingsBackToChats`
- `settingsCog_actionsToSettingsBackToActions`
- `settingsCog_toolsToSettingsBackToTools`
- `settingsCog_launchSingleTopPreventsDuplicateSettingsDestination` (validates `launchSingleTop` guard via programmatic second navigation)

## #1211 Tools search/filtering

Added a local, deterministic search field to the Tools hub.

### Search UX
- Search field at the top of the Tools hub with search icon and clear affordance
- Empty query preserves the full grouped Tools layout unchanged
- Non-empty query filters tool destinations and example prompts

### Matching
- Tool destinations matched by title, subtitle, category, and keywords
- Learn example prompts matched by label, prompt text, and section title
- Case-insensitive substring matching
- `ToolSearchEntry` data class with `allToolSearchEntries` list (private to `ToolsHubScreen.kt`)
- `ExampleSearchEntry` data class derived from `allExampleSections` in `ToolsLearnScreen.kt`

### Results display
- "Tools" and "Example prompts" section headers with matching entries
- Clicking a tool destination navigates to that route (including Models → Model Management via `buildModelManagementRoute()`)
- Clicking an example prompt opens Actions as a draft/prefill only (`onOpenPrompt` callback)
- No auto-execution — user must tap Send
- "No results found" state for empty matches

### Tests added (8)
- `search_emptyShowsGroupedLayout`
- `search_matchesDestinationByTitle`
- `search_matchesDestinationByKeyword`
- `search_matchesModelsAndNavigates`
- `search_matchesExamplePrompt`
- `search_noResultsState`
- `search_clearRestoresLayout`
- `search_tappedExampleOpensDraftOnly`

## Validation

```bash
python3 -m py_compile scripts/*.py              # all pass
./gradlew lint --no-daemon                        # BUILD SUCCESSFUL
./gradlew test --no-daemon                        # BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin --no-daemon  # BUILD SUCCESSFUL
./gradlew assembleDebug --no-daemon               # BUILD SUCCESSFUL
```

**Connected tests**: 24/24 passed on SM-G991B (S21). S23 Ultra was unavailable for this round.

## Limitations / follow-ups
- Drawer simplification remains #1212
- Deeper Tools visual polish (status chips, recently used) remains #1213
- Search is local keyword/metadata matching, not semantic/model search