### PR TITLE
docs(#1263): add release attribution sign-off snapshot

### DIFF
--- a/docs/LEGAL_AND_ATTRIBUTION.md
+++ b/docs/LEGAL_AND_ATTRIBUTION.md
@@ -6,6 +6,8 @@ This document supports #868 and the Play Store launch gate. It is a practical en
 
 This PR now records the known licence position for the components we can identify from the repo and public upstream metadata. Final release still needs an automated release-variant notice/SBOM pass to catch transitive dependencies and confirm exactly what is bundled in the APK/AAB.
 
+The current release-attribution snapshot for #1263 is [`RELEASE_ATTRIBUTION_SIGNOFF.md`](RELEASE_ATTRIBUTION_SIGNOFF.md). Use that document as the short-form launch sign-off view, and use this document as the detailed inventory.
+
 ## Source licence
 
 Jandal AI source code is distributed under the Apache License 2.0. See [`../LICENSE`](../LICENSE).
@@ -68,7 +70,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | sqlite-vec | Local vector search extension in `core/memory/src/main/cpp` | Dual MIT OR Apache-2.0 upstream | Include chosen licence text/notice if source/native library is bundled. |
 | SQLite amalgamation | SQLite C source referenced by native build | Public domain / blessing text upstream | Confirm bundling; include SQLite public-domain notice/blessing if bundled. |
 | Sherpa-ONNX AAR/runtime | Local STT/TTS runtime when AAR is packaged | Apache-2.0 | Confirm whether packaged in release; include notice if bundled. |
-| Wake-word ONNX model assets | Bundled wake-word detector/verifier assets | Jandal-owned/provenance not yet documented | Record provenance/training data and ownership before launch. |
+| Wake-word ONNX model assets | Bundled wake-word detector/verifier assets | openWakeWord Apache-2.0 lineage for Stage 1/2; Stage 3 `hey_jandal.onnx` generated from local training data recorded in `training/wakeword/README.md` | Keep openWakeWord notice; before final release, maintainer should confirm real-recording ownership/consent for the generated Stage 3 model. |
 | Local model binaries under `models/` | Dev/test local model cache | Not committed / not shipped from source | Keep gitignored; release artefact still needs audit. |
 
 ### Downloaded or bundled model assets
@@ -78,7 +80,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | Gemma-4 E-2B LiteRT-LM | Required launch-compatible chat tier | Hugging Face page lists `apache-2.0` | Document model card/source and include Apache-2.0 notice if redistributed. |
 | Gemma-4 E-4B LiteRT-LM | Optional flagship chat tier | Hugging Face page lists `apache-2.0` | Document model card/source and include Apache-2.0 notice if redistributed. |
 | EmbeddingGemma 300M generic | Embedding/RAG model | Hugging Face page lists `gemma`; gated terms must be accepted | Keep gated-model language; do not present as Apache-2.0. |
-| EmbeddingGemma 300M SM8550 | Qualcomm-optimised EmbeddingGemma variant | Hugging Face page lists `gemma`; gated terms must be accepted | Confirm if hidden/deprecated for launch; if exposed, document terms. |
+| EmbeddingGemma 300M SM8550 | Qualcomm-optimised EmbeddingGemma variant | Hugging Face page lists `gemma`; gated terms must be accepted | Deprecated/hidden from generic model management; if exposed, document terms. |
 | FunctionGemma / mobile actions model | Optional/experimental mobile-actions model | Hugging Face page lists `gemma`; gated terms must be accepted | Keep optional/experimental; document terms if exposed. |
 | MiniLM-L6 intent classifier | Bundled/fallback intent classifier asset | `sentence-transformers/all-MiniLM-L6-v2` page lists `apache-2.0` | Confirm exact converted asset provenance and include Apache-2.0 notice if bundled. |
 
@@ -102,7 +104,7 @@ These direct dependencies are declared in `gradle/libs.versions.toml`. Release n
 | Piper runtime/project | Source project for Piper voices | MIT | Include MIT notice if Piper runtime/code is bundled. |
 | rhasspy/piper-voices repository | Source for many Piper ONNX voice files | Hugging Face page lists `mit` for repository | Repository-level MIT is not enough for all dataset provenance; keep per-voice review. |
 | en_GB-cori-high Piper voice | Release-safe British English female voice | Sourced from `rhasspy/piper-voices` (MIT-licensed repo). Upstream model card: dataset = LibriVox (public domain). | Release-visible based on the documented upstream licence/provenance reviewed for #1268. |
-| Kokoro experimental voice pack | Experimental TTS path | Must verify Kokoro model/voice licence if exposed | Keep research/dev-only unless licence is confirmed and documented. |
+| Kokoro experimental voice pack | Experimental TTS path | Exact app asset is Sherpa-ONNX `tts-models/kokoro-int8-multi-lang-v1_0.tar.bz2`; upstream Kokoro 82M lineage is Apache-2.0 | Consider licence trace acceptable if release-exposed, but keep product wording experimental/conservative. |
 
 ## External services and data sources
 
@@ -124,7 +126,7 @@ These are not all OSS attribution items, but they must be reflected in Play Stor
 Decision implemented in #1268:
 - Semaine is hidden from release builds (releaseVisible=false).
 - Retained for debug/internal research and future licence review.
-- Replacement: en_GB-cori-high voice pack (~116 MB, LibriVox public-domain voice, MIT Piper code).
+- Replacement: en_GB-cori-high voice pack (~116 MB, `rhasspy/piper-voices` MIT repository, upstream model card lists LibriVox public-domain dataset).
 
 Semaine is not deleted. If compatible rights are later obtained, Semaine can be re-enabled by setting releaseVisible=true.
 
@@ -144,10 +146,12 @@ Avoid promising that every feature is offline if a skill may call an external so
 - [x] `models/README.md` documents approximate model sizes and gated-model requirements.
 - [x] `NOTICE` includes source-code adaptation notices and points to this review for runtime/downloadable assets.
 - [x] Direct dependency licence classes are recorded in this document.
-- [ ] Generate release dependency notices/SBOM from the resolved release variant and compare against this table.
 - [x] #1268: Semaine hidden from release; CoriHigh promoted as release-safe British English alternative.
-- [ ] Confirm per-model/per-voice licences for every release-exposed STT/TTS asset.
-- [ ] Record wake-word ONNX model provenance/training-data ownership.
-- [ ] Decide whether an in-app open-source licences screen is required for release.
+- [x] #1263: release-attribution snapshot added in `docs/RELEASE_ATTRIBUTION_SIGNOFF.md`.
+- [x] Wake-word training/provenance path is traceable through `training/wakeword/README.md` and `NOTICE`.
+- [ ] Generate release dependency notices/SBOM from the resolved release variant and compare against this table.
+- [ ] Confirm exact bundled/downloaded Vosk model provenance if Vosk model files are exposed in the release build.
+- [ ] Confirm maintainer ownership/consent for real recordings used in the generated Hey Jandal Stage 3 wake-word model.
+- [ ] Decide whether an in-app open-source licences screen is required after the generated release notice/SBOM is reviewed.
 - [ ] Play Store privacy/data disclosures match the actual release build.
 - [ ] #868 is closed only after the final release scope is known and the checklist above has been reviewed.

--- a/docs/LEGAL_AND_ATTRIBUTION.md
+++ b/docs/LEGAL_AND_ATTRIBUTION.md
@@ -154,4 +154,4 @@ Avoid promising that every feature is offline if a skill may call an external so
 - [ ] Confirm maintainer ownership/consent for real recordings used in the generated Hey Jandal Stage 3 wake-word model.
 - [ ] Decide whether an in-app open-source licences screen is required after the generated release notice/SBOM is reviewed.
 - [ ] Play Store privacy/data disclosures match the actual release build.
-- [ ] #868 is closed only after the final release scope is known and the checklist above has been reviewed.
+- [ ] Confirm #868's closed state still reflects the final release scope after the SBOM/AAB audit.

--- a/docs/RELEASE_ATTRIBUTION_SIGNOFF.md
+++ b/docs/RELEASE_ATTRIBUTION_SIGNOFF.md
@@ -1,0 +1,101 @@
+# Release attribution sign-off snapshot
+
+Parent issue: #1263  
+Related: #868, #1257, #1258, #1268, #1014, #441
+
+This document captures the release-attribution state after the Semaine release-visibility decision landed. It is a practical engineering sign-off aid, not legal advice.
+
+## Status
+
+This is a **pre-release-candidate attribution snapshot**. It verifies the release-exposed model/voice decisions that can be checked from source, but it does **not** replace the final release artefact audit in #1259.
+
+Before Play Store publication, #1259 still needs to produce and inspect the actual release `.aab`, and #1263 still needs a generated dependency notice/SBOM from the resolved release variant.
+
+## Release scope decisions captured
+
+| Area | Decision | Status |
+|---|---|---|
+| Jandal source | Apache-2.0 repository licence plus `NOTICE` file. | Recorded. |
+| Semaine Piper/VITS voice | Hidden from release builds; retained for debug/internal research. | Implemented by #1268 / PR #1269. |
+| CoriHigh Piper/VITS voice | Release-visible British English fallback. Source: `rhasspy/piper-voices` repository listed as MIT; upstream model card lists LibriVox dataset with public-domain dataset licence. | Recorded as release-visible based on #1268 review. |
+| Kokoro experimental voice | Can be considered release-visible from a licence perspective if exposed: Jandal downloads the Sherpa-ONNX `kokoro-int8-multi-lang-v1_0.tar.bz2` asset; upstream Kokoro 82M lineage is recorded as Apache-2.0. | Attribution recorded; keep experimental/product wording conservative. |
+| Hey Jandal wake-word ONNX assets | Runtime uses openWakeWord-derived pipeline. Training README records that Stage 1/2 backbones come from openWakeWord and Stage 3 `hey_jandal.onnx` is trained from local positive clips. | Provenance now traceable in repo; final release should confirm owner consent for real recordings if any were used. |
+| Runtime/downloader model files | Downloadable models and voices are not committed to the source repo unless explicitly bundled in a release artefact. | Final `.aab` inspection still required in #1259. |
+| Play monetisation | First Play launch remains free-only; no Play Billing, paid app, IAP, or subscriptions. | Captured in #1264. |
+
+## Release-exposed downloadable model and voice inventory
+
+### Chat / embedding / local inference
+
+| Asset | Release role | Source / terms status | Sign-off status |
+|---|---|---|---|
+| Gemma 4 E-2B LiteRT-LM | Required launch-compatible chat tier. | `litert-community/gemma-4-E2B-it-litert-lm`, repository page records Apache-2.0 in current docs. | OK for release inventory; verify exact model card in final sign-off notes. |
+| Gemma 4 E-4B LiteRT-LM | Optional flagship chat tier. | `litert-community/gemma-4-E4B-it-litert-lm`, repository page records Apache-2.0 in current docs. | OK as optional release-exposed download. |
+| EmbeddingGemma 300M + SentencePiece | Required embedding/RAG dependency when authenticated. | `litert-community/embeddinggemma-300m`, gated Gemma terms. | Keep gated-model language; do not describe as Apache-only. |
+| EmbeddingGemma SM8550 variant | Deprecated/hidden in generic model management; may remain on existing devices. | Same gated Gemma terms as generic EmbeddingGemma. | Treat as deprecated / not promoted in release. |
+| MiniLM-L6 intent classifier | Bundled/fallback classifier. | `sentence-transformers/all-MiniLM-L6-v2`, documented as Apache-2.0. | Confirm bundle presence during #1259 artefact audit. |
+| FunctionGemma mobile actions | Optional/experimental if surfaced. | Gated Gemma terms. | Keep optional/experimental; do not promote in store copy unless current release UI exposes it intentionally. |
+
+### Speech-to-text
+
+| Asset | Release role | Source / terms status | Sign-off status |
+|---|---|---|---|
+| Android native STT | Platform fallback/option. | Android platform/system service. | Store/privacy copy must not promise guaranteed offline operation for this path. |
+| Vosk Android runtime | Offline STT runtime. | Apache-2.0 runtime dependency. | Runtime notice required if bundled. |
+| Vosk model files | Offline STT data if exposed. | Per-model provenance must be checked against final selected/downloaded model. | Keep as sign-off item until exact release model is known. |
+| Sherpa Zipformer STT | Optional Sherpa STT model. | `csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-02-21`, documented as Apache-2.0 / upstream lineage. | OK if release-exposed; cite exact HF export page. |
+| Sherpa SenseVoice STT | Optional Sherpa STT model. | ONNX export from SenseVoice/FunASR. FunASR code is MIT; model weights use separate FunASR model licence. | Release docs must not describe as MIT-only. |
+| Sherpa Whisper tiny.en STT | Optional Sherpa STT model. | `csukuangfj/sherpa-onnx-whisper-tiny.en` plus upstream `openai/whisper-tiny.en`, Apache-2.0. | OK if release-exposed; cite both export and upstream model lineage. |
+| Sherpa Paraformer STT | Optional Sherpa STT model. | HF export lists Apache-2.0; upstream ModelScope/FunASR lineage and model-weight terms should be recorded. | Release docs must not simplify to MIT-only. |
+
+### Text-to-speech
+
+| Asset | Release role | Source / terms status | Sign-off status |
+|---|---|---|---|
+| Android TTS | Platform fallback. | Android platform/system service. | OK; describe as platform fallback. |
+| Piper/VITS voice packs | User-selectable Sherpa/Piper voices. | Sherpa-ONNX release assets; per-voice dataset provenance still matters. | Release-visible voices must retain per-voice provenance in docs. |
+| Semaine | Debug/internal only. | Potential non-commercial/share-alike risk. | Hidden from release; not a Play launch blocker after #1268. |
+| CoriHigh | Release-visible replacement for Semaine. | `rhasspy/piper-voices` MIT repo; model card lists LibriVox public-domain dataset. | OK for release-visible catalogue based on #1268. |
+| Kokoro experimental | Optional/experimental Sherpa Kokoro TTS. | Exact app asset is Sherpa-ONNX `kokoro-int8-multi-lang-v1_0.tar.bz2`; upstream Kokoro 82M lineage recorded as Apache-2.0. | OK from current attribution trace; avoid overclaiming quality/stability in store copy. |
+
+## Wake-word asset provenance
+
+The bundled Hey Jandal wake-word path has three ONNX stages:
+
+1. `melspectrogram.onnx` — openWakeWord Stage 1 backbone.
+2. `embedding_model.onnx` — openWakeWord Stage 2 backbone.
+3. `hey_jandal.onnx` — Jandal-specific Stage 3 classifier.
+
+`training/wakeword/README.md` records that Stage 3 training used 954 positive clips:
+
+- 174 from local real recordings, expanded from 29 originals through augmentation;
+- 780 generated from Piper TTS across 11 voices and 13 phonetic variants.
+
+Release treatment:
+
+- keep openWakeWord Apache-2.0 attribution in `NOTICE`;
+- keep the training README as the source-of-truth provenance for the generated model;
+- before final Play release, the maintainer should confirm that the local real recordings are owned/consented for use in the bundled wake-word model.
+
+## In-app open-source notices decision
+
+For first launch, an in-app open-source licences screen is **deferred** unless the generated release dependency notice/SBOM or bundled SDK notices show a licence that requires in-app reproduction.
+
+Required first-launch minimum:
+
+- repository `LICENSE` and `NOTICE` remain present;
+- `docs/LEGAL_AND_ATTRIBUTION.md`, `docs/VOICE_MODEL_ATTRIBUTION.md`, and this file remain linked from release/internal launch notes;
+- Play Store copy does not claim ownership of upstream models/voices;
+- final release artefact audit confirms no unexpected bundled model files or debug-only dependencies.
+
+## Final release artefact audit still required
+
+The following items cannot be completed from static source docs alone:
+
+- generate release dependency notices or SBOM from the resolved release variant;
+- inspect the release `.aab` contents for bundled models, debug artefacts, and native ABIs;
+- confirm exact runtime dependency set after Gradle resolution;
+- confirm whether any licence notice needs to appear inside the app rather than only in repository/docs;
+- record final versionCode/versionName, commit SHA, and release artefact hash/path.
+
+Track those in #1259 and feed the result back into #1263 before closing the launch gate.


### PR DESCRIPTION
## Summary

Updates #1263.

Adds a release-attribution sign-off snapshot after the #1268 Semaine/CoriHigh decision and links it from the main legal inventory.

## What changed

- Adds `docs/RELEASE_ATTRIBUTION_SIGNOFF.md` as a short-form launch sign-off snapshot.
- Records current release-scope decisions for:
  - Semaine hidden from release / debug-only retained;
  - CoriHigh release-visible fallback;
  - Kokoro attribution trace via Sherpa-ONNX asset and upstream Kokoro 82M lineage;
  - Hey Jandal wake-word provenance trace via `training/wakeword/README.md`;
  - first-launch no-Play-monetisation decision from #1264.
- Updates `docs/LEGAL_AND_ATTRIBUTION.md` to link the sign-off snapshot and tighten the remaining launch checklist.

## Important limitation

This PR does **not** claim #1263 is complete.

The following still require a release candidate / build-machine pass before #1263 can close:

- generated release dependency notices or SBOM from the resolved release variant;
- `.aab` inspection from #1259;
- exact final dependency set after Gradle resolution;
- final decision on whether any licence notice must appear inside the app;
- maintainer confirmation for any local real recordings used in the generated Hey Jandal wake-word model.

## Validation

Docs-only change. No build/test run from this connector session.

## Reviewer notes

I also updated closed issue #1258 directly to remove the older over-strong CoriHigh wording and align it with the safer provenance language used by #1268/#1263.
