### PR TITLE
fix(#1284): improve Learn screen readability and section hierarchy

### DIFF
--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -346,6 +346,25 @@ class ToolsHubNavTest {
     }
 
     @Test
+    fun toolsLearnScreen_showsSectionHeadings() {
+        composeTestRule.setContent {
+            ToolsLearnScreen(
+                onBack = {},
+                onOpenPrompt = {},
+            )
+        }
+
+        val screenNode = composeTestRule.onNodeWithTag("tools_learn_screen")
+        screenNode.performScrollToNode(hasTestTag("tools_learn_group_lists"))
+        composeTestRule.onNodeWithTag("tools_learn_group_lists").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lists").assertIsDisplayed()
+
+        screenNode.performScrollToNode(hasTestTag("tools_learn_group_weather"))
+        composeTestRule.onNodeWithTag("tools_learn_group_weather").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Weather").assertIsDisplayed()
+    }
+
+    @Test
     fun toolsLearnScreen_showsDefaultExamplesCollapsed() {
         composeTestRule.setContent {
             ToolsLearnScreen(

--- a/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
+++ b/app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt
@@ -381,7 +381,7 @@ class ToolsHubNavTest {
         screenNode.performScrollToNode(hasTestTag("tools_learn_meal_plan_family"))
         composeTestRule.onNodeWithTag("tools_learn_meal_plan_family").assertIsDisplayed()
         screenNode.performScrollToNode(hasTestTag("tools_learn_view_more_meal_planning"))
-        composeTestRule.onNodeWithText("Show less").assertIsDisplayed()
+        composeTestRule.onNodeWithText("View less").assertIsDisplayed()
     }
 
     @Test
@@ -401,7 +401,7 @@ class ToolsHubNavTest {
         screenNode.performScrollToNode(hasTestTag("tools_learn_weather_wellington"))
         composeTestRule.onNodeWithTag("tools_learn_weather_wellington").assertIsDisplayed()
         screenNode.performScrollToNode(hasTestTag("tools_learn_view_more_weather"))
-        composeTestRule.onNodeWithText("Show less").assertIsDisplayed()
+        composeTestRule.onNodeWithText("View less").assertIsDisplayed()
     }
 
     @Test
@@ -436,7 +436,7 @@ class ToolsHubNavTest {
         composeTestRule.waitForIdle()
 
         screenNode.performScrollToNode(hasTestTag("tools_learn_view_more_weather"))
-        composeTestRule.onNodeWithText("Show less").performClick()
+        composeTestRule.onNodeWithText("View less").performClick()
         composeTestRule.waitForIdle()
 
         // After collapse, weather section shows "View more" again

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,6 +34,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 data class ToolExamplePrompt(
@@ -187,16 +189,19 @@ fun ToolsLearnScreen(
                     .testTag("tools_learn_privacy_note"),
             )
             Spacer(modifier = Modifier.height(8.dp))
-
-            allExampleSections.forEach { section ->
+            allExampleSections.forEachIndexed { index, section ->
                 val isExpanded = section.id in expandedSectionIds
-                Text(
-                    text = section.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .testTag(section.groupTag),
+                if (index > 0) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+                LearnSectionHeader(
+                    title = section.title,
+                    testTag = section.groupTag,
+                    modifier = Modifier.padding(horizontal = 16.dp),
                 )
 
                 section.defaultExamples.forEach { example ->
@@ -253,6 +258,28 @@ fun ToolsLearnScreen(
                 Spacer(modifier = Modifier.height(4.dp))
             }
         }
+    }
+}
+
+@Composable
+private fun LearnSectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    testTag: String,
+) {
+    Column(modifier = modifier.testTag(testTag)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(6.dp))
+        HorizontalDivider(
+            modifier = Modifier.width(96.dp),
+            color = MaterialTheme.colorScheme.primary,
+            thickness = 2.dp,
+        )
     }
 }
 

--- a/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt
@@ -9,6 +9,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.ui.Alignment
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -167,7 +173,7 @@ fun ToolsLearnScreen(
             Text(
                 text = "Example prompts for actions, planning, weather, maps, media, and more",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.outline,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .testTag("tools_learn_helper_copy"),
@@ -175,7 +181,7 @@ fun ToolsLearnScreen(
             Text(
                 text = "Examples open in Actions so you can review or edit before running. Some examples may ask a follow-up question.",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.outline,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 4.dp)
                     .testTag("tools_learn_privacy_note"),
@@ -186,7 +192,7 @@ fun ToolsLearnScreen(
                 val isExpanded = section.id in expandedSectionIds
                 Text(
                     text = section.title,
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
                         .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -215,7 +221,15 @@ fun ToolsLearnScreen(
                             .padding(horizontal = 16.dp)
                             .testTag(section.viewMoreTag),
                     ) {
-                        Text("Show less")
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("View less")
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Icon(
+                                Icons.Default.ExpandLess,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
                     }
                 } else {
                     TextButton(
@@ -224,7 +238,15 @@ fun ToolsLearnScreen(
                             .padding(horizontal = 16.dp)
                             .testTag(section.viewMoreTag),
                     ) {
-                        Text("View more")
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("View more")
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Icon(
+                                Icons.Default.ExpandMore,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixes contrast, hierarchy, and affordance issues on the "Learn what Jandal can do" screen (Tools → Learn).

### 1. Extracted `LearnSectionHeader` composable
New reusable component with:
- **Typography:** `titleMedium` (16sp) + `FontWeight.SemiBold` — reads clearly as a heading
- **Colour:** `onSurface` (`#E8E8E8` dark / `#1C1B1F` light) — **not** `primary` (FernGreen), which fails WCAG AA (~3.9:1 on dark backgrounds)
- **Under-heading accent divider:** `HorizontalDivider`, 96dp wide, 2dp thick, `primary` colour (passes WCAG non-text 3:1 contrast)
- **6dp spacer** between heading text and divider

### 2. Between-section separators
Added subtle full-width dividers between sections:
- `HorizontalDivider` with `outlineVariant` at 50% alpha
- 12dp spacing before and after each separator
- Only rendered between sections (not before the first)

### 3. Helper text contrast (kept from previous pass)
- Descriptive copy: `outline` → `onSurfaceVariant` for both description and privacy note

### 4. Expand/collapse affordance (kept from previous pass)
- Chevron icons: `ExpandMore` ↓ (collapsed) / `ExpandLess` ↑ (expanded)
- Consistent "View less" label (previously "Show less")
- Icons decorative (null contentDescription) since button text conveys action

### 5. Section hierarchy summary
| Element | Before | After |
|---|---|---|
| Heading typography | `titleSmall`, `primary` (FernGreen) | `titleMedium`, `SemiBold`, `onSurface` |
| Heading contrast | ~3.9:1 on dark (fails AA) | passes AA (>7:1 on dark) |
| Under-heading divider | none | 96dp accent line, 2dp thick |
| Between-section separation | 4dp spacer | subtle divider + 24dp spacing break |
| Section grouping | flat one-tone list | clear visual breaks + heading anchors |

### Files changed
- `app/src/main/java/com/kernel/ai/navigation/ToolsLearnScreen.kt` — new `LearnSectionHeader` composable, updated section loop with `forEachIndexed` and dividers, added `HorizontalDivider`/`FontWeight` imports
- `app/src/androidTest/java/com/kernel/ai/navigation/ToolsHubNavTest.kt` — "Show less" → "View less" in 3 assertions, new `toolsLearnScreen_showsSectionHeadings` test

### Tests run
- `./gradlew :app:testDebugUnitTest --no-daemon` — **PASS**
- `./gradlew :app:assembleDebug --no-daemon` — **BUILD SUCCESSFUL**

### Manual S21 smoke checklist
- [ ] Open Tools.
- [ ] Open "Learn what Jandal can do".
- [ ] **System colours enabled:**
  - [ ] Top helper text is readable.
  - [ ] Section headings are clearly larger/stronger than body text.
  - [ ] Section separation is visible (dividing lines between sections).
  - [ ] View more / View less has chevron state and readable text.
- [ ] **System colours disabled / Jandal theme:**
  - [ ] Top helper text is readable.
  - [ ] Jandal green/accent text does not disappear into the background.
  - [ ] Headings are clearly readable (onSurface, not FernGreen).
  - [ ] Accent divider under headings is visible.
  - [ ] Between-section separation is visible.
  - [ ] View more / View less is readable and clearly expandable/collapsible.
- [ ] Expand and collapse at least one section.
- [ ] Tap an example prompt and confirm it still opens Actions for review/edit before running.
- [ ] Check light and dark theme if quick to do.

**Do not merge without human review.**

Closes #1284