### PR TITLE
fix: post-merge remediation for S21 model-readiness preflight + review blocker fixes

### DIFF
--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -265,17 +265,17 @@ class ModelDownloadManager @Inject constructor(
             else -> KernelModel.GEMMA_4_E2B.isDownloaded(context)
         }
         // All other required models must be present (e.g. SentencePiece tokenizer).
-        // Gated models (EmbeddingGemma, SentencePiece, etc.) are skipped when
-        // unauthenticated because they are non-conversation dependencies used
-        // for RAG/vector search, not for conversation engine init.
-        // SAFETY: this skip-by-gated-status is correct ONLY as long as ALL gated
-        // required models are non-conversation dependencies. If a new gated model
-        // is needed for conversation init, add it to an explicit separate check
-        // that does not depend on auth status.
+        // Explicit allowlist of gated required models known to be non-conversation
+        // dependencies (RAG/vector search only). Only these may be skipped when
+        // HuggingFace authentication is missing.
+        val gatedNonConversationModels = setOf(
+            KernelModel.EMBEDDING_GEMMA_300M,   // RAG embeddings
+            KernelModel.EMBEDDING_GEMMA_SP_MODEL, // SentencePiece tokenizer
+        )
         val isHfAuthenticated = authRepository.isAuthenticated.value
         val otherRequiredReady = KernelModel.entries
             .filter { it.isRequired && it != KernelModel.GEMMA_4_E2B }
-            .filterNot { it.isGated && !isHfAuthenticated }
+            .filterNot { it in gatedNonConversationModels && !isHfAuthenticated }
             .all { it.isDownloaded(context) }
         return conversationModelReady && otherRequiredReady
     }

--- a/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
+++ b/core/inference/src/main/java/com/kernel/ai/core/inference/download/ModelDownloadManager.kt
@@ -264,11 +264,14 @@ class ModelDownloadManager @Inject constructor(
                 KernelModel.GEMMA_4_E2B.isDownloaded(context)
             else -> KernelModel.GEMMA_4_E2B.isDownloaded(context)
         }
-        // All other required models must be present
-        // All other required models must be present.
-        // Exclude gated models when the user hasn't authenticated —
-        // they are required for RAG/vector search but not for the
-        // conversation engine to initialise and run.
+        // All other required models must be present (e.g. SentencePiece tokenizer).
+        // Gated models (EmbeddingGemma, SentencePiece, etc.) are skipped when
+        // unauthenticated because they are non-conversation dependencies used
+        // for RAG/vector search, not for conversation engine init.
+        // SAFETY: this skip-by-gated-status is correct ONLY as long as ALL gated
+        // required models are non-conversation dependencies. If a new gated model
+        // is needed for conversation init, add it to an explicit separate check
+        // that does not depend on auth status.
         val isHfAuthenticated = authRepository.isAuthenticated.value
         val otherRequiredReady = KernelModel.entries
             .filter { it.isRequired && it != KernelModel.GEMMA_4_E2B }

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -9,6 +9,7 @@
 | [`docs/testing/test-evidence-schema.md`](./test-evidence-schema.md) | Normalised evidence schema, `ci` vs `on_device` definitions, field reference |
 | [`.docs/agents/test-evidence-workflow.md`](../../.docs/agents/test-evidence-workflow.md) | Agent guidance on evidence lifecycle — generation, reporting, publishing, dashboard |
 | [`docs/testing/llm-tools-harness.md`](./llm-tools-harness.md) | Deep reference for the `llm_tools` harness phase — markers, assertions, troubleshooting |
+| [`docs/testing/s21-model-readiness.md`](./s21-model-readiness.md) | S21 model readiness preflight — after reinstall, run this before accepting model-backed ADB evidence |
 
 ## Design / specification docs
 

--- a/docs/testing/s21-model-readiness.md
+++ b/docs/testing/s21-model-readiness.md
@@ -4,8 +4,8 @@ After a clean reinstall, the required conversation model (Gemma 4 E-2B) must be 
 
 ## Target
 
-- **Device:** S21 over USB ADB
-- **Model tier:** Gemma 4 E-2B (S21 launch-compatible)
+- **Device:** S21 over USB ADB (serial `R5CR605B71K`)
+- **Model tier:** Gemma 4 E-2B (S21 path — not S23U E4B)
 - **Model file:** `gemma-4-E2B-it.litertlm`
 
 ## Selecting the device
@@ -13,12 +13,31 @@ After a clean reinstall, the required conversation model (Gemma 4 E-2B) must be 
 Two equivalent ways:
 
 1. `ANDROID_SERIAL=R5CR605B71K` environment variable (preferred — works with any tool)
-2. `--serial R5CR605B71K` where supported (standalone module only)
+2. `--serial R5CR605B71K` where supported
 
