### PR TITLE
chore: add backlog hygiene guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-implementation.md
+++ b/.github/ISSUE_TEMPLATE/agent-implementation.md
@@ -6,6 +6,15 @@ labels: ''
 assignees: ''
 ---
 
+## Metadata Checklist
+<!-- Ensure the following metadata is set before handing this issue to an agent. -->
+- [ ] Type label (exactly one: `type:epic`, `type:feature`, `type:bug`, `type:chore`, `type:spike`, `type:performance`)
+- [ ] Size label (exactly one: `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`)
+- [ ] Priority label (exactly one: `priority:high`, `priority:medium`, `priority:low`)
+- [ ] Launch-status label (exactly one: `launch:blocking`, `launch:post`, `launch:deferred`)
+- [ ] Domain label(s) (one or more from the affected area, e.g. `UX`, `voice`, `testing`, `technical-debt`, `model-management`)
+- [ ] Milestone assigned, or parked/no-milestone rationale added
+
 ## Parent Epic
 <!-- Link to parent epic issue if applicable -->
 

--- a/.github/ISSUE_TEMPLATE/jandal_work_item.yml
+++ b/.github/ISSUE_TEMPLATE/jandal_work_item.yml
@@ -1,0 +1,137 @@
+name: Jandal work item
+description: Create a Jandal feature, bug, chore, spike, performance item, or epic with implementation-ready metadata.
+title: "type(scope): concise summary"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for backlog items that may be handed to an agent or linked from a parent epic.
+
+        After the issue is created, apply the matching GitHub labels and milestone selected below.
+
+  - type: dropdown
+    id: type_label
+    attributes:
+      label: Type label
+      description: Apply exactly one matching type label after creating the issue.
+      options:
+        - type:epic
+        - type:feature
+        - type:bug
+        - type:chore
+        - type:spike
+        - type:performance
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size_label
+    attributes:
+      label: Size label
+      description: Apply exactly one matching size label after creating the issue.
+      options:
+        - size:XS
+        - size:S
+        - size:M
+        - size:L
+        - size:XL
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority_label
+    attributes:
+      label: Priority label
+      description: Apply exactly one matching priority label after creating the issue.
+      options:
+        - priority:high
+        - priority:medium
+        - priority:low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: launch_label
+    attributes:
+      label: Launch status label
+      description: Apply exactly one launch-status label after creating the issue.
+      options:
+        - launch:blocking
+        - launch:post
+        - launch:deferred
+    validations:
+      required: true
+
+  - type: input
+    id: domain_labels
+    attributes:
+      label: Domain labels
+      description: Add one or more domain labels such as UX, voice, testing, technical-debt, skills, memory, or model-management.
+      placeholder: "technical-debt, testing"
+    validations:
+      required: true
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Add the intended milestone, or state the parked/no-milestone rationale.
+      placeholder: "Launch readiness / Post-launch / Milestone intentionally omitted: parked until ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: parent_context
+    attributes:
+      label: Parent epic / workstream
+      description: Link the parent epic, launch plan, or state that this is standalone.
+      placeholder: "Parent epic: #123"
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should change, and why is it valuable?
+      placeholder: "Describe the desired outcome in a few sentences."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Include in-scope and not-in-scope notes so agents stay focused.
+      value: |
+        ## In scope
+        - 
+
+        ## Not in scope
+        - 
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Use a checklist with observable outcomes.
+      value: |
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing / device validation expectations
+      description: State unit, instrumentation, manual testing, and whether S21/S23U validation is required.
+      value: |
+        - [ ] Unit tests: 
+        - [ ] Instrumentation/UIAutomator tests: 
+        - [ ] Device validation: S21 default unless this is high-risk model/runtime work or explicitly requires S23U.
+        - [ ] Evidence to attach: 
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+- 
+
+## Linked issues / parent epic updates
+
+- Closes / relates to: #
+- [ ] Linked issue metadata remains accurate after this PR.
+- [ ] Parent epic or launch plan is updated when this PR creates, completes, supersedes, or defers child work.
+- [ ] Follow-up issues are created only where needed and include labels, milestone, parent epic/workstream, acceptance criteria, and test expectations.
+
+## Testing
+
+- [ ] Unit tests
+- [ ] Instrumentation/UIAutomator tests
+- [ ] S21 device validation, if required
+- [ ] S23U device validation, if required
+- [ ] Not required / docs-only rationale: 
+
+## Documentation
+
+- [ ] Relevant docs updated, or docs-not-needed rationale provided below.
+
+Docs not needed: 
+
+## Agent / reviewer notes
+
+- [ ] Do Not Merge — wait for Nick's explicit approval unless Nick has already approved merge in the PR thread.

--- a/.github/workflows/backlog-hygiene.yml
+++ b/.github/workflows/backlog-hygiene.yml
@@ -1,0 +1,62 @@
+name: Backlog hygiene
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+  schedule:
+    # Weekly lightweight audit for stale metadata drift.
+    - cron: '0 20 * * 0'
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Optional issue number to check instead of the whole open backlog
+        required: false
+        type: string
+      fail_on_violations:
+        description: Fail the workflow when hygiene warnings are found
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  check:
+    name: Check issue metadata
+    runs-on: ubuntu-latest
+    if: github.event_name != 'issues' || github.event.issue.pull_request == null
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run backlog hygiene check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          FAIL_ON_VIOLATIONS: ${{ inputs.fail_on_violations }}
+        run: |
+          set -euo pipefail
+
+          args=(--repo "$GITHUB_REPOSITORY")
+
+          if [[ -n "${EVENT_ISSUE_NUMBER:-}" ]]; then
+            args+=(--issue-number "$EVENT_ISSUE_NUMBER")
+          elif [[ -n "${INPUT_ISSUE_NUMBER:-}" ]]; then
+            args+=(--issue-number "$INPUT_ISSUE_NUMBER")
+          fi
+
+          if [[ "${FAIL_ON_VIOLATIONS:-false}" == "true" ]]; then
+            args+=(--fail-on-violations)
+          fi
+
+          python3 scripts/check_issue_hygiene.py "${args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           test -f README.md || (echo "README.md missing" && exit 1)
           echo "Repo structure OK"
 
