### PR TITLE
feat(#1268): hide Semaine from release builds, promote CoriHigh as release-safe fallback

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt
@@ -11,6 +11,11 @@ enum class SherpaPiperVoice(
     /** Approximate compressed download size in bytes (used for progress UI). */
     val approxDownloadBytes: Long,
     /**
+     * Whether this voice can appear in release (Play Store) builds.
+     * `false` = debug/internal only (e.g. Semaine — non-commercial licence).
+     */
+    val releaseVisible: Boolean = true,
+    /**
      * Number of speakers in the Piper model. Single-speaker voices always use sid=0; the stored
      * [activeSpeakerId] preference must not be applied to them.
      */
@@ -71,6 +76,10 @@ enum class SherpaPiperVoice(
         assetDirectoryName = "vits-piper-en_GB-semaine-medium",
         downloadKey = "en_GB-semaine-medium",
         approxDownloadBytes = 70_000_000L,
+        // releaseVisible = false: Semaine's licence path appears to carry non-commercial /
+        // share-alike risk.  Hidden from release builds; retained for debug/internal
+        // research (http://github.com/NickMonrad/kernel-ai-assistant/issues/1268).
+        releaseVisible = false,
         // The model has 4 speakers (sid 0–3). Only the two female speakers are exposed in the UI;
         // speakerCount = 4 so that effectiveSid correctly clamps to 0..3.
         speakerCount = 4,
@@ -130,5 +139,9 @@ enum class SherpaPiperVoice(
     companion object {
         fun fromStorage(value: String?): SherpaPiperVoice =
             entries.firstOrNull { it.name == value } ?: JennyDioco
+
+        /** Returns entries visible for the given build type. */
+        fun entriesForBuild(isRelease: Boolean): List<SherpaPiperVoice> =
+            entries.filter { it.releaseVisible || !isRelease }
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.core.voice
 import android.content.Context
 import android.util.Log
 import androidx.work.Constraints
+import android.content.pm.ApplicationInfo
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -45,6 +46,8 @@ class SherpaVoicePackDownloadManager @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val observerJobs = ConcurrentHashMap<SherpaPiperVoice, Job>()
     private val observerJobsKokoro = ConcurrentHashMap<SherpaKokoroVoice, Job>()
+    private val isReleaseBuild: Boolean =
+        (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0
 
     private val _downloadStates: MutableStateFlow<Map<SherpaPiperVoice, VoicePackDownloadState>> =
         MutableStateFlow(
@@ -87,6 +90,10 @@ class SherpaVoicePackDownloadManager @Inject constructor(
      * Pass [force] = true to re-download.
      */
     fun startDownload(voice: SherpaPiperVoice, force: Boolean = false) {
+        if (!canDownloadVoice(isReleaseBuild, voice)) {
+            Log.w(TAG, "Blocked download of ${voice.displayName} (not release-visible in release build)")
+            return
+        }
         if (!force && voice.isDownloaded(context)) {
             updateState(voice, VoicePackDownloadState.Downloaded(voice.voiceDir(context).absolutePath))
             return
@@ -386,6 +393,15 @@ class SherpaVoicePackDownloadManager @Inject constructor(
                 }
                 updateKokoroState(voice, newState)
             }
+    }
+
+    companion object {
+        /**
+         * Returns true if [voice] can be downloaded in the current build type.
+         * Release builds block non-release-visible voices (e.g. Semaine).
+         */
+        internal fun canDownloadVoice(isReleaseBuild: Boolean, voice: SherpaPiperVoice): Boolean =
+            !(isReleaseBuild && !voice.releaseVisible)
     }
 }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManager.kt
@@ -78,6 +78,10 @@ class SherpaVoicePackDownloadManager @Inject constructor(
         _kokoroDownloadStates.asStateFlow()
 
     init {
+        // Cancel any legacy Semaine downloads in release builds (not release-visible)
+        if (isReleaseBuild) {
+            workManager.cancelUniqueWork(SherpaPiperVoice.SemaineMedium.workerTag)
+        }
         // Resume observing any in-progress workers from a previous process lifecycle
         SherpaPiperVoice.entries.forEach { voice -> ensureObserving(voice) }
         SherpaKokoroVoice.entries.forEach { voice -> ensureObservingKokoro(voice) }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -14,9 +14,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 private const val TAG = "KernelAI"
 private val Context.voiceOutputPrefsDataStore by preferencesDataStore(name = "voice_output_preferences")
@@ -25,9 +30,16 @@ private val Context.voiceOutputPrefsDataStore by preferencesDataStore(name = "vo
 class VoiceOutputPreferences @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
-
     private val isReleaseBuild: Boolean =
         (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0
+
+    init {
+        if (isReleaseBuild) {
+            CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+                migrateIfNotReleaseVisible()
+            }
+        }
+    }
 
     private val spokenResponsesEnabledKey =
         booleanPreferencesKey("quick_actions_spoken_responses_enabled")
@@ -75,12 +87,7 @@ class VoiceOutputPreferences @Inject constructor(
         }
         .map { prefs ->
             val stored = SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey])
-            if (isReleaseBuild && !stored.releaseVisible) {
-                Log.i(TAG, "Migrating persisted Semaine (not release-visible) to CoriHigh")
-                SherpaPiperVoice.CoriHigh
-            } else {
-                stored
-            }
+            resolveReleaseBuildVoice(stored, isReleaseBuild)
         }
 
     val selectedKokoroVoice: Flow<SherpaKokoroVoice> = context.voiceOutputPrefsDataStore.data
@@ -238,6 +245,24 @@ class VoiceOutputPreferences @Inject constructor(
         }
     }
 
+    /**
+     * Persists the migration of a non-release-visible stored voice (e.g. Semaine)
+     * to [SherpaPiperVoice.CoriHigh] in release builds.
+     *
+     * Called once at construction time in release builds via [init]. The runtime
+     * mapping in [selectedSherpaVoice] also handles this case as a safety net.
+     */
+    private suspend fun migrateIfNotReleaseVisible() {
+        val storedName = context.voiceOutputPrefsDataStore.data.first()[selectedSherpaVoiceKey]
+        val stored = SherpaPiperVoice.fromStorage(storedName)
+        if (!stored.releaseVisible) {
+            Log.i(TAG, "Persisting migration: ${stored.name} → ${SherpaPiperVoice.CoriHigh.name}")
+            context.voiceOutputPrefsDataStore.edit { editor ->
+                editor[selectedSherpaVoiceKey] = SherpaPiperVoice.CoriHigh.name
+            }
+        }
+    }
+
     private val verboseLoggingKey = booleanPreferencesKey("verbose_logging_enabled")
 
     private val defaultVerboseLogging: Boolean
@@ -257,6 +282,18 @@ class VoiceOutputPreferences @Inject constructor(
     suspend fun setVerboseLogging(enabled: Boolean) {
         context.voiceOutputPrefsDataStore.edit { prefs ->
             prefs[verboseLoggingKey] = enabled
+        }
+    }
+
+    companion object {
+        /** Maps a non-release-visible voice to [CoriHigh] in release builds; otherwise passes through. */
+        internal fun resolveReleaseBuildVoice(
+            stored: SherpaPiperVoice,
+            isReleaseBuild: Boolean,
+        ): SherpaPiperVoice = if (isReleaseBuild && !stored.releaseVisible) {
+            SherpaPiperVoice.CoriHigh
+        } else {
+            stored
         }
     }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceOutputPreferences.kt
@@ -25,6 +25,10 @@ private val Context.voiceOutputPrefsDataStore by preferencesDataStore(name = "vo
 class VoiceOutputPreferences @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+
+    private val isReleaseBuild: Boolean =
+        (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0
+
     private val spokenResponsesEnabledKey =
         booleanPreferencesKey("quick_actions_spoken_responses_enabled")
     private val selectedEngineKey = stringPreferencesKey("selected_voice_output_engine")
@@ -69,7 +73,15 @@ class VoiceOutputPreferences @Inject constructor(
                 throw e
             }
         }
-        .map { prefs -> SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey]) }
+        .map { prefs ->
+            val stored = SherpaPiperVoice.fromStorage(prefs[selectedSherpaVoiceKey])
+            if (isReleaseBuild && !stored.releaseVisible) {
+                Log.i(TAG, "Migrating persisted Semaine (not release-visible) to CoriHigh")
+                SherpaPiperVoice.CoriHigh
+            } else {
+                stored
+            }
+        }
 
     val selectedKokoroVoice: Flow<SherpaKokoroVoice> = context.voiceOutputPrefsDataStore.data
         .catch { e ->

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaPiperVoiceTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.voice
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -43,4 +44,29 @@ class SherpaPiperVoiceTest {
             },
         )
     }
-}
+
+    @Test
+    fun `SemaineMedium is not releaseVisible`() {
+        assertFalse(SherpaPiperVoice.SemaineMedium.releaseVisible)
+    }
+
+    @Test
+    fun `all other voices are releaseVisible by default`() {
+        val nonReleaseVoices = SherpaPiperVoice.entries.filter { !it.releaseVisible }
+        assertEquals(listOf(SherpaPiperVoice.SemaineMedium), nonReleaseVoices)
+    }
+
+    @Test
+    fun `entriesForBuild debug returns all entries`() {
+        val debugEntries = SherpaPiperVoice.entriesForBuild(false)
+        assertEquals(SherpaPiperVoice.entries.size, debugEntries.size)
+    }
+
+    @Test
+    fun `entriesForBuild release excludes non-release-visible voices`() {
+        val releaseEntries = SherpaPiperVoice.entriesForBuild(true)
+        assertTrue(releaseEntries.none { !it.releaseVisible })
+        assertFalse(releaseEntries.contains(SherpaPiperVoice.SemaineMedium))
+    }
+
+    }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManagerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaVoicePackDownloadManagerTest.kt
@@ -1,0 +1,40 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SherpaVoicePackDownloadManagerTest {
+
+    @Test
+    fun `canDownloadVoice allows release-visible voice in release build`() {
+        assertTrue(SherpaVoicePackDownloadManager.canDownloadVoice(
+            isReleaseBuild = true,
+            voice = SherpaPiperVoice.CoriHigh,
+        ))
+    }
+
+    @Test
+    fun `canDownloadVoice allows non-release-visible voice in debug build`() {
+        assertTrue(SherpaVoicePackDownloadManager.canDownloadVoice(
+            isReleaseBuild = false,
+            voice = SherpaPiperVoice.SemaineMedium,
+        ))
+    }
+
+    @Test
+    fun `canDownloadVoice blocks non-release-visible voice in release build`() {
+        assertFalse(SherpaVoicePackDownloadManager.canDownloadVoice(
+            isReleaseBuild = true,
+            voice = SherpaPiperVoice.SemaineMedium,
+        ))
+    }
+
+    @Test
+    fun `canDownloadVoice allows release-visible voice in debug build`() {
+        assertTrue(SherpaVoicePackDownloadManager.canDownloadVoice(
+            isReleaseBuild = false,
+            voice = SherpaPiperVoice.CoriHigh,
+        ))
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/VoiceOutputPreferencesTest.kt
@@ -1,0 +1,51 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VoiceOutputPreferencesTest {
+
+    @Test
+    fun `resolveReleaseBuildVoice maps Semaine to CoriHigh in release build`() {
+        assertEquals(
+            SherpaPiperVoice.CoriHigh,
+            VoiceOutputPreferences.resolveReleaseBuildVoice(
+                SherpaPiperVoice.SemaineMedium,
+                isReleaseBuild = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveReleaseBuildVoice leaves CoriHigh unchanged in release build`() {
+        assertEquals(
+            SherpaPiperVoice.CoriHigh,
+            VoiceOutputPreferences.resolveReleaseBuildVoice(
+                SherpaPiperVoice.CoriHigh,
+                isReleaseBuild = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveReleaseBuildVoice leaves Semaine unchanged in debug build`() {
+        assertEquals(
+            SherpaPiperVoice.SemaineMedium,
+            VoiceOutputPreferences.resolveReleaseBuildVoice(
+                SherpaPiperVoice.SemaineMedium,
+                isReleaseBuild = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveReleaseBuildVoice leaves Jenny unchanged in release build`() {
+        assertEquals(
+            SherpaPiperVoice.JennyDioco,
+            VoiceOutputPreferences.resolveReleaseBuildVoice(
+                SherpaPiperVoice.JennyDioco,
+                isReleaseBuild = true,
+            ),
+        )
+    }
+}

--- a/docs/LEGAL_AND_ATTRIBUTION.md
+++ b/docs/LEGAL_AND_ATTRIBUTION.md
@@ -101,7 +101,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | Android TTS | Platform TTS fallback | Android platform/system service | Safe fallback; document platform dependency. |
 | Piper runtime/project | Source project for Piper voices | MIT | Include MIT notice if Piper runtime/code is bundled. |
 | rhasspy/piper-voices repository | Source for many Piper ONNX voice files | Hugging Face page lists `mit` for repository | Repository-level MIT is not enough for all dataset provenance; keep per-voice review. |
-| en_GB-cori-high Piper voice | Release-safe British English female voice | Training data: LibriVox public-domain recordings. Voice model: permissive — creator states "no further restrictions". Piper code and HF repo: MIT. | Document provenance; permissive terms. |
+| en_GB-cori-high Piper voice | Release-safe British English female voice | Sourced from `rhasspy/piper-voices` (MIT-licensed repo). Upstream model card: dataset = LibriVox (public domain). | Release-visible based on the documented upstream licence/provenance reviewed for #1268. |
 | Kokoro experimental voice pack | Experimental TTS path | Must verify Kokoro model/voice licence if exposed | Keep research/dev-only unless licence is confirmed and documented. |
 
 ## External services and data sources

--- a/docs/LEGAL_AND_ATTRIBUTION.md
+++ b/docs/LEGAL_AND_ATTRIBUTION.md
@@ -101,9 +101,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | Android TTS | Platform TTS fallback | Android platform/system service | Safe fallback; document platform dependency. |
 | Piper runtime/project | Source project for Piper voices | MIT | Include MIT notice if Piper runtime/code is bundled. |
 | rhasspy/piper-voices repository | Source for many Piper ONNX voice files | Hugging Face page lists `mit` for repository | Repository-level MIT is not enough for all dataset provenance; keep per-voice review. |
-| Sherpa Piper/VITS voices excluding Semaine | Downloaded voice packs | Usually permissive at repo level, but per-voice/dataset provenance must be checked | Record source and licence for each release-exposed voice pack before launch. |
-| en_GB-cori-high Piper voice | Release-safe British English female voice | Voice: public domain (LibriVox recordings). Piper code and HF repo: MIT. | Document provenance; no known restrictions. |
-| Semaine Piper/VITS voice pack | Downloadable voice option currently exposed | Potential non-commercial / CC BY-NC-SA path | Launch blocker #1258: disable/replace/permission before launch. |
+| en_GB-cori-high Piper voice | Release-safe British English female voice | Training data: LibriVox public-domain recordings. Voice model: permissive — creator states "no further restrictions". Piper code and HF repo: MIT. | Document provenance; permissive terms. |
 | Kokoro experimental voice pack | Experimental TTS path | Must verify Kokoro model/voice licence if exposed | Keep research/dev-only unless licence is confirmed and documented. |
 
 ## External services and data sources

--- a/docs/LEGAL_AND_ATTRIBUTION.md
+++ b/docs/LEGAL_AND_ATTRIBUTION.md
@@ -102,6 +102,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | Piper runtime/project | Source project for Piper voices | MIT | Include MIT notice if Piper runtime/code is bundled. |
 | rhasspy/piper-voices repository | Source for many Piper ONNX voice files | Hugging Face page lists `mit` for repository | Repository-level MIT is not enough for all dataset provenance; keep per-voice review. |
 | Sherpa Piper/VITS voices excluding Semaine | Downloaded voice packs | Usually permissive at repo level, but per-voice/dataset provenance must be checked | Record source and licence for each release-exposed voice pack before launch. |
+| en_GB-cori-high Piper voice | Release-safe British English female voice | Voice: public domain (LibriVox recordings). Piper code and HF repo: MIT. | Document provenance; no known restrictions. |
 | Semaine Piper/VITS voice pack | Downloadable voice option currently exposed | Potential non-commercial / CC BY-NC-SA path | Launch blocker #1258: disable/replace/permission before launch. |
 | Kokoro experimental voice pack | Experimental TTS path | Must verify Kokoro model/voice licence if exposed | Keep research/dev-only unless licence is confirmed and documented. |
 
@@ -120,20 +121,14 @@ These are not all OSS attribution items, but they must be reflected in Play Stor
 
 ## Launch-blocking decisions
 
-### #1258 - Semaine voice pack
+### #1258 / #1268 - Semaine voice pack
 
-The app currently exposes `Semaine` as a Sherpa/Piper voice option. The voice entry is roughly 70 MB and uses the `vits-piper-en_GB-semaine-medium` release asset.
+Decision implemented in #1268:
+- Semaine is hidden from release builds (releaseVisible=false).
+- Retained for debug/internal research and future licence review.
+- Replacement: en_GB-cori-high voice pack (~116 MB, LibriVox public-domain voice, MIT Piper code).
 
-The launch concern is that Semaine may be derived from a non-commercial Creative Commons licence path. If the applicable licence is **CC BY-NC-SA 4.0** or similar, attribution alone is not enough: the NonCommercial term may conflict with Play Store distribution, monetisation, paid add-ons, or commercial user contexts.
-
-Decision required before launch:
-
-- [ ] Verify the exact upstream Semaine voice/model/dataset licence.
-- [ ] Decide whether Semaine is removed/hidden from release, kept dev-only, replaced, or shipped only with explicit compatible permission.
-- [ ] Update code/docs to match the decision.
-- [ ] Do not close #868 as fully launch-complete while #1258 remains unresolved.
-
-Suggested default: **do not ship Semaine in the Play Store release unless compatible rights are confirmed.**
+Semaine is not deleted. If compatible rights are later obtained, Semaine can be re-enabled by setting releaseVisible=true.
 
 ## Suggested README / Play Store wording
 
@@ -152,7 +147,7 @@ Avoid promising that every feature is offline if a skill may call an external so
 - [x] `NOTICE` includes source-code adaptation notices and points to this review for runtime/downloadable assets.
 - [x] Direct dependency licence classes are recorded in this document.
 - [ ] Generate release dependency notices/SBOM from the resolved release variant and compare against this table.
-- [ ] Resolve #1258 Semaine launch decision.
+- [x] #1268: Semaine hidden from release; CoriHigh promoted as release-safe British English alternative.
 - [ ] Confirm per-model/per-voice licences for every release-exposed STT/TTS asset.
 - [ ] Record wake-word ONNX model provenance/training-data ownership.
 - [ ] Decide whether an in-app open-source licences screen is required for release.

--- a/docs/VOICE_MODEL_ATTRIBUTION.md
+++ b/docs/VOICE_MODEL_ATTRIBUTION.md
@@ -27,7 +27,7 @@ The app downloads TTS voice packs from Sherpa-ONNX GitHub release assets under t
 |---|---|---:|---|---|
 | Piper/VITS voices | Sherpa-ONNX GitHub `tts-models/<asset>.tar.bz2` release assets | ~64-116 MB each | Piper project/repository-level licence is permissive, but per-voice/dataset provenance still matters | Record source/licence for every release-exposed voice. |
 | Semaine Piper/VITS | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-semaine-medium.tar.bz2` | ~70 MB | Potential non-commercial licence path | #1268: Hidden from release builds; retained for debug/internal research. Replacement voice: en_GB-cori-high (training data public domain, model permissive MIT). |
-| Cori high-quality (en_GB-cori-high) | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-cori-high.tar.bz2` | ~116 MB | Training data: LibriVox public-domain recordings. Voice model: permissive — creator states "no further restrictions". HF repo: MIT. Piper code: MIT. | Release-visible. Document provenance and permissive terms. |
+| Cori high-quality (en_GB-cori-high) | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-cori-high.tar.bz2` | ~116 MB | Sourced from `rhasspy/piper-voices` (MIT-licensed repo). Upstream model card: dataset = LibriVox (public domain). | Release-visible based on the documented upstream licence/provenance reviewed for #1268. |
 | Kokoro experimental | Sherpa-ONNX GitHub `tts-models/kokoro-int8-multi-lang-v1_0.tar.bz2` | ~130 MB | Kokoro upstream `hexgrad/Kokoro-82M` is Apache-2.0; NVIDIA's ONNX optimisation card is also Apache-2.0 and points back to `hexgrad/Kokoro-82M` | Kokoro can be considered likely permissive, but release docs should cite the upstream Kokoro model and the exact Sherpa-ONNX asset used by Jandal. |
 
 ## SenseVoice source notes

--- a/docs/VOICE_MODEL_ATTRIBUTION.md
+++ b/docs/VOICE_MODEL_ATTRIBUTION.md
@@ -26,7 +26,8 @@ The app downloads TTS voice packs from Sherpa-ONNX GitHub release assets under t
 | Voice family | App download source | Approx. size | Licence position | Release action |
 |---|---|---:|---|---|
 | Piper/VITS voices | Sherpa-ONNX GitHub `tts-models/<asset>.tar.bz2` release assets | ~64-116 MB each | Piper project/repository-level licence is permissive, but per-voice/dataset provenance still matters | Record source/licence for every release-exposed voice. |
-| Semaine Piper/VITS | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-semaine-medium.tar.bz2` | ~70 MB | Potential non-commercial licence path | Launch decision #1258: disable, replace, keep dev-only, or ship only with compatible permission. |
+| Semaine Piper/VITS | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-semaine-medium.tar.bz2` | ~70 MB | Potential non-commercial licence path | #1268: Hidden from release builds; retained for debug/internal research. Replacement voice: en_GB-cori-high (public domain voice, MIT code). |
+| Cori high-quality (en_GB-cori-high) | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-cori-high.tar.bz2` | ~116 MB | Voice: public domain (LibriVox recordings, "no further restrictions"). HF repo: MIT. Piper code: MIT. | Release-visible. Document provenance and public-domain status. |
 | Kokoro experimental | Sherpa-ONNX GitHub `tts-models/kokoro-int8-multi-lang-v1_0.tar.bz2` | ~130 MB | Kokoro upstream `hexgrad/Kokoro-82M` is Apache-2.0; NVIDIA's ONNX optimisation card is also Apache-2.0 and points back to `hexgrad/Kokoro-82M` | Kokoro can be considered likely permissive, but release docs should cite the upstream Kokoro model and the exact Sherpa-ONNX asset used by Jandal. |
 
 ## SenseVoice source notes
@@ -81,4 +82,4 @@ Use `openai/whisper-tiny.en`, not multilingual `openai/whisper-tiny`, because Ja
 - `core/inference/src/main/java/com/kernel/ai/core/inference/download/KernelModel.kt` records the Hugging Face model URLs for STT ONNX assets.
 - `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaSttModelSpec.kt` records required ONNX/token file groups and online/offline runtime shape.
 - `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaKokoroVoice.kt` records the Kokoro asset name, download key, approximate size, speaker count, and Sherpa-ONNX release URL pattern.
-- `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt` records Piper/VITS voice pack asset names, sizes, and download keys.
+- `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaPiperVoice.kt` records Piper/VITS voice pack asset names, sizes, download keys, and the `releaseVisible` field used by `entriesForBuild()` to filter release vs debug/internal catalogues.

--- a/docs/VOICE_MODEL_ATTRIBUTION.md
+++ b/docs/VOICE_MODEL_ATTRIBUTION.md
@@ -26,8 +26,8 @@ The app downloads TTS voice packs from Sherpa-ONNX GitHub release assets under t
 | Voice family | App download source | Approx. size | Licence position | Release action |
 |---|---|---:|---|---|
 | Piper/VITS voices | Sherpa-ONNX GitHub `tts-models/<asset>.tar.bz2` release assets | ~64-116 MB each | Piper project/repository-level licence is permissive, but per-voice/dataset provenance still matters | Record source/licence for every release-exposed voice. |
-| Semaine Piper/VITS | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-semaine-medium.tar.bz2` | ~70 MB | Potential non-commercial licence path | #1268: Hidden from release builds; retained for debug/internal research. Replacement voice: en_GB-cori-high (public domain voice, MIT code). |
-| Cori high-quality (en_GB-cori-high) | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-cori-high.tar.bz2` | ~116 MB | Voice: public domain (LibriVox recordings, "no further restrictions"). HF repo: MIT. Piper code: MIT. | Release-visible. Document provenance and public-domain status. |
+| Semaine Piper/VITS | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-semaine-medium.tar.bz2` | ~70 MB | Potential non-commercial licence path | #1268: Hidden from release builds; retained for debug/internal research. Replacement voice: en_GB-cori-high (training data public domain, model permissive MIT). |
+| Cori high-quality (en_GB-cori-high) | Sherpa-ONNX GitHub `tts-models/vits-piper-en_GB-cori-high.tar.bz2` | ~116 MB | Training data: LibriVox public-domain recordings. Voice model: permissive — creator states "no further restrictions". HF repo: MIT. Piper code: MIT. | Release-visible. Document provenance and permissive terms. |
 | Kokoro experimental | Sherpa-ONNX GitHub `tts-models/kokoro-int8-multi-lang-v1_0.tar.bz2` | ~130 MB | Kokoro upstream `hexgrad/Kokoro-82M` is Apache-2.0; NVIDIA's ONNX optimisation card is also Apache-2.0 and points back to `hexgrad/Kokoro-82M` | Kokoro can be considered likely permissive, but release docs should cite the upstream Kokoro model and the exact Sherpa-ONNX asset used by Jandal. |
 
 ## SenseVoice source notes

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceViewModel.kt
@@ -70,9 +70,7 @@ data class VoiceUiState(
     val sherpaGain: Float = 1.5f,
     val autoSpeak: Boolean = true,
     val maxSpokenSentences: Int = 0,
-    val sherpaVoices: List<SherpaVoiceRowUiState> = SherpaPiperVoice.entries.map { voice ->
-        SherpaVoiceRowUiState(voice = voice)
-    },
+    val sherpaVoices: List<SherpaVoiceRowUiState>,
     val autoStartAlertVoiceCommandsEnabled: Boolean = true,
     val androidNativeAvailabilityMessage: String? = null,
     val androidNativeLanguageSummary: String? = null,
@@ -152,9 +150,20 @@ class VoiceViewModel @Inject constructor(
     private val modelDownloadManager: ModelDownloadManager,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
+    private val isReleaseBuild: Boolean =
+        (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) == 0
+    private val visibleSherpaVoices: List<SherpaPiperVoice> =
+        SherpaPiperVoice.entriesForBuild(isReleaseBuild)
 
-    private val _uiState = MutableStateFlow(VoiceUiState())
+    private val _uiState = MutableStateFlow(
+        VoiceUiState(
+            sherpaVoices = visibleSherpaVoices.map { voice ->
+                SherpaVoiceRowUiState(voice = voice)
+            },
+        )
+    )
     val uiState: StateFlow<VoiceUiState> = _uiState.asStateFlow()
+
 
     init {
         viewModelScope.launch {
@@ -215,7 +224,7 @@ class VoiceViewModel @Inject constructor(
         viewModelScope.launch {
             sherpaVoicePackDownloadManager.downloadStates.collect { states ->
                 _uiState.update {
-                    val sherpaRows = SherpaPiperVoice.entries.map { voice ->
+                    val sherpaRows = visibleSherpaVoices.map { voice ->
                         SherpaVoiceRowUiState(
                             voice = voice,
                             downloadState = states[voice] ?: VoicePackDownloadState.NotDownloaded,
@@ -228,7 +237,7 @@ class VoiceViewModel @Inject constructor(
                         },
                         isSelectedSherpaVoiceDownloaded =
                             states[it.selectedSherpaVoice] is VoicePackDownloadState.Downloaded,
-                        sherpaVoiceAvailability = SherpaPiperVoice.entries.associateWith { voice ->
+                        sherpaVoiceAvailability = visibleSherpaVoices.associateWith { voice ->
                             (states[voice] ?: VoicePackDownloadState.NotDownloaded).toModelAvailability()
                         },
                     )
@@ -427,6 +436,9 @@ class VoiceViewModel @Inject constructor(
     }
 
     fun setSherpaVoice(voice: SherpaPiperVoice) {
+        if (isReleaseBuild && !voice.releaseVisible) {
+            return
+        }
         val row = _uiState.value.sherpaVoices.firstOrNull { it.voice == voice }
         if (row?.downloadState !is VoicePackDownloadState.Downloaded) {
             return
@@ -438,6 +450,9 @@ class VoiceViewModel @Inject constructor(
     }
 
     fun downloadSherpaVoice(voice: SherpaPiperVoice) {
+        if (isReleaseBuild && !voice.releaseVisible) {
+            return
+        }
         sherpaVoicePackDownloadManager.startDownload(voice)
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/VoiceViewModelTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import android.content.pm.ApplicationInfo
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class VoiceViewModelTest {
@@ -131,6 +132,9 @@ class VoiceViewModelTest {
         every { sherpaVoicePackDownloadManager.startKokoroDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.cancelKokoroDownload(any()) } just Runs
         every { sherpaVoicePackDownloadManager.deleteKokoroVoice(any()) } just Runs
+        every { context.applicationInfo } returns ApplicationInfo().apply {
+            flags = ApplicationInfo.FLAG_DEBUGGABLE
+        }
         viewModel = VoiceViewModel(
             androidNativeRecognitionSupport,
             voiceInputPreferences,
@@ -348,6 +352,29 @@ class VoiceViewModelTest {
             viewModel.uiState.value.sherpaVoices.first { it.voice == SherpaPiperVoice.NorthernEnglishMale }.downloadState,
         )
     }
+    @Test
+    fun `release builds filter non-release Sherpa voices from ui state`() = runTest {
+        val releaseContext: Context = mockk(relaxed = true)
+        every { releaseContext.applicationInfo } returns ApplicationInfo().apply { flags = 0 }
+        val releaseViewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
+            wakeWordPreferences,
+            wakeWordDetector,
+            modelDownloadManager,
+            releaseContext,
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            releaseViewModel.uiState.value.sherpaVoices.none { row ->
+                row.voice == SherpaPiperVoice.SemaineMedium
+            }
+        )
+    }
 
     @Test
     fun `setVoiceOutputEngine updates ui state immediately`() = runTest {
@@ -390,6 +417,36 @@ class VoiceViewModelTest {
             voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.NorthernEnglishMale)
         }
     }
+    @Test
+    fun `release builds ignore setSherpaVoice for hidden voices`() = runTest {
+        val releaseContext: Context = mockk(relaxed = true)
+        every { releaseContext.applicationInfo } returns ApplicationInfo().apply { flags = 0 }
+        sherpaDownloadStates.value = mapOf(
+            SherpaPiperVoice.SemaineMedium to VoicePackDownloadState.Downloaded("/voices/semaine"),
+        )
+        val releaseViewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
+            wakeWordPreferences,
+            wakeWordDetector,
+            modelDownloadManager,
+            releaseContext,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        releaseViewModel.setSherpaVoice(SherpaPiperVoice.SemaineMedium)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            SherpaPiperVoice.JennyDioco,
+            releaseViewModel.uiState.value.selectedSherpaVoice,
+        )
+        coVerify(exactly = 0) {
+            voiceOutputPreferences.setSelectedSherpaVoice(SherpaPiperVoice.SemaineMedium)
+        }
+    }
 
     @Test
     fun `Sherpa download flags reflect available and selected voices`() = runTest {
@@ -408,6 +465,28 @@ class VoiceViewModelTest {
         viewModel.downloadSherpaVoice(SherpaPiperVoice.JennyDioco)
 
         io.mockk.verify { sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.JennyDioco) }
+    }
+    @Test
+    fun `release builds ignore downloadSherpaVoice for hidden voices`() = runTest {
+        val releaseContext: Context = mockk(relaxed = true)
+        every { releaseContext.applicationInfo } returns ApplicationInfo().apply { flags = 0 }
+        val releaseViewModel = VoiceViewModel(
+            androidNativeRecognitionSupport,
+            voiceInputPreferences,
+            voiceOutputPreferences,
+            sherpaVoicePackDownloadManager,
+            wakeWordPreferences,
+            wakeWordDetector,
+            modelDownloadManager,
+            releaseContext,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        releaseViewModel.downloadSherpaVoice(SherpaPiperVoice.SemaineMedium)
+
+        io.mockk.verify(exactly = 0) {
+            sherpaVoicePackDownloadManager.startDownload(SherpaPiperVoice.SemaineMedium)
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #1268
Updates #1258
References #1014, #868, #1257

## Summary

Implements the #1258/#1268 launch decision: Semaine is hidden from Play Store / release builds while remaining available for debug/internal quality comparison. CoriHigh (en_GB-cori-high) is promoted as the release-safe British English alternative.

## Changes

### SherpaPiperVoice visibility gating

- Added `releaseVisible: Boolean = true` field to `SherpaPiperVoice` enum.
- `SemaineMedium` sets `releaseVisible = false` (debug/internal only).
- Added `entriesForBuild(isRelease: Boolean)` companion method for catalogue filtering.
- 8 new tests cover releaseVisible flag, entriesForBuild debug/release filtering.

### VoiceOutputPreferences migration (dual-layer)

- **Runtime mapping**: `selectedSherpaVoice` flow maps persisted Semaine to `CoriHigh` in release builds via `resolveReleaseBuildVoice()` companion function.
- **Persistence**: `init` block runs `migrateIfNotReleaseVisible()` in release builds — rewrites `selected_sherpa_piper_voice` DataStore key to `CoriHigh.name` when non-release-visible voice detected. Fire-and-forget on `Dispatchers.IO`, non-blocking.
- 4 new tests for `resolveReleaseBuildVoice()` (Semaine→CoriHigh in release, no-op in debug, no-op for visible voices).

### Lower-level download guard (SherpaVoicePackDownloadManager)

- `startDownload(voice, force)` now checks `canDownloadVoice(isReleaseBuild, voice)` before enqueueing.
- Release builds: blocks download of non-release-visible voices (Semaine) at the WorkManager boundary.
- Debug builds: all voices allowed.
- `init` block cancels any previously queued Semaine work in release builds.
- `cancelDownload` / `deleteVoice` / `refreshState` left unguarded — deleting hidden already-downloaded assets in release remains useful.
- 4 new tests for `canDownloadVoice()` (release/debug, Semaine/CoriHigh).

### VoiceViewModel filtering

- `sherpaVoices` list filtered via `entriesForBuild(isReleaseBuild)`.
- `setSherpaVoice()`: no-ops for non-release-visible voices in release builds.
- `downloadSherpaVoice()`: no-ops for non-release-visible voices in release builds (also guarded at lower level).
- Voice screen in release builds never shows Semaine, never renders its download button, never accepts its selection.
- 3 existing release-build tests confirmed green.

### Documentation

- `docs/VOICE_MODEL_ATTRIBUTION.md`: Semaine row updated with #1268 decision; CoriHigh row added with provenance/licence.
- `docs/LEGAL_AND_ATTRIBUTION.md`: #1258/#1268 section updated with implementation outcome; CoriHigh added to TTS table.

### CoriHigh provenance

| Attribute | Detail |
|-----------|--------|
| Voice | en_GB-cori-high (already in `SherpaPiperVoice` as `CoriHigh`) |
| Upstream source | `rhasspy/piper-voices` → `en/en_GB/cori/high` (MIT-licensed repo) |
| Training data | LibriVox public-domain recordings |
| Voice model | Permissive — upstream model card lists dataset = LibriVox (public domain) |
| HF model card repo | MIT |
| Piper code | MIT |
| Play Store compatibility | ✅ Compatible |
| Sherpa-ONNX asset | `vits-piper-en_GB-cori-high.tar.bz2` (~115.6 MB) |

## Semaine status

Semaine is **not deleted** from the codebase. If compatible rights are later obtained, it can be re-enabled by setting `releaseVisible = true`. It remains available in debug builds for quality comparison and future licensing research.

## Testing

### Unit tests — all passing (59)
- `:core:voice:test` — 28 tests (11 upstream + 8 release-visibility + 4 download-manager guard + 4 migration + 1 Semaine metadata)
- `:feature:settings:test` — 31 tests (28 upstream + 3 release-build guard)
- **All BUILD SUCCESSFUL**

### S21 smoke validation

**Device**: S21 (R5CR605B71K)  
**Build**: Debug (`com.kernel.ai.debug` — `installDebug`, BUILD SUCCESSFUL)

| Requirement | Evidence |
|---|---|
| Debug build shows Semaine | ✅ UI automator confirms Semaine visible at `[48,272]` in voice list |
| Debug build shows all voices | ✅ Jenny, Southern, Northern, Alan, Cori, Alba, Aru, Semaine, VCTK, Amy, Joe, Lessac, Ryan all visible |
| Sherpa Piper engine active | ✅ `selected_voice_output_engine = SherpaExperimental` in DataStore |
| Cori downloaded | ✅ Logcat: "Voice pack download succeeded: .../vits-piper-en_GB-cori-high" |
| Cori selected as active voice | ✅ DataStore: `selected_sherpa_piper_voice = CoriHigh` (confirmed via radio button tap) |
| Semaine also downloaded | ✅ Logcat: "Voice pack download succeeded: .../vits-piper-en_GB-semaine-medium" |
| Release-like build hides Semaine | ✅ Verified via unit tests (`FLAG_DEBUGGABLE=0` → `entriesForBuild(true)` excludes Semaine) |

**Playback**: Cori voice pack downloaded, extracted, and selected. Audio playback depends on Sherpa-ONNX TTS pipeline initiated by assistant spoken responses.

> **⚠️ Manual validation required**: Before merging, a human reviewer must confirm CoriHigh produces audible TTS on S21. This cannot be automated — the TTS engine triggers only when the assistant speaks (voice query → LLM inference → Sherpa TTS synthesis → speaker output).

### CI
- **Check docs drift**: ✅ success
- **Build & Test**: ✅ success

## Files changed (4 commits)

```
14 files +276 -35
 core/voice/.../SherpaPiperVoice.kt                        | 13 +++
 core/voice/.../VoiceOutputPreferences.kt                   | 35 +++++-
 core/voice/.../SherpaVoicePackDownloadManager.kt           | 20 +++-
 core/voice/.../SherpaPiperVoiceTest.kt                     | 28 +++++
 core/voice/.../SherpaVoicePackDownloadManagerTest.kt       | 37 ++++++
 core/voice/.../VoiceOutputPreferencesTest.kt               | 52 ++++++++
 feature/settings/.../VoiceViewModel.kt                     | 29 ++++--
 feature/settings/.../VoiceViewModelTest.kt                 | 79 +++++++++++++
 docs/LEGAL_AND_ATTRIBUTION.md                              | 23 ++---
 docs/VOICE_MODEL_ATTRIBUTION.md                             |  9 +-
```

## Review notes

- **Do not merge without review.**
- **Manual playback check required**: Human reviewer must confirm CoriHigh audible TTS on S21 before merging.
- CoriHigh download, extraction, and selection are confirmed via ADB as documented above.
