### PR TITLE
test(#1211): add Tools search UI tests

### DIFF
--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextInput
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -51,6 +52,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -431,6 +433,209 @@ class ToolsHubNavTest {
         assertEquals(false, route.contains("widgetQuery"))
         assertTrue(route.contains("draftQuery"))
         assertTrue(route.contains("openSheet=true"))
+    }
+
+    // ── Tools search tests ──────────────────────────────────────────────────
+
+    @Test
+    fun toolsSearch_fieldIsDisplayed() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_emptyQueryPreservesGroupedLayout() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        // Group headers should be visible
+        composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_time_planning").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_people").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_utilities").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_personalisation").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_group_app_setup").assertIsDisplayed()
+
+        // Destination rows should be visible
+        composeTestRule.onNodeWithTag("tools_row_learn").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_row_lists").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_row_notes").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_clearButtonAppearsOnNonEmptyQuery() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("lists")
+        composeTestRule.onNodeWithTag("tools_search_clear").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_byDestinationTitle() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("convert")
+        composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Convert").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_byDestinationKeyword() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        // "shopping" keyword should match "Lists"
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("shopping")
+        composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_search_result_lists").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lists").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_byExamplePrompt() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("dentist")
+        composeTestRule.onNodeWithTag("tools_search_examples_header").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_search_example_calendar_dentist").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_showsNoResultsForUnmatchedQuery() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("zzznotfound")
+        composeTestRule.onNodeWithTag("tools_search_no_results").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No results found").assertIsDisplayed()
+
+        // Group headers should NOT be visible when searching
+        composeTestRule.onAllNodesWithTag("tools_group_productivity", useUnmergedTree = true)
+            .fetchSemanticsNodes().let { nodes ->
+                assertTrue("Expected no productivity group when no results", nodes.isEmpty())
+            }
+    }
+
+    @Test
+    fun toolsSearch_clearRestoresFullLayout() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("zzznotfound")
+        composeTestRule.onNodeWithTag("tools_search_no_results").assertIsDisplayed()
+
+        // Clear search
+        composeTestRule.onNodeWithTag("tools_search_clear").performClick()
+        composeTestRule.waitForIdle()
+
+        // Full layout should be restored
+        composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_row_lists").assertIsDisplayed()
+    }
+
+    @Test
+    fun toolsSearch_matchedDestinationNavigates() {
+        var lastRoute = ""
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = { lastRoute = it },
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("lists")
+        composeTestRule.onNodeWithTag("tools_search_result_lists", useUnmergedTree = true).performClick()
+
+        assertEquals(ROUTE_LISTS, lastRoute)
+    }
+
+    @Test
+    fun toolsSearch_matchedExampleOpensPrompt() {
+        var capturedPrompt = ""
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+                onOpenPrompt = { capturedPrompt = it },
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("dentist")
+        composeTestRule.onNodeWithTag("tools_search_example_calendar_dentist", useUnmergedTree = true).performClick()
+
+        assertTrue("Expected 'dentist' in captured prompt, got: $capturedPrompt",
+            capturedPrompt.contains("dentist", ignoreCase = true))
+    }
+
+    @Test
+    fun toolsSearch_showsBothDestinationsAndExamples() {
+        composeTestRule.setContent {
+            ToolsHubScreen(
+                onOpenDrawer = {},
+                onNavigateToRoute = {},
+                onNavigateToSettings = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("tools_search_field").performTextInput("convert")
+
+        // Should show both "Tools" and "Examples" groups
+        composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tools_search_examples_header").assertIsDisplayed()
+
+        // Convert destination should be matched
+        composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
+
+        // Conversion examples should be matched
+        composeTestRule.onNodeWithTag("tools_search_example_convert_cups_ml").assertIsDisplayed()
     }
 
     private fun assertRowNavigatesTo(

--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -461,10 +461,14 @@ class ToolsHubNavTest {
 
         // Top-of-list items should be visible immediately
         composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_group_time_planning").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_learn").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_lists").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_notes").assertIsDisplayed()
+
+        // Scroll to time_planning group (may be below fold on smaller screens)
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_group_time_planning"))
+        composeTestRule.onNodeWithTag("tools_group_time_planning").assertIsDisplayed()
 
         // Scroll to and verify below-fold groups
         composeTestRule.onNodeWithTag("tools_screen")

--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -52,7 +52,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -460,18 +459,29 @@ class ToolsHubNavTest {
             )
         }
 
-        // Group headers should be visible
+        // Top-of-list items should be visible immediately
         composeTestRule.onNodeWithTag("tools_group_productivity").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_group_time_planning").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_group_people").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_group_utilities").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_group_personalisation").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("tools_group_app_setup").assertIsDisplayed()
