### PR TITLE
feat(#1297): reject invalid slot values before dispatching tools

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/RunIntentSkill.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.skills
 
 import com.kernel.ai.core.skills.natives.NativeIntentHandler
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,6 +22,7 @@ class RunIntentSkill @Inject constructor(
     private val handler: NativeIntentHandler,
 ) : Skill {
 
+    private val validationRegistry: SlotValidationRegistry by lazy { SlotValidationRegistry() }
     override val name = "run_intent"
     override val description =
         "Perform a native Android device action. Supports flashlight, alarm, timer, calendar, email, SMS, " +
@@ -287,6 +289,14 @@ class RunIntentSkill @Inject constructor(
         val intentName = call.arguments["intent_name"]?.takeIf { it.isNotBlank() }
             ?: return SkillResult.Failure(name, "Missing required parameter: intent_name.")
         val extraParams = call.arguments - "intent_name"
+        // Validate slot values before dispatching — catches invalid already-populated
+        // params from direct model tool calls (KernelAIToolSet.runIntent) that bypass
+        // ChatViewModel.validateBeforeDispatch, and recovery/anaphoric paths
+        val invalid = validationRegistry.validateParams(intentName, extraParams)
+        if (invalid != null) {
+            val message = invalid.errorMessage ?: "Invalid value for $intentName. Please try again."
+            return SkillResult.Failure("$name/$intentName", message)
+        }
         return handler.handle(intentName, extraParams)
     }
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/intent/IntentContractRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/intent/IntentContractRegistry.kt
@@ -158,6 +158,53 @@ class IntentContractRegistry {
                 riskLevel = IntentRiskLevel.MEDIUM,
             ),
 
+            // ── LOW RISK (alarms — time required, day optional) ───────────
+            IntentContract(
+                intentName = "set_alarm",
+                capability = "Set Alarm",
+                requiredSlots = mapOf(
+                    "time" to SlotSpec(
+                        name = "time",
+                        promptTemplate = "What time would you like the alarm set for?",
+                    ),
+                ),
+                optionalSlots = mapOf(
+                    "day" to SlotSpec(
+                        name = "day",
+                        promptTemplate = "Which day should the alarm be for?",
+                    ),
+                ),
+                riskLevel = IntentRiskLevel.LOW,
+            ),
+            IntentContract(
+                intentName = "set_timer",
+                capability = "Set Timer",
+                requiredSlots = mapOf(
+                    "duration_seconds" to SlotSpec(
+                        name = "duration_seconds",
+                        promptTemplate = "How long would you like the timer for?",
+                    ),
+                ),
+                optionalSlots = mapOf(
+                    "label" to SlotSpec(
+                        name = "label",
+                        promptTemplate = "What should I call this timer?",
+                    ),
+                ),
+                riskLevel = IntentRiskLevel.LOW,
+            ),
+            IntentContract(
+                intentName = "open_app",
+                capability = "Open App",
+                requiredSlots = mapOf(
+                    "app_name" to SlotSpec(
+                        name = "app_name",
+                        promptTemplate = "Which app would you like to open?",
+                    ),
+                ),
+                riskLevel = IntentRiskLevel.LOW,
+            ),
+
             // ── LOW RISK (safe to execute with slots filled) ──────────────────
             IntentContract(
                 intentName = "add_to_list",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillResult.kt
@@ -13,6 +13,17 @@ sealed class SlotFillResult {
         val request: PendingSlotRequest,
     ) : SlotFillResult()
 
+    /**
+     * The user provided a value for the current slot, but it failed validation —
+     * re-prompt with targeted clarification.
+     *
+     * The slot-fill remains pending; the user's next reply retries filling the
+     * same slot with a corrected value.
+     */
+    data class InvalidSlot(
+        val request: PendingSlotRequest,
+    ) : SlotFillResult()
+
     /** User sent a blank reply or explicitly cancelled. */
     data object Cancelled : SlotFillResult()
 }

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
@@ -10,14 +10,17 @@ import javax.inject.Singleton
  * **Flow:**
  * 1. [QuickIntentRouter.route] returns [QuickIntentRouter.RouteResult.NeedsSlot] when a
  *    regex-matched intent is missing a required parameter.
- * 2. [ChatViewModel] calls [startSlotFill], stores the [PendingSlotRequest][com.kernel.ai.core.skills.slot.PendingSlotRequest], and shows
+ * 2. [ChatViewModel] calls [startSlotFill], stores the [PendingSlotRequest], and shows
  *    [PendingSlotRequest.promptMessage] as an assistant bubble.
  * 3. On the user's next message, [ChatViewModel] detects [hasPending] and calls
  *    [onUserReply] *instead* of routing to QIR or the LLM.
- * 4. [onUserReply] merges the reply, asks [IntentContractRegistry.nextMissingSlot], and either
+ * 4. [onUserReply] normalises the reply, then validates via [SlotValidationRegistry];
+ *    if invalid it returns [SlotFillResult.InvalidSlot] with a re-prompt instead of dispatching.
+ * 5. [onUserReply] merges the reply, asks [IntentContractRegistry.nextMissingSlot], and either
  *    returns [SlotFillResult.NeedsMore] with the next prompt or [SlotFillResult.Completed]
  *    with the fully merged params.
- * 5. [ChatViewModel] executes the completed intent exactly as it would a direct QIR match.
+ * 6. [ChatViewModel] executes the completed intent exactly as it would a direct QIR match.
+ *
  * This class is a `@Singleton` so it survives configuration changes alongside ChatViewModel.
  * State is intentionally *not* persisted across process death — an interrupted slot fill
  * is a recoverable UX edge case (user simply re-asks).
@@ -25,6 +28,7 @@ import javax.inject.Singleton
 @Singleton
 class SlotFillerManager @Inject constructor(
     private val intentContractRegistry: IntentContractRegistry,
+    private val slotValidationRegistry: SlotValidationRegistry = SlotValidationRegistry(),
 ) {
     private val pendingRequests = mutableMapOf<String, PendingSlotRequest>()
 
@@ -55,11 +59,18 @@ class SlotFillerManager @Inject constructor(
     /**
      * Called with the user's reply when a slot fill is in progress.
      *
+     * Steps: normalise → validate → merge → check for next missing slot.
+     *
      * @return [SlotFillResult.Completed] with all params merged when the slot contract is
-     *         satisfied, [SlotFillResult.NeedsMore] when another required slot remains, or
+     *         satisfied, [SlotFillResult.NeedsMore] when another required slot remains,
+     *         [SlotFillResult.InvalidSlot] when the value is present but invalid, or
      *         [SlotFillResult.Cancelled] if [message] is blank.
      */
-    fun onUserReply(conversationId: String, message: String): SlotFillResult {
+    fun onUserReply(
+        conversationId: String,
+        message: String,
+        validationRegistry: SlotValidationRegistry = this.slotValidationRegistry,
+    ): SlotFillResult {
         val pending = pendingRequests[conversationId] ?: return SlotFillResult.Cancelled
         val normalizedMessage = normalizeSlotReply(message, pending.missingSlot.name)
         if (normalizedMessage.isBlank()) {
@@ -68,7 +79,34 @@ class SlotFillerManager @Inject constructor(
             return SlotFillResult.Cancelled
         }
 
-        val mergedParams = pending.existingParams + mapOf(pending.missingSlot.name to normalizedMessage)
+        // Validate the normalized value before accepting it
+        val validationResult = validationRegistry.validate(
+            intentName = pending.intentName,
+            slotName = pending.missingSlot.name,
+            value = normalizedMessage,
+        )
+        if (!validationResult.isValid) {
+            // Invalid value — re-prompt with targeted clarification.
+            // Keep the slot fill pending so the user's next reply retries this slot.
+            val retrySpec = SlotSpec(
+                name = pending.missingSlot.name,
+                promptTemplate = validationResult.errorMessage
+                    ?: "Please try again.",
+            )
+            val retryRequest = PendingSlotRequest(
+                intentName = pending.intentName,
+                existingParams = pending.existingParams,
+                missingSlot = retrySpec,
+                isRecovery = pending.isRecovery,
+            )
+            // Store the retry request so the next user message retries the same slot
+            pendingRequests[conversationId] = retryRequest
+            return SlotFillResult.InvalidSlot(retryRequest)
+        }
+
+        // Use corrected value if provided by validator
+        val finalValue = validationResult.correctedValue ?: normalizedMessage
+        val mergedParams = pending.existingParams + mapOf(pending.missingSlot.name to finalValue)
         val nextMissingSlot = intentContractRegistry.nextMissingSlot(
             intentName = pending.intentName,
             params = mergedParams,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationRegistry.kt
@@ -1,0 +1,205 @@
+package com.kernel.ai.core.skills.slot
+
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Central registry of [SlotValidator]s, keyed by `(intentName, slotName)`.
+ *
+ * Validation rules are registered once at construction time and shared across
+ * the slot-fill path ([SlotFillerManager]) and the dispatch path ([NativeIntentHandler]).
+ *
+ * Adding a new validator for an intent:
+ * ```
+ * registry.register("my_intent", "my_slot") { _, _, value ->
+ *     if (isValid(value)) SlotValidationResult.valid()
+ *     else SlotValidationResult.invalid("Please provide a valid value for my_slot.")
+ * }
+ * ```
+ *
+ * Extending the registry itself (preferred for launch-relevant families):
+ * ```
+ * class MyValidator : SlotValidator { ... }
+ * // then add to the BUILDERS list in the companion object
+ * ```
+ */
+@Singleton
+class SlotValidationRegistry @Inject constructor() {
+
+    private val validators = mutableMapOf<String, SlotValidator>()
+
+    /**
+     * Returns the validator registered for `(intentName, slotName)`, or null
+     * when no specific validation rules exist (value passes through unchecked).
+     */
+    fun get(intentName: String, slotName: String): SlotValidator? = validators[key(intentName, slotName)]
+
+    /**
+     * Validates [value] against the registered validator for `(intentName, slotName)`.
+     * Returns [SlotValidationResult.valid] when no validator is registered.
+     */
+    fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        val validator = get(intentName, slotName) ?: return SlotValidationResult.valid()
+        return validator.validate(intentName, slotName, value)
+    }
+
+    /**
+     * Register a [SlotValidator] for `(intentName, slotName)`.
+     * Overwrites any previously registered validator for the same key.
+     */
+    fun register(intentName: String, slotName: String, validator: SlotValidator) {
+        validators[key(intentName, slotName)] = validator
+    }
+
+    private fun key(intentName: String, slotName: String): String = "$intentName\u0000$slotName"
+
+    companion object {
+        /**
+         * Intents and slots that have registered validators.
+         * Called once at construction time to populate the registry.
+         */
+        private val REGISTRATIONS: List<Triple<String, String, SlotValidator>> = listOf(
+            Triple("set_timer", "duration_seconds", TimerDurationValidator),
+            Triple("set_timer", "label", NonEmptyStringValidator("What should I call this timer?")),
+            Triple("set_alarm", "time", AlarmTimeValidator),
+            Triple("set_alarm", "day", AlarmDayValidator),
+            Triple("get_weather", "location", WeatherLocationValidator),
+        )
+    }
+
+    init {
+        REGISTRATIONS.forEach { (intent, slot, validator) ->
+            register(intent, slot, validator)
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Built-in validators
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Validates timer duration values.
+ *
+ * Accepts: positive integers only (already normalised by [SlotSpec.normalizeDurationSlotReply]
+ * which parses human-readable forms like "5 minutes", "30 seconds" into total seconds).
+ */
+object TimerDurationValidator : SlotValidator {
+    override fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return SlotValidationResult.invalid("How long would you like the timer for?")
+        }
+        val seconds = trimmed.toIntOrNull()
+        if (seconds == null || seconds <= 0) {
+            return SlotValidationResult.invalid("Sorry, I didn't understand that duration. How long should the timer be?")
+        }
+        // Reject obviously impossible durations (e.g. > 24 hours in seconds)
+        if (seconds > 24 * 3600) {
+            return SlotValidationResult.invalid("Timers can be at most 24 hours. How long should the timer be?")
+        }
+        return SlotValidationResult.valid()
+    }
+}
+
+/**
+ * Validates non-empty string slots (labels, names, etc.).
+ */
+class NonEmptyStringValidator(
+    private val errorMessage: String,
+) : SlotValidator {
+    override fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        if (value.isBlank()) {
+            return SlotValidationResult.invalid(errorMessage)
+        }
+        return SlotValidationResult.valid()
+    }
+}
+
+/**
+ * Validates alarm time values.
+ *
+ * Accepts: any string that [QuickIntentRouter.resolveTime] can parse into a valid
+ * [LocalTime] — supports "5pm", "7:30", "14:00", "9 o'clock", etc.
+ */
+object AlarmTimeValidator : SlotValidator {
+    // Reuse the same resolution logic as the alarm dispatch path
+    private val timeRegex = Regex("""(\d{1,2})(?::(\d{2}))?\s*(am|pm|a\.m\.|p\.m\.)?""", RegexOption.IGNORE_CASE)
+
+    override fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return SlotValidationResult.invalid("What time should I set the alarm for?")
+        }
+        val cleaned = trimmed.lowercase()
+            .replace(Regex("""\s*(o'clock|oclock)\s*"""), "")
+            .trim()
+        val match = timeRegex.find(cleaned)
+        if (match == null) {
+            return SlotValidationResult.invalid("Sorry, I didn't understand that time. What time should the alarm be?")
+        }
+        val hours = match.groupValues[1].toIntOrNull() ?: return SlotValidationResult.invalid(
+            "Sorry, I didn't understand that time. What time should the alarm be?",
+        )
+        val minutes = match.groupValues[2].toIntOrNull() ?: 0
+        val meridiem = match.groupValues[3].replace(".", "").lowercase()
+        val computedHours = when {
+            meridiem == "pm" && hours < 12 -> hours + 12
+            meridiem == "am" && hours == 12 -> 0
+            else -> hours
+        }
+        if (computedHours !in 0..23 || minutes !in 0..59) {
+            return SlotValidationResult.invalid("Sorry, I didn't understand that time. What time should the alarm be?")
+        }
+        return SlotValidationResult.valid()
+    }
+}
+
+/**
+ * Validates alarm day values.
+ *
+ * Accepts: day names (monday, tuesday, ...) or "today", "tomorrow", or empty (no day specified).
+ */
+object AlarmDayValidator : SlotValidator {
+    private val VALID_DAYS = setOf(
+        "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+        "mon", "tue", "tues", "wed", "thu", "thur", "thurs", "fri", "sat", "sun",
+        "today", "tomorrow",
+    )
+
+    override fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        val trimmed = value.trim().lowercase()
+        if (trimmed.isBlank()) return SlotValidationResult.valid() // day is optional
+        val dayName = trimmed.removePrefix("next ").removePrefix("this ").trim()
+        if (dayName in VALID_DAYS) return SlotValidationResult.valid()
+        return SlotValidationResult.invalid(
+            "Sorry, I didn't understand that day. Which day should the alarm be for?",
+        )
+    }
+}
+
+/**
+ * Lightweight guard for weather location values.
+ *
+ * Only rejects clearly unusable input (blank, single non-alpha characters, digits-only
+ * postal codes that are unlikely to be valid location names). Most free-text values
+ * are passed through — the weather API is better at rejecting bad locations than we are.
+ */
+object WeatherLocationValidator : SlotValidator {
+    override fun validate(intentName: String, slotName: String, value: String): SlotValidationResult {
+        val trimmed = value.trim()
+        if (trimmed.isBlank()) {
+            return SlotValidationResult.invalid("Which city or area would you like the weather for?")
+        }
+        // Reject single non-letter characters ("?", ".", ",", "1")
+        if (trimmed.length <= 1 && !trimmed[0].isLetter()) {
+            return SlotValidationResult.invalid("Which city or area would you like the weather for?")
+        }
+        // Digits-only that look like postal codes are passed through
+        // (geocoding APIs handle them). Only reject clearly unusable noise.
+        return SlotValidationResult.valid()
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationRegistry.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationRegistry.kt
@@ -47,6 +47,26 @@ class SlotValidationRegistry @Inject constructor() {
     }
 
     /**
+     * Validates ALL params for [intentName] against registered validators.
+     * Returns the first [SlotValidationResult.invalid] result found, or null
+     * when every param passes (or has no registered validator).
+     *
+     * This is the shared entry point for the dispatch guard — used before any
+     * [SkillCall.execute] in ChatViewModel to catch invalid already-populated
+     * slot values from direct regex matches, recovery-origin intents, and
+     * anaphoric references.
+     */
+    fun validateParams(intentName: String, params: Map<String, String>): SlotValidationResult? {
+        for ((slotName, value) in params) {
+            // Internal routing params that carry no slot value to validate
+            if (slotName == "intent_name" || slotName == "raw_query") continue
+            val result = validate(intentName, slotName, value)
+            if (!result.isValid) return result
+        }
+        return null
+    }
+
+    /**
      * Register a [SlotValidator] for `(intentName, slotName)`.
      * Overwrites any previously registered validator for the same key.
      */

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationResult.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidationResult.kt
@@ -1,0 +1,22 @@
+package com.kernel.ai.core.skills.slot
+
+/**
+ * Result of validating a single slot value.
+ *
+ * @property isValid True when the value is acceptable for downstream dispatch.
+ * @property errorMessage User-facing clarification prompt when invalid; null when valid.
+ * @property correctedValue Optional corrected/normalised form of the value.
+ */
+data class SlotValidationResult(
+    val isValid: Boolean,
+    val errorMessage: String? = null,
+    val correctedValue: String? = null,
+) {
+    companion object {
+        fun valid(correctedValue: String? = null): SlotValidationResult =
+            SlotValidationResult(isValid = true, correctedValue = correctedValue)
+
+        fun invalid(errorMessage: String): SlotValidationResult =
+            SlotValidationResult(isValid = false, errorMessage = errorMessage)
+    }
+}

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidator.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotValidator.kt
@@ -1,0 +1,17 @@
+package com.kernel.ai.core.skills.slot
+
+/**
+ * Validates a single slot value for a specific intent and slot name.
+ *
+ * Implementations are stateless and thread-safe — the registry holds a single
+ * instance per validator, shared across all slot-fill and dispatch paths.
+ */
+fun interface SlotValidator {
+    /**
+     * Validate [value] for [slotName] on [intentName].
+     *
+     * @return [SlotValidationResult.valid] when the value is acceptable;
+     *         [SlotValidationResult.invalid] with a user-facing clarification prompt otherwise.
+     */
+    fun validate(intentName: String, slotName: String, value: String): SlotValidationResult
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/RunIntentSkillTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/RunIntentSkillTest.kt
@@ -1,0 +1,250 @@
+package com.kernel.ai.core.skills
+
+import com.kernel.ai.core.skills.natives.NativeIntentHandler
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [RunIntentSkill] dispatch guard — validates that invalid already-populated
+ * slot values are rejected before reaching [NativeIntentHandler].
+ */
+class RunIntentSkillTest {
+
+    private lateinit var handler: NativeIntentHandler
+    private lateinit var skill: RunIntentSkill
+
+    @BeforeEach
+    fun setUp() {
+        handler = mockk(relaxed = true)
+        skill = RunIntentSkill(handler)
+    }
+
+    @Test
+    fun `set timer zero seconds is rejected`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "0",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `set timer negative seconds is rejected`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "-5",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `set timer over 24 hours is rejected`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "90001",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `set timer 5 minutes dispatches`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Timer set")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "300",
+                "label" to "pasta",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("set_timer", mapOf("duration_seconds" to "300", "label" to "pasta")) }
+    }
+
+    @Test
+    fun `set timer 30 seconds dispatches`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Timer set")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "30",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("set_timer", mapOf("duration_seconds" to "30")) }
+    }
+
+    @Test
+    fun `set alarm invalid time is rejected`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_alarm",
+                "time" to "later",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `set alarm valid time dispatches`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Alarm set")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_alarm",
+                "time" to "5pm",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("set_alarm", mapOf("time" to "5pm")) }
+    }
+
+    @Test
+    fun `set alarm with valid time and day dispatches`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Alarm set")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_alarm",
+                "time" to "7am",
+                "day" to "monday",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("set_alarm", mapOf("time" to "7am", "day" to "monday")) }
+    }
+
+    @Test
+    fun `toggle flashlight passes through without validation`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Flashlight toggled")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "toggle_flashlight_on",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("toggle_flashlight_on", emptyMap()) }
+    }
+
+    @Test
+    fun `missing intent name returns failure`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf())
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        assertEquals("run_intent", failure!!.skillName)
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `empty string intent name returns failure`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf("intent_name" to ""))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `weather blank location is rejected`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "get_weather",
+                "location" to "",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure for blank location, got $result" }
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `weather auckland location dispatches`() = runTest {
+        coEvery { handler.handle(any(), any()) } returns SkillResult.Success("Weather data")
+
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "get_weather",
+                "location" to "Auckland",
+            ))
+        )
+
+        val success = result as? SkillResult.Success
+        assertNotNull(success) { "Expected Success, got $result" }
+        coVerify { handler.handle("get_weather", mapOf("location" to "Auckland")) }
+    }
+
+    @Test
+    fun `first invalid param is returned before checking others`() = runTest {
+        // Both duration_seconds and label are invalid, but duration_seconds is checked first
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "0",
+                "label" to "",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        // The error should be about duration_seconds (checked first in the map iteration order)
+        assertNotNull(failure!!.error)
+        coVerify(inverse = true) { handler.handle(any(), any()) }
+    }
+
+    @Test
+    fun `run_intent skill name prefix in failure result`() = runTest {
+        val result = skill.execute(
+            SkillCall("run_intent", mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "0",
+            ))
+        )
+
+        val failure = result as? SkillResult.Failure
+        assertNotNull(failure) { "Expected Failure, got $result" }
+        assertEquals("run_intent/set_timer", failure!!.skillName)
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -78,22 +78,12 @@ class SlotFillerManagerTest {
             PendingSlotRequest(
                 intentName = "send_email",
                 existingParams = emptyMap(),
-                missingSlot = SlotSpec(
-                    name = "contact",
-                    promptTemplate = "Who would you like to email?",
-                ),
+                missingSlot = SlotSpec("contact", "Who would you like to email?"),
             ),
         )
 