-## Recommended standalone command
+## Integrated harness command (recommended)
+
+For full runs including model readiness preflight + ADB skill tests:
+
+```bash
+ANDROID_SERIAL=R5CR605B71K python3 scripts/adb_skill_test.py \
+  --model-readiness \
+  --serial R5CR605B71K \
+  --unlock-pin <PIN> \
+  --timeout-download 480 \
+  --timeout-engine 120 \
+  --case <MODEL_BACKED_SMOKE_CASE>
+```
+
+The `--model-readiness` flag runs the preflight before any tests. If it fails
+(exit 44), no tests execute — the report clearly distinguishes setup failure
+from product regression.
+
+## Standalone preflight (diagnostic only)
 
 ```bash
 ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
+  --serial R5CR605B71K \
   --unlock-pin <PIN> \
   --timeout-download 480 \
   --timeout-engine 120 \
@@ -30,7 +49,7 @@ ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
 | Flag | Description |
 |------|-------------|
 | `--unlock-pin <PIN>` | Device unlock PIN to dismiss keyguard (required if device has PIN lock) |
-| `--timeout-download 480` | Max seconds to wait for model download (default 600; 480 is enough for S21 on USB) |
+| `--timeout-download 480` | Max seconds to wait for model download (default 360; 480 is enough for S21 on USB) |
 | `--timeout-engine 120` | Max seconds to wait for engine initialisation after download |
 | `--json` | Prints structured evidence record to stdout (use with `> evidence.json` to capture) |
 | `--serial` | Explicit device serial if `ANDROID_SERIAL` isn't set |
@@ -40,8 +59,25 @@ ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
 | Code | Meaning |
 |------|---------|
 | 0 | Model ready — `final_state=Ready`, `engine_ready=true` |
-| 44 | Model not ready (MODEL_NOT_READY bucket — download never started and model not present) |
+| 44 | Model not ready — see `failure_bucket` for detail |
 | 45 | Preflight crashed (unexpected error) |
+
+Bootstrapping failures (44-45) indicate a **setup/environment issue**, not a
+product regression. Treat them as environment health checks and resolve the
+underlying device or network state before retrying.
+
+## Required acceptance evidence
+
+Before merging PRs that touch model readiness logic, an agent must validate on
+a physical S21 (R5CR605B71K) over USB ADB and attach evidence showing:
+
+- Device is S21 (not S23U default — gated-model path differs)
+- Selected model is Gemma 4 E-2B (not E4B)
+- `final_state = Ready`
+- `failure_bucket = null`
+- `logcat_markers.engine_ready = true`
+- Model readiness evidence is present in the generated JSON report
+- At least one model-backed smoke test ran after readiness
 
 ## Evidence JSON structure (`--json`)
 
@@ -75,12 +111,27 @@ ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
 | `failure_bucket` | string \| null | Failure classification, or null on success |
 | `logcat_markers` | object | Detected logcat markers during preflight |
 
+## Failure bucket reference
+
+Model readiness bootstrap failure **is not a product regression**. These
+buckets indicate environment, network, or device state problems:
+
+| Bucket | Meaning |
+|--------|---------|
+| `MODEL_NOT_READY` | Download never started and model not present — verify app installed and network accessible |
+| `MODEL_DOWNLOAD_TIMEOUT` | Download started but didn't finish within timeout — check network speed and screen-on |
+| `MODEL_DOWNLOAD_FAILED` | Download worker errored — check logcat for error detail |
+| `ENGINE_NOT_READY` | Engine didn't init after download — try longer timeout |
+| `ENGINE_BLOCKED_BY_KEYGUARD` | Lock screen preventing engine init — use `--unlock-pin` |
+
 ## Typical workflow
 
 1. Reinstall the APK on the S21.
-2. Run the preflight with `--json` to capture evidence.
+2. Run the integrated harness with `--model-readiness` or standalone with `--json`.
 3. Check `final_state` is `Ready` and `failure_bucket` is `null`.
-4. Proceed with ADB test runs.
+4. Confirm model readiness evidence in generated report JSON.
+5. Confirm at least one model-backed smoke test ran after readiness.
+6. Proceed with ADB test runs.
 
 ## Troubleshooting
 
@@ -91,8 +142,14 @@ ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
 
 ### HF sign-in automation
 
-The preflight automatically taps "Sign in to Hugging Face" when the dialog appears.
-If the device is already signed in (browser session cached), the OAuth flow
-completes silently and the gated model download proceeds through the normal
-polling loop — no manual intervention needed. See
+The preflight automatically taps "Sign in to Hugging Face" when the dialog appears,
+then dismisses the dialog with Back so the device is left in a clean state.
+The OAuth flow proceeds in the background browser; if the device is already
+signed into HuggingFace (cached browser session), the gated models will
+auto-queue on the next app check. See
 [model_readiness.py](../../scripts/adb_harness/model_readiness.py) Phase 2 for details.
+
+This is a **best-effort** interaction. If no sign-in dialog is detected, the
+preflight proceeds directly to the download/engine polling loop — the main
+loop's timeout mechanisms (`MODEL_NOT_READY`, `MODEL_DOWNLOAD_TIMEOUT`,
+`ENGINE_NOT_READY`) catch stalled preflights.

--- a/docs/testing/s21-model-readiness.md
+++ b/docs/testing/s21-model-readiness.md
@@ -1,0 +1,89 @@
+# S21 Model Readiness Preflight
+
+After a clean reinstall, the required conversation model (Gemma 4 E-2B) must be downloaded and the inference engine initialised before ADB test evidence can be trusted. This preflight automates that bootstrap.
+
+## Target
+
+- **Device:** S21 over USB ADB
+- **Model tier:** Gemma 4 E-2B (S21 launch-compatible)
+- **Model file:** `gemma-4-E2B-it.litertlm`
+
+## Selecting the device
+
+Two equivalent ways:
+
+1. `ANDROID_SERIAL=R5CR605B71K` environment variable (preferred — works with any tool)
+2. `--serial R5CR605B71K` where supported (standalone module only)
+
+## Recommended standalone command
+
+```bash
+ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
+  --unlock-pin <PIN> \
+  --timeout-download 480 \
+  --timeout-engine 120 \
+  --json
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--unlock-pin <PIN>` | Device unlock PIN to dismiss keyguard (required if device has PIN lock) |
+| `--timeout-download 480` | Max seconds to wait for model download (default 600; 480 is enough for S21 on USB) |
+| `--timeout-engine 120` | Max seconds to wait for engine initialisation after download |
+| `--json` | Prints structured evidence record to stdout (use with `> evidence.json` to capture) |
+| `--serial` | Explicit device serial if `ANDROID_SERIAL` isn't set |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Model ready — `final_state=Ready`, `engine_ready=true` |
+| 44 | Model not ready (MODEL_NOT_READY bucket — download never started and model not present) |
+| 45 | Preflight crashed (unexpected error) |
+
+## Evidence JSON structure (`--json`)
+
+```json
+{
+  "device_serial": "R5CR605B71K",
+  "required_model": "Gemma 4 E-2B",
+  "model_file": "gemma-4-E2B-it.litertlm",
+  "initial_state": "<state>",
+  "hf_signin_shown": false,
+  "hf_signin_clicked": false,
+  "download_triggered": true,
+  "readiness_wait_seconds": 245.3,
+  "final_state": "Ready",
+  "failure_bucket": null,
+  "logcat_markers": {}
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `device_serial` | string | Target device serial number |
+| `required_model` | string | Expected model name (`Gemma 4 E-2B`) |
+| `model_file` | string | Expected model filename on device |
+| `initial_state` | string \| null | State detected before preflight began |
+| `hf_signin_shown` | bool | Whether a Hugging Face sign-in dialog was observed |
+| `hf_signin_clicked` | bool | Whether HF sign-in was clicked |
+| `download_triggered` | bool | Whether download was initiated |
+| `readiness_wait_seconds` | float | Time spent waiting for engine readiness |
+| `final_state` | string \| null | Final state of the preflight |
+| `failure_bucket` | string \| null | Failure classification, or null on success |
+| `logcat_markers` | object | Detected logcat markers during preflight |
+
+## Typical workflow
+
+1. Reinstall the APK on the S21.
+2. Run the preflight with `--json` to capture evidence.
+3. Check `final_state` is `Ready` and `failure_bucket` is `null`.
+4. Proceed with ADB test runs.
+
+## Troubleshooting
+
+- **`hf_signin_shown=true`** — The app is prompting for Hugging Face credentials. Enter them on the device before running the preflight, or dismiss the dialog manually.
+- **`timeout-download` too short** — The model download was interrupted. Increase the timeout for slow connections.
+- **`failure_bucket=MODEL_NOT_READY`** — The model file was never downloaded and the download path was not triggered. Verify the app is installed and the device has network access.

--- a/docs/testing/s21-model-readiness.md
+++ b/docs/testing/s21-model-readiness.md
@@ -36,13 +36,16 @@ from product regression.
 ## Standalone preflight (diagnostic only)
 
 ```bash
-ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
+PYTHONPATH=scripts ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
   --serial R5CR605B71K \
   --unlock-pin <PIN> \
   --timeout-download 480 \
   --timeout-engine 120 \
   --json
 ```
+
+> `PYTHONPATH=scripts` is required when running the module from repo root.
+> Alternatively, `cd scripts && python3 -m adb_harness.model_readiness ...`.
 
 ### Flags
 

--- a/docs/testing/s21-model-readiness.md
+++ b/docs/testing/s21-model-readiness.md
@@ -84,6 +84,15 @@ ANDROID_SERIAL=R5CR605B71K python3 -m adb_harness.model_readiness \
 
 ## Troubleshooting
 
-- **`hf_signin_shown=true`** — The app is prompting for Hugging Face credentials. Enter them on the device before running the preflight, or dismiss the dialog manually.
 - **`timeout-download` too short** — The model download was interrupted. Increase the timeout for slow connections.
 - **`failure_bucket=MODEL_NOT_READY`** — The model file was never downloaded and the download path was not triggered. Verify the app is installed and the device has network access.
+- **`failure_bucket=MODEL_DOWNLOAD_TIMEOUT`** — Download started but didn't finish. Check device network connectivity and power (screen-on recommended).
+- **`failure_bucket=ENGINE_NOT_READY` or `ENGINE_BLOCKED_BY_KEYGUARD`** — Engine init failed; try with `--unlock-pin` to keep device unlocked.
+
+### HF sign-in automation
+
+The preflight automatically taps "Sign in to Hugging Face" when the dialog appears.
+If the device is already signed in (browser session cached), the OAuth flow
+completes silently and the gated model download proceeds through the normal
+polling loop — no manual intervention needed. See
+[model_readiness.py](../../scripts/adb_harness/model_readiness.py) Phase 2 for details.

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -512,12 +512,13 @@ def preflight_model_readiness(
     # initial_state "Preparing". But the embedding models (isGated=true) show
     # a HF sign-in dialog simultaneously. We must dismiss or tap it.
     #
-    # Run on every non-Ready path — UIAutomator checks are ~2s and cheap.
     signin_tapped = False
     if _uiautomator_has_text("Sign in to Hugging Face"):
+        evidence.hf_signin_shown = True
         signin_tapped = _uiautomator_tap_text("Sign in")
         _print("  [readiness] Tapped HF sign-in button (dialog)")
     elif _uiautomator_has_text("Sign in"):
+        evidence.hf_signin_shown = True
         signin_tapped = _uiautomator_tap_text("Sign in")
         _print("  [readiness] Tapped HF sign-in button")
     if signin_tapped:
@@ -538,13 +539,11 @@ def preflight_model_readiness(
                 evidence.download_triggered = True
                 _print("  [readiness] Gated model downloads enqueued after sign-in")
         else:
-            _print("  [readiness] ⚠️  HF sign-in approval NOT detected within timeout")
-    else:
-        _print("  [readiness] No HF sign-in dialog detected")
-
-    # ── Phase 3+4 combined: Continuous poll for download + engine ──
-    # Deadline starts NOW (after Phase 1+2), not from start_ts — avoids
-    # the combined window being consumed by Phase 1's 30s initial detection.
+            evidence.failure_bucket = "HF_SIGNIN_FAILED"
+            _print("  [readiness] ❌ HF sign-in approval NOT detected within timeout — preflight aborting")
+            evidence.readiness_wait_seconds = time.time() - start_ts
+            clear_logcat()
+            return evidence
     phase34_start = time.time()
     # If the model is already on disk, skip the download wait
     download_matched = (evidence.initial_state == "Downloaded")

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -1,7 +1,7 @@
 """
 ADB Harness — Model Readiness Preflight.
 
-Deterministic S21 model-readiness check for ADB/device test runs after reinstall.
+Orchestrated S21 model-readiness check for ADB/device test runs after reinstall.
 Runs after a fresh install or clean reinstall and ensures the required conversation
 model is downloaded and the inference engine is ready before test execution begins.
 
@@ -18,6 +18,7 @@ Failure buckets:
   - ``MODEL_DOWNLOAD_FAILED`` — download worker errored
   - ``MODEL_DOWNLOAD_TIMEOUT`` — download started but did not finish within timeout
   - ``ENGINE_NOT_READY`` — engine did not initialise after download completed
+  - ``ENGINE_BLOCKED_BY_KEYGUARD`` — lock screen prevented engine initialisation
 """
 
 from __future__ import annotations
@@ -352,9 +353,8 @@ def _uiautomator_tap_text(target_text: str) -> bool:
 
 def preflight_model_readiness(
     serial: str | None = None,
-    timeout_download: float = 600.0,
+    timeout_download: float = 360.0,
     timeout_engine: float = 120.0,
-    hf_signin_timeout: float = 60.0,
     verbose: bool = True,
     unlock_pin: str | None = None,
 ) -> ModelReadinessEvidence:
@@ -377,15 +377,13 @@ def preflight_model_readiness(
     serial : str or None
         Device serial. Falls back to ``ANDROID_SERIAL`` / ``ADB_SERIAL`` env vars.
     timeout_download : float
-        Max seconds to wait for the model to finish downloading (default 600).
+        Max seconds to wait for model download (default 360).
     timeout_engine : float
         Max seconds to wait for the inference engine to init after download (default 120).
-    hf_signin_timeout : float
-        Reserved — no longer blocking. HF sign-in is tapped best-effort then
-        the main download/engine loop proceeds regardless. Kept for API
-        compatibility (default 60).
     verbose : bool
-        Print progress output.
+        Print progress lines (default True).
+    unlock_pin : str | None
+        Device PIN to dismiss keyguard before starting (default None).
 
     Returns
     -------

--- a/scripts/adb_harness/model_readiness.py
+++ b/scripts/adb_harness/model_readiness.py
@@ -18,7 +18,6 @@ Failure buckets:
   - ``MODEL_DOWNLOAD_FAILED`` — download worker errored
   - ``MODEL_DOWNLOAD_TIMEOUT`` — download started but did not finish within timeout
   - ``ENGINE_NOT_READY`` — engine did not initialise after download completed
-  - ``HF_SIGNIN_FAILED`` — HuggingFace sign-in UI shown but could not be completed
 """
 
 from __future__ import annotations
@@ -382,7 +381,9 @@ def preflight_model_readiness(
     timeout_engine : float
         Max seconds to wait for the inference engine to init after download (default 120).
     hf_signin_timeout : float
-        Max seconds to wait for HuggingFace sign-in flow to complete (default 60).
+        Reserved — no longer blocking. HF sign-in is tapped best-effort then
+        the main download/engine loop proceeds regardless. Kept for API
+        compatibility (default 60).
     verbose : bool
         Print progress output.
 
@@ -510,41 +511,49 @@ def preflight_model_readiness(
     # ── Phase 2: Handle HF sign-in dialog ────────────────────────────
     # On S21, the conversation model (E-2B) auto-queues immediately, giving
     # initial_state "Preparing". But the embedding models (isGated=true) show
-    # a HF sign-in dialog simultaneously. We must dismiss or tap it.
+    # a HF sign-in dialog listing each gated model with a "Sign in" button.
+    # We tap the dialog header to trigger the OAuth flow (opens browser in
+    # background), then dismiss the dialog with Back so the device is in a
+    # clean state. If the device is already signed into HuggingFace (cached
+    # browser session), the OAuth completes silently and the gated models
+    # will auto-queue on next app check.
+    #
+    # The main download/engine polling loop handles the rest; its timeout
+    # mechanisms (MODEL_NOT_READY, MODEL_DOWNLOAD_TIMEOUT, ENGINE_NOT_READY)
+    # catch a stalled preflight if sign-in truly failed.
     #
     signin_tapped = False
     if _uiautomator_has_text("Sign in to Hugging Face"):
         evidence.hf_signin_shown = True
-        signin_tapped = _uiautomator_tap_text("Sign in")
-        _print("  [readiness] Tapped HF sign-in button (dialog)")
+        # Tap the dialog header — this opens a browser tab for OAuth
+        signin_tapped = _uiautomator_tap_text("Sign in to Hugging Face")
+        _print("  [readiness] Tapped HF sign-in header")
+        # If the first tap missed, try the generic "Sign in" on the header area
+        if not signin_tapped:
+            signin_tapped = _uiautomator_tap_text("Sign in")
+            _print("  [readiness] Tapped HF sign-in (fallback)")
     elif _uiautomator_has_text("Sign in"):
         evidence.hf_signin_shown = True
         signin_tapped = _uiautomator_tap_text("Sign in")
-        _print("  [readiness] Tapped HF sign-in button")
+        _print("  [readiness] Tapped HF sign-in (generic)")
     if signin_tapped:
         evidence.hf_signin_clicked = True
-        _print("  [readiness] Waiting for HF sign-in approval …")
-        signin_seen = _poll_logcat_until(
-            ["hf_signin_approved"],
-            timeout=hf_signin_timeout,
-        )
-        if signin_seen.get("hf_signin_approved"):
-            evidence.logcat_markers["hf_signin_approved"] = True
-            _print("  [readiness] ✅ HF sign-in approved — awaiting gated model auto-queues")
-            gated_seen = _poll_logcat_until(
-                ["auto_queue_seen", "enqueue_seen"],
-                timeout=30.0,
-            )
-            if gated_seen.get("auto_queue_seen") or gated_seen.get("enqueue_seen"):
-                evidence.download_triggered = True
-                _print("  [readiness] Gated model downloads enqueued after sign-in")
+        # Give OAuth flow time to launch the browser tab
+        time.sleep(3)
+        # Dismiss the dialog so device is in a clean state.
+        # The browser handles OAuth in the background; completed redirect
+        # back to the app will pick up the auth token on next launch.
+        for attempt in range(3):
+            time.sleep(1)
+            run_adb("shell", "input", "keyevent", "KEYCODE_BACK")
+            if not _uiautomator_has_text("Sign in to Hugging Face"):
+                _print("  [readiness] ✅ HF sign-in dialog dismissed")
+                break
         else:
-            evidence.failure_bucket = "HF_SIGNIN_FAILED"
-            _print("  [readiness] ❌ HF sign-in approval NOT detected within timeout — preflight aborting")
-            evidence.readiness_wait_seconds = time.time() - start_ts
-            clear_logcat()
-            return evidence
-    phase34_start = time.time()
+            _print("  [readiness] ⚠ Could not dismiss HF sign-in dialog — continuing anyway")
+        phase34_start = time.time()
+    else:
+        phase34_start = time.time()
     # If the model is already on disk, skip the download wait
     download_matched = (evidence.initial_state == "Downloaded")
     if download_matched:

--- a/scripts/adb_harness/reporting.py
+++ b/scripts/adb_harness/reporting.py
@@ -87,6 +87,7 @@ def save_report(
     elapsed: float = 0.0,
     partial: bool = False,
     run_ts: str | None = None,
+    model_readiness_evidence: dict | None = None,
 ) -> Path:
     """Serialise results to a JSON file in scripts/test-reports/ and return the path.
 
@@ -135,6 +136,7 @@ def save_report(
             "xpass": xpasses,
             "failed": failures,
         },
+        "model_readiness_evidence": model_readiness_evidence,
         "results": [
             {
                 "index": r.index,

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -498,8 +498,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
               case_ids: list[str] | None = None, model_readiness: bool = False,
               serial: str | None = None, unlock_pin: str | None = None,
               timeout_download: float | None = None,
-              timeout_engine: float | None = None,
-              hf_signin_timeout: float | None = None) -> int:
+              timeout_engine: float | None = None) -> int:
 
     """Execute all test cases. Returns non-zero on failures."""
 
@@ -630,14 +629,11 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
             mr_kwargs["timeout_download"] = timeout_download
         if timeout_engine is not None:
             mr_kwargs["timeout_engine"] = timeout_engine
-        if hf_signin_timeout is not None:
-            mr_kwargs["hf_signin_timeout"] = hf_signin_timeout
         evidence = preflight_model_readiness(verbose=True, **mr_kwargs)
-        # Persist failure evidence before early return
-        _save_readiness_failure(evidence)
         model_readiness_evidence = evidence
-
         if evidence.failure_bucket:
+            # Persist failure evidence before early return
+            _save_readiness_failure(evidence)
             print(f"  [preflight] ❌ ABORT: {evidence.failure_bucket}")
             print(f"  [preflight]    Model readiness failed after {evidence.readiness_wait_seconds:.0f}s")
             print(f"  [preflight]    Initial state was: {evidence.initial_state}")
@@ -646,6 +642,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
             run_adb("shell", "svc", "power", "stayon", "false")
             run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
             return EXIT_MODEL_NOT_READY
+
         print(f"  [preflight] ✅ Model ready ({evidence.readiness_wait_seconds:.0f}s)")
         print(f"  [preflight]    Initial state: {evidence.initial_state}")
         print(f"  [preflight]    Download triggered: {evidence.download_triggered}")

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -477,11 +477,29 @@ def run_llm_tools(dry_run: bool = False, case_ids: list[str] | None = None) -> i
     run_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
     report_path = save_llm_tools_report(results, elapsed=0, partial=False, run_ts=run_ts)
     print(f"  Report saved → {report_path}")
+    return 1 if failures > 0 else 0
+
+def _save_readiness_failure(evidence: ModelReadinessEvidence) -> None:
+    """Persist model-readiness failure evidence to a JSON file before exit."""
+    from datetime import datetime, timezone
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    path = REPORTS_DIR / f"{ts}_model-readiness-failure.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        __import__("json").dumps(evidence.to_dict(), indent=2)
+    )
+    print(f"  [preflight] Failure evidence saved → {path}")
+
+
 
 def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | None = None,
               phases: list[str] | None = None, categories: list[str] | None = None,
               tags: list[str] | None = None, exclude_tags: list[str] | None = None,
-              case_ids: list[str] | None = None, model_readiness: bool = False) -> int:
+              case_ids: list[str] | None = None, model_readiness: bool = False,
+              serial: str | None = None, unlock_pin: str | None = None,
+              timeout_download: float | None = None,
+              timeout_engine: float | None = None,
+              hf_signin_timeout: float | None = None) -> int:
 
     """Execute all test cases. Returns non-zero on failures."""
 
@@ -598,10 +616,27 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
     # downloaded. The preflight handles download wait, HuggingFace sign-in,
     # and engine initialisation.  Fails fast with MODEL_NOT_READY (44) so
     # the caller can distinguish setup failure from product failure.
+    model_readiness_evidence = None
+
     if model_readiness:
         print()
         print("  ── Model readiness preflight ──")
-        evidence = preflight_model_readiness(verbose=True)
+        mr_kwargs = {}
+        if serial is not None:
+            mr_kwargs["serial"] = serial
+        if unlock_pin is not None:
+            mr_kwargs["unlock_pin"] = unlock_pin
+        if timeout_download is not None:
+            mr_kwargs["timeout_download"] = timeout_download
+        if timeout_engine is not None:
+            mr_kwargs["timeout_engine"] = timeout_engine
+        if hf_signin_timeout is not None:
+            mr_kwargs["hf_signin_timeout"] = hf_signin_timeout
+        evidence = preflight_model_readiness(verbose=True, **mr_kwargs)
+        # Persist failure evidence before early return
+        _save_readiness_failure(evidence)
+        model_readiness_evidence = evidence
+
         if evidence.failure_bucket:
             print(f"  [preflight] ❌ ABORT: {evidence.failure_bucket}")
             print(f"  [preflight]    Model readiness failed after {evidence.readiness_wait_seconds:.0f}s")
@@ -1070,6 +1105,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
         elapsed=time.time() - suite_start,
         partial=False,
         run_ts=run_ts,
+        model_readiness_evidence=model_readiness_evidence.to_dict() if model_readiness_evidence else None,
     )
     print(f"  Report saved → {report_path}")
     print()

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -8,6 +8,7 @@ Delegates to the ``adb_harness`` package modules for all logic.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from adb_harness.config import (

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -127,12 +127,6 @@ Reports dir: {REPORTS_DIR}
         default=None,
         help="Max seconds to wait for engine init after download (model readiness preflight)",
     )
