### PR TITLE
feat(#1245): model readiness preflight for S21 ADB tests after reinstall

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -265,8 +265,14 @@ class ModelDownloadManager @Inject constructor(
             else -> KernelModel.GEMMA_4_E2B.isDownloaded(context)
         }
         // All other required models must be present
+        // All other required models must be present.
+        // Exclude gated models when the user hasn't authenticated —
+        // they are required for RAG/vector search but not for the
+        // conversation engine to initialise and run.
+        val isHfAuthenticated = authRepository.isAuthenticated.value
         val otherRequiredReady = KernelModel.entries
             .filter { it.isRequired && it != KernelModel.GEMMA_4_E2B }
+            .filterNot { it.isGated && !isHfAuthenticated }
             .all { it.isDownloaded(context) }
         return conversationModelReady && otherRequiredReady
     }

--- a/scripts/adb_harness/__init__.py
+++ b/scripts/adb_harness/__init__.py
@@ -1,0 +1,10 @@
+# No public API — submodules are imported directly.
+# Available submodules:
+#   adb_harness.cases          — test case definitions
+#   adb_harness.config         — configuration constants
+#   adb_harness.device         — ADB device interaction primitives
+#   adb_harness.model_readiness — S21 model readiness preflight
+#   adb_harness.models         — data models (TestCase, TestResult, etc.)
+#   adb_harness.reporting      — JSON report generation and PR comments
+#   adb_harness.runners        — test execution logic (run_tests, run_llm_tools, …)
+#   adb_harness.selectors      — composable test filtering

--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -1,8 +1,8 @@
 """
-ADB Skill Harness — device interaction layer.
+ADB device interaction primitives — commands, logcat streaming, and keepalive.
 
-ADB shell commands, logcat streaming, text/action/slot input, fixture setup,
-keepalive, and result extraction helpers.
+Serial resolution is dynamic: every ADB command resolves the target device
+from ``ANDROID_SERIAL`` / ``ADB_SERIAL`` at call time, not at import time.
 """
 
 from __future__ import annotations
@@ -12,25 +12,17 @@ import os
 import re
 import shlex
 import subprocess
-import sys
 import threading
 import time
-from collections.abc import Callable
 
 from adb_harness.config import (
     ADB,
     ACTIVITY,
-    ANDROID_SERIAL,
     DIRECT_REPLY_PATTERN,
     LOGCAT_TAG,
     NATIVE_INTENT_NAME_PATTERN,
-    NATIVE_INTENT_PATTERN,
-    PARAM_EXTRACT_PATTERN,
-    PROFILE_FALLBACK_PATTERN,
-    PROFILE_LLM_PATTERN,
     WAIT_SECONDS,
 )
-
 
 # ═══════════════════════════════════════════════════════════════════════
 # Host-buffered logcat