+      # ── Repository script tests ──────────────────────────────────────
+      - name: Python script tests
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
       # ── Android build ──────────────────────────────────────────────
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           echo "Repo structure OK"
 
       # ── Repository script tests ──────────────────────────────────────
-      - name: Python script tests
-        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+      - name: Backlog hygiene checker tests
+        run: python3 -m unittest scripts/tests/test_check_issue_hygiene.py
 
       # ── Android build ──────────────────────────────────────────────
       - name: Set up JDK 21

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -54,7 +54,7 @@ Use the lightest validation that can prove the change safely:
 
 ## Project views and saved searches
 
-Preferred durable backlog dashboard: create a GitHub Project named **Jandal Launch Backlog** and add views using the queries below. A local/browser agent can create and maintain this Project if it has GitHub Project management permissions. Personal saved searches are optional UI shortcuts and may still need to be created manually by the signed-in user.
+Preferred durable backlog dashboard: create a GitHub Project named **Jandal Launch Backlog** and add views using the queries below. A local or browser agent can create and maintain this Project if it has GitHub Project management permissions. Personal saved searches are optional UI shortcuts and may still need to be created manually by the signed-in user.
 
 Recommended Project views:
 
@@ -70,10 +70,6 @@ Recommended Project views:
 | Deferred backlog | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:deferred` | Dream/deferred backlog |
 
 If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead. The setup agent should comment on #1271 with the Project URL and any filters left as manual saved searches.
-
-## Project setup follow-up
-
-The backlog dashboard can be created after this PR lands. Create or reuse **Jandal Launch Backlog**, link it to this repository, add the views above, and add existing matching issues so the views are useful immediately.
 
 ## Automated warning signal
 

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -52,30 +52,24 @@ Use the lightest validation that can prove the change safely:
 - Routine docs/process-only changes do not need physical device validation; state this explicitly in the issue or PR.
 - Every PR with device evidence should state the device used, Android version when relevant, commands run, and evidence artifact paths.
 
-## Saved searches / project views
+## Project views and saved searches
 
-Create GitHub saved searches or Project views for the following queries:
+Preferred durable backlog dashboard: create a GitHub Project named **Jandal Launch Backlog** and add views using the queries below. A local/browser agent can create and maintain this Project if it is authenticated with GitHub permissions that can manage Projects. Personal saved searches are optional UI shortcuts and may still need to be created manually by the signed-in user.
 
-```text
-repo:NickMonrad/kernel-ai-assistant is:issue is:open no:label
-repo:NickMonrad/kernel-ai-assistant is:issue is:open no:milestone
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:blocking
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:type:epic
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:priority:high label:launch:post
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:deferred
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:testing
-repo:NickMonrad/kernel-ai-assistant is:issue is:open label:technical-debt
-```
+Recommended Project views:
 
-Recommended dashboard sections:
+| View | Query / filter | Purpose |
+| --- | --- | --- |
+| Launch blockers | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:blocking` | Current release blockers |
+| High-priority post-launch | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:priority:high label:launch:post` | Valuable work that should not block launch |
+| Epics and parent streams | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:type:epic` | Parent workstreams and child status |
+| Missing labels | `repo:NickMonrad/kernel-ai-assistant is:issue is:open no:label` | Metadata cleanup queue |
+| Missing milestones | `repo:NickMonrad/kernel-ai-assistant is:issue is:open no:milestone` | Planning cleanup queue |
+| Testing / evidence | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:testing` | Test harness and evidence reliability |
+| Technical debt | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:technical-debt` | Maintenance work |
+| Deferred backlog | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:deferred` | Dream/deferred backlog |
 
-1. Launch blockers
-2. High-priority post-launch
-3. Ready for agent
-4. Needs design / spike
-5. Missing metadata
-6. Deferred / dream backlog
-7. Epics and parent streams
+If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead.
 
 ## Automated warning signal
 
@@ -102,7 +96,7 @@ python3 -m unittest scripts/tests/test_check_issue_hygiene.py
 
 | Frequency | Activity |
 | --- | --- |
-| Weekly, or before agent handoff | Review workflow warnings plus the missing-label and missing-milestone saved searches. Fix anything that blocks clean agent handoff. |
+| Weekly, or before agent handoff | Review workflow warnings plus the missing-label and missing-milestone Project views or saved searches. Fix anything that blocks clean agent handoff. |
 | Before assigning work to an agent | Verify parent epic/workstream, labels, milestone, acceptance criteria, and test expectations. Add a comment if anything is missing; do not let the agent discover ambiguity mid-turn. |
 | After PR merge | Close or update the linked issue, update the parent epic child status, and close completed child trackers where appropriate. |
 | Monthly | Review `launch:deferred` and old `priority:low` items for closure, consolidation, or promotion to active work. |

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -71,6 +71,10 @@ Recommended Project views:
 
 If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead. The setup agent should comment on #1271 with the Project URL and any filters left as manual saved searches.
 
+## Project setup follow-up
+
+The backlog dashboard can be created after this PR lands. Create or reuse **Jandal Launch Backlog**, link it to this repository, add the views above, and add existing matching issues so the views are useful immediately.
+
 ## Automated warning signal
 
 The repository includes `scripts/check_issue_hygiene.py` and the `Backlog hygiene` workflow.

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -54,7 +54,7 @@ Use the lightest validation that can prove the change safely:
 
 ## Project views and saved searches
 
-Preferred durable backlog dashboard: create a GitHub Project named **Jandal Launch Backlog** and add views using the queries below. A local/browser agent can create and maintain this Project if it is authenticated with GitHub permissions that can manage Projects. Personal saved searches are optional UI shortcuts and may still need to be created manually by the signed-in user.
+Preferred durable backlog dashboard: create a GitHub Project named **Jandal Launch Backlog** and add views using the queries below. A local/browser agent can create and maintain this Project if it has GitHub Project management permissions. Personal saved searches are optional UI shortcuts and may still need to be created manually by the signed-in user.
 
 Recommended Project views:
 
@@ -69,7 +69,7 @@ Recommended Project views:
 | Technical debt | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:technical-debt` | Maintenance work |
 | Deferred backlog | `repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:deferred` | Dream/deferred backlog |
 