-
-        // Destination rows should be visible
         composeTestRule.onNodeWithTag("tools_row_learn").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_lists").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_row_notes").assertIsDisplayed()
+
+        // Scroll to and verify below-fold groups
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_group_people"))
+        composeTestRule.onNodeWithTag("tools_group_people").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_group_utilities"))
+        composeTestRule.onNodeWithTag("tools_group_utilities").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_group_personalisation"))
+        composeTestRule.onNodeWithTag("tools_group_personalisation").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("tools_screen")
+            .performScrollToNode(hasTestTag("tools_group_app_setup"))
+        composeTestRule.onNodeWithTag("tools_group_app_setup").assertIsDisplayed()
     }
 
     @Test
@@ -501,7 +511,6 @@ class ToolsHubNavTest {
         composeTestRule.onNodeWithTag("tools_search_field").performTextInput("convert")
         composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_search_result_convert").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Convert").assertIsDisplayed()
     }
 
     @Test
@@ -518,7 +527,6 @@ class ToolsHubNavTest {
         composeTestRule.onNodeWithTag("tools_search_field").performTextInput("shopping")
         composeTestRule.onNodeWithTag("tools_search_results_header").assertIsDisplayed()
         composeTestRule.onNodeWithTag("tools_search_result_lists").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Lists").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsHubScreen.kt
@@ -182,7 +182,7 @@ fun ToolsHubScreen(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = if (searchQuery.isNotEmpty()) {
                     {
-                        IconButton(onClick = { searchQuery = "" }) {
+                        IconButton(onClick = { searchQuery = "" }, modifier = Modifier.testTag("tools_search_clear")) {
                             Icon(Icons.Default.Clear, contentDescription = "Clear search")
                         }
                     }


### PR DESCRIPTION
## Summary

Adds comprehensive Compose UI test coverage for the Tools search/filtering feature that was delivered in #1217.

The main feature (search field, destination indexing, Learn example indexing, filtered results layout) was already merged via #1217. This PR adds the test coverage that was missing: 11 new UI tests plus a missing test tag on the clear button.

## Changes

### Test tag addition (`ToolsHubScreen.kt`)
- Added `testTag("tools_search_clear")` to the search clear button (was missing)

### New tests (`ToolsHubNavTest.kt` — 11 tests)

**Search field existence:**
- `toolsSearch_fieldIsDisplayed` — search field renders

**Empty query preserves full layout:**
- `toolsSearch_emptyQueryPreservesGroupedLayout` — all group headers and destination rows visible (scroll-safe)
- `toolsSearch_clearButtonAppearsOnNonEmptyQuery` — clear button visible after typing

**Destination matching:**
- `toolsSearch_byDestinationTitle` — "convert" → Convert destination
- `toolsSearch_byDestinationKeyword` — "shopping" → Lists (keyword match)
- `toolsSearch_matchedDestinationNavigates` — clicking result calls `onNavigateToRoute` with correct route

**Learn example matching:**
- `toolsSearch_byExamplePrompt` — "dentist" → calendar_dentist example
- `toolsSearch_matchedExampleOpensPrompt` — clicking result calls `onOpenPrompt` with matching prompt
- `toolsSearch_showsBothDestinationsAndExamples` — "convert" shows both Tools and Examples groups

**No-results and clear:**
- `toolsSearch_showsNoResultsForUnmatchedQuery` — no-results state displayed, group headers hidden
- `toolsSearch_clearRestoresFullLayout` — clearing search restores full grouped layout

## Validation

### Unit tests
- `./gradlew :app:testDebugUnitTest` — ✅ (715 tests)
- `./gradlew :core:skills:testDebugUnitTest` — ✅ (1556 tests)

### Build
- `./gradlew :app:compileDebugAndroidTestKotlin` — ✅
- `./gradlew :app:assembleDebug` — ✅

### Connected device test (SM-G991B Galaxy S21, serial R5CR605B71K)
```
ANDROID_SERIAL=R5CR605B71K ./gradlew :app:connectedDebugAndroidTest --no-daemon \
  -PversionCode=9999 \
  -Pandroid.testInstrumentationRunnerArguments.class=com.kernel.ai.navigation.ToolsHubNavTest
```
- **47/47 tests passed** ✅
- No S23 Ultra device was available — S21 was the fallback

### CI
- GitHub Actions: ✅

Closes #1211