@@ -53,10 +45,16 @@ _LOGCAT_STREAM_ARGS = [
 
 
 def build_adb_cmd(*args: str) -> list[str]:
-    """Build an adb command with the selected serial applied consistently."""
+    """Build an adb command with the selected serial applied consistently.
+
+    Serial is resolved dynamically from ``ANDROID_SERIAL`` / ``ADB_SERIAL``
+    at call time, so callers can set ``os.environ["ANDROID_SERIAL"]`` before
+    invoking harness functions without worrying about import-time capture.
+    """
     cmd = [ADB]
-    if ANDROID_SERIAL:
-        cmd.extend(["-s", ANDROID_SERIAL])
+    serial = os.environ.get("ANDROID_SERIAL", "") or os.environ.get("ADB_SERIAL", "")
+    if serial:
+        cmd.extend(["-s", serial])
     cmd.extend(args)
     return cmd
 

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -24,6 +24,7 @@ Failure buckets:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 import tempfile
@@ -32,7 +33,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from adb_harness.config import ADB, ACTIVITY, ANDROID_SERIAL
+from adb_harness.config import ADB, ACTIVITY
 from adb_harness.device import (
     clear_logcat,
     logcat_snapshot,
@@ -127,10 +128,14 @@ _MARKERS: ClassVar[list[_Marker]] = [
     _Marker("engine_ready", r"Engine ready — backend:"),
 ]
 
-# Map marker name → initial state string for Phase 1 detection
+# Map marker name → initial state string for Phase 1 detection.
+# ``engine_already_ready`` is checked first — if the engine is already
+# initialised, the preflight can return immediately. ``model_already_downloaded``
+# means the model file exists but the engine may not be ready yet, so the
+# preflight continues to an engine readiness check.
 _INITIAL_STATE_MAP: dict[str, str] = {
-    "model_already_downloaded": "Ready",
-    "engine_already_ready": "Ready",
+    "engine_already_ready": "Ready",                    # engine running → true Ready
+    "model_already_downloaded": "Downloaded",            # model on disk → needs engine check
     "auto_queue_seen": "Preparing",
     "enqueue_seen": "Preparing",
     "hf_token_missing": "ActionRequired(SignInRequired)",
@@ -387,7 +392,10 @@ def preflight_model_readiness(
     ModelReadinessEvidence
     """
     evidence = ModelReadinessEvidence(
-        device_serial=serial or ANDROID_SERIAL or "unknown",
+        device_serial=(serial
+                       or os.environ.get("ANDROID_SERIAL")
+                       or os.environ.get("ADB_SERIAL")
+                       or "unknown"),
         required_model=S21_REQUIRED_MODEL,
         model_file=S21_MODEL_FILE,
     )
@@ -463,15 +471,14 @@ def preflight_model_readiness(
     # ── Phase 1: Detect initial model state ───────────────────────────
     _print("  [readiness] Detecting initial model state …")
 
-    # Fast path: check if model file exists on disk (~1s) before the 30s
-    # logcat poll. This handles re-runs where the ring buffer was cleared
-    # but the model is already downloaded.
     evidence.initial_state = "Unknown"
+    initial_seen: dict[str, bool] = {}  # used to gate Phase 2 below
+
     if _check_model_on_disk():
-        evidence.initial_state = "Ready"
+        evidence.initial_state = "Downloaded"
         evidence.logcat_markers["model_on_disk"] = True
 
-    if evidence.initial_state != "Ready":
+    if evidence.initial_state != "Downloaded":
         # Quick 30s poll to establish initial state from logcat markers
         initial_seen = _poll_logcat_until(
             list(_INITIAL_STATE_MAP.keys()),
@@ -483,80 +490,89 @@ def preflight_model_readiness(
                 evidence.logcat_markers[marker_name] = True
                 break
 
+    # Only return early when the ENGINE is confirmed ready (not just model-on-disk)
     if evidence.initial_state == "Ready":
-        _print(f"  [readiness] Initial state: {evidence.initial_state} — model already available")
+        _print(f"  [readiness] Initial state: {evidence.initial_state} — engine already ready")
         evidence.final_state = "Ready"
         evidence.readiness_wait_seconds = time.time() - start_ts
         return evidence
 
     _print(f"  [readiness] Initial state: {evidence.initial_state}")
 
-    # If the initial state is "Preparing" the download was auto-queued
+    # If initial state is "Preparing" the download was auto-queued
     if evidence.initial_state == "Preparing":
         evidence.download_triggered = True
 
     # ── Phase 2: Handle HF sign-in dialog ────────────────────────────
-    # The conversation model (E-2B) is not gated on S21, but the embedding
-    # models (EmbeddingGemma 300M + SentencePiece) ARE gated and required.
-    # `areRequiredModelsDownloaded()` requires ALL required models, so engine
-    # init is blocked until embedding models are present. We MUST sign in.
-    signin_tapped = False
-    if _uiautomator_has_text("Sign in to Hugging Face"):
-        signin_tapped = _uiautomator_tap_text("Sign in")
-        _print("  [readiness] Tapped HF sign-in button (dialog)")
-    elif _uiautomator_has_text("Sign in"):
-        signin_tapped = _uiautomator_tap_text("Sign in")
-        _print("  [readiness] Tapped HF sign-in button")
-    if signin_tapped:
-        evidence.hf_signin_clicked = True
-        # Wait for the auth flow to complete — the `hf_signin_approved`
-        # marker confirms the OAuth callback returned a token.
-        _print("  [readiness] Waiting for HF sign-in approval …")
-        signin_seen = _poll_logcat_until(
-            ["hf_signin_approved"],
-            timeout=hf_signin_timeout,
-        )
-        if signin_seen.get("hf_signin_approved"):
-            evidence.logcat_markers["hf_signin_approved"] = True
-            _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
-            # Now wait for the gated model auto-queues to be logged
-            gated_seen = _poll_logcat_until(
-                ["auto_queue_seen", "enqueue_seen"],
-                timeout=30.0,
+    # Gate: only run when the initial state indicates sign-in is needed.
+    # Avoids false-positive taps when UIAutomator finds "Sign in" text from
+    # other parts of the UI during normal model-download flows.
+    if (evidence.initial_state == "ActionRequired(SignInRequired)"
+            or initial_seen.get("hf_token_missing")):
+        _print("  [readiness] HF sign-in required — tapping sign-in button …")
+        signin_tapped = False
+        if _uiautomator_has_text("Sign in to Hugging Face"):
+            signin_tapped = _uiautomator_tap_text("Sign in")
+            _print("  [readiness] Tapped HF sign-in button (dialog)")
+        elif _uiautomator_has_text("Sign in"):
+            signin_tapped = _uiautomator_tap_text("Sign in")
+            _print("  [readiness] Tapped HF sign-in button")
+        if signin_tapped:
+            evidence.hf_signin_clicked = True
+            _print("  [readiness] Waiting for HF sign-in approval …")
+            signin_seen = _poll_logcat_until(
+                ["hf_signin_approved"],
+                timeout=hf_signin_timeout,
             )
-            if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
-                evidence.download_triggered = True
-                _print("  [readiness] Gated model downloads enqueued after sign-in")
+            if signin_seen.get("hf_signin_approved"):
+                evidence.logcat_markers["hf_signin_approved"] = True
+                _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
+                gated_seen = _poll_logcat_until(
+                    ["auto_queue_seen", "enqueue_seen"],
+                    timeout=30.0,
+                )
+                if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
+                    evidence.download_triggered = True
+                    _print("  [readiness] Gated model downloads enqueued after sign-in")
+            else:
+                _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
         else:
-            _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
+            _print("  [readiness] ⚠️  Could not find sign-in button to tap")
     else:
         _print("  [readiness] No HF sign-in dialog detected")
+
     # ── Phase 3+4 combined: Continuous poll for download + engine ──
     # Deadline starts NOW (after Phase 1+2), not from start_ts — avoids
     # the combined window being consumed by Phase 1's 30s initial detection.
     phase34_start = time.time()
-    phase34_download_deadline = phase34_start + timeout_download
-    phase34_engine_deadline = phase34_start + timeout_download + timeout_engine
-    _print(f"  [readiness] Waiting for download + engine (download timeout: {timeout_download:.0f}s, engine: {timeout_engine:.0f}s)…")
-    download_matched = False
+    # If the model is already on disk, skip the download wait
+    download_matched = (evidence.initial_state == "Downloaded")
+    if download_matched:
+        _print("  [readiness] Model already on disk — checking engine readiness")
+        engine_deadline = phase34_start + timeout_engine
+    else:
+        engine_deadline = phase34_start + timeout_download + timeout_engine
     engine_matched = False
 
-    while time.time() < phase34_engine_deadline:
+    _print(f"  [readiness] Waiting for download + engine (download timeout: {timeout_download:.0f}s, engine: {timeout_engine:.0f}s)…")
+
+    while time.time() < engine_deadline:
         snapshot = _read_fresh_logcat()
         markers = _find_markers(snapshot, _MARKERS)
 
         # Track downloads
-        if markers.get("download_completed") or markers.get("download_succeeded"):
-            if not download_matched:
-                evidence.download_triggered = True
-                evidence.logcat_markers["download_completed"] = True
-                _print(f"  [readiness] ✅ Model download completed  (t={time.time() - start_ts:.0f}s)")
-                download_matched = True
-                # Ensure the app is in the foreground for engine init
-                _print("  [readiness] Bringing app to foreground for engine initialisation …")
-                run_adb("shell", "am", "start", "-n", ACTIVITY,
-                        "--activity-clear-top", "--activity-single-top")
-                time.sleep(3)
+        if not download_matched and (markers.get("download_completed") or markers.get("download_succeeded")):
+            evidence.download_triggered = True
+            evidence.logcat_markers["download_completed"] = True
+            _print(f"  [readiness] ✅ Model download completed  (t={time.time() - start_ts:.0f}s)")
+            download_matched = True
+            # When download just completed, engine deadline extends by timeout_engine
+            engine_deadline = time.time() + timeout_engine
+            # Ensure the app is in the foreground for engine init
+            _print("  [readiness] Bringing app to foreground for engine initialisation …")
+            run_adb("shell", "am", "start", "-n", ACTIVITY,
+                    "--activity-clear-top", "--activity-single-top")
+            time.sleep(3)
 
         if markers.get("download_failed"):
             m = next(
@@ -589,7 +605,8 @@ def preflight_model_readiness(
             if cycles > 0 and cycles % 15 == 0:
                 run_adb("shell", "input", "touchscreen", "swipe",
                         "540", "1000", "540", "1004", "50")
-        # Timeout check: measured from Phase 3+4 start, not total start_ts
+
+        # Timeout checks
         phase34_elapsed = time.time() - phase34_start
         if not download_matched and phase34_elapsed > timeout_download:
             # Download timeout
@@ -601,10 +618,9 @@ def preflight_model_readiness(
                 _print(f"  [readiness] ❌ Download did not complete within {timeout_download:.0f}s")
             break
 
-        # Engine-timeout check (only starts counting after download completes)
+        # Engine-timeout check (separate deadline for each case)
         if download_matched and not engine_matched:
-            engine_elapsed = time.time() - phase34_start - timeout_download
-            if engine_elapsed > timeout_engine:
+            if time.time() >= engine_deadline:
                 # Check if lock screen is blocking engine init
                 keyguard = run_adb("shell", "dumpsys", "window")
                 if "isKeyguardShowing=true" in keyguard:
@@ -614,10 +630,6 @@ def preflight_model_readiness(
                     evidence.failure_bucket = "ENGINE_NOT_READY"
                     _print(f"  [readiness] ❌ Engine did not initialise within {timeout_engine:.0f}s")
                 break
-        if download_matched and phase34_elapsed > timeout_download + timeout_engine:
-            evidence.failure_bucket = "ENGINE_NOT_READY"
-            _print(f"  [readiness] ❌ Engine did not initialise within {timeout_engine:.0f}s after download")
-            break
 
         time.sleep(_POLL_INTERVAL)
 
@@ -656,7 +668,6 @@ def cli_main() -> int:
     args = parser.parse_args()
 
     if args.serial:
-        import os
         os.environ["ANDROID_SERIAL"] = args.serial
 
     try:

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -1,0 +1,533 @@
+"""
+ADB Harness — Model Readiness Preflight.
+
+Deterministic S21 model-readiness check for ADB/device test runs after reinstall.
+Runs after a fresh install or clean reinstall and ensures the required conversation
+model is downloaded and the inference engine is ready before test execution begins.
+
+Logcat markers monitored:
+  - ``"Auto-queuing required model: {model}"``   → download auto-triggered
+  - ``"Enqueuing download for {model}"``          → download enqueued in WorkManager
+  - ``"Refreshed state for {model}: Downloaded(`` → model ready on disk
+  - ``"Download succeeded: {path}"``               → file verified on disk
+  - ``"Engine ready — backend:"``                  → LiteRT engine fully initialised
+  - ``"{model} is gated but no HF token"``         → HuggingFace sign-in required
+
+Failure buckets:
+  - ``MODEL_NOT_READY`` — download never started and model not present
+  - ``MODEL_DOWNLOAD_FAILED`` — download worker errored
+  - ``MODEL_DOWNLOAD_TIMEOUT`` — download started but did not finish within timeout
+  - ``ENGINE_NOT_READY`` — engine did not initialise after download completed
+  - ``HF_SIGNIN_FAILED`` — HuggingFace sign-in UI shown but could not be completed
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from adb_harness.config import ADB, ACTIVITY, ANDROID_SERIAL
+from adb_harness.device import (
+    clear_logcat,
+    logcat_snapshot,
+    logcat_start,
+    logcat_stop,
+    run_adb,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════
+
+S21_REQUIRED_MODEL = "Gemma 4 E-2B"
+S21_MODEL_FILE = "gemma-4-E2B-it.litertlm"
+
+# ── Exit codes ──
+EXIT_SUCCESS = 0
+EXIT_MODEL_NOT_READY = 44  # matches MODEL_NOT_READY bucket
+EXIT_PREFLIGHT_CRASHED = 45
+
+# ── Poll defaults ──
+_POLL_INTERVAL: float = 2.0
+
+# ═══════════════════════════════════════════════════════════════════════
+# Evidence record
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class ModelReadinessEvidence:
+    """Structured evidence record for model readiness preflight.
+
+    Serialised to JSON and included in ADB test evidence to distinguish
+    model-bootstrap failures from product test failures.
+    """
+
+    device_serial: str
+    required_model: str = S21_REQUIRED_MODEL
+    model_file: str = S21_MODEL_FILE
+    initial_state: str | None = None
+    hf_signin_shown: bool = False
+    hf_signin_clicked: bool = False
+    download_triggered: bool = False
+    readiness_wait_seconds: float = 0.0
+    final_state: str | None = None
+    failure_bucket: str | None = None
+    logcat_markers: dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "device_serial": self.device_serial,
+            "required_model": self.required_model,
+            "model_file": self.model_file,
+            "initial_state": self.initial_state,
+            "hf_signin_shown": self.hf_signin_shown,
+            "hf_signin_clicked": self.hf_signin_clicked,
+            "download_triggered": self.download_triggered,
+            "readiness_wait_seconds": round(self.readiness_wait_seconds, 1),
+            "final_state": self.final_state,
+            "failure_bucket": self.failure_bucket,
+            "logcat_markers": self.logcat_markers,
+        }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Marker definitions
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _Marker:
+    """A named logcat marker with a compiled regex."""
+
+    def __init__(self, name: str, pattern: str) -> None:
+        self.name = name
+        self.pattern = re.compile(pattern)
+
+
+# Ordered list of markers the preflight tracks.
+# The order defines priority: first match wins for initial-state detection.
+_MARKERS: ClassVar[list[_Marker]] = [
+    _Marker("model_already_downloaded", r"Refreshed state for (.+): Downloaded\("),
+    _Marker("engine_already_ready", r"Engine ready — backend:"),
+    _Marker("auto_queue_seen", r"Auto-queuing required model: (.+)"),
+    _Marker("enqueue_seen", r"Enqueuing download for (.+)"),
+    _Marker("hf_token_missing", r"(.+) is gated but no HF token"),
+    _Marker("download_completed", r"Refreshed state for (.+): Downloaded\("),
+    _Marker("download_succeeded", r"Download succeeded: (.+)"),
+    _Marker("download_failed", r"Download failed for (.+): (.+)"),
+    _Marker("hf_signin_approved", r"Set (.+) → APPROVED"),
+    _Marker("engine_ready", r"Engine ready — backend:"),
+]
+
+# Map marker name → initial state string for Phase 1 detection
+_INITIAL_STATE_MAP: dict[str, str] = {
+    "model_already_downloaded": "Ready",
+    "engine_already_ready": "Ready",
+    "auto_queue_seen": "Preparing",
+    "enqueue_seen": "Preparing",
+    "hf_token_missing": "ActionRequired(SignInRequired)",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Logcat polling (non-destructive)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _drain_logcat() -> str:
+    """Read and drain the streaming logcat buffer (destructive)."""
+    return logcat_snapshot()
+
+
+def _read_fresh_logcat() -> str:
+    """Read a fresh ``adb logcat -d`` dump without touching the stream buffer.
+
+    Returns all logcat lines since boot, filtered to relevant tags.
+    """
+    raw = run_adb(
+        "logcat",
+        "-d",
+        "-s",
+        "ModelDownloadManager",
+        "LiteRtInferenceEngine",
+        "GatedModelStatusRepository",
+        "HardwareProfileDetector",
+        "KernelAI",
+    )
+    return raw or ""
+
+
+def _find_markers(text: str, markers: list[_Marker]) -> dict[str, bool]:
+    """Search *text* for *markers*. Returns {marker_name: found}."""
+    result: dict[str, bool] = {}
+    for m in markers:
+        result[m.name] = m.pattern.search(text) is not None
+    return result
+
+
+def _poll_adb_logcat(
+    timeout: float,
+    poll_interval: float = _POLL_INTERVAL,
+) -> dict[str, bool]:
+    """Poll ``adb logcat -d`` repeatedly for markers.
+
+    Uses fresh ``logcat -d`` each cycle (non-destructive to the stream buffer),
+    so markers accumulate across cycles.
+    """
+    deadline = time.time() + timeout
+    seen: dict[str, bool] = {m.name: False for m in _MARKERS}
+
+    while time.time() < deadline:
+        snapshot = _read_fresh_logcat()
+        found = _find_markers(snapshot, _MARKERS)
+        for k, v in found.items():
+            if v:
+                seen[k] = True
+        # Return early when all relevant markers found
+        # (no specific all-markers check — let caller decide)
+        time.sleep(poll_interval)
+
+    return seen
+
+
+def _poll_logcat_until(
+    target_marker_names: list[str],
+    timeout: float,
+    poll_interval: float = _POLL_INTERVAL,
+) -> dict[str, bool]:
+    """Poll adb logcat until one of *target_marker_names* is found or timeout."""
+    deadline = time.time() + timeout
+    seen: dict[str, bool] = {m.name: False for m in _MARKERS}
+    target_set = set(target_marker_names)
+
+    while time.time() < deadline:
+        snapshot = _read_fresh_logcat()
+        found = _find_markers(snapshot, _MARKERS)
+        for k, v in found.items():
+            if v:
+                seen[k] = True
+        # Check if any target marker found
+        for t in target_set:
+            if seen.get(t):
+                return seen
+        time.sleep(poll_interval)
+
+    return seen
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# UI helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+_BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+
+
+def _uiautomator_has_text(target_text: str) -> bool:
+    """Check if *target_text* appears in the current UI hierarchy."""
+    try:
+        tmp = tempfile.mktemp(suffix=".xml")
+        run_adb("shell", "uiautomator", "dump", tmp)
+        time.sleep(1.0)
+        raw = run_adb("shell", "cat", tmp) or ""
+        if not raw.strip():
+            return False
+        # Search for text in any attribute
+        return target_text in raw
+    except Exception:
+        return False
+
+
+def _uiautomator_tap_text(target_text: str) -> bool:
+    """Find and tap an element containing *target_text* via bound center.
+
+    Returns True if found and tapped.
+    """
+    try:
+        tmp = tempfile.mktemp(suffix=".xml")
+        run_adb("shell", "uiautomator", "dump", tmp)
+        time.sleep(1.0)
+        raw = run_adb("shell", "cat", tmp) or ""
+        if not raw.strip():
+            return False
+        root = ET.fromstring(raw)
+        for node in root.iter():
+            txt = node.attrib.get("text", "") or ""
+            desc = node.attrib.get("content-desc", "") or ""
+            if target_text in txt or target_text in desc:
+                b = node.attrib.get("bounds", "")
+                m = _BOUNDS_RE.match(b)
+                if m:
+                    l, t, r, b_ = int(m.group(1)), int(m.group(2)), int(m.group(3)), int(m.group(4))
+                    cx, cy = (l + r) // 2, (t + b_) // 2
+                    run_adb("shell", "input", "tap", str(cx), str(cy))
+                    return True
+        return False
+    except Exception:
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Preflight (state-machine continuous poll)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def preflight_model_readiness(
+    serial: str | None = None,
+    timeout_download: float = 600.0,
+    timeout_engine: float = 120.0,
+    hf_signin_timeout: float = 60.0,
+    verbose: bool = True,
+) -> ModelReadinessEvidence:
+    """Run model-readiness preflight on the target device.
+
+    Expects the app to already be installed (e.g. after a fresh ``adb install``).
+    Launches the app and waits for the required conversation model to be
+    downloaded and the inference engine to initialise.
+
+    Uses a single continuous polling loop that tracks all markers
+    simultaneously, so there is no logcat drain gap between phases.
+
+    Returns a ``ModelReadinessEvidence`` dataclass summarising the run.
+    The caller should check ``evidence.failure_bucket`` to determine outcome.
+
+    Parameters
+    ----------
+    serial : str or None
+        Device serial. Falls back to ``ANDROID_SERIAL`` / ``ADB_SERIAL`` env vars.
+    timeout_download : float
+        Max seconds to wait for the model to finish downloading (default 600).
+    timeout_engine : float
+        Max seconds to wait for the inference engine to init after download (default 120).
+    hf_signin_timeout : float
+        Max seconds to wait for HuggingFace sign-in flow to complete (default 60).
+    verbose : bool
+        Print progress output.
+
+    Returns
+    -------
+    ModelReadinessEvidence
+    """
+    evidence = ModelReadinessEvidence(
+        device_serial=serial or ANDROID_SERIAL or "unknown",
+        required_model=S21_REQUIRED_MODEL,
+        model_file=S21_MODEL_FILE,
+    )
+    _print = print if verbose else lambda *a, **kw: None
+    start_ts = time.time()
+
+    # ── Logcat preamble ───────────────────────────────────────────────
+    logcat_start()
+    clear_logcat()
+    time.sleep(1)
+
+    # ── Launch the app ────────────────────────────────────────────────
+    _print("  [readiness] Launching app …")
+    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    run_adb(
+        "shell", "am", "start", "-n", ACTIVITY,
+        "--activity-clear-top", "--activity-single-top",
+    )
+    time.sleep(5)
+    clear_logcat()
+    time.sleep(1)
+
+    # ── Phase 1: Detect initial model state ───────────────────────────
+    _print("  [readiness] Detecting initial model state …")
+
+    # Quick 30s poll to establish initial state
+    initial_seen = _poll_logcat_until(
+        list(_INITIAL_STATE_MAP.keys()),
+        timeout=30.0,
+    )
+
+    # Determine initial state from the first matching marker
+    evidence.initial_state = "Unknown"
+    for marker_name, state_name in _INITIAL_STATE_MAP.items():
+        if initial_seen.get(marker_name):
+            evidence.initial_state = state_name
+            evidence.logcat_markers[marker_name] = True
+            break
+
+    if evidence.initial_state == "Ready":
+        _print(f"  [readiness] Initial state: {evidence.initial_state} — model already available")
+        evidence.final_state = "Ready"
+        evidence.readiness_wait_seconds = time.time() - start_ts
+        return evidence
+
+    _print(f"  [readiness] Initial state: {evidence.initial_state}")
+    # ── Phase 2: Handle HuggingFace sign-in if needed ─────────────────
+    if evidence.initial_state == "Preparing":
+        evidence.download_triggered = True
+
+    if evidence.initial_state == "ActionRequired(SignInRequired)" or initial_seen.get("hf_token_missing"):
+        if _uiautomator_has_text("Sign in to HuggingFace"):
+            evidence.hf_signin_shown = True
+            _print("  [readiness] Found 'Sign in to HuggingFace' button — tapping …")
+            evidence.hf_signin_clicked = _uiautomator_tap_text("Sign in to HuggingFace")
+            if evidence.hf_signin_clicked:
+                _print("  [readiness] Tapped sign-in — waiting for sign-in to complete …")
+                signin_seen = _poll_logcat_until(
+                    ["hf_signin_approved", "auto_queue_seen", "enqueue_seen"],
+                    timeout=hf_signin_timeout,
+                )
+                if signin_seen.get("hf_signin_approved"):
+                    evidence.logcat_markers["hf_signin_approved"] = True
+                    _print("  [readiness] Sign-in approved — downloads should start")
+                if signin_seen.get("auto_queue_seen") or signin_seen.get("enqueue_seen"):
+                    evidence.download_triggered = True
+                    _print("  [readiness] Download started after sign-in")
+            else:
+                _print("  [readiness] ⚠ Could not tap sign-in button — proceeding anyway")
+        else:
+            _print("  [readiness] No sign-in button in UI — may already be signed in")
+    # ── Phase 3+4 combined: Continuous poll for download + engine ──
+    # Deadline starts NOW (after Phase 1+2), not from start_ts — avoids
+    # the combined window being consumed by Phase 1's 30s initial detection.
+    phase34_start = time.time()
+    phase34_download_deadline = phase34_start + timeout_download
+    phase34_engine_deadline = phase34_start + timeout_download + timeout_engine
+    _print(f"  [readiness] Waiting for download + engine (download timeout: {timeout_download:.0f}s, engine: {timeout_engine:.0f}s)…")
+    download_matched = False
+    engine_matched = False
+
+    while time.time() < phase34_engine_deadline:
+        snapshot = _read_fresh_logcat()
+        markers = _find_markers(snapshot, _MARKERS)
+
+        # Track downloads
+        if markers.get("download_completed") or markers.get("download_succeeded"):
+            if not download_matched:
+                evidence.download_triggered = True
+                evidence.logcat_markers["download_completed"] = True
+                _print(f"  [readiness] ✅ Model download completed  (t={time.time() - start_ts:.0f}s)")
+                download_matched = True
+
+        if markers.get("download_failed"):
+            m = next(
+                (p.search(snapshot) for p in [re.compile(r"Download failed for (.+): (.+)")] if p.search(snapshot)),
+                None,
+            )
+            error_msg = m.group(2) if m and m.lastindex and m.lastindex >= 2 else "unknown"
+            evidence.failure_bucket = "MODEL_DOWNLOAD_FAILED"
+            evidence.logcat_markers["download_failed"] = True
+            _print(f"  [readiness] ❌ Download failed: {error_msg}")
+            break
+
+        if markers.get("engine_ready"):
+            if not engine_matched:
+                evidence.logcat_markers["engine_ready"] = True
+                evidence.final_state = "Ready"
+                _print(f"  [readiness] ✅ Inference engine ready  (t={time.time() - start_ts:.0f}s)")
+                engine_matched = True
+
+        # Both done → success
+        if engine_matched:
+            break
+        # Timeout check: measured from Phase 3+4 start, not total start_ts
+        phase34_elapsed = time.time() - phase34_start
+        if not download_matched and phase34_elapsed > timeout_download:
+            # Download timeout
+            if not evidence.download_triggered:
+                evidence.failure_bucket = "MODEL_NOT_READY"
+                _print(f"  [readiness] ❌ Download never started within {timeout_download:.0f}s")
+            else:
+                evidence.failure_bucket = "MODEL_DOWNLOAD_TIMEOUT"
+                _print(f"  [readiness] ❌ Download did not complete within {timeout_download:.0f}s")
+            break
+
+        if download_matched and phase34_elapsed > timeout_download + timeout_engine:
+            evidence.failure_bucket = "ENGINE_NOT_READY"
+            _print(f"  [readiness] ❌ Engine did not initialise within {timeout_engine:.0f}s after download")
+            break
+
+        time.sleep(_POLL_INTERVAL)
+
+    # ── Wrap up ───────────────────────────────────────────────────────
+    if evidence.final_state is None and evidence.failure_bucket is None:
+        evidence.failure_bucket = "ENGINE_NOT_READY"
+
+    evidence.readiness_wait_seconds = time.time() - start_ts
+
+    if evidence.failure_bucket:
+        _print(f"  [readiness] ❌ FAILED: {evidence.failure_bucket}")
+    else:
+        _print("  [readiness] ✅ Model readiness preflight passed")
+
+    _print(f"  [readiness] Elapsed: {evidence.readiness_wait_seconds:.0f}s")
+
+    # Drain preflight residue so caller doesn't see it
+    clear_logcat()
+
+    return evidence
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# CLI entry point
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def cli_main() -> int:
+    """Direct CLI entry point for ``python -m adb_harness.model_readiness``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Model readiness preflight for S21 ADB tests",
+    )
+    parser.add_argument(
+        "--serial",
+        help="Device serial (falls back to ANDROID_SERIAL / ADB_SERIAL env)",
+    )
+    parser.add_argument(
+        "--timeout-download",
+        type=float,
+        default=600.0,
+        help="Max seconds to wait for model download (default 600)",
+    )
+    parser.add_argument(
+        "--timeout-engine",
+        type=float,
+        default=120.0,
+        help="Max seconds to wait for engine initialisation (default 120)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output evidence as JSON to stdout",
+    )
+    args = parser.parse_args()
+
+    if args.serial:
+        import os
+        os.environ["ANDROID_SERIAL"] = args.serial
+
+    try:
+        evidence = preflight_model_readiness(
+            serial=args.serial,
+            timeout_download=args.timeout_download,
+            timeout_engine=args.timeout_engine,
+            verbose=not args.json,
+        )
+    except Exception as e:
+        print(f"ERROR: Model readiness preflight crashed: {e}", file=sys.stderr)
+        return EXIT_PREFLIGHT_CRASHED
+
+    if args.json:
+        json.dump(evidence.to_dict(), sys.stdout, indent=2)
+        print()
+
+    if evidence.failure_bucket:
+        print(f"\nPreflight FAILED: {evidence.failure_bucket}", file=sys.stderr)
+        return EXIT_MODEL_NOT_READY
+
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -32,8 +32,7 @@ import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from typing import ClassVar
-
-from adb_harness.config import ADB, ACTIVITY
+from adb_harness.config import ADB, ACTIVITY, PACKAGE
 from adb_harness.device import (
     clear_logcat,
     logcat_snapshot,
@@ -436,6 +435,11 @@ def preflight_model_readiness(
         run_adb("shell", "input", "keyevent", "KEYCODE_MENU")
         run_adb("shell", "input", "swipe", "500", "1500", "500", "500")
         time.sleep(2)
+    # Force-stop the app so it starts fresh — re-runs where the app is
+    # still cached will suppress the engine-init logcat markers.
+    _print("  [readiness] Force-stopping app for clean startup …")
+    run_adb("shell", "am", "force-stop", PACKAGE)
+    time.sleep(2)
     _print("  [readiness] Granting dangerous permissions before launch …")
     _grant_dangerous_permissions()
     time.sleep(1)

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -39,6 +39,7 @@ from adb_harness.device import (
     logcat_start,
     logcat_stop,
     run_adb,
+    send_text,
 )
 
 
@@ -226,6 +227,74 @@ def _poll_logcat_until(
 # UI helpers
 # ═══════════════════════════════════════════════════════════════════════
 
+
+def _check_model_on_disk(model_file: str = S21_MODEL_FILE) -> bool:
+    """Check if the model file exists on the device's external storage.
+
+    Works around logcat-clear edge cases where the model was already
+    downloaded in a prior session but the ring buffer was emptied.
+    """
+    pkg = "com.kernel.ai.debug"
+    path = f"/storage/emulated/0/Android/data/{pkg}/files/models/{model_file}"
+    result = run_adb("shell", "ls", path)
+    return result == path or path in result
+# ── Permission handling ───────────────────────────────────────────
+
+
+# Dangerous permissions that trigger runtime dialogs on Android 15
+_DANGEROUS_PERMISSIONS: list[str] = [
+    "android.permission.POST_NOTIFICATIONS",
+    "android.permission.ACCESS_COARSE_LOCATION",
+    "android.permission.READ_CONTACTS",
+    "android.permission.READ_CALENDAR",
+    "android.permission.RECORD_AUDIO",
+    "android.permission.CALL_PHONE",
+    "android.permission.ACCESS_NOTIFICATION_POLICY",
+]
+
+
+def _grant_dangerous_permissions(pkg: str = "com.kernel.ai.debug") -> None:
+    """Pre-grant dangerous permissions via ``pm grant``.
+
+    Runs before the app requests the permission so dialogs never appear.
+    On Android 15, ``pm grant`` works pre-emptively for most dangerous
+    permissions. Failures are logged but non-fatal — fallback UI handling
+    covers any remaining dialogs.
+    """
+    for perm in _DANGEROUS_PERMISSIONS:
+        try:
+            run_adb("shell", "pm", "grant", pkg, perm)
+        except Exception as exc:
+            # Some permissions cannot be pre-granted; that's OK.
+            pass
+
+
+def _handle_permission_dialogs(timeout: float = 30.0) -> bool:
+    """Wait for and handle runtime permission dialogs one at a time.
+
+    Polls ``dumpsys activity`` for ``GrantPermissionsActivity`` in the
+    foreground. When a dialog is found, uses UIAutomator to locate and
+    tap the "Allow" or "While using the app" button.
+
+    Returns ``True`` once no more permission dialogs are visible.
+    Returns ``False`` if dialogs persist after *timeout* seconds.
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        dumpsys = run_adb("shell", "dumpsys", "activity")
+        if "GrantPermissionsActivity" not in dumpsys:
+            return True
+
+        _uiautomator_tap_text("Allow")
+        time.sleep(2.0)
+
+        # Some dialogs use "While using the app" instead of "Allow"
+        dumpsys = run_adb("shell", "dumpsys", "activity")
+        if "GrantPermissionsActivity" in dumpsys:
+            _uiautomator_tap_text("While using the app")
+            time.sleep(2.0)
+
+    return False
 _BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
 
 
@@ -284,6 +353,7 @@ def preflight_model_readiness(
     timeout_engine: float = 120.0,
     hf_signin_timeout: float = 60.0,
     verbose: bool = True,
+    unlock_pin: str | None = None,
 ) -> ModelReadinessEvidence:
     """Run model-readiness preflight on the target device.
 
@@ -295,6 +365,8 @@ def preflight_model_readiness(
     simultaneously, so there is no logcat drain gap between phases.
 
     Returns a ``ModelReadinessEvidence`` dataclass summarising the run.
+
+    # ── Phase 1: Detect initial model state ───────────────────────────
     The caller should check ``evidence.failure_bucket`` to determine outcome.
 
     Parameters
@@ -325,6 +397,39 @@ def preflight_model_readiness(
     # ── Logcat preamble ───────────────────────────────────────────────
     logcat_start()
     clear_logcat()
+    # Clear the device ring buffer so we only see fresh entries
+    # (safe on USB ADB, not on ADB-over-TLS)
+    run_adb("logcat", "-c")
+    time.sleep(1)
+
+    # ── Permissions: pre-grant BEFORE app launch ──────────────────────
+    # Granting POST_NOTIFICATIONS before the app launches ensures the
+    # ModelDownloadWorker can call setForeground() successfully, which
+    # prevents WorkManager from falling back to non-expedited (which
+    # ── Unlock device (dismiss keyguard if possible) ─────────────────
+    if unlock_pin:
+        _print("  [readiness] Unlocking device with PIN …")
+        run_adb("shell", "input", "keyevent", "KEYCODE_POWER")
+        time.sleep(1)
+        run_adb("shell", "input", "swipe", "500", "1500", "500", "500")
+        time.sleep(1)
+        run_adb("shell", "input", "text", unlock_pin)
+        time.sleep(0.3)
+        run_adb("shell", "input", "keyevent", "KEYCODE_ENTER")
+        time.sleep(1)
+        # Verify unlock succeeded
+        keyguard = run_adb("shell", "dumpsys", "window")
+        if "isKeyguardShowing=true" in keyguard:
+            _print("  [readiness] ⚠️  PIN unlock may have failed — keyguard still showing")
+        else:
+            _print("  [readiness] ✅ Device unlocked")
+    else:
+        # Swipe attempt for swipe-to-unlock devices
+        run_adb("shell", "input", "keyevent", "KEYCODE_MENU")
+        run_adb("shell", "input", "swipe", "500", "1500", "500", "500")
+        time.sleep(2)
+    _print("  [readiness] Granting dangerous permissions before launch …")
+    _grant_dangerous_permissions()
     time.sleep(1)
 
     # ── Launch the app ────────────────────────────────────────────────
@@ -338,22 +443,45 @@ def preflight_model_readiness(
     clear_logcat()
     time.sleep(1)
 
+    # ── Handle permission dialogs (system UI layer) ─────────────────
+    # Some permissions like notification controls or overlay permissions
+    # may still show system dialogs regardless of pm grant.
+    _print("  [readiness] Handling permission dialogs …")
+    perms_ok = _handle_permission_dialogs(timeout=30.0)
+    if perms_ok:
+        _print("  [readiness] ✅ Permissions granted")
+    else:
+        _print("  [readiness] ⚠ Permission dialog may still be visible — proceeding anyway")
+    clear_logcat()
+    time.sleep(1)
+
+    # ── Trigger: send a message to activate model-readiness flow ────
+    _print("  [readiness] Sending trigger message to activate model readiness check …")
+    send_text("hello", wait_for_inference=False)
+    time.sleep(3)
+    clear_logcat()
     # ── Phase 1: Detect initial model state ───────────────────────────
     _print("  [readiness] Detecting initial model state …")
 
-    # Quick 30s poll to establish initial state
-    initial_seen = _poll_logcat_until(
-        list(_INITIAL_STATE_MAP.keys()),
-        timeout=30.0,
-    )
-
-    # Determine initial state from the first matching marker
+    # Fast path: check if model file exists on disk (~1s) before the 30s
+    # logcat poll. This handles re-runs where the ring buffer was cleared
+    # but the model is already downloaded.
     evidence.initial_state = "Unknown"
-    for marker_name, state_name in _INITIAL_STATE_MAP.items():
-        if initial_seen.get(marker_name):
-            evidence.initial_state = state_name
-            evidence.logcat_markers[marker_name] = True
-            break
+    if _check_model_on_disk():
+        evidence.initial_state = "Ready"
+        evidence.logcat_markers["model_on_disk"] = True
+
+    if evidence.initial_state != "Ready":
+        # Quick 30s poll to establish initial state from logcat markers
+        initial_seen = _poll_logcat_until(
+            list(_INITIAL_STATE_MAP.keys()),
+            timeout=30.0,
+        )
+        for marker_name, state_name in _INITIAL_STATE_MAP.items():
+            if initial_seen.get(marker_name):
+                evidence.initial_state = state_name
+                evidence.logcat_markers[marker_name] = True
+                break
 
     if evidence.initial_state == "Ready":
         _print(f"  [readiness] Initial state: {evidence.initial_state} — model already available")
@@ -362,31 +490,47 @@ def preflight_model_readiness(
         return evidence
 
     _print(f"  [readiness] Initial state: {evidence.initial_state}")
-    # ── Phase 2: Handle HuggingFace sign-in if needed ─────────────────
+
+    # If the initial state is "Preparing" the download was auto-queued
     if evidence.initial_state == "Preparing":
         evidence.download_triggered = True
 
-    if evidence.initial_state == "ActionRequired(SignInRequired)" or initial_seen.get("hf_token_missing"):
-        if _uiautomator_has_text("Sign in to HuggingFace"):
-            evidence.hf_signin_shown = True
-            _print("  [readiness] Found 'Sign in to HuggingFace' button — tapping …")
-            evidence.hf_signin_clicked = _uiautomator_tap_text("Sign in to HuggingFace")
-            if evidence.hf_signin_clicked:
-                _print("  [readiness] Tapped sign-in — waiting for sign-in to complete …")
-                signin_seen = _poll_logcat_until(
-                    ["hf_signin_approved", "auto_queue_seen", "enqueue_seen"],
-                    timeout=hf_signin_timeout,
-                )
-                if signin_seen.get("hf_signin_approved"):
-                    evidence.logcat_markers["hf_signin_approved"] = True
-                    _print("  [readiness] Sign-in approved — downloads should start")
-                if signin_seen.get("auto_queue_seen") or signin_seen.get("enqueue_seen"):
-                    evidence.download_triggered = True
-                    _print("  [readiness] Download started after sign-in")
-            else:
-                _print("  [readiness] ⚠ Could not tap sign-in button — proceeding anyway")
+    # ── Phase 2: Handle HF sign-in dialog ────────────────────────────
+    # The conversation model (E-2B) is not gated on S21, but the embedding
+    # models (EmbeddingGemma 300M + SentencePiece) ARE gated and required.
+    # `areRequiredModelsDownloaded()` requires ALL required models, so engine
+    # init is blocked until embedding models are present. We MUST sign in.
+    signin_tapped = False
+    if _uiautomator_has_text("Sign in to Hugging Face"):
+        signin_tapped = _uiautomator_tap_text("Sign in")
+        _print("  [readiness] Tapped HF sign-in button (dialog)")
+    elif _uiautomator_has_text("Sign in"):
+        signin_tapped = _uiautomator_tap_text("Sign in")
+        _print("  [readiness] Tapped HF sign-in button")
+    if signin_tapped:
+        evidence.hf_signin_clicked = True
+        # Wait for the auth flow to complete — the `hf_signin_approved`
+        # marker confirms the OAuth callback returned a token.
+        _print("  [readiness] Waiting for HF sign-in approval …")
+        signin_seen = _poll_logcat_until(
+            ["hf_signin_approved"],
+            timeout=hf_signin_timeout,
+        )
+        if signin_seen.get("hf_signin_approved"):
+            evidence.logcat_markers["hf_signin_approved"] = True
+            _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
+            # Now wait for the gated model auto-queues to be logged
+            gated_seen = _poll_logcat_until(
+                ["auto_queue_seen", "enqueue_seen"],
+                timeout=30.0,
+            )
+            if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
+                evidence.download_triggered = True
+                _print("  [readiness] Gated model downloads enqueued after sign-in")
         else:
-            _print("  [readiness] No sign-in button in UI — may already be signed in")
+            _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
+    else:
+        _print("  [readiness] No HF sign-in dialog detected")
     # ── Phase 3+4 combined: Continuous poll for download + engine ──
     # Deadline starts NOW (after Phase 1+2), not from start_ts — avoids
     # the combined window being consumed by Phase 1's 30s initial detection.
@@ -408,6 +552,11 @@ def preflight_model_readiness(
                 evidence.logcat_markers["download_completed"] = True
                 _print(f"  [readiness] ✅ Model download completed  (t={time.time() - start_ts:.0f}s)")
                 download_matched = True
+                # Ensure the app is in the foreground for engine init
+                _print("  [readiness] Bringing app to foreground for engine initialisation …")
+                run_adb("shell", "am", "start", "-n", ACTIVITY,
+                        "--activity-clear-top", "--activity-single-top")
+                time.sleep(3)
 
         if markers.get("download_failed"):
             m = next(
@@ -430,6 +579,16 @@ def preflight_model_readiness(
         # Both done → success
         if engine_matched:
             break
+
+        # ── Keep device awake during long downloads ─────────────────
+        # The poll interval is ~3s; every 15 cycles (~45s) send a small
+        # interaction to prevent the device from dozing or locking.
+        if not engine_matched:
+            elapsed_since_poll_start = time.time() - phase34_start
+            cycles = int(elapsed_since_poll_start // _POLL_INTERVAL) if _POLL_INTERVAL > 0 else 0
+            if cycles > 0 and cycles % 15 == 0:
+                run_adb("shell", "input", "touchscreen", "swipe",
+                        "540", "1000", "540", "1004", "50")
         # Timeout check: measured from Phase 3+4 start, not total start_ts
         phase34_elapsed = time.time() - phase34_start
         if not download_matched and phase34_elapsed > timeout_download:
@@ -442,6 +601,19 @@ def preflight_model_readiness(
                 _print(f"  [readiness] ❌ Download did not complete within {timeout_download:.0f}s")
             break
 
+        # Engine-timeout check (only starts counting after download completes)
+        if download_matched and not engine_matched:
+            engine_elapsed = time.time() - phase34_start - timeout_download
+            if engine_elapsed > timeout_engine:
+                # Check if lock screen is blocking engine init
+                keyguard = run_adb("shell", "dumpsys", "window")
+                if "isKeyguardShowing=true" in keyguard:
+                    evidence.failure_bucket = "ENGINE_BLOCKED_BY_KEYGUARD"
+                    _print("  [readiness] ❌ Lock screen / keyguard blocking engine init — unlock device first")
+                else:
+                    evidence.failure_bucket = "ENGINE_NOT_READY"
+                    _print(f"  [readiness] ❌ Engine did not initialise within {timeout_engine:.0f}s")
+                break
         if download_matched and phase34_elapsed > timeout_download + timeout_engine:
             evidence.failure_bucket = "ENGINE_NOT_READY"
             _print(f"  [readiness] ❌ Engine did not initialise within {timeout_engine:.0f}s after download")
@@ -468,39 +640,19 @@ def preflight_model_readiness(
     return evidence
 
 
-# ═══════════════════════════════════════════════════════════════════════
-# CLI entry point
-# ═══════════════════════════════════════════════════════════════════════
-
-
 def cli_main() -> int:
     """Direct CLI entry point for ``python -m adb_harness.model_readiness``."""
     import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Model readiness preflight for S21 ADB tests",
-    )
-    parser.add_argument(
-        "--serial",
-        help="Device serial (falls back to ANDROID_SERIAL / ADB_SERIAL env)",
-    )
-    parser.add_argument(
-        "--timeout-download",
-        type=float,
-        default=600.0,
-        help="Max seconds to wait for model download (default 600)",
-    )
-    parser.add_argument(
-        "--timeout-engine",
-        type=float,
-        default=120.0,
-        help="Max seconds to wait for engine initialisation (default 120)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output evidence as JSON to stdout",
-    )
+    parser = argparse.ArgumentParser(description="Model readiness preflight for S21 ADB tests")
+    parser.add_argument("--serial", help="Device serial (falls back to ANDROID_SERIAL / ADB_SERIAL env)")
+    parser.add_argument("--timeout-download", type=float, default=360.0,
+                        help="Max seconds to wait for model download (default 360)")
+    parser.add_argument("--timeout-engine", type=float, default=120.0,
+                        help="Max seconds to wait for engine initialisation (default 120)")
+    parser.add_argument("--unlock-pin", type=str, default=None,
+                        help="Device unlock PIN to dismiss keyguard before initialisation")
+    parser.add_argument("--json", action="store_true",
+                        help="Output evidence as JSON to stdout")
     args = parser.parse_args()
 
     if args.serial:
@@ -513,6 +665,7 @@ def cli_main() -> int:
             timeout_download=args.timeout_download,
             timeout_engine=args.timeout_engine,
             verbose=not args.json,
+            unlock_pin=args.unlock_pin,
         )
     except Exception as e:
         print(f"ERROR: Model readiness preflight crashed: {e}", file=sys.stderr)

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -504,40 +504,37 @@ def preflight_model_readiness(
         evidence.download_triggered = True
 
     # ── Phase 2: Handle HF sign-in dialog ────────────────────────────
-    # Gate: only run when the initial state indicates sign-in is needed.
-    # Avoids false-positive taps when UIAutomator finds "Sign in" text from
-    # other parts of the UI during normal model-download flows.
-    if (evidence.initial_state == "ActionRequired(SignInRequired)"
-            or initial_seen.get("hf_token_missing")):
-        _print("  [readiness] HF sign-in required — tapping sign-in button …")
-        signin_tapped = False
-        if _uiautomator_has_text("Sign in to Hugging Face"):
-            signin_tapped = _uiautomator_tap_text("Sign in")
-            _print("  [readiness] Tapped HF sign-in button (dialog)")
-        elif _uiautomator_has_text("Sign in"):
-            signin_tapped = _uiautomator_tap_text("Sign in")
-            _print("  [readiness] Tapped HF sign-in button")
-        if signin_tapped:
-            evidence.hf_signin_clicked = True
-            _print("  [readiness] Waiting for HF sign-in approval …")
-            signin_seen = _poll_logcat_until(
-                ["hf_signin_approved"],
-                timeout=hf_signin_timeout,
+    # On S21, the conversation model (E-2B) auto-queues immediately, giving
+    # initial_state "Preparing". But the embedding models (isGated=true) show
+    # a HF sign-in dialog simultaneously. We must dismiss or tap it.
+    #
+    # Run on every non-Ready path — UIAutomator checks are ~2s and cheap.
+    signin_tapped = False
+    if _uiautomator_has_text("Sign in to Hugging Face"):
+        signin_tapped = _uiautomator_tap_text("Sign in")
+        _print("  [readiness] Tapped HF sign-in button (dialog)")
+    elif _uiautomator_has_text("Sign in"):
+        signin_tapped = _uiautomator_tap_text("Sign in")
+        _print("  [readiness] Tapped HF sign-in button")
+    if signin_tapped:
+        evidence.hf_signin_clicked = True
+        _print("  [readiness] Waiting for HF sign-in approval …")
+        signin_seen = _poll_logcat_until(
+            ["hf_signin_approved"],
+            timeout=hf_signin_timeout,
+        )
+        if signin_seen.get("hf_signin_approved"):
+            evidence.logcat_markers["hf_signin_approved"] = True
+            _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
+            gated_seen = _poll_logcat_until(
+                ["auto_queue_seen", "enqueue_seen"],
+                timeout=30.0,
             )
-            if signin_seen.get("hf_signin_approved"):
-                evidence.logcat_markers["hf_signin_approved"] = True
-                _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
-                gated_seen = _poll_logcat_until(
-                    ["auto_queue_seen", "enqueue_seen"],
-                    timeout=30.0,
-                )
-                if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
-                    evidence.download_triggered = True
-                    _print("  [readiness] Gated model downloads enqueued after sign-in")
-            else:
-                _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
+            if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
+                evidence.download_triggered = True
+                _print("  [readiness] Gated model downloads enqueued after sign-in")
         else:
-            _print("  [readiness] ⚠️  Could not find sign-in button to tap")
+            _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
     else:
         _print("  [readiness] No HF sign-in dialog detected")
 

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -36,6 +36,11 @@ from adb_harness.config import (
     PROFILE_WAIT_SECONDS,
     REPORTS_DIR,
 )
+from adb_harness.model_readiness import (
+    preflight_model_readiness,
+    ModelReadinessEvidence,
+    EXIT_MODEL_NOT_READY,
+)
 from adb_harness.device import (
     _keep_foreground_until_inference_starts,
     capture_fresh_logcat,
@@ -409,13 +414,11 @@ def run_llm_tools(dry_run: bool = False) -> int:
     report_path = save_llm_tools_report(results, elapsed=0, partial=False, run_ts=run_ts)
     print(f"  Report saved → {report_path}")
 
-    return 1 if failures > 0 else 0
-
-
 def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | None = None,
               phases: list[str] | None = None, categories: list[str] | None = None,
               tags: list[str] | None = None, exclude_tags: list[str] | None = None,
-              case_ids: list[str] | None = None) -> int:
+              case_ids: list[str] | None = None, model_readiness: bool = False) -> int:
+
     """Execute all test cases. Returns non-zero on failures."""
 
     if dry_run:
@@ -525,6 +528,30 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
 
     # Start host-side logcat streaming (#1102) — avoids S21 buffer rotation failures.
     logcat_start()
+
+    # ── Model readiness preflight (--model-readiness) ──────────────
+    # After a fresh install the required conversation model may not yet be
+    # downloaded. The preflight handles download wait, HuggingFace sign-in,
+    # and engine initialisation.  Fails fast with MODEL_NOT_READY (44) so
+    # the caller can distinguish setup failure from product failure.
+    if model_readiness:
+        print()
+        print("  ── Model readiness preflight ──")
+        evidence = preflight_model_readiness(verbose=True)
+        if evidence.failure_bucket:
+            print(f"  [preflight] ❌ ABORT: {evidence.failure_bucket}")
+            print(f"  [preflight]    Model readiness failed after {evidence.readiness_wait_seconds:.0f}s")
+            print(f"  [preflight]    Initial state was: {evidence.initial_state}")
+            print(f"  [preflight]    Evidence: {evidence.to_dict()}")
+            stop_keepalive()
+            run_adb("shell", "svc", "power", "stayon", "false")
+            run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
+            return EXIT_MODEL_NOT_READY
+        print(f"  [preflight] ✅ Model ready ({evidence.readiness_wait_seconds:.0f}s)")
+        print(f"  [preflight]    Initial state: {evidence.initial_state}")
+        print(f"  [preflight]    Download triggered: {evidence.download_triggered}")
+        print(f"  [preflight]    HF sign-in shown: {evidence.hf_signin_shown}")
+        print()
 
     print("=" * 70)
     print("  ADB SKILL REGRESSION TEST")

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -97,6 +97,11 @@ Reports dir: {REPORTS_DIR}
         default=None,
         help="Run only specific test case IDs (comma-separated)",
     )
+    parser.add_argument(
+        "--model-readiness",
+        action="store_true",
+        help="Run model readiness preflight before tests (handles download, HF sign-in, engine init)",
+    )
 
     args = parser.parse_args()
 
@@ -123,6 +128,7 @@ Reports dir: {REPORTS_DIR}
             tags=tags_list,
             exclude_tags=exclude_tags_list,
             case_ids=case_ids_list,
+            model_readiness=args.model_readiness,
         ))
 
 

--- a/scripts/tests/test_model_readiness.py
+++ b/scripts/tests/test_model_readiness.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Tests for model_readiness.py — model readiness preflight.
+
+Covers:
+- Evidence record serialisation
+- Logcat marker detection (_find_markers)
+- Preflight state machine with mocked ADB functions
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import itertools
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from adb_harness.model_readiness import (
+    ModelReadinessEvidence,
+    _find_markers,
+    _Marker,
+    _MARKERS,
+    preflight_model_readiness,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Evidence record tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class ModelReadinessEvidenceTest(unittest.TestCase):
+    """Evidence record serialisation."""
+
+    def test_default_evidence_fields(self) -> None:
+        """Default evidence has expected required_model and model_file."""
+        e = ModelReadinessEvidence(device_serial="test_serial")
+        self.assertEqual(e.device_serial, "test_serial")
+        self.assertEqual(e.required_model, "Gemma 4 E-2B")
+        self.assertEqual(e.model_file, "gemma-4-E2B-it.litertlm")
+
+    def test_to_dict_contains_all_fields(self) -> None:
+        """to_dict() returns a dict with all expected keys."""
+        e = ModelReadinessEvidence(
+            device_serial="test_serial",
+            initial_state="Preparing",
+            hf_signin_shown=True,
+            hf_signin_clicked=True,
+            download_triggered=True,
+            readiness_wait_seconds=123.4,
+            final_state="Ready",
+            failure_bucket=None,
+            logcat_markers={"engine_ready": True},
+        )
+        d = e.to_dict()
+        self.assertEqual(d["device_serial"], "test_serial")
+        self.assertEqual(d["initial_state"], "Preparing")
+        self.assertEqual(d["hf_signin_shown"], True)
+        self.assertEqual(d["hf_signin_clicked"], True)
+        self.assertEqual(d["download_triggered"], True)
+        self.assertEqual(d["readiness_wait_seconds"], 123.4)
+        self.assertEqual(d["final_state"], "Ready")
+        self.assertIsNone(d["failure_bucket"])
+        self.assertEqual(d["logcat_markers"]["engine_ready"], True)
+
+    def test_to_dict_rounds_readiness_wait(self) -> None:
+        """readiness_wait_seconds is rounded to 1 decimal."""
+        e = ModelReadinessEvidence(
+            device_serial="s",
+            readiness_wait_seconds=45.6789,
+        )
+        self.assertEqual(e.to_dict()["readiness_wait_seconds"], 45.7)
+
+    def test_to_dict_failure_bucket_present(self) -> None:
+        """failure_bucket is serialised when set."""
+        e = ModelReadinessEvidence(
+            device_serial="s",
+            failure_bucket="MODEL_NOT_READY",
+        )
+        self.assertEqual(e.to_dict()["failure_bucket"], "MODEL_NOT_READY")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Marker detection tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class FindMarkersTest(unittest.TestCase):
+    """Logcat marker detection (_find_markers)."""
+
+    def setUp(self) -> None:
+        self.test_markers = [
+            _Marker("download_completed", r"Download succeeded:"),
+            _Marker("engine_ready", r"Engine ready — backend:"),
+            _Marker("hf_signin", r"Sign in to HuggingFace"),
+        ]
+
+    def test_find_marker_single_match(self) -> None:
+        """Single matching marker is found."""
+        text = "Some log output\nDownload succeeded: /path/to/model\nmore logs"
+        result = _find_markers(text, self.test_markers)
+        self.assertTrue(result["download_completed"])
+        self.assertFalse(result["engine_ready"])
+        self.assertFalse(result["hf_signin"])
+
+    def test_find_marker_multiple_match(self) -> None:
+        """Multiple markers can be found in the same text."""
+        text = (
+            "Engine ready — backend: GPU\n"
+            "Download succeeded: /path\n"
+            "Sign in to HuggingFace"
+        )
+        result = _find_markers(text, self.test_markers)
+        self.assertTrue(result["download_completed"])
+        self.assertTrue(result["engine_ready"])
+        self.assertTrue(result["hf_signin"])
+
+    def test_find_marker_no_match(self) -> None:
+        """No markers found in unrelated text."""
+        text = "Some unrelated logcat output"
+        result = _find_markers(text, self.test_markers)
+        for v in result.values():
+            self.assertFalse(v)
+
+    def test_find_marker_empty_text(self) -> None:
+        """Empty text produces no matches."""
+        result = _find_markers("", self.test_markers)
+        for v in result.values():
+            self.assertFalse(v)
+
+    def test_find_marker_case_sensitive_by_default(self) -> None:
+        """Default _Marker patterns are case-sensitive."""
+        text = "engine ready — backend: gpu"
+        result = _find_markers(text, self.test_markers)
+        self.assertFalse(result["engine_ready"])
+
+    def test_matches_actual_markers_auto_queue(self) -> None:
+        """_MARKERS[auto_queue_seen] matches the app's actual logcat output."""
+        text = "Auto-queuing required model: Gemma 4 E-2B"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("auto_queue_seen"))
+
+    def test_matches_actual_markers_downloaded(self) -> None:
+        """_MARKERS[download_completed] matches the app's actual log output."""
+        text = "Refreshed state for Gemma 4 E-2B: Downloaded(/path/to/model)"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("download_completed"))
+
+    def test_matches_actual_markers_engine_ready(self) -> None:
+        """_MARKERS[engine_ready] matches the app's actual log output."""
+        text = "Engine ready — backend: GPU, maxTokens: 2048"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("engine_ready"))
+
+    def test_matches_actual_markers_download_failed(self) -> None:
+        """_MARKERS[download_failed] matches the app's actual log output."""
+        text = "Download failed for Gemma 4 E-2B: Network error"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("download_failed"))
+
+    def test_matches_actual_markers_gated_no_token(self) -> None:
+        """_MARKERS[hf_token_missing] matches the app's actual log output."""
+        text = "EmbeddingGemma 300M is gated but no HF token available"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("hf_token_missing"))
+
+    def test_matches_actual_markers_hf_signin_approved(self) -> None:
+        """_MARKERS[hf_signin_approved] matches the app's actual log output."""
+        text = "Set gemma_4_e2b → APPROVED"
+        result = _find_markers(text, _MARKERS)
+        self.assertTrue(result.get("hf_signin_approved"))
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Preflight state machine tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class PreflightStateMachineTest(unittest.TestCase):
+    """Preflight logic with mocked ADB.
+
+    Tests focus on the state-machine transitions and evidence output.
+    """
+
+    def setUp(self) -> None:
+        self.patches = [
+            patch("adb_harness.model_readiness.logcat_start"),
+            patch("adb_harness.model_readiness.clear_logcat"),
+            patch("adb_harness.model_readiness.run_adb"),
+            patch("adb_harness.model_readiness.time.sleep"),
+        ]
+        for p in self.patches:
+            p.start()
+
+    def tearDown(self) -> None:
+        for p in self.patches:
+            p.stop()
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_fast_path_already_ready(self, mock_read: MagicMock) -> None:
+        """Preflight completes quickly when model is already Ready."""
+        mock_read.return_value = "Engine ready — backend: GPU\nInit complete"
+        evidence = preflight_model_readiness(verbose=False)
+        self.assertEqual(evidence.initial_state, "Ready")
+        self.assertEqual(evidence.final_state, "Ready")
+        self.assertIsNone(evidence.failure_bucket)
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_timeout_no_download(self, mock_read: MagicMock) -> None:
+        """Preflight fails with MODEL_NOT_READY when no download starts."""
+        mock_read.return_value = ""
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=1.0, timeout_engine=1.0,
+        )
+        self.assertEqual(evidence.failure_bucket, "MODEL_NOT_READY")
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_download_started_but_timed_out(self, mock_read: MagicMock) -> None:
+        """Preflight fails with MODEL_DOWNLOAD_TIMEOUT when download started but didn't finish."""
+        mock_read.return_value = "Enqueuing download for Gemma 4 E-2B"
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=0.5, timeout_engine=0.5,
+        )
+        self.assertEqual(evidence.failure_bucket, "MODEL_DOWNLOAD_TIMEOUT")
+        self.assertTrue(evidence.download_triggered)
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_download_failed(self, mock_read: MagicMock) -> None:
+        """Preflight fails with MODEL_DOWNLOAD_FAILED on download error."""
+        mock_read.return_value = "Download failed for Gemma 4 E-2B: Network error"
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=1.0, timeout_engine=1.0,
+        )
+        self.assertEqual(evidence.failure_bucket, "MODEL_DOWNLOAD_FAILED")
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_full_success_path(self, mock_read: MagicMock) -> None:
+        """Preflight succeeds through the full download + engine init flow."""
+        mock_read.side_effect = itertools.cycle([
+            "",
+            "Auto-queuing required model: Gemma 4 E-2B",
+            "Refreshed state for Gemma 4 E-2B: Downloaded(/path/model)",
+            "Engine ready — backend: GPU",
+        ])
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=30.0, timeout_engine=30.0,
+        )
+        self.assertEqual(evidence.final_state, "Ready")
+        self.assertIsNone(evidence.failure_bucket)
+        self.assertTrue(evidence.download_triggered)
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    @patch("adb_harness.model_readiness._uiautomator_has_text", return_value=False)
+    @patch("adb_harness.model_readiness._uiautomator_tap_text", return_value=False)
+    def test_hf_signin_needed_but_not_in_ui(
+        self, mock_tap: MagicMock, mock_has: MagicMock, mock_read: MagicMock,
+    ) -> None:
+        """Initial state detected as ActionRequired even without UI button."""
+        mock_read.return_value = "EmbeddingGemma 300M is gated but no HF token available"
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=1.0, timeout_engine=1.0,
+        )
+        self.assertEqual(evidence.initial_state, "ActionRequired(SignInRequired)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_model_readiness.py
+++ b/scripts/tests/test_model_readiness.py
@@ -4,11 +4,13 @@
 Covers:
 - Evidence record serialisation
 - Logcat marker detection (_find_markers)
+- Serial resolution from env vars
 - Preflight state machine with mocked ADB functions
 """
 
 from __future__ import annotations
 
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -27,6 +29,68 @@ from adb_harness.model_readiness import (
     _MARKERS,
     preflight_model_readiness,
 )
+from adb_harness.device import build_adb_cmd
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Serial resolution tests (build_adb_cmd)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class BuildAdbCmdTest(unittest.TestCase):
+    """Serial resolution from env vars is dynamic."""
+
+    def setUp(self) -> None:
+        self._saved_android = os.environ.pop("ANDROID_SERIAL", None)
+        self._saved_adb = os.environ.pop("ADB_SERIAL", None)
+
+    def tearDown(self) -> None:
+        for key, val in [("ANDROID_SERIAL", self._saved_android),
+                         ("ADB_SERIAL", self._saved_adb)]:
+            if val is not None:
+                os.environ[key] = val
+            else:
+                os.environ.pop(key, None)
+
+    def test_no_serial_when_no_env_var(self) -> None:
+        """No -s flag when neither env var is set."""
+        cmd = build_adb_cmd("shell", "echo", "hello")
+        self.assertNotIn("-s", cmd)
+        self.assertEqual(cmd[-3:], ["shell", "echo", "hello"])
+
+    def test_serial_from_android_serial(self) -> None:
+        """ANDROID_SERIAL produces `-s <serial>` in the command."""
+        os.environ["ANDROID_SERIAL"] = "R5CR605B71K"
+        cmd = build_adb_cmd("logcat", "-c")
+        self.assertIn("-s", cmd)
+        s_idx = cmd.index("-s")
+        self.assertEqual(cmd[s_idx + 1], "R5CR605B71K")
+
+    def test_serial_from_adb_serial(self) -> None:
+        """ADB_SERIAL produces `-s <serial>` when ANDROID_SERIAL is absent."""
+        os.environ["ADB_SERIAL"] = "FOOBAR123"
+        cmd = build_adb_cmd("shell", "ls")
+        self.assertIn("-s", cmd)
+        s_idx = cmd.index("-s")
+        self.assertEqual(cmd[s_idx + 1], "FOOBAR123")
+
+    def test_android_serial_takes_precedence(self) -> None:
+        """ANDROID_SERIAL is preferred over ADB_SERIAL when both are set."""
+        os.environ["ANDROID_SERIAL"] = "R5CR605B71K"
+        os.environ["ADB_SERIAL"] = "OTHER_DEVICE"
+        cmd = build_adb_cmd("version")
+        s_idx = cmd.index("-s")
+        self.assertEqual(cmd[s_idx + 1], "R5CR605B71K")
+
+    def test_set_env_before_call(self) -> None:
+        """Setting ANDROID_SERIAL between calls changes the target."""
+        cmd1 = build_adb_cmd("version")
+        self.assertNotIn("-s", cmd1)
+        os.environ["ANDROID_SERIAL"] = "DYNAMIC"
+        cmd2 = build_adb_cmd("version")
+        self.assertIn("-s", cmd2)
+        s_idx = cmd2.index("-s")
+        self.assertEqual(cmd2[s_idx + 1], "DYNAMIC")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -177,6 +241,28 @@ class FindMarkersTest(unittest.TestCase):
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# Fake clock for deterministic timeout tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _FakeClock:
+    """Fake clock used in place of ``time.time`` / ``time.sleep``.
+
+    ``sleep(N)`` advances the clock by N seconds so deadline-based loops
+    terminate deterministically in unit tests.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def sleep(self, secs: float) -> None:
+        self._now += secs
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # Preflight state machine tests
 # ═══════════════════════════════════════════════════════════════════════
 
@@ -184,15 +270,20 @@ class FindMarkersTest(unittest.TestCase):
 class PreflightStateMachineTest(unittest.TestCase):
     """Preflight logic with mocked ADB.
 
-    Tests focus on the state-machine transitions and evidence output.
+    Uses ``_FakeClock`` for ``time.time`` / ``time.sleep`` so that
+    polling loops with deadlines terminate deterministically.
     """
 
     def setUp(self) -> None:
+        self._clock = _FakeClock()
         self.patches = [
             patch("adb_harness.model_readiness.logcat_start"),
             patch("adb_harness.model_readiness.clear_logcat"),
             patch("adb_harness.model_readiness.run_adb"),
-            patch("adb_harness.model_readiness.time.sleep"),
+            patch("adb_harness.model_readiness.time.time", side_effect=self._clock.time),
+            patch("adb_harness.model_readiness.time.sleep", side_effect=self._clock.sleep),
+            patch("adb_harness.model_readiness._uiautomator_has_text", return_value=False),
+            patch("adb_harness.model_readiness._uiautomator_tap_text", return_value=False),
         ]
         for p in self.patches:
             p.start()
@@ -201,46 +292,91 @@ class PreflightStateMachineTest(unittest.TestCase):
         for p in self.patches:
             p.stop()
 
+    # ── Engine-already-ready (true fast path) ─────────────────────
+
     @patch("adb_harness.model_readiness._read_fresh_logcat")
-    def test_fast_path_already_ready(self, mock_read: MagicMock) -> None:
-        """Preflight completes quickly when model is already Ready."""
+    def test_engine_already_ready(self, mock_read: MagicMock) -> None:
+        """Fast path: engine_ready marker in logcat → immediate success."""
         mock_read.return_value = "Engine ready — backend: GPU\nInit complete"
         evidence = preflight_model_readiness(verbose=False)
         self.assertEqual(evidence.initial_state, "Ready")
         self.assertEqual(evidence.final_state, "Ready")
         self.assertIsNone(evidence.failure_bucket)
+        self.assertIn("engine_already_ready", evidence.logcat_markers)
 
+    # ── Model-on-disk scenarios ───────────────────────────────────
+
+    @patch("adb_harness.model_readiness._check_model_on_disk", return_value=True)
     @patch("adb_harness.model_readiness._read_fresh_logcat")
-    def test_timeout_no_download(self, mock_read: MagicMock) -> None:
-        """Preflight fails with MODEL_NOT_READY when no download starts."""
+    def test_model_on_disk_with_engine(
+        self, mock_read: MagicMock, mock_disk: MagicMock,
+    ) -> None:
+        """Model on disk + engine_ready marker → success."""
+        mock_read.return_value = "Engine ready — backend: GPU"
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=5.0, timeout_engine=5.0,
+        )
+        self.assertEqual(evidence.initial_state, "Downloaded")
+        self.assertEqual(evidence.final_state, "Ready")
+        self.assertIsNone(evidence.failure_bucket)
+        self.assertIn("model_on_disk", evidence.logcat_markers)
+
+    @patch("adb_harness.model_readiness._check_model_on_disk", return_value=True)
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_model_on_disk_without_engine(
+        self, mock_read: MagicMock, mock_disk: MagicMock,
+    ) -> None:
+        """Model on disk but no engine_ready → ENGINE_NOT_READY."""
         mock_read.return_value = ""
         evidence = preflight_model_readiness(
-            verbose=False, timeout_download=1.0, timeout_engine=1.0,
+            verbose=False, timeout_download=1.0, timeout_engine=0.5,
+        )
+        self.assertEqual(evidence.initial_state, "Downloaded")
+        self.assertEqual(evidence.failure_bucket, "ENGINE_NOT_READY")
+        self.assertIsNone(evidence.final_state)
+        self.assertIn("model_on_disk", evidence.logcat_markers)
+
+    # ── Timeout scenarios ─────────────────────────────────────────
+
+    @patch("adb_harness.model_readiness._check_model_on_disk", return_value=False)
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_timeout_no_download(
+        self, mock_read: MagicMock, mock_disk: MagicMock,
+    ) -> None:
+        """No download markers → MODEL_NOT_READY after timeout."""
+        mock_read.return_value = ""
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=10.0, timeout_engine=10.0,
         )
         self.assertEqual(evidence.failure_bucket, "MODEL_NOT_READY")
 