-If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead.
+If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead. The setup agent should comment on #1271 with the Project URL and any filters left as manual saved searches.
 
 ## Automated warning signal
 

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -1,0 +1,110 @@
+# Backlog hygiene and triage policy
+
+This policy keeps Jandal issues ready for agent handoff without adding heavy project-management ceremony. It supports issue #1251 and applies to every open issue unless the issue is intentionally parked with an explicit rationale.
+
+## Required issue metadata
+
+Every open issue should have exactly one label from each required category:
+
+| Category | Allowed labels |
+| --- | --- |
+| Type | `type:epic`, `type:feature`, `type:bug`, `type:chore`, `type:spike`, `type:performance` |
+| Size | `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL` |
+| Priority | `priority:high`, `priority:medium`, `priority:low` |
+| Launch status | `launch:blocking`, `launch:post`, `launch:deferred` |
+
+Each open issue should also have:
+
+- one or more domain labels, for example `UX`, `ui`, `voice`, `wake-word`, `skills`, `lists`, `meal-planning`, `memory`, `model-management`, `testing`, `technical-debt`, `research`, or `optimisation`;
+- a milestone, unless the issue body or comment clearly states why the issue is parked without one;
+- a parent epic/workstream reference, or an explicit note that it is standalone;
+- clear acceptance criteria;
+- testing expectations, including when S21 or S23U validation is required.
+
+## Issue readiness checklist
+
+Before giving an issue to an agent, confirm:
+
+- [ ] The issue has one `type:*`, one `size:*`, one `priority:*`, and one `launch:*` label.
+- [ ] The issue has at least one domain label.
+- [ ] The issue has a milestone, or a clear parked/no-milestone rationale.
+- [ ] The issue links to its parent epic/workstream, or says it is standalone.
+- [ ] The issue has observable acceptance criteria.
+- [ ] The issue states automated, manual, and device validation expectations.
+- [ ] The issue is implementation-ready; otherwise create or keep it as a `type:spike`.
+
+## Device validation expectations
+
+Use the lightest validation that can prove the change safely:
+
+- S21 is the default device for permission, QIR, navigation, and test-harness work.
+- S23U should be used only for high-risk model/runtime comparison or where explicitly required.
+- Manual device evidence remains important for STT/TTS quality, wake-word behaviour, model availability, UI alignment, and any flow that automated tests cannot prove reliably.
+- Routine docs/process-only changes do not need physical device validation; state this explicitly in the issue or PR.
+
+## Saved searches / project views
+
+Create GitHub saved searches or Project views for the following queries:
+
+```text
+repo:NickMonrad/kernel-ai-assistant is:issue is:open no:label
+repo:NickMonrad/kernel-ai-assistant is:issue is:open no:milestone
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:blocking
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:type:epic
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:priority:high label:launch:post
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:launch:deferred
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:testing
+repo:NickMonrad/kernel-ai-assistant is:issue is:open label:technical-debt
+```
+
+Recommended dashboard sections:
+
+1. Launch blockers
+2. High-priority post-launch
+3. Ready for agent
+4. Needs design / spike
+5. Missing metadata
+6. Deferred / dream backlog
+7. Epics and parent streams
+
+## Automated warning signal
+
+The repository includes `scripts/check_issue_hygiene.py` and the `Backlog hygiene` workflow.
+
+The workflow runs:
+
+- when issues are opened, edited, reopened, labeled, unlabeled, milestoned, or demilestoned;
+- weekly on a schedule;
+- manually via `workflow_dispatch`.
+
+By default the workflow is warning-only. Maintainers can run it manually with `fail_on_violations=true` when they want a hard audit before a cleanup pass.
+
+Local usage:
+
+```bash
+python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant
+python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant --issue-number 1251
+python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant --fail-on-violations
+```
+
+## Triage cadence
+
+- Weekly: review the workflow summary plus missing-label and missing-milestone saved searches.
+- Before assigning work to an agent: confirm the readiness checklist above.
+- After PR merge: close or update the linked issue, and update the parent epic child status.
+- Monthly: review `launch:deferred` and old `priority:low` issues for closure, consolidation, or promotion.
+
+## Parent epic update convention
+
+When a child issue is created, completed, superseded, or deferred:
+
+- update the child issue with its parent epic/workstream;
+- update the parent epic child list or status summary;
+- close duplicate or superseded children with the correct state reason where appropriate;
+- leave a short comment when an issue is intentionally parked without a milestone.
+
+## Spike vs implementation issue
+
+Use `type:spike` when the implementation path, risk, licensing, store-policy impact, or test strategy is not yet clear.
+
+Convert or replace the spike with a `type:feature`, `type:bug`, `type:chore`, or `type:performance` implementation issue when the outcome is known and acceptance criteria are concrete.

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -1,24 +1,27 @@
 # Backlog hygiene and triage policy
 
