### PR TITLE
feat(#961): in-chat model settings apply without app restart

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/InferenceEngine.kt
@@ -10,8 +10,9 @@ import kotlinx.coroutines.flow.emptyFlow
  * Lifecycle:
  * 1. [initialize] — loads model weights onto the chosen hardware backend (10–30 s).
  * 2. [generate] — streams [GenerationResult] tokens for one or more turns.
- * 3. [resetConversation] — clears context window while keeping the engine warm.
- * 4. [shutdown] — releases all native resources.
+ * 3. [reconfigureConversation] — recreates the conversation with new sampler/thinking settings (warm).
+ * 4. [resetConversation] — clears context window while keeping the engine warm.
+ * 5. [shutdown] — releases all native resources.
  *
  * Thread-safety: implementations pin all work to [LlmDispatcher].
  */
@@ -115,6 +116,28 @@ interface InferenceEngine {
      * The engine stays warm — no model reload required.
      */
     suspend fun updateSystemPrompt(systemPrompt: String)
+
+    /**
+     * Recreate the conversation with a new [ModelConfig] while keeping the engine warm.
+     *
+     * Closes the active LiteRT conversation and creates a new one with the updated
+     * [ModelConfig] settings (temperature, top-p, top-k, thinking mode). The engine
+     * itself is **not** shut down or re-initialised — only the conversation/session
+     * is rebuilt.
+     *
+     * Safe to call while [isReady] is true and a [generate] call is in flight — the
+     * active generation is cancelled before the conversation is reset. After this
+     * returns, the next [generate] call starts a fresh conversation with the new
+     * configuration.
+     *
+     * Only conversation-scoped settings are applied. Engine-level settings
+     * (model path, backend type, max tokens, speculative decoding) from the original
+     * [initialize] call remain in effect — use the full [shutdown]/[initialize] cycle
+     * to change those.
+     *
+     * @throws [InferenceException] if conversation creation fails.
+     */
+    suspend fun reconfigureConversation(config: ModelConfig)
 
     /** Release the engine and all native resources. Safe to call multiple times. */
     suspend fun shutdown()

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/LiteRtInferenceEngine.kt
@@ -619,6 +619,17 @@ class LiteRtInferenceEngine @Inject constructor(
         }
     }
 
+    override suspend fun reconfigureConversation(config: ModelConfig) {
+        withContext(LlmDispatcher) {
+            if (engine == null) {
+                Log.w(TAG, "reconfigureConversation: engine not initialized — ignoring")
+                return@withContext
+            }
+            resetConversationForConfig(config)
+            Log.i(TAG, "Conversation reconfigured with new settings")
+        }
+    }
+
     override suspend fun shutdown() {
         withContext(LlmDispatcher) {
             _isReady.value = false

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatScreen.kt
@@ -171,6 +171,8 @@ import kotlin.math.roundToInt
 import kotlin.ranges.ClosedFloatingPointRange
 import androidx.compose.runtime.mutableFloatStateOf
 import com.kernel.ai.core.inference.ModelCapabilities
+import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.verticalScroll
@@ -376,52 +378,91 @@ fun ChatScreen(
                 showModelSettings = showModelSettings,
                 onShowModelSettingsChange = { showModelSettings = it },
             )
-            if (showModelSettings && state.modelCapabilities != null && viewModel.currentModel.value != null) {
+            // Model settings overlay — always shown on icon tap, not guarded by
+            // modelCapabilities/currentModel null-check (#961).
+            if (showModelSettings) {
                 val currentModel by viewModel.currentModel.collectAsStateWithLifecycle()
                 val capabilities = state.modelCapabilities
-                var temp by remember { mutableFloatStateOf(viewModel.uiState.value.let { s ->
-                    if (s is ChatUiState.Ready) s.temperature else 0.7f
-                }) }
-                var topP by remember { mutableFloatStateOf(viewModel.uiState.value.let { s ->
-                    if (s is ChatUiState.Ready) s.topP else 0.9f
-                }) }
-                var topK by remember { mutableIntStateOf(viewModel.uiState.value.let { s ->
-                    if (s is ChatUiState.Ready) s.topK else 64
-                }) }
+                val modelReady = currentModel != null && capabilities != null
+
+                // Draft state: loaded when sheet opens, discarded on cancel
+                var temp by remember { mutableFloatStateOf(state.temperature) }
+                var topP by remember { mutableFloatStateOf(state.topP) }
+                var topK by remember { mutableIntStateOf(state.topK) }
                 var showThinking by remember { mutableStateOf(state.showThinkingProcess) }
 
                 ModalBottomSheet(
                     onDismissRequest = { showModelSettings = false },
                     dragHandle = { ModelSettingsDragHandle() },
                 ) {
-                    ModelSettingsSheet(
-                        model = currentModel!!,
-                        capabilities = capabilities,
-                        temperature = temp,
-                        onTemperatureChange = {
-                            temp = it
-                            viewModel.setTemperature(it)
-                        },
-                        topP = topP,
-                        onTopPChange = {
-                            topP = it
-                            viewModel.setTopP(it)
-                        },
-                        topK = topK,
-                        onTopKChange = {
-                            topK = it
-                            viewModel.setTopK(it)
-                        },
-                        showThinking = showThinking,
-                        onShowThinkingChange = {
-                            showThinking = it
-                            viewModel.setThinkingEnabled(it)
-                        },
-                        onReset = {
-                            viewModel.resetModelSettings()
-                            showModelSettings = false
-                        },
-                    )
+                    if (!modelReady) {
+                        // Model/settings not available — show explanatory text
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Tune,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(40.dp),
+                            )
+                            Spacer(Modifier.height(12.dp))
+                            Text(text = "Model settings", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = "Model settings are available once the chat model is ready.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        ModelSettingsSheet(
+                            model = currentModel!!,
+                            capabilities = capabilities!!,
+                            activeBackend = state.activeBackend,
+                            temperature = temp,
+                            onTemperatureChange = { temp = it },
+                            topP = topP,
+                            onTopPChange = { topP = it },
+                            topK = topK,
+                            onTopKChange = { topK = it },
+                            showThinking = showThinking,
+                            onShowThinkingChange = { showThinking = it },
+                            onApply = {
+                                val active = viewModel.activeModelSettings.value
+                                val draft = ModelSettingsEntity(
+                                    modelId = currentModel!!.modelId,
+                                    contextWindowSize = active?.contextWindowSize ?: 4096,
+                                    temperature = temp,
+                                    topP = topP,
+                                    topK = topK,
+                                    showThinkingProcess = showThinking,
+                                    speculativeDecodingEnabled = active?.speculativeDecodingEnabled ?: false,
+                                )
+                                viewModel.applyModelSettingsAndStartNewChat(draft)
+                                showModelSettings = false
+                            },
+                            onCancel = { showModelSettings = false },
+                            onReset = {
+                                viewModel.resetModelSettings()
+                                val defaults = viewModel.activeModelSettings.value
+                                if (defaults != null) {
+                                    temp = defaults.temperature
+                                    topP = defaults.topP
+                                    topK = defaults.topK
+                                    showThinking = defaults.showThinkingProcess
+                                } else {
+                                    temp = 1.0f
+                                    topP = 0.95f
+                                    topK = 64
+                                    showThinking = true
+                                }
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -2393,6 +2434,7 @@ private fun ModelSettingsDragHandle() {
 private fun ModelSettingsSheet(
     model: KernelModel,
     capabilities: ModelCapabilities,
+    activeBackend: BackendType?,
     temperature: Float,
     onTemperatureChange: (Float) -> Unit,
     topP: Float,
@@ -2401,6 +2443,8 @@ private fun ModelSettingsSheet(
     onTopKChange: (Int) -> Unit,
     showThinking: Boolean,
     onShowThinkingChange: (Boolean) -> Unit,
+    onApply: () -> Unit,
+    onCancel: () -> Unit,
     onReset: () -> Unit,
 ) {
     Column(
@@ -2409,6 +2453,7 @@ private fun ModelSettingsSheet(
             .padding(horizontal = 16.dp, vertical = 16.dp)
             .verticalScroll(rememberScrollState()),
     ) {
+        // Header
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Default.Tune,
@@ -2422,47 +2467,73 @@ private fun ModelSettingsSheet(
             )
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(8.dp))
 
-        // Temperature
-        _SliderRow(
-            label = "Temperature",
-            valueLabel = "%.1f".format(temperature),
-            value = temperature,
-            valueRange = 0.1f..2.0f,
-            steps = 18,
-            onValueChangeFinished = { newVal ->
-                val snapped = (newVal * 10).roundToInt() / 10f
-                onTemperatureChange(snapped)
-            },
-        )
+        // Backend info label
+        val backendLabel = when (activeBackend) {
+            BackendType.NPU -> "NPU (hardware sampler — temperature/top-p/top-k use fixed values)"
+            BackendType.GPU -> "GPU"
+            BackendType.CPU -> "CPU"
+            else -> ""
+        }
+        if (backendLabel.isNotBlank()) {
+            Text(
+                text = backendLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+        }
 
-        // Top-P
-        _SliderRow(
-            label = "Top-P",
-            valueLabel = "%.2f".format(topP),
-            value = topP,
-            valueRange = 0.0f..1.0f,
-            steps = 19,
-            onValueChangeFinished = { newVal ->
-                val snapped = (newVal * 20).roundToInt() / 20f
-                onTopPChange(snapped)
-            },
-        )
+        // Sampler controls — hidden when NPU (hardware sampler, SamplerConfig ignored)
+        if (activeBackend != BackendType.NPU) {
+            // Temperature
+            _SliderRow(
+                label = "Temperature",
+                valueLabel = "%.1f".format(temperature),
+                value = temperature,
+                valueRange = 0.1f..2.0f,
+                steps = 18,
+                onValueChangeFinished = { newVal ->
+                    val snapped = (newVal * 10).roundToInt() / 10f
+                    onTemperatureChange(snapped)
+                },
+            )
 
-        // Top-K
-        _SliderRow(
-            label = "Top-K",
-            valueLabel = "$topK",
-            value = topK.toFloat(),
-            valueRange = 1f..100f,
-            steps = 98,
-            onValueChangeFinished = { newVal ->
-                onTopKChange(newVal.roundToInt())
-            },
-        )
+            // Top-P
+            _SliderRow(
+                label = "Top-P",
+                valueLabel = "%.2f".format(topP),
+                value = topP,
+                valueRange = 0.0f..1.0f,
+                steps = 19,
+                onValueChangeFinished = { newVal ->
+                    val snapped = (newVal * 20).roundToInt() / 20f
+                    onTopPChange(snapped)
+                },
+            )
 
-        // Thinking toggle
+            // Top-K
+            _SliderRow(
+                label = "Top-K",
+                valueLabel = "$topK",
+                value = topK.toFloat(),
+                valueRange = 1f..100f,
+                steps = 98,
+                onValueChangeFinished = { newVal ->
+                    onTopKChange(newVal.roundToInt())
+                },
+            )
+        } else {
+            Text(
+                text = "Sampler controls (temperature, top-p, top-k) are not available with " +
+                    "the NPU backend, which uses a fixed hardware sampler.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // Thinking toggle — only when the model supports it
         if (capabilities.supportsThinking) {
             Spacer(Modifier.height(8.dp))
             Row(
@@ -2487,7 +2558,7 @@ private fun ModelSettingsSheet(
             }
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(12.dp))
 
         // Reset button
         OutlinedButton(
@@ -2495,6 +2566,27 @@ private fun ModelSettingsSheet(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Reset to defaults")
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Apply / Cancel buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("Cancel")
+            }
+            Button(
+                onClick = onApply,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("Apply")
+            }
         }
 
         Spacer(Modifier.height(32.dp))

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -34,6 +34,7 @@ import com.kernel.ai.core.inference.download.ModelDownloadManager
 import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
 import com.kernel.ai.core.inference.hardware.HardwareTier
 import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
 import com.kernel.ai.core.memory.repository.ConversationRepository
 import com.kernel.ai.core.memory.repository.MemoryRepository
 import com.kernel.ai.core.memory.repository.ModelSettingsRepository
@@ -310,6 +311,14 @@ class ChatViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private val _showThinkingProcess = MutableStateFlow(true)
+
+    /**
+     * Snapshot of the currently active [ModelSettingsEntity] loaded into the inference engine.
+     * Updated during engine init and after [applyModelSettingsAndStartNewChat]. Used by
+     * [baseUiState] to populate temperature/top-p/top-k/thinking values reactively without
+     * calling [ModelSettingsRepository.getSettings] inside the combine lambda.
+     */
+    private val _activeModelSettings = MutableStateFlow<ModelSettingsEntity?>(null)
     /** Combined visual customisation prefs, updated from ChatPreferences. */
     @Suppress("UNCHECKED_CAST")
     private val visualPrefs: StateFlow<VisualPrefs> = combine(
@@ -363,6 +372,7 @@ class ChatViewModel @Inject constructor(
         val isGenerating: Boolean,
         val isLoadingModel: Boolean,
         val conversationInitialized: Boolean,
+        val activeBackend: BackendType?,
     )
     private data class InputState(
         val messages: List<ChatMessage>,
@@ -371,14 +381,14 @@ class ChatViewModel @Inject constructor(
         val conversationTitle: String?,
         val isSpeakingResponse: Boolean,
     )
-
     private val engineState = combine(
         inferenceEngine.isReady,
         inferenceEngine.isGenerating,
         _isLoadingModel,
         _conversationInitialized,
-    ) { isReady, isGenerating, isLoadingModel, conversationInitialized ->
-        EngineState(isReady, isGenerating, isLoadingModel, conversationInitialized)
+        inferenceEngine.activeBackend,
+    ) { isReady, isGenerating, isLoadingModel, conversationInitialized, activeBackend ->
+        EngineState(isReady, isGenerating, isLoadingModel, conversationInitialized, activeBackend)
     }
 
     private val inputState = combine(
@@ -404,13 +414,14 @@ class ChatViewModel @Inject constructor(
             gatedModels.zip(array.asList()) { model, status -> model to status }
                 .toMap()
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
-    /** Base uiState without visual prefs (8-input combine). */
+    /** Base uiState without visual prefs (9-input combine). */
     private val baseUiState: StateFlow<ChatUiState> = combine(
         engineState,
         downloadManager.downloadStates,
         downloadManager.downloadSources,
         inputState,
         _showThinkingProcess,
+        _activeModelSettings,
         isArchived,
         authRepository.isAuthenticated,
         gatedStatuses,
@@ -424,10 +435,11 @@ class ChatViewModel @Inject constructor(
         @Suppress("UNCHECKED_CAST")
         val input = array[3] as InputState
         val showThinking = array[4] as Boolean
-        val archived = array[5] as Boolean
-        val hfAuth = array[6] as Boolean
+        val activeModelSettings = array[5] as ModelSettingsEntity?
+        val archived = array[6] as Boolean
+        val hfAuth = array[7] as Boolean
         @Suppress("UNCHECKED_CAST")
-        val gatedStatusesMap = array[7] as Map<KernelModel, GatedModelStatus>
+        val gatedStatusesMap = array[8] as Map<KernelModel, GatedModelStatus>
         val allDownloaded = downloadManager.areRequiredModelsDownloaded()
         val tier = downloadManager.deviceTier
         val displayModels: List<KernelModel> = if (tier == HardwareTier.FLAGSHIP) {
@@ -474,9 +486,10 @@ class ChatViewModel @Inject constructor(
                 isLoadingModel = engine.isLoadingModel,
                 showThinkingProcess = showThinking,
                 modelCapabilities = activeModel?.capabilities,
-                temperature = activeModel?.let { modelSettingsRepository.getSettings(it.modelId).temperature } ?: 0.7f,
-                topP = activeModel?.let { modelSettingsRepository.getSettings(it.modelId).topP } ?: 0.9f,
-                topK = activeModel?.let { modelSettingsRepository.getSettings(it.modelId).topK } ?: 64,
+                temperature = activeModelSettings?.temperature ?: 0.7f,
+                topP = activeModelSettings?.topP ?: 0.9f,
+                topK = activeModelSettings?.topK ?: 64,
+                activeBackend = engine.activeBackend,
                 // ---- Visual customisation (#906) — filled from visualPrefs below ----
                 fontSize = 1,
                 bubbleTheme = "system",
@@ -907,6 +920,7 @@ class ChatViewModel @Inject constructor(
                 val settings = modelSettingsRepository.getSettings(preferred.modelId)
                 activeContextWindowSize = settings.contextWindowSize
                 _showThinkingProcess.value = settings.showThinkingProcess
+                _activeModelSettings.value = settings
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
@@ -965,6 +979,7 @@ class ChatViewModel @Inject constructor(
                 Log.d(TAG, "initEngineWhenReady: modelId=${preferred.modelId} speculativeDecodingEnabled=${settings.speculativeDecodingEnabled}")
                 activeContextWindowSize = settings.contextWindowSize
                 _showThinkingProcess.value = settings.showThinkingProcess
+                _activeModelSettings.value = settings
                 inferenceEngine.initialize(ModelConfig(
                     modelPath = modelPath,
                     systemPrompt = buildSystemPrompt(),
@@ -3133,51 +3148,150 @@ class ChatViewModel @Inject constructor(
     val currentModel: StateFlow<KernelModel?> =
         activeModelState.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    /** Set thinking mode for the current model. Requires app restart to take effect. */
+    /** Snapshot of the currently active model settings, used by the settings overlay. */
+    val activeModelSettings: StateFlow<ModelSettingsEntity?> = _activeModelSettings.asStateFlow()
+
+    /**
+     * Apply conversation-scoped model settings and start a fresh chat session
+     * without restarting the app.
+     *
+     * The engine stays warm — only the conversation is recreated with the new
+     * [ModelConfig] derived from [draft]. The following settings are applied:
+     * temperature, top-p, top-k, thinking mode.
+     *
+     * Engine-level settings (model path, backend, max tokens, speculative decoding)
+     * are **not** changed — those require a full [initEngineWhenReady] cycle.
+     *
+     * On success the settings sheet should be dismissed; on failure [ChatUiState.error]
+     * is set with a descriptive message.
+     */
+    fun applyModelSettingsAndStartNewChat(draft: ModelSettingsEntity) {
+        viewModelScope.launch {
+            val model = activeModel ?: run {
+                _error.value = "Cannot apply settings: no active model"
+                return@launch
+            }
+            val modelPath = downloadManager.getModelPath(model) ?: run {
+                _error.value = "Cannot apply settings: model file not found"
+                return@launch
+            }
+            try {
+                // 1. Cancel active generation
+                inferenceEngine.cancelGeneration()
+
+                // 2. Stop/clear voice input/output state
+                stopVoicePlayback()
+                _voiceMode.value = null
+                pendingVoiceReply = false
+                voiceInputController.stopListening()
+                voiceOutputController.stop()
+                _voiceCaptureState.value = VoiceCaptureState.Idle
+                _voicePlaybackState.value = VoicePlaybackState.Idle
+
+                // 3. Persist draft settings and update reactive state
+                modelSettingsRepository.saveSettings(draft)
+                _activeModelSettings.value = draft
+                _showThinkingProcess.value = draft.showThinkingProcess
+
+                // 4. Build fresh ModelConfig from active model + draft settings
+                //    Only conversation-scoped fields are changed (temperature, top-p,
+                //    top-k, thinking). Engine-level fields (backend, maxTokens,
+                //    speculativeDecoding) carry over from the active model.
+                val newConfig = ModelConfig(
+                    modelPath = modelPath,
+                    systemPrompt = buildSystemPrompt(),
+                    maxTokens = draft.contextWindowSize,
+                    temperature = draft.temperature,
+                    topP = draft.topP,
+                    topK = draft.topK,
+                    thinkingEnabled = draft.showThinkingProcess,
+                    speculativeDecodingEnabled = draft.speculativeDecodingEnabled,
+                    toolProvider = toolProvider,
+                )
+
+                // 5. Reconfigure the engine conversation with new settings
+                inferenceEngine.reconfigureConversation(newConfig)
+
+                // 6. Start a fresh conversation record
+                val id = conversationRepository.createConversation()
+                conversationId = id
+
+                // 7. Clear all transient chat state for the new conversation
+                _messages.value = emptyList()
+                _inputText.value = ""
+                _error.value = null
+                _conversationTitle.value = null
+                titleGenerationStarted = false
+                titleIsPlaceholder = false
+
+                // 8. Reset token/context counters and replay flags
+                estimatedTokensUsed = 0
+                turnsSinceReset = 0
+                needsHistoryReplay = false
+                pendingConfirmationIntent = null
+
+                // 9. Rebuild system prompt now that backend + settings are resolved
+                inferenceEngine.updateSystemPrompt(buildSystemPrompt())
+
+                Log.i(TAG, "Settings applied and new conversation started for ${model.modelId}")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "applyModelSettingsAndStartNewChat failed", e)
+                _error.value = "Failed to apply settings: ${e.message}"
+            }
+        }
+    }
+
+    /** Persist thinking mode for the current model and update active settings snapshot. */
     fun setThinkingEnabled(enabled: Boolean) {
         viewModelScope.launch {
             val model = activeModel ?: return@launch
             val settings = modelSettingsRepository.getSettings(model.modelId)
             modelSettingsRepository.saveSettings(settings.copy(showThinkingProcess = enabled))
-            // Update the running engine immediately if ready
+            _activeModelSettings.value = _activeModelSettings.value?.copy(showThinkingProcess = enabled)
             if (inferenceEngine.isReady.value) {
                 _showThinkingProcess.value = enabled
             }
         }
     }
 
-    /** Set temperature for the current model. Requires app restart to take effect. */
+    /** Persist temperature for the current model and update active settings snapshot. */
     fun setTemperature(temp: Float) {
         viewModelScope.launch {
             val model = activeModel ?: return@launch
             val settings = modelSettingsRepository.getSettings(model.modelId)
             modelSettingsRepository.saveSettings(settings.copy(temperature = temp))
+            _activeModelSettings.value = _activeModelSettings.value?.copy(temperature = temp)
         }
     }
 
-    /** Set top-P for the current model. Requires app restart to take effect. */
+    /** Persist top-P for the current model and update active settings snapshot. */
     fun setTopP(topP: Float) {
         viewModelScope.launch {
             val model = activeModel ?: return@launch
             val settings = modelSettingsRepository.getSettings(model.modelId)
             modelSettingsRepository.saveSettings(settings.copy(topP = topP))
+            _activeModelSettings.value = _activeModelSettings.value?.copy(topP = topP)
         }
     }
 
-    /** Set top-K for the current model. Requires app restart to take effect. */
+    /** Persist top-K for the current model and update active settings snapshot. */
     fun setTopK(topK: Int) {
         viewModelScope.launch {
             val model = activeModel ?: return@launch
             val settings = modelSettingsRepository.getSettings(model.modelId)
             modelSettingsRepository.saveSettings(settings.copy(topK = topK))
+            _activeModelSettings.value = _activeModelSettings.value?.copy(topK = topK)
         }
     }
 
-    /** Reset current model settings to hardware-aware defaults. */
+    /** Reset current model settings to hardware-aware defaults and update snapshot. */
     fun resetModelSettings() {
         viewModelScope.launch {
             val model = activeModel ?: return@launch
-            modelSettingsRepository.resetToDefaults(model.modelId)
+            val defaults = modelSettingsRepository.resetToDefaults(model.modelId)
+            _activeModelSettings.value = defaults
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/model/ChatUiState.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.feature.chat.model
 
 import com.kernel.ai.core.inference.ModelCapabilities
+import com.kernel.ai.core.inference.BackendType
 import com.kernel.ai.core.inference.download.DownloadSource
 import com.kernel.ai.core.inference.download.DownloadState
 import com.kernel.ai.core.model.availability.ConversationModelReadiness
@@ -28,6 +29,8 @@ sealed interface ChatUiState {
         val topP: Float = 0.9f,
         /** Current model top-K (synced from ModelSettingsEntity). */
         val topK: Int = 64,
+        /** The hardware backend currently in use by the inference engine, or null. */
+        val activeBackend: BackendType? = null,
         // ---- Visual customisation (#906) ----
         /** 0=small, 1=medium, 2=large */
         val fontSize: Int = 1,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
@@ -1,0 +1,393 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import com.google.ai.edge.litertlm.ToolProvider
+import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.JandalPersona
+import com.kernel.ai.core.inference.PersonaMode
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.DownloadSource
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.model.availability.GatedModelStatusRepository
+import com.kernel.ai.core.inference.hardware.HardwareTier
+import com.kernel.ai.core.memory.entity.ModelSettingsEntity
+import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
+import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
+import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
+import com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase
+import com.kernel.ai.core.skills.KernelAIToolSet
+import com.kernel.ai.core.skills.QuickIntentRouter
+import com.kernel.ai.core.skills.SkillExecutor
+import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
+import com.kernel.ai.core.skills.intent.IntentContractRegistry
+import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.feature.chat.model.ChatUiState
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.StartListeningCuePlayer
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import com.kernel.ai.core.memory.prefs.ChatPreferences
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelSettingsApplyTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    // Mutable flows we can update across the test lifecycle.
+    private val isReadyFlow = MutableStateFlow(false)
+    private val isGeneratingFlow = MutableStateFlow(false)
+    private val activeBackendFlow = MutableStateFlow<BackendType?>(null)
+    private val resolvedMaxTokensFlow = MutableStateFlow(0)
+    private val downloadStatesFlow = MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+    private val downloadSourcesFlow = MutableStateFlow<Map<KernelModel, DownloadSource>>(emptyMap())
+
+    private val inferenceEngine: InferenceEngine = mockk(relaxed = true)
+    private val downloadManager: ModelDownloadManager = mockk(relaxed = true)
+    private val conversationRepository: ConversationRepository = mockk(relaxed = true)
+    private val ragRepository: RagRepository = mockk(relaxed = true)
+    private val userProfileRepository: UserProfileRepository = mockk(relaxed = true)
+    private val memoryRepository: MemoryRepository = mockk(relaxed = true)
+    private val mealPlanSessionRepository: MealPlanSessionRepository = mockk(relaxed = true)
+    private val episodicDistillationUseCase: EpisodicDistillationUseCase = mockk(relaxed = true)
+    private val modelSettingsRepository: ModelSettingsRepository = mockk(relaxed = true)
+    private val mealPlannerCoordinator: MealPlannerCoordinator = mockk(relaxed = true)
+    private val skillRegistry: SkillRegistry = mockk(relaxed = true)
+    private val skillExecutor: SkillExecutor = mockk(relaxed = true)
+    private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
+    private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
+    private val toolProvider: ToolProvider = mockk(relaxed = true)
+    private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
+    private val voiceInputController: VoiceInputController = mockk(relaxed = true)
+    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
+    private val jandalPersona: JandalPersona = mockk(relaxed = true)
+    private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
+    private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+    private val gatedModelStatusRepository: GatedModelStatusRepository = mockk(relaxed = true)
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
+    private val authRepository: HuggingFaceAuthRepository = mockk(relaxed = true)
+    private val chatPreferences: ChatPreferences = mockk(relaxed = true)
+    private val intentRecoveryOrchestrator: IntentRecoveryOrchestrator = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+
+        // Reset mutable flows
+        isReadyFlow.value = false
+        isGeneratingFlow.value = false
+        activeBackendFlow.value = null
+        resolvedMaxTokensFlow.value = 0
+        downloadStatesFlow.value = emptyMap()
+        downloadSourcesFlow.value = emptyMap()
+
+        every { inferenceEngine.isReady } returns isReadyFlow
+        every { inferenceEngine.isGenerating } returns isGeneratingFlow
+        every { inferenceEngine.activeBackend } returns activeBackendFlow
+        every { inferenceEngine.resolvedMaxTokens } returns resolvedMaxTokensFlow
+        every { inferenceEngine.evictionEvents } returns emptyFlow()
+        coEvery { inferenceEngine.resetConversation() } just runs
+        coEvery { inferenceEngine.reconfigureConversation(any()) } just runs
+        coEvery { inferenceEngine.cancelGeneration() } just runs
+
+        every { downloadManager.downloadStates } returns downloadStatesFlow
+        every { downloadManager.downloadSources } returns downloadSourcesFlow
+        every { downloadManager.areRequiredModelsDownloaded() } returns false
+        every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
+
+        coEvery { conversationRepository.createConversation() } returns "conv-new"
+        coEvery { conversationRepository.getConversation(any()) } returns
+            com.kernel.ai.core.memory.entity.ConversationEntity(
+                id = "conv-new", title = null, createdAt = 1L, updatedAt = 1L,
+            )
+        coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
+        every { conversationRepository.observeConversationById(any()) } answers {
+            val id = firstArg<String>()
+            flowOf(com.kernel.ai.core.memory.entity.ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L))
+        }
+
+        every { authRepository.isAuthenticated } returns MutableStateFlow(false)
+        every { chatPreferences.fontSize } returns flowOf(1)
+        every { chatPreferences.bubbleTheme } returns flowOf("system")
+        every { chatPreferences.userFontColor } returns flowOf(null)
+        every { chatPreferences.assistantFontColor } returns flowOf(null)
+        every { chatPreferences.wallpaperType } returns flowOf("none")
+        every { chatPreferences.wallpaperColor } returns flowOf(null)
+        every { chatPreferences.wallpaperImageUri } returns flowOf(null)
+        every { chatPreferences.copyToolCalls } returns flowOf(false)
+        every { chatPreferences.copyThinking } returns flowOf(false)
+        every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
+        every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
+        every { voiceOutputPreferences.spokenResponsesEnabled } returns MutableStateFlow(false)
+        every { voiceOutputPreferences.autoSpeak } returns MutableStateFlow(false)
+        every { voiceOutputPreferences.maxSpokenSentences } returns flowOf(0)
+        every { nzTruthSeedingService.isSeeding } returns MutableStateFlow(false)
+        every { nzTruthSeedingService.seedIfNeeded() } just runs
+        coEvery { verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference() } just runs
+        coEvery { modelSettingsRepository.saveSettings(any()) } just runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    /** Set up mocks so engine init can complete. */
+    private fun setupInitPrerequisites() {
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        downloadStatesFlow.value = mapOf(
+            KernelModel.GEMMA_4_E4B to DownloadState.Downloaded("/path/to/model"),
+        )
+        coEvery { downloadManager.preferredConversationModel() } returns KernelModel.GEMMA_4_E4B
+        coEvery { downloadManager.getModelPath(any()) } returns "/path/to/model"
+        coEvery { modelSettingsRepository.getSettings(any()) } returns ModelSettingsEntity(
+            modelId = "gemma_4_e4b",
+            contextWindowSize = 8192,
+            temperature = 0.5f,
+            topP = 0.85f,
+            topK = 32,
+            showThinkingProcess = false,
+            speculativeDecodingEnabled = true,
+            updatedAt = 2L,
+        )
+    }
+
+    private fun clearViewModel(viewModel: ChatViewModel) {
+        val method = androidx.lifecycle.ViewModel::class.java
+            .getDeclaredMethod("clear\$lifecycle_viewmodel_release")
+        method.isAccessible = true
+        method.invoke(viewModel)
+    }
+
+    /** Common draft used across tests. */
+    private fun draft(
+        modelId: String = "gemma_4_e4b",
+        contextWindowSize: Int = 4096,
+        temperature: Float = 0.7f,
+        topP: Float = 0.9f,
+        topK: Int = 64,
+        showThinkingProcess: Boolean = true,
+        speculativeDecodingEnabled: Boolean = false,
+    ) = ModelSettingsEntity(
+        modelId = modelId,
+        contextWindowSize = contextWindowSize,
+        temperature = temperature,
+        topP = topP,
+        topK = topK,
+        showThinkingProcess = showThinkingProcess,
+        speculativeDecodingEnabled = speculativeDecodingEnabled,
+        updatedAt = 1L,
+    )
+
+    @Test
+    fun `apply without active model sets error`() = runTest(dispatcher) {
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { inferenceEngine.reconfigureConversation(any()) }
+        coVerify(exactly = 1) { conversationRepository.createConversation() }
+        coVerify(exactly = 0) { modelSettingsRepository.saveSettings(any()) }
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertNotNull(state.error)
+        assertTrue(state.error!!.contains("no active model", ignoreCase = true))
+
+        clearViewModel(viewModel)
+    }
+
+    @Test
+    fun `apply with valid state calls reconfigureConversation`() = runTest(dispatcher) {
+        setupInitPrerequisites()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        isReadyFlow.value = true
+        advanceUntilIdle()
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { inferenceEngine.reconfigureConversation(any()) }
+        coVerify(exactly = 2) { conversationRepository.createConversation() }
+        coVerify(exactly = 1) { modelSettingsRepository.saveSettings(d) }
+
+        clearViewModel(viewModel)
+    }
+
+    @Test
+    fun `apply clears messages and creates new conversation`() = runTest(dispatcher) {
+        setupInitPrerequisites()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        isReadyFlow.value = true
+        advanceUntilIdle()
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertEquals(0, state.messages.size)
+        assertNull(state.conversationTitle)
+        assertNull(state.error)
+
+        clearViewModel(viewModel)
+    }
+
+    @Test
+    fun `apply with no model path sets error`() = runTest(dispatcher) {
+        setupInitPrerequisites()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        isReadyFlow.value = true
+        advanceUntilIdle()
+
+        // Override getModelPath after init — activeModel is set but path retrieval fails
+        coEvery { downloadManager.getModelPath(any()) } returns null
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { inferenceEngine.reconfigureConversation(any()) }
+        val state = viewModel.uiState.first { it is ChatUiState.Ready } as ChatUiState.Ready
+        assertNotNull(state.error)
+        assertTrue(state.error!!.contains("model file not found", ignoreCase = true))
+
+        clearViewModel(viewModel)
+    }
+
+    @Test
+    fun `activeModelSettings updated after apply`() = runTest(dispatcher) {
+        setupInitPrerequisites()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        isReadyFlow.value = true
+        advanceUntilIdle()
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        assertEquals(d, viewModel.activeModelSettings.value)
+        clearViewModel(viewModel)
+    }
+
+    @Test
+    fun `reconfigureConversation propagates conversation-scoped settings`() = runTest(dispatcher) {
+        setupInitPrerequisites()
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        isReadyFlow.value = true
+        advanceUntilIdle()
+
+        val d = draft()
+        viewModel.applyModelSettingsAndStartNewChat(d)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            inferenceEngine.reconfigureConversation(
+                withArg { config ->
+                    assertEquals("/path/to/model", config.modelPath)
+                    assertEquals(d.contextWindowSize, config.maxTokens)
+                    assertEquals(d.temperature, config.temperature)
+                    assertEquals(d.topP, config.topP)
+                    assertEquals(d.topK, config.topK)
+                    assertEquals(d.showThinkingProcess, config.thinkingEnabled)
+                    assertEquals(d.speculativeDecodingEnabled, config.speculativeDecodingEnabled)
+                },
+            )
+        }
+        clearViewModel(viewModel)
+    }
+
+    private fun createViewModel(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    ): ChatViewModel = ChatViewModel(
+        savedStateHandle = savedStateHandle,
+        chatPreferences = chatPreferences,
+        authRepository = authRepository,
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = quickIntentRouter,
+        intentRecoveryOrchestrator = intentRecoveryOrchestrator,
+        intentContractRegistry = IntentContractRegistry(),
+        slotFillerManager = slotFillerManager,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        gatedModelStatusRepository = gatedModelStatusRepository,
+        startListeningCuePlayer = startListeningCuePlayer,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+    )
+}


### PR DESCRIPTION
## Description

Implements the first low-risk slice of #961. The chat toolbar tune/sliders icon now opens a reliable model settings overlay with draft/apply/cancel semantics. Conversation-scoped settings (temperature, top-p, top-k, thinking mode) apply immediately by recreating the LiteRT conversation — no app restart required.

### Changes

**Inference layer:**
- Added `reconfigureConversation(config: ModelConfig)` to `InferenceEngine` interface
- Implemented in `LiteRtInferenceEngine` as a public wrapper around the existing private `resetConversationForConfig` helper
- Engine stays warm — only the conversation/session is recreated

**ChatViewModel:**
- Added `activeModelSettings` MutableStateFlow for reactive settings state
- `applyModelSettingsAndStartNewChat(draft)` method:
  - Cancels active generation, stops voice state
  - Persists draft settings to Room
  - Builds new ModelConfig from active model + draft
  - Calls `inferenceEngine.reconfigureConversation(newConfig)`
  - Creates fresh conversation record, clears messages/input/error/title
  - Updates `_showThinkingProcess` and `_activeModelSettings`
- Existing individual setters (`setTemperature`, etc.) updated to keep `_activeModelSettings` in sync
- Added `activeBackend` to EngineState → ChatUiState.Ready

**Chat UI:**
- Toolbar tune icon always opens the sheet (no silent no-op)
- Shows loading/disabled explanation when model isn't ready
- Draft/apply/cancel: slider changes update local state only; Apply persists + reconfigures + starts fresh chat; Cancel discards
- NPU-aware: sampler controls (temperature, top-p, top-k) hidden when active backend is NPU with explanatory copy
- Reset updates local draft to defaults

**Tests:**
- 6 new unit tests in `ChatViewModelSettingsApplyTest` covering:
  - Apply without active model → error
  - Apply with valid state → reconfigureConversation called
  - Apply clears messages and creates new conversation
  - Apply with no model path → error
  - activeModelSettings updated after apply
  - Conversation-scoped settings propagated correctly
- All 448 existing tests continue to pass

### Smoke test instructions

1. Install debug build on device: `adb install -r app/build/outputs/apk/debug/app-debug.apk`
2. Open chat
3. Tap the tune/sliders icon in the toolbar — model settings sheet should open
4. Adjust temperature slider (draft changes visible, no persistence)
5. Tap Cancel — sheet closes, no changes applied
6. Re-open sheet, adjust temperature, tap Apply — settings persist, new conversation starts
7. Send a message — generation works with new settings
8. Verify NPU/GPU backend label shown in sheet header

### Out of scope (future PRs)

- Model switching
- Context window / max tokens live reload
- Speculative decoding live reload
- Full Settings screen redesign

Closes #961