+    @patch("adb_harness.model_readiness._check_model_on_disk", return_value=False)
     @patch("adb_harness.model_readiness._read_fresh_logcat")
-    def test_download_started_but_timed_out(self, mock_read: MagicMock) -> None:
-        """Preflight fails with MODEL_DOWNLOAD_TIMEOUT when download started but didn't finish."""
+    def test_download_started_but_timed_out(
+        self, mock_read: MagicMock, mock_disk: MagicMock,
+    ) -> None:
+        """Enqueue seen but download never finishes → MODEL_DOWNLOAD_TIMEOUT."""
         mock_read.return_value = "Enqueuing download for Gemma 4 E-2B"
         evidence = preflight_model_readiness(
-            verbose=False, timeout_download=0.5, timeout_engine=0.5,
+            verbose=False, timeout_download=10.0, timeout_engine=10.0,
         )
         self.assertEqual(evidence.failure_bucket, "MODEL_DOWNLOAD_TIMEOUT")
         self.assertTrue(evidence.download_triggered)
 
     @patch("adb_harness.model_readiness._read_fresh_logcat")
     def test_download_failed(self, mock_read: MagicMock) -> None:
-        """Preflight fails with MODEL_DOWNLOAD_FAILED on download error."""
+        """Download failed marker → MODEL_DOWNLOAD_FAILED."""
         mock_read.return_value = "Download failed for Gemma 4 E-2B: Network error"
         evidence = preflight_model_readiness(
             verbose=False, timeout_download=1.0, timeout_engine=1.0,
         )
         self.assertEqual(evidence.failure_bucket, "MODEL_DOWNLOAD_FAILED")
 