-    parser.add_argument(
-        "--hf-signin-timeout",
-        type=float,
-        default=None,
-        help="Max seconds to wait for HuggingFace sign-in flow (model readiness preflight)",
-    )
     args = parser.parse_args()
 
     # Set ANDROID_SERIAL early so all ADB calls use the selected device
@@ -167,7 +161,6 @@ Reports dir: {REPORTS_DIR}
             unlock_pin=args.unlock_pin,
             timeout_download=args.timeout_download,
             timeout_engine=args.timeout_engine,
-            hf_signin_timeout=args.hf_signin_timeout,
         ))
 
 

--- a/scripts/adb_skill_test.py
+++ b/scripts/adb_skill_test.py
@@ -102,8 +102,41 @@ Reports dir: {REPORTS_DIR}
         action="store_true",
         help="Run model readiness preflight before tests (handles download, HF sign-in, engine init)",
     )
-
+    parser.add_argument(
+        "--serial",
+        metavar="SERIAL",
+        default=None,
+        help="Device serial (overrides ANDROID_SERIAL env var)",
+    )
+    parser.add_argument(
+        "--unlock-pin",
+        metavar="PIN",
+        default=None,
+        help="Device unlock PIN for model readiness preflight",
+    )
+    parser.add_argument(
+        "--timeout-download",
+        type=float,
+        default=None,
+        help="Max seconds to wait for model download (model readiness preflight)",
+    )
+    parser.add_argument(
+        "--timeout-engine",
+        type=float,
+        default=None,
+        help="Max seconds to wait for engine init after download (model readiness preflight)",
+    )
+    parser.add_argument(
+        "--hf-signin-timeout",
+        type=float,
+        default=None,
+        help="Max seconds to wait for HuggingFace sign-in flow (model readiness preflight)",
+    )
     args = parser.parse_args()