-This policy keeps Jandal issues ready for agent handoff without adding heavy project-management ceremony. It supports issue #1251 and applies to every open issue unless the issue is intentionally parked with an explicit rationale.
+> **Status:** Active policy
+> **Related:** #1251 and launch plan #1255
+
+This policy keeps the Jandal AI backlog trustworthy for agent-driven development without adding heavy project-management ceremony. Agents rely on issue metadata, milestones, parent epics, acceptance criteria, and test evidence expectations to pick the right work and produce reviewable changes.
 
 ## Required issue metadata
 
 Every open issue should have exactly one label from each required category:
 
-| Category | Allowed labels |
-| --- | --- |
-| Type | `type:epic`, `type:feature`, `type:bug`, `type:chore`, `type:spike`, `type:performance` |
-| Size | `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL` |
-| Priority | `priority:high`, `priority:medium`, `priority:low` |
-| Launch status | `launch:blocking`, `launch:post`, `launch:deferred` |
+| Category | Allowed labels | Notes |
+| --- | --- | --- |
+| Type | `type:epic`, `type:feature`, `type:bug`, `type:chore`, `type:spike`, `type:performance` | Exactly one. |
+| Size | `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL` | Exactly one. |
+| Priority | `priority:high`, `priority:medium`, `priority:low` | Exactly one. Never duplicate. |
+| Launch status | `launch:blocking`, `launch:post`, `launch:deferred` | Exactly one for launch-track work. Parked/dream backlog items should normally be `launch:deferred`. |
 
 Each open issue should also have:
 
 - one or more domain labels, for example `UX`, `ui`, `voice`, `wake-word`, `skills`, `lists`, `meal-planning`, `memory`, `model-management`, `testing`, `technical-debt`, `research`, or `optimisation`;
-- a milestone, unless the issue body or comment clearly states why the issue is parked without one;
+- a milestone, unless the issue body or a comment clearly states why the issue is parked without one;
 - a parent epic/workstream reference, or an explicit note that it is standalone;
-- clear acceptance criteria;
+- observable acceptance criteria;
 - testing expectations, including when S21 or S23U validation is required.
 
 ## Issue readiness checklist
@@ -33,14 +36,21 @@ Before giving an issue to an agent, confirm:
 - [ ] The issue states automated, manual, and device validation expectations.
 - [ ] The issue is implementation-ready; otherwise create or keep it as a `type:spike`.
 
+## Spike vs implementation issue
+
+Use `type:spike` when the implementation path, risk, licensing, store-policy impact, or test strategy is not yet clear. A spike should produce a decision, recommendation, evidence bundle, or concrete child issue; it should not quietly turn into broad production implementation.
+
+Use `type:feature`, `type:bug`, `type:chore`, or `type:performance` when the approach is understood and the acceptance criteria are concrete enough for an agent to implement and test.
+
 ## Device validation expectations
 
 Use the lightest validation that can prove the change safely:
 
-- S21 is the default device for permission, QIR, navigation, and test-harness work.
-- S23U should be used only for high-risk model/runtime comparison or where explicitly required.
-- Manual device evidence remains important for STT/TTS quality, wake-word behaviour, model availability, UI alignment, and any flow that automated tests cannot prove reliably.
+- S21 is the default device for permission, QIR, navigation, test-harness, and model-readiness work.
+- S23U should be used only for high-risk model/runtime/voice comparison or where explicitly required.
+- Manual device evidence remains important for STT/TTS quality, wake-word behaviour, model availability, UI alignment, and flows that automated tests cannot prove reliably.
 - Routine docs/process-only changes do not need physical device validation; state this explicitly in the issue or PR.
+- Every PR with device evidence should state the device used, Android version when relevant, commands run, and evidence artifact paths.
 
 ## Saved searches / project views
 
@@ -85,14 +95,17 @@ Local usage:
 python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant
 python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant --issue-number 1251
 python3 scripts/check_issue_hygiene.py --repo NickMonrad/kernel-ai-assistant --fail-on-violations
