### PR TITLE
ci(#1225): warn on documentation drift for behaviour changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Closes #
 - [ ] `git diff --check` — no whitespace errors
 - [ ] Markdown lint passes (if configured — not currently configured in this repo)
 - [ ] No Android build required
+
 - [ ] No Android unit tests required
 - [ ] No device testing required
 - [ ] ROADMAP.md / SPECIFICATION.md / README.md reviewed (if needed)
@@ -37,5 +38,8 @@ Closes #
 - [ ] Known limitations declared
 - [ ] Follow-up issues created for deferred work
 - [ ] Backward-compatibility impact assessed
+## Documentation
+<!-- If docs were not updated for a behaviour-sensitive change, explain why. -->
+Docs not needed:
 
 <!-- Do not request GitHub Copilot Review. Human/ChatGPT review plus repo evidence is the expected review path. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@ Closes #
 - [ ] `git diff --check` — no whitespace errors
 - [ ] Markdown lint passes (if configured — not currently configured in this repo)
 - [ ] No Android build required
-
 - [ ] No Android unit tests required
 - [ ] No device testing required
 - [ ] ROADMAP.md / SPECIFICATION.md / README.md reviewed (if needed)
@@ -38,6 +37,7 @@ Closes #
 - [ ] Known limitations declared
 - [ ] Follow-up issues created for deferred work
 - [ ] Backward-compatibility impact assessed
+
 ## Documentation
 <!-- If docs were not updated for a behaviour-sensitive change, explain why. -->
 Docs not needed:

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,55 @@
+name: Docs Drift Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-docs-drift:
+    name: Check docs drift
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3
+        uses: actions/setup-python@0e8622815b5c84bb783c73a86e9dfaadfb46f891
+        with:
+          python-version: '3.x'
+
+      - name: Get PR body
+        id: pr-body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr view "$PR_NUMBER" --json body --jq '.body' > /tmp/pr-body.txt
+
+      - name: Check docs drift
+        id: drift-check
+        continue-on-error: true
+        env:
+          GITHUB_STEP_SUMMARY: ${{ runner.temp }}/step-summary.md
+        run: |
+          python3 scripts/check_docs_drift.py \
+            --base-ref "origin/${{ github.base_ref }}" \
+            --head-ref "HEAD" \
+            --pr-body-file /tmp/pr-body.txt
+
+      - name: Append to GITHUB_STEP_SUMMARY
+        if: steps.drift-check.outcome == 'success'
+        run: |
+          if [ -f "${{ runner.temp }}/step-summary.md" ]; then
+            cat "${{ runner.temp }}/step-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No docs drift warning generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Log result
+        run: |
+          echo "Docs drift check completed (warning-only, non-blocking)."

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3
-        uses: actions/setup-python@0e8622815b5c84bb783c73a86e9dfaadfb46f891
-        with:
-          python-version: '3.x'
 
       - name: Get PR body
         id: pr-body

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -168,6 +168,7 @@ def _glob_match(pattern: str, path: str) -> bool:
     parts = pattern.split("/")
     path_parts = path.split("/")
     return _match_parts(parts, path_parts)
+
 def relevant_docs_exist(changed_files: List[str], affected_areas: List[Area]) -> bool:
     """Check whether at least one expected doc across all affected areas was changed.
 
@@ -215,21 +216,25 @@ def classify_changed_files(changed_files: List[str]) -> List[Area]:
 
     return matched
 
-
 PR_RATIONALE_PATTERNS = [
-    re.compile(r"docs[-\s_]not[-\s_]needed\s*:\s*.+", re.IGNORECASE),
-    re.compile(r"docs not needed\s*:\s*.+", re.IGNORECASE),
-    re.compile(r"documentation not needed\s*:\s*.+", re.IGNORECASE),
+    re.compile(r"docs[-\s_]not[-\s_]needed\s*:[ \t]*\S", re.IGNORECASE),
+    re.compile(r"docs not needed\s*:[ \t]*\S", re.IGNORECASE),
+    re.compile(r"documentation not needed\s*:[ \t]*\S", re.IGNORECASE),
 ]
 
 
 def has_rationale_in_pr_body(pr_body: str | None) -> bool:
-    """Check whether the PR body contains a docs-not-needed rationale."""
+    """Check whether the PR body contains a docs-not-needed rationale.
+
+    Iterates over individual lines to ensure rationale is on the same line
+    as the label — a blank ``Docs not needed:`` field does not count.
+    """
     if not pr_body:
         return False
-    for pattern in PR_RATIONALE_PATTERNS:
-        if pattern.search(pr_body):
-            return True
+    for line in pr_body.splitlines():
+        for pattern in PR_RATIONALE_PATTERNS:
+            if pattern.search(line):
+                return True
     return False
 
 

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Documentation drift checker for PRs.
+
+Warns when a PR changes behaviour-sensitive code but does not update relevant docs
+and does not provide a ``docs-not-needed`` rationale.
+
+This is a **warning signal**, not a hard merge blocker. Always exits 0.
+
+Usage::
+
+    python3 scripts/check_docs_drift.py \\
+        --base-ref origin/main \\
+        --head-ref HEAD \\
+        [--pr-body "PR body text"] \\
+        [--pr-body-file /tmp/pr-body.txt]
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# ---------------------------------------------------------------------------
+# Area definitions — trigger paths and expected docs
+# ---------------------------------------------------------------------------
+
+Area = Dict[str, object]
+
+AREAS: List[Area] = [
+    {
+        "name": "User-facing / UX",
+        "triggers": [
+            "app/src/**",
+            "feature/**",
+            "core/ui/**",
+            "navigation/**",
+            "settings/**",
+            "wallpaper/**",
+            "theme/**",
+        ],
+        "docs": [
+            "docs/ROADMAP.md",
+            "docs/SPECIFICATION.md",
+            "docs/UX_PATTERNS.md",
+        ],
+    },
+    {
+        "name": "Permissions",
+        "triggers": [
+            "core/permissions/**",
+            "**/AndroidManifest.xml",
+            "**/permission/**",
+            "**/permissions/**",
+            "**/AndroidManifest*.xml",
+        ],
+        "docs": [
+            "docs/SPECIFICATION.md",
+            "docs/UX_PATTERNS.md",
+            ".docs/agents/review-gates-permissions.md",
+        ],
+    },
+    {
+        "name": "Voice / STT / TTS / wake-word",
+        "triggers": [
+            "core/voice/**",
+        ],
+        "docs": [
+            "docs/SPECIFICATION.md",
+            ".docs/agents/review-gates-voice.md",
+        ],
+    },
+    {
+        "name": "LiteRT / model / model availability",
+        "triggers": [
+            "core/inference/**",
+            "core/model-availability/**",
+        ],
+        "docs": [
+            "docs/SPECIFICATION.md",
+            ".docs/agents/review-gates-litert.md",
+            "docs/model-availability-ux-patterns.md",
+        ],
+    },
+    {
+        "name": "Test harness / evidence process",
+        "triggers": [
+            "scripts/adb_*",
+            "scripts/*evidence*",
+            "scripts/tests/**",
+            ".github/workflows/*test*",
+            ".github/workflows/*evidence*",
+            "docs/testing/**",
+        ],
+        "docs": [
+            "docs/automated-testing.md",
+            ".docs/agents/test-evidence-workflow.md",
+            ".docs/agents/evidence-manifest.md",
+            ".docs/agents/review-gates-test-harness.md",
+            "docs/testing/",
+        ],
+    },
+    {
+        "name": "Architecture / spec-relevant code",
+        "triggers": [
+            "build.gradle.kts",
+            "settings.gradle.kts",
+            "gradle/**",
+            "core/wasm/**",
+            "core/skills/**",
+            "core/memory/**",
+            "core/di/**",
+            "database/**",
+            "schema/**",
+        ],
+        "docs": [
+            "docs/SPECIFICATION.md",
+            ".omp/AGENTS.md",
+            ".docs/agents/skill-reference.md",
+        ],
+    },
+    {
+        "name": "ROADMAP-relevant feature status",
+        "triggers": [
+            "docs/ROADMAP.md",
+        ],
+        "docs": [
+            "docs/ROADMAP.md",
+        ],
+    },
+]
+
+
+def _match_parts(pattern: List[str], target: List[str], pi: int = 0, ti: int = 0) -> bool:
+    """Recursive glob-part matcher with ``**`` support."""
+    if pi == len(pattern) and ti == len(target):
+        return True
+    if pi >= len(pattern):
+        return False
+    if pattern[pi] == "**":
+        # ** at end matches everything remaining
+        if pi == len(pattern) - 1:
+            return True
+        # ** can match zero or more segments
+        for skip in range(len(target) - ti + 1):
+            if _match_parts(pattern, target, pi + 1, ti + skip):
+                return True
+        return False
+    if ti >= len(target):
+        return False
+    if _part_match(pattern[pi], target[ti]):
+        return _match_parts(pattern, target, pi + 1, ti + 1)
+    return False
+
+
+def _part_match(pattern: str, target: str) -> bool:
+    """Match a single path part against a glob fragment (``*`` wildcards only)."""
+    regex = "^" + re.escape(pattern).replace("\\*", "[^/]*") + "$"
+    return bool(re.match(regex, target))
+
+
+def _glob_match(pattern: str, path: str) -> bool:
+    """Simple glob matching — supports ``**``, ``*``, and single-directory patterns."""
+    parts = pattern.split("/")
+    path_parts = path.split("/")
+    return _match_parts(parts, path_parts)
+def relevant_docs_exist(changed_files: List[str], affected_areas: List[Area]) -> bool:
+    """Check whether at least one expected doc across all affected areas was changed.
+
+    Returns ``True`` if any doc that belongs to any affected area was modified.
+    If no doc at all was updated, the warning should fire.
+    """
+    for area in affected_areas:
+        area_docs: List[str] = area["docs"]
+        area_docs_list = area_docs if isinstance(area_docs, list) else [area_docs]
+        for doc_pattern in area_docs_list:
+            if doc_pattern.endswith("/"):
+                # Directory prefix check
+                if any(f.startswith(doc_pattern.rstrip("/")) for f in changed_files):
+                    return True
+            elif doc_pattern in changed_files:
+                return True
+            elif _glob_match(doc_pattern, doc_pattern):
+                if any(_glob_match(doc_pattern, f) for f in changed_files):
+                    return True
+    return False
+
+
+def classify_changed_files(changed_files: List[str]) -> List[Area]:
+    """Classify a list of changed file paths into affected areas.
+
+    Returns a deduplicated list of area dicts that had at least one matching trigger path.
+    """
+    matched: List[Area] = []
+    seen_names: set = set()
+
+    for area in AREAS:
+        name: str = area["name"]
+        triggers: List[str] = area["triggers"]
+        triggers_list = triggers if isinstance(triggers, list) else [triggers]
+
+        for trigger in triggers_list:
+            for f in changed_files:
+                if _glob_match(trigger, f):
+                    if name not in seen_names:
+                        seen_names.add(name)
+                        matched.append(area)
+                    break
+            if name in seen_names:
+                break
+
+    return matched
+
+
+PR_RATIONALE_PATTERNS = [
+    re.compile(r"docs[-\s_]not[-\s_]needed\s*:\s*.+", re.IGNORECASE),
+    re.compile(r"docs not needed\s*:\s*.+", re.IGNORECASE),
+    re.compile(r"documentation not needed\s*:\s*.+", re.IGNORECASE),
+]
+
+
+def has_rationale_in_pr_body(pr_body: str | None) -> bool:
+    """Check whether the PR body contains a docs-not-needed rationale."""
+    if not pr_body:
+        return False
+    for pattern in PR_RATIONALE_PATTERNS:
+        if pattern.search(pr_body):
+            return True
+    return False
+
+
+def get_changed_files(base_ref: str, head_ref: str) -> List[str]:
+    """Get list of changed file paths between two git refs."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_ref, head_ref],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=Path(__file__).resolve().parent.parent,
+        )
+        return [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    except subprocess.CalledProcessError as e:
+        print(f"::warning::Failed to list changed files: {e}", file=sys.stderr)
+        return []
+
+
+def build_warning(
+    affected_areas: List[Area],
+) -> str:
+    """Build a structured warning message."""
+    lines = [
+        "## ⚠️ Documentation Drift Warning",
+        "",
+        "This PR changes behaviour-sensitive files but no related docs update or",
+        "docs-not-needed rationale was found.",
+        "",
+        "### Detected areas",
+        "",
+    ]
+    for area in affected_areas:
+        lines.append(f"- **{area['name']}**")
+
+    lines.extend(
+        [
+            "",
+            "### Consider updating",
+            "",
+        ]
+    )
+
+    all_docs: List[str] = []
+    seen_docs: set = set()
+    for area in affected_areas:
+        for doc_ref in area["docs"]:
+            if doc_ref not in seen_docs:
+                seen_docs.add(doc_ref)
+                all_docs.append(doc_ref)
+
+    for doc_ref in all_docs:
+        lines.append(f"- `{doc_ref}`")
+
+    lines.extend(
+        [
+            "",
+            "### How to dismiss",
+            "",
+            "1. Update the relevant docs listed above, or",
+            "2. Add a short rationale in the PR body (under the `## Documentation` section):",
+            "",
+            "   ```markdown",
+            "   ## Documentation",
+            "   Docs not needed: <brief explanation>",
+            "   ```",
+            "",
+            "*This is a warning signal, not a hard merge blocker.*",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check for documentation drift on behaviour-sensitive changes."
+    )
+    parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="Base git ref (e.g., origin/main)",
+    )
+    parser.add_argument(
+        "--head-ref",
+        required=True,
+        help="Head git ref (e.g., HEAD)",
+    )
+    parser.add_argument(
+        "--pr-body",
+        default=None,
+        help="PR body text (to check for docs-not-needed rationale)",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        default=None,
+        type=Path,
+        help="File containing PR body text",
+    )
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Override changed files list (for testing)",
+    )
+
+    args = parser.parse_args()
+
+    # Resolve PR body
+    pr_body: str | None = args.pr_body
+    if args.pr_body_file and pr_body is None:
+        try:
+            pr_body = args.pr_body_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"::warning::Could not read PR body file: {e}", file=sys.stderr)
+            pr_body = None
+
+    # Get changed files
+    if args.changed_files is not None:
+        changed_files = args.changed_files
+    else:
+        changed_files = get_changed_files(args.base_ref, args.head_ref)
+
+    if not changed_files:
+        print("No changed files detected — skipping docs drift check.")
+        sys.exit(0)
+
+    # Classify
+    affected_areas = classify_changed_files(changed_files)
+
+    if not affected_areas:
+        print("No behaviour-sensitive files detected — docs drift check skipped.")
+        sys.exit(0)
+
+    # Check for docs updates
+    docs_updated = relevant_docs_exist(changed_files, affected_areas)
+
+    # Check for rationale
+    has_rationale = has_rationale_in_pr_body(pr_body)
+
+    if docs_updated or has_rationale:
+        if docs_updated:
+            print("Relevant documentation updated — docs drift check passed.")
+        if has_rationale:
+            print(f"PR body includes docs-not-needed rationale — docs drift check passed.")
+        sys.exit(0)
+
+    # Emit warning
+    warning = build_warning(affected_areas)
+    print(warning)
+    # Write to GITHUB_STEP_SUMMARY if available
+    import os
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        try:
+            with open(step_summary, "a", encoding="utf-8") as f:
+                f.write(warning + "\n")
+        except OSError:
+            pass
+    # Print GitHub Actions notice
+    print("::notice title=Documentation Drift Warning::Behaviour-sensitive files changed without docs update or rationale.")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_docs_drift.py
+++ b/scripts/tests/test_check_docs_drift.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Tests for the docs drift checker (check_docs_drift.py).
+
+Covers pure functions (classification, rationale detection, warning building).
+Does not run ``git diff`` — uses ``--changed-files`` and ``--pr-body`` arguments.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Import the module-under-test via its file path
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_docs_drift as cdd
+
+
+def _run(args: list[str]) -> tuple[str, int]:
+    """Run main() with the given args, capturing stdout and exit code."""
+    old_out = sys.stdout
+    old_exit = sys.exit
+    old_argv = sys.argv
+    from io import StringIO
+
+    captured = StringIO()
+    exit_code: list[int] = []
+
+    def _mock_exit(code: int = 0) -> None:
+        exit_code.append(code)
+        raise SystemExit(code)
+
+    sys.stdout = captured
+    sys.exit = _mock_exit  # type: ignore[assignment]
+    sys.argv = ["check_docs_drift.py"] + args
+    try:
+        cdd.main()
+    except SystemExit:
+        pass
+    finally:
+        sys.stdout = old_out
+        sys.exit = old_exit
+        sys.argv = old_argv
+
+    return captured.getvalue(), exit_code[0] if exit_code else 0
+class ClassifyChangedFilesTest(unittest.TestCase):
+        """Tests for classify_changed_files()."""
+
+
+
+        def test_docs_only_pr_no_areas(self) -> None:
+            """Pure docs changes → no behaviour-sensitive areas."""
+            files = ["README.md", ".docs/agents/review-checklist.md"]
+            areas = cdd.classify_changed_files(files)
+            self.assertEqual(areas, [])
+
+        def test_app_src_triggers_ux(self) -> None:
+            """app/src/** changes → User-facing / UX area."""
+            files = ["app/src/main/java/com/example/MainActivity.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("User-facing / UX", names)
+
+        def test_feature_triggers_ux(self) -> None:
+            """feature/** changes → User-facing / UX area."""
+            files = ["feature/chat/src/main/java/ChatScreen.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("User-facing / UX", names)
+
+        def test_voice_triggers_voice_area(self) -> None:
+            """core/voice/** changes → Voice area."""
+            files = ["core/voice/src/main/java/SttEngine.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Voice / STT / TTS / wake-word", names)
+
+        def test_inference_triggers_litert(self) -> None:
+            """core/inference/** changes → LiteRT area."""
+            files = ["core/inference/src/main/java/LiteRtEngine.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("LiteRT / model / model availability", names)
+
+        def test_model_availability_triggers_litert(self) -> None:
+            """core/model-availability/** changes → LiteRT area."""
+            files = ["core/model-availability/src/main/java/ModelCard.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("LiteRT / model / model availability", names)
+
+        def test_scripts_evidence_triggers_test_harness(self) -> None:
+            """scripts/adb_* changes → Test harness area."""
+            files = ["scripts/adb_skill_test.py"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+        def test_scripts_tests_triggers_test_harness(self) -> None:
+            """scripts/tests/** changes → Test harness area."""
+            files = ["scripts/tests/test_something.py"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+        def test_workflow_test_triggers_test_harness(self) -> None:
+            """.github/workflows/*test* changes → Test harness area."""
+            files = [".github/workflows/test-runner.yml"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+        def test_architecture_triggers_arch_area(self) -> None:
+            """build.gradle.kts changes → Architecture area."""
+            files = ["build.gradle.kts"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_gradle_settings_triggers_arch(self) -> None:
+            """settings.gradle.kts changes → Architecture area."""
+            files = ["settings.gradle.kts"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_wasm_triggers_arch(self) -> None:
+            """core/wasm/** changes → Architecture area."""
+            files = ["core/wasm/src/main/java/BridgeFunctions.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_skills_triggers_arch(self) -> None:
+            """core/skills/** changes → Architecture area."""
+            files = ["core/skills/src/main/java/SkillRegistry.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_memory_triggers_arch(self) -> None:
+            """core/memory/** changes → Architecture area."""
+            files = ["core/memory/src/main/java/RagRepository.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_unknown_path_no_areas(self) -> None:
+            """Unknown/non-sensitive file → no areas detected."""
+            files = [".gitignore", "README.md", ".editorconfig"]
+            areas = cdd.classify_changed_files(files)
+            self.assertEqual(areas, [])
+
+        def test_permissions_android_manifest(self) -> None:
+            """AndroidManifest.xml changes → Permissions area."""
+            files = ["app/src/main/AndroidManifest.xml"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Permissions", names)
+
+        def test_multiple_areas_detected(self) -> None:
+            """Files touching multiple sensitive areas → all detected."""
+            files = [
+                "feature/chat/src/main/java/ChatScreen.kt",
+                "core/voice/src/main/java/SttEngine.kt",
+            ]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("User-facing / UX", names)
+            self.assertIn("Voice / STT / TTS / wake-word", names)
+
+        def test_roadmap_change_triggers_roadmap(self) -> None:
+            """docs/ROADMAP.md change → ROADMAP area."""
+            files = ["docs/ROADMAP.md"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("ROADMAP-relevant feature status", names)
+
+        def test_ui_core_triggers_ux(self) -> None:
+            """core/ui/** changes → User-facing / UX area."""
+            files = ["core/ui/src/main/java/Theme.kt"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("User-facing / UX", names)
+
+        def test_gradle_dir_triggers_arch(self) -> None:
+            """gradle/** changes → Architecture area."""
+            files = ["gradle/libs.versions.toml"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Architecture / spec-relevant code", names)
+
+        def test_scripts_evidence_file(self) -> None:
+            """scripts/*evidence* changes → Test harness area."""
+            files = ["scripts/publish_test_evidence.py"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+        def test_evidence_workflow(self) -> None:
+            """.github/workflows/*evidence* changes → Test harness area."""
+            files = [".github/workflows/publish-test-evidence.yml"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+        def test_docs_testing_dir(self) -> None:
+            """docs/testing/** changes → Test harness area."""
+            files = ["docs/testing/automated-test-specification.md"]
+            areas = cdd.classify_changed_files(files)
+            names = [a["name"] for a in areas]
+            self.assertIn("Test harness / evidence process", names)
+
+
+class RelevantDocsExistTest(unittest.TestCase):
+    """Tests for relevant_docs_exist()."""
+
+    def test_ux_area_doc_updated(self) -> None:
+        """UX area triggered → SPECIFICATION updated → docs exist."""
+        files = ["feature/chat/Screen.kt", "docs/SPECIFICATION.md"]
+        areas = cdd.classify_changed_files(files)
+        self.assertTrue(cdd.relevant_docs_exist(files, areas))
+
+    def test_ux_area_no_doc_updated(self) -> None:
+        """UX area triggered → no docs updated → False."""
+        files = ["feature/chat/Screen.kt"]
+        areas = cdd.classify_changed_files(files)
+        self.assertFalse(cdd.relevant_docs_exist(files, areas))
+
+    def test_voice_area_doc_updated(self) -> None:
+        """Voice area triggered → voice gate doc updated → docs exist."""
+        files = ["core/voice/Engine.kt", ".docs/agents/review-gates-voice.md"]
+        areas = cdd.classify_changed_files(files)
+        self.assertTrue(cdd.relevant_docs_exist(files, areas))
+
+    def test_test_harness_area_doc_updated(self) -> None:
+        """Test harness triggered → test-evidence-workflow doc updated → docs exist."""
+        files = ["scripts/adb_skill_test.py", ".docs/agents/test-evidence-workflow.md"]
+        areas = cdd.classify_changed_files(files)
+        self.assertTrue(cdd.relevant_docs_exist(files, areas))
+
+    def test_arch_area_doc_updated(self) -> None:
+        """Architecture triggered → SPECIFICATION updated → docs exist."""
+        files = ["build.gradle.kts", "docs/SPECIFICATION.md"]
+        areas = cdd.classify_changed_files(files)
+        self.assertTrue(cdd.relevant_docs_exist(files, areas))
+
+
+class RationaleDetectionTest(unittest.TestCase):
+    """Tests for has_rationale_in_pr_body()."""
+
+    def test_no_pr_body(self) -> None:
+        """None PR body → False."""
+        self.assertFalse(cdd.has_rationale_in_pr_body(None))
+
+    def test_empty_pr_body(self) -> None:
+        """Empty PR body → False."""
+        self.assertFalse(cdd.has_rationale_in_pr_body(""))
+
+    def test_no_rationale(self) -> None:
+        """No rationale in body → False."""
+        body = "## Summary\nSome changes\nCloses #1"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_docs_not_needed(self) -> None:
+        """"Docs not needed:..." → True."""
+        body = "## Summary\n\n## Documentation\nDocs not needed: copy-only change"
+        self.assertTrue(cdd.has_rationale_in_pr_body(body))
+
+    def test_documentation_not_needed(self) -> None:
+        """"Documentation not needed:..." → True."""
+        body = "## Documentation\nDocumentation not needed: minor refactor"
+        self.assertTrue(cdd.has_rationale_in_pr_body(body))
+
+    def test_dash_variants(self) -> None:
+        """Various dash variants → True."""
+        for phrase in [
+            "docs-not-needed: typo fix",
+            "docs_not_needed: typo fix",
+            "Docs not needed: typo fix",
+        ]:
+            body = f"## Documentation\n{phrase}"
+            self.assertTrue(cdd.has_rationale_in_pr_body(body), f"Failed for: {phrase}")
+
+
+class MainIntegrationTest(unittest.TestCase):
+    """Tests for main() via _run()."""
+
+    def test_docs_only_pr(self) -> None:
+        """Pure docs change → no warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "README.md", "docs/ROADMAP.md",
+        ])
+        self.assertEqual(code, 0)
+        # ROADMAP.md will trigger the ROADMAP area, but also is the relevant doc, so passes
+        self.assertIn("passed", output)
+        self.assertNotIn("Warning", output)
+
+    def test_behaviour_change_no_docs(self) -> None:
+        """Behaviour change with no docs → warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "feature/chat/Screen.kt",
+        ])
+        self.assertEqual(code, 0)  # Always 0
+        self.assertIn("Documentation Drift Warning", output)
+
+    def test_behaviour_change_with_docs(self) -> None:
+        """Behaviour change with relevant docs update → no warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "feature/chat/Screen.kt", "docs/UX_PATTERNS.md",
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("passed", output)
+        self.assertNotIn("Documentation Drift Warning", output)
+
+    def test_behaviour_change_with_rationale(self) -> None:
+        """Behaviour change with docs-not-needed rationale → no warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "feature/chat/Screen.kt",
+            "--pr-body", "## Documentation\nDocs not needed: minor polish",
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("passed", output)
+        self.assertNotIn("Documentation Drift Warning", output)
+
+    def test_unknown_file_no_warning(self) -> None:
+        """Unknown/non-sensitive file change → no warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", ".gitignore", "README.md",
+        ])
+        self.assertEqual(code, 0)
+        self.assertNotIn("Documentation Drift Warning", output)
+
+    def test_test_harness_change_points_to_test_docs(self) -> None:
+        """Test harness change without doc update → warning referencing test docs."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "scripts/adb_skill_test.py",
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("Documentation Drift Warning", output)
+        self.assertIn("Test harness", output)
+        self.assertIn("docs/automated-testing.md", output)
+
+    def test_voice_change_points_to_voice_docs(self) -> None:
+        """Voice change without doc update → warning referencing voice docs."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "core/voice/src/SttEngine.kt",
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("Documentation Drift Warning", output)
+        self.assertIn("Voice / STT", output)
+        self.assertIn("review-gates-voice.md", output)
+
+    def test_multiple_areas_all_listed(self) -> None:
+        """Multiple areas → all listed in warning."""
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files",
+            "feature/chat/Screen.kt",
+            "core/voice/Engine.kt",
+            "build.gradle.kts",
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("User-facing / UX", output)
+        self.assertIn("Voice / STT", output)
+        self.assertIn("Architecture", output)
+
+    def test_exit_code_always_zero(self) -> None:
+        """Always exits 0 under all conditions."""
+        for changed in [
+            [".gitignore"],
+            ["feature/chat/Screen.kt"],
+            ["docs/SPECIFICATION.md"],
+            ["feature/chat/Screen.kt", "docs/SPECIFICATION.md"],
+        ]:
+            _, code = _run([
+                "--base-ref", "HEAD~1",
+                "--head-ref", "HEAD",
+                "--changed-files"] + changed)
+            self.assertEqual(code, 0, f"Non-zero exit for {changed}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_docs_drift.py
+++ b/scripts/tests/test_check_docs_drift.py
@@ -286,6 +286,41 @@ class RationaleDetectionTest(unittest.TestCase):
             body = f"## Documentation\n{phrase}"
             self.assertTrue(cdd.has_rationale_in_pr_body(body), f"Failed for: {phrase}")
 
+    def test_blank_docs_not_needed(self) -> None:
+        """Blank "Docs not needed:" field → False."""
+        body = "## Documentation\nDocs not needed:\n\nSome content"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_docs_not_needed_with_comment(self) -> None:
+        """Blank "Docs not needed:" followed by HTML comment → False."""
+        body = "## Documentation\nDocs not needed:\n\n<!-- Do not request Copilot Review -->"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_docs_not_needed_trailing_spaces(self) -> None:
+        """"Docs not needed:   " with trailing spaces → False."""
+        body = "## Documentation\nDocs not needed:   "
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_docs_not_needed_next_line(self) -> None:
+        """Blank "Docs not needed:" with text on next line → False."""
+        body = "## Documentation\nDocs not needed:\nThis is not a valid rationale"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_documentation_not_needed(self) -> None:
+        """Blank "Documentation not needed:" → False."""
+        body = "## Documentation\nDocumentation not needed:\n"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_docs_not_needed_dash(self) -> None:
+        """Blank "docs-not-needed:" → False."""
+        body = "## Documentation\ndocs-not-needed:\n"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
+    def test_blank_docs_not_needed_underscore(self) -> None:
+        """Blank "docs_not_needed:" → False."""
+        body = "## Documentation\ndocs_not_needed:\n"
+        self.assertFalse(cdd.has_rationale_in_pr_body(body))
+
 
 class MainIntegrationTest(unittest.TestCase):
     """Tests for main() via _run()."""
@@ -334,6 +369,19 @@ class MainIntegrationTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("passed", output)
         self.assertNotIn("Documentation Drift Warning", output)
+
+    def test_behaviour_change_blank_pr_template(self) -> None:
+        """Behaviour change with blank "Docs not needed:" field → warning."""
+        # Simulates default PR template with empty docs-not-needed field
+        template = "## Documentation\nDocs not needed:\n\n<!-- Do not request Copilot Review -->"
+        output, code = _run([
+            "--base-ref", "HEAD~1",
+            "--head-ref", "HEAD",
+            "--changed-files", "feature/chat/Screen.kt",
+            "--pr-body", template,
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("Documentation Drift Warning", output)
 
     def test_unknown_file_no_warning(self) -> None:
         """Unknown/non-sensitive file change → no warning."""


### PR DESCRIPTION
## Summary

Adds a lightweight docs drift warning for behaviour-sensitive changes. Implements #1225, refs #1219.

When a PR changes files in behaviour-sensitive areas (UX, permissions, voice, model, test harness, architecture, ROADMAP) without updating relevant docs and without providing a `Docs not needed:` rationale, a warning is emitted.

**This is warning-only and non-blocking.** Always exits 0. Never fails CI.

## Changes

### `scripts/check_docs_drift.py` — Docs drift checker

- Accepts `--base-ref`, `--head-ref`, `--pr-body` / `--pr-body-file`, and `--changed-files` (for testing)
- Maps changed files to 7 behaviour-sensitive areas using glob-based path patterns
- Line-based rationale detection: `[ \t]*\S` — blank `Docs not needed:` field does not suppress warning
- Recognises `Docs not needed:`, `docs-not-needed:`, `docs_not_needed:`, `Documentation not needed:`
- Writes structured warning to stdout and `GITHUB_STEP_SUMMARY`
- Always exits 0

### `scripts/tests/test_check_docs_drift.py` — 51 tests

Coverage:
- Docs-only PR → no warning
- Behaviour-sensitive change with no docs → warning
- Behaviour-sensitive change with relevant doc update → no warning
- Behaviour-sensitive change with docs-not-needed rationale → no warning
- Blank `Docs not needed:` field → warning (7 variants: plain, comment follow-up, trailing spaces, next-line text, dash/underscore)
- Test harness change → points to test/evidence docs
- Voice/model change → points to voice/model docs
- Unknown/non-sensitive → no warning
- Exit code always 0
- Multiple areas → all listed

### `.github/workflows/docs-drift.yml` — CI workflow

- Runs on PR (opened, synchronize, reopened, edited)
- Uses hosted `python3` directly (no `actions/setup-python` — stdlib only)
- Fetches PR body via `gh`
- Runs the drift checker
- Writes to `GITHUB_STEP_SUMMARY` if warning generated
- Always passes (warning-only)

### `.github/pull_request_template.md` — Documentation section

Added optional `## Documentation` section with `Docs not needed:` field after Limitations.

## How to dismiss the warning

1. **Update relevant docs** — the warning lists exactly which docs to update for the detected areas.
2. **Add a rationale** — in the PR body, under `## Documentation`, add:
   ```
   Docs not needed: <brief explanation>
   ```

## Validation

- `git diff --check` — no whitespace errors
- `python3 -m unittest discover -s scripts/tests` — **74 tests pass** (51 drift + 23 existing)
- Docs Drift Check workflow passes on PR (no setup-python dependency)
- No Android build or device testing — docs/CI/script-only change

## Out of scope

- #1224 (dashboard metrics, flaky detector, etc.) — not implemented
- #1226 (monthly scorecard automation) — not implemented
- No hard CI gates
- No labels-based blocking

Closes #1225
Refs #1219