+
+    # Set ANDROID_SERIAL early so all ADB calls use the selected device
+    if args.serial:
+        os.environ["ANDROID_SERIAL"] = args.serial
 
     if args.start_phase and args.phases:
         parser.error("--start-phase and --phases are mutually exclusive. Use one or the other.")
@@ -129,6 +162,11 @@ Reports dir: {REPORTS_DIR}
             exclude_tags=exclude_tags_list,
             case_ids=case_ids_list,
             model_readiness=args.model_readiness,
+            serial=args.serial,
+            unlock_pin=args.unlock_pin,
+            timeout_download=args.timeout_download,
+            timeout_engine=args.timeout_engine,
+            hf_signin_timeout=args.hf_signin_timeout,
         ))
 
 

--- a/scripts/tests/test_model_readiness.py
+++ b/scripts/tests/test_model_readiness.py
@@ -31,7 +31,6 @@ from adb_harness.model_readiness import (
 )
 from adb_harness.device import build_adb_cmd
 
-
 # ═══════════════════════════════════════════════════════════════════════
 # Serial resolution tests (build_adb_cmd)
 # ═══════════════════════════════════════════════════════════════════════
@@ -403,6 +402,37 @@ class PreflightStateMachineTest(unittest.TestCase):
         )
         self.assertEqual(evidence.initial_state, "ActionRequired(SignInRequired)")
 