+python3 -m unittest scripts/tests/test_check_issue_hygiene.py
 ```
 
 ## Triage cadence
 
-- Weekly: review the workflow summary plus missing-label and missing-milestone saved searches.
-- Before assigning work to an agent: confirm the readiness checklist above.
-- After PR merge: close or update the linked issue, and update the parent epic child status.
-- Monthly: review `launch:deferred` and old `priority:low` issues for closure, consolidation, or promotion.
+| Frequency | Activity |
+| --- | --- |
+| Weekly, or before agent handoff | Review workflow warnings plus the missing-label and missing-milestone saved searches. Fix anything that blocks clean agent handoff. |
+| Before assigning work to an agent | Verify parent epic/workstream, labels, milestone, acceptance criteria, and test expectations. Add a comment if anything is missing; do not let the agent discover ambiguity mid-turn. |
+| After PR merge | Close or update the linked issue, update the parent epic child status, and close completed child trackers where appropriate. |
+| Monthly | Review `launch:deferred` and old `priority:low` items for closure, consolidation, or promotion to active work. |
 
 ## Parent epic update convention
 
@@ -103,8 +116,43 @@ When a child issue is created, completed, superseded, or deferred:
 - close duplicate or superseded children with the correct state reason where appropriate;
 - leave a short comment when an issue is intentionally parked without a milestone.
 
-## Spike vs implementation issue
+## Launch reclassification rules
 
-Use `type:spike` when the implementation path, risk, licensing, store-policy impact, or test strategy is not yet clear.
+When reclassifying an issue's launch status:
 
-Convert or replace the spike with a `type:feature`, `type:bug`, `type:chore`, or `type:performance` implementation issue when the outcome is known and acceptance criteria are concrete.
+- Keep `launch:blocking` if the issue affects first-run reliability, Store compliance, model readiness, permission UX, release evidence, or any launch claim.
+- Move to `launch:post` if the issue is valuable but not launch-critical and should not block release.
+- Move to `launch:deferred` if the issue is a dream feature, depends on unavailable technology, or has no clear implementation path within the next two milestones.
+- Close as `not_planned` if the issue is superseded, a duplicate, or no longer relevant.
+- If uncertain, leave the current label and add a comment explaining what decision or evidence is needed.
+
+## Launch-blocking audit baseline
+
+The #1255 Gate 0 audit grouped launch-track issues as follows:
+
+**Keep as `launch:blocking`:**
+
+- #1014 — Launch readiness parent epic
+- #441 — Play Store publish
+- #427 — Verification matrix
+- #824 — Voice QA gate
+- #1142 — Wake-word battery drain
+- #1140 — Permission UX epic
+- #428 — Memory profiling decision spike
+
+**Already non-blocking / post-launch / deferred:**
+
+- #928 — Lists UX, `launch:post`
+- #885 — Messaging reply, `launch:post`
+- #886 — Group chat, `launch:post`
+- #756 — Piper voice, `launch:deferred`
+- #713 — Vision, `launch:deferred`
+- #432 — Compat swap, `launch:post`
+- #430 — Dynamic loading, `launch:post`
+
+**Closed / completed baseline:**
+
+- #868 — completed
+- #1245 — completed by PR #1256
+
+Use this baseline as a starting point, not a permanent truth. Reclassify launch blockers when evidence changes, especially after S21 model-readiness and verification-matrix work lands.

--- a/docs/backlog-hygiene.md
+++ b/docs/backlog-hygiene.md
@@ -71,10 +71,6 @@ Recommended Project views:
 
 If the Project implementation cannot express one of the filters as a saved Project view, keep the query in this document and create it as a personal saved search instead. The setup agent should comment on #1271 with the Project URL and any filters left as manual saved searches.
 
-## Project setup follow-up
-
-The backlog dashboard can be created after this PR lands. Create or reuse **Jandal Launch Backlog**, link it to this repository, add the views above, and add existing matching issues so the views are useful immediately.
-
 ## Automated warning signal
 
 The repository includes `scripts/check_issue_hygiene.py` and the `Backlog hygiene` workflow.

--- a/scripts/check_issue_hygiene.py
+++ b/scripts/check_issue_hygiene.py
@@ -102,13 +102,28 @@ def _has_testing_expectations(body: str) -> bool:
     return any(marker in lower for marker in TEST_MARKERS)
 
 
-def _is_milestone_intentionally_parked(body: str) -> bool:
-    lower = body.lower()
+def _is_milestone_intentionally_parked(text: str) -> bool:
+    lower = text.lower()
     return any(marker in lower for marker in PARKED_MARKERS)
 
 
-def validate_issue(issue: dict[str, Any]) -> IssueViolation | None:
-    """Return an IssueViolation when the issue does not satisfy the policy."""
+def _body_plus_comments(body: str, comment_bodies: Iterable[str] | None) -> str:
+    comments = [comment for comment in comment_bodies or [] if comment]
+    if not comments:
+        return body
+    return body + "\n\n" + "\n\n".join(comments)
+
+
+def validate_issue(
+    issue: dict[str, Any],
+    comment_bodies: Iterable[str] | None = None,
+) -> IssueViolation | None:
+    """Return an IssueViolation when the issue does not satisfy the policy.
+
+    The issue body remains the source of truth for implementation readiness.
+    Comments are only used for the explicit no-milestone/parked rationale
+    allowed by the backlog hygiene policy.
+    """
 
     # GitHub's issues endpoint returns PRs as issue-shaped records.
     if issue.get("pull_request"):
@@ -116,6 +131,7 @@ def validate_issue(issue: dict[str, Any]) -> IssueViolation | None:
 
     labels = _issue_labels(issue)
     body = issue.get("body") or ""
+    body_and_comments = _body_plus_comments(body, comment_bodies)
     messages: list[str] = []
 
     for category, allowed in (
@@ -132,7 +148,7 @@ def validate_issue(issue: dict[str, Any]) -> IssueViolation | None:
     if not domain_labels:
         messages.append("missing at least one domain label such as `UX`, `voice`, `testing`, or `technical-debt`")
 
-    if not issue.get("milestone") and not _is_milestone_intentionally_parked(body):
+    if not issue.get("milestone") and not _is_milestone_intentionally_parked(body_and_comments):
         messages.append("missing milestone or explicit parked/no-milestone rationale")
 
     if not _has_parent_or_standalone_marker(body, labels):
@@ -176,6 +192,24 @@ def _github_request(url: str, token: str | None) -> Any:
 def fetch_issue(repo: str, issue_number: int, token: str | None) -> dict[str, Any]:
     url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
     return _github_request(url, token)
+
+
+def fetch_issue_comments(repo: str, issue_number: int, token: str | None) -> list[str]:
+    """Fetch issue comment bodies for no-milestone parked rationale checks."""
+
+    comment_bodies: list[str] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+            f"?per_page=100&page={page}"
+        )
+        batch = _github_request(url, token)
+        if not batch:
+            break
+        comment_bodies.extend(comment.get("body") or "" for comment in batch)
+        page += 1
+    return comment_bodies
 
 
 def fetch_open_issues(repo: str, token: str | None) -> list[dict[str, Any]]:
@@ -227,6 +261,17 @@ def emit_github_annotations(violations: Iterable[IssueViolation]) -> None:
         )
 
 
+def _comment_bodies_for_issue(repo: str, issue: dict[str, Any], token: str | None) -> list[str]:
+    """Fetch comments only when they are needed for no-milestone rationale."""
+
+    if issue.get("pull_request") or issue.get("milestone"):
+        return []
+    issue_number = int(issue.get("number", 0))
+    if issue_number <= 0:
+        return []
+    return fetch_issue_comments(repo, issue_number, token)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Check GitHub issue backlog hygiene metadata.")
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="Repository in owner/name form")
@@ -249,7 +294,12 @@ def main() -> None:
 
     token = os.environ.get(args.token_env)
     issues = [fetch_issue(args.repo, args.issue_number, token)] if args.issue_number else fetch_open_issues(args.repo, token)
-    violations = [violation for issue in issues if (violation := validate_issue(issue))]
+    violations: list[IssueViolation] = []
+    for issue in issues:
+        comment_bodies = _comment_bodies_for_issue(args.repo, issue, token)
+        violation = validate_issue(issue, comment_bodies=comment_bodies)
+        if violation:
+            violations.append(violation)
 
     summary = build_summary(violations)
     print(summary)

--- a/scripts/check_issue_hygiene.py
+++ b/scripts/check_issue_hygiene.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Backlog hygiene checker for GitHub issues.
+
+The checker is intentionally a warning signal by default. It helps agents and
+maintainers spot issues that are not ready for implementation handoff without
+turning lightweight triage into a hard merge gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+TYPE_LABELS = {
+    "type:epic",
+    "type:feature",
+    "type:bug",
+    "type:chore",
+    "type:spike",
+    "type:performance",
+}
+SIZE_LABELS = {"size:XS", "size:S", "size:M", "size:L", "size:XL"}
+PRIORITY_LABELS = {"priority:high", "priority:medium", "priority:low"}
+LAUNCH_LABELS = {"launch:blocking", "launch:post", "launch:deferred"}
+
+POLICY_LABELS = TYPE_LABELS | SIZE_LABELS | PRIORITY_LABELS | LAUNCH_LABELS
+
+PARKED_MARKERS = (
+    "intentionally parked",
+    "parked without milestone",
+    "milestone intentionally omitted",
+    "no milestone required",
+    "no milestone: parked",
+)
+
+PARENT_MARKERS = (
+    "parent epic",
+    "parent tracker",
+    "parent / launch context",
+    "workstream",
+    "standalone issue",
+    "standalone:",
+)
+
+TEST_MARKERS = (
+    "## testing",
+    "testing expectations",
+    "test plan",
+    "device validation",
+    "manual test",
+    "automated test",
+    "s21",
+    "s23",
+    "evidence",
+    "validation",
+)
+
+
+@dataclass(frozen=True)
+class IssueViolation:
+    """Validation result for one issue."""
+
+    number: int
+    title: str
+    url: str
+    messages: list[str]
+
+
+def _issue_labels(issue: dict[str, Any]) -> set[str]:
+    return {label.get("name", "") for label in issue.get("labels", []) if label.get("name")}
+
+
+def _exactly_one_label(labels: set[str], allowed: set[str], category: str) -> str | None:
+    matches = sorted(labels & allowed)
+    if len(matches) == 1:
+        return None
+    if not matches:
+        return f"missing exactly one `{category}` label"
+    return f"has multiple `{category}` labels: {', '.join(matches)}"
+
+
+def _has_acceptance_criteria(body: str) -> bool:
+    lower = body.lower()
+    return "acceptance criteria" in lower and ("- [ ]" in lower or "- [x]" in lower)
+
+
+def _has_parent_or_standalone_marker(body: str, labels: set[str]) -> bool:
+    if "type:epic" in labels:
+        return True
+    lower = body.lower()
+    return any(marker in lower for marker in PARENT_MARKERS)
+
+
+def _has_testing_expectations(body: str) -> bool:
+    lower = body.lower()
+    return any(marker in lower for marker in TEST_MARKERS)
+
+
+def _is_milestone_intentionally_parked(body: str) -> bool:
+    lower = body.lower()
+    return any(marker in lower for marker in PARKED_MARKERS)
+
+
+def validate_issue(issue: dict[str, Any]) -> IssueViolation | None:
+    """Return an IssueViolation when the issue does not satisfy the policy."""
+
+    # GitHub's issues endpoint returns PRs as issue-shaped records.
+    if issue.get("pull_request"):
+        return None
+
+    labels = _issue_labels(issue)
+    body = issue.get("body") or ""
+    messages: list[str] = []
+
+    for category, allowed in (
+        ("type:*", TYPE_LABELS),
+        ("size:*", SIZE_LABELS),
+        ("priority:*", PRIORITY_LABELS),
+        ("launch:*", LAUNCH_LABELS),
+    ):
+        result = _exactly_one_label(labels, allowed, category)
+        if result:
+            messages.append(result)
+
+    domain_labels = sorted(labels - POLICY_LABELS)
+    if not domain_labels:
+        messages.append("missing at least one domain label such as `UX`, `voice`, `testing`, or `technical-debt`")
+
+    if not issue.get("milestone") and not _is_milestone_intentionally_parked(body):
+        messages.append("missing milestone or explicit parked/no-milestone rationale")
+
+    if not _has_parent_or_standalone_marker(body, labels):
+        messages.append("missing parent epic/workstream reference or explicit standalone marker")
+
+    if not _has_acceptance_criteria(body):
+        messages.append("missing `Acceptance criteria` checklist")
+
+    if not _has_testing_expectations(body):
+        messages.append("missing testing/device validation expectations")
+
+    if not messages:
+        return None
+
+    return IssueViolation(
+        number=int(issue.get("number", 0)),
+        title=str(issue.get("title", "<untitled>")),
+        url=str(issue.get("html_url", "")),
+        messages=messages,
+    )
+
+
+def _github_request(url: str, token: str | None) -> Any:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "jandal-backlog-hygiene-checker",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API request failed: {exc.code} {exc.reason}: {detail}") from exc
+
+
+def fetch_issue(repo: str, issue_number: int, token: str | None) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
+    return _github_request(url, token)
+
+
+def fetch_open_issues(repo: str, token: str | None) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/issues?state=open&per_page=100&page={page}"
+        batch = _github_request(url, token)
+        if not batch:
+            break
+        issues.extend(batch)
+        page += 1
+    return issues
+
+
+def _escape_annotation(text: str) -> str:
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def build_summary(violations: Iterable[IssueViolation]) -> str:
+    items = list(violations)
+    if not items:
+        return "## Backlog hygiene\n\nAll checked issues satisfy the backlog hygiene policy."
+
+    lines = [
+        "## Backlog hygiene warnings",
+        "",
+        "These warnings do not block CI by default, but the issues below are not ready for clean agent handoff.",
+        "",
+    ]
+    for violation in items:
+        title = f"#{violation.number} — {violation.title}"
+        if violation.url:
+            title = f"[#{violation.number} — {violation.title}]({violation.url})"
+        lines.append(f"### {title}")
+        for message in violation.messages:
+            lines.append(f"- {message}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def emit_github_annotations(violations: Iterable[IssueViolation]) -> None:
+    for violation in violations:
+        joined = "; ".join(violation.messages[:4])
+        if len(violation.messages) > 4:
+            joined += f"; +{len(violation.messages) - 4} more"
+        print(
+            f"::warning title=Backlog hygiene #{violation.number}::{_escape_annotation(joined)}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check GitHub issue backlog hygiene metadata.")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="Repository in owner/name form")
+    parser.add_argument("--issue-number", type=int, default=None, help="Check a single issue number")
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit 1 when hygiene violations are found. Default is warning-only.",
+    )
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="Environment variable containing a GitHub token. Default: GITHUB_TOKEN",
+    )
+    args = parser.parse_args()
+
+    if not args.repo:
+        print("::error::Repository is required via --repo or GITHUB_REPOSITORY", file=sys.stderr)
+        sys.exit(2)
+
+    token = os.environ.get(args.token_env)
+    issues = [fetch_issue(args.repo, args.issue_number, token)] if args.issue_number else fetch_open_issues(args.repo, token)
+    violations = [violation for issue in issues if (violation := validate_issue(issue))]
+
+    summary = build_summary(violations)
+    print(summary)
+    emit_github_annotations(violations)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as handle:
+            handle.write(summary)
+
+    if violations and args.fail_on_violations:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_issue_hygiene.py
+++ b/scripts/tests/test_check_issue_hygiene.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for the backlog hygiene issue checker."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_issue_hygiene as cih
+
+
+def _issue(
+    *,
+    labels: list[str],
+    body: str | None = None,
+    milestone: dict[str, object] | None = {"number": 3, "title": "Launch"},
+) -> dict[str, object]:
+    return {
+        "number": 123,
+        "title": "Test issue",
+        "html_url": "https://github.com/NickMonrad/kernel-ai-assistant/issues/123",
+        "labels": [{"name": label} for label in labels],
+        "body": body
+        or """Parent epic: #1
+
+## Summary
+Do the thing.
+
+## Acceptance criteria
+- [ ] Thing works.
+
+## Testing
+- [ ] Unit tests pass.
+""",
+        "milestone": milestone,
+    }
+
+
+class ValidateIssueTest(unittest.TestCase):
+    def test_valid_issue_passes(self) -> None:
+        issue = _issue(
+            labels=[
+                "type:feature",
+                "size:S",
+                "priority:medium",
+                "launch:post",
+                "UX",
+            ]
+        )
+
+        self.assertIsNone(cih.validate_issue(issue))
+
+    def test_detects_missing_launch_and_domain_labels(self) -> None:
+        issue = _issue(labels=["type:chore", "size:S", "priority:high"])
+
+        violation = cih.validate_issue(issue)
+
+        self.assertIsNotNone(violation)
+        messages = "\n".join(violation.messages) if violation else ""
+        self.assertIn("launch:*", messages)
+        self.assertIn("domain label", messages)
+
+    def test_detects_missing_milestone(self) -> None:
+        issue = _issue(
+            labels=["type:bug", "size:XS", "priority:high", "launch:blocking", "testing"],
+            milestone=None,
+        )
+
+        violation = cih.validate_issue(issue)
+
+        self.assertIsNotNone(violation)
+        messages = "\n".join(violation.messages) if violation else ""
+        self.assertIn("missing milestone", messages)
+
+    def test_parked_issue_can_omit_milestone(self) -> None:
+        issue = _issue(
+            labels=["type:spike", "size:S", "priority:low", "launch:deferred", "research"],
+            milestone=None,
+            body="""Standalone issue.
+
+Milestone intentionally omitted: intentionally parked until post-launch.
+
+## Acceptance criteria
+- [ ] Decision is captured.
+
+## Testing
+- [ ] No device testing required for research-only spike.
+""",
+        )
+
+        self.assertIsNone(cih.validate_issue(issue))
+
+    def test_epic_does_not_need_parent_marker(self) -> None:
+        issue = _issue(
+            labels=["type:epic", "size:XL", "priority:medium", "launch:post", "skills"],
+            body="""## Summary
+Parent tracker for a workstream.
+
+## Acceptance criteria
+- [ ] Children are listed.
+
+## Testing
+- [ ] Child issues define test evidence.
+""",
+        )
+
+        self.assertIsNone(cih.validate_issue(issue))
+
+    def test_pull_requests_are_skipped(self) -> None:
+        issue = _issue(labels=[])
+        issue["pull_request"] = {"url": "https://api.github.com/repos/x/y/pulls/1"}
+
+        self.assertIsNone(cih.validate_issue(issue))
+
+
+class SummaryTest(unittest.TestCase):
+    def test_summary_for_clean_result(self) -> None:
+        summary = cih.build_summary([])
+
+        self.assertIn("All checked issues satisfy", summary)
+
+    def test_summary_lists_violation(self) -> None:
+        violation = cih.IssueViolation(
+            number=1,
+            title="Needs metadata",
+            url="https://github.com/NickMonrad/kernel-ai-assistant/issues/1",
+            messages=["missing label"],
+        )
+
+        summary = cih.build_summary([violation])
+
+        self.assertIn("Needs metadata", summary)
+        self.assertIn("missing label", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_issue_hygiene.py
+++ b/scripts/tests/test_check_issue_hygiene.py
@@ -18,8 +18,9 @@ def _issue(
     *,
     labels: list[str],
     body: str | None = None,
-    milestone: dict[str, object] | None = {"number": 3, "title": "Launch"},
+    milestone: dict[str, object] | None = None,
 ) -> dict[str, object]:
+    resolved_milestone = milestone if milestone is not None else {"number": 3, "title": "Launch"}
     return {
         "number": 123,
         "title": "Test issue",
@@ -37,8 +38,14 @@ Do the thing.
 ## Testing
 - [ ] Unit tests pass.
 """,
-        "milestone": milestone,
+        "milestone": resolved_milestone,
     }
+
+
+def _issue_without_milestone(*, labels: list[str], body: str | None = None) -> dict[str, object]:
+    issue = _issue(labels=labels, body=body)
+    issue["milestone"] = None
+    return issue
 
 
 class ValidateIssueTest(unittest.TestCase):
@@ -66,9 +73,8 @@ class ValidateIssueTest(unittest.TestCase):
         self.assertIn("domain label", messages)
 
     def test_detects_missing_milestone(self) -> None:
-        issue = _issue(
-            labels=["type:bug", "size:XS", "priority:high", "launch:blocking", "testing"],
-            milestone=None,
+        issue = _issue_without_milestone(
+            labels=["type:bug", "size:XS", "priority:high", "launch:blocking", "testing"]
         )
 
         violation = cih.validate_issue(issue)
@@ -77,10 +83,9 @@ class ValidateIssueTest(unittest.TestCase):
         messages = "\n".join(violation.messages) if violation else ""
         self.assertIn("missing milestone", messages)
 
-    def test_parked_issue_can_omit_milestone(self) -> None:
-        issue = _issue(
+    def test_parked_issue_can_omit_milestone_from_body_rationale(self) -> None:
+        issue = _issue_without_milestone(
             labels=["type:spike", "size:S", "priority:low", "launch:deferred", "research"],
-            milestone=None,
             body="""Standalone issue.
 
 Milestone intentionally omitted: intentionally parked until post-launch.
@@ -94,6 +99,47 @@ Milestone intentionally omitted: intentionally parked until post-launch.
         )
 
         self.assertIsNone(cih.validate_issue(issue))
+
+    def test_parked_issue_can_omit_milestone_from_comment_rationale(self) -> None:
+        issue = _issue_without_milestone(
+            labels=["type:spike", "size:S", "priority:low", "launch:deferred", "research"],
+            body="""Standalone issue.
+
+## Acceptance criteria
+- [ ] Decision is captured.
+
+## Testing
+- [ ] No device testing required for research-only spike.
+""",
+        )
+
+        self.assertIsNone(
+            cih.validate_issue(
+                issue,
+                comment_bodies=["Milestone intentionally omitted: parked until the post-launch review."],
+            )
+        )
+
+    def test_comment_rationale_only_applies_to_milestone_check(self) -> None:
+        issue = _issue_without_milestone(
+            labels=["type:spike", "size:S", "priority:low", "launch:deferred", "research"],
+            body="""Standalone issue.
+
+## Summary
+Needs decision.
+""",
+        )
+
+        violation = cih.validate_issue(
+            issue,
+            comment_bodies=["Milestone intentionally omitted: parked until post-launch."],
+        )
+
+        self.assertIsNotNone(violation)
+        messages = "\n".join(violation.messages) if violation else ""
+        self.assertNotIn("missing milestone", messages)
+        self.assertIn("Acceptance criteria", messages)
+        self.assertIn("testing/device", messages)
 
     def test_epic_does_not_need_parent_marker(self) -> None:
         issue = _issue(


### PR DESCRIPTION
## Summary

- Makes #1271 the surviving #1251 implementation and supersedes #1266 rather than merging two competing backlog-hygiene PRs.
- Adds a backlog hygiene policy doc for issue metadata, saved searches / views, triage cadence, parent epic updates, reclassification rules, launch-blocking baseline, and device-validation expectations.
- Adds a Jandal work-item issue form so new issues capture labels, milestone, parent context, acceptance criteria, and test expectations up front.
- Updates the existing `agent-implementation.md` template with a metadata checklist ported from #1266.
- Adds a warning-only `Backlog hygiene` workflow plus `scripts/check_issue_hygiene.py` to audit issue metadata on issue changes, schedule, or manual dispatch.
- Adds unit tests for the issue hygiene checker, including parked/no-milestone rationale in issue comments.
- Wires the hygiene checker tests into CI with `python3 -m unittest scripts/tests/test_check_issue_hygiene.py`.
- Adds a PR template reminding agents to update linked issues / parent epics and not merge without Nick's approval.

## Linked issues / parent epic updates

- Closes #1251
- Supersedes #1266
- References #1255
- Follow-up/manual: GitHub saved searches or Project views still need to be created in the GitHub UI using the queries documented in `docs/backlog-hygiene.md`.
- Also cleaned #1265 metadata directly: added `launch:post`, `testing`, and milestone 3.

## Testing

- Not run locally from this connector session.
- CI now runs: `python3 -m unittest scripts/tests/test_check_issue_hygiene.py`
- No device validation required; this is repo process/docs/CI hygiene only.

## Documentation

- Added `docs/backlog-hygiene.md` with #1266's stronger policy/reclassification guidance folded in.

## Agent / reviewer notes

- Do Not Merge — wait for Nick's explicit approval.