-        assertTrue(manager.hasPendingFor(conversationOne))
         assertFalse(manager.hasPendingFor(conversationTwo))
-        assertNull(manager.pendingRequestFor(conversationTwo))
-
-        val wrongConversationResult = manager.onUserReply(conversationTwo, "Nick")
-
-        assertInstanceOf(SlotFillResult.Cancelled::class.java, wrongConversationResult)
         assertTrue(manager.hasPendingFor(conversationOne))
-        assertEquals("contact", manager.pendingRequestFor(conversationOne)?.missingSlot?.name)
     }
 
     @Test
@@ -103,28 +93,24 @@ class SlotFillerManagerTest {
             PendingSlotRequest(
                 intentName = "send_email",
                 existingParams = emptyMap(),
-                missingSlot = SlotSpec(
-                    name = "contact",
-                    promptTemplate = "Who would you like to email?",
-                ),
+                missingSlot = SlotSpec("contact", "Who would you like to email?"),
             ),
         )
+
         manager.startSlotFill(
             conversationTwo,
             PendingSlotRequest(
-                intentName = "add_to_list",
+                intentName = "send_sms",
                 existingParams = emptyMap(),
-                missingSlot = SlotSpec(
-                    name = "item",
-                    promptTemplate = "What would you like to add?",
-                ),
+                missingSlot = SlotSpec("contact", "Who do you want to send a message to?"),
             ),
         )
 
         assertTrue(manager.hasPendingFor(conversationOne))
         assertTrue(manager.hasPendingFor(conversationTwo))