+
+    # ── HF sign-in field accuracy tests ────────────────────────────
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_hf_signin_shown_when_dialog_present(
+        self, mock_read: MagicMock,
+    ) -> None:
+        """hf_signin_shown=True when HF dialog text is detected."""
+        # Must NOT return engine_ready marker — that triggers early return before Phase 2.
+        # Return empty logcat (model not on disk) so preflight reaches Phase 2 HF handling.
+        mock_read.return_value = ""
+        with patch("adb_harness.model_readiness._uiautomator_has_text",
+                    side_effect=lambda text: "Sign in to Hugging Face" in text):
+            with patch("adb_harness.model_readiness._uiautomator_tap_text", return_value=True):
+                evidence = preflight_model_readiness(
+                    verbose=False, timeout_download=1.0, timeout_engine=1.0,
+                )
+                self.assertTrue(evidence.hf_signin_shown)
+                self.assertTrue(evidence.hf_signin_clicked)
+
+    @patch("adb_harness.model_readiness._read_fresh_logcat")
+    def test_hf_signin_not_shown_when_no_dialog(
+        self, mock_read: MagicMock,
+    ) -> None:
+        """hf_signin_shown=False when no HF dialog text is detected."""
+        mock_read.return_value = ""
+        evidence = preflight_model_readiness(
+            verbose=False, timeout_download=1.0, timeout_engine=1.0,
+        )
+        self.assertFalse(evidence.hf_signin_shown)
+        self.assertFalse(evidence.hf_signin_clicked)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1245
References #1256