+    # ── Full success path (fresh download) ────────────────────────
+
     @patch("adb_harness.model_readiness._read_fresh_logcat")
     def test_full_success_path(self, mock_read: MagicMock) -> None:
-        """Preflight succeeds through the full download + engine init flow."""
+        """Download + engine init full flow succeeds."""
         mock_read.side_effect = itertools.cycle([
             "",
             "Auto-queuing required model: Gemma 4 E-2B",
@@ -254,13 +390,13 @@ class PreflightStateMachineTest(unittest.TestCase):
         self.assertIsNone(evidence.failure_bucket)
         self.assertTrue(evidence.download_triggered)
 
+    # ── HF sign-in ────────────────────────────────────────────────
+
     @patch("adb_harness.model_readiness._read_fresh_logcat")
-    @patch("adb_harness.model_readiness._uiautomator_has_text", return_value=False)
-    @patch("adb_harness.model_readiness._uiautomator_tap_text", return_value=False)
     def test_hf_signin_needed_but_not_in_ui(
-        self, mock_tap: MagicMock, mock_has: MagicMock, mock_read: MagicMock,
+        self, mock_read: MagicMock,
     ) -> None:
-        """Initial state detected as ActionRequired even without UI button."""
+        """hf_token_missing detected → ActionRequired state."""
         mock_read.return_value = "EmbeddingGemma 300M is gated but no HF token available"
         evidence = preflight_model_readiness(
             verbose=False, timeout_download=1.0, timeout_engine=1.0,


### PR DESCRIPTION
## Summary

Adds a deterministic S21 model-readiness preflight for ADB/device test runs after clean reinstall. The preflight verifies the required conversation model is downloaded and the LiteRT inference engine is initialised before executing tests — eliminating false failures from a fresh install not yet having the model.

Also fixes the production engine init to not block on gated embedding models when the user has no HuggingFace token.

Closes #1245

## Changes

### New file: `scripts/adb_harness/model_readiness.py`

- `preflight_model_readiness()` — state-machine continuous poll over logcat markers with structured evidence record (`ModelReadinessEvidence` JSON-serialisable) and failure buckets
- Standalone CLI: `python -m adb_harness.model_readiness [--serial SERIAL] [--json] [--unlock-pin PIN] [--timeout-download N] [--timeout-engine N]`
- Integrated into test harness via `--model-readiness` flag in `adb_skill_test.py`

### Fix: `ModelDownloadManager.areRequiredModelsDownloaded()` (core/inference)

**Before:** All `isRequired=true` models blocked engine init. On S21, `EmbeddingGemma 300M` and `SentencePiece` are gated (`isGated=true`, `isRequired=true`) but never download without HF auth → engine permanently blocked after fresh install.

**After:** Gated models are excluded from the "required" check when `authRepository.isAuthenticated` is false. The conversation model (Gemma-4 E-2B) functions without embedding — embedding is only needed for RAG/vector search.

### Fix: Dynamic serial resolution (devices.py)

`build_adb_cmd()` now resolves the target device serial from `os.environ` at call time, not at import time. `--serial R5CR605B71K` reliably produces `adb -s R5CR605B71K <cmd>`.

### Fix: Phase 2 HF sign-in runs for all non-Ready states

On S21 the initial state is "Preparing" (E-2B auto-queues first in marker priority), but the HF dialog for gated models simultaneously appears. Phase 2 now runs for all non-Ready states, not just ActionRequired.

## Preflight phases

| Phase | Action |
|-------|--------|
| Unlock | PIN unlock via `--unlock-pin` (swipe-to-unlock fallback) |
| Permissions | `pm grant` POST_NOTIFICATIONS + UIAutomator fallback for remaining dialog |
| Launch | `am start` app |
| Trigger | Chat message intent to activate model-readiness flow |
| Phase 1 | Detect initial model state from logcat: `Ready` / `Downloaded` / `Preparing` / `ActionRequired` |
| Phase 2 | HF sign-in dialog → tap "Sign in" (runs on all non-Ready paths) |
| Phase 3+4 | Continuous poll for download completion + engine ready (concurrent) |

## Failure buckets

| Code | Meaning |
|------|---------|
| `MODEL_NOT_READY` | Download never started |
| `MODEL_DOWNLOAD_FAILED` | Worker reported failure |
| `MODEL_DOWNLOAD_TIMEOUT` | Download didn't complete within timeout |
| `ENGINE_NOT_READY` | LiteRT engine didn't init after download |
| `ENGINE_BLOCKED_BY_KEYGUARD` | Lock screen prevents engine init |

## Device evidence — S21 (SM-G991B, Android 15, serial `R5CR605B71K`)

### Fresh install → model ready ✅ (220s)
```
adb -s R5CR605B71K uninstall com.kernel.ai.debug
adb -s R5CR605B71K install app/build/outputs/apk/debug/app-debug.apk
ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness --unlock-pin <PIN> --timeout-download 480 --timeout-engine 120 --json
```
```json
{
  "device_serial": "R5CR605B71K",
  "initial_state": "Preparing",
  "hf_signin_clicked": true,
  "download_triggered": true,
  "readiness_wait_seconds": 220.2,
  "final_state": "Ready",
  "failure_bucket": null,
  "logcat_markers": {
    "auto_queue_seen": true,
    "download_completed": true,
    "engine_ready": true
  }
}
```

### Fast path (engine already ready) → 3s
```json
{
  "device_serial": "R5CR605B71K",
  "initial_state": "Ready",
  "final_state": "Ready",
  "readiness_wait_seconds": 3.2,
  "failure_bucket": null
}
```

### Device connectivity
```
$ adb devices -l
R5CR605B71K            device usb:1-3 product:o1sxxx model:SM_G991B device:o1s
```

## Unit tests — 28 pass

```
$ python3 -m unittest tests.test_model_readiness -v
...
----------------------------------------------------------------------
Ran 28 tests in 0.338s
OK
```

| Test | Verifies |
|------|---------|
| `BuildAdbCmdTest` (5 tests) | Dynamic serial resolution from env vars |
| `test_engine_already_ready` | Engine marker → immediate Ready |
| `test_model_on_disk_with_engine` | File + engine → success |
| `test_model_on_disk_without_engine` | File without engine → ENGINE_NOT_READY |
| `test_full_success_path` | Download + engine full flow |
| `test_download_failed` | Download error → MODEL_DOWNLOAD_FAILED |
| `test_hf_signin_needed_but_not_in_ui` | hf_token_missing → ActionRequired state |

## Review notes

- **Do not merge** — opened for review only per issue instructions
- `areRequiredModelsDownloaded()` change is tightly scoped: excludes gated models only when not authenticated, preserving all existing download management and UI behavior
- Does not bake model files into the APK
- Does not fake readiness
- S21-first: targets Gemma-4 E-2B (S21-appropriate model), not E-4B