### PR TITLE
feat(#1295): add launch validation evidence publication workflow

### DIFF
--- a/docs/test-triage/evidence/1287-s21-launch-validation-2026-06-18.md
+++ b/docs/test-triage/evidence/1287-s21-launch-validation-2026-06-18.md
@@ -99,11 +99,15 @@ The S21 exhibits a consistent degradation pattern when running >45 tests sequent
   - Targeted daily-driver smoke: alarms, timers, weather, slot-fill, media (with Spotify installed), navigation, voice interactions
 - **orchestrator_recovery** tests — never reached (~12 tests due to timeout)
 - **false_positives** tests — never reached (~15 tests due to timeout)
-- **Dashboard / raw JSON evidence publication** — not performed. This PR publishes only the Markdown evidence summary.
-  - Raw harness JSON output is available from the ADB test runs for any follow-up tooling
-  - Dashboard publication would require either:
-    - Manual evidence entry into the test dashboard UI, or
-    - A follow-up automation script to ingest the harness JSON output
+  - **Dashboard / raw JSON evidence publication** — not performed. This PR publishes only the Markdown evidence summary.
+  - Raw harness JSON files from this run were on the ADB test device and have not been preserved.
+    They are **not recoverable** — the evidence pipeline was not yet in place to capture them durably.
+  - The launch validation evidence publication workflow has since been implemented
+    (issue [#1295](https://github.com/NickMonrad/kernel-ai-assistant/issues/1295)):
+    - `scripts/publish_launch_validation_evidence.py` chains harness output → normalise → publish
+    - See `docs/testing/launch-validation-evidence.md` for documentation
+    - All future launch validation runs should use this workflow to produce durable raw JSON,
+      normalised evidence, and dashboard entries
 
 ### #1287 Status
 

--- a/docs/testing/launch-validation-evidence.md
+++ b/docs/testing/launch-validation-evidence.md
@@ -1,0 +1,190 @@
+# Launch Validation Evidence
+
+How to run launch validation on physical devices and publish the results as
+durable evidence for the dashboard, PR summaries, and release snapshots.
+
+## Overview
+
+Launch validation verifies the on-device model and skill routing work correctly
+on a real Android device. Evidence is captured as:
+
+1. **Raw harness JSON** — full per-case results from `scripts/adb_skill_test.py`
+2. **Normalised evidence JSON** — transformed to the standard schema (see `test-evidence-schema.md`)
+3. **Markdown summary** — human-readable overview with metadata
+4. **Dashboard entry** — published to GitHub Pages via the `test-results` branch
+
+## Pipeline
+
+```
+ADB device → adb_skill_test.py → scripts/test-reports/{ts}_skills.json
+                                        ↓
+              scripts/publish_launch_validation_evidence.py
+                        ├── normalise_skills_report.py
+                        ├── publish_test_evidence.py
+                        └── docs/test-triage/evidence/{date}/{device}/
+```
+
+### Sequence
+
+1. **Run the harness** on the device.
+2. **Publish evidence** from the raw output.
+3. **Trigger dashboard rebuild** (optional — done automatically when published via the CI workflow).
+
+## Device-specific instructions
+
+### S21 (tracked reference)
+
+The S21 (SM-G991B, serial `R5CR605B71K`) is the primary tracked device for
+launch validation. It runs the full action-routing skills suite.
+
+```bash
+# Full launch-scope validation (all phases, destructive excluded)
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=15 \
+  python3 scripts/adb_skill_test.py \
+  --exclude-tags destructive,device_state --model-readiness
+
+# Resume from a specific phase (if previous run timed out)
+ANDROID_SERIAL=R5CR605B71K ADB_WAIT_SECONDS=20 \
+  python3 scripts/adb_skill_test.py \
+  --exclude-tags destructive,device_state --start-phase navigation --model-readiness
+```
+
+**Publishing:**
+
+```bash
+# Publish evidence from the most recent complete harness run
+python3 scripts/publish_launch_validation_evidence.py \
+  --latest --source on_device \
+  --device-id s21-exynos \
+  --serial R5CR605B71K \
+  --model-name "Gemma 4 E-2B" \
+  --model-runtime LiteRT \
+  --model-backend GPU \
+  --pr <PR_NUMBER>
+```
+
+Or with an explicit input path:
+
+```bash
+python3 scripts/publish_launch_validation_evidence.py \
+  --input scripts/test-reports/2026-06-18T12-00-00Z_skills.json \
+  --device-id s21-exynos \
+  --serial R5CR605B71K \
+  --model-name "Gemma 4 E-2B" \
+  --model-runtime LiteRT \
+  --model-backend GPU \
+  --pr <PR_NUMBER>
+```
+
+### S23 Ultra (reference / release-blocking)
+
+The S23 Ultra (SM-S918B) is the **reference** device. Run only **targeted
+smoke tests** — it is a daily driver and must not run full suites.
+
+```bash
+# Targeted smoke — individual phases only, short timeout
+ANDROID_SERIAL=<S23U_SERIAL> ADB_WAIT_SECONDS=15 \
+  python3 scripts/adb_skill_test.py \
+  --phases alarm_timer,weather,slot_fill \
+  --exclude-tags destructive,device_state --model-readiness
+```
+
+**Publishing:**
+
+```bash
+python3 scripts/publish_launch_validation_evidence.py \
+  --latest --source on_device \
+  --device-id s23-ultra \
+  --serial <S23U_SERIAL> \
+  --model-name "Gemma 4 E-2B" \
+  --model-runtime LiteRT \
+  --model-backend GPU \
+  --pr <PR_NUMBER> \
+  --suite skills-targeted
+```
+
+> ⚠ **Do not run full suites on S23 Ultra.** It is a daily driver.
+> Only targeted smoke/comparison tests as approved.
+
+## Data flow
+
+### Raw files
+
+| File | Location | Description |
+|---|---|---|
+| Raw harness JSON | `scripts/test-reports/{ts}_skills.json` | Full per-case results |
+| Normalised evidence | `docs/test-triage/evidence/{date}/{device}/*_evidence.json` | Schema-compliant |
+| Case CSV | `docs/test-triage/evidence/{date}/{device}/*_cases.csv` | Spreadsheet-friendly |
+| Markdown summary | `docs/test-triage/evidence/{date}/{device}/launch-validation-summary.md` | Human-readable |
+| CI/Markdown evidence | `docs/test-triage/evidence/{date}/` (date-organised) | Published for wider reference |
+
+### Dashboard publication
+
+The normalised evidence JSON is pushed to the `test-results` git branch by
+`scripts/publish_test_evidence.py`. The GitHub Pages dashboard
+(`.github/workflows/publish-test-dashboard.yml`) reads from this branch and
+rebuilds on every push or when triggered manually.
+
+**Manual dashboard trigger:**
+
+```bash
+gh api repos/NickMonrad/kernel-ai-assistant/dispatches \
+  -f event_type=test-evidence-published \
+  -f client_payload[source]=on_device \
+  -f client_payload[pr]=<PR_NUMBER> \
+  -f client_payload[commit]=<40-char-SHA>
+```
+
+Or use the "Publish test evidence" GitHub Actions workflow from the Actions
+tab, providing the CI run ID (if publishing CI results) or running
+`publish_test_evidence.py` locally first for on_device results.
+
+## Evidence accounting
+
+Every evidence publication includes these fields for reliable accounting:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `summary.total` | int | Total cases in the run |
+| `summary.passed` | int | Cases that passed (incl. xfail) |
+| `summary.failed` | int | Cases that failed |
+| `summary.pass_rate` | float | Passed / total |
+| `cases[].passed` | bool | Individual case result |
+| `cases[].failure_category` | str\|null | Reason for failure |
+| `cases[].expected_tool` | str\|null | Expected intent/tool |
+| `cases[].actual_tool` | str\|null | Actual intent/tool |
+| `device.model` | str | Device model e.g. SM-G991B |
+| `device.serial` | str | ADB device serial |
+| `device.tier` | str | reference/tracked/experimental/ci |
+| `model.name` | str | Model name e.g. Gemma 4 E-2B |
+| `commit` | str | Full 40-char build SHA |
+| `branch` | str | Git branch |
+| `pr` | int\|null | PR number (if applicable) |
+| `timestamp` | string | ISO 8601 run start time |
+
+## Known limitations
+
+- **Raw JSON from runs before this workflow existed is not recoverable.**
+  The S21 full launch validation (June 18, 2026, PR #1292) produced a Markdown
+  summary only; the raw harness JSON files were on the ADB device and not
+  committed. All future runs should use this workflow to capture evidence.
+- **Dashboard rebuild requires manual trigger or CI push.**
+  Local `publish_test_evidence.py` runs push to `test-results` branch but do
+  not automatically trigger the Pages rebuild workflow. Use the dispatch
+  command above or the Actions UI to rebuild.
+- **Normalised schema does not preserve per-phase breakdown.**
+  Phase-level data exists in the raw harness JSON; the normalised evidence
+  schema (v1.0) treats all cases in a flat list. Per-phase filtering requires
+  reading the raw JSON or the Markdown summary.
+
+## Related
+
+- Issue [#1295](https://github.com/NickMonrad/kernel-ai-assistant/issues/1295) — Publish raw harness JSON and dashboard evidence for launch validation
+- Issue [#1287](https://github.com/NickMonrad/kernel-ai-assistant/issues/1287) — Full launch-scope validation on S21 and S23U (still open)
+- PR [#1292](https://github.com/NickMonrad/kernel-ai-assistant/pull/1292) — S21 Markdown evidence summary (merged)
+- `scripts/publish_launch_validation_evidence.py` — the unified publication script
+- `scripts/normalise_skills_report.py` — skills harness normaliser
+- `scripts/publish_test_evidence.py` — evidence publisher to test-results branch
+- `scripts/build_test_dashboard.py` — dashboard builder
+- `.github/workflows/publish-test-dashboard.yml` — dashboard CI/CD
+- `docs/testing/test-evidence-schema.md` — evidence schema documentation

--- a/docs/testing/launch-validation-evidence.md
+++ b/docs/testing/launch-validation-evidence.md
@@ -76,10 +76,33 @@ python3 scripts/publish_launch_validation_evidence.py \
   --pr <PR_NUMBER>
 ```
 
+
+**Partial / timeout-affected runs:**
+
+For runs that timed out or were resumed from a specific phase, provide the
+`--suite-context` and `--not-reached` flags to make the summary accurate:
+
+```bash
+# After a resumed run that caught the last 6 phases
+python3 scripts/publish_launch_validation_evidence.py \
+  --latest --source on_device \
+  --device-id s21-exynos \
+  --serial R5CR605B71K \
+  --model-name "Gemma 4 E-2B" \
+  --model-runtime LiteRT \
+  --model-backend GPU \
+  --pr <PR_NUMBER> \
+  --suite-context "partial (resumed at navigation phase)" \
+  --not-reached 29
+```
 ### S23 Ultra (reference / release-blocking)
 
-The S23 Ultra (SM-S918B) is the **reference** device. Run only **targeted
-smoke tests** — it is a daily driver and must not run full suites.
+The S23 Ultra (SM-S918B) is the **reference** device. It runs the **reference
+model (Gemma 4 E-4B)** — NOT the tracked E-2B used on S21.
+
+> ⚠ **IMPORTANT: Do not run full suites on S23 Ultra.** It is a daily driver.
+> Only targeted smoke/comparison tests as explicitly approved by Nick.
+> Broad or full-suite runs are never permitted on this device.
 
 ```bash
 # Targeted smoke — individual phases only, short timeout
@@ -87,43 +110,47 @@ ANDROID_SERIAL=<S23U_SERIAL> ADB_WAIT_SECONDS=15 \
   python3 scripts/adb_skill_test.py \
   --phases alarm_timer,weather,slot_fill \
   --exclude-tags destructive,device_state --model-readiness
-```
-
 **Publishing:**
 
 ```bash
+# NOTE: S23U uses the reference model (E-4B), not the tracked E-2B.
 python3 scripts/publish_launch_validation_evidence.py \
   --latest --source on_device \
   --device-id s23-ultra \
   --serial <S23U_SERIAL> \
-  --model-name "Gemma 4 E-2B" \
+  --model-name "Gemma 4 E-4B" \
   --model-runtime LiteRT \
   --model-backend GPU \
   --pr <PR_NUMBER> \
-  --suite skills-targeted
+  --suite skills-targeted \
+  --suite-context "targeted smoke (3 phases)"
 ```
-
-> ⚠ **Do not run full suites on S23 Ultra.** It is a daily driver.
-> Only targeted smoke/comparison tests as approved.
-
 ## Data flow
 
-### Raw files
+### Published bundle
 
-| File | Location | Description |
-|---|---|---|
-| Raw harness JSON | `scripts/test-reports/{ts}_skills.json` | Full per-case results |
-| Normalised evidence | `docs/test-triage/evidence/{date}/{device}/*_evidence.json` | Schema-compliant |
-| Case CSV | `docs/test-triage/evidence/{date}/{device}/*_cases.csv` | Spreadsheet-friendly |
-| Markdown summary | `docs/test-triage/evidence/{date}/{device}/launch-validation-summary.md` | Human-readable |
-| CI/Markdown evidence | `docs/test-triage/evidence/{date}/` (date-organised) | Published for wider reference |
+The `publish_launch_validation_evidence.py` script creates a **full evidence
+bundle** at `docs/test-triage/evidence/{date}/{device}/`:
+
+| Path | Description | Published to dashboard? |
+|------|-------------|------------------------|
+| `raw/{ts}_skills.json` | Raw harness JSON (copied from source) | No (in `raw/` subdir) |
+| `{ts}_skills_evidence.json` | Normalised evidence (v1.0 with per-case `phase`) | Yes |
+| `{ts}_skills_cases.csv` | Spreadsheet-friendly case results | Yes |
+| `{ts}_skills_summary.md` | Normalised Markdown summary | Yes |
+| `launch-validation-summary.md` | Enriched Markdown with phase breakdown | Yes |
+
+The non-raw files are pushed to the `test-results` branch by
+`publish_test_evidence.py --input-dir <out_dir>`, which publishes every
+`.json`, `.csv`, and `.md` file in the top level of the bundle directory.
+The `raw/` subdirectory is excluded from dashboard publication.
 
 ### Dashboard publication
 
-The normalised evidence JSON is pushed to the `test-results` git branch by
-`scripts/publish_test_evidence.py`. The GitHub Pages dashboard
-(`.github/workflows/publish-test-dashboard.yml`) reads from this branch and
-rebuilds on every push or when triggered manually.
+The normalised evidence JSON, CSV, and summaries are pushed to the `test-results`
+git branch by `scripts/publish_test_evidence.py` using `--input-dir <out_dir>`
+directory mode. The GitHub Pages dashboard (`.github/workflows/publish-test-dashboard.yml`)
+reads from this branch and rebuilds on every push or when triggered manually.
 
 **Manual dashboard trigger:**
 
@@ -150,6 +177,7 @@ Every evidence publication includes these fields for reliable accounting:
 | `summary.failed` | int | Cases that failed |
 | `summary.pass_rate` | float | Passed / total |
 | `cases[].passed` | bool | Individual case result |
+| `cases[].phase` | str\|null | Test phase e.g. `alarm_timer` (from raw harness) |
 | `cases[].failure_category` | str\|null | Reason for failure |
 | `cases[].expected_tool` | str\|null | Expected intent/tool |
 | `cases[].actual_tool` | str\|null | Actual intent/tool |
@@ -169,19 +197,23 @@ Every evidence publication includes these fields for reliable accounting:
   summary only; the raw harness JSON files were on the ADB device and not
   committed. All future runs should use this workflow to capture evidence.
 - **Dashboard rebuild requires manual trigger or CI push.**
-  Local `publish_test_evidence.py` runs push to `test-results` branch but do
-  not automatically trigger the Pages rebuild workflow. Use the dispatch
-  command above or the Actions UI to rebuild.
-- **Normalised schema does not preserve per-phase breakdown.**
-  Phase-level data exists in the raw harness JSON; the normalised evidence
-  schema (v1.0) treats all cases in a flat list. Per-phase filtering requires
-  reading the raw JSON or the Markdown summary.
+  Local `publish_test_evidence.py --input-dir` runs push to `test-results`
+  branch but do not automatically trigger the Pages rebuild workflow. Use the
+  dispatch command above or the Actions UI to rebuild.
+- **Phase breakdown is now available in the normalised schema.**
+  Each case carries a `phase` field populated from the raw harness. The
+  `launch-validation-summary.md` includes a phase-level pass/fail table.
+  Raw JSON still contains the most detailed per-case data.
+- **not_reached / excluded counts**: these are optional CLI arguments
+  (`--not-reached`, `--excluded`). When not provided, the summary reports
+  `not provided by source evidence` rather than assuming zero.
 
 ## Related
 
 - Issue [#1295](https://github.com/NickMonrad/kernel-ai-assistant/issues/1295) — Publish raw harness JSON and dashboard evidence for launch validation
-- Issue [#1287](https://github.com/NickMonrad/kernel-ai-assistant/issues/1287) — Full launch-scope validation on S21 and S23U (still open)
+- Issue [#1287](https://github.com/NickMonrad/kernel-ai-assistant/issues/1287) — Full launch-scope validation on S21 and S23U (**remains open** until S23U targeted evidence is captured and published)
 - PR [#1292](https://github.com/NickMonrad/kernel-ai-assistant/pull/1292) — S21 Markdown evidence summary (merged)
+- PR [#1299](https://github.com/NickMonrad/kernel-ai-assistant/pull/1299) — Launch validation evidence publication workflow (this PR)
 - `scripts/publish_launch_validation_evidence.py` — the unified publication script
 - `scripts/normalise_skills_report.py` — skills harness normaliser
 - `scripts/publish_test_evidence.py` — evidence publisher to test-results branch

--- a/docs/testing/launch-validation-evidence.md
+++ b/docs/testing/launch-validation-evidence.md
@@ -110,6 +110,8 @@ ANDROID_SERIAL=<S23U_SERIAL> ADB_WAIT_SECONDS=15 \
   python3 scripts/adb_skill_test.py \
   --phases alarm_timer,weather,slot_fill \
   --exclude-tags destructive,device_state --model-readiness
+```
+
 **Publishing:**
 
 ```bash
@@ -144,6 +146,10 @@ The non-raw files are pushed to the `test-results` branch by
 `publish_test_evidence.py --input-dir <out_dir>`, which publishes every
 `.json`, `.csv`, and `.md` file in the top level of the bundle directory.
 The `raw/` subdirectory is excluded from dashboard publication.
+**Durable storage:** The `raw/` subdirectory is local-only. To preserve raw JSON
+across runs, commit the evidence bundle directory (`docs/test-triage/evidence/`)
+or archive it externally. The `test-results` branch stores only normalised
+evidence for dashboard rendering — raw JSON is not recoverable from it.
 
 ### Dashboard publication
 
@@ -207,6 +213,12 @@ Every evidence publication includes these fields for reliable accounting:
 - **not_reached / excluded counts**: these are optional CLI arguments
   (`--not-reached`, `--excluded`). When not provided, the summary reports
   `not provided by source evidence` rather than assuming zero.
+- **Raw JSON durability:** The raw harness JSON is copied into a `raw/`
+  subdirectory of the local evidence bundle but is **not** pushed to the
+  `test-results` branch. The `test-results` branch stores only normalised
+  evidence (`.json`, `.csv`, `.md`) for dashboard rendering. To make raw
+  JSON durable across runs, commit the evidence bundle directory
+  (`docs/test-triage/evidence/`) or archive it externally.
 
 ## Related
 

--- a/scripts/normalise_skills_report.py
+++ b/scripts/normalise_skills_report.py
@@ -147,6 +147,7 @@ def _build_failures(r: dict) -> list[str]:
 def normalise_skills_case(r: dict) -> dict:
     """Normalise one raw skills result dict into a schema-compliant case dict."""
     name = _slugify(r.get("message", f"case_{r.get('index', 0)}"))
+    phase = r.get("phase", None)
 
     xfail = r.get("xfail", False)
     intent_passed = r.get("intent_passed", False)
@@ -156,6 +157,7 @@ def normalise_skills_case(r: dict) -> dict:
     if xfail:
         return {
             "name": name,
+            "phase": phase,
             "passed": True,
             "expected_tool": r.get("expect_intent"),
             "actual_tool": r.get("actual_intent"),
@@ -181,6 +183,7 @@ def normalise_skills_case(r: dict) -> dict:
 
     return {
         "name": name,
+        "phase": phase,
         "passed": passed,
         "expected_tool": r.get("expect_intent"),
         "actual_tool": actual_tool,

--- a/scripts/publish_launch_validation_evidence.py
+++ b/scripts/publish_launch_validation_evidence.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Publish launch validation evidence from ADB harness raw JSON output.
 
-Chains: raw harness JSON → normalise → publish → dashboard trigger.
+Chains: raw harness JSON → normalise → bundle → publish → dashboard trigger.
 
 Usage:
-  # From a raw harness report in scripts/test-reports/:
+  # Publish a specific harness report with full evidence bundle:
   python3 scripts/publish_launch_validation_evidence.py \\
     --input scripts/test-reports/2026-06-18T12-00-00Z_skills.json \\
     --device-id s21-exynos \\
@@ -14,30 +14,42 @@ Usage:
     --serial R5CR605B71K \\
     --pr 1292
 
-  # Publish the most recent skills or llm_tools report in test-reports/:
+  # Publish the most recent skills/llm_tools report in test-reports/:
   python3 scripts/publish_launch_validation_evidence.py --latest --source on_device
 
   # Publish S23U targeted smoke evidence (when run):
+  # NOTE: S23U uses the reference model (Gemma 4 E-4B), not E-2B.
+  #       Broad/full suites are NOT permitted on the daily driver.
   python3 scripts/publish_launch_validation_evidence.py \\
     --input path/to/s23u-skills.json \\
     --device-id s23-ultra \\
-    --model-name "Gemma 4 E-2B" \\
+    --model-name "Gemma 4 E-4B" \\
     --model-runtime LiteRT \\
     --model-backend GPU \\
     --serial <S23U_SERIAL> \\
     --pr <PR_NUM> \\
-    --suite "skills-targeted"
+    --suite skills-targeted
 
   # After a harness run finishes, auto-publish:
   python3 scripts/adb_skill_test.py [..args..] && \\
   python3 scripts/publish_launch_validation_evidence.py --latest --source on_device --pr <PR_NUM>
+
+Output bundle (in docs/test-triage/evidence/{date}/{device-id}/):
+  - Raw harness JSON (copied from source)
+  - Normalised evidence JSON (*_evidence.json)
+  - Case CSV (*_cases.csv)
+  - Markdown summary (*_summary.md, from normaliser)
+  - Launch validation summary (launch-validation-summary.md, enriched Markdown)
+
+The full bundle is published to the test-results branch via
+scripts/publish_test_evidence.py --input-dir <out_dir>.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
+import shutil
 import re
 import subprocess
 import sys
@@ -154,6 +166,9 @@ def _build_launch_markdown(
     serial: str,
     build_sha: str,
     branch: str,
+    excluded: int | None = None,
+    not_reached: int | None = None,
+    suite_context: str | None = None,
 ) -> str:
     """Build an evidence-summary Markdown document with full accounting.
 
@@ -169,13 +184,10 @@ def _build_launch_markdown(
     dev = normalised["device"]
     md = normalised["model"]
 
-    # Phase breakdown from cases
+    # Phase breakdown from normalised cases (now carrying phase from raw harness)
     phases: dict[str, dict[str, int]] = {}
     for c in cases:
-        # Derive phase from the raw case_name convention (first segment)
-        phase = c.get("name", "unknown").split("_")[0] if c.get("name") else "unknown"
-        # Adjust: some phases have multi-word names we can't reconstruct from cases alone.
-        # Use the raw report's phase field if available.
+        phase = c.get("phase") or "unknown"
         if phase not in phases:
             phases[phase] = {"pass": 0, "fail": 0, "xfail": 0, "total": 0}
         if c["passed"]:
@@ -188,8 +200,31 @@ def _build_launch_markdown(
     PHASE_ORDER = [
         "alarm_timer", "weather", "media", "lists", "smart_home",
         "memory", "navigation", "system", "misc", "slot_fill",
-        "orchestrator", "false",
+        "orchestrator_recovery", "false_positives",
     ]
+
+    total = s["total"]
+    passed = s["passed"]
+    failed = s["failed"]
+
+    # Handle not_reached / excluded — honest about unknowns
+    not_reached_str: str
+    if not_reached is not None:
+        not_reached_str = str(not_reached)
+    else:
+        not_reached_str = "not provided by source evidence"
+
+    excluded_str: str
+    if excluded is not None:
+        excluded_str = str(excluded)
+    else:
+        excluded_str = "not provided by source evidence"
+
+    reached_str: str
+    if not_reached is not None and not_reached > 0:
+        reached_str = f"{total} (not-reached phases: {not_reached})"
+    else:
+        reached_str = f"{total}"
 
     lines = [
         f"# Launch Validation Evidence",
@@ -199,26 +234,59 @@ def _build_launch_markdown(
         f"Build: `{build_sha[:10]}` on `{branch}`  ",
         f"Timestamp: {normalised['timestamp']}",
         f"",
+    ]
+
+    if suite_context:
+        lines.extend([
+            f"> **Suite context:** {suite_context}",
+            f"",
+        ])
+
+    lines.extend([
         f"## Suite Sizing",
         f"",
         f"| Level | Count |",
         f"|-------|-------|",
         f"| Full suite (all test phases) | See raw report |",
-        f"| Excluded (destructive, device_state) | See raw report |",
-        f"| **In-scope (selected by harness)** | **{s['total']}** |",
-        f"| Reached (phases that completed) | **{s['total']}** (all in this report) |",
-        f"| Not reached (timeout / not started) | 0 (single-run report) |",
+        f"| Excluded (destructive, device_state) | {excluded_str} |",
+        f"| **In-scope (selected by harness)** | **{total}** |",
+        f"| Reached (phases that completed) | {reached_str} |",
+        f"| Not reached (timeout / not started) | {not_reached_str} |",
         f"",
         f"## Pass/Fail Summary",
         f"",
         f"| Metric | Value |",
         f"|--------|-------|",
-        f"| Total | {s['total']} |",
-        f"| Passed | {s['passed']} |",
-        f"| Failed | {s['failed']} |",
+        f"| Total | {total} |",
+        f"| Passed | {passed} |",
+        f"| Failed | {failed} |",
         f"| Pass rate | {s['pass_rate']:.1%} |",
         f"",
-    ]
+    ])
+
+    # Phase breakdown table
+    if phases:
+        lines.extend([
+            f"## Phase Breakdown",
+            f"",
+            f"| Phase | Total | Pass | Fail |",
+            f"|-------|-------|------|------|",
+        ])
+        for phase_name in PHASE_ORDER:
+            if phase_name in phases:
+                p = phases[phase_name]
+                lines.append(
+                    f"| {phase_name} | {p['total']} | {p['pass']} | {p['fail']} |"
+                )
+        # Any phases not in the standard order
+        for phase_name in sorted(phases):
+            if phase_name not in PHASE_ORDER:
+                p = phases[phase_name]
+                lines.append(
+                    f"| {phase_name} | {p['total']} | {p['pass']} | {p['fail']} |"
+                )
+        lines.append(f"| **Total** | **{total}** | **{passed}** | **{failed}** |")
+        lines.append(f"")
 
     if md.get("name"):
         lines.extend([
@@ -238,8 +306,10 @@ def _build_launch_markdown(
         f"",
         f"| Type | Path |",
         f"|------|------|",
-        f"| Raw harness JSON | `{raw_report_path}` |",
+        f"| Raw harness JSON | `{raw_report_path}` (in `raw/` subdirectory) |",
         f"| Normalised evidence JSON | `{evidence_path}` |",
+        f"| Case CSV | `{evidence_path.parent / ('*_cases.csv')}` |",
+        f"| Normalised summary | `{evidence_path.parent / ('*_summary.md')}` |",
         f"",
     ])
 
@@ -316,6 +386,19 @@ def main() -> None:
     parser.add_argument(
         "--dry-run", action="store_true",
         help="Show what would be done without publishing",
+    )
+    parser.add_argument(
+        "--excluded", type=int, default=None,
+        help="Number of excluded cases (destructive, device_state, etc.)",
+    )
+    parser.add_argument(
+        "--not-reached", type=int, default=None,
+        help="Number of cases not reached due to timeout or resume boundary",
+    )
+    parser.add_argument(
+        "--suite-context", default=None,
+        help="Short phrase describing suite context, e.g. 'partial (resumed at navigation)', "
+             "'targeted smoke (3 phases)', 'timeout-affected after ~46 cases'",
     )
 
     args = parser.parse_args()
@@ -415,9 +498,23 @@ def main() -> None:
             print(f"    --release {args.release}")
         if suite != raw_suite:
             print(f"    --suite {suite}")
-        print(f"\n  Then publish via scripts/publish_test_evidence.py")
+        print(f"\n  Then publish bundle via scripts/publish_test_evidence.py \\")
+        print(f"    --input-dir {out_dir} \\")
+        print(f"    --source {args.source} \\")
+        print(f"    --commit {build_sha} \\")
+        if args.pr:
+            print(f"    --pr {args.pr}")
+        if args.release:
+            print(f"    --release {args.release}")
+        print(f"\n  Then publish bundle via scripts/publish_test_evidence.py \\")
+        print(f"    --input-dir {out_dir} \\")
+        print(f"\n  Bundle will contain:")
+        print(f"    - raw/ (subdirectory with raw harness JSON)")
+        print(f"    - *_evidence.json (normalised)")
+        print(f"    - *_cases.csv (spreadsheet)")
+        print(f"    - *_summary.md (normalised summary)")
+        print(f"    - launch-validation-summary.md (enriched Markdown)")
         print(f"  SKIP: --dry-run flag set")
-        return
 
     # ── Step 1: Normalise ──────────────────────────────────────────────
     normaliser_path = HERE / normaliser
@@ -449,6 +546,15 @@ def main() -> None:
         sys.exit(result.returncode)
     print(f"  ✓ Normalisation complete\n")
 
+    # ── Step 1.5: Copy raw JSON into evidence bundle (in raw/ subdir) ──
+    raw_subdir = out_dir / "raw"
+    raw_subdir.mkdir(parents=True, exist_ok=True)
+    raw_in_bundle = raw_subdir / raw_path.name
+    if not raw_in_bundle.exists():
+        shutil.copy2(str(raw_path), str(raw_in_bundle))
+        print(f"  ✓ Raw JSON copied to bundle: {raw_in_bundle}")
+    else:
+        print(f"  ✓ Raw JSON already in bundle: {raw_in_bundle}")
     # ── Find the normalised JSON output ────────────────────────────────
     norm_jsons = sorted(out_dir.glob("*_evidence.json")) + sorted(out_dir.glob("*_skills_evidence.json"))
     if not norm_jsons:
@@ -460,24 +566,25 @@ def main() -> None:
     normalised = _load_json(evidence_json)
     md = _build_launch_markdown(
         evidence_path=evidence_json,
-        raw_report_path=raw_path,
+        raw_report_path=raw_in_bundle,
         normalised=normalised,
         device_id=device_id,
         serial=serial or "",
         build_sha=build_sha,
         branch=branch,
+        excluded=args.excluded,
+        not_reached=args.not_reached,
+        suite_context=args.suite_context,
     )
     md_path = out_dir / "launch-validation-summary.md"
     md_path.write_text(md)
     print(f"  ✓ Launch validation summary: {md_path}\n")
-
-    # ── Step 3: Publish to test-results branch ─────────────────────────
     _check_git_available()
     publish_script = HERE / "publish_test_evidence.py"
 
     publish_cmd = [
         sys.executable, str(publish_script),
-        "--input", str(evidence_json),
+        "--input-dir", str(out_dir),
         "--source", args.source,
         "--commit", build_sha,
     ]
@@ -493,20 +600,20 @@ def main() -> None:
         print(f"  This may be due to test-results branch not existing yet,", file=sys.stderr)
         print(f"  or no changes to commit. The normalised evidence files", file=sys.stderr)
         print(f"  are still available locally.", file=sys.stderr)
-    else:
-        print(f"  ✓ Evidence published to test-results branch\n")
-
-    # ── Final summary ──────────────────────────────────────────────────
     s = normalised.get("summary", {})
+    bundle_files = sorted(out_dir.iterdir())
     print(f"{'=' * 56}")
     print(f"  Evidence publication complete:")
     print(f"  • {s.get('total', 0)} cases | {s.get('passed', 0)} passed | {s.get('failed', 0)} failed")
-    print(f"  • Normalised: {evidence_json}")
-    print(f"  • Summary:    {md_path}")
+    print(f"  • Bundle location: {out_dir}/")
+    for bf in bundle_files:
+        if bf.is_dir():
+            print(f"    - {bf.name}/")
+        elif bf.is_file():
+            print(f"    - {bf.name}")
     if pub_result.returncode == 0:
         print(f"  • Published to test-results branch ✓")
     print(f"{'=' * 56}")
-
     # ── Dashboard rebuild trigger note ─────────────────────────────────
     if args.pr:
         print(f"\n  To trigger dashboard rebuild:")

--- a/scripts/publish_launch_validation_evidence.py
+++ b/scripts/publish_launch_validation_evidence.py
@@ -514,8 +514,8 @@ def main() -> None:
         print(f"    - *_cases.csv (spreadsheet)")
         print(f"    - *_summary.md (normalised summary)")
         print(f"    - launch-validation-summary.md (enriched Markdown)")
-    print(f"  SKIP: --dry-run flag set")
-    return
+        print(f"  SKIP: --dry-run flag set")
+        return
 
     # ── Step 1: Normalise ──────────────────────────────────────────────
     normaliser_path = HERE / normaliser

--- a/scripts/publish_launch_validation_evidence.py
+++ b/scripts/publish_launch_validation_evidence.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Publish launch validation evidence from ADB harness raw JSON output.
+
+Chains: raw harness JSON → normalise → publish → dashboard trigger.
+
+Usage:
+  # From a raw harness report in scripts/test-reports/:
+  python3 scripts/publish_launch_validation_evidence.py \\
+    --input scripts/test-reports/2026-06-18T12-00-00Z_skills.json \\
+    --device-id s21-exynos \\
+    --model-name "Gemma 4 E-2B" \\
+    --model-runtime LiteRT \\
+    --model-backend GPU \\
+    --serial R5CR605B71K \\
+    --pr 1292
+
+  # Publish the most recent skills or llm_tools report in test-reports/:
+  python3 scripts/publish_launch_validation_evidence.py --latest --source on_device
+
+  # Publish S23U targeted smoke evidence (when run):
+  python3 scripts/publish_launch_validation_evidence.py \\
+    --input path/to/s23u-skills.json \\
+    --device-id s23-ultra \\
+    --model-name "Gemma 4 E-2B" \\
+    --model-runtime LiteRT \\
+    --model-backend GPU \\
+    --serial <S23U_SERIAL> \\
+    --pr <PR_NUM> \\
+    --suite "skills-targeted"
+
+  # After a harness run finishes, auto-publish:
+  python3 scripts/adb_skill_test.py [..args..] && \\
+  python3 scripts/publish_launch_validation_evidence.py --latest --source on_device --pr <PR_NUM>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_DIR = HERE.parent  # repo root
+REPORTS_DIR = HERE / "test-reports"
+
+# Device registry key → serial mapping (injected from known runs)
+# The primary source of truth is testdata/devices.yaml; serial is appended here
+# as a convenience for scripts that have the serial.
+KNOWN_SERIALS: dict[str, str] = {
+    "s21-exynos": "R5CR605B71K",
+    "s23-ultra": "",  # unknown, user must provide --serial
+}
+
+# Process exit codes to check for in the harness
+HARNESS_DEGRADED_EXIT = 2  # some tests failed (harness common path)
+
+
+def _check_git_available() -> None:
+    """Ensure git is available."""
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=True)
+    except (subprocess.FileNotFoundError, subprocess.CalledProcessError):
+        print("Error: git not available.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run git in the repo root directory."""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_DIR),
+        check=check,
+    )
+    return result
+
+
+def _get_current_sha() -> str:
+    """Return the full 40-char SHA of HEAD."""
+    result = _git("rev-parse", "HEAD")
+    return result.stdout.strip()
+
+
+def _get_current_branch() -> str:
+    """Return the current branch name."""
+    result = _git("rev-parse", "--abbrev-ref", "HEAD")
+    return result.stdout.strip()
+
+
+def _detect_latest_report(report_type: str | None = None) -> Path | None:
+    """Find the most recent complete report in test-reports/.
+
+    Args:
+        report_type: 'skills', 'llm_tools', or None for either.
+        When report_type is None, tries skills first then llm_tools.
+
+    Returns:
+        Path to the most recent JSON report, or None.
+    """
+    if not REPORTS_DIR.exists():
+        return None
+
+    candidates: list[Path] = []
+    for f in sorted(REPORTS_DIR.iterdir(), reverse=True):
+        if f.suffix != ".json":
+            continue
+        if "_partial" in f.stem:
+            continue  # skip in-progress reports
+        name = f.stem
+        if report_type:
+            if name.endswith(f"_{report_type}"):
+                candidates.append(f)
+        else:
+            if name.endswith("_skills") or name.endswith("_llm_tools"):
+                candidates.append(f)
+
+    return candidates[0] if candidates else None
+
+
+def _load_json(path: Path) -> dict:
+    """Load and parse a JSON file, exiting on error."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON in {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _resolve_device_id(serial: str | None) -> str | None:
+    """Look up device registry key from serial number."""
+    if not serial:
+        return None
+    for device_id, known_serial in KNOWN_SERIALS.items():
+        if serial == known_serial:
+            return device_id
+    return None  # unknown serial
+
+
+def _build_launch_markdown(
+    evidence_path: Path,
+    raw_report_path: Path,
+    normalised: dict,
+    device_id: str,
+    serial: str,
+    build_sha: str,
+    branch: str,
+) -> str:
+    """Build an evidence-summary Markdown document with full accounting.
+
+    Enriches the standard normalised summary with:
+      - full suite sizing (total, excluded, in-scope)
+      - reached vs not-reached phases
+      - pass/fail/xfail/skipped/excluded breakdown
+      - model degradation notes
+      - device/build metadata
+    """
+    s = normalised["summary"]
+    cases = normalised.get("cases", [])
+    dev = normalised["device"]
+    md = normalised["model"]
+
+    # Phase breakdown from cases
+    phases: dict[str, dict[str, int]] = {}
+    for c in cases:
+        # Derive phase from the raw case_name convention (first segment)
+        phase = c.get("name", "unknown").split("_")[0] if c.get("name") else "unknown"
+        # Adjust: some phases have multi-word names we can't reconstruct from cases alone.
+        # Use the raw report's phase field if available.
+        if phase not in phases:
+            phases[phase] = {"pass": 0, "fail": 0, "xfail": 0, "total": 0}
+        if c["passed"]:
+            phases[phase]["pass"] += 1
+        else:
+            phases[phase]["fail"] += 1
+        phases[phase]["total"] += 1
+
+    # Phase order (to reproduce the evidence table):
+    PHASE_ORDER = [
+        "alarm_timer", "weather", "media", "lists", "smart_home",
+        "memory", "navigation", "system", "misc", "slot_fill",
+        "orchestrator", "false",
+    ]
+
+    lines = [
+        f"# Launch Validation Evidence",
+        f"",
+        f"Device: **{dev['label']}** ({dev['model']})  ",
+        f"Serial: `{serial or dev.get('serial', 'unknown')}`  ",
+        f"Build: `{build_sha[:10]}` on `{branch}`  ",
+        f"Timestamp: {normalised['timestamp']}",
+        f"",
+        f"## Suite Sizing",
+        f"",
+        f"| Level | Count |",
+        f"|-------|-------|",
+        f"| Full suite (all test phases) | See raw report |",
+        f"| Excluded (destructive, device_state) | See raw report |",
+        f"| **In-scope (selected by harness)** | **{s['total']}** |",
+        f"| Reached (phases that completed) | **{s['total']}** (all in this report) |",
+        f"| Not reached (timeout / not started) | 0 (single-run report) |",
+        f"",
+        f"## Pass/Fail Summary",
+        f"",
+        f"| Metric | Value |",
+        f"|--------|-------|",
+        f"| Total | {s['total']} |",
+        f"| Passed | {s['passed']} |",
+        f"| Failed | {s['failed']} |",
+        f"| Pass rate | {s['pass_rate']:.1%} |",
+        f"",
+    ]
+
+    if md.get("name"):
+        lines.extend([
+            f"## Model",
+            f"",
+            f"| Field | Value |",
+            f"|-------|-------|",
+            f"| Name | {md['name']} |",
+            f"| Runtime | {md['runtime']} |",
+            f"| Backend | {md['backend']} |",
+            f"",
+        ])
+
+    # Evidence references
+    lines.extend([
+        f"## Evidence Files",
+        f"",
+        f"| Type | Path |",
+        f"|------|------|",
+        f"| Raw harness JSON | `{raw_report_path}` |",
+        f"| Normalised evidence JSON | `{evidence_path}` |",
+        f"",
+    ])
+
+    lines.append(f"*Report generated by `scripts/publish_launch_validation_evidence.py`*  ")
+    lines.append(f"*Normalised using `scripts/normalise_skills_report.py`*  ")
+    lines.append(f"")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Publish launch validation evidence from ADB harness output.",
+    )
+    # Input source: either explicit --input or --latest
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--input", help="Path to raw harness JSON report")
+    input_group.add_argument(
+        "--latest", action="store_true",
+        help="Use the most recent complete report in scripts/test-reports/",
+    )
+
+    parser.add_argument(
+        "--source", default="on_device",
+        choices=["on_device", "ci"],
+        help="Evidence source type (default: on_device)",
+    )
+    parser.add_argument(
+        "--device-id", default=None,
+        help="Device registry key (see scripts/testdata/devices.yaml). "
+             "Auto-detected from serial if omitted.",
+    )
+    parser.add_argument(
+        "--model-name", default="Gemma 4 E-2B",
+        help="Model name (default: Gemma 4 E-2B)",
+    )
+    parser.add_argument(
+        "--model-runtime", default="LiteRT",
+        help="Inference runtime (default: LiteRT)",
+    )
+    parser.add_argument(
+        "--model-backend", default="GPU",
+        help="Hardware backend (default: GPU)",
+    )
+    parser.add_argument(
+        "--serial", default=None,
+        help="ADB device serial (auto-detects device-id if known)",
+    )
+    parser.add_argument(
+        "--pr", type=int, default=None,
+        help="PR number for PR-scoped evidence",
+    )
+    parser.add_argument(
+        "--suite", default=None,
+        help="Suite name override (default: 'skills' or 'llm_tools' from report)",
+    )
+    parser.add_argument(
+        "--commit", default=None,
+        help="Commit SHA (default: auto-detect from HEAD)",
+    )
+    parser.add_argument(
+        "--branch", default=None,
+        help="Branch name (default: auto-detect from HEAD)",
+    )
+    parser.add_argument(
+        "--release", default=None,
+        help="Release tag (optional, for release-scoped evidence)",
+    )
+    parser.add_argument(
+        "--out-dir", default=None,
+        help="Output directory for intermediate normalised files "
+             "(default: <repo_root>/docs/test-triage/evidence/<device>/<timestamp>)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would be done without publishing",
+    )
+
+    args = parser.parse_args()
+
+    # ── Resolve input file ─────────────────────────────────────────────
+    if args.latest:
+        raw_path = _detect_latest_report()
+        if raw_path is None:
+            print("Error: no complete report found in scripts/test-reports/", file=sys.stderr)
+            print("Run the harness first, or pass --input <path>.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Using latest report: {raw_path}")
+    else:
+        raw_path = Path(args.input)
+        if not raw_path.exists():
+            print(f"Error: input file not found: {raw_path}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── Determine report type ──────────────────────────────────────────
+    raw = _load_json(raw_path)
+    raw_suite = raw.get("suite", "")
+    if raw_suite in ("skills",):
+        normaliser = "normalise_skills_report.py"
+        is_skills = True
+    elif raw_suite in ("llm_tools",):
+        normaliser = "summarise_test_report.py"
+        is_skills = False
+    else:
+        print(f"Warning: unknown suite '{raw_suite}'. Treating as skills.", file=sys.stderr)
+        normaliser = "normalise_skills_report.py"
+        is_skills = True
+
+    # ── Auto-detect commit and branch ──────────────────────────────────
+    build_sha = args.commit or _get_current_sha()
+    branch = args.branch or _get_current_branch()
+
+    # ── Resolve device ─────────────────────────────────────────────────
+    serial = args.serial
+    device_id = args.device_id
+    if device_id is None and serial:
+        device_id = _resolve_device_id(serial)
+        if device_id is None:
+            print(
+                f"Warning: serial '{serial}' not in known device list.",
+                file=sys.stderr,
+            )
+            print("Use --device-id to specify a device registry key.", file=sys.stderr)
+            sys.exit(1)
+
+    if device_id is None:
+        print("Error: could not determine device-id.", file=sys.stderr)
+        print("Provide --serial (with a known serial) or --device-id.", file=sys.stderr)
+        sys.exit(1)
+
+    # ── Build suite name ───────────────────────────────────────────────
+    suite = args.suite or raw_suite
+
+    # ── Build output directory ─────────────────────────────────────────
+    ts_normal = raw.get("timestamp", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ"))
+    ts_date = ts_normal[:10] if "T" in ts_normal else "unknown-date"
+    if args.out_dir:
+        out_dir = Path(args.out_dir)
+    else:
+        out_dir = HERE.parent / "docs" / "test-triage" / "evidence" / ts_date / device_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Print plan ─────────────────────────────────────────────────────
+    print(f"\n{'=' * 56}")
+    print(f"  Raw report:   {raw_path}")
+    print(f"  Normaliser:   scripts/{normaliser}")
+    print(f"  Device:       {device_id} (serial: {serial or 'unknown'})")
+    print(f"  Build:        {build_sha[:10]} on {branch}")
+    print(f"  Suite:        {suite}")
+    if args.pr:
+        print(f"  PR:           #{args.pr}")
+    print(f"  Output dir:   {out_dir}")
+    print(f"{'=' * 56}\n")
+
+    if args.dry_run:
+        print("[DRY RUN] Would run:")
+        normaliser_path = HERE / normaliser
+        print(f"  python3 {normaliser_path} \\")
+        print(f"    --input {raw_path} \\")
+        print(f"    --source {args.source} \\")
+        print(f"    --device-id {device_id} \\")
+        print(f"    --model-name '{args.model_name}' \\")
+        print(f"    --model-runtime '{args.model_runtime}' \\")
+        print(f"    --model-backend '{args.model_backend}' \\")
+        print(f"    --commit {build_sha} \\")
+        print(f"    --branch {branch} \\")
+        print(f"    --out-dir {out_dir} \\")
+        if args.pr:
+            print(f"    --pr {args.pr} \\")
+        if serial:
+            print(f"    --serial {serial}")
+        if args.release:
+            print(f"    --release {args.release}")
+        if suite != raw_suite:
+            print(f"    --suite {suite}")
+        print(f"\n  Then publish via scripts/publish_test_evidence.py")
+        print(f"  SKIP: --dry-run flag set")
+        return
+
+    # ── Step 1: Normalise ──────────────────────────────────────────────
+    normaliser_path = HERE / normaliser
+    norm_cmd = [
+        sys.executable, str(normaliser_path),
+        "--input", str(raw_path),
+        "--source", args.source,
+        "--device-id", device_id,
+        "--model-name", args.model_name,
+        "--model-runtime", args.model_runtime,
+        "--model-backend", args.model_backend,
+        "--commit", build_sha,
+        "--branch", branch,
+        "--out-dir", str(out_dir),
+    ]
+    if args.pr:
+        norm_cmd.extend(["--pr", str(args.pr)])
+    if serial:
+        norm_cmd.extend(["--serial", serial])
+    if args.release:
+        norm_cmd.extend(["--release", args.release])
+    if suite != raw_suite:
+        norm_cmd.extend(["--suite", suite])
+
+    print(f"  ► Normalising report…")
+    result = subprocess.run(norm_cmd, capture_output=False)
+    if result.returncode != 0:
+        print(f"  ✗ Normalisation failed (exit {result.returncode})", file=sys.stderr)
+        sys.exit(result.returncode)
+    print(f"  ✓ Normalisation complete\n")
+
+    # ── Find the normalised JSON output ────────────────────────────────
+    norm_jsons = sorted(out_dir.glob("*_evidence.json")) + sorted(out_dir.glob("*_skills_evidence.json"))
+    if not norm_jsons:
+        print(f"Error: normalised JSON not found in {out_dir}", file=sys.stderr)
+        sys.exit(1)
+    evidence_json = norm_jsons[-1]
+
+    # ── Step 2: Generate launch validation markdown ────────────────────
+    normalised = _load_json(evidence_json)
+    md = _build_launch_markdown(
+        evidence_path=evidence_json,
+        raw_report_path=raw_path,
+        normalised=normalised,
+        device_id=device_id,
+        serial=serial or "",
+        build_sha=build_sha,
+        branch=branch,
+    )
+    md_path = out_dir / "launch-validation-summary.md"
+    md_path.write_text(md)
+    print(f"  ✓ Launch validation summary: {md_path}\n")
+
+    # ── Step 3: Publish to test-results branch ─────────────────────────
+    _check_git_available()
+    publish_script = HERE / "publish_test_evidence.py"
+
+    publish_cmd = [
+        sys.executable, str(publish_script),
+        "--input", str(evidence_json),
+        "--source", args.source,
+        "--commit", build_sha,
+    ]
+    if args.pr:
+        publish_cmd.extend(["--pr", str(args.pr)])
+    if args.release:
+        publish_cmd.extend(["--release", args.release])
+
+    print(f"  ► Publishing evidence to test-results branch…")
+    pub_result = subprocess.run(publish_cmd, capture_output=False)
+    if pub_result.returncode != 0:
+        print(f"  ⚠ Publish returned exit {pub_result.returncode}.", file=sys.stderr)
+        print(f"  This may be due to test-results branch not existing yet,", file=sys.stderr)
+        print(f"  or no changes to commit. The normalised evidence files", file=sys.stderr)
+        print(f"  are still available locally.", file=sys.stderr)
+    else:
+        print(f"  ✓ Evidence published to test-results branch\n")
+
+    # ── Final summary ──────────────────────────────────────────────────
+    s = normalised.get("summary", {})
+    print(f"{'=' * 56}")
+    print(f"  Evidence publication complete:")
+    print(f"  • {s.get('total', 0)} cases | {s.get('passed', 0)} passed | {s.get('failed', 0)} failed")
+    print(f"  • Normalised: {evidence_json}")
+    print(f"  • Summary:    {md_path}")
+    if pub_result.returncode == 0:
+        print(f"  • Published to test-results branch ✓")
+    print(f"{'=' * 56}")
+
+    # ── Dashboard rebuild trigger note ─────────────────────────────────
+    if args.pr:
+        print(f"\n  To trigger dashboard rebuild:")
+        print(f"  gh api repos/NickMonrad/kernel-ai-assistant/dispatches \\")
+        print(f"    -f event_type=test-evidence-published \\")
+        print(f"    -f client_payload[source]={args.source} \\")
+        print(f"    -f client_payload[pr]={args.pr} \\")
+        print(f"    -f client_payload[commit]={build_sha}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_launch_validation_evidence.py
+++ b/scripts/publish_launch_validation_evidence.py
@@ -514,7 +514,8 @@ def main() -> None:
         print(f"    - *_cases.csv (spreadsheet)")
         print(f"    - *_summary.md (normalised summary)")
         print(f"    - launch-validation-summary.md (enriched Markdown)")
-        print(f"  SKIP: --dry-run flag set")
+    print(f"  SKIP: --dry-run flag set")
+    return
 
     # ── Step 1: Normalise ──────────────────────────────────────────────
     normaliser_path = HERE / normaliser

--- a/scripts/testdata/test_evidence.schema.json
+++ b/scripts/testdata/test_evidence.schema.json
@@ -166,6 +166,7 @@
         ],
         "properties": {
           "name": { "type": "string" },
+          "phase": { "type": "string", "description": "Test phase/group from the raw harness (e.g. alarm_timer, weather)" },
           "passed": { "type": "boolean" },
           "expected_tool": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
           "actual_tool": { "oneOf": [{ "type": "string" }, { "type": "null" }] },

--- a/scripts/tests/test_publish_launch_validation_evidence.py
+++ b/scripts/tests/test_publish_launch_validation_evidence.py
@@ -107,3 +107,160 @@ class DryRunFlagTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class NonDryRunTest(unittest.TestCase):
+    """Verify that non-dry-run execution reaches the normalisation and publish paths."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.mkdtemp(prefix="non_dryrun_test_")
+        self._tmp = Path(self._tmpdir)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    @staticmethod
+    def _make_minimal_fixture(path: Path) -> None:
+        """Write a minimal valid harness raw JSON to *path*."""
+        import json
+        data = {
+            "suite": "skills",
+            "device_id": "s21-exynos",
+            "serial": "R5CR605B71K",
+            "model_name": "Gemma 4 E-2B",
+            "model_runtime": "LiteRT",
+            "model_backend": "GPU",
+            "timestamp": "2026-06-18T12:00:00",
+            "status": "completed",
+            "results": [
+                {"name": "test_alarm", "status": "pass", "phase": "alarm_timer"},
+            ],
+            "summary": {"total": 1, "passed": 1, "failed": 0,
+                         "skipped": 0, "xfail": 0},
+        }
+        path.write_text(json.dumps(data))
+
+    def test_non_dry_run_reaches_normaliser(self) -> None:
+        """Without ``--dry-run`` the normalisation subprocess should be invoked."""
+        import json
+        from unittest import mock
+
+        fixture = self._tmp / "fixture.json"
+        self._make_minimal_fixture(fixture)
+
+        out_dir = self._tmp / "out"
+
+        normaliser_cmds: list[list[str]] = []
+        publisher_cmds: list[list[str]] = []
+
+        def mock_run(cmd, *args, **kwargs):               # type: ignore
+            cmd_str = " ".join(str(p) for p in cmd)
+            if "normalise_skills_report" in cmd_str:
+                normaliser_cmds.append(cmd)
+                # Create the expected output files so the script can continue
+                idx = cmd.index("--out-dir")
+                cmd_out = Path(cmd[idx + 1])
+                (cmd_out / "mock_skills_evidence.json").write_text(json.dumps({
+                    "timestamp": "2026-06-18T12:00:00",
+                    "source": "test",
+                    "schema_version": "1.0",
+                    "suite": "skills",
+                    "device": {
+                        "id": "s21-exynos",
+                        "label": "Samsung Galaxy S21 (Exynos)",
+                        "manufacturer": "Samsung",
+                        "model": "SM-G991B",
+                        "soc": "Exynos 2100",
+                        "tier": "tracked",
+                        "android_api": 35,
+                        "execution": "physical",
+                        "serial": "R5CR605B71K",
+                    },
+                    "model": {
+                        "name": "Gemma 4 E-2B",
+                        "runtime": "LiteRT",
+                        "backend": "GPU",
+                    },
+                    "summary": {
+                        "total": 1, "passed": 1, "failed": 0,
+                        "pass_rate": 1.0,
+                    },
+                    "cases": [{
+                        "name": "test_alarm",
+                        "passed": True,
+                        "phase": "alarm_timer",
+                        "expected_tool": "alarm_set",
+                        "actual_tool": "alarm_set",
+                        "expected_result_mode": "success",
+                        "actual_result_mode": "success",
+                        "chip_present": True,
+                        "skill_result_present": True,
+                        "message_saved": True,
+                        "retry_seen": False,
+                        "slot_fill_seen": False,
+                        "failure_category": None,
+                        "failures": [],
+                    }],
+                }))
+                (cmd_out / "mock_skills_cases.csv").write_text(
+                    "case,status\ntest_alarm,pass\n"
+                )
+                (cmd_out / "mock_skills_summary.md").write_text(
+                    "# Summary\n\nAll passed."
+                )
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=b"", stderr=b""
+                )
+            elif "publish_test_evidence" in cmd_str:
+                publisher_cmds.append(cmd)
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=b"", stderr=b""
+                )
+            # any other subprocess (git, etc.) -> pretend success
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=b"", stderr=b""
+            )
+
+        old_argv = list(sys.argv)
+        old_path = list(sys.path)
+        try:
+            sys.argv = [
+                str(LAUNCH_SCRIPT),
+                "--input", str(fixture),
+                "--out-dir", str(out_dir),
+                "--device-id", "s21-exynos",
+                "--model-name", "Gemma 4 E-2B",
+                "--model-runtime", "LiteRT",
+                "--model-backend", "GPU",
+                "--commit", "abc123def456",
+                "--branch", "test-branch",
+                "--serial", "R5CR605B71K",
+                "--pr", "9999",
+            ]
+
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(
+                "_test_launch_module", str(LAUNCH_SCRIPT),
+            )
+            mod = importlib.util.module_from_spec(spec)
+
+            with mock.patch.object(subprocess, "run", side_effect=mock_run):
+                spec.loader.exec_module(mod)
+                mod.main()
+        finally:
+            sys.argv = old_argv
+            sys.path = old_path
+
+        self.assertEqual(
+            len(normaliser_cmds), 1,
+            "Normalisation should be called exactly once (dry-run=False)",
+        )
+        self.assertIn(
+            "normalise_skills_report.py",
+            " ".join(str(p) for p in normaliser_cmds[0]),
+            "Normalisation command should reference the normaliser script",
+        )
+        self.assertEqual(
+            len(publisher_cmds), 1,
+            "Publisher should be called exactly once (dry-run=False)",
+        )

--- a/scripts/tests/test_publish_launch_validation_evidence.py
+++ b/scripts/tests/test_publish_launch_validation_evidence.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for publish_launch_validation_evidence.py.
+
+Covers the ``--dry-run`` flag: verifies it prints the plan and exits before
+running the normaliser, copying raw JSON, generating Markdown, or publishing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+REPO_DIR = SCRIPT_DIR.parent
+FIXTURE = SCRIPT_DIR / "testdata" / "fixtures" / "llm_tools_sample_raw.json"
+LAUNCH_SCRIPT = SCRIPT_DIR / "publish_launch_validation_evidence.py"
+
+
+class DryRunFlagTest(unittest.TestCase):
+    """Verify that ``--dry-run`` prints the plan and exits without side effects."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.mkdtemp(prefix="dryrun_test_")
+        self._tmp = Path(self._tmpdir)
+
+    def tearDown(self) -> None:
+        # Clean up temp dir
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _run_dry_run(self, extra_args: list[str] | None = None) -> subprocess.CompletedProcess:
+        """Run the launch validation script with ``--dry-run`` and return the result."""
+        cmd = [
+            sys.executable, str(LAUNCH_SCRIPT),
+            "--dry-run",
+            "--input", str(FIXTURE),
+            "--serial", "R5CR605B71K",
+            "--out-dir", self._tmpdir,
+            "--commit", "abcdef1234567890abcdef1234567890abcdef12",
+            "--branch", "test-branch",
+            "--pr", "9999",
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_DIR),
+        )
+
+    def test_dry_run_returns_zero(self) -> None:
+        """``--dry-run`` should exit 0."""
+        result = self._run_dry_run()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_dry_run_prints_plan(self) -> None:
+        """``--dry-run`` should print the dry-run plan."""
+        result = self._run_dry_run()
+        self.assertIn("[DRY RUN]", result.stdout)
+        self.assertIn("SKIP: --dry-run flag set", result.stdout)
+
+    def test_dry_run_does_not_create_evidence_files(self) -> None:
+        """``--dry-run`` should not create any evidence output files."""
+        self._run_dry_run()
+        # No evidence JSON
+        ev_jsons = list(self._tmp.glob("*_evidence.json"))
+        self.assertEqual(ev_jsons, [], f"Unexpected evidence JSON: {ev_jsons}")
+        # No CSV
+        csvs = list(self._tmp.glob("*_cases.csv"))
+        self.assertEqual(csvs, [], f"Unexpected CSV: {csvs}")
+        # No summary MD
+        summaries = list(self._tmp.glob("*_summary.md"))
+        self.assertEqual(summaries, [], f"Unexpected summary: {summaries}")
+        # No launch validation summary
+        lv_md = self._tmp / "launch-validation-summary.md"
+        self.assertFalse(lv_md.exists(), "launch-validation-summary.md should not exist")
+        # No raw/ subdirectory
+        raw_dir = self._tmp / "raw"
+        self.assertFalse(raw_dir.exists(), "raw/ subdirectory should not exist")
+
+    def test_dry_run_does_not_fail_on_unknown_suite(self) -> None:
+        """``--dry-run`` should work even with warnings (unknown suite type)."""
+        # Create a fixture with an unknown suite
+        import json
+        weird = self._tmp / "weird_suite.json"
+        weird.write_text(json.dumps({"suite": "unknown_suite", "results": [], "status": "passed"}))
+        cmd = [
+            sys.executable, str(LAUNCH_SCRIPT),
+            "--dry-run",
+            "--input", str(weird),
+            "--serial", "R5CR605B71K",
+            "--out-dir", self._tmp,
+            "--commit", "abcdef1234567890abcdef1234567890abcdef12",
+            "--branch", "test-branch",
+            "--pr", "9999",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO_DIR))
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("SKIP: --dry-run flag set", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #1295 — publish raw harness JSON and dashboard evidence for launch validation.

### Review fixes applied

#### Commit `842f05d7` (first round)
The previous version only published the normalised evidence JSON via `--input`. This fix publishes the full evidence bundle via `--input-dir` and addresses all review findings:

- **Full evidence bundle**: raw JSON copied to `raw/` subdirectory alongside normalised JSON, CSV, and summaries
- **Bundle publishing**: changed from `--input <single_json>` to `--input-dir <out_dir>`
- **not_reached / excluded accuracy**: added CLI args with `not provided by source evidence` fallback
- **Phase breakdown**: derived from raw harness `results[].phase`, carried through normalised schema
- **Schema update**: optional `phase` string on case items
- **S23U documentation**: model corrected to Gemma 4 E-4B, daily driver warning strengthened
- **Docs updated**: bundle structure, directory publish mode, new CLI flags documented
- **Schema JSON fixed**: restored missing `"properties"` wrapper in cases items schema

#### Commit `edb92996` (second round — CHANGES_REQUESTED fixes)

1. **`--dry-run` guard**: `--dry-run` now exits immediately after printing the plan. It no longer runs the normaliser, copies raw JSON, generates Markdown, or calls `publish_test_evidence.py`. Added 4 unit tests in `test_publish_launch_validation_evidence.py` verifying: exit code 0, plan output, no evidence files created, and tolerance for unknown suite types.

2. **S23U Markdown fix**: The targeted-smoke bash block is now properly closed before the `**Publishing:**` heading. The publishing command lives in its own separate fenced bash block. The section renders correctly as Markdown.

3. **Raw JSON durability clarified**:
   - Added note in the *Published bundle* section: `raw/` subdirectory is local-only; to preserve raw JSON across runs, commit the evidence bundle directory or archive it externally
   - Added *Known limitations* entry: raw JSON is **not** pushed to `test-results` branch; must be committed/archived separately for durable storage
   - `test-results` branch stores only normalised evidence (`.json`, `.csv`, `.md`) for dashboard rendering

#### Commit `3737dda4` (this round — dry-run control flow regression fix)

1. **Dry-run control flow fix**: The `print("  SKIP: --dry-run flag set")` and `return` from the previous round were accidentally placed **outside** the `if args.dry_run:` block. This caused every invocation (including real publishing) to exit before reaching normalisation, raw JSON copy, Markdown generation, and the publisher. Fixed by indenting both statements inside the `if args.dry_run:` block.

2. **Non-dry-run regression test**: Added `NonDryRunTest.test_non_dry_run_reaches_normaliser` — imports the module with patched `sys.argv` and mocked `subprocess.run` to capture command construction. Verifies that: the normalisation subprocess command is invoked exactly once; the publisher subprocess command is also invoked exactly once; the full normalise → raw JSON copy → markdown → publish pipeline runs to completion for non-dry-run invocations.

### Generated/published artifact paths
| Artifact | Location | Published to dashboard? |
|---|---|---|
| Raw harness JSON | `raw/{report}.json` | **No** (local-only — commit separately for durable storage) |
| Normalised evidence | `{report}_evidence.json` | Yes |
| Case CSV | `{report}_cases.csv` | Yes |
| Normalised summary | `{report}_summary.md` | Yes |
| Launch validation summary | `launch-validation-summary.md` | Yes |

### #1287
**Remains open** until S23U targeted evidence is captured and published using this workflow.

### Validation
- [x] **196 Python unit tests (all pass)** — includes 5 publish-evidence tests (4 dry-run + 1 non-dry-run regression)
- [x] `--dry-run` produces plan output, exits 0, creates no files
- [x] Non-dry-run reaches normalisation, raw JSON copy, Markdown generation, and publisher
- [x] CI and Docs Drift Check currently green
- [x] No S23U device testing performed or required for this PR

**Do not merge without human review.**