## Summary

Post-merge remediation from PR #1256 review. Fixes:
- CLI passthrough gaps (`--serial`, `--unlock-pin`, `--timeout-download`, `--timeout-engine`)
- Evidence reporting: `_save_readiness_failure` only on failure; model readiness evidence in final report
- HF sign-in: best-effort tap + Back dismiss (no blocking wait, no `HF_SIGNIN_FAILED` bucket)
- `hf_signin_shown`/`hf_signin_clicked` field accuracy
- `run_llm_tools()` return code restored (was returning `None`)
- S21 model-readiness runbook with integrated harness command and acceptance criteria
- Gated-model skip in `areRequiredModelsDownloaded()` narrowed to explicit allowlist

## Changes

### New files

- **`docs/testing/s21-model-readiness.md`** — Agent-facing runbook covering:
  - Purpose: after clean reinstall, run preflight before accepting model-backed ADB evidence
  - Target: S21 (R5CR605B71K), Gemma 4 E-2B path
  - Integrated harness command with `--model-readiness`
  - Required acceptance evidence for agents
  - Bootstrap failures are not product regressions

### Modified files

- **`scripts/adb_skill_test.py`** — Added `--serial`, `--unlock-pin`, `--timeout-download`, `--timeout-engine` CLI arguments. Removed `--hf-signin-timeout` (no longer meaningful). `ANDROID_SERIAL` is set early after `parse_args()`.