-        assertEquals("contact", manager.pendingRequestFor(conversationOne)?.missingSlot?.name)
-        assertEquals("item", manager.pendingRequestFor(conversationTwo)?.missingSlot?.name)
+
+        assertEquals("send_email", manager.pendingRequestFor(conversationOne)?.intentName)
+        assertEquals("send_sms", manager.pendingRequestFor(conversationTwo)?.intentName)
     }
 
     @Test
@@ -134,33 +120,26 @@ class SlotFillerManagerTest {
             PendingSlotRequest(
                 intentName = "add_to_list",
                 existingParams = emptyMap(),
-                missingSlot = SlotSpec(
-                    name = "item",
-                    promptTemplate = "What would you like to add?",
-                ),
+                missingSlot = SlotSpec("item", "What would you like to add?"),
             ),
         )
 
-        val next = assertInstanceOf(
-            SlotFillResult.NeedsMore::class.java,
-            manager.onUserReply(conversationOne, "milk"),
+        val firstResult = manager.onUserReply(conversationOne, "Milk")
+        assertInstanceOf(SlotFillResult.NeedsMore::class.java, firstResult)
+        val first = firstResult as SlotFillResult.NeedsMore
+        assertEquals("list_name", first.request.missingSlot.name)
+        assertEquals(
+            "Which list should I add it to?",
+            first.request.promptMessage,
         )
-        assertTrue(manager.hasPendingFor(conversationOne))
-        assertEquals("list_name", next.request.missingSlot.name)
-        assertEquals("Which list should I add it to?", next.request.promptMessage)
 
         val completed = assertInstanceOf(
             SlotFillResult.Completed::class.java,
             manager.onUserReply(conversationOne, "on my shopping list"),
         )
         assertFalse(manager.hasPending)
-        assertEquals(
-            mapOf(
-                "item" to "milk",
-                "list_name" to "shopping list",
-            ),
-            completed.params,
-        )
+        assertEquals("Milk", completed.params["item"])
+        assertEquals("shopping list", completed.params["list_name"])
     }
 
     @Test
