### PR TITLE
fix(#1039): Model Management row-level cleanup after PR #1230

### DIFF
--- a/core/model-availability/src/main/java/com/kernel/ai/core/model/availability/ModelCard.kt
+++ b/core/model-availability/src/main/java/com/kernel/ai/core/model/availability/ModelCard.kt
@@ -263,7 +263,7 @@ fun defaultActionLabel(state: ModelAvailabilityState): String? = when (state) {
     is ModelAvailabilityState.Preparing -> if (state.isAutoQueued) null else "Cancel"
     is ModelAvailabilityState.ActionRequired -> when (state.reason) {
         is ActionReason.SignInRequired -> "Sign in to HuggingFace"
-        is ActionReason.LicenseRequired -> "View license"
+        is ActionReason.LicenseRequired -> "Accept license"
         is ActionReason.ApprovalPending -> null
         is ActionReason.AccessApprovalRequired -> "Request access"
         is ActionReason.InsufficientStorage -> "Manage storage"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementScreen.kt
@@ -51,6 +51,7 @@ import com.kernel.ai.core.model.availability.ModelCard
 import com.kernel.ai.core.model.availability.ModelAvailabilityState
 import com.kernel.ai.core.model.availability.toAvailability
 import com.kernel.ai.core.model.availability.ConversationModelReadiness
+import com.kernel.ai.core.model.availability.ActionReason
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -127,6 +128,7 @@ fun ModelManagementScreen(
                     model = rowState.model,
                     hfAuth = uiState.hfAuthenticated,
                     source = rowState.downloadSource,
+                    gated = rowState.gatedStatus,
                 )
                 val canDelete = availabilityState is ModelAvailabilityState.Ready &&
                     !rowState.model.isBundled &&
@@ -153,27 +155,28 @@ fun ModelManagementScreen(
                     title = rowState.model.displayName,
                     description = description,
                     state = availabilityState,
-                    showLock = rowState.model.isGated && rowState.downloadState is DownloadState.NotDownloaded,
+                    showLock = rowState.model.isGated && availabilityState !is ModelAvailabilityState.ActionRequired,
                     onPrimaryAction = {
-                        when (val state = rowState.downloadState) {
-                            is DownloadState.Downloading -> viewModel.cancelDownload(rowState.model)
-                            is DownloadState.Downloaded -> viewModel.updateModel(rowState.model)
-                            is DownloadState.NotDownloaded -> {
-                                if (!uiState.hfAuthenticated && rowState.model.isGated) {
-                                    viewModel.startAuth()
-                                } else {
-                                    viewModel.downloadModel(rowState.model)
-                                }
-                            }
-                            is DownloadState.Error -> {
-                                if (state.licenceRequired) {
+                        when (val avail = availabilityState) {
+                            is ModelAvailabilityState.ActionRequired -> when (avail.reason) {
+                                is ActionReason.SignInRequired -> viewModel.startAuth()
+                                is ActionReason.LicenseRequired ->
                                     rowState.model.licenceUrl?.let { url ->
-                                        CustomTabsIntent.Builder().build().launchUrl(context, url.toUri())
+                                        openInAppBrowser(context, url)
                                     }
-                                } else {
-                                    viewModel.downloadModel(rowState.model)
-                                }
+                                is ActionReason.DownloadFailed -> viewModel.downloadModel(rowState.model)
+                                is ActionReason.ApprovalPending -> { /* no action — label is null */ }
+                                is ActionReason.AccessApprovalRequired ->
+                                    rowState.model.licenceUrl?.let { url ->
+                                        openInAppBrowser(context, url)
+                                    }
+                                is ActionReason.InsufficientStorage -> { /* no direct action */ }
                             }
+                            is ModelAvailabilityState.Preparing -> {
+                                if (!avail.isAutoQueued) viewModel.cancelDownload(rowState.model)
+                            }
+                            is ModelAvailabilityState.Ready -> viewModel.updateModel(rowState.model)
+                            else -> viewModel.downloadModel(rowState.model)
                         }
                     },
                     onSecondaryAction = if (canDelete) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ModelManagementViewModel.kt
@@ -38,6 +38,7 @@ data class ModelRowState(
     val model: KernelModel,
     val downloadState: DownloadState,
     val downloadSource: DownloadSource = DownloadSource.USER_INITIATED,
+    val gatedStatus: GatedModelStatus = GatedModelStatus.NONE,
 )
 
 data class ModelManagementUiState(
@@ -131,6 +132,7 @@ class ModelManagementViewModel @Inject constructor(
                 model = model,
                 downloadState = downloadStates[model] ?: DownloadState.NotDownloaded,
                 downloadSource = downloadSources[model] ?: DownloadSource.USER_INITIATED,
+                gatedStatus = gatedStatuses[model] ?: GatedModelStatus.NONE,
             )
         }
         val summary = computeAvailabilitySummary(


### PR DESCRIPTION
Refs #1039
Refs #1043
Refs #1229
Refs #1230

## Summary

Narrow post-#1230 cleanup for the remaining #1039 Model Management row-level behaviours. Keeps #1230 Chat gate and blocking banner behaviour unchanged.

## Changes

### `ModelManagementViewModel.kt`
- **`ModelRowState.gatedStatus`** — new field carrying per-model `GatedModelStatus` into the UI layer
- **Row mapping** now passes `gatedStatus = gatedStatuses[model] ?: NONE` into each `ModelRowState`

### `ModelManagementScreen.kt`
- **`gated = rowState.gatedStatus`** — `toAvailability()` now receives the model's persisted gated status, so `APPROVAL_PENDING` and `ACCESS_DENIED` correctly render as `ActionRequired(ApprovalPending)` / `Unavailable(AccessDenied)` instead of falling through to `NotDisplayed`
- **Lock icon**: `showLock = rowState.model.isGated && availabilityState !is ModelAvailabilityState.ActionRequired` — lock is hidden when Action Required badge is shown (per #1039 AC3)
- **`onPrimaryAction` refactored** to switch on resolved `availabilityState` instead of raw `downloadState`. This ensures the correct action fires for each state:
  | Availability | Action |
  |---|---|
  | `ActionRequired(SignInRequired)` | startAuth |
  | `ActionRequired(LicenseRequired)` | Open licence URL |
  | `ActionRequired(DownloadFailed)` | Retry download |
  | `ActionRequired(AccessApprovalRequired)` | Open provider URL |
  | `Preparing` (user-initiated) | Cancel download |
  | `Ready` | Update model |
  | `NotDisplayed` / other | Download model |

### `ModelCard.kt`
- **`defaultActionLabel`**: `LicenseRequired` label changed from `"View license"` → `"Accept license"` (per #1039 AC, using US spelling per app convention)

### Access-denied semantics
`ACCESS_DENIED` remains `Unavailable(AccessDenied)` in the `toAvailability()` mapper. This is a terminal state (provider denied the request) — no in-app action can resolve it. Keeping it consistent with the mapper's truth table and the #1230 Chat handling.

## Files changed (3)
- `core/model-availability/src/main/java/.../ModelCard.kt` (+0 -1)
- `feature/settings/src/main/java/.../ModelManagementViewModel.kt` (+1 -0, +1 -1)
- `feature/settings/src/main/java/.../ModelManagementScreen.kt` (+22 -15)

## Validation

```
:core:model-availability:test        ✓
:feature:settings:test               ✓
:app:testDebugUnitTest               ✓ (715 tests)
:app:assembleDebug                   ✓
```

No Chat or device testing — settings-only scope. #1230 Chat gated behaviour not regressed.

## Out of scope
- Chat gate / blocking banner changes
- Device testing
- Flaky detection
- Battery/thermal telemetry
- Network latency metrics

## Pre-merge checks
- [x] model-availability:test
- [x] settings:test
- [x] app:testDebugUnitTest
- [x] assembleDebug
- [x] CI (Docs Drift + Build & Test)