- **`scripts/adb_harness/runners.py`**:
  - `run_tests()`: accepts and forwards serial, unlock_pin, timeout_download, timeout_engine
  - `_save_readiness_failure()`: only called inside failure branch (success path produces no failure-named file)
  - `run_llm_tools()`: restored `return 1 if failures > 0 else 0`
  - `save_report()` call includes `model_readiness_evidence` in final report

- **`scripts/adb_harness/reporting.py`** — `save_report()` accepts optional `model_readiness_evidence: dict | None`

- **`scripts/adb_harness/model_readiness.py`**:
  - HF sign-in is best-effort (tap + Back dismiss, no blocking wait)
  - Removed `hf_signin_timeout` parameter (no longer used)
  - Removed `HF_SIGNIN_FAILED` failure bucket
  - Updated docstring to reflect current failure buckets
  - Cleaned up docstring language

- **`core/inference/.../ModelDownloadManager.kt`** — Replaced broad `filterNot { it.isGated && !isHfAuthenticated }` with explicit allowlist of gated non-conversation models (`EMBEDDING_GEMMA_300M`, `EMBEDDING_GEMMA_SP_MODEL`)

- **`docs/testing/README.md`** — Linked new S21 model-readiness runbook in operational docs table

- **`scripts/tests/test_model_readiness.py`** — Added 2 tests for HF sign-in field accuracy; 30 total tests

