### PR TITLE
feat(#1159): reduce startup prompts and align App Permissions repair dashboard

### DIFF
--- a/.omp/permission-gate.json
+++ b/.omp/permission-gate.json
@@ -1,0 +1,1 @@
+{"mode": "accept-all"}

--- a/app/src/main/java/com/kernel/ai/MainActivity.kt
+++ b/app/src/main/java/com/kernel/ai/MainActivity.kt
@@ -179,15 +179,13 @@ class MainActivity : ComponentActivity() {
         if (!forcePromptForTests && prefs.getBoolean(KEY_ONBOARDING_PERMISSIONS_REQUESTED, false)) return
 
         val missingPermissions = buildList {
+            // Notifications: needed for alarms, timers, reminders, and download progress.
+            // Kept as a startup prompt because these are launch-critical notification-backed
+            // features. Other runtime permissions (Location, Contacts, Calendar, Phone) are
+            // requested on first feature use via contextual permission overlays (#1312).
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                 ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 add(Manifest.permission.POST_NOTIFICATIONS)
-            }
-            if (ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                add(Manifest.permission.ACCESS_COARSE_LOCATION)
-            }
-            if (ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
-                add(Manifest.permission.READ_CONTACTS)
             }
         }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -1563,11 +1563,11 @@ class QuickIntentRouter(
             requiredSlots = emptyMap(),
         ),
 
-        // "What's the 5 day forecast?" — exact Learn wording
+        // "What's the 5 day forecast?" / "What's the 5-day forecast?" — exact Learn wording + hyphen variant
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(?:what(?:'s| is)\s+)?(?:the\s+)?(\d+)\s+day\s+(?:weather\s+)?forecast\s*[.!?]*$""",
+                """(?:what(?:'s| is)\s+)?(?:the\s+)?(\d+)\s*[ -]?\s*day\s+(?:weather\s+)?forecast\s*[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -1696,11 +1696,11 @@ class QuickIntentRouter(
                 }
             },
         ),
-        // Multi-day forecast (digit): "7 day weather forecast for Brisbane"
+        // Multi-day forecast (digit): "7 day weather forecast for Brisbane" / "7-day weather forecast for Brisbane"
         IntentPattern(
             intentName = "get_weather",
             regex = Regex(
-                """(\d+)\s+day\s+(?:weather\s+)?forecast\s+(?:in|for|at)\s+([\w\s,]+?)[.!?]*$""",
+                """(\d+)\s*[ -]?\s*day\s+(?:weather\s+)?forecast\s+(?:in|for|at)\s+([\w\s,]+?)[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
@@ -2058,6 +2058,41 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { _, _ -> emptyMap() },
+        ),
+        // Expanded bare/local weather: "whats the weather", "weather here", "local weather",
+        // "what's the weather here" (no-apostrophe, "here", and "local" forms not covered by GPS pattern)
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """(?:what(?:'s|s| is)\s+(?:the\s+)?weather(?:\s+(?:here|like|today|tonight|now|outside|currently))?|weather(?:\s+here)?|local\s+weather)[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        // Bare/local forecast: "forecast", "what's the forecast", "what is the forecast", "whats the forecast"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """(?:what(?:'s|s| is)\s+(?:the\s+)?)?forecast[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { _, _ -> emptyMap() },
+        ),
+        // Word-form bare forecast: "five day forecast", "five-day forecast"
+        IntentPattern(
+            intentName = "get_weather",
+            regex = Regex(
+                """(?:what(?:'s|s| is)\s+)?(?:the\s+)?(one|two|three|four|five|six|seven|eight|nine|ten)\s*[ -]?\s*day\s+forecast[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                val daysWord = match.groupValues[1].lowercase()
+                val wordToNum = mapOf(
+                    "one" to "1", "two" to "2", "three" to "3", "four" to "4", "five" to "5",
+                    "six" to "6", "seven" to "7", "eight" to "8", "nine" to "9", "ten" to "10",
+                )
+                mapOf("forecast_days" to (wordToNum[daysWord] ?: daysWord))
+            },
         ),
         // Precipitation: current state only — "will it rain", "is it raining", "do I need an umbrella"
         IntentPattern(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
@@ -40,8 +40,15 @@ class QuickIntentRouterSmokeTest {
             // get_weather
             Arguments.of("what's the weather", "get_weather"),
             Arguments.of("what's the forecast for the next seven days", "get_weather"),
-
-            // set_alarm
+            // #1318 — expanded bare weather and forecast
+            Arguments.of("whats the weather", "get_weather"),
+            Arguments.of("weather here", "get_weather"),
+            Arguments.of("local weather", "get_weather"),
+            Arguments.of("what's the weather here", "get_weather"),
+            Arguments.of("what's the forecast", "get_weather"),
+            Arguments.of("what's the 5-day forecast", "get_weather"),
+            Arguments.of("5-day forecast", "get_weather"),
+            Arguments.of("five day forecast", "get_weather"),
             Arguments.of("set an alarm for 7am", "set_alarm"),
             Arguments.of("wake me up at 6:30", "set_alarm"),
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3334,6 +3334,7 @@ class QuickIntentRouterTest {
 
         @JvmStatic
         fun weatherGpsRegexPhrases(): Stream<Arguments> = Stream.of(
+            // Existing GPS weather patterns
             Arguments.of("what's the weather"),
             Arguments.of("what is the weather"),
             Arguments.of("weather today"),
@@ -3349,6 +3350,17 @@ class QuickIntentRouterTest {
             Arguments.of("what's the weather like"),
             Arguments.of("how's the weather like"),
             Arguments.of("What's the weather?"),
+            // #1318 — expanded bare/local weather coverage
+            Arguments.of("whats the weather"),
+            Arguments.of("weather"),
+            Arguments.of("weather here"),
+            Arguments.of("local weather"),
+            Arguments.of("what's the weather here"),
+            // #1318 — bare forecast coverage
+            Arguments.of("forecast"),
+            Arguments.of("what's the forecast"),
+            Arguments.of("what is the forecast"),
+            Arguments.of("whats the forecast"),
         )
 
         @JvmStatic
@@ -3413,6 +3425,12 @@ class QuickIntentRouterTest {
             Arguments.of("what's the weather looking like for the next few days in Wellington", "3", "Wellington"),
             // Issue #1280 — explicit exact prompt coverage
             Arguments.of("What's the 5 day forecast?", "5", null),
+            // #1318 — hyphenated and word-form forecast coverage
+            Arguments.of("what's the 5-day forecast", "5", null),
+            Arguments.of("5-day forecast", "5", null),
+            Arguments.of("five day forecast", "5", null),
+            Arguments.of("what's the five day forecast", "5", null),
+            Arguments.of("five-day forecast", "5", null),
         )
 
         @JvmStatic

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelQuickIntentRouterTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelQuickIntentRouterTest.kt
@@ -1,0 +1,338 @@
+package com.kernel.ai.feature.chat
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import com.google.ai.edge.litertlm.ToolProvider
+import com.kernel.ai.core.inference.BackendType
+import com.kernel.ai.core.inference.EmbeddingEngine
+import com.kernel.ai.core.inference.GenerationResult
+import com.kernel.ai.core.inference.InferenceEngine
+import com.kernel.ai.core.inference.JandalPersona
+import com.kernel.ai.core.inference.PersonaMode
+import com.kernel.ai.core.inference.download.DownloadState
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.inference.hardware.HardwareTier
+import com.kernel.ai.core.memory.entity.ConversationEntity
+import com.kernel.ai.core.memory.rag.RagRepository
+import com.kernel.ai.core.memory.repository.ConversationRepository
+import com.kernel.ai.core.memory.repository.MemoryRepository
+import com.kernel.ai.core.memory.repository.ModelSettingsRepository
+import com.kernel.ai.core.memory.repository.MealPlanSessionRepository
+import com.kernel.ai.core.memory.repository.UserProfileRepository
+import com.kernel.ai.core.memory.usecase.EpisodicDistillationUseCase
+import com.kernel.ai.core.memory.usecase.VerboseLoggingPreferenceUseCase
+import com.kernel.ai.core.model.availability.GatedModelStatusRepository
+import com.kernel.ai.core.skills.KernelAIToolSet
+import com.kernel.ai.core.skills.QuickIntentRouter
+import com.kernel.ai.core.skills.Skill
+import com.kernel.ai.core.skills.SkillCall
+import com.kernel.ai.core.skills.SkillExecutor
+import com.kernel.ai.core.skills.SkillRegistry
+import com.kernel.ai.core.skills.SkillResult
+import com.kernel.ai.core.skills.SkillSchema
+import com.kernel.ai.core.skills.slot.SlotFillerManager
+import com.kernel.ai.core.skills.slot.SlotValidationRegistry
+import com.kernel.ai.core.skills.slot.SlotValidationResult
+import com.kernel.ai.core.skills.mealplan.MealPlannerCoordinator
+import com.kernel.ai.core.skills.intent.IntentRecoveryOrchestrator
+import com.kernel.ai.core.skills.intent.IntentContractRegistry
+import com.kernel.ai.core.memory.prefs.ChatPreferences
+import com.kernel.ai.core.voice.StartListeningCuePlayer
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceOutputController
+import com.kernel.ai.core.voice.VoiceOutputEvent
+import com.kernel.ai.core.voice.VoiceOutputPreferences
+import com.kernel.ai.core.voice.VoiceOutputResult
+import com.kernel.ai.core.voice.VoiceOutputStreamingSession
+import com.kernel.ai.core.voice.VoiceSpeakRequest
+import com.kernel.ai.core.inference.auth.HuggingFaceAuthRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Chat path test for [QuickIntentRouter] integration — verifies that in-chat text input
+ * routes through QIR (Tier 2) before falling through to the LLM (Tier 3).
+ *
+ * Uses a real [QuickIntentRouter] (no classifier, regex-only) to prove deterministic
+ * routing, unlike the mocked QIR tests in [ChatViewModelVoiceTest].
+ *
+ * Run with: ./gradlew :feature:chat:testDebugUnitTest --tests "*.ChatViewModelQuickIntentRouterTest"
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatViewModelQuickIntentRouterTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    // Mocked dependencies (everything except QIR)
+    private val inferenceEngine: InferenceEngine = mockk(relaxed = true)
+    private val downloadManager: ModelDownloadManager = mockk(relaxed = true)
+    private val conversationRepository: ConversationRepository = mockk(relaxed = true)
+    private val ragRepository: RagRepository = mockk(relaxed = true)
+    private val userProfileRepository: UserProfileRepository = mockk(relaxed = true)
+    private val memoryRepository: MemoryRepository = mockk(relaxed = true)
+    private val mealPlanSessionRepository: MealPlanSessionRepository = mockk(relaxed = true)
+    private val episodicDistillationUseCase: EpisodicDistillationUseCase = mockk(relaxed = true)
+    private val modelSettingsRepository: ModelSettingsRepository = mockk(relaxed = true)
+    private val mealPlannerCoordinator: MealPlannerCoordinator = mockk(relaxed = true)
+    private val skillRegistry: SkillRegistry = mockk(relaxed = true)
+    private val skillExecutor: SkillExecutor = mockk(relaxed = true)
+    private val slotFillerManager: SlotFillerManager = mockk(relaxed = true)
+    private val slotValidationRegistry: SlotValidationRegistry = mockk(relaxed = true)
+    private val kernelAIToolSet: KernelAIToolSet = mockk(relaxed = true)
+    private val toolProvider: ToolProvider = mockk(relaxed = true)
+    private val embeddingEngine: EmbeddingEngine = mockk(relaxed = true)
+    private val voiceInputController: VoiceInputController = mockk(relaxed = true)
+    private val voiceOutputController: VoiceOutputController = mockk(relaxed = true)
+    private val voiceStreamingSession: VoiceOutputStreamingSession = mockk(relaxed = true)
+    private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
+    private val jandalPersona: JandalPersona = mockk(relaxed = true)
+    private val nzTruthSeedingService: NzTruthSeedingService = mockk(relaxed = true)
+    private val verboseLoggingPreferenceUseCase: VerboseLoggingPreferenceUseCase = mockk(relaxed = true)
+    private val gatedModelStatusRepository: GatedModelStatusRepository = mockk(relaxed = true)
+    private val startListeningCuePlayer: StartListeningCuePlayer = mockk(relaxed = true)
+    private val chatPreferences: ChatPreferences = mockk(relaxed = true)
+    private val intentRecoveryOrchestrator: IntentRecoveryOrchestrator = mockk(relaxed = true)
+    private val authRepository: HuggingFaceAuthRepository = mockk(relaxed = true)
+
+    // Real QIR (no classifier — regex-only)
+    private val realRouter = QuickIntentRouter()
+
+    // Fake weather skill for testing
+    private val weatherSkill = object : Skill {
+        override val name = "get_weather"
+        override val description = "Get weather"
+        override val schema = SkillSchema()
+
+        override suspend fun execute(call: SkillCall): SkillResult =
+            SkillResult.Success("Currently 18°C and partly cloudy in your area.")
+    }
+
+    private val spokenResponsesEnabled = MutableStateFlow(false)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any()) } returns 0
+
+        // Inference engine — ready, generating not called
+        every { inferenceEngine.isReady } returns MutableStateFlow(true)
+        every { inferenceEngine.isGenerating } returns MutableStateFlow(false)
+        every { inferenceEngine.activeBackend } returns MutableStateFlow<BackendType?>(null)
+        every { inferenceEngine.resolvedMaxTokens } returns MutableStateFlow(0)
+        every { inferenceEngine.evictionEvents } returns emptyFlow()
+        coEvery { inferenceEngine.updateSystemPrompt(any()) } just runs
+        coEvery { inferenceEngine.resetConversation() } just runs
+
+        // Download state
+        every { downloadManager.downloadStates } returns MutableStateFlow<Map<KernelModel, DownloadState>>(emptyMap())
+        every { downloadManager.downloadSources } returns MutableStateFlow(emptyMap())
+        every { downloadManager.areRequiredModelsDownloaded() } returns true
+        every { downloadManager.deviceTier } returns HardwareTier.FLAGSHIP
+
+        // Conversation repo
+        coEvery { conversationRepository.getConversation(any()) } answers {
+            val id = firstArg<String>()
+            ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L)
+        }
+        coEvery { conversationRepository.getMessagesOnce(any()) } returns emptyList()
+        coEvery { conversationRepository.addMessage(any(), any(), any(), any(), any()) } returnsMany
+            listOf("user-msg", "assistant-msg")
+        every { conversationRepository.observeConversationById(any()) } answers {
+            val id = firstArg<String>()
+            flowOf(ConversationEntity(id = id, title = null, createdAt = 1L, updatedAt = 1L))
+        }
+
+        // Auth
+        every { authRepository.isAuthenticated } returns MutableStateFlow(false)
+
+        // Chat preferences
+        every { chatPreferences.fontSize } returns flowOf(1)
+        every { chatPreferences.bubbleTheme } returns flowOf("system")
+        every { chatPreferences.userFontColor } returns flowOf(null)
+        every { chatPreferences.assistantFontColor } returns flowOf(null)
+        every { chatPreferences.wallpaperType } returns flowOf("none")
+        every { chatPreferences.wallpaperColor } returns flowOf(null)
+        every { chatPreferences.wallpaperImageUri } returns flowOf(null)
+        every { chatPreferences.copyToolCalls } returns flowOf(false)
+        every { chatPreferences.copyThinking } returns flowOf(false)
+
+        // Persona
+        every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
+        every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
+
+        // Validation
+        every { slotValidationRegistry.validateParams(any(), any()) } returns null
+        every { slotValidationRegistry.validate(any(), any(), any()) } returns SlotValidationResult.valid()
+
+        // Skill registry — return real weather skill for get_weather
+        every { skillRegistry.get("get_weather") } returns weatherSkill
+
+        // NZ truth seeding
+        every { nzTruthSeedingService.isSeeding } returns MutableStateFlow(false)
+        every { nzTruthSeedingService.seedIfNeeded() } just runs
+
+        // Verbose logging
+        coEvery { verboseLoggingPreferenceUseCase.loadAndApplyVerboseLoggingPreference() } just runs
+
+        // Voice — disable spoken responses for text-only test
+        every { voiceOutputPreferences.spokenResponsesEnabled } returns spokenResponsesEnabled
+        every { voiceOutputPreferences.autoSpeak } returns MutableStateFlow(false)
+        every { voiceOutputPreferences.maxSpokenSentences } returns flowOf(0)
+        every { voiceInputController.events } returns emptyFlow()
+        every { voiceOutputController.events } returns emptyFlow()
+        coEvery { voiceOutputController.warmUp() } returns VoiceOutputResult.Spoken
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    @ParameterizedTest(name = "\"{0}\" routes through QIR, not LLM")
+    @ValueSource(strings = [
+        "what's the weather",
+        "whats the weather",
+        "what is the weather",
+        "weather",
+        "weather here",
+        "local weather",
+        "what's the weather here",
+        "what's the forecast",
+        "what is the forecast",
+        "forecast",
+        "whats the forecast",
+        "what's the 5-day forecast",
+        "what's the 5 day forecast",
+        "5-day forecast",
+        "5 day forecast",
+        "five day forecast",
+    ])
+    fun `weather query routes through QIR regex match`(input: String) = runTest(dispatcher) {
+        // Verify QIR route returns a RegexMatch (not FallThrough)
+        val routeResult = realRouter.route(input)
+        val isRegexMatch = routeResult is QuickIntentRouter.RouteResult.RegexMatch
+        assert(isRegexMatch) { "Expected RegexMatch for '$input' but got ${routeResult::class.simpleName}" }
+
+        // Create ChatViewModel with real QIR
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Send text input
+        viewModel.onInputChanged(input)
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        // Verify the LLM was NOT called → QIR routed it before reaching Tier 3
+        verify(exactly = 0) { inferenceEngine.generate(any()) }
+
+        // Verify the response was added to chat
+        val chatText = viewModel.getConversationAsText()
+        assert(chatText.contains("partly cloudy") || chatText.contains("weather")) {
+            "Expected weather response in chat for '$input' but got: $chatText"
+        }
+    }
+
+    @Test
+    fun `weather with location still routes through QIR and preserves location`() = runTest(dispatcher) {
+        val input = "what's the weather in London"
+
+        // Verify QIR routes to weather with location param
+        val routeResult = realRouter.route(input)
+        assert(routeResult is QuickIntentRouter.RouteResult.RegexMatch) {
+            "Expected RegexMatch for '$input' but got ${routeResult::class.simpleName}"
+        }
+        val intent = (routeResult as QuickIntentRouter.RouteResult.RegexMatch).intent
+        assertEquals("get_weather", intent.intentName)
+        assertEquals("London", intent.params["location"])
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onInputChanged(input)
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        verify(exactly = 0) { inferenceEngine.generate(any()) }
+    }
+
+    @Test
+    fun `non-weather query falls through to LLM as expected`() = runTest(dispatcher) {
+        val input = "tell me a joke"
+
+        // Verify QIR does NOT match this
+        val routeResult = realRouter.route(input)
+        assert(routeResult is QuickIntentRouter.RouteResult.FallThrough) {
+            "Expected FallThrough for '$input' but got ${routeResult::class.simpleName}"
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onInputChanged(input)
+        viewModel.sendMessage()
+        advanceUntilIdle()
+    }
+
+    private fun createViewModel(): ChatViewModel = ChatViewModel(
+        savedStateHandle = SavedStateHandle(mapOf("conversationId" to "conv-existing")),
+        chatPreferences = chatPreferences,
+        authRepository = authRepository,
+        inferenceEngine = inferenceEngine,
+        downloadManager = downloadManager,
+        conversationRepository = conversationRepository,
+        ragRepository = ragRepository,
+        userProfileRepository = userProfileRepository,
+        memoryRepository = memoryRepository,
+        episodicDistillationUseCase = episodicDistillationUseCase,
+        modelSettingsRepository = modelSettingsRepository,
+        skillRegistry = skillRegistry,
+        skillExecutor = skillExecutor,
+        quickIntentRouter = realRouter,
+        intentRecoveryOrchestrator = intentRecoveryOrchestrator,
+        intentContractRegistry = IntentContractRegistry(),
+        slotFillerManager = slotFillerManager,
+        slotValidationRegistry = slotValidationRegistry,
+        kernelAIToolSet = kernelAIToolSet,
+        toolProvider = toolProvider,
+        embeddingEngine = embeddingEngine,
+        voiceInputController = voiceInputController,
+        voiceOutputController = voiceOutputController,
+        voiceOutputPreferences = voiceOutputPreferences,
+        jandalPersona = jandalPersona,
+        nzTruthSeedingService = nzTruthSeedingService,
+        verboseLoggingPreferenceUseCase = verboseLoggingPreferenceUseCase,
+        gatedModelStatusRepository = gatedModelStatusRepository,
+        startListeningCuePlayer = startListeningCuePlayer,
+        mealPlanSessionRepository = mealPlanSessionRepository,
+        mealPlannerCoordinator = mealPlannerCoordinator,
+    )
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
@@ -87,7 +87,7 @@ fun AppPermissionsScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = "These are the permissions Jandal uses. Tap any revoked permission to open the right system settings page.",
+                text = "Review the permissions and Android access Jandal uses for specific features. Tap an item to repair access in Android settings.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -112,7 +112,7 @@ fun AppPermissionsScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = "Tip: Revoked runtime permissions open App info. Revoked special-access items open their dedicated system settings page.",
+            // Removed: tip text was redundant with per-item repair actions
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsScreen.kt
@@ -109,14 +109,6 @@ fun AppPermissionsScreen(
                 HorizontalDivider()
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-            // Removed: tip text was redundant with per-item repair actions
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
         }
     }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AppPermissionsViewModel.kt
@@ -94,7 +94,7 @@ class AppPermissionsViewModel @Inject constructor(
         val knownPermissions = listOf(
             AppPermissionItem(
                 label = "Phone",
-                description = "Hands-free calling via make_call and voicemail",
+                description = "Hands-free calling",
                 permission = Manifest.permission.CALL_PHONE,
             ),
             AppPermissionItem(
@@ -104,22 +104,22 @@ class AppPermissionsViewModel @Inject constructor(
             ),
             AppPermissionItem(
                 label = "Notifications",
-                description = "Alarm, timer and download notifications",
+                description = "Alarms, timers, and download notifications",
                 permission = Manifest.permission.POST_NOTIFICATIONS,
             ),
             AppPermissionItem(
                 label = "Location",
-                description = "GPS-based weather lookup",
+                description = "Local weather",
                 permission = Manifest.permission.ACCESS_COARSE_LOCATION,
             ),
             AppPermissionItem(
                 label = "Contacts",
-                description = "Call, SMS and email by contact name",
+                description = "Contact lookup for calls, SMS, and email",
                 permission = Manifest.permission.READ_CONTACTS,
             ),
             AppPermissionItem(
                 label = "Calendar",
-                description = "Synced birthday reminders",
+                description = "Calendar lookup for important dates",
                 permission = Manifest.permission.READ_CALENDAR,
             ),
         )
@@ -128,7 +128,7 @@ class AppPermissionsViewModel @Inject constructor(
         val specialPermissions = listOf(
             AppPermissionItem(
                 label = "Do Not Disturb",
-                description = "Toggle DND mode on/off",
+                description = "Do Not Disturb control",
                 permission = Manifest.permission.ACCESS_NOTIFICATION_POLICY,
                 isGranted = checkNotificationPolicyAccess(),
                 isSpecial = true,
@@ -137,7 +137,7 @@ class AppPermissionsViewModel @Inject constructor(
             // but included for completeness on devices that deny it.
             AppPermissionItem(
                 label = "Modify system settings",
-                description = "Change screen brightness",
+                description = "Brightness and system settings",
                 permission = Manifest.permission.WRITE_SETTINGS,
                 isGranted = Settings.System.canWrite(context),
                 isSpecial = true,

--- a/scripts/adb_harness/cases.py
+++ b/scripts/adb_harness/cases.py
@@ -89,6 +89,10 @@ PHASES: list[tuple[str, list[TestCase]]] = [
         TestCase("how long until the timer goes off", "get_timer_remaining"),
     ]),
     ("weather", [
+        # #1318 — bare/local weather and forecast
+        TestCase("what's the weather", "get_weather"),
+        TestCase("what's the 5-day forecast", "get_weather"),
+        # Location-based weather
         TestCase("what's the weather in Auckland", "get_weather"),
         TestCase("will it rain today", "get_weather"),
         TestCase("how hot is it outside", "get_weather"),


### PR DESCRIPTION
Closes #1159

## Changes

### Startup prompt policy
Reduced startup permission requests to only `POST_NOTIFICATIONS`:

- **Notifications**: kept at startup. Needed for alarms, timers, reminders, and download progress — these are launch-critical notification-backed features.
- **Location**: removed from startup. Requested on first use via contextual overlays (#1312/#1164).
- **Contacts**: removed from startup. Requested on first use via contextual overlays (#1312/#1164).
- **Calendar**: removed from startup. Requested on first use via contextual overlays (#1312/#1164).
- **Phone**: removed from startup (was never part of the startup bundle — only requested on make_call/voicemail via #1312).
- **DND special access**: removed from startup (was never part of the startup bundle — requested on first DND toggle).
- **Write Settings**: removed from startup (was never part of the startup bundle — requested on first brightness/settings change).
- **Default Assistant role**: removed from startup (was never part of the startup bundle — configured in Voice settings).

### App Permissions dashboard alignment
- Intro copy: \"Review the permissions and Android access Jandal uses for specific features. Tap an item to repair access in Android settings.\"
- Descriptions updated to capability-first wording:
  - \"Hands-free calling\" (was \"Hands-free calling via make_call and voicemail\")
  - \"Local weather\" (was \"GPS-based weather lookup\")
  - \"Contact lookup for calls, SMS, and email\" (was \"Call, SMS and email by contact name\")
  - \"Calendar lookup for important dates\" (was \"Synced birthday reminders\")
  - \"Do Not Disturb control\" (was \"Toggle DND mode on/off\")
  - \"Brightness and system settings\" (was \"Change screen brightness\")
  - \"Alarms, timers, and download notifications\" (was \"Alarm, timer and download notifications\")
- Redundant tip text removed (per-item repair actions are self-explanatory).

### Files changed
| File | Change |
|---|---|
| `app/src/main/java/com/kernel/ai/MainActivity.kt` | Removed Location and Contacts from startup permission bundle |
| `feature/settings/.../AppPermissionsScreen.kt` | Updated intro text, removed redundant tip |
| `feature/settings/.../AppPermissionsViewModel.kt` | Capability-first descriptions |

### Notification startup policy decision
Notifications are kept as a startup prompt because alarms, timers, reminders, and download progress all require notification access. Without notifications, these features silently fail. Other permissions are non-blocking: if denied, the user simply cannot use that specific feature until they grant it through a contextual prompt.

### Registry alignment
Full `CapabilityRegistry` backing is deferred as a follow-up. The current row definitions are manually aligned to known capabilities. A follow-up should bind the dashboard to the capability registry described in `docs/permissions/capability-registry.md`.

## CI status
CI pending on push.

**Do not merge.** Wait for Nick's explicit approval.