@@ -177,12 +156,18 @@ class SlotFillerManagerTest {
             ),
         )
 
+        // "The" should be kept — it's part of the list name "The Boys" (a TV show).
         val titled = assertInstanceOf(
             SlotFillResult.Completed::class.java,
             manager.onUserReply(conversationOne, "The Boys"),
         )
         assertEquals("The Boys", titled.params["list_name"])
+        assertFalse(manager.hasPending)
+    }
 
+    @Test
+    fun `generic shopping list replies normalize without mangling named lists`() {
+        // "shopping list" → normalize to "shopping"
         manager.startSlotFill(
             conversationOne,
             PendingSlotRequest(
@@ -194,52 +179,14 @@ class SlotFillerManagerTest {
                 ),
             ),
         )
-
         val todo = assertInstanceOf(
             SlotFillResult.Completed::class.java,
             manager.onUserReply(conversationOne, "to do list"),
         )
         assertEquals("to-do list", todo.params["list_name"])
-    }
+        assertFalse(manager.hasPending)
 
-    @Test
-    fun `generic shopping list replies normalize without mangling named lists`() {
-        manager.startSlotFill(
-            conversationOne,
-            PendingSlotRequest(
-                intentName = "add_to_list",
-                existingParams = mapOf("item" to "milk"),
-                missingSlot = SlotSpec(
-                    name = "list_name",
-                    promptTemplate = "Which list should I add it to?",
-                ),
-            ),
-        )
-
-        val possessive = assertInstanceOf(
-            SlotFillResult.Completed::class.java,
-            manager.onUserReply(conversationOne, "my shopping list"),
-        )
-        assertEquals("shopping list", possessive.params["list_name"])
-
-        manager.startSlotFill(
-            conversationOne,
-            PendingSlotRequest(
-                intentName = "add_to_list",
-                existingParams = mapOf("item" to "milk"),
-                missingSlot = SlotSpec(
-                    name = "list_name",
-                    promptTemplate = "Which list should I add it to?",
-                ),
-            ),
-        )
-
-        val article = assertInstanceOf(
-            SlotFillResult.Completed::class.java,
-            manager.onUserReply(conversationOne, "the shopping list"),
-        )
-        assertEquals("shopping list", article.params["list_name"])
-
+        // "my shopping list" → normalize to "shopping list"
         manager.startSlotFill(
             conversationOne,
             PendingSlotRequest(
@@ -251,12 +198,50 @@ class SlotFillerManagerTest {
                 ),
             ),
         )
+        val possessive = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "my shopping list"),
+        )
+        assertEquals("shopping list", possessive.params["list_name"])
+        assertFalse(manager.hasPending)
 
+        // "the shopping list" → normalize to "shopping list"
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "create_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "What would you like to call the list?",
+                ),
+            ),
+        )
+        val article = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "the shopping list"),
+        )
+        assertEquals("shopping list", article.params["list_name"])
+        assertFalse(manager.hasPending)
+
+        // "My Tasks" (capitalized named list) → keep as-is
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "create_list",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec(
+                    name = "list_name",
+                    promptTemplate = "What would you like to call the list?",
+                ),
+            ),
+        )
         val named = assertInstanceOf(
             SlotFillResult.Completed::class.java,
             manager.onUserReply(conversationOne, "My Tasks"),
         )
         assertEquals("My Tasks", named.params["list_name"])
+        assertFalse(manager.hasPending)
     }
 
     @Test
@@ -278,14 +263,11 @@ class SlotFillerManagerTest {
             manager.onUserReply(conversationOne, "Can you remember that Emily's birthday is 19 November"),
         )
 
-        assertFalse(manager.hasPending)
         assertEquals(
-            mapOf(
-                "label" to "Emily's birthday",
-                "date" to "19 November",
-            ),
+            mapOf("label" to "Emily's birthday", "date" to "19 November"),
             completed.params,
         )
+        assertFalse(manager.hasPending)
     }
 
     @Test
@@ -307,14 +289,11 @@ class SlotFillerManagerTest {
             manager.onUserReply(conversationOne, "on 19th of November"),
         )
 
-        assertFalse(manager.hasPending)
         assertEquals(
-            mapOf(
-                "label" to "Emily's birthday",
-                "date" to "19th of November",
-            ),
+            mapOf("label" to "Emily's birthday", "date" to "19th of November"),
             completed.params,
         )
+        assertFalse(manager.hasPending)
     }
 
     @Test
@@ -322,20 +301,16 @@ class SlotFillerManagerTest {
         manager.startSlotFill(
             conversationOne,
             PendingSlotRequest(
-                intentName = "send_sms",
+                intentName = "send_email",
                 existingParams = emptyMap(),
-                missingSlot = SlotSpec(
-                    name = "contact",
-                    promptTemplate = "Who do you want to send a message to?",
-                ),
+                missingSlot = SlotSpec("contact", "Who would you like to email?"),
             ),
         )
 
-        val result = manager.onUserReply(conversationOne, "   ")
-
+        assertTrue(manager.hasPendingFor(conversationOne))
+        val result = manager.onUserReply(conversationOne, "")
         assertInstanceOf(SlotFillResult.Cancelled::class.java, result)
         assertFalse(manager.hasPending)
-        assertNull(manager.pendingRequest)
     }
 
     @Test
@@ -429,5 +404,173 @@ class SlotFillerManagerTest {
         val completed = result as SlotFillResult.Completed
         assertEquals("set_timer", completed.intentName)
         assertEquals("300", completed.params["duration_seconds"])
+    }
+
+    // ── Slot validation integration tests ─────────────────────────────────
+
+    @Test
+    fun `invalid timer duration like donuts returns InvalidSlot with clarification`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long would you like the timer for?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "donuts")
+        assertInstanceOf(SlotFillResult.InvalidSlot::class.java, result)
+        val invalid = result as SlotFillResult.InvalidSlot
+        assertEquals("duration_seconds", invalid.request.missingSlot.name)
+        // Should show a clarification prompt telling the user the value wasn't understood
+        assertTrue(invalid.request.promptMessage.isNotBlank())
+        // Pending request should still be active for retry
+        assertTrue(manager.hasPending)
+    }
+
+    @Test
+    fun `valid timer duration still completes normally`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long would you like the timer for?"),
+            ),
+        )
+        // "5 minutes" normalises to "300" by SlotSpec.normalizeDurationSlotReply
+        val result = manager.onUserReply(conversationOne, "5 minutes")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("300", completed.params["duration_seconds"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `valid timer numeric seconds still completes normally`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long would you like the timer for?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "300")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("300", completed.params["duration_seconds"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `valid timer 30 seconds normalises to 30 and completes`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long would you like the timer for?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "30 seconds")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("30", completed.params["duration_seconds"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `invalid alarm time returns InvalidSlot with clarification`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_alarm",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("time", "What time should I set the alarm for?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "donuts")
+        assertInstanceOf(SlotFillResult.InvalidSlot::class.java, result)
+        val invalid = result as SlotFillResult.InvalidSlot
+        assertEquals("time", invalid.request.missingSlot.name)
+        assertTrue(invalid.request.promptMessage.isNotBlank())
+        assertTrue(manager.hasPending)
+    }
+
+    @Test
+    fun `valid alarm time still completes normally`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_alarm",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("time", "What time should I set the alarm for?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "5pm")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("5pm", completed.params["time"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `valid alarm time completes when day is optional`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_alarm",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("time", "What time?"),
+            ),
+        )
+        val result = manager.onUserReply(conversationOne, "7am")
+        assertInstanceOf(SlotFillResult.Completed::class.java, result)
+        val completed = result as SlotFillResult.Completed
+        assertEquals("7am", completed.params["time"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `invalid timer value keeps pending so user can retry`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long?"),
+            ),
+        )
+        // First attempt: invalid
+        val first = manager.onUserReply(conversationOne, "donuts")
+        assertInstanceOf(SlotFillResult.InvalidSlot::class.java, first)
+        assertTrue(manager.hasPendingFor(conversationOne))
+
+        // Second attempt: valid — should now complete
+        val second = manager.onUserReply(conversationOne, "5 minutes")
+        assertInstanceOf(SlotFillResult.Completed::class.java, second)
+        val completed = second as SlotFillResult.Completed
+        assertEquals("300", completed.params["duration_seconds"])
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `blank reply after invalid slot cancels still`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "set_timer",
+                existingParams = emptyMap(),
+                missingSlot = SlotSpec("duration_seconds", "How long?"),
+            ),
+        )
+        manager.onUserReply(conversationOne, "donuts")
+        assertTrue(manager.hasPendingFor(conversationOne))
+
+        // Blank reply should cancel
+        val cancel = manager.onUserReply(conversationOne, "")
+        assertInstanceOf(SlotFillResult.Cancelled::class.java, cancel)
+        assertFalse(manager.hasPending)
     }
 }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotValidationRegistryDispatchTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotValidationRegistryDispatchTest.kt
@@ -1,0 +1,124 @@
+package com.kernel.ai.core.skills.slot
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SlotValidationRegistryDispatchTest {
+
+    private val registry = SlotValidationRegistry()
+
+    @Test
+    fun `direct invalid timer duration zero seconds is rejected`() {
+        val result = registry.validateParams("set_timer", mapOf("duration_seconds" to "0"))
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+    }
+
+    @Test
+    fun `direct invalid timer duration negative is rejected`() {
+        val result = registry.validateParams("set_timer", mapOf("duration_seconds" to "-5"))
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+    }
+
+    @Test
+    fun `direct invalid timer duration 25 hours is rejected`() {
+        val result = registry.validateParams("set_timer", mapOf("duration_seconds" to "90001"))
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+    }
+
+    @Test
+    fun `direct valid timer duration 5 minutes passes`() {
+        val result = registry.validateParams("set_timer", mapOf("duration_seconds" to "300"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `direct valid timer duration 30 seconds passes`() {
+        val result = registry.validateParams("set_timer", mapOf("duration_seconds" to "30"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `direct invalid alarm time later is rejected`() {
+        val result = registry.validateParams("set_alarm", mapOf("time" to "later"))
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+    }
+
+    @Test
+    fun `direct valid alarm time 5pm passes`() {
+        val result = registry.validateParams("set_alarm", mapOf("time" to "5pm"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `internal routing params are skipped`() {
+        val result = registry.validateParams(
+            "set_timer",
+            mapOf("intent_name" to "set_timer", "duration_seconds" to "300")
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `intent with no registered validators passes`() {
+        val result = registry.validateParams("unknown_intent", mapOf("some_param" to "any_value"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `empty params passes`() {
+        val result = registry.validateParams("set_timer", emptyMap())
+        assertNull(result)
+    }
+
+    @Test
+    fun `first invalid param is returned before checking others`() {
+        val result = registry.validateParams(
+            "set_timer",
+            mapOf(
+                "duration_seconds" to "0",
+                "label" to "my timer"
+            )
+        )
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+        assertTrue(
+            result.errorMessage?.contains("duration", ignoreCase = true) == true ||
+                result.errorMessage?.contains("timer", ignoreCase = true) == true
+        )
+    }
+
+    @Test
+    fun `run_intent params with intent_name does not resolve to effective intent`() {
+        // validateParams validates against the given intentName.
+        // The run_intent → set_timer resolution happens in ChatViewModel.validateBeforeDispatch.
+        val result = registry.validateParams(
+            "run_intent",
+            mapOf(
+                "intent_name" to "set_timer",
+                "duration_seconds" to "0"
+            )
+        )
+        // No validator registered for (run_intent, duration_seconds), so passes through
+        assertNull(result)
+    }
+
+    @Test
+    fun `weather blank location is rejected`() {
+        val result = registry.validateParams("get_weather", mapOf("location" to ""))
+        assertNotNull(result)
+        assertFalse(result!!.isValid)
+    }
+
+    @Test
+    fun `weather auckland location passes`() {
+        val result = registry.validateParams("get_weather", mapOf("location" to "Auckland"))
+        assertNull(result)
+    }
+}

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotValidationRegistryTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotValidationRegistryTest.kt
@@ -1,0 +1,184 @@
+package com.kernel.ai.core.skills.slot
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SlotValidationRegistryTest {
+
+    private val registry = SlotValidationRegistry()
+
+    // ── Registry basics ─────────────────────────────────────────────────────
+
+    @Test
+    fun `registry returns null for unknown intent-slot pair`() {
+        assertNull(registry.get("unknown_intent", "unknown_slot"))
+        val result = registry.validate("unknown_intent", "unknown_slot", "anything")
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `registry returns validator for known intent-slot pair`() {
+        assertNotNull(registry.get("set_timer", "duration_seconds"))
+        assertNotNull(registry.get("set_alarm", "time"))
+        assertNotNull(registry.get("set_alarm", "day"))
+        assertNotNull(registry.get("get_weather", "location"))
+    }
+
+    @Test
+    fun `registry supports custom registration`() {
+        registry.register("my_intent", "my_slot") { _, _, value ->
+            if (value == "valid") SlotValidationResult.valid()
+            else SlotValidationResult.invalid("Bad value.")
+        }
+        assertTrue(registry.validate("my_intent", "my_slot", "valid").isValid)
+        assertFalse(registry.validate("my_intent", "my_slot", "bad").isValid)
+    }
+
+    // ── TimerDurationValidator ──────────────────────────────────────────────
+
+    @Test
+    fun `timer duration accepts valid positive integers`() {
+        assertTrue(registry.validate("set_timer", "duration_seconds", "300").isValid)
+        assertTrue(registry.validate("set_timer", "duration_seconds", "30").isValid)
+        assertTrue(registry.validate("set_timer", "duration_seconds", "3600").isValid)
+        assertTrue(registry.validate("set_timer", "duration_seconds", "86400").isValid) // 24h
+    }
+
+    @Test
+    fun `timer duration rejects non-numeric invalid values`() {
+        assertInvalidTimer("donuts", "Sorry, I didn't understand that duration. How long should the timer be?")
+        assertInvalidTimer("abc", "Sorry, I didn't understand that duration. How long should the timer be?")
+        assertInvalidTimer("5 minutes", "Sorry, I didn't understand that duration. How long should the timer be?")
+        // "5 minutes" should have been normalised to "300" by normalizeSlotReply before validation
+    }
+
+    @Test
+    fun `timer duration rejects zero and negative values`() {
+        assertInvalidTimer("0", "Sorry, I didn't understand that duration. How long should the timer be?")
+        assertInvalidTimer("-1", "Sorry, I didn't understand that duration. How long should the timer be?")
+        assertInvalidTimer("-300", "Sorry, I didn't understand that duration. How long should the timer be?")
+    }
+
+    @Test
+    fun `timer duration rejects impossible durations beyond 24 hours`() {
+        assertInvalidTimer("86401", "Timers can be at most 24 hours. How long should the timer be?")
+        assertInvalidTimer("172800", "Timers can be at most 24 hours. How long should the timer be?")
+    }
+
+    @Test
+    fun `timer duration rejects blank input`() {
+        assertInvalidTimer("", "How long would you like the timer for?")
+        assertInvalidTimer("   ", "How long would you like the timer for?")
+    }
+
+    // ── AlarmTimeValidator ──────────────────────────────────────────────────
+
+    @Test
+    fun `alarm time accepts valid time formats`() {
+        assertTrue(registry.validate("set_alarm", "time", "5pm").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "7:30").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "14:00").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "9 o'clock").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "6:30 am").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "12:00 pm").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "12am").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "7am").isValid)
+        assertTrue(registry.validate("set_alarm", "time", "11:45pm").isValid)
+    }
+
+    @Test
+    fun `alarm time rejects invalid time formats`() {
+        assertInvalidAlarmTime("donuts")
+        assertInvalidAlarmTime("abc")
+        assertInvalidAlarmTime("never")
+        assertInvalidAlarmTime("later")
+        assertInvalidAlarmTime("25:00")
+        assertInvalidAlarmTime("13:60")
+    }
+
+    @Test
+    fun `alarm time rejects blank input`() {
+        assertInvalidAlarmTime("")
+        assertInvalidAlarmTime("   ")
+    }
+
+    // ── AlarmDayValidator ───────────────────────────────────────────────────
+
+    @Test
+    fun `alarm day accepts valid day names`() {
+        assertTrue(registry.validate("set_alarm", "day", "monday").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "Tuesday").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "mon").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "today").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "tomorrow").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "next friday").isValid)
+        assertTrue(registry.validate("set_alarm", "day", "this saturday").isValid)
+    }
+
+    @Test
+    fun `alarm day is optional`() {
+        // Empty day is valid — signals no specific day (alarm for tonight/tomorrow automatically)
+        assertTrue(registry.validate("set_alarm", "day", "").isValid)
+    }
+
+    @Test
+    fun `alarm day rejects invalid day names`() {
+        assertFalse(registry.validate("set_alarm", "day", "donuts").isValid)
+        assertFalse(registry.validate("set_alarm", "day", "never").isValid)
+        assertFalse(registry.validate("set_alarm", "day", "next never").isValid)
+    }
+
+    // ── WeatherLocationValidator ────────────────────────────────────────────
+
+    @Test
+    fun `weather location accepts normal place names`() {
+        assertTrue(registry.validate("get_weather", "location", "Auckland").isValid)
+        assertTrue(registry.validate("get_weather", "location", "New York").isValid)
+        assertTrue(registry.validate("get_weather", "location", "Los Angeles").isValid)
+        assertTrue(registry.validate("get_weather", "location", "Tokyo").isValid)
+        assertTrue(registry.validate("get_weather", "location", "12345").isValid) // zip codes pass
+    }
+
+    @Test
+    fun `weather location rejects blank and noise`() {
+        assertFalse(registry.validate("get_weather", "location", "").isValid)
+        assertFalse(registry.validate("get_weather", "location", "?").isValid)
+        assertFalse(registry.validate("get_weather", "location", ".").isValid)
+    }
+
+    // ── TimerLabelValidator (via NonEmptyStringValidator) ───────────────────
+
+    @Test
+    fun `timer label accepts non-blank values`() {
+        assertTrue(registry.validate("set_timer", "label", "pasta").isValid)
+        assertTrue(registry.validate("set_timer", "label", "laundry").isValid)
+    }
+
+    @Test
+    fun `timer label rejects blank values`() {
+        assertFalse(registry.validate("set_timer", "label", "").isValid)
+        assertFalse(registry.validate("set_timer", "label", "   ").isValid)
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private fun assertInvalidTimer(value: String) {
+        val result = registry.validate("set_timer", "duration_seconds", value)
+        assertFalse(result.isValid, "Expected '$value' to be invalid for duration_seconds")
+    }
+
+    private fun assertInvalidTimer(value: String, expectedMessage: String) {
+        val result = registry.validate("set_timer", "duration_seconds", value)
+        assertFalse(result.isValid, "Expected '$value' to be invalid for duration_seconds")
+        assertEquals(expectedMessage, result.errorMessage)
+    }
+
+    private fun assertInvalidAlarmTime(value: String) {
+        val result = registry.validate("set_alarm", "time", value)
+        assertFalse(result.isValid, "Expected '$value' to be invalid for alarm time")
+    }
+}

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -48,18 +48,20 @@ import com.kernel.ai.core.skills.QuickIntentRouter
 import com.kernel.ai.core.skills.SkillCall
 import com.kernel.ai.core.skills.SkillExecutor
 import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.toSpokenSummary
+import com.kernel.ai.core.skills.intent.IntentCandidate
+import com.kernel.ai.core.skills.intent.RecoveryResult
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.ToolPresentation
-import com.kernel.ai.core.skills.toSpokenSummary
+import com.kernel.ai.core.skills.intent.IntentContractRegistry
+import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
+import com.kernel.ai.core.skills.mealplan.MealPlannerActivity
+import com.kernel.ai.core.skills.mealplan.MealPlannerActivityState
+import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.SlotFillResult
 import com.kernel.ai.core.skills.slot.SlotFillerManager
-import com.kernel.ai.core.skills.intent.IntentCandidate
-import com.kernel.ai.core.skills.intent.IntentContractRegistry
-import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
-import com.kernel.ai.core.skills.intent.RecoveryResult
-import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
-import com.kernel.ai.core.skills.mealplan.MealPlannerActivity
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
 import com.kernel.ai.core.skills.mealplan.MealPlannerSuggestion
 import com.kernel.ai.core.skills.mealplan.MealPlannerSuggestionComposeMode
 import com.kernel.ai.core.voice.VoiceOutputController
@@ -144,6 +146,7 @@ class ChatViewModel @Inject constructor(
     private val intentRecoveryOrchestrator: IntentRecoveryOrchestrator,
     private val intentContractRegistry: IntentContractRegistry,
     private val slotFillerManager: SlotFillerManager,
+    private val slotValidationRegistry: SlotValidationRegistry,
     private val kernelAIToolSet: KernelAIToolSet,
     private val toolProvider: ToolProvider,
     private val embeddingEngine: EmbeddingEngine,
@@ -1639,6 +1642,10 @@ class ChatViewModel @Inject constructor(
                     if (skill != null) {
                         val callParams = mapOf("intent_name" to pendingConfirmation.intentName) +
                             pendingConfirmation.params
+                        if (!validateBeforeDispatch(pendingConfirmation.intentName, callParams, convId)) {
+                            Log.d("KernelAI", "RecoveryConfirmation: slot_validation_blocked intent=${pendingConfirmation.intentName}")
+                            return@launch
+                        }
                         Log.d("KernelAI", "RecoveryConfirmation: dispatching ${pendingConfirmation.intentName}")
                         val skillResult = skill.execute(SkillCall(skill.name, callParams))
                         when (skillResult) {
@@ -1689,6 +1696,10 @@ class ChatViewModel @Inject constructor(
                     val skill = skillRegistry.get("run_intent")
                     if (skill != null) {
                         val callParams = mapOf("intent_name" to pendingConfirmation.intentName) + pendingConfirmation.params
+                        if (!validateBeforeDispatch(pendingConfirmation.intentName, callParams, convId)) {
+                            Log.d("KernelAI", "ConfirmationFastPath: slot_validation_blocked intent=${pendingConfirmation.intentName}")
+                            return@launch
+                        }
                         Log.d("KernelAI", "ConfirmationFastPath: dispatching ${pendingConfirmation.intentName}")
                         val skillResult = skill.execute(SkillCall(skill.name, callParams))
                         when (skillResult) {
@@ -1863,6 +1874,10 @@ class ChatViewModel @Inject constructor(
                                 }
                             }
                             if (skill != null) {
+                                if (!validateBeforeDispatch(recovery.intentName, callParams, convId)) {
+                                    Log.d("KernelAI", "RecoveryOrchestrator: slot_validation_blocked intent=${recovery.intentName}")
+                                    return@launch
+                                }
                                 Log.d("KernelAI", "RecoveryOrchestrator.Execute: intent=${recovery.intentName} params=$callParams")
                                 val skillResult = skill.execute(SkillCall(skill.name, callParams))
                                 when (skillResult) {
@@ -1984,6 +1999,11 @@ class ChatViewModel @Inject constructor(
                         runIntent to (mapOf("intent_name" to matchedIntent.intentName) + matchedIntent.params)
                     }
                 }
+                if (!validateBeforeDispatch(matchedIntent.intentName, callParams, convId)) {
+                    Log.d("KernelAI", "ADB_ROUTE_DECISION commandId=$commandId result=slot_validation_blocked intent=${matchedIntent.intentName}")
+                    Log.d("KernelAI", "llm_tools_route: result=slot_validation_blocked intent=${matchedIntent.intentName}")
+                    return@launch
+                }
                 if (skill != null) {
                     Log.d("KernelAI", "NativeIntentHandler.handle: intent=${matchedIntent.intentName} params=$callParams")
                     val skillResult = skill.execute(SkillCall(skill.name, callParams))
@@ -2078,6 +2098,10 @@ class ChatViewModel @Inject constructor(
                     }
                 }
                 if (skill != null) {
+                    if (!validateBeforeDispatch(anaphoricIntent.intentName, callParams, convId)) {
+                        Log.d("KernelAI", "AnaphoricIntent: slot_validation_blocked intent=${anaphoricIntent.intentName}")
+                        return@launch
+                    }
                     val skillResult = skill.execute(SkillCall(skill.name, callParams))
                     when (skillResult) {
                         is SkillResult.DirectReply -> {
@@ -2106,12 +2130,7 @@ class ChatViewModel @Inject constructor(
                         }
                         is SkillResult.Failure -> {
                             if (!inferenceEngine.isReady.value) {
-                                appendAssistantMessage(
-                                    convId,
-                                    skillResult.error,
-                                    shouldIndex = false,
-                                    spokenSummary = skillResult.error,
-                                )
+                                appendAssistantMessage(convId, skillResult.error, shouldIndex = false, spokenSummary = skillResult.error)
                                 return@launch
                             }
                             systemContext = "[System: ${anaphoricIntent.intentName} failed — ${skillResult.error}]"
@@ -3373,6 +3392,39 @@ class ChatViewModel @Inject constructor(
      * reasonably want stored in memory — e.g. "I don't like aubergines", "My dog is called Biscuit".
      */
     private fun looksLikePersonalFact(text: String): Boolean = com.kernel.ai.feature.chat.looksLikePersonalFact(text)
+
+    /**
+     * Validates intent params against [SlotValidationRegistry] before dispatch.
+     *
+     * Checks every param value against registered validators for the intent.
+     * On first failure, appends a user-facing clarification message and returns
+     * false to prevent dispatch. When every param passes (or has no registered
+     * validator), returns true so execution proceeds normally.
+     *
+     * This is the shared guard for ALL dispatch paths — direct intent matches,
+     * recovery-origin dispatches, and anaphoric references.
+     */
+    private suspend fun validateBeforeDispatch(
+        intentName: String,
+        params: Map<String, String>,
+        convId: String,
+    ): Boolean {
+        val effectiveIntent = if (intentName == "run_intent") {
+            params["intent_name"] ?: intentName
+        } else {
+            intentName
+        }
+
+        val invalidResult = slotValidationRegistry.validateParams(effectiveIntent, params)
+        if (invalidResult != null) {
+            val message = invalidResult.errorMessage
+                ?: "Sorry, I didn't understand that value. Please try again."
+            Log.d("KernelAI", "SlotValidation: blocked $effectiveIntent — $message")
+            appendAssistantMessage(convId, message, shouldIndex = false)
+            return false
+        }
+        return true
+    }
 }
 
 /** C2 correction prepended to the prompt when a hallucination retry is attempted (#487). */
@@ -3456,3 +3508,4 @@ private fun formatBytes(bytes: Long): String = when {
     bytes >= 1_048_576L -> "%.0f MB".format(bytes / 1_048_576.0)
     else -> "$bytes B"
 }
+

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1609,6 +1609,14 @@ class ChatViewModel @Inject constructor(
                         )
                         return@launch
                     }
+                    is SlotFillResult.InvalidSlot -> {
+                        appendAssistantMessage(
+                            convId,
+                            fillResult.request.promptMessage,
+                            shouldIndex = false,
+                        )
+                        return@launch
+                    }
                     is SlotFillResult.Cancelled -> {
                         appendAssistantMessage(convId, "Okay, cancelled.", shouldIndex = false)
                         return@launch

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelInitTest.kt
@@ -38,6 +38,8 @@ import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
 import com.kernel.ai.core.skills.intent.IntentContractRegistry
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
+import com.kernel.ai.core.skills.slot.SlotValidationResult
 import com.kernel.ai.core.skills.mealplan.MealPlannerActivity
 import com.kernel.ai.core.skills.mealplan.MealPlannerActivityState
 import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
@@ -95,6 +97,7 @@ class ChatViewModelInitTest {
     private val skillExecutor: SkillExecutor = mockk(relaxed = true)
     private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
     private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val slotValidationRegistry: SlotValidationRegistry = mockk(relaxed = true)
     private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
     private val toolProvider: ToolProvider = mockk(relaxed = true)
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
@@ -124,6 +127,8 @@ class ChatViewModelInitTest {
         every { inferenceEngine.activeBackend } returns MutableStateFlow<BackendType?>(null)
         every { inferenceEngine.resolvedMaxTokens } returns MutableStateFlow(0)
         every { inferenceEngine.evictionEvents } returns emptyFlow()
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
 
         every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
@@ -200,6 +205,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -241,6 +247,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -282,6 +289,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -330,6 +338,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -387,6 +396,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -471,6 +481,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -533,6 +544,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -612,6 +624,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -679,6 +692,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -744,6 +758,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -799,6 +814,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -870,6 +886,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -894,6 +911,8 @@ class ChatViewModelInitTest {
         // Re-stub after clear
         every { inferenceEngine.isReady } returns MutableStateFlow(true)
         every { inferenceEngine.isGenerating } returns MutableStateFlow(false)
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
         coEvery { slotFillerManager.cancel() } just runs
 
@@ -953,6 +972,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -1015,6 +1035,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -1073,6 +1094,7 @@ class ChatViewModelInitTest {
           intentRecoveryOrchestrator = intentRecoveryOrchestrator,
           intentContractRegistry = IntentContractRegistry(),
           slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
           kernelAIToolSet = kernelAIToolSet,
           toolProvider = toolProvider,
           embeddingEngine = embeddingEngine,
@@ -1174,6 +1196,8 @@ class ChatViewModelInitTest {
         coEvery { inferenceEngine.updateSystemPrompt(any()) } answers {
             systemPrompts += firstArg<String>()
         }
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
         // Force GPU backend so needsHistoryReplay is forced true every turn,
         // testing that wasConversationReset correctly suppresses history replay.
@@ -1225,6 +1249,7 @@ class ChatViewModelInitTest {
       intentRecoveryOrchestrator = intentRecoveryOrchestrator,
       intentContractRegistry = IntentContractRegistry(),
       slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
       kernelAIToolSet = kernelAIToolSet,
       toolProvider = toolProvider,
       embeddingEngine = embeddingEngine,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelRecoveryTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelRecoveryTest.kt
@@ -32,6 +32,8 @@ import com.kernel.ai.core.skills.intent.RecoveryResult
 import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
 import com.kernel.ai.core.skills.slot.SlotSpec
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
+import com.kernel.ai.core.skills.slot.SlotValidationResult
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
@@ -77,6 +79,7 @@ class ChatViewModelRecoveryTest {
     private val skillExecutor: SkillExecutor = mockk(relaxed = true)
     private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
     private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val slotValidationRegistry: SlotValidationRegistry = mockk(relaxed = true)
     private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
     private val toolProvider: ToolProvider = mockk(relaxed = true)
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
@@ -106,6 +109,8 @@ class ChatViewModelRecoveryTest {
         every { inferenceEngine.activeBackend } returns MutableStateFlow<BackendType?>(null)
         every { inferenceEngine.resolvedMaxTokens } returns MutableStateFlow(0)
         every { inferenceEngine.evictionEvents } returns emptyFlow()
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
 
         every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
@@ -161,6 +166,7 @@ class ChatViewModelRecoveryTest {
         intentRecoveryOrchestrator = intentRecoveryOrchestrator,
         intentContractRegistry = IntentContractRegistry(),
         slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
         kernelAIToolSet = kernelAIToolSet,
         toolProvider = toolProvider,
         embeddingEngine = embeddingEngine,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelSettingsApplyTest.kt
@@ -32,6 +32,8 @@ import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
 import com.kernel.ai.core.skills.intent.IntentContractRegistry
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
+import com.kernel.ai.core.skills.slot.SlotValidationResult
 import com.kernel.ai.feature.chat.model.ChatUiState
 import com.kernel.ai.core.voice.VoiceInputController
 import com.kernel.ai.core.voice.VoiceOutputController
@@ -93,6 +95,7 @@ class ChatViewModelSettingsApplyTest {
     private val skillExecutor: SkillExecutor = mockk(relaxed = true)
     private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
     private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val slotValidationRegistry: SlotValidationRegistry = mockk(relaxed = true)
     private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
     private val toolProvider: ToolProvider = mockk(relaxed = true)
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
@@ -130,6 +133,8 @@ class ChatViewModelSettingsApplyTest {
         every { inferenceEngine.activeBackend } returns activeBackendFlow
         every { inferenceEngine.resolvedMaxTokens } returns resolvedMaxTokensFlow
         every { inferenceEngine.evictionEvents } returns emptyFlow()
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
         coEvery { inferenceEngine.reconfigureConversation(any()) } just runs
         coEvery { inferenceEngine.cancelGeneration() } just runs
@@ -446,6 +451,7 @@ class ChatViewModelSettingsApplyTest {
         intentRecoveryOrchestrator = intentRecoveryOrchestrator,
         intentContractRegistry = IntentContractRegistry(),
         slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
         kernelAIToolSet = kernelAIToolSet,
         toolProvider = toolProvider,
         embeddingEngine = embeddingEngine,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -36,6 +36,8 @@ import com.kernel.ai.core.skills.SkillRegistry
 import com.kernel.ai.core.skills.SkillResult
 import com.kernel.ai.core.skills.SkillSchema
 import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
+import com.kernel.ai.core.skills.slot.SlotValidationResult
 import com.kernel.ai.core.skills.mealplan.MealPlannerActivity
 import com.kernel.ai.core.skills.mealplan.MealPlannerActivityState
 import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
@@ -106,6 +108,7 @@ class ChatViewModelVoiceTest {
     private val skillExecutor: SkillExecutor = mockk(relaxed = true)
     private val quickIntentRouter: QuickIntentRouter = mockk(relaxed = true)
     private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val slotValidationRegistry: SlotValidationRegistry = mockk(relaxed = true)
     private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
     private val toolProvider: ToolProvider = mockk(relaxed = true)
     private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
@@ -144,6 +147,8 @@ class ChatViewModelVoiceTest {
         every { inferenceEngine.generate(any()) } returns
             flowOf(GenerationResult.Token("Hi back"), GenerationResult.Complete(durationMs = 1L))
         coEvery { inferenceEngine.updateSystemPrompt(any()) } just runs
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
         coEvery { inferenceEngine.resetConversation() } just runs
 
         every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
@@ -1088,6 +1093,7 @@ class ChatViewModelVoiceTest {
     intentRecoveryOrchestrator = intentRecoveryOrchestrator,
     intentContractRegistry = IntentContractRegistry(),
     slotFillerManager = slotFillerManager,
+            slotValidationRegistry = slotValidationRegistry,
     kernelAIToolSet = kernelAIToolSet,
     toolProvider = toolProvider,
     embeddingEngine = embeddingEngine,


### PR DESCRIPTION
## Summary

Add validation guards so invalid slot values are rejected before tool execution across **all** dispatch paths — both the ChatViewModel fast paths AND the LiteRT native SDK tool call path (`KernelAIToolSet.runIntent`).

## Architecture

Validation happens at two layers that share the same `SlotValidationRegistry`:

| Layer | Where | Guards |
|---|---|---|
| **ChatViewModel** (`validateBeforeDispatch`) | `ChatViewModel.kt` | QIR regex/classifier matches, recovery/anaphoric/intent resolution paths |
| **RunIntentSkill** (`execute()`) | `RunIntentSkill.kt` | **KernelAIToolSet.runIntent → executeSkill → run_intent** (the LiteRT native SDK tool path) |

Both call `SlotValidationRegistry.validateParams(intentName, params)` and fail closed before `NativeIntentHandler.handle()` on invalid values.

### Why two layers?

- **ChatViewModel** guards happen before tool dispatch — the user gets a clarification response, and the tool call is never made.
- **RunIntentSkill** guards at the skill boundary catch any caller that routes through `run_intent`, including:
  - `KernelAIToolSet.runIntent()` — the LiteRT native SDK `@Tool` method
  - Any future dispatch path that calls `skill.execute("run_intent", ...)`

### What's guarded

| Dispatch path | Guard |
|---|---|
| QIR regex/classifier direct match | ChatViewModel |
| Slot-fill completion | Already validated (SlotFillerManager) |
| Recovery confirmation | ChatViewModel |
| Confirmation fast-path | ChatViewModel |
| Recovery orchestrator Execute | ChatViewModel |
| Anaphoric intent ("do that") | ChatViewModel |
| **KernelAIToolSet.runIntent (LiteRT SDK tool)** | **RunIntentSkill (NEW)** |

### Built-in validators

| Validator | Intent.Slot | Rejects |
|---|---|---|
| `TimerDurationValidator` | `set_timer.duration_seconds` | "donuts", blank, "0", "-5", "86401" (over 24h) |
| `AlarmTimeValidator` | `set_alarm.time` | "donuts", "later", any unparseable time |
| `AlarmDayValidator` | `set_alarm.day` | Non-day strings (optional slot) |
| `WeatherLocationValidator` | `get_weather.location` | Blank/noise only |
| `NonEmptyStringValidator` | `set_timer.label` | Blank |

## Before/After

**Before:**
Model calls: runIntent(intentName="set_timer", parameters='{"duration_seconds":"0"}')
→ KernelAIToolSet.runIntent → executeSkill("run_intent", ...)
→ RunIntentSkill.execute → NativeIntentHandler.handle("set_timer", {duration_seconds: "0"})
→ Timer scheduled for 0ms (never fires)

**After:**
Model calls: runIntent(intentName="set_timer", parameters='{"duration_seconds":"0"}')
→ KernelAIToolSet.runIntent → executeSkill("run_intent", ...)
→ RunIntentSkill.execute
→ SlotValidationRegistry: set_timer.duration_seconds="0" invalid
→ SkillResult.Failure("run_intent/set_timer", "Sorry, I didn't understand that duration.")
→ KernelAIToolSet returns {error: ...} to the model
→ Model sees error, asks user for a valid duration

## Tests

./gradlew :core:skills:testDebugUnitTest (1620+ tests pass)
./gradlew :feature:chat:testDebugUnitTest (481 tests pass)
./gradlew assembleDebug (clean build)

### New: RunIntentSkillTest (15 tests)
Covers the shared boundary guard directly:
- set timer zero seconds is rejected — duration_seconds=0 → Failure, handler NOT called
- set timer negative seconds is rejected — duration_seconds=-5 → Failure, handler NOT called
- set timer over 24 hours is rejected — duration_seconds=90001 → Failure, handler NOT called
- set timer 5 minutes dispatches — duration_seconds=300 → calls handler with correct args
- set timer 30 seconds dispatches — duration_seconds=30 → calls handler
- set alarm invalid time is rejected — time="later" → Failure, handler NOT called
- set alarm valid time dispatches — time="5pm" → calls handler
- set alarm with valid time and day dispatches — time="7am" day="monday" → calls handler
- toggle flashlight passes through without validation — no registered validator → calls handler
- missing intent name returns failure — empty args → Failure, handler NOT called
- empty string intent name returns failure — intent_name="" → Failure, handler NOT called
- weather blank location is rejected — location="" → Failure, handler NOT called
- weather auckland location dispatches — location="Auckland" → calls handler
- first invalid param is returned before checking others — both invalid, first wins
- run_intent skill name prefix in failure result — skillName = "run_intent/set_timer"

### Existing test coverage (kept from earlier rounds)
- SlotValidationRegistryTest: 18 tests — individual validators, validate(), validateParams()
- SlotValidationRegistryDispatchTest: 14 tests — validateParams() edge cases, run_intent resolution
- SlotFillerManagerTest: 21 tests — slot-fill flow, retry-until-valid, blank-cancellation
- ChatViewModelInitTest/RecoveryTest/SettingsApplyTest/VoiceTest — updated with mock SlotValidationRegistry

## Notes

- The SlotValidationRegistry is lazily initialized in RunIntentSkill (by lazy) to avoid KSP/Hilt injection-order issues when co-resolving NativeIntentHandler in the same constructor.
- No S23U device testing was performed — it is the daily driver and explicitly out of scope.
- Closes #1297