### Evidence reporting

The test report JSON includes a top-level `model_readiness_evidence` field when `--model-readiness` is used:

```json
{
  "suite": "skills",
  "model_readiness_evidence": {
    "device_serial": "R5CR605B71K",
    "required_model": "Gemma 4 E-2B",
    "hf_signin_shown": true,
    "hf_signin_clicked": true,
    "final_state": "Ready",
    "failure_bucket": null,
    "logcat_markers": { "engine_ready": true }
  },
  "results": [...]
}
```

On preflight failure, a separate `{timestamp}_model-readiness-failure.json` is saved **before** exit 44. On success, no failure-named file is created.

### Failure buckets

| Bucket | Status | Code path |
|---|---|---|
| `MODEL_NOT_READY` | ✅ | Download never started |
| `MODEL_DOWNLOAD_TIMEOUT` | ✅ | Download started but didn't finish |
| `MODEL_DOWNLOAD_FAILED` | ✅ | Download worker errored |
| `ENGINE_NOT_READY` | ✅ | Engine didn't init after download |
| `ENGINE_BLOCKED_BY_KEYGUARD` | ✅ | Lock screen blocking engine init |
| `EXIT_PREFLIGHT_CRASHED` | ✅ | Unexpected error in preflight |

HF sign-in is **best-effort**: if the dialog appears, it is tapped and dismissed with Back. No dedicated failure bucket — the main loop's timeout mechanism catches stalled preflights.

## Testing & Device Validation

- **Unit tests**: All 30 model readiness tests + 137 total pass
- **Python syntax**: All Python files verified
- **Kotlin**: Explicit allowlist with documented invariant
- **Device**: S21 (R5CR605B71K) over USB ADB
  - Fresh install → model download → engine init → Ready
  - HF sign-in dialog detected and dismissed
  - No failure evidence on success
  - Failure evidence saved on failure before exit 44
  - See PR comment for full evidence

## Review notes

- Do not merge without review.
- All 8 review blocker categories remediated.
