### PR TITLE
feat(#1151): add contextual Do Not Disturb special-access flow

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -867,11 +867,11 @@ class NativeIntentHandler @Inject constructor(
     private fun setDoNotDisturb(enabled: Boolean): SkillResult {
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (!nm.isNotificationPolicyAccessGranted) {
-            val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            }
-            context.startActivity(intent)
-            return SkillResult.Success("Please grant Do Not Disturb access in settings")
+            return SkillResult.CapabilityRequired(
+                capabilityKey = CapabilityKey.DoNotDisturbControl,
+                skillName = if (enabled) "toggle_dnd_on" else "toggle_dnd_off",
+                contextParams = mapOf("enabled" to enabled.toString()),
+            )
         }
         val filter = if (enabled) NotificationManager.INTERRUPTION_FILTER_NONE
                      else NotificationManager.INTERRUPTION_FILTER_ALL

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -3,6 +3,8 @@ package com.kernel.ai.core.skills.natives
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
+import android.app.NotificationManager
+import com.kernel.ai.core.permissions.CapabilityKey
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.media.AudioManager
@@ -2368,5 +2370,92 @@ class NativeIntentHandlerTest {
             date4,
         )
         assertEquals("3:00 p.m.", resolved4.second)
-     }
+    }
+
+    @Nested
+    @DisplayName("Do Not Disturb")
+    inner class DoNotDisturbRow {
+
+        @Test
+        fun `toggle_dnd_on with granted access returns success`() {
+            val nm = mockk<NotificationManager>(relaxed = true)
+            every { nm.isNotificationPolicyAccessGranted } returns true
+            every {
+                context.getSystemService(Context.NOTIFICATION_SERVICE)
+            } returns nm
+
+            val result = handleIntent("toggle_dnd_on", emptyMap())
+
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertEquals("Do Not Disturb is on", (result as SkillResult.Success).content)
+            verify { nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE) }
+        }
+
+        @Test
+        fun `toggle_dnd_off with granted access returns success`() {
+            val nm = mockk<NotificationManager>(relaxed = true)
+            every { nm.isNotificationPolicyAccessGranted } returns true
+            every {
+                context.getSystemService(Context.NOTIFICATION_SERVICE)
+            } returns nm
+
+            val result = handleIntent("toggle_dnd_off", emptyMap())
+
+            assertInstanceOf(SkillResult.Success::class.java, result)
+            assertEquals("Do Not Disturb is off", (result as SkillResult.Success).content)
+            verify { nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) }
+        }
+
+        @Test
+        fun `toggle_dnd_on with missing access returns CapabilityRequired`() {
+            val nm = mockk<NotificationManager>(relaxed = true)
+            every { nm.isNotificationPolicyAccessGranted } returns false
+            every {
+                context.getSystemService(Context.NOTIFICATION_SERVICE)
+            } returns nm
+
+            val result = handleIntent("toggle_dnd_on", emptyMap())
+
+            assertInstanceOf(SkillResult.CapabilityRequired::class.java, result)
+            val capResult = result as SkillResult.CapabilityRequired
+            assertEquals(CapabilityKey.DoNotDisturbControl, capResult.capabilityKey)
+            assertEquals("toggle_dnd_on", capResult.skillName)
+            assertEquals("true", capResult.contextParams["enabled"])
+            // Must NOT directly launch settings
+            verify(exactly = 0) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `toggle_dnd_off with missing access returns CapabilityRequired`() {
+            val nm = mockk<NotificationManager>(relaxed = true)
+            every { nm.isNotificationPolicyAccessGranted } returns false
+            every {
+                context.getSystemService(Context.NOTIFICATION_SERVICE)
+            } returns nm
+
+            val result = handleIntent("toggle_dnd_off", emptyMap())
+
+            assertInstanceOf(SkillResult.CapabilityRequired::class.java, result)
+            val capResult = result as SkillResult.CapabilityRequired
+            assertEquals(CapabilityKey.DoNotDisturbControl, capResult.capabilityKey)
+            assertEquals("toggle_dnd_off", capResult.skillName)
+            assertEquals("false", capResult.contextParams["enabled"])
+            // Must NOT directly launch settings
+            verify(exactly = 0) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `missing access does not produce misleading success result`() {
+            val nm = mockk<NotificationManager>(relaxed = true)
+            every { nm.isNotificationPolicyAccessGranted } returns false
+            every {
+                context.getSystemService(Context.NOTIFICATION_SERVICE)
+            } returns nm
+
+            val result = handleIntent("toggle_dnd_on", emptyMap())
+
+            // Must NOT be Success
+            assertInstanceOf(SkillResult.CapabilityRequired::class.java, result)
+        }
+    }
 }

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -1,0 +1,250 @@
+package com.kernel.ai.feature.chat
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented Compose UI tests for the DND special-access AlertDialog.
+ *
+ * The dialog is rendered inline in [ActionsScreen] (lines 615–650 of ActionsScreen.kt).
+ * This test verifies the dialog rendering and CTA callbacks in isolation using a
+ * test wrapper that replicates the same conditional [AlertDialog] structure.
+ *
+ * OS-boundary notes:
+ *   - The "Open DND access settings" CTA triggers [ActionsViewModel.onDndOpenSettings],
+ *     which emits [ActionsViewModel.UiEvent.OpenDndSettings]. The actual
+ *     [android.provider.Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS] intent launch
+ *     is handled in [ActionsScreen]'s LaunchedEffect event collector (lines 280–289)
+ *     via [android.content.Context.startActivity]. This final OS call is not directly
+ *     verified at the Compose UI layer — it is covered by the ViewModel unit test
+ *     (`dnd open settings emits OpenDndSettings event`) and by manual smoke test.
+ *   - Full grant/revoke automation (toggling the notification-policy-access switch)
+ *     is OEM-specific and inherently unstable across Samsung One UI vs AOSP — no
+ *     stable third-party helper exists for this.
+ *   - The lifecycle resume path (ON_RESUME → onDndResumeCheck) is tested at the
+ *     ViewModel unit-test layer (retry-with-grant and blocked-without-grant).
+ */
+class ActionsDndDialogTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // ── Initial state ──────────────────────────────────────────────────────────
+
+    @Test
+    fun showsInitialDialogWithExpectedTitleAndBody() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(null)
+        composeTestRule.setContent {
+            DndDialogContent(dndState = dndState, onOpenSettings = {}, onDismiss = {})
+        }
+
+        dndState.value = ActionsViewModel.DndState(
+            intentName = "toggle_dnd_on",
+            enabled = true,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            "Android requires special access before Jandal can turn Do Not Disturb on or off."
+        ).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Open DND access settings")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Not now")
+            .assertIsDisplayed()
+    }
+
+    // ── Blocked state ──────────────────────────────────────────────────────────
+
+    @Test
+    fun showsBlockedDialogWithExpectedTitleAndBody() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(null)
+        composeTestRule.setContent {
+            DndDialogContent(dndState = dndState, onOpenSettings = {}, onDismiss = {})
+        }
+
+        dndState.value = ActionsViewModel.DndState(
+            intentName = "toggle_dnd_on",
+            enabled = true,
+            isAccessBlocked = true,
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Jandal still needs Do Not Disturb access")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            "Jandal still does not have Do Not Disturb access. " +
+                "Open DND access settings to grant it, then return to Jandal."
+        ).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Open DND access settings")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Not now")
+            .assertIsDisplayed()
+    }
+
+    // ── Hidden when state is null ──────────────────────────────────────────────
+
+    @Test
+    fun doesNotShowDialogWhenDndStateIsNull() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(null)
+        composeTestRule.setContent {
+            DndDialogContent(dndState = dndState, onOpenSettings = {}, onDismiss = {})
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Jandal still needs Do Not Disturb access")
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun hidesDialogWhenStateReturnsToNull() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(
+            ActionsViewModel.DndState(intentName = "toggle_dnd_on", enabled = true)
+        )
+        composeTestRule.setContent {
+            DndDialogContent(dndState = dndState, onOpenSettings = {}, onDismiss = {})
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsDisplayed()
+
+        dndState.value = null
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsNotDisplayed()
+    }
+
+    // ── CTA: "Open DND access settings" ────────────────────────────────────────
+
+    @Test
+    fun openSettingsButtonTriggersCallback() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(
+            ActionsViewModel.DndState(intentName = "toggle_dnd_on", enabled = true)
+        )
+        var openSettingsCalled = false
+        composeTestRule.setContent {
+            DndDialogContent(
+                dndState = dndState,
+                onOpenSettings = { openSettingsCalled = true },
+                onDismiss = {},
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Open DND access settings").performClick()
+        assertTrue("Open DND access settings callback was not invoked", openSettingsCalled)
+    }
+
+    // ── CTA: "Not now" ─────────────────────────────────────────────────────────
+
+    @Test
+    fun notNowButtonTriggersDismiss() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(
+            ActionsViewModel.DndState(intentName = "toggle_dnd_on", enabled = true)
+        )
+        var dismissCalled = false
+        composeTestRule.setContent {
+            DndDialogContent(
+                dndState = dndState,
+                onOpenSettings = {},
+                onDismiss = { dismissCalled = true; dndState.value = null },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Not now").performClick()
+        assertTrue("Not now dismiss callback was not invoked", dismissCalled)
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun dialogDismissesViaBackdropTap() {
+        val dndState = mutableStateOf<ActionsViewModel.DndState?>(
+            ActionsViewModel.DndState(intentName = "toggle_dnd_on", enabled = true)
+        )
+        var dismissCalled = false
+        composeTestRule.setContent {
+            DndDialogContent(
+                dndState = dndState,
+                onOpenSettings = {},
+                onDismiss = { dismissCalled = true; dndState.value = null },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        // AlertDialog's onDismissRequest fires when tapping outside the dialog.
+        // Simulate by calling the dismiss lambda directly.
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsDisplayed()
+        assertFalse("Dismiss should not have been called before interaction", dismissCalled)
+    }
+
+    // ── Test wrapper composable ────────────────────────────────────────────────
+
+    /**
+     * Replicates the exact [AlertDialog] structure from [ActionsScreen] lines 615–650.
+     *
+     * Kept as a local composable so the test mirrors the production rendering
+     * without depending on the full [ActionsViewModel] or lifecycle infrastructure.
+     */
+    @Composable
+    private fun DndDialogContent(
+        dndState: MutableState<ActionsViewModel.DndState?>,
+        onOpenSettings: () -> Unit,
+        onDismiss: () -> Unit,
+    ) {
+        dndState.value?.let { state ->
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = {
+                    Text(
+                        if (state.isAccessBlocked) {
+                            "Jandal still needs Do Not Disturb access"
+                        } else {
+                            "Allow Jandal to control Do Not Disturb?"
+                        },
+                    )
+                },
+                text = {
+                    Text(
+                        if (state.isAccessBlocked) {
+                            "Jandal still does not have Do Not Disturb access. " +
+                                "Open DND access settings to grant it, then return to Jandal."
+                        } else {
+                            "Android requires special access before Jandal can " +
+                                "turn Do Not Disturb on or off."
+                        },
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = onOpenSettings) {
+                        Text("Open DND access settings")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) {
+                        Text("Not now")
+                    }
+                },
+            )
+        }
+    }
+}

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -91,8 +91,8 @@ class ActionsDndDialogTest {
         composeTestRule.onNodeWithText("Jandal still needs Do Not Disturb access")
             .assertIsDisplayed()
         composeTestRule.onNodeWithText(
-            "Jandal still does not have Do Not Disturb access. " +
-                "Open DND access settings to grant it, then return to Jandal."
+            "Grant Do Not Disturb access in Android settings, " +
+                "then return to Jandal to continue."
         ).assertIsDisplayed()
         composeTestRule.onNodeWithText("Open DND access settings")
             .assertIsDisplayed()

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -11,6 +11,10 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.click
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -190,11 +194,19 @@ class ActionsDndDialogTest {
         }
 
         composeTestRule.waitForIdle()
-        // AlertDialog's onDismissRequest fires when tapping outside the dialog.
-        // Simulate by calling the dismiss lambda directly.
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
             .assertIsDisplayed()
         assertFalse("Dismiss should not have been called before interaction", dismissCalled)
+
+        // Click outside the dialog (top-left corner of the screen on the scrim)
+        // to trigger AlertDialog's onDismissRequest.
+        composeTestRule.onRoot().performTouchInput {
+            click(position = Offset(0f, 0f))
+        }
+
+        assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
+        composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
+            .assertIsNotDisplayed()
     }
 
     // ── Test wrapper composable ────────────────────────────────────────────────

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -628,8 +628,8 @@ fun ActionsScreen(
             text = {
                 Text(
                     if (state.isAccessBlocked) {
-                        "Jandal still does not have Do Not Disturb access. " +
-                            "Open DND access settings to grant it, then return to Jandal."
+                        "Grant Do Not Disturb access in Android settings, " +
+                            "then return to Jandal to continue."
                     } else {
                         "Android requires special access before Jandal can " +
                             "turn Do Not Disturb on or off."

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -1,7 +1,9 @@
 package com.kernel.ai.feature.chat
 
 import android.Manifest
+import android.app.NotificationManager
 import android.content.Intent
+import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
@@ -128,6 +130,7 @@ fun ActionsScreen(
     val slotReplyAutoRearmArmed by viewModel.slotReplyAutoRearmArmed.collectAsStateWithLifecycle()
     val slotPromptPlaybackStarted by viewModel.slotPromptPlaybackStarted.collectAsStateWithLifecycle()
     val handsFreeCallingState by viewModel.handsFreeCallingState.collectAsStateWithLifecycle()
+    val dndState by viewModel.dndState.collectAsStateWithLifecycle()
     val currentVoiceCaptureState = voiceCaptureState
     val isCommandVoiceActive = when (currentVoiceCaptureState) {
         is ActionsViewModel.VoiceCaptureState.Preparing -> currentVoiceCaptureState.mode == VoiceCaptureMode.Command
@@ -274,12 +277,27 @@ fun ActionsScreen(
                 }
                 ActionsViewModel.UiEvent.NavigateToAppPermissions ->
                     onNavigateToAppPermissions()
+                ActionsViewModel.UiEvent.OpenDndSettings -> {
+                    val dndSettingsIntent = Intent(
+                        android.provider.Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
+                    ).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    runCatching {
+                        context.startActivity(dndSettingsIntent)
+                    }
+                }
             }
         }
     }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val hasDndAccess = (context.getSystemService(Context.NOTIFICATION_SERVICE)
+                    as? NotificationManager)?.isNotificationPolicyAccessGranted == true
+                viewModel.onDndResumeCheck(hasDndAccess)
+            }
             if (event == Lifecycle.Event.ON_STOP) {
                 Log.d(
                     ACTIONS_SCREEN_TAG,
@@ -590,6 +608,43 @@ fun ActionsScreen(
             },
             dismissButton = {
                 TextButton(onClick = { showClearConfirmation = false }) { Text("Cancel") }
+            },
+        )
+    }
+
+    // DND special-access contextual surface
+    dndState?.let { state ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDndDialog() },
+            title = {
+                Text(
+                    if (state.isAccessBlocked) {
+                        "Jandal still needs Do Not Disturb access"
+                    } else {
+                        "Allow Jandal to control Do Not Disturb?"
+                    },
+                )
+            },
+            text = {
+                Text(
+                    if (state.isAccessBlocked) {
+                        "Jandal still does not have Do Not Disturb access. " +
+                            "Open DND access settings to grant it, then return to Jandal."
+                    } else {
+                        "Android requires special access before Jandal can " +
+                            "turn Do Not Disturb on or off."
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.onDndOpenSettings() }) {
+                    Text("Open DND access settings")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissDndDialog() }) {
+                    Text("Not now")
+                }
             },
         )
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -601,8 +601,14 @@ class ActionsViewModel @Inject constructor(
             }
         } else {
             // Show blocked/repair state — access still not granted
-            val currentState = _dndState.value ?: return
-            _dndState.value = currentState.copy(isAccessBlocked = true)
+            // Reconstruct DndState from pending rather than relying on _dndState,
+            // which may have been cleared by onDndOpenSettings() when the user
+            // navigated to Android Settings.
+            _dndState.value = DndState(
+                intentName = pending.intentName,
+                enabled = pending.enabled,
+                isAccessBlocked = true,
+            )
         }
     }
 

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -1004,12 +1004,23 @@ class ActionsViewModel @Inject constructor(
             resultText = "Action failed: ${result.error}",
             isSuccess = false,
         )
-        is SkillResult.CapabilityRequired -> QuickActionEntity(
-            userQuery = query,
-            skillName = skillName,
-            resultText = "Permission required for $skillName",
-            isSuccess = false,
-        )
+        is SkillResult.CapabilityRequired -> {
+            val resultText = if (result.capabilityKey == CapabilityKey.DoNotDisturbControl) {
+                when (result.skillName) {
+                    "toggle_dnd_on" -> "Jandal needs Do Not Disturb access before it can turn DND on."
+                    "toggle_dnd_off" -> "Jandal needs Do Not Disturb access before it can turn DND off."
+                    else -> "Jandal needs Do Not Disturb access before it can change DND."
+                }
+            } else {
+                "Permission required for $skillName"
+            }
+            QuickActionEntity(
+                userQuery = query,
+                skillName = skillName,
+                resultText = resultText,
+                isSuccess = false,
+            )
+        }
         is SkillResult.UnknownSkill -> QuickActionEntity(
             userQuery = query,
             skillName = skillName,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -568,11 +568,16 @@ class ActionsViewModel @Inject constructor(
     /**
      * Called when the app resumes after the user returns from DND access settings.
      * Re-checks access and either retries the original DND action or shows a blocked result.
+     *
+     * [pendingDndAction] is consumed only in the grant path (retry succeeded or failed).
+     * In the blocked path, [pendingDndAction] is kept alive so the user can open settings
+     * again from the blocked/repair dialog and retry on a subsequent grant.
      */
     fun onDndResumeCheck(hasAccess: Boolean) {
         val pending = pendingDndAction ?: return
-        pendingDndAction = null
         if (hasAccess) {
+            // Clear pending before retry — will be re-set if retry returns CapabilityRequired.
+            pendingDndAction = null
             viewModelScope.launch {
                 _uiState.value = UiState.Executing
                 try {
@@ -600,10 +605,9 @@ class ActionsViewModel @Inject constructor(
                 }
             }
         } else {
-            // Show blocked/repair state — access still not granted
-            // Reconstruct DndState from pending rather than relying on _dndState,
-            // which may have been cleared by onDndOpenSettings() when the user
-            // navigated to Android Settings.
+            // Show blocked/repair state — access still not granted.
+            // Keep pendingDndAction alive for future settings-round trips
+            // so the original command can be retried when access is eventually granted.
             _dndState.value = DndState(
                 intentName = pending.intentName,
                 enabled = pending.enabled,

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -109,6 +109,8 @@ class ActionsViewModel @Inject constructor(
         data class LaunchDialer(val phoneNumber: String, val contact: String) : UiEvent
         /** Navigate to internal Settings → App Permissions for manual repair. */
         object NavigateToAppPermissions : UiEvent
+        /** Open Android DND special-access settings for notification policy grant. */
+        object OpenDndSettings : UiEvent
     }
 
     private data class PendingPhonePermissionAction(
@@ -118,6 +120,14 @@ class ActionsViewModel @Inject constructor(
         val inputMode: InputMode,
         val phoneNumber: String? = null,
         val capabilityKey: CapabilityKey = CapabilityKey.HandsFreeCalling,
+    )
+
+    private data class PendingDndAction(
+        val query: String,
+        val intentName: String,
+        val params: Map<String, String>,
+        val inputMode: InputMode,
+        val enabled: Boolean,
     )
 
     private data class ExecutedAction(
@@ -142,6 +152,14 @@ class ActionsViewModel @Inject constructor(
         val isPermanentlyDenied: Boolean = false,
     )
 
+    /** State for the contextual DND special-access surface. */
+    data class DndState(
+        val intentName: String,
+        val enabled: Boolean,
+        /** True when the user returned from settings without granting access. */
+        val isAccessBlocked: Boolean = false,
+    )
+
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
@@ -160,6 +178,10 @@ class ActionsViewModel @Inject constructor(
     private val _handsFreeCallingState = MutableStateFlow<HandsFreeCallingState?>(null)
     val handsFreeCallingState: StateFlow<HandsFreeCallingState?> = _handsFreeCallingState.asStateFlow()
 
+    /** Non-null while the DND special-access contextual surface should be shown. */
+    private val _dndState = MutableStateFlow<DndState?>(null)
+    val dndState: StateFlow<DndState?> = _dndState.asStateFlow()
+
     private val _voiceCaptureState = MutableStateFlow<VoiceCaptureState>(VoiceCaptureState.Idle)
     val voiceCaptureState: StateFlow<VoiceCaptureState> = _voiceCaptureState.asStateFlow()
 
@@ -174,6 +196,7 @@ class ActionsViewModel @Inject constructor(
     private var pendingVoiceSlotReplyRestartJob: Job? = null
     private var pendingVoiceSpeechJob: Job? = null
     private var pendingPhonePermissionAction: PendingPhonePermissionAction? = null
+    private var pendingDndAction: PendingDndAction? = null
     private var recentVoiceCommand: String? = null
     private var recentVoiceCommandAtMs: Long = 0L
     private var spokenResponsesEnabled = true
@@ -525,6 +548,64 @@ class ActionsViewModel @Inject constructor(
         _error.value = null
     }
 
+    // ── DND special-access ─────────────────────────────────────────────────────
+
+    /** Open Android DND access settings for the user to grant notification policy access. */
+    fun onDndOpenSettings() {
+        _dndState.value = null
+        viewModelScope.launch {
+            _events.emit(UiEvent.OpenDndSettings)
+        }
+    }
+
+    /** Dismiss the DND special-access surface without any action. */
+    fun dismissDndDialog() {
+        _dndState.value = null
+        pendingDndAction = null
+        _error.value = null
+    }
+
+    /**
+     * Called when the app resumes after the user returns from DND access settings.
+     * Re-checks access and either retries the original DND action or shows a blocked result.
+     */
+    fun onDndResumeCheck(hasAccess: Boolean) {
+        val pending = pendingDndAction ?: return
+        pendingDndAction = null
+        if (hasAccess) {
+            viewModelScope.launch {
+                _uiState.value = UiState.Executing
+                try {
+                    setSlotReplyAutoRearmArmed(false, "onDndResumeCheck")
+                    clearExpectedSlotPromptSpeech()
+                    voiceOutputController.stop()
+                    val result = executeIntent(
+                        query = pending.query,
+                        intentName = pending.intentName,
+                        params = pending.params,
+                        inputMode = pending.inputMode,
+                    )
+                    quickActionDao.insert(result.entity)
+                    speakForVoice(
+                        pending.inputMode,
+                        result.entity.resultText,
+                        spokenOverride = result.spokenSummary,
+                    )
+                } catch (e: Exception) {
+                    Log.e(TAG, "ActionsViewModel: onDndResumeCheck failed — ${e.message}", e)
+                    _error.value = e.message ?: "Unknown error"
+                } finally {
+                    _voiceCaptureState.value = VoiceCaptureState.Idle
+                    _uiState.value = UiState.Idle
+                }
+            }
+        } else {
+            // Show blocked/repair state — access still not granted
+            val currentState = _dndState.value ?: return
+            _dndState.value = currentState.copy(isAccessBlocked = true)
+        }
+    }
+
     /**
      * Executes a quick-action command via the [QuickIntentRouter] Tier 2 fast intent layer.
      *
@@ -820,7 +901,7 @@ class ActionsViewModel @Inject constructor(
         }
         return if (skill != null) {
             val skillResult = skill.execute(SkillCall(skill.name, callParams))
-            if (shouldRequestPhonePermission(intentName, skillResult)) {
+            if (shouldRequestPhonePermission(skillResult)) {
                 val capResult = skillResult as SkillResult.CapabilityRequired
                 val phoneNumber = capResult.contextParams["phoneNumber"]
                 val contact = capResult.contextParams["contact"]
@@ -835,6 +916,21 @@ class ActionsViewModel @Inject constructor(
                 _handsFreeCallingState.value = HandsFreeCallingState(
                     phoneNumber = phoneNumber ?: "",
                     contact = contact ?: "",
+                )
+            }
+            if (shouldRequestDndAccess(skillResult)) {
+                val capResult = skillResult as SkillResult.CapabilityRequired
+                val enabled = capResult.contextParams["enabled"]?.toBoolean() ?: true
+                pendingDndAction = PendingDndAction(
+                    query = query,
+                    intentName = intentName,
+                    params = params,
+                    inputMode = inputMode,
+                    enabled = enabled,
+                )
+                _dndState.value = DndState(
+                    intentName = intentName,
+                    enabled = enabled,
                 )
             }
             ExecutedAction(
@@ -918,11 +1014,15 @@ class ActionsViewModel @Inject constructor(
         )
     }
 
-    private fun shouldRequestPhonePermission(intentName: String, result: SkillResult): Boolean {
+    private fun shouldRequestPhonePermission(result: SkillResult): Boolean {
         return result is SkillResult.CapabilityRequired &&
             result.capabilityKey == CapabilityKey.HandsFreeCalling
     }
 
+    private fun shouldRequestDndAccess(result: SkillResult): Boolean {
+        return result is SkillResult.CapabilityRequired &&
+            result.capabilityKey == CapabilityKey.DoNotDisturbControl
+    }
 
     private fun ownsVoiceCapture(mode: VoiceCaptureMode): Boolean =
         when (val state = _voiceCaptureState.value) {

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1391,6 +1391,154 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `dnd two-step repair loop with grant on second settings attempt`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returnsMany listOf(
+            SkillResult.CapabilityRequired(
+                capabilityKey = CapabilityKey.DoNotDisturbControl,
+                skillName = "toggle_dnd_on",
+                contextParams = mapOf("enabled" to "true"),
+            ),
+            SkillResult.Success("Do Not Disturb is on"),
+        )
+
+        // Step 1: Create DND missing-access state via executeAction
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+        assertEquals("toggle_dnd_on", viewModel.dndState.value!!.intentName)
+
+        // Step 2: First settings round trip — user opens DND access settings
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+        assertNull(viewModel.dndState.value)
+
+        // Step 3: Return without access — blocked/repair state shown
+        viewModel.onDndResumeCheck(hasAccess = false)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(true, viewModel.dndState.value!!.isAccessBlocked)
+        assertEquals("toggle_dnd_on", viewModel.dndState.value!!.intentName)
+        // PendingDndAction must still be alive here for the second round trip
+        // (verified indirectly by successful retry in step 7)
+
+        // Step 4: Second settings round trip — user taps "Open DND access settings"
+        // from the blocked/repair dialog
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+        assertNull(viewModel.dndState.value)
+
+        // Step 5: Return with access granted
+        viewModel.onDndResumeCheck(hasAccess = true)
+        advanceUntilIdle()
+
+        // Step 6: Assert the original DND action was retried exactly once more
+        // (total 2 calls: initial executeAction + retry from second round trip)
+        coVerify(exactly = 2) { runIntentSkill.execute(any()) }
+
+        // Step 7: Assert success is inserted only after the retried action succeeds
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_on" &&
+                        it.resultText == "Do Not Disturb is on" &&
+                        it.isSuccess
+                }
+            )
+        }
+
+        // Step 8: Assert pending state is cleared after the successful retry
+        assertNull(viewModel.dndState.value)
+    }
+
+    @Test
+    fun `dnd repeated return without grant preserves pending action until Not now`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returnsMany listOf(
+            SkillResult.CapabilityRequired(
+                capabilityKey = CapabilityKey.DoNotDisturbControl,
+                skillName = "toggle_dnd_on",
+                contextParams = mapOf("enabled" to "true"),
+            ),
+            SkillResult.Success("Do Not Disturb is on"),
+        )
+
+        // 1. Create DND missing-access state
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        // 2. First return without grant — blocked state shown
+        viewModel.onDndResumeCheck(hasAccess = false)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(true, viewModel.dndState.value!!.isAccessBlocked)
+
+        // 3. Open settings again (from blocked dialog)
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+        assertNull(viewModel.dndState.value)
+
+        // 4. Return without grant again — blocked state still shown, pending still alive
+        viewModel.onDndResumeCheck(hasAccess = false)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(true, viewModel.dndState.value!!.isAccessBlocked)
+
+        // 5. Open settings a third time
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+        assertNull(viewModel.dndState.value)
+
+        // 6. Return with grant — pending still alive, retry succeeds
+        viewModel.onDndResumeCheck(hasAccess = true)
+        advanceUntilIdle()
+
+        // 7. Assert original action was retried exactly once (total 2 calls)
+        coVerify(exactly = 2) { runIntentSkill.execute(any()) }
+
+        // 8. Assert success inserted
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_on" &&
+                        it.resultText == "Do Not Disturb is on" &&
+                        it.isSuccess
+                }
+            )
+        }
+
+        // 9. Assert pending state cleared after successful retry
+        assertNull(viewModel.dndState.value)
+    }
+
+    @Test
     fun `voice command normalizes spoken numbers before routing`() = runTest(dispatcher) {
         every { quickIntentRouter.route("set timer for 5 minutes") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "set timer for 5 minutes")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1139,7 +1139,47 @@ class ActionsViewModelVoiceTest {
             quickActionDao.insert(
                 match {
                     it.skillName == "toggle_dnd_on" &&
-                        it.resultText == "Permission required for toggle_dnd_on" &&
+                        it.resultText == "Jandal needs Do Not Disturb access before it can turn DND on." &&
+                        !it.isSuccess
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `dnd toggle_dnd_off capability required inserts user-facing copy`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn off do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_off",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_off") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returns SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.DoNotDisturbControl,
+            skillName = "toggle_dnd_off",
+            contextParams = mapOf("enabled" to "false"),
+        )
+
+        viewModel.executeAction("turn off do not disturb", InputMode.Text)
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.dndState.value)
+        assertEquals("toggle_dnd_off", viewModel.dndState.value!!.intentName)
+        assertEquals(false, viewModel.dndState.value!!.enabled)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_off" &&
+                        it.resultText == "Jandal needs Do Not Disturb access before it can turn DND off." &&
                         !it.isSuccess
                 }
             )

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -1276,6 +1276,121 @@ class ActionsViewModelVoiceTest {
     }
 
     @Test
+    fun `dnd resume check settings flow without grant shows blocked state`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returns SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.DoNotDisturbControl,
+            skillName = "toggle_dnd_on",
+            contextParams = mapOf("enabled" to "true"),
+        )
+
+        // 1. Create DND missing-access state via executeAction
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        // 2. Call onDndOpenSettings() — simulates user tapping the settings button
+        val events = mutableListOf<ActionsViewModel.UiEvent>()
+        val collectJob = launch { viewModel.events.collect { events += it } }
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+
+        // 3. Assert settings-open event is emitted
+        assertEquals(1, events.size)
+        assert(events[0] is ActionsViewModel.UiEvent.OpenDndSettings)
+        // _dndState is cleared so the dialog hides during settings navigation
+        assertNull(viewModel.dndState.value)
+
+        // 4. Simulate return from settings with access still missing
+        viewModel.onDndResumeCheck(hasAccess = false)
+        advanceUntilIdle()
+
+        // 5. Assert blocked/repair DND state is shown
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(true, viewModel.dndState.value!!.isAccessBlocked)
+        assertEquals("toggle_dnd_on", viewModel.dndState.value!!.intentName)
+
+        // 6. Assert pending state was not silently dropped — blocked state exists
+        // 7. Assert no successful DND action result was inserted (only the initial attempt)
+        coVerify(exactly = 1) { runIntentSkill.execute(any()) }
+
+        // 8. Assert dismiss clears both blocked and pending state
+        viewModel.dismissDndDialog()
+        advanceUntilIdle()
+        assertNull(viewModel.dndState.value)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `dnd resume check settings flow with grant retries action`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returnsMany listOf(
+            SkillResult.CapabilityRequired(
+                capabilityKey = CapabilityKey.DoNotDisturbControl,
+                skillName = "toggle_dnd_on",
+                contextParams = mapOf("enabled" to "true"),
+            ),
+            SkillResult.Success("Do Not Disturb is on"),
+        )
+
+        // 1. Create DND missing-access state via executeAction
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        // 2. Call onDndOpenSettings() — simulates user tapping the settings button
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+        // _dndState is cleared during settings navigation
+        assertNull(viewModel.dndState.value)
+
+        // 3. Simulate return from settings with access granted
+        viewModel.onDndResumeCheck(hasAccess = true)
+        advanceUntilIdle()
+
+        // 4. Assert the original DND action was retried
+        coVerify(exactly = 2) { runIntentSkill.execute(any()) }
+
+        // 5. Assert success is inserted only after the retried action succeeds
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_on" &&
+                        it.resultText == "Do Not Disturb is on" &&
+                        it.isSuccess
+                }
+            )
+        }
+    }
+
+    @Test
     fun `voice command normalizes spoken numbers before routing`() = runTest(dispatcher) {
         every { quickIntentRouter.route("set timer for 5 minutes") } returns
             QuickIntentRouter.RouteResult.FallThrough(input = "set timer for 5 minutes")

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.skills.SkillSchema
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.slot.SlotSpec
+import com.kernel.ai.core.permissions.CapabilityKey
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.voice.VoiceInputController
@@ -47,6 +48,7 @@ import kotlinx.coroutines.test.resetMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -1102,6 +1104,175 @@ class ActionsViewModelVoiceTest {
             )
         }
         collectJob.cancel()
+    }
+
+    @Test
+    fun `dnd capability required creates pending DND action state`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returns SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.DoNotDisturbControl,
+            skillName = "toggle_dnd_on",
+            contextParams = mapOf("enabled" to "true"),
+        )
+
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.dndState.value)
+        assertEquals("toggle_dnd_on", viewModel.dndState.value!!.intentName)
+        assertEquals(true, viewModel.dndState.value!!.enabled)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_on" &&
+                        it.resultText == "Permission required for toggle_dnd_on" &&
+                        !it.isSuccess
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `dnd open settings emits OpenDndSettings event`() = runTest(dispatcher) {
+        val events = mutableListOf<ActionsViewModel.UiEvent>()
+        val collectJob = launch { viewModel.events.collect { events += it } }
+
+        viewModel.onDndOpenSettings()
+        advanceUntilIdle()
+
+        assertEquals(1, events.size)
+        assert(events[0] is ActionsViewModel.UiEvent.OpenDndSettings)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `dnd dismiss clears pending state`() = runTest(dispatcher) {
+        // Prime DND state
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn off do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_off",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_off") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returns SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.DoNotDisturbControl,
+            skillName = "toggle_dnd_off",
+            contextParams = mapOf("enabled" to "false"),
+        )
+
+        viewModel.executeAction("turn off do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+
+        viewModel.dismissDndDialog()
+        advanceUntilIdle()
+
+        assertNull(viewModel.dndState.value)
+    }
+
+    @Test
+    fun `dnd resume check with granted access retries action`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returnsMany listOf(
+            SkillResult.CapabilityRequired(
+                capabilityKey = CapabilityKey.DoNotDisturbControl,
+                skillName = "toggle_dnd_on",
+                contextParams = mapOf("enabled" to "true"),
+            ),
+            SkillResult.Success("Do Not Disturb is on"),
+        )
+
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+
+        // Simulate resume with granted access
+        viewModel.onDndResumeCheck(hasAccess = true)
+        advanceUntilIdle()
+
+        // Should have retried the action
+        coVerify(exactly = 2) { runIntentSkill.execute(any()) }
+        // Should have inserted success result
+        coVerify {
+            quickActionDao.insert(
+                match {
+                    it.skillName == "toggle_dnd_on" &&
+                        it.resultText == "Do Not Disturb is on" &&
+                        it.isSuccess
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `dnd resume check without grant shows blocked state`() = runTest(dispatcher) {
+        val runIntentSkill = mockk<Skill>()
+        every { quickIntentRouter.route("turn on do not disturb") } returns
+            QuickIntentRouter.RouteResult.RegexMatch(
+                QuickIntentRouter.MatchedIntent(
+                    intentName = "toggle_dnd_on",
+                    params = emptyMap(),
+                ),
+            )
+        every { skillRegistry.get("toggle_dnd_on") } returns null
+        every { skillRegistry.get("run_intent") } returns runIntentSkill
+        every { runIntentSkill.name } returns "run_intent"
+        every { runIntentSkill.description } returns "Run intent"
+        every { runIntentSkill.schema } returns SkillSchema()
+        coEvery { runIntentSkill.execute(any()) } returns SkillResult.CapabilityRequired(
+            capabilityKey = CapabilityKey.DoNotDisturbControl,
+            skillName = "toggle_dnd_on",
+            contextParams = mapOf("enabled" to "true"),
+        )
+
+        viewModel.executeAction("turn on do not disturb", InputMode.Text)
+        advanceUntilIdle()
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(false, viewModel.dndState.value!!.isAccessBlocked)
+
+        // Simulate resume without granted access
+        viewModel.onDndResumeCheck(hasAccess = false)
+        advanceUntilIdle()
+
+        // Should now show blocked state
+        assertNotNull(viewModel.dndState.value)
+        assertEquals(true, viewModel.dndState.value!!.isAccessBlocked)
+
+        // Should NOT have inserted a second action result
+        coVerify(exactly = 1) { runIntentSkill.execute(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds contextual Do Not Disturb special-access flow for Jandal's `toggle_dnd_on`/`toggle_dnd_off` actions. Third slice of the contextual permissions UX epic (#1140).

### Changes

**`NativeIntentHandler.setDoNotDisturb`** — no longer launches `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` directly when access is missing. Now returns `SkillResult.CapabilityRequired(CapabilityKey.DoNotDisturbControl, ...)` with the enabled state in context params. Existing granted-path behaviour is unchanged.

**`ActionsViewModel`** — added structured DND state (`DndState`) and pending action tracking (`PendingDndAction`). Methods:
- `onDndOpenSettings()` — emits `UiEvent.OpenDndSettings` to launch Android DND access settings
- `dismissDndDialog()` — clears pending state
- `onDndResumeCheck(hasAccess: Boolean)` — called on lifecycle `ON_RESUME`; retries original DND action if access was granted, or shows blocked/repair state (keeping `pendingDndAction` alive for future settings round trips)

**`ActionsScreen`** — added contextual `AlertDialog` with two states:
- **Initial**: title "Allow Jandal to control Do Not Disturb?", body explains Android requires special access. Buttons: "Open DND access settings", "Not now"
- **Blocked**: title "Jandal still needs Do Not Disturb access", body shows repair guidance. Buttons: "Open DND access settings", "Not now"

**Lifecycle handling** — `ON_RESUME` observer checks `NotificationManager.isNotificationPolicyAccessGranted` and calls `viewModel.onDndResumeCheck()` for automatic retry.

### Fix 1: return-from-Android-Settings blocked state (f91046be)

**Bug:** When the user tapped "Open DND access settings", `onDndOpenSettings()` cleared `_dndState` before launching Settings. On return without grant, `onDndResumeCheck(false)` tried to copy the current `_dndState` into blocked state, but `_dndState` was already null — so it silently returned, dropping the pending action and never showing the repair dialog.

**Fix:** `onDndResumeCheck` now reconstructs `DndState` from the `pendingDndAction` variable instead of reading from `_dndState`. This ensures the blocked/repair state is correctly shown regardless of whether `onDndOpenSettings()` cleared the dialog state.

### Fix 2: keep pending DND action alive in blocked/repair state (6ee9acb8)

**Bug:** `onDndResumeCheck()` unconditionally nulled `pendingDndAction` before branching on `hasAccess`. In the blocked state (else branch), the pending action was already consumed — a second settings round trip from the blocked/repair dialog found nothing to retry.

**Fix:** Moved `pendingDndAction = null` into only the `hasAccess = true` branch. In the blocked else branch, `pendingDndAction` is kept alive so the user can open DND access settings again from the blocked/repair dialog and retry on a subsequent grant. Pending is cleared only when:
- The user taps "Not now" / dismisses either dialog
- The retried action succeeds (grant path completes)
- The action fails with an exception

### Fix 3: user-facing copy polish (61cef54f)

**Problem:** The action history card showed developer-facing copy:
- `Permission required for toggle_dnd_on`
- `Permission required for toggle_dnd_off`

**Fix:** In `buildEntityFromSkillResult`, the `CapabilityRequired` branch now detects `DoNotDisturbControl` and produces intent-specific user-facing messages:
- `toggle_dnd_on` → "Jandal needs Do Not Disturb access before it can turn DND on."
- `toggle_dnd_off` → "Jandal needs Do Not Disturb access before it can turn DND off."
- Other DND → "Jandal needs Do Not Disturb access before it can change DND."
- Non-DND capability-required copy remains unchanged (`Permission required for <skillName>`)

**Dialog polish:** Blocked dialog body updated for consistency:
- Old: "Jandal still does not have Do Not Disturb access. Open DND access settings to grant it, then return to Jandal."
- New: "Grant Do Not Disturb access in Android settings, then return to Jandal to continue."

### Files changed

| File | Change |
|------|--------|
| `NativeIntentHandler.kt` | `setDoNotDisturb` now returns `CapabilityRequired` instead of launching settings directly |
| `ActionsViewModel.kt` | `+DndState`, `+PendingDndAction`, `_dndState` flow, DND methods; fixes for blocked state reconstruction and pending action lifecycle; user-facing DND copy in `buildEntityFromSkillResult` |
| `ActionsScreen.kt` | DND `AlertDialog`, `OpenDndSettings` event handling, lifecycle `ON_RESUME` re-check; polished blocked dialog body |
| `NativeIntentHandlerTest.kt` | +5 DND tests for granted/missing/on/off flows |
| `ActionsViewModelVoiceTest.kt` | +10 DND tests: state, settings launch, dismiss, retry, blocked state, full lifecycle settings-flow paths, two-step repair loop, repeated no-grant preservation, user-facing copy verification for both `toggle_dnd_on` and `toggle_dnd_off` |
| `ActionsDndDialogTest.kt` | +7 Compose UI instrumented tests for dialog rendering and CTA callbacks; backdrop dismiss test now performs actual interaction |

## Linked issues / parent epic updates

- Closes #1151
- Parent epic: #1140 Contextual permissions UX

## Automated Testing

### Native handler unit tests (5)
- `toggle_dnd_on` with granted access → `Success("Do Not Disturb is on")`
- `toggle_dnd_off` with granted access → `Success("Do Not Disturb is off")`
- `toggle_dnd_on` with missing access → `CapabilityRequired(DoNotDisturbControl, "toggle_dnd_on", enabled=true)`
- `toggle_dnd_off` with missing access → `CapabilityRequired(DoNotDisturbControl, "toggle_dnd_off", enabled=false)`
- Missing access does not produce misleading `Success` result
- All missing-access tests verify `context.startActivity` is never called directly

### ViewModel unit tests (10)
1. DND `CapabilityRequired` creates pending DND action state with user-facing copy: "Jandal needs Do Not Disturb access before it can turn DND on."
2. DND `toggle_dnd_off` capability required inserts user-facing copy: "Jandal needs Do Not Disturb access before it can turn DND off."
3. `onDndOpenSettings()` emits `OpenDndSettings` event
4. `dismissDndDialog()` clears pending state
5. `onDndResumeCheck(hasAccess=true)` retries original DND action and inserts success result
6. `onDndResumeCheck(hasAccess=false)` sets `isAccessBlocked=true` without inserting misleading success
7. `dnd resume check settings flow without grant shows blocked state` — full lifecycle path: `executeAction` → `onDndOpenSettings()` → `onDndResumeCheck(false)` shows blocked repair state → `dismissDndDialog()` clears everything
8. `dnd resume check settings flow with grant retries action` — full lifecycle path: `executeAction` → `onDndOpenSettings()` → `onDndResumeCheck(true)` retries original action and inserts success
9. `dnd two-step repair loop with grant on second settings attempt` — full two-step repair: `executeAction` → 1st settings round trip (blocked return) → 2nd settings round trip (granted return) → retry succeeds → pending cleared
10. `dnd repeated return without grant preserves pending action until Not now` — 3 settings round trips (2 without grant, 1 with grant) → pending still alive on 3rd attempt → retry succeeds → pending cleared

### Compose UI dialog instrumented tests (7)
- Initial dialog renders with expected title ("Allow Jandal to control Do Not Disturb?"), body ("Android requires special access..."), "Open DND access settings" CTA, and "Not now" CTA
- Blocked dialog renders with expected title ("Jandal still needs Do Not Disturb access"), repair body ("Grant Do Not Disturb access in Android settings, then return to Jandal to continue."), and same CTAs
- No dialog is shown when `dndState` is null
- Dialog hides when state transitions back to null
- "Open DND access settings" tap invokes ViewModel callback
- "Not now" tap invokes dismiss callback and clears state
- Backdrop dismiss test performs actual scrim tap interaction and asserts dialog disappearance

### OS-boundary automation notes

The Compose UI tests verify the app-owned explanation dialog and CTA callbacks rendered on-device — this is the stable part of the DND special-access flow. The final OS boundary (launching `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` from the event handler) is verified at the ViewModel unit-test level (`dnd open settings emits OpenDndSettings event`) and requires a manual smoke test to confirm end-to-end behavior across OEMs.

Full grant/revoke automation of notification policy access is OEM-specific and inherently unstable — Samsung One UI presents a different DND access settings flow than AOSP, and programmatic grant requires `MANAGE_NOTIFICATION_POLICY_ACCESS_PRESET` (not available to third-party apps). See `docs/permissions/capability-registry.md` for the grant-path documentation.

## Manual smoke test checklist (S23 Ultra)

1. Ensure Jandal does not have Do Not Disturb access.
2. Ask Jandal to turn on Do Not Disturb.
3. ✅ Verify the app-owned contextual surface appears before Android Settings.
4. Verify title/body copy:
   - "Allow Jandal to control Do Not Disturb?"
   - "Android requires special access before Jandal can turn Do Not Disturb on or off."
5. Tap **Not now**.
6. ✅ Verify no misleading successful DND result is recorded.
7. ✅ Verify action history shows: "Jandal needs Do Not Disturb access before it can turn DND on."
8. Trigger DND again.
9. Tap **Open DND access settings**.
10. ✅ Verify Android DND access settings opens.
11. Return without granting access.
12. ✅ Verify Jandal shows blocked/repair state and does not claim DND changed.
13. ✅ Verify blocked dialog body: "Grant Do Not Disturb access in Android settings, then return to Jandal to continue."
14. Tap **Open DND access settings** again from the blocked/repair dialog.
15. ✅ Verify Android DND access settings opens again.
16. Grant DND access.
17. Return to Jandal.
18. ✅ Verify Jandal re-checks access and retries the original DND command.
19. ✅ Verify DND turns on successfully.
20. ✅ Verify action history shows: "Do Not Disturb is on."
21. Ask Jandal to turn DND off.
22. ✅ Verify the already-granted path works and DND turns off.
23. Revoke DND access and verify the missing-access path still appears.

## Pre-merge Verification

- [x] `./gradlew test --no-daemon` — 314 tasks, all passing
- [x] `./gradlew lint --no-daemon` — passes (only pre-existing sqlite-vec C warnings in lint-baseline.xml)
- [x] `./gradlew assembleDebug --no-daemon` — passes
- [x] `./gradlew :feature:chat:compileDebugAndroidTestSources --no-daemon` — 117 tasks, compiles cleanly
- [x] `git diff --check` — passes
- [x] Targeted unit tests added: 5 native handler + 10 ViewModel + 7 Compose UI = **22 new tests**
- [x] User-facing copy verified: no raw `toggle_dnd_on`/`toggle_dnd_off` intent names appear in action history

**Note:** `./gradlew :feature:chat:connectedDebugAndroidTest` requires a connected device/emulator. Run on S23 Ultra with:
```
./gradlew :feature:chat:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.kernel.ai.feature.chat.ActionsDndDialogTest
```

## Documentation

The permission capability registry is documented in `docs/permissions/capability-registry.md` from #1291 (#1144). The DND special-access requirement (`NotificationPolicyAccess`) was already defined. No new docs needed.

## Agent / reviewer notes

- Do Not Merge — wait for Nick's explicit approval.
- Write-settings/brightness is NOT migrated in this slice — future scope (#1158).
- Phone-call behaviour is NOT changed — only DND special-access flow added alongside existing #1298 hands-free calling flow.
- The `OpenDndSettings` event opens `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` from the ActionsScreen, not from NativeIntentHandler. The native handler no longer owns settings navigation.
- DND access state is checked on every `ON_RESUME` event — this is intentionally broad to catch the user returning from Android Settings. It only triggers DND retry if a pending DND action exists (no-op otherwise).
- `VoiceCommandHandler` already branches on `CapabilityRequired` and shows "Permission required" for widget voice commands — no change needed.
- **Fix 1 (`f91046be`):** `onDndResumeCheck` reconstructs blocked state from pending action data rather than relying on `_dndState` (which `onDndOpenSettings()` clears during settings navigation).
- **Fix 2 (`6ee9acb8`):** `pendingDndAction` is no longer nulled unconditionally in `onDndResumeCheck`. It is only cleared in the grant-retry path. In the blocked/repair else branch, it stays alive so the user can attempt a second settings round trip.
- **Fix 3 (`61cef54f`):** User-facing copy now shows "Jandal needs Do Not Disturb access before it can turn DND on/off" instead of "Permission required for toggle_dnd_on/off". Blocked dialog body polished to "Grant Do Not Disturb access in Android settings, then return to Jandal to continue."