### PR TITLE
feat(#1165): Slice 8 — add capability-aware scheduling result model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Unit tests
         continue-on-error: true
         id: gradle-unit-tests
-        run: ./gradlew :core:skills:testDebugUnitTest :feature:chat:testDebugUnitTest :app:testDebugUnitTest :feature:settings:testDebugUnitTest
+        run: ./gradlew :core:memory:testDebugUnitTest :core:skills:testDebugUnitTest :feature:chat:testDebugUnitTest :app:testDebugUnitTest :feature:settings:testDebugUnitTest
 
       - name: Upload test results
         if: always()

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
@@ -11,6 +11,7 @@ import com.kernel.ai.core.memory.clock.ClockEventType
 import com.kernel.ai.core.memory.clock.ClockPlatformState
 import com.kernel.ai.core.memory.clock.ClockScheduledEvent
 import com.kernel.ai.core.memory.clock.ClockScheduler
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,14 +26,22 @@ class AlarmManagerClockScheduler @Inject constructor(
     private val notificationManager: NotificationManager
         get() = context.getSystemService(NotificationManager::class.java)
 
-    override fun getPlatformState(): ClockPlatformState =
-        ClockPlatformState(
-            canScheduleExactAlarms = alarmManager.canScheduleExactAlarms(),
+    override fun getPlatformState(): ClockPlatformState {
+        val canScheduleExact = alarmManager.canScheduleExactAlarms()
+        return ClockPlatformState(
+            canScheduleExactAlarms = canScheduleExact,
             notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled(),
             canUseFullScreenIntent = notificationManager.canUseFullScreenIntent(),
+            bootRestoreLimited = !canScheduleExact,
         )
+    }
 
-    override fun schedule(event: ClockScheduledEvent) {
+    override fun schedule(event: ClockScheduledEvent): SchedulingResult<Unit> {
+        val state = getPlatformState()
+        if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
+        if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
+        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
+
         val pendingIntent = PendingIntent.getBroadcast(
             context,
             event.eventId.hashCode(),
@@ -44,6 +53,7 @@ class AlarmManagerClockScheduler @Inject constructor(
             event.triggerAtMillis,
             pendingIntent,
         )
+        return SchedulingResult.Success(Unit)
     }
 
     override fun cancel(event: ClockScheduledEvent) {

--- a/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/AlarmManagerClockScheduler.kt
@@ -37,10 +37,8 @@ class AlarmManagerClockScheduler @Inject constructor(
     }
 
     override fun schedule(event: ClockScheduledEvent): SchedulingResult<Unit> {
-        val state = getPlatformState()
-        if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
-        if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
-        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
+        if (!alarmManager.canScheduleExactAlarms()) return SchedulingResult.ExactAlarmBlocked
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return SchedulingResult.NotificationBlocked
 
         val pendingIntent = PendingIntent.getBroadcast(
             context,

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat
 import com.kernel.ai.MainActivity
 import com.kernel.ai.core.memory.clock.ClockEventType
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import com.kernel.ai.core.voice.VoiceCaptureMode
 import com.kernel.ai.core.memory.clock.ClockAlertConfig
 import com.kernel.ai.core.voice.VoiceInputController
@@ -641,7 +642,7 @@ class ClockAlertService : Service() {
             ClockEventType.TIMER -> clockRepository.scheduleTimer(
                 durationMs = ALERT_ADD_MINUTE_MS,
                 label = alert.label.takeIf { it.isNotBlank() },
-            ) != null
+            ) is SchedulingResult.Success
 
             ClockEventType.PRE_ALARM -> false
         }

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -129,7 +129,34 @@ data class ClockPlatformState(
     val canScheduleExactAlarms: Boolean,
     val notificationsEnabled: Boolean,
     val canUseFullScreenIntent: Boolean,
+    /** True when boot-complete restore of scheduled events may be limited. */
+    val bootRestoreLimited: Boolean = false,
  )
+
+/**
+ * Result of scheduling an alarm, timer, or reminder — distinguishes platform
+ * blockers from ordinary failures so callers can offer contextual repair.
+ */
+sealed class SchedulingResult<out T> {
+    /** The event was successfully scheduled. */
+    data class Success<T>(val data: T) : SchedulingResult<T>()
+
+    /** Android's [AlarmManager.canScheduleExactAlarms] returned false. */
+    data object ExactAlarmBlocked : SchedulingResult<Nothing>()
+
+    /** Notifications are disabled at the system or permission level. */
+    data object NotificationBlocked : SchedulingResult<Nothing>()
+
+    /** [NotificationManager.canUseFullScreenIntent] returned false. */
+    data object FullScreenIntentUnavailable : SchedulingResult<Nothing>()
+
+    /** Device boot restore of scheduled events is limited or unavailable. */
+    data object BootRestoreLimited : SchedulingResult<Nothing>()
+
+    /** An internal scheduling error occurred (DB, parsing, etc.). */
+    data class SchedulingFailed(val message: String? = null) : SchedulingResult<Nothing>()
+}
+
 
 data class ClockRestoreReport(
     val restoredCount: Int,

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockModels.kt
@@ -134,12 +134,23 @@ data class ClockPlatformState(
  )
 
 /**
+ * Warnings that don't prevent scheduling but indicate degraded delivery.
+ * Carried inside [SchedulingResult.Success.warnings].
+ */
+enum class SchedulingWarning {
+    /** [NotificationManager.canUseFullScreenIntent] returned false — alert may use a standard notification. */
+    FULL_SCREEN_INTENT_UNAVAILABLE,
+    /** Device boot restore of scheduled events is limited or unavailable. */
+    BOOT_RESTORE_LIMITED,
+}
+
+/**
  * Result of scheduling an alarm, timer, or reminder — distinguishes platform
  * blockers from ordinary failures so callers can offer contextual repair.
  */
 sealed class SchedulingResult<out T> {
-    /** The event was successfully scheduled. */
-    data class Success<T>(val data: T) : SchedulingResult<T>()
+    /** The event was successfully scheduled. [warnings] contains any non-blocking platform limitations. */
+    data class Success<T>(val data: T, val warnings: List<SchedulingWarning> = emptyList()) : SchedulingResult<T>()
 
     /** Android's [AlarmManager.canScheduleExactAlarms] returned false. */
     data object ExactAlarmBlocked : SchedulingResult<Nothing>()
@@ -147,15 +158,10 @@ sealed class SchedulingResult<out T> {
     /** Notifications are disabled at the system or permission level. */
     data object NotificationBlocked : SchedulingResult<Nothing>()
 
-    /** [NotificationManager.canUseFullScreenIntent] returned false. */
-    data object FullScreenIntentUnavailable : SchedulingResult<Nothing>()
-
-    /** Device boot restore of scheduled events is limited or unavailable. */
-    data object BootRestoreLimited : SchedulingResult<Nothing>()
-
     /** An internal scheduling error occurred (DB, parsing, etc.). */
     data class SchedulingFailed(val message: String? = null) : SchedulingResult<Nothing>()
 }
+
 
 
 data class ClockRestoreReport(

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepository.kt
@@ -40,8 +40,8 @@ interface ClockRepository {
 
     fun getPlatformState(): ClockPlatformState
 
-    suspend fun createAlarm(draft: AlarmDraft): ClockAlarm?
-    suspend fun updateAlarm(alarmId: String, draft: AlarmDraft): ClockAlarm?
+    suspend fun createAlarm(draft: AlarmDraft): SchedulingResult<ClockAlarm>
+    suspend fun updateAlarm(alarmId: String, draft: AlarmDraft): SchedulingResult<ClockAlarm>
     suspend fun setAlarmEnabled(alarmId: String, enabled: Boolean): Boolean
     suspend fun cancelAlarm(alarmId: String)
     suspend fun cancelAlarms(alarmIds: Collection<String>)
@@ -50,7 +50,7 @@ interface ClockRepository {
     suspend fun skipAlarmOccurrence(alarmId: String, occurrenceTriggerAtMillis: Long): Boolean
     suspend fun setDefaultAlarmSoundUri(soundUri: String?)
 
-    suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer?
+    suspend fun scheduleTimer(durationMs: Long, label: String?): SchedulingResult<ClockTimer>
     suspend fun cancelTimer(timerId: String)
     suspend fun deleteCompletedTimer(timerId: String): Boolean
     suspend fun clearCompletedTimers(): Int

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -220,10 +220,15 @@ class ClockRepositoryImpl @Inject constructor(
 
     override fun getPlatformState(): ClockPlatformState = scheduler.getPlatformState()
 
-    override suspend fun createAlarm(draft: AlarmDraft): ClockAlarm? {
-        if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
+    override suspend fun createAlarm(draft: AlarmDraft): SchedulingResult<ClockAlarm> {
+        val state = scheduler.getPlatformState()
+        if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
+        if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
+        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
+        if (state.bootRestoreLimited) return SchedulingResult.BootRestoreLimited
+
         val now = System.currentTimeMillis()
-        val triggerAtMillis = draft.nextTriggerAtMillis(now) ?: return null
+        val triggerAtMillis = draft.nextTriggerAtMillis(now) ?: return SchedulingResult.SchedulingFailed("Could not compute next trigger time")
         val entity = ScheduledAlarmEntity(
             id = UUID.randomUUID().toString(),
             ownerId = null,
@@ -240,21 +245,29 @@ class ClockRepositoryImpl @Inject constructor(
             timeZoneId = draft.timeZoneId,
             soundUri = draft.soundUri,
         ).withDefaultOwnerId()
-        scheduleAlarmEvents(entity, now)
+
+        val scheduleResult = scheduler.schedule(entity.toScheduledEvent())
+        if (scheduleResult !is SchedulingResult.Success) {
+            return scheduleResult as SchedulingResult<ClockAlarm>
+        }
         return try {
             scheduledAlarmDao.insert(entity)
-            entity.toClockAlarm()
-        } catch (_: Exception) {
-            cancelAlarmEvents(entity, now)
-            null
+            SchedulingResult.Success(
+                entity.toClockAlarm() ?: error("created alarm entity could not be converted to ClockAlarm")
+            )
+        } catch (e: Exception) {
+            scheduler.cancel(entity.toScheduledEvent())
+            SchedulingResult.SchedulingFailed(e.message)
         }
     }
 
-    override suspend fun updateAlarm(alarmId: String, draft: AlarmDraft): ClockAlarm? {
-        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId() ?: return null
-        if (existing.entryType != ClockEventType.ALARM.name) return null
+    override suspend fun updateAlarm(alarmId: String, draft: AlarmDraft): SchedulingResult<ClockAlarm> {
+        val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId()
+            ?: return SchedulingResult.SchedulingFailed("Alarm not found")
+        if (existing.entryType != ClockEventType.ALARM.name) return SchedulingResult.SchedulingFailed("Not an alarm")
         val now = System.currentTimeMillis()
-        val triggerAtMillis = draft.nextTriggerAtMillis(now) ?: return null
+        val triggerAtMillis = draft.nextTriggerAtMillis(now)
+            ?: return SchedulingResult.SchedulingFailed("Could not compute next trigger time")
         val updated = existing.copy(
             triggerAtMillis = triggerAtMillis,
             label = draft.label?.takeIf { it.isNotBlank() },
@@ -270,14 +283,21 @@ class ClockRepositoryImpl @Inject constructor(
             snoozedUntilMs = null,
         )
         cancelAlarmEvents(existing, now)
-        scheduleAlarmEvents(updated, now)
+
+        val scheduleResult = scheduler.schedule(updated.toScheduledEvent())
+        if (scheduleResult !is SchedulingResult.Success) {
+            scheduleAlarmEvents(existing, now)
+            return scheduleResult as SchedulingResult<ClockAlarm>
+        }
         return try {
             scheduledAlarmDao.insert(updated)
-            updated.toClockAlarm()
-        } catch (_: Exception) {
+            SchedulingResult.Success(
+                updated.toClockAlarm() ?: error("updated alarm entity could not be converted to ClockAlarm")
+            )
+        } catch (e: Exception) {
             cancelAlarmEvents(updated, now)
             scheduleAlarmEvents(existing, now)
-            null
+            SchedulingResult.SchedulingFailed(e.message)
         }
     }
 
@@ -400,8 +420,13 @@ class ClockRepositoryImpl @Inject constructor(
         clockSoundPreferences.setDefaultAlarmSoundUri(soundUri)
     }
 
-    override suspend fun scheduleTimer(durationMs: Long, label: String?): ClockTimer? {
-        if (!scheduler.getPlatformState().canScheduleExactAlarms) return null
+    override suspend fun scheduleTimer(durationMs: Long, label: String?): SchedulingResult<ClockTimer> {
+        val state = scheduler.getPlatformState()
+        if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
+        if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
+        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
+        if (state.bootRestoreLimited) return SchedulingResult.BootRestoreLimited
+
         val now = System.currentTimeMillis()
         val entity = ScheduledAlarmEntity(
             id = UUID.randomUUID().toString(),
@@ -414,13 +439,19 @@ class ClockRepositoryImpl @Inject constructor(
             durationMs = durationMs,
             startedAtMs = now,
         ).withDefaultOwnerId()
-        scheduler.schedule(entity.toScheduledEvent())
+
+        val scheduleResult = scheduler.schedule(entity.toScheduledEvent())
+        if (scheduleResult !is SchedulingResult.Success) {
+            return scheduleResult as SchedulingResult<ClockTimer>
+        }
         return try {
             scheduledAlarmDao.insert(entity)
-            entity.toClockTimer() ?: error("Timer schedule missing duration metadata")
-        } catch (_: Exception) {
+            SchedulingResult.Success(
+                entity.toClockTimer() ?: error("Timer schedule missing duration metadata")
+            )
+        } catch (e: Exception) {
             scheduler.cancel(entity.toScheduledEvent())
-            null
+            SchedulingResult.SchedulingFailed(e.message)
         }
     }
 

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -298,9 +298,15 @@ class ClockRepositoryImpl @Inject constructor(
         cancelAlarmEvents(existing, now)
         val scheduleResult = scheduleAlarmEvents(updated, now)
         if (scheduleResult !is SchedulingResult.Success) {
-            // Scheduling failed (timing race: state changed between check and schedule)
-            scheduleAlarmEvents(existing, now)
-            return scheduleResult as SchedulingResult<ClockAlarm>
+            // Replacement scheduling failed — attempt to restore old schedule
+            val restoreResult = scheduleAlarmEvents(existing, now)
+            return when (restoreResult) {
+                is SchedulingResult.Success -> scheduleResult as SchedulingResult<ClockAlarm>
+                else -> SchedulingResult.SchedulingFailed(
+                    "Replacement scheduling failed and old schedule could not be restored. " +
+                        "Manual intervention may be required."
+                )
+            }
         }
 
         val warnings = buildList {
@@ -316,7 +322,13 @@ class ClockRepositoryImpl @Inject constructor(
             )
         } catch (e: Exception) {
             cancelAlarmEvents(updated, now)
-            scheduleAlarmEvents(existing, now)
+            val restoreResult = scheduleAlarmEvents(existing, now)
+            if (restoreResult !is SchedulingResult.Success) {
+                return SchedulingResult.SchedulingFailed(
+                    "DB insert failed and old schedule could not be restored. " +
+                        "Manual intervention may be required."
+                )
+            }
             SchedulingResult.SchedulingFailed(e.message)
         }
     }
@@ -668,13 +680,24 @@ class ClockRepositoryImpl @Inject constructor(
         clockAlertPreferences.setMaxAutoSnoozes(value)
     }
 
-    /** Schedules the full alarm event set. Returns the primary event result. */
+    /** Schedules the full alarm event set. Every required event must succeed or the operation is rolled back. */
     private fun scheduleAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long, currentAutoSnoozeCount: Int = 0): SchedulingResult<Unit> {
-        val primary = entity.toPrimaryAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
-            ?: return SchedulingResult.SchedulingFailed("Could not create primary alarm event")
-        entity.toSnoozeScheduledEvent(nowMillis, currentAutoSnoozeCount)?.let(scheduler::schedule)
-        entity.toPreAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
-        return primary
+        val events = listOfNotNull(
+            entity.toPrimaryAlarmScheduledEvent(nowMillis),
+            entity.toSnoozeScheduledEvent(nowMillis, currentAutoSnoozeCount),
+            entity.toPreAlarmScheduledEvent(nowMillis),
+        )
+        val scheduled = mutableListOf<ClockScheduledEvent>()
+        for (event in events) {
+            when (val result = scheduler.schedule(event)) {
+                is SchedulingResult.Success -> scheduled.add(event)
+                else -> {
+                    scheduled.forEach(scheduler::cancel)
+                    return result as SchedulingResult<Unit>
+                }
+            }
+        }
+        return SchedulingResult.Success(Unit)
     }
 
     private fun cancelAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockRepositoryImpl.kt
@@ -224,8 +224,6 @@ class ClockRepositoryImpl @Inject constructor(
         val state = scheduler.getPlatformState()
         if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
         if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
-        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
-        if (state.bootRestoreLimited) return SchedulingResult.BootRestoreLimited
 
         val now = System.currentTimeMillis()
         val triggerAtMillis = draft.nextTriggerAtMillis(now) ?: return SchedulingResult.SchedulingFailed("Could not compute next trigger time")
@@ -246,17 +244,24 @@ class ClockRepositoryImpl @Inject constructor(
             soundUri = draft.soundUri,
         ).withDefaultOwnerId()
 
-        val scheduleResult = scheduler.schedule(entity.toScheduledEvent())
+        val scheduleResult = scheduleAlarmEvents(entity, now)
         if (scheduleResult !is SchedulingResult.Success) {
             return scheduleResult as SchedulingResult<ClockAlarm>
         }
+
+        val warnings = buildList {
+            if (!state.canUseFullScreenIntent) add(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)
+            if (state.bootRestoreLimited) add(SchedulingWarning.BOOT_RESTORE_LIMITED)
+        }
+
         return try {
             scheduledAlarmDao.insert(entity)
             SchedulingResult.Success(
-                entity.toClockAlarm() ?: error("created alarm entity could not be converted to ClockAlarm")
+                entity.toClockAlarm() ?: error("created alarm entity could not be converted to ClockAlarm"),
+                warnings = warnings,
             )
         } catch (e: Exception) {
-            scheduler.cancel(entity.toScheduledEvent())
+            cancelAlarmEvents(entity, now)
             SchedulingResult.SchedulingFailed(e.message)
         }
     }
@@ -265,6 +270,12 @@ class ClockRepositoryImpl @Inject constructor(
         val existing = scheduledAlarmDao.getById(alarmId)?.withDefaultOwnerId()
             ?: return SchedulingResult.SchedulingFailed("Alarm not found")
         if (existing.entryType != ClockEventType.ALARM.name) return SchedulingResult.SchedulingFailed("Not an alarm")
+
+        // Check platform readiness before touching the existing schedule
+        val state = scheduler.getPlatformState()
+        if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
+        if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
+
         val now = System.currentTimeMillis()
         val triggerAtMillis = draft.nextTriggerAtMillis(now)
             ?: return SchedulingResult.SchedulingFailed("Could not compute next trigger time")
@@ -282,17 +293,26 @@ class ClockRepositoryImpl @Inject constructor(
             soundUri = draft.soundUri,
             snoozedUntilMs = null,
         )
-        cancelAlarmEvents(existing, now)
 
-        val scheduleResult = scheduler.schedule(updated.toScheduledEvent())
+        // Readiness confirmed — cancel old and schedule replacement
+        cancelAlarmEvents(existing, now)
+        val scheduleResult = scheduleAlarmEvents(updated, now)
         if (scheduleResult !is SchedulingResult.Success) {
+            // Scheduling failed (timing race: state changed between check and schedule)
             scheduleAlarmEvents(existing, now)
             return scheduleResult as SchedulingResult<ClockAlarm>
         }
+
+        val warnings = buildList {
+            if (!state.canUseFullScreenIntent) add(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)
+            if (state.bootRestoreLimited) add(SchedulingWarning.BOOT_RESTORE_LIMITED)
+        }
+
         return try {
             scheduledAlarmDao.insert(updated)
             SchedulingResult.Success(
-                updated.toClockAlarm() ?: error("updated alarm entity could not be converted to ClockAlarm")
+                updated.toClockAlarm() ?: error("updated alarm entity could not be converted to ClockAlarm"),
+                warnings = warnings,
             )
         } catch (e: Exception) {
             cancelAlarmEvents(updated, now)
@@ -424,8 +444,6 @@ class ClockRepositoryImpl @Inject constructor(
         val state = scheduler.getPlatformState()
         if (!state.canScheduleExactAlarms) return SchedulingResult.ExactAlarmBlocked
         if (!state.notificationsEnabled) return SchedulingResult.NotificationBlocked
-        if (!state.canUseFullScreenIntent) return SchedulingResult.FullScreenIntentUnavailable
-        if (state.bootRestoreLimited) return SchedulingResult.BootRestoreLimited
 
         val now = System.currentTimeMillis()
         val entity = ScheduledAlarmEntity(
@@ -444,10 +462,17 @@ class ClockRepositoryImpl @Inject constructor(
         if (scheduleResult !is SchedulingResult.Success) {
             return scheduleResult as SchedulingResult<ClockTimer>
         }
+
+        val warnings = buildList {
+            if (!state.canUseFullScreenIntent) add(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)
+            if (state.bootRestoreLimited) add(SchedulingWarning.BOOT_RESTORE_LIMITED)
+        }
+
         return try {
             scheduledAlarmDao.insert(entity)
             SchedulingResult.Success(
-                entity.toClockTimer() ?: error("Timer schedule missing duration metadata")
+                entity.toClockTimer() ?: error("Timer schedule missing duration metadata"),
+                warnings = warnings,
             )
         } catch (e: Exception) {
             scheduler.cancel(entity.toScheduledEvent())
@@ -643,10 +668,13 @@ class ClockRepositoryImpl @Inject constructor(
         clockAlertPreferences.setMaxAutoSnoozes(value)
     }
 
-    private fun scheduleAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long, currentAutoSnoozeCount: Int = 0) {
-        entity.toPrimaryAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
+    /** Schedules the full alarm event set. Returns the primary event result. */
+    private fun scheduleAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long, currentAutoSnoozeCount: Int = 0): SchedulingResult<Unit> {
+        val primary = entity.toPrimaryAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
+            ?: return SchedulingResult.SchedulingFailed("Could not create primary alarm event")
         entity.toSnoozeScheduledEvent(nowMillis, currentAutoSnoozeCount)?.let(scheduler::schedule)
         entity.toPreAlarmScheduledEvent(nowMillis)?.let(scheduler::schedule)
+        return primary
     }
 
     private fun cancelAlarmEvents(entity: ScheduledAlarmEntity, nowMillis: Long) {

--- a/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockScheduler.kt
+++ b/core/memory/src/main/java/com/kernel/ai/core/memory/clock/ClockScheduler.kt
@@ -3,7 +3,9 @@ package com.kernel.ai.core.memory.clock
 interface ClockScheduler {
     fun getPlatformState(): ClockPlatformState
 
-    fun schedule(event: ClockScheduledEvent)
+    /** Schedule an event. Returns [SchedulingResult.Success] on success,
+     *  or a specific [SchedulingResult] subtype describing the blocker. */
+    fun schedule(event: ClockScheduledEvent): SchedulingResult<Unit>
 
     fun cancel(event: ClockScheduledEvent)
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -14,14 +14,15 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertTrue
+import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
+import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -598,132 +599,4 @@ class ClockRepositoryImplTest {
         oneOffDateEpochDay = Instant.ofEpochMilli(triggerAtMillis).atZone(ZoneId.systemDefault()).toLocalDate().toEpochDay(),
         timeZoneId = ZoneId.systemDefault().id,
     )
-}
-
-private fun weekdayMaskFor(day: DayOfWeek): Int = 1 shl (day.value - 1)
-
-// ── Full event-set rollback ────────────────────────────────────────────
-
-@Test
-fun `createAlarm rolls back primary if snooze scheduling fails`() = runTest {
-    // Primary event succeeds, snooze event fails
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM })
-    } returns SchedulingResult.Success(Unit)
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
-    } returns SchedulingResult.SchedulingFailed("snooze unavailable")
-    // Pre-alarm: allow to succeed
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
-    } returns SchedulingResult.Success(Unit)
-
-    coEvery { scheduledAlarmDao.insert(any()) } just Runs
-    val draft = dailyDraft(label = "Rollback", hour = 7, minute = 0)
-
-    val result = repository.createAlarm(draft)
-
-    assertTrue(result is SchedulingResult.SchedulingFailed)
-    // Primary must have been cancelled as part of rollback
-    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
-    // DB must NOT have been written
-    coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Rollback" }) }
-}
-
-@Test
-fun `createAlarm rolls back primary if pre alarm scheduling fails`() = runTest {
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM })
-    } returns SchedulingResult.Success(Unit)
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
-    } returns SchedulingResult.Success(Unit)
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
-    } returns SchedulingResult.SchedulingFailed("pre-alarm unavailable")
-
-    coEvery { scheduledAlarmDao.insert(any()) } just Runs
-    val draft = dailyDraft(label = "RollbackPre", hour = 8, minute = 0)
-
-    val result = repository.createAlarm(draft)
-
-    assertTrue(result is SchedulingResult.SchedulingFailed)
-    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
-    coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "RollbackPre" }) }
-}
-
-// ── Update replacement failure and restore ─────────────────────────────
-
-@Test
-fun `updateAlarm restores old schedule when replacement scheduling fails`() = runTest {
-    val now = System.currentTimeMillis()
-    val existingId = "alarm-existing"
-    val existingEntity = ScheduledAlarmEntity(
-        id = existingId,
-        ownerId = existingId,
-        triggerAtMillis = now + 86_400_000L,
-        label = "Old",
-        createdAt = now - 86_400_000L,
-        enabled = true,
-        entryType = ClockEventType.ALARM.name,
-        alarmHour = 7,
-        alarmMinute = 0,
-    )
-    coEvery { scheduledAlarmDao.getById(existingId) } returns existingEntity
-
-    // New schedule fails on snooze event
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId == existingId })
-    } returns SchedulingResult.Success(Unit)
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
-    } returns SchedulingResult.SchedulingFailed("snooze unavailable")
-
-    // Old schedule restore: allow all events to succeed
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId != existingId })
-    } returns SchedulingResult.Success(Unit)
-
-    val draft = oneOffDraft(label = "Updated", hour = 8, minute = 0)
-
-    val result = repository.updateAlarm(existingId, draft)
-
-    // Must be a failure because replacement was not fully scheduled
-    assertTrue(result is SchedulingResult.SchedulingFailed)
-    // Old schedule must have been restored (primary event re-scheduled)
-    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
-}
-
-@Test
-fun `updateAlarm returns clear failure when restore also fails`() = runTest {
-    val now = System.currentTimeMillis()
-    val existingId = "alarm-restore-fail"
-    val existingEntity = ScheduledAlarmEntity(
-        id = existingId,
-        ownerId = existingId,
-        triggerAtMillis = now + 86_400_000L,
-        label = "Original",
-        createdAt = now - 86_400_000L,
-        enabled = true,
-        entryType = ClockEventType.ALARM.name,
-        alarmHour = 7,
-        alarmMinute = 0,
-    )
-    coEvery { scheduledAlarmDao.getById(existingId) } returns existingEntity
-
-    // Replacement primary fails on exact alarm blocker
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId == existingId })
-    } returns SchedulingResult.ExactAlarmBlocked
-    // Restore also fails
-    every {
-        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId != existingId })
-    } returns SchedulingResult.ExactAlarmBlocked
-
-    val draft = oneOffDraft(label = "Updated", hour = 8, minute = 0)
-
-    val result = repository.updateAlarm(existingId, draft)
-
-    assertTrue(result is SchedulingResult.SchedulingFailed)
-    assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -57,6 +58,7 @@ class ClockRepositoryImplTest {
             notificationsEnabled = true,
             canUseFullScreenIntent = false,
         )
+        every { scheduler.schedule(any()) } returns SchedulingResult.Success(Unit)
         every { clockSoundPreferences.soundConfig } returns flowOf(ClockSoundConfig())
         every { clockAlertPreferences.alertConfig } returns flowOf(ClockAlertConfig())
     }
@@ -73,11 +75,13 @@ class ClockRepositoryImplTest {
             timeZoneId = zoneId,
         )
 
-        val result = repository.createAlarm(draft)
+        val schedulingResult = repository.createAlarm(draft)
 
-        assertEquals("Morning", result?.label)
-        assertEquals(7, result?.hour)
-        assertEquals(30, result?.minute)
+        assertTrue(schedulingResult is SchedulingResult.Success)
+        val result = (schedulingResult as SchedulingResult.Success).data
+        assertEquals("Morning", result.label)
+        assertEquals(7, result.hour)
+        assertEquals(30, result.minute)
         coVerify(exactly = 1) {
             scheduledAlarmDao.insert(match {
                 it.entryType == ClockEventType.ALARM.name &&
@@ -96,9 +100,11 @@ class ClockRepositoryImplTest {
         coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = dailyDraft(label = "Gym", hour = 8, minute = 0)
 
-        val result = repository.createAlarm(draft)
+        val schedulingResult = repository.createAlarm(draft)
 
-        assertEquals(AlarmRepeatRule.Daily, result?.repeatRule)
+        assertTrue(schedulingResult is SchedulingResult.Success)
+        val result = (schedulingResult as SchedulingResult.Success).data
+        assertEquals(AlarmRepeatRule.Daily, result.repeatRule)
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM }) }
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM }) }
     }
@@ -109,9 +115,11 @@ class ClockRepositoryImplTest {
         val draft = dailyDraft(label = "Gym", hour = 8, minute = 0)
             .copy(soundUri = "content://media/internal/audio/media/7")
 
-        val result = repository.createAlarm(draft)
+        val schedulingResult = repository.createAlarm(draft)
 
-        assertEquals("content://media/internal/audio/media/7", result?.soundUri)
+        assertTrue(schedulingResult is SchedulingResult.Success)
+        val result = (schedulingResult as SchedulingResult.Success).data
+        assertEquals("content://media/internal/audio/media/7", result.soundUri)
         coVerify(exactly = 1) {
             scheduledAlarmDao.insert(match { it.soundUri == "content://media/internal/audio/media/7" })
         }
@@ -593,3 +601,129 @@ class ClockRepositoryImplTest {
 }
 
 private fun weekdayMaskFor(day: DayOfWeek): Int = 1 shl (day.value - 1)
+
+// ── Full event-set rollback ────────────────────────────────────────────
+
+@Test
+fun `createAlarm rolls back primary if snooze scheduling fails`() = runTest {
+    // Primary event succeeds, snooze event fails
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM })
+    } returns SchedulingResult.Success(Unit)
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
+    } returns SchedulingResult.SchedulingFailed("snooze unavailable")
+    // Pre-alarm: allow to succeed
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
+    } returns SchedulingResult.Success(Unit)
+
+    coEvery { scheduledAlarmDao.insert(any()) } just Runs
+    val draft = dailyDraft(label = "Rollback", hour = 7, minute = 0)
+
+    val result = repository.createAlarm(draft)
+
+    assertTrue(result is SchedulingResult.SchedulingFailed)
+    // Primary must have been cancelled as part of rollback
+    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
+    // DB must NOT have been written
+    coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Rollback" }) }
+}
+
+@Test
+fun `createAlarm rolls back primary if pre alarm scheduling fails`() = runTest {
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM })
+    } returns SchedulingResult.Success(Unit)
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
+    } returns SchedulingResult.Success(Unit)
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
+    } returns SchedulingResult.SchedulingFailed("pre-alarm unavailable")
+
+    coEvery { scheduledAlarmDao.insert(any()) } just Runs
+    val draft = dailyDraft(label = "RollbackPre", hour = 8, minute = 0)
+
+    val result = repository.createAlarm(draft)
+
+    assertTrue(result is SchedulingResult.SchedulingFailed)
+    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
+    coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "RollbackPre" }) }
+}
+
+// ── Update replacement failure and restore ─────────────────────────────
+
+@Test
+fun `updateAlarm restores old schedule when replacement scheduling fails`() = runTest {
+    val now = System.currentTimeMillis()
+    val existingId = "alarm-existing"
+    val existingEntity = ScheduledAlarmEntity(
+        id = existingId,
+        ownerId = existingId,
+        triggerAtMillis = now + 86_400_000L,
+        label = "Old",
+        createdAt = now - 86_400_000L,
+        enabled = true,
+        entryType = ClockEventType.ALARM.name,
+        alarmHour = 7,
+        alarmMinute = 0,
+    )
+    coEvery { scheduledAlarmDao.getById(existingId) } returns existingEntity
+
+    // New schedule fails on snooze event
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId == existingId })
+    } returns SchedulingResult.Success(Unit)
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.SNOOZE })
+    } returns SchedulingResult.SchedulingFailed("snooze unavailable")
+
+    // Old schedule restore: allow all events to succeed
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId != existingId })
+    } returns SchedulingResult.Success(Unit)
+
+    val draft = oneOffDraft(label = "Updated", hour = 8, minute = 0)
+
+    val result = repository.updateAlarm(existingId, draft)
+
+    // Must be a failure because replacement was not fully scheduled
+    assertTrue(result is SchedulingResult.SchedulingFailed)
+    // Old schedule must have been restored (primary event re-scheduled)
+    verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
+}
+
+@Test
+fun `updateAlarm returns clear failure when restore also fails`() = runTest {
+    val now = System.currentTimeMillis()
+    val existingId = "alarm-restore-fail"
+    val existingEntity = ScheduledAlarmEntity(
+        id = existingId,
+        ownerId = existingId,
+        triggerAtMillis = now + 86_400_000L,
+        label = "Original",
+        createdAt = now - 86_400_000L,
+        enabled = true,
+        entryType = ClockEventType.ALARM.name,
+        alarmHour = 7,
+        alarmMinute = 0,
+    )
+    coEvery { scheduledAlarmDao.getById(existingId) } returns existingEntity
+
+    // Replacement primary fails on exact alarm blocker
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId == existingId })
+    } returns SchedulingResult.ExactAlarmBlocked
+    // Restore also fails
+    every {
+        scheduler.schedule(match { it.type == ClockEventType.ALARM && it.ownerId != existingId })
+    } returns SchedulingResult.ExactAlarmBlocked
+
+    val draft = oneOffDraft(label = "Updated", hour = 8, minute = 0)
+
+    val result = repository.updateAlarm(existingId, draft)
+
+    assertTrue(result is SchedulingResult.SchedulingFailed)
+    assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
+}

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositoryImplTest.kt
@@ -14,15 +14,13 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.assertTrue
-import com.kernel.ai.core.memory.clock.SchedulingResult
-import com.kernel.ai.core.memory.clock.SchedulingWarning
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -30,7 +28,8 @@ import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-
+import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
 @ExtendWith(MockKExtension::class)
 class ClockRepositoryImplTest {
     private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
@@ -52,6 +51,7 @@ class ClockRepositoryImplTest {
             clockSoundPreferences,
             clockAlertPreferences,
         )
+        every { scheduler.schedule(any()) } returns SchedulingResult.Success(Unit)
         every {
             scheduler.getPlatformState()
         } returns ClockPlatformState(
@@ -59,7 +59,6 @@ class ClockRepositoryImplTest {
             notificationsEnabled = true,
             canUseFullScreenIntent = false,
         )
-        every { scheduler.schedule(any()) } returns SchedulingResult.Success(Unit)
         every { clockSoundPreferences.soundConfig } returns flowOf(ClockSoundConfig())
         every { clockAlertPreferences.alertConfig } returns flowOf(ClockAlertConfig())
     }
@@ -76,13 +75,13 @@ class ClockRepositoryImplTest {
             timeZoneId = zoneId,
         )
 
-        val schedulingResult = repository.createAlarm(draft)
+        val result = repository.createAlarm(draft)
+        assertTrue(result is SchedulingResult.Success)
+        val alarm = (result as SchedulingResult.Success).data
 
-        assertTrue(schedulingResult is SchedulingResult.Success)
-        val result = (schedulingResult as SchedulingResult.Success).data
-        assertEquals("Morning", result.label)
-        assertEquals(7, result.hour)
-        assertEquals(30, result.minute)
+        assertEquals("Morning", alarm.label)
+        assertEquals(7, alarm.hour)
+        assertEquals(30, alarm.minute)
         coVerify(exactly = 1) {
             scheduledAlarmDao.insert(match {
                 it.entryType == ClockEventType.ALARM.name &&
@@ -101,11 +100,11 @@ class ClockRepositoryImplTest {
         coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = dailyDraft(label = "Gym", hour = 8, minute = 0)
 
-        val schedulingResult = repository.createAlarm(draft)
+        val result = repository.createAlarm(draft)
+        assertTrue(result is SchedulingResult.Success)
+        val alarm = (result as SchedulingResult.Success).data
 
-        assertTrue(schedulingResult is SchedulingResult.Success)
-        val result = (schedulingResult as SchedulingResult.Success).data
-        assertEquals(AlarmRepeatRule.Daily, result.repeatRule)
+        assertEquals(AlarmRepeatRule.Daily, alarm.repeatRule)
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM }) }
         verify(exactly = 1) { scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM }) }
     }
@@ -116,11 +115,11 @@ class ClockRepositoryImplTest {
         val draft = dailyDraft(label = "Gym", hour = 8, minute = 0)
             .copy(soundUri = "content://media/internal/audio/media/7")
 
-        val schedulingResult = repository.createAlarm(draft)
+        val result = repository.createAlarm(draft)
+        assertTrue(result is SchedulingResult.Success)
+        val alarm = (result as SchedulingResult.Success).data
 
-        assertTrue(schedulingResult is SchedulingResult.Success)
-        val result = (schedulingResult as SchedulingResult.Success).data
-        assertEquals("content://media/internal/audio/media/7", result.soundUri)
+        assertEquals("content://media/internal/audio/media/7", alarm.soundUri)
         coVerify(exactly = 1) {
             scheduledAlarmDao.insert(match { it.soundUri == "content://media/internal/audio/media/7" })
         }
@@ -600,3 +599,5 @@ class ClockRepositoryImplTest {
         timeZoneId = ZoneId.systemDefault().id,
     )
 }
+
+private fun weekdayMaskFor(day: DayOfWeek): Int = 1 shl (day.value - 1)

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -23,7 +23,7 @@ import java.time.ZoneId
 @ExtendWith(MockKExtension::class)
 class ClockRepositorySchedulingTest {
     private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
-    private val scheduler = mockk<ClockScheduler>()
+    private val scheduler = mockk<ClockScheduler>(relaxed = true)
     private val stopwatchDao = mockk<StopwatchDao>()
     private val worldClockDao = mockk<WorldClockDao>()
     private val clockSoundPreferences = mockk<ClockSoundPreferences>()
@@ -52,38 +52,10 @@ class ClockRepositorySchedulingTest {
     // ── Full event-set rollback ────────────────────────────────────────
 
     @Test
-    fun `createAlarm rolls back primary if snooze scheduling fails`() = runTest {
-        every {
-            scheduler.schedule(match { it.type == ClockEventType.ALARM && it.autoSnoozeCount == 0 })
-        } returns SchedulingResult.Success(Unit)
-        every {
-            scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
-        } returns SchedulingResult.Success(Unit)
-        every {
-            scheduler.schedule(match { it.type == ClockEventType.ALARM && it.autoSnoozeCount > 0 })
-        } returns SchedulingResult.SchedulingFailed("snooze unavailable")
-
-        coEvery { scheduledAlarmDao.insert(any()) } just Runs
-        val draft = AlarmDraft(
-            label = "Rollback",
-            hour = 7,
-            minute = 0,
-            repeatRule = AlarmRepeatRule.OneOff(java.time.LocalDate.now(ZoneId.systemDefault()).plusDays(1).toEpochDay()),
-            timeZoneId = ZoneId.systemDefault().id,
-        )
-
-        val result = repository.createAlarm(draft)
-
-        assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
-        coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Rollback" }) }
-    }
-
-    @Test
-    fun `createAlarm rolls back primary if pre alarm scheduling fails`() = runTest {
-        every {
-            scheduler.schedule(match { it.type != ClockEventType.PRE_ALARM })
-        } returns SchedulingResult.Success(Unit)
+    fun `pre alarm failure cancels primary and skips DB insert`() = runTest {
+        // Default: all scheduling succeeds
+        every { scheduler.schedule(any()) } returns SchedulingResult.Success(Unit)
+        // Pre-alarm scheduling fails
         every {
             scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
         } returns SchedulingResult.SchedulingFailed("pre-alarm unavailable")
@@ -100,14 +72,16 @@ class ClockRepositorySchedulingTest {
         val result = repository.createAlarm(draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.PRE_ALARM }) }
+        verify(atLeast = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM }) }
+        verify(atLeast = 1) { scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM }) }
+        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
         coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "RollbackPre" }) }
     }
 
     // ── Update replacement failure and restore ─────────────────────────
 
     @Test
-    fun `updateAlarm restores old schedule when replacement scheduling fails`() = runTest {
+    fun `update restores old schedule when replacement fails`() = runTest {
         val now = System.currentTimeMillis()
         val existingId = "alarm-existing"
         coEvery { scheduledAlarmDao.getById(existingId) } returns ScheduledAlarmEntity(
@@ -122,10 +96,14 @@ class ClockRepositorySchedulingTest {
             alarmMinute = 0,
         )
 
-        every {
-            scheduler.schedule(any())
-        } returns SchedulingResult.Success(Unit) andThen SchedulingResult.SchedulingFailed("snooze unavailable")
+        // First schedule (replacement) fails; subsequent calls (restore) succeed
+        every { scheduler.schedule(any()) } returns
+            SchedulingResult.SchedulingFailed("replacement failed") andThen
+            SchedulingResult.Success(Unit) andThen
+            SchedulingResult.Success(Unit) andThen
+            SchedulingResult.Success(Unit)
 
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = AlarmDraft(
             label = "Updated",
             hour = 8,
@@ -137,10 +115,14 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
+        // Existing alarm events were cancelled
+        verify(atLeast = 1) { scheduler.cancel(any()) }
+        // Replacement schedule was attempted and failed
+        // Restore was attempted and succeeded
     }
 
     @Test
-    fun `updateAlarm returns clear failure when restore also fails`() = runTest {
+    fun `update returns clear failure when restore also fails`() = runTest {
         val now = System.currentTimeMillis()
         val existingId = "alarm-restore-fail"
         coEvery { scheduledAlarmDao.getById(existingId) } returns ScheduledAlarmEntity(
@@ -155,8 +137,10 @@ class ClockRepositorySchedulingTest {
             alarmMinute = 0,
         )
 
+        // All schedule attempts fail (exact alarm blocked)
         every { scheduler.schedule(any()) } returns SchedulingResult.ExactAlarmBlocked
 
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = AlarmDraft(
             label = "Updated",
             hour = 8,
@@ -168,6 +152,8 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
+        // Replacement scheduling was attempted via scheduleAlarmEvents
+        // Restore was also attempted (second invocation of scheduleAlarmEvents)
         assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
     }
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,12 +54,15 @@ class ClockRepositorySchedulingTest {
 
     @Test
     fun `pre alarm failure cancels primary and skips DB insert`() = runTest {
-        // Default: all scheduling succeeds
-        every { scheduler.schedule(any()) } returns SchedulingResult.Success(Unit)
-        // Pre-alarm scheduling fails
-        every {
-            scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
-        } returns SchedulingResult.SchedulingFailed("pre-alarm unavailable")
+        val scheduledEvents = mutableListOf<ClockScheduledEvent>()
+        every { scheduler.schedule(any()) } answers {
+            scheduledEvents += args[0] as ClockScheduledEvent
+            if (scheduledEvents.size == 1) {
+                SchedulingResult.Success(Unit)
+            } else {
+                SchedulingResult.SchedulingFailed("pre-alarm unavailable")
+            }
+        }
 
         coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = AlarmDraft(
@@ -72,10 +76,12 @@ class ClockRepositorySchedulingTest {
         val result = repository.createAlarm(draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 1) { scheduler.schedule(match { it.type == ClockEventType.ALARM }) }
-        verify(atLeast = 1) { scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM }) }
-        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
-        coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "RollbackPre" }) }
+        assertEquals(
+            listOf(ClockEventType.ALARM, ClockEventType.PRE_ALARM),
+            scheduledEvents.map { it.type },
+        )
+        verify(exactly = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(any()) }
     }
 
     // ── Update replacement failure and restore ─────────────────────────
@@ -96,12 +102,15 @@ class ClockRepositorySchedulingTest {
             alarmMinute = 0,
         )
 
-        // First schedule (replacement) fails; subsequent calls (restore) succeed
-        every { scheduler.schedule(any()) } returns
-            SchedulingResult.SchedulingFailed("replacement failed") andThen
-            SchedulingResult.Success(Unit) andThen
-            SchedulingResult.Success(Unit) andThen
-            SchedulingResult.Success(Unit)
+        val scheduledEvents = mutableListOf<ClockScheduledEvent>()
+        every { scheduler.schedule(any()) } answers {
+            scheduledEvents += args[0] as ClockScheduledEvent
+            if (scheduledEvents.size == 1) {
+                SchedulingResult.SchedulingFailed("replacement failed")
+            } else {
+                SchedulingResult.Success(Unit)
+            }
+        }
 
         coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = AlarmDraft(
@@ -115,8 +124,9 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 1) { scheduler.cancel(any()) }
-        verify(atLeast = 1) { scheduler.schedule(any()) }
+        verify(atLeast = 1) { scheduler.cancel(match { it.label == "Old" }) }
+        assertEquals(listOf("Updated", "Old"), scheduledEvents.map { it.label })
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(any()) }
     }
 
     @Test
@@ -135,8 +145,11 @@ class ClockRepositorySchedulingTest {
             alarmMinute = 0,
         )
 
-        // All schedule attempts fail (exact alarm blocked)
-        every { scheduler.schedule(any()) } returns SchedulingResult.ExactAlarmBlocked
+        val scheduledEvents = mutableListOf<ClockScheduledEvent>()
+        every { scheduler.schedule(any()) } answers {
+            scheduledEvents += args[0] as ClockScheduledEvent
+            SchedulingResult.ExactAlarmBlocked
+        }
 
         coEvery { scheduledAlarmDao.insert(any()) } just Runs
         val draft = AlarmDraft(
@@ -150,7 +163,9 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 2) { scheduler.schedule(any()) }
+        verify(atLeast = 1) { scheduler.cancel(match { it.label == "Original" }) }
+        assertEquals(listOf("Updated", "Original"), scheduledEvents.map { it.label })
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(any()) }
         assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
     }
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -1,0 +1,173 @@
+package com.kernel.ai.core.memory.clock
+
+import com.kernel.ai.core.memory.dao.ScheduledAlarmDao
+import com.kernel.ai.core.memory.dao.StopwatchDao
+import com.kernel.ai.core.memory.dao.WorldClockDao
+import com.kernel.ai.core.memory.entity.ScheduledAlarmEntity
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.ZoneId
+
+@ExtendWith(MockKExtension::class)
+class ClockRepositorySchedulingTest {
+    private val scheduledAlarmDao = mockk<ScheduledAlarmDao>()
+    private val scheduler = mockk<ClockScheduler>()
+    private val stopwatchDao = mockk<StopwatchDao>()
+    private val worldClockDao = mockk<WorldClockDao>()
+    private val clockSoundPreferences = mockk<ClockSoundPreferences>()
+    private val clockAlertPreferences = mockk<ClockAlertPreferences>()
+    private lateinit var repository: ClockRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        repository = ClockRepositoryImpl(
+            scheduledAlarmDao,
+            worldClockDao,
+            stopwatchDao,
+            scheduler,
+            clockSoundPreferences,
+            clockAlertPreferences,
+        )
+        every { scheduler.getPlatformState() } returns ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+        every { clockSoundPreferences.soundConfig } returns flowOf(ClockSoundConfig())
+        every { clockAlertPreferences.alertConfig } returns flowOf(ClockAlertConfig())
+    }
+
+    // ── Full event-set rollback ────────────────────────────────────────
+
+    @Test
+    fun `createAlarm rolls back primary if snooze scheduling fails`() = runTest {
+        every {
+            scheduler.schedule(match { it.type == ClockEventType.ALARM && it.autoSnoozeCount == 0 })
+        } returns SchedulingResult.Success(Unit)
+        every {
+            scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
+        } returns SchedulingResult.Success(Unit)
+        every {
+            scheduler.schedule(match { it.type == ClockEventType.ALARM && it.autoSnoozeCount > 0 })
+        } returns SchedulingResult.SchedulingFailed("snooze unavailable")
+
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+        val draft = AlarmDraft(
+            label = "Rollback",
+            hour = 7,
+            minute = 0,
+            repeatRule = AlarmRepeatRule.OneOff(java.time.LocalDate.now(ZoneId.systemDefault()).plusDays(1).toEpochDay()),
+            timeZoneId = ZoneId.systemDefault().id,
+        )
+
+        val result = repository.createAlarm(draft)
+
+        assertTrue(result is SchedulingResult.SchedulingFailed)
+        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.ALARM }) }
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Rollback" }) }
+    }
+
+    @Test
+    fun `createAlarm rolls back primary if pre alarm scheduling fails`() = runTest {
+        every {
+            scheduler.schedule(match { it.type != ClockEventType.PRE_ALARM })
+        } returns SchedulingResult.Success(Unit)
+        every {
+            scheduler.schedule(match { it.type == ClockEventType.PRE_ALARM })
+        } returns SchedulingResult.SchedulingFailed("pre-alarm unavailable")
+
+        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+        val draft = AlarmDraft(
+            label = "RollbackPre",
+            hour = 8,
+            minute = 0,
+            repeatRule = AlarmRepeatRule.Daily,
+            timeZoneId = ZoneId.systemDefault().id,
+        )
+
+        val result = repository.createAlarm(draft)
+
+        assertTrue(result is SchedulingResult.SchedulingFailed)
+        verify(atLeast = 1) { scheduler.cancel(match { it.type == ClockEventType.PRE_ALARM }) }
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "RollbackPre" }) }
+    }
+
+    // ── Update replacement failure and restore ─────────────────────────
+
+    @Test
+    fun `updateAlarm restores old schedule when replacement scheduling fails`() = runTest {
+        val now = System.currentTimeMillis()
+        val existingId = "alarm-existing"
+        coEvery { scheduledAlarmDao.getById(existingId) } returns ScheduledAlarmEntity(
+            id = existingId,
+            ownerId = existingId,
+            triggerAtMillis = now + 86_400_000L,
+            label = "Old",
+            createdAt = now - 86_400_000L,
+            enabled = true,
+            entryType = ClockEventType.ALARM.name,
+            alarmHour = 7,
+            alarmMinute = 0,
+        )
+
+        every {
+            scheduler.schedule(any())
+        } returns SchedulingResult.Success(Unit) andThen SchedulingResult.SchedulingFailed("snooze unavailable")
+
+        val draft = AlarmDraft(
+            label = "Updated",
+            hour = 8,
+            minute = 0,
+            repeatRule = AlarmRepeatRule.OneOff(java.time.LocalDate.now(ZoneId.systemDefault()).plusDays(1).toEpochDay()),
+            timeZoneId = ZoneId.systemDefault().id,
+        )
+
+        val result = repository.updateAlarm(existingId, draft)
+
+        assertTrue(result is SchedulingResult.SchedulingFailed)
+    }
+
+    @Test
+    fun `updateAlarm returns clear failure when restore also fails`() = runTest {
+        val now = System.currentTimeMillis()
+        val existingId = "alarm-restore-fail"
+        coEvery { scheduledAlarmDao.getById(existingId) } returns ScheduledAlarmEntity(
+            id = existingId,
+            ownerId = existingId,
+            triggerAtMillis = now + 86_400_000L,
+            label = "Original",
+            createdAt = now - 86_400_000L,
+            enabled = true,
+            entryType = ClockEventType.ALARM.name,
+            alarmHour = 7,
+            alarmMinute = 0,
+        )
+
+        every { scheduler.schedule(any()) } returns SchedulingResult.ExactAlarmBlocked
+
+        val draft = AlarmDraft(
+            label = "Updated",
+            hour = 8,
+            minute = 0,
+            repeatRule = AlarmRepeatRule.OneOff(java.time.LocalDate.now(ZoneId.systemDefault()).plusDays(1).toEpochDay()),
+            timeZoneId = ZoneId.systemDefault().id,
+        )
+
+        val result = repository.updateAlarm(existingId, draft)
+
+        assertTrue(result is SchedulingResult.SchedulingFailed)
+        assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
+    }
+}

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -115,10 +115,8 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        // Existing alarm events were cancelled
         verify(atLeast = 1) { scheduler.cancel(any()) }
-        // Replacement schedule was attempted and failed
-        // Restore was attempted and succeeded
+        verify(atLeast = 1) { scheduler.schedule(any()) }
     }
 
     @Test
@@ -152,8 +150,7 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        // Replacement scheduling was attempted via scheduleAlarmEvents
-        // Restore was also attempted (second invocation of scheduleAlarmEvents)
+        verify(atLeast = 2) { scheduler.schedule(any()) }
         assertTrue((result as SchedulingResult.SchedulingFailed).message?.contains("Manual intervention") == true)
     }
 }

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -12,6 +12,7 @@ import io.mockk.just
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifySequence
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -105,14 +106,15 @@ class ClockRepositorySchedulingTest {
         val scheduledEvents = mutableListOf<ClockScheduledEvent>()
         every { scheduler.schedule(any()) } answers {
             scheduledEvents += args[0] as ClockScheduledEvent
-            if (scheduledEvents.size == 1) {
-                SchedulingResult.SchedulingFailed("replacement failed")
-            } else {
-                SchedulingResult.Success(Unit)
+            when (scheduledEvents.size) {
+                1 -> SchedulingResult.SchedulingFailed("replacement failed")
+                2, 3, 4, 5, 6 -> SchedulingResult.Success(Unit)
+                else -> error("unexpected extra schedule call")
             }
         }
 
-        coEvery { scheduledAlarmDao.insert(any()) } just Runs
+        val oldTrigger = now + 86_400_000L
+        coEvery { scheduledAlarmDao.insert(match { it.label == "Updated" }) } just Runs
         val draft = AlarmDraft(
             label = "Updated",
             hour = 8,
@@ -124,9 +126,15 @@ class ClockRepositorySchedulingTest {
         val result = repository.updateAlarm(existingId, draft)
 
         assertTrue(result is SchedulingResult.SchedulingFailed)
-        verify(atLeast = 1) { scheduler.cancel(match { it.label == "Old" }) }
+        result as SchedulingResult.SchedulingFailed
+        assertEquals("replacement failed", result.message)
+        assertEquals(2, scheduledEvents.size)
         assertEquals(listOf("Updated", "Old"), scheduledEvents.map { it.label })
-        coVerify(exactly = 0) { scheduledAlarmDao.insert(any()) }
+        assertEquals(listOf(ClockEventType.ALARM, ClockEventType.ALARM), scheduledEvents.map { it.type })
+        assertTrue(scheduledEvents[0].occurrenceTriggerAtMillis != oldTrigger)
+        assertEquals(oldTrigger, scheduledEvents[1].occurrenceTriggerAtMillis)
+        verify(atLeast = 1) { scheduler.cancel(match { it.eventId == existingId && it.type == ClockEventType.ALARM && it.label == "Old" }) }
+        coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Updated" }) }
     }
 
     @Test

--- a/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
+++ b/core/memory/src/test/java/com/kernel/ai/core/memory/clock/ClockRepositorySchedulingTest.kt
@@ -108,9 +108,14 @@ class ClockRepositorySchedulingTest {
             scheduledEvents += args[0] as ClockScheduledEvent
             when (scheduledEvents.size) {
                 1 -> SchedulingResult.SchedulingFailed("replacement failed")
-                2, 3, 4, 5, 6 -> SchedulingResult.Success(Unit)
+                2 -> SchedulingResult.Success(Unit)
                 else -> error("unexpected extra schedule call")
             }
+        }
+
+        val cancelEvents = mutableListOf<ClockScheduledEvent>()
+        every { scheduler.cancel(any()) } answers {
+            cancelEvents += args[0] as ClockScheduledEvent
         }
 
         val oldTrigger = now + 86_400_000L
@@ -133,7 +138,7 @@ class ClockRepositorySchedulingTest {
         assertEquals(listOf(ClockEventType.ALARM, ClockEventType.ALARM), scheduledEvents.map { it.type })
         assertTrue(scheduledEvents[0].occurrenceTriggerAtMillis != oldTrigger)
         assertEquals(oldTrigger, scheduledEvents[1].occurrenceTriggerAtMillis)
-        verify(atLeast = 1) { scheduler.cancel(match { it.eventId == existingId && it.type == ClockEventType.ALARM && it.label == "Old" }) }
+        assertTrue(cancelEvents.any { it.eventId == existingId && it.type == ClockEventType.ALARM && it.label == "Old" })
         coVerify(exactly = 0) { scheduledAlarmDao.insert(match { it.label == "Updated" }) }
     }
 

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -27,6 +27,8 @@ import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.WorldClockCatalog
 import com.kernel.ai.core.memory.clock.WorldClockResolution
+import com.kernel.ai.core.memory.clock.ClockTimer
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -434,49 +436,66 @@ class NativeIntentHandler @Inject constructor(
             timeZoneId = zone.id,
         )
 
-        val scheduled = runBlocking {
+        val result = runBlocking {
             clockRepository.createAlarm(draft)
         }
-        if (scheduled != null) {
-            val formatter = DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
-                .withZone(ZoneId.systemDefault())
-            val formattedTime = formatter.format(Instant.ofEpochMilli(scheduled.triggerAtMillis))
-            return SkillResult.Success(
-                "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
-            )
-        }
-        if (!clockRepository.getPlatformState().canScheduleExactAlarms) {
-            return SkillResult.Failure(
-                "run_intent",
-                "Exact alarms are unavailable right now.",
-            )
-        }
 
-        return SkillResult.Failure("run_intent", "Could not schedule the alarm.")
+        return when (result) {
+            is SchedulingResult.Success -> {
+                val scheduled = result.data
+                val formatter = DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
+                    .withZone(ZoneId.systemDefault())
+                val formattedTime = formatter.format(Instant.ofEpochMilli(scheduled.triggerAtMillis))
+                SkillResult.Success(
+                    "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
+                )
+            }
+            is SchedulingResult.ExactAlarmBlocked ->
+                SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission in system settings.")
+            is SchedulingResult.NotificationBlocked ->
+                SkillResult.Failure("run_intent", "Notifications are disabled. Jandal needs notification access to alert you. You can enable it in Settings.")
+            is SchedulingResult.FullScreenIntentUnavailable ->
+                SkillResult.Failure("run_intent", "Full-screen alerts are unavailable for this alarm. The alarm was registered but may use a less prominent alert.")
+            is SchedulingResult.BootRestoreLimited ->
+                SkillResult.Failure("run_intent", "Alarm scheduled, but boot restore is limited — the alarm may not persist across device restarts.")
+            is SchedulingResult.SchedulingFailed ->
+                SkillResult.Failure("run_intent", result.message ?: "Could not schedule the alarm.")
+        }
     }
-
-    // ── Timer ─────────────────────────────────────────────────────────────────
 
     private fun setTimer(params: Map<String, String>): SkillResult {
         val seconds = params["duration_seconds"]?.toIntOrNull()
             ?: return SkillResult.Failure("run_intent", "duration_seconds is required and must be an integer.")
         val durationMs = seconds * 1000L
         val label = params["label"]?.takeIf { it.isNotBlank() }
-        val scheduled = runBlocking {
+
+        val result = runBlocking {
             clockRepository.scheduleTimer(durationMs, label)
-        } ?: return if (!clockRepository.getPlatformState().canScheduleExactAlarms) {
-            SkillResult.Failure("run_intent", "Exact alarms are unavailable right now.")
-        } else {
-            SkillResult.Failure("run_intent", "Could not schedule the timer.")
         }
-        val mins = (scheduled.durationMs / 1000) / 60
-        val secs = (scheduled.durationMs / 1000) % 60
-        val labelStr = when {
-            mins > 0 && secs > 0 -> "$mins min $secs sec"
-            mins > 0 -> "$mins minute${if (mins != 1L) "s" else ""}"
-            else -> "${scheduled.durationMs / 1000} seconds"
+
+        return when (result) {
+            is SchedulingResult.Success -> {
+                val scheduled = result.data
+                val mins = (scheduled.durationMs / 1000) / 60
+                val secs = (scheduled.durationMs / 1000) % 60
+                val labelStr = when {
+                    mins > 0 && secs > 0 -> "$mins min $secs min"
+                    mins > 0 -> "$mins minute${if (mins != 1L) "s" else ""}"
+                    else -> "${scheduled.durationMs / 1000} seconds"
+                }
+                SkillResult.Success("Timer set for $labelStr.")
+            }
+            is SchedulingResult.ExactAlarmBlocked ->
+                SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission.")
+            is SchedulingResult.NotificationBlocked ->
+                SkillResult.Failure("run_intent", "Notifications are disabled. Jandal needs notification access to alert you.")
+            is SchedulingResult.FullScreenIntentUnavailable ->
+                SkillResult.Failure("run_intent", "Full-screen timer alerts are unavailable.")
+            is SchedulingResult.BootRestoreLimited ->
+                SkillResult.Failure("run_intent", "Timer set, but boot restore is limited.")
+            is SchedulingResult.SchedulingFailed ->
+                SkillResult.Failure("run_intent", result.message ?: "Could not schedule the timer.")
         }
-        return SkillResult.Success("Timer set for $labelStr.")
     }
 
     private fun cancelTimer(): SkillResult {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -29,6 +29,7 @@ import com.kernel.ai.core.memory.clock.WorldClockCatalog
 import com.kernel.ai.core.memory.clock.WorldClockResolution
 import com.kernel.ai.core.memory.clock.ClockTimer
 import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
 import com.kernel.ai.core.memory.clock.ClockRepository
 import com.kernel.ai.core.memory.dao.ListItemDao
 import com.kernel.ai.core.memory.dao.ListNameDao
@@ -446,18 +447,24 @@ class NativeIntentHandler @Inject constructor(
                 val formatter = DateTimeFormatter.ofPattern("EEE d MMM 'at' h:mma")
                     .withZone(ZoneId.systemDefault())
                 val formattedTime = formatter.format(Instant.ofEpochMilli(scheduled.triggerAtMillis))
-                SkillResult.Success(
-                    "Alarm set for $formattedTime${if (label != null) " — $label" else ""}"
-                )
+                val warningText = result.warnings.joinToString(" ") { warning ->
+                    when (warning) {
+                        SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            "Full-screen alerts are unavailable for this alarm."
+                        SchedulingWarning.BOOT_RESTORE_LIMITED ->
+                            "The alarm may not persist across device restarts."
+                    }
+                }
+                val message = buildString {
+                    append("Alarm set for $formattedTime${if (label != null) " — $label" else ""}.")
+                    if (warningText.isNotEmpty()) append(" $warningText")
+                }
+                SkillResult.Success(message)
             }
             is SchedulingResult.ExactAlarmBlocked ->
                 SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission in system settings.")
             is SchedulingResult.NotificationBlocked ->
                 SkillResult.Failure("run_intent", "Notifications are disabled. Jandal needs notification access to alert you. You can enable it in Settings.")
-            is SchedulingResult.FullScreenIntentUnavailable ->
-                SkillResult.Failure("run_intent", "Full-screen alerts are unavailable for this alarm. The alarm was registered but may use a less prominent alert.")
-            is SchedulingResult.BootRestoreLimited ->
-                SkillResult.Failure("run_intent", "Alarm scheduled, but boot restore is limited — the alarm may not persist across device restarts.")
             is SchedulingResult.SchedulingFailed ->
                 SkillResult.Failure("run_intent", result.message ?: "Could not schedule the alarm.")
         }
@@ -478,21 +485,29 @@ class NativeIntentHandler @Inject constructor(
                 val scheduled = result.data
                 val mins = (scheduled.durationMs / 1000) / 60
                 val secs = (scheduled.durationMs / 1000) % 60
-                val labelStr = when {
-                    mins > 0 && secs > 0 -> "$mins min $secs min"
+                val durationStr = when {
+                    mins > 0 && secs > 0 -> "$mins min $secs sec"
                     mins > 0 -> "$mins minute${if (mins != 1L) "s" else ""}"
                     else -> "${scheduled.durationMs / 1000} seconds"
                 }
-                SkillResult.Success("Timer set for $labelStr.")
+                val warningText = result.warnings.joinToString(" ") { warning ->
+                    when (warning) {
+                        SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            "Full-screen alerts are unavailable for this timer."
+                        SchedulingWarning.BOOT_RESTORE_LIMITED ->
+                            "The timer may not persist across device restarts."
+                    }
+                }
+                val message = buildString {
+                    append("Timer set for $durationStr.")
+                    if (warningText.isNotEmpty()) append(" $warningText")
+                }
+                SkillResult.Success(message)
             }
             is SchedulingResult.ExactAlarmBlocked ->
                 SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission.")
             is SchedulingResult.NotificationBlocked ->
                 SkillResult.Failure("run_intent", "Notifications are disabled. Jandal needs notification access to alert you.")
-            is SchedulingResult.FullScreenIntentUnavailable ->
-                SkillResult.Failure("run_intent", "Full-screen timer alerts are unavailable.")
-            is SchedulingResult.BootRestoreLimited ->
-                SkillResult.Failure("run_intent", "Timer set, but boot restore is limited.")
             is SchedulingResult.SchedulingFailed ->
                 SkillResult.Failure("run_intent", result.message ?: "Could not schedule the timer.")
         }

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -975,6 +975,30 @@ class NativeIntentHandlerTest {
     }
 
     @Test
+    fun `set_timer mixed duration formats minutes and seconds correctly`() {
+        every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
+            canScheduleExactAlarms = true,
+            notificationsEnabled = true,
+            canUseFullScreenIntent = false,
+        )
+        coEvery { clockRepository.scheduleTimer(90_000L, "Tea") } returns SchedulingResult.Success(
+            com.kernel.ai.core.memory.clock.ClockTimer(
+                id = "timer-1",
+                triggerAtMillis = 5_000L,
+                label = "Tea",
+                createdAtMillis = 1_000L,
+                durationMs = 90_000L,
+                startedAtMillis = 2_000L,
+            )
+        )
+
+        val result = handleIntent("set_timer", mapOf("duration_seconds" to "90", "label" to "Tea"))
+
+        assertTrue(result is SkillResult.Success)
+        assertEquals("Timer set for 1 min 30 sec.", (result as SkillResult.Success).content)
+    }
+
+    @Test
     fun `cancel_timer dismisses active timer alert when no running timers remain`() {
         coEvery { clockRepository.cancelAllTimers() } returns 0
         every { clockAlertController.dismissActiveTimerAlerts() } returns true

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -17,6 +17,7 @@ import com.kernel.ai.core.memory.ContactAliasRepository
 import com.kernel.ai.core.memory.ImportantDateRepository
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.StopwatchLap
 import com.kernel.ai.core.memory.clock.StopwatchStatus
@@ -828,7 +829,7 @@ class NativeIntentHandlerTest {
 
     @Test
     fun `set_alarm without explicit date uses internal clock repository`() {
-        coEvery { clockRepository.createAlarm(any()) } returns ClockAlarm(
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.Success(ClockAlarm(
             id = "alarm-1",
             label = "Wake",
             createdAtMillis = 1_699_000_000_000L,
@@ -838,7 +839,7 @@ class NativeIntentHandlerTest {
             repeatRule = com.kernel.ai.core.memory.clock.AlarmRepeatRule.OneOff(19_000L),
             timeZoneId = java.time.ZoneId.systemDefault().id,
             triggerAtMillis = 1_700_000_000_000L,
-        )
+        ))
 
         val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
 
@@ -850,7 +851,7 @@ class NativeIntentHandlerTest {
 
     @Test
     fun `set_alarm returns exact alarm unavailable failure when platform scheduling is off`() {
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.ExactAlarmBlocked
         every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
             canScheduleExactAlarms = false,
             notificationsEnabled = true,
@@ -859,13 +860,13 @@ class NativeIntentHandlerTest {
 
         val result = handleIntent("set_alarm", mapOf("time" to "07:00", "label" to "Wake"))
 
-        assertEquals(SkillResult.Failure("run_intent", "Exact alarms are unavailable right now."), result)
+        assertEquals(SkillResult.Failure("run_intent", "Exact alarm scheduling is unavailable right now. Please grant exact alarm permission in system settings."), result)
         verify(exactly = 0) { context.startActivity(any()) }
     }
 
     @Test
     fun `set_alarm returns failure when repository rejects alarm despite exact alarm availability`() {
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.SchedulingFailed()
         every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
             canScheduleExactAlarms = true,
             notificationsEnabled = true,
@@ -960,7 +961,7 @@ class NativeIntentHandlerTest {
 
     @Test
     fun `set_timer returns generic failure when repository rejects despite exact alarm availability`() {
-        coEvery { clockRepository.scheduleTimer(any(), any()) } returns null
+        coEvery { clockRepository.scheduleTimer(any(), any()) } returns SchedulingResult.SchedulingFailed()
         every { clockRepository.getPlatformState() } returns com.kernel.ai.core.memory.clock.ClockPlatformState(
             canScheduleExactAlarms = true,
             notificationsEnabled = true,

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -1,16 +1,16 @@
 package com.kernel.ai.feature.settings
 
 import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
 
 /**
  * Result of saving an alarm from the UI layer.
  * [STORED] is the success case; all other values indicate a specific blocker.
- * Warnings (full-screen, boot-restore) are embedded in [SchedulingResult.Success.warnings]
- * and the event is genuinely saved — they are not separate [AlarmSaveResult] variants.
+ * [warnings] carries non-blocking platform limitations (e.g. full-screen unavailable).
  */
 sealed class AlarmSaveResult {
-    /** Alarm was successfully stored and scheduled. */
-    data object STORED : AlarmSaveResult()
+    /** Alarm was successfully stored and scheduled. [warnings] lists any degraded-delivery conditions. */
+    data class STORED(val warnings: List<SchedulingWarning> = emptyList()) : AlarmSaveResult()
 
     /** Exact alarm scheduling is blocked on this device. */
     data object EXACT_ALARM_BLOCKED : AlarmSaveResult()
@@ -24,8 +24,21 @@ sealed class AlarmSaveResult {
 
 /** Convert a [SchedulingResult] from the repository layer into an [AlarmSaveResult]. */
 internal fun SchedulingResult<*>.toAlarmSaveResult(): AlarmSaveResult = when (this) {
-    is SchedulingResult.Success -> AlarmSaveResult.STORED
+    is SchedulingResult.Success -> AlarmSaveResult.STORED(warnings = this.warnings)
     is SchedulingResult.ExactAlarmBlocked -> AlarmSaveResult.EXACT_ALARM_BLOCKED
     is SchedulingResult.NotificationBlocked -> AlarmSaveResult.NOTIFICATION_BLOCKED
     is SchedulingResult.SchedulingFailed -> AlarmSaveResult.FAILED(this.message)
+}
+
+/** Build a user-facing warning message from scheduling warnings, or null if there are none. */
+internal fun List<SchedulingWarning>.toWarningMessage(): String? {
+    if (isEmpty()) return null
+    return joinToString(" ") { warning ->
+        when (warning) {
+            SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                "Full-screen alerts are unavailable."
+            SchedulingWarning.BOOT_RESTORE_LIMITED ->
+                "Scheduled events may not persist across device restarts."
+        }
+    }
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -5,6 +5,8 @@ import com.kernel.ai.core.memory.clock.SchedulingResult
 /**
  * Result of saving an alarm from the UI layer.
  * [STORED] is the success case; all other values indicate a specific blocker.
+ * Warnings (full-screen, boot-restore) are embedded in [SchedulingResult.Success.warnings]
+ * and the event is genuinely saved — they are not separate [AlarmSaveResult] variants.
  */
 sealed class AlarmSaveResult {
     /** Alarm was successfully stored and scheduled. */
@@ -16,12 +18,6 @@ sealed class AlarmSaveResult {
     /** Notifications are disabled, so the alarm alert cannot be shown. */
     data object NOTIFICATION_BLOCKED : AlarmSaveResult()
 
-    /** Full-screen intent (for alarm alerts) is unavailable. */
-    data object FULL_SCREEN_INTENT_UNAVAILABLE : AlarmSaveResult()
-
-    /** Boot-restore of scheduled events is limited. */
-    data object BOOT_RESTORE_LIMITED : AlarmSaveResult()
-
     /** An internal scheduling error occurred. */
     data class FAILED(val message: String? = null) : AlarmSaveResult()
 }
@@ -31,7 +27,5 @@ internal fun SchedulingResult<*>.toAlarmSaveResult(): AlarmSaveResult = when (th
     is SchedulingResult.Success -> AlarmSaveResult.STORED
     is SchedulingResult.ExactAlarmBlocked -> AlarmSaveResult.EXACT_ALARM_BLOCKED
     is SchedulingResult.NotificationBlocked -> AlarmSaveResult.NOTIFICATION_BLOCKED
-    is SchedulingResult.FullScreenIntentUnavailable -> AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE
-    is SchedulingResult.BootRestoreLimited -> AlarmSaveResult.BOOT_RESTORE_LIMITED
     is SchedulingResult.SchedulingFailed -> AlarmSaveResult.FAILED(this.message)
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -31,14 +31,22 @@ internal fun SchedulingResult<*>.toAlarmSaveResult(): AlarmSaveResult = when (th
 }
 
 /** Build a user-facing warning message from scheduling warnings, or null if there are none. */
-internal fun List<SchedulingWarning>.toWarningMessage(): String? {
+internal fun List<SchedulingWarning>.toWarningMessage(isTimer: Boolean): String? {
     if (isEmpty()) return null
-    return joinToString(" ") { warning ->
-        when (warning) {
-            SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                "Full-screen alerts are unavailable."
-            SchedulingWarning.BOOT_RESTORE_LIMITED ->
-                "Scheduled events may not persist across device restarts."
-        }
+    val messages = mutableListOf<String>()
+    
+    val savedPrefix = if (isTimer) "Timer set." else "Alarm saved."
+    
+    if (contains(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)) {
+        messages.add("$savedPrefix It may appear as a notification instead of opening full-screen.")
     }
+    
+    if (contains(SchedulingWarning.BOOT_RESTORE_LIMITED)) {
+        if (!contains(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)) {
+            messages.add(savedPrefix)
+        }
+        messages.add("Scheduled events may need to be recreated after a device restart.")
+    }
+    
+    return messages.joinToString(" ")
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AlarmSaveResult.kt
@@ -1,6 +1,37 @@
 package com.kernel.ai.feature.settings
 
-enum class AlarmSaveResult {
-    STORED,
-    FAILED,
+import com.kernel.ai.core.memory.clock.SchedulingResult
+
+/**
+ * Result of saving an alarm from the UI layer.
+ * [STORED] is the success case; all other values indicate a specific blocker.
+ */
+sealed class AlarmSaveResult {
+    /** Alarm was successfully stored and scheduled. */
+    data object STORED : AlarmSaveResult()
+
+    /** Exact alarm scheduling is blocked on this device. */
+    data object EXACT_ALARM_BLOCKED : AlarmSaveResult()
+
+    /** Notifications are disabled, so the alarm alert cannot be shown. */
+    data object NOTIFICATION_BLOCKED : AlarmSaveResult()
+
+    /** Full-screen intent (for alarm alerts) is unavailable. */
+    data object FULL_SCREEN_INTENT_UNAVAILABLE : AlarmSaveResult()
+
+    /** Boot-restore of scheduled events is limited. */
+    data object BOOT_RESTORE_LIMITED : AlarmSaveResult()
+
+    /** An internal scheduling error occurred. */
+    data class FAILED(val message: String? = null) : AlarmSaveResult()
+}
+
+/** Convert a [SchedulingResult] from the repository layer into an [AlarmSaveResult]. */
+internal fun SchedulingResult<*>.toAlarmSaveResult(): AlarmSaveResult = when (this) {
+    is SchedulingResult.Success -> AlarmSaveResult.STORED
+    is SchedulingResult.ExactAlarmBlocked -> AlarmSaveResult.EXACT_ALARM_BLOCKED
+    is SchedulingResult.NotificationBlocked -> AlarmSaveResult.NOTIFICATION_BLOCKED
+    is SchedulingResult.FullScreenIntentUnavailable -> AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE
+    is SchedulingResult.BootRestoreLimited -> AlarmSaveResult.BOOT_RESTORE_LIMITED
+    is SchedulingResult.SchedulingFailed -> AlarmSaveResult.FAILED(this.message)
 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -179,8 +179,8 @@ fun ScheduledAlarmsScreen(
                 viewModel.scheduleAlarm(triggerAtMillis, label) { result ->
                     when (result) {
                         is AlarmSaveResult.STORED -> {
-                            schedulingError = null
                             showCreateDialog = false
+                            schedulingError = result.warnings.toWarningMessage()
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
                             schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
@@ -203,8 +203,8 @@ fun ScheduledAlarmsScreen(
                 viewModel.editAlarm(alarm, triggerAtMillis, label) { result ->
                     when (result) {
                         is AlarmSaveResult.STORED -> {
-                            schedulingError = null
                             editingAlarm = null
+                            schedulingError = result.warnings.toWarningMessage()
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
                             schedulingError = "Exact alarm scheduling is unavailable."

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.CheckBox
 import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
@@ -72,6 +73,7 @@ fun ScheduledAlarmsScreen(
     var showCreateDialog by remember { mutableStateOf(false) }
     var selectedIds by remember { mutableStateOf(emptySet<String>()) }
     var schedulingError by remember { mutableStateOf<String?>(null) }
+    var schedulingWarning by remember { mutableStateOf<String?>(null) }
     val inSelectionMode = selectedIds.isNotEmpty()
 
     Scaffold(
@@ -180,7 +182,7 @@ fun ScheduledAlarmsScreen(
                     when (result) {
                         is AlarmSaveResult.STORED -> {
                             showCreateDialog = false
-                            schedulingError = result.warnings.toWarningMessage()
+                            schedulingWarning = result.warnings.toWarningMessage(isTimer = false)
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
                             schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
@@ -204,7 +206,7 @@ fun ScheduledAlarmsScreen(
                     when (result) {
                         is AlarmSaveResult.STORED -> {
                             editingAlarm = null
-                            schedulingError = result.warnings.toWarningMessage()
+                            schedulingWarning = result.warnings.toWarningMessage(isTimer = false)
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
                             schedulingError = "Exact alarm scheduling is unavailable."
@@ -271,6 +273,16 @@ fun ScheduledAlarmsScreen(
             text = { Text(message) },
             confirmButton = {
                 TextButton(onClick = { schedulingError = null }) { Text("OK") }
+            },
+        )
+    }
+    schedulingWarning?.let { message ->
+        AlertDialog(
+            onDismissRequest = { schedulingWarning = null },
+            icon = { Icon(Icons.Default.Info, contentDescription = null) },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { schedulingWarning = null }) { Text("OK") }
             },
         )
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -178,12 +178,20 @@ fun ScheduledAlarmsScreen(
             onConfirm = { triggerAtMillis, label ->
                 viewModel.scheduleAlarm(triggerAtMillis, label) { result ->
                     when (result) {
-                        AlarmSaveResult.STORED -> {
+                        is AlarmSaveResult.STORED -> {
                             schedulingError = null
                             showCreateDialog = false
                         }
-                        AlarmSaveResult.FAILED -> {
-                            schedulingError = "Couldn't save the alarm."
+                        is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
+                            schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+                        is AlarmSaveResult.NOTIFICATION_BLOCKED ->
+                            schedulingError = "Notifications are disabled. Enable in Settings."
+                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            schedulingError = "Full-screen alerts unavailable."
+                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
+                            schedulingError = "Alarm saved, but boot restore is limited."
+                        is AlarmSaveResult.FAILED -> {
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                         }
                     }
                 }
@@ -198,12 +206,20 @@ fun ScheduledAlarmsScreen(
             onConfirm = { triggerAtMillis, label ->
                 viewModel.editAlarm(alarm, triggerAtMillis, label) { result ->
                     when (result) {
-                        AlarmSaveResult.STORED -> {
+                        is AlarmSaveResult.STORED -> {
                             schedulingError = null
                             editingAlarm = null
                         }
-                        AlarmSaveResult.FAILED -> {
-                            schedulingError = "Couldn't save the alarm."
+                        is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
+                            schedulingError = "Exact alarm scheduling is unavailable."
+                        is AlarmSaveResult.NOTIFICATION_BLOCKED ->
+                            schedulingError = "Notifications are disabled."
+                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            schedulingError = "Full-screen alerts unavailable."
+                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
+                            schedulingError = "Alarm saved, but boot restore is limited."
+                        is AlarmSaveResult.FAILED -> {
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                         }
                     }
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsScreen.kt
@@ -186,10 +186,6 @@ fun ScheduledAlarmsScreen(
                             schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
                             schedulingError = "Notifications are disabled. Enable in Settings."
-                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                            schedulingError = "Full-screen alerts unavailable."
-                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
-                            schedulingError = "Alarm saved, but boot restore is limited."
                         is AlarmSaveResult.FAILED -> {
                             schedulingError = result.message ?: "Couldn't save the alarm."
                         }
@@ -214,10 +210,6 @@ fun ScheduledAlarmsScreen(
                             schedulingError = "Exact alarm scheduling is unavailable."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
                             schedulingError = "Notifications are disabled."
-                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                            schedulingError = "Full-screen alerts unavailable."
-                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
-                            schedulingError = "Alarm saved, but boot restore is limited."
                         is AlarmSaveResult.FAILED -> {
                             schedulingError = result.message ?: "Couldn't save the alarm."
                         }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kernel.ai.core.memory.clock.AlarmDraft
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,9 +12,9 @@ import java.time.Instant
 import java.time.ZoneId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ScheduledAlarmsViewModel @Inject constructor(
@@ -24,22 +25,17 @@ class ScheduledAlarmsViewModel @Inject constructor(
         clockRepository.observeUpcomingAlarms()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): Boolean =
-        clockRepository.createAlarm(triggerAtMillis.toOneOffAlarmDraft(label)) != null
+    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): AlarmSaveResult =
+        clockRepository.createAlarm(triggerAtMillis.toOneOffAlarmDraft(label)).toAlarmSaveResult()
 
     fun scheduleAlarm(triggerAtMillis: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            val result = if (tryScheduleAlarm(triggerAtMillis, label)) {
-                AlarmSaveResult.STORED
-            } else {
-                AlarmSaveResult.FAILED
-            }
-            onResult(result)
+            onResult(tryScheduleAlarm(triggerAtMillis, label))
         }
     }
 
-    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): Boolean =
-        clockRepository.updateAlarm(alarm.id, newTriggerAtMillis.toOneOffAlarmDraft(newLabel)) != null
+    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): AlarmSaveResult =
+        clockRepository.updateAlarm(alarm.id, newTriggerAtMillis.toOneOffAlarmDraft(newLabel)).toAlarmSaveResult()
 
     fun editAlarm(
         alarm: ClockAlarm,
@@ -48,11 +44,7 @@ class ScheduledAlarmsViewModel @Inject constructor(
         onResult: (AlarmSaveResult) -> Unit = {},
     ) {
         viewModelScope.launch {
-            val result = if (tryEditAlarm(alarm, newTriggerAtMillis, newLabel)) {
-                AlarmSaveResult.STORED
-            } else {
-                AlarmSaveResult.FAILED
-            }
+            val result = tryEditAlarm(alarm, newTriggerAtMillis, newLabel)
             onResult(result)
         }
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -168,10 +168,6 @@ fun SidePanelScreen(
                 "Exact alarm scheduling is unavailable. Grant exact alarm permission."
             is AlarmSaveResult.NOTIFICATION_BLOCKED ->
                 "Notifications are disabled. Enable in Settings."
-            is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                "Full-screen alerts unavailable."
-            is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
-                "Alarm saved, but boot restore is limited."
             is AlarmSaveResult.FAILED ->
                 result.message ?: "Couldn't schedule the timer."
         }
@@ -494,11 +490,7 @@ fun SidePanelScreen(
                             schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
                             schedulingError = "Notifications are disabled. Enable in Settings."
-                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                            schedulingError = "Full-screen alerts unavailable."
-                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
-                            schedulingError = "Alarm saved, but boot restore is limited."
-                        is AlarmSaveResult.FAILED ->
+                                                is AlarmSaveResult.FAILED ->
                             schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }
@@ -522,11 +514,7 @@ fun SidePanelScreen(
                             schedulingError = "Exact alarm scheduling is unavailable."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
                             schedulingError = "Notifications are disabled."
-                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
-                            schedulingError = "Full-screen alerts unavailable."
-                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
-                            schedulingError = "Alarm saved, but boot restore is limited."
-                        is AlarmSaveResult.FAILED ->
+                                                is AlarmSaveResult.FAILED ->
                             schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -162,7 +162,7 @@ fun SidePanelScreen(
         schedulingError = when (result) {
             is AlarmSaveResult.STORED -> {
                 if (closeDialog) showCreateTimerDialog = false
-                null
+                result.warnings.toWarningMessage()
             }
             is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
                 "Exact alarm scheduling is unavailable. Grant exact alarm permission."
@@ -481,17 +481,17 @@ fun SidePanelScreen(
             defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.scheduleAlarm(draft) { result ->
-                    when (result) {
+                    schedulingError = when (result) {
                         is AlarmSaveResult.STORED -> {
-                            schedulingError = null
                             showCreateAlarmDialog = false
+                            result.warnings.toWarningMessage()
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
-                            schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+                            "Exact alarm scheduling is unavailable. Grant exact alarm permission."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
-                            schedulingError = "Notifications are disabled. Enable in Settings."
-                                                is AlarmSaveResult.FAILED ->
-                            schedulingError = result.message ?: "Couldn't save the alarm."
+                            "Notifications are disabled. Enable in Settings."
+                        is AlarmSaveResult.FAILED ->
+                            result.message ?: "Couldn't save the alarm."
                     }
                 }
             },
@@ -505,17 +505,17 @@ fun SidePanelScreen(
             defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.editAlarm(alarm, draft) { result ->
-                    when (result) {
+                    schedulingError = when (result) {
                         is AlarmSaveResult.STORED -> {
-                            schedulingError = null
                             editingAlarm = null
+                            result.warnings.toWarningMessage()
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
-                            schedulingError = "Exact alarm scheduling is unavailable."
+                            "Exact alarm scheduling is unavailable."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
-                            schedulingError = "Notifications are disabled."
-                                                is AlarmSaveResult.FAILED ->
-                            schedulingError = result.message ?: "Couldn't save the alarm."
+                            "Notifications are disabled."
+                        is AlarmSaveResult.FAILED ->
+                            result.message ?: "Couldn't save the alarm."
                     }
                 }
             },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Alarm
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Mic
@@ -126,6 +127,7 @@ fun SidePanelScreen(
     var showCreateTimerDialog by remember { mutableStateOf(false) }
     var showAddWorldClockDialog by remember { mutableStateOf(false) }
     var schedulingError by remember { mutableStateOf<String?>(null) }
+    var schedulingWarning by remember { mutableStateOf<String?>(null) }
 
     var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
     var nowElapsedRealtimeMs by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
@@ -159,17 +161,17 @@ fun SidePanelScreen(
     }
 
     fun onTimerScheduled(result: AlarmSaveResult, closeDialog: Boolean = false) {
-        schedulingError = when (result) {
+        when (result) {
             is AlarmSaveResult.STORED -> {
                 if (closeDialog) showCreateTimerDialog = false
-                result.warnings.toWarningMessage()
+                schedulingWarning = result.warnings.toWarningMessage(isTimer = true)
             }
             is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
-                "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+                schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
             is AlarmSaveResult.NOTIFICATION_BLOCKED ->
-                "Notifications are disabled. Enable in Settings."
+                schedulingError = "Notifications are disabled. Enable in Settings."
             is AlarmSaveResult.FAILED ->
-                result.message ?: "Couldn't schedule the timer."
+                schedulingError = result.message ?: "Couldn't schedule the timer."
         }
     }
 
@@ -481,17 +483,17 @@ fun SidePanelScreen(
             defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.scheduleAlarm(draft) { result ->
-                    schedulingError = when (result) {
+                    when (result) {
                         is AlarmSaveResult.STORED -> {
                             showCreateAlarmDialog = false
-                            result.warnings.toWarningMessage()
+                            schedulingWarning = result.warnings.toWarningMessage(isTimer = false)
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
-                            "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+                            schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
-                            "Notifications are disabled. Enable in Settings."
+                            schedulingError = "Notifications are disabled. Enable in Settings."
                         is AlarmSaveResult.FAILED ->
-                            result.message ?: "Couldn't save the alarm."
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }
             },
@@ -505,17 +507,17 @@ fun SidePanelScreen(
             defaultAlarmSoundUri = clockSoundConfig.defaultAlarmSoundUri,
             onConfirm = { draft ->
                 viewModel.editAlarm(alarm, draft) { result ->
-                    schedulingError = when (result) {
+                    when (result) {
                         is AlarmSaveResult.STORED -> {
                             editingAlarm = null
-                            result.warnings.toWarningMessage()
+                            schedulingWarning = result.warnings.toWarningMessage(isTimer = false)
                         }
                         is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
-                            "Exact alarm scheduling is unavailable."
+                            schedulingError = "Exact alarm scheduling is unavailable."
                         is AlarmSaveResult.NOTIFICATION_BLOCKED ->
-                            "Notifications are disabled."
+                            schedulingError = "Notifications are disabled."
                         is AlarmSaveResult.FAILED ->
-                            result.message ?: "Couldn't save the alarm."
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }
             },
@@ -559,6 +561,16 @@ fun SidePanelScreen(
             text = { Text(message) },
             confirmButton = {
                 TextButton(onClick = { schedulingError = null }) { Text("OK") }
+            },
+        )
+    }
+    schedulingWarning?.let { message ->
+        AlertDialog(
+            onDismissRequest = { schedulingWarning = null },
+            icon = { Icon(Icons.Default.Info, contentDescription = null) },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { schedulingWarning = null }) { Text("OK") }
             },
         )
     }

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -158,12 +158,22 @@ fun SidePanelScreen(
         ClockSurfaceTab.WORLD_CLOCK, ClockSurfaceTab.STOPWATCH -> emptyList()
     }
 
-    fun onTimerScheduled(success: Boolean, closeDialog: Boolean = false) {
-        if (success) {
-            schedulingError = null
-            if (closeDialog) showCreateTimerDialog = false
-        } else {
-            schedulingError = "Couldn't schedule the timer."
+    fun onTimerScheduled(result: AlarmSaveResult, closeDialog: Boolean = false) {
+        schedulingError = when (result) {
+            is AlarmSaveResult.STORED -> {
+                if (closeDialog) showCreateTimerDialog = false
+                null
+            }
+            is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
+                "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+            is AlarmSaveResult.NOTIFICATION_BLOCKED ->
+                "Notifications are disabled. Enable in Settings."
+            is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                "Full-screen alerts unavailable."
+            is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
+                "Alarm saved, but boot restore is limited."
+            is AlarmSaveResult.FAILED ->
+                result.message ?: "Couldn't schedule the timer."
         }
     }
 
@@ -273,8 +283,8 @@ fun SidePanelScreen(
                     selectedIds = selectedIds,
                     onCreateCustomTimer = { showCreateTimerDialog = true },
                     onPresetTimer = { durationMs ->
-                        viewModel.scheduleTimer(durationMs, null) { success ->
-                            onTimerScheduled(success)
+                        viewModel.scheduleTimer(durationMs, null) { result ->
+                            onTimerScheduled(result)
                         }
                     },
                     onTimerTap = { timer ->
@@ -285,8 +295,8 @@ fun SidePanelScreen(
                     },
                     onCancelTimer = { timer -> pendingCancel = timer },
                     onRestartTimer = { timer ->
-                        viewModel.restartTimer(timer) { success ->
-                            onTimerScheduled(success)
+                        viewModel.restartTimer(timer) { result ->
+                            onTimerScheduled(result)
                         }
                     },
                     onDeleteCompletedTimer = { timer -> pendingDeleteCompleted = timer },
@@ -476,11 +486,20 @@ fun SidePanelScreen(
             onConfirm = { draft ->
                 viewModel.scheduleAlarm(draft) { result ->
                     when (result) {
-                        AlarmSaveResult.STORED -> {
+                        is AlarmSaveResult.STORED -> {
                             schedulingError = null
                             showCreateAlarmDialog = false
                         }
-                        AlarmSaveResult.FAILED -> schedulingError = "Couldn't save the alarm."
+                        is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
+                            schedulingError = "Exact alarm scheduling is unavailable. Grant exact alarm permission."
+                        is AlarmSaveResult.NOTIFICATION_BLOCKED ->
+                            schedulingError = "Notifications are disabled. Enable in Settings."
+                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            schedulingError = "Full-screen alerts unavailable."
+                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
+                            schedulingError = "Alarm saved, but boot restore is limited."
+                        is AlarmSaveResult.FAILED ->
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }
             },
@@ -495,11 +514,20 @@ fun SidePanelScreen(
             onConfirm = { draft ->
                 viewModel.editAlarm(alarm, draft) { result ->
                     when (result) {
-                        AlarmSaveResult.STORED -> {
+                        is AlarmSaveResult.STORED -> {
                             schedulingError = null
                             editingAlarm = null
                         }
-                        AlarmSaveResult.FAILED -> schedulingError = "Couldn't save the alarm."
+                        is AlarmSaveResult.EXACT_ALARM_BLOCKED ->
+                            schedulingError = "Exact alarm scheduling is unavailable."
+                        is AlarmSaveResult.NOTIFICATION_BLOCKED ->
+                            schedulingError = "Notifications are disabled."
+                        is AlarmSaveResult.FULL_SCREEN_INTENT_UNAVAILABLE ->
+                            schedulingError = "Full-screen alerts unavailable."
+                        is AlarmSaveResult.BOOT_RESTORE_LIMITED ->
+                            schedulingError = "Alarm saved, but boot restore is limited."
+                        is AlarmSaveResult.FAILED ->
+                            schedulingError = result.message ?: "Couldn't save the alarm."
                     }
                 }
             },
@@ -510,8 +538,8 @@ fun SidePanelScreen(
     if (showCreateTimerDialog) {
         TimerCreateDialog(
             onConfirm = { durationMs, label ->
-                viewModel.scheduleTimer(durationMs, label) { success ->
-                    onTimerScheduled(success, closeDialog = true)
+                viewModel.scheduleTimer(durationMs, label) { result ->
+                    onTimerScheduled(result, closeDialog = true)
                 }
             },
             onDismiss = { showCreateTimerDialog = false },

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelViewModel.kt
@@ -143,7 +143,7 @@ class SidePanelViewModel @Inject constructor(
         }
     }
 
-    fun restartTimer(timer: ClockTimer, onResult: (Boolean) -> Unit = {}) {
+    fun restartTimer(timer: ClockTimer, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
             onResult(tryScheduleTimer(timer.durationMs, timer.label))
         }
@@ -161,20 +161,15 @@ class SidePanelViewModel @Inject constructor(
         }
     }
 
-    suspend fun tryScheduleAlarm(draft: AlarmDraft): Boolean =
-        clockRepository.createAlarm(draft) != null
+    suspend fun tryScheduleAlarm(draft: AlarmDraft): AlarmSaveResult =
+        clockRepository.createAlarm(draft).toAlarmSaveResult()
 
-    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): Boolean =
+    suspend fun tryScheduleAlarm(triggerAtMillis: Long, label: String?): AlarmSaveResult =
         tryScheduleAlarm(triggerAtMillis.toOneOffAlarmDraft(label))
 
     fun scheduleAlarm(draft: AlarmDraft, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
-            val result = if (tryScheduleAlarm(draft)) {
-                AlarmSaveResult.STORED
-            } else {
-                AlarmSaveResult.FAILED
-            }
-            onResult(result)
+            onResult(tryScheduleAlarm(draft))
         }
     }
 
@@ -182,10 +177,10 @@ class SidePanelViewModel @Inject constructor(
         scheduleAlarm(triggerAtMillis.toOneOffAlarmDraft(label), onResult)
     }
 
-    suspend fun tryEditAlarm(alarm: ClockAlarm, draft: AlarmDraft): Boolean =
-        clockRepository.updateAlarm(alarm.id, draft) != null
+    suspend fun tryEditAlarm(alarm: ClockAlarm, draft: AlarmDraft): AlarmSaveResult =
+        clockRepository.updateAlarm(alarm.id, draft).toAlarmSaveResult()
 
-    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): Boolean =
+    suspend fun tryEditAlarm(alarm: ClockAlarm, newTriggerAtMillis: Long, newLabel: String?): AlarmSaveResult =
         tryEditAlarm(alarm, newTriggerAtMillis.toOneOffAlarmDraft(newLabel))
 
     fun editAlarm(
@@ -194,12 +189,7 @@ class SidePanelViewModel @Inject constructor(
         onResult: (AlarmSaveResult) -> Unit = {},
     ) {
         viewModelScope.launch {
-            val result = if (tryEditAlarm(alarm, draft)) {
-                AlarmSaveResult.STORED
-            } else {
-                AlarmSaveResult.FAILED
-            }
-            onResult(result)
+            onResult(tryEditAlarm(alarm, draft))
         }
     }
 
@@ -221,10 +211,10 @@ class SidePanelViewModel @Inject constructor(
         }
     }
 
-    suspend fun tryScheduleTimer(durationMs: Long, label: String?): Boolean =
-        clockRepository.scheduleTimer(durationMs, label) != null
+    suspend fun tryScheduleTimer(durationMs: Long, label: String?): AlarmSaveResult =
+        clockRepository.scheduleTimer(durationMs, label).toAlarmSaveResult()
 
-    fun scheduleTimer(durationMs: Long, label: String?, onResult: (Boolean) -> Unit = {}) {
+    fun scheduleTimer(durationMs: Long, label: String?, onResult: (AlarmSaveResult) -> Unit = {}) {
         viewModelScope.launch {
             onResult(tryScheduleTimer(durationMs, label))
         }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AlarmSaveResultTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AlarmSaveResultTest.kt
@@ -1,0 +1,106 @@
+package com.kernel.ai.feature.settings
+
+import com.kernel.ai.core.memory.clock.SchedulingResult
+import com.kernel.ai.core.memory.clock.SchedulingWarning
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure JVM tests for [AlarmSaveResult] conversion and warning message rendering.
+ */
+class AlarmSaveResultTest {
+
+    @Test
+    fun `toAlarmSaveResult maps Success without warnings to STORED with empty warnings`() {
+        val sr = SchedulingResult.Success("data")
+        val result = sr.toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.STORED(emptyList()), result)
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps Success with full screen warning`() {
+        val sr = SchedulingResult.Success("data", warnings = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE))
+        val result = sr.toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.STORED(listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE)), result)
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps Success with boot restore warning`() {
+        val sr = SchedulingResult.Success("data", warnings = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED))
+        val result = sr.toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.STORED(listOf(SchedulingWarning.BOOT_RESTORE_LIMITED)), result)
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps Success with both warnings`() {
+        val sr = SchedulingResult.Success(
+            "data",
+            warnings = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE, SchedulingWarning.BOOT_RESTORE_LIMITED),
+        )
+        val result = sr.toAlarmSaveResult()
+
+        assertEquals(
+            AlarmSaveResult.STORED(listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE, SchedulingWarning.BOOT_RESTORE_LIMITED)),
+            result,
+        )
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps ExactAlarmBlocked`() {
+        val result = SchedulingResult.ExactAlarmBlocked.toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.EXACT_ALARM_BLOCKED, result)
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps NotificationBlocked`() {
+        val result = SchedulingResult.NotificationBlocked.toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.NOTIFICATION_BLOCKED, result)
+    }
+
+    @Test
+    fun `toAlarmSaveResult maps SchedulingFailed`() {
+        val result = SchedulingResult.SchedulingFailed("db error").toAlarmSaveResult()
+
+        assertEquals(AlarmSaveResult.FAILED("db error"), result)
+    }
+
+    // ── toWarningMessage ────────────────────────────────────────────────
+
+    @Test
+    fun `toWarningMessage returns null for empty warnings`() {
+        assertNull(emptyList<SchedulingWarning>().toWarningMessage())
+    }
+
+    @Test
+    fun `toWarningMessage renders full screen warning`() {
+        val msg = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE).toWarningMessage()
+
+        assertEquals("Full-screen alerts are unavailable.", msg)
+    }
+
+    @Test
+    fun `toWarningMessage renders boot restore warning`() {
+        val msg = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED).toWarningMessage()
+
+        assertEquals("Scheduled events may not persist across device restarts.", msg)
+    }
+
+    @Test
+    fun `toWarningMessage renders both warnings`() {
+        val msg = listOf(
+            SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE,
+            SchedulingWarning.BOOT_RESTORE_LIMITED,
+        ).toWarningMessage()
+
+        assertEquals(
+            "Full-screen alerts are unavailable. Scheduled events may not persist across device restarts.",
+            msg,
+        )
+    }
+}

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AlarmSaveResultTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AlarmSaveResultTest.kt
@@ -74,32 +74,55 @@ class AlarmSaveResultTest {
 
     @Test
     fun `toWarningMessage returns null for empty warnings`() {
-        assertNull(emptyList<SchedulingWarning>().toWarningMessage())
+        assertNull(emptyList<SchedulingWarning>().toWarningMessage(isTimer = false))
     }
 
     @Test
-    fun `toWarningMessage renders full screen warning`() {
-        val msg = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE).toWarningMessage()
-
-        assertEquals("Full-screen alerts are unavailable.", msg)
+    fun `toWarningMessage renders full screen warning for alarm`() {
+        val msg = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE).toWarningMessage(isTimer = false)
+        assertEquals("Alarm saved. It may appear as a notification instead of opening full-screen.", msg)
     }
 
     @Test
-    fun `toWarningMessage renders boot restore warning`() {
-        val msg = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED).toWarningMessage()
-
-        assertEquals("Scheduled events may not persist across device restarts.", msg)
+    fun `toWarningMessage renders full screen warning for timer`() {
+        val msg = listOf(SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE).toWarningMessage(isTimer = true)
+        assertEquals("Timer set. It may appear as a notification instead of opening full-screen.", msg)
     }
 
     @Test
-    fun `toWarningMessage renders both warnings`() {
+    fun `toWarningMessage renders boot restore warning for alarm`() {
+        val msg = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED).toWarningMessage(isTimer = false)
+        assertEquals("Alarm saved. Scheduled events may need to be recreated after a device restart.", msg)
+    }
+
+    @Test
+    fun `toWarningMessage renders boot restore warning for timer`() {
+        val msg = listOf(SchedulingWarning.BOOT_RESTORE_LIMITED).toWarningMessage(isTimer = true)
+        assertEquals("Timer set. Scheduled events may need to be recreated after a device restart.", msg)
+    }
+
+    @Test
+    fun `toWarningMessage renders both warnings for alarm`() {
         val msg = listOf(
             SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE,
             SchedulingWarning.BOOT_RESTORE_LIMITED,
-        ).toWarningMessage()
+        ).toWarningMessage(isTimer = false)
 
         assertEquals(
-            "Full-screen alerts are unavailable. Scheduled events may not persist across device restarts.",
+            "Alarm saved. It may appear as a notification instead of opening full-screen. Scheduled events may need to be recreated after a device restart.",
+            msg,
+        )
+    }
+
+    @Test
+    fun `toWarningMessage renders both warnings for timer`() {
+        val msg = listOf(
+            SchedulingWarning.FULL_SCREEN_INTENT_UNAVAILABLE,
+            SchedulingWarning.BOOT_RESTORE_LIMITED,
+        ).toWarningMessage(isTimer = true)
+
+        assertEquals(
+            "Timer set. It may appear as a notification instead of opening full-screen. Scheduled events may need to be recreated after a device restart.",
             msg,
         )
     }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -96,11 +96,25 @@ class MemoryViewModelTest {
         viewModel.openAddDialog()
         viewModel.onAddDialogTextChange("  remember this  ")
         viewModel.addCoreMemory()
+
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify(timeout = 2_000, exactly = 1) {
+            embeddingEngine.embed("remember this")
+        }
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) {
             memoryRepository.addCoreMemory(
                 content = "remember this",
+                source = "user",
+                embeddingVector = match { it.isNotEmpty() },
+            )
+        }
+        coVerify(exactly = 0) {
+            memoryRepository.addCoreMemory(
+                content = "  remember this  ",
                 source = "user",
                 embeddingVector = any<FloatArray>(),
             )
@@ -124,9 +138,15 @@ class MemoryViewModelTest {
         viewModel.openAddDialog()
         viewModel.onAddDialogTextChange("some text")
         viewModel.addCoreMemory()
+
         testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(timeout = 2_000, exactly = 1) { embeddingEngine.embed(any()) }
+        coVerify(timeout = 2_000, exactly = 1) {
+            embeddingEngine.embed("some text")
+        }
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
         coVerify(exactly = 0) { memoryRepository.addCoreMemory(any(), any(), any()) }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/MemoryViewModelTest.kt
@@ -98,7 +98,7 @@ class MemoryViewModelTest {
         viewModel.addCoreMemory()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(exactly = 1) {
+        coVerify(timeout = 2_000, exactly = 1) {
             memoryRepository.addCoreMemory(
                 content = "remember this",
                 source = "user",
@@ -126,6 +126,7 @@ class MemoryViewModelTest {
         viewModel.addCoreMemory()
         testDispatcher.scheduler.advanceUntilIdle()
 
+        coVerify(timeout = 2_000, exactly = 1) { embeddingEngine.embed(any()) }
         coVerify(exactly = 0) { memoryRepository.addCoreMemory(any(), any(), any()) }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.feature.settings
 import com.kernel.ai.core.memory.clock.AlarmRepeatRule
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -36,25 +37,25 @@ class ScheduledAlarmsViewModelTest {
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.ExactAlarmBlocked
         val viewModel = ScheduledAlarmsViewModel(clockRepository)
 
         val result = viewModel.tryScheduleAlarm(1_234L, "Wake")
 
-        assertEquals(false, result)
+        assertEquals(AlarmSaveResult.EXACT_ALARM_BLOCKED, result)
     }
 
     @Test
     fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
-        coEvery { clockRepository.createAlarm(any()) } returns null
+        coEvery { clockRepository.createAlarm(any()) } returns SchedulingResult.SchedulingFailed(null)
         val viewModel = ScheduledAlarmsViewModel(clockRepository)
         var result: AlarmSaveResult? = null
 
         viewModel.scheduleAlarm(System.currentTimeMillis() + 172_800_000L, "Wake") { result = it }
         advanceUntilIdle()
 
-        assertEquals(AlarmSaveResult.FAILED, result)
+        assertEquals(AlarmSaveResult.FAILED(null), result)
     }
 
     @Test
@@ -71,11 +72,11 @@ class ScheduledAlarmsViewModelTest {
             triggerAtMillis = 1_234L,
         )
         every { clockRepository.observeUpcomingAlarms() } returns emptyFlow()
-        coEvery { clockRepository.updateAlarm(alarm.id, any()) } returns alarm
+        coEvery { clockRepository.updateAlarm(alarm.id, any()) } returns SchedulingResult.Success(alarm)
         val viewModel = ScheduledAlarmsViewModel(clockRepository)
 
         val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
 
-        assertEquals(true, result)
+        assertEquals(AlarmSaveResult.STORED, result)
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/ScheduledAlarmsViewModelTest.kt
@@ -77,6 +77,6 @@ class ScheduledAlarmsViewModelTest {
 
         val result = viewModel.tryEditAlarm(alarm, 2_345L, "Updated")
 
-        assertEquals(AlarmSaveResult.STORED, result)
+ assertEquals(AlarmSaveResult.STORED(), result)
     }
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -2,6 +2,7 @@ package com.kernel.ai.feature.settings
 
 import com.kernel.ai.core.memory.clock.ClockAlarm
 import com.kernel.ai.core.memory.clock.ClockRepository
+import com.kernel.ai.core.memory.clock.SchedulingResult
 import com.kernel.ai.core.memory.clock.ClockSoundConfig
 import com.kernel.ai.core.memory.clock.ClockStopwatch
 import com.kernel.ai.core.memory.clock.ClockTimer
@@ -56,42 +57,42 @@ class SidePanelViewModelTest {
     @Test
     fun `scheduleAlarm returns false when repository rejects exact alarm`() = runTest {
         val draft = sampleAlarmDraft(label = "Wake")
-        coEvery { clockRepository.createAlarm(draft) } returns null
+        coEvery { clockRepository.createAlarm(draft) } returns SchedulingResult.ExactAlarmBlocked
         val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryScheduleAlarm(draft)
 
-        assertEquals(false, result)
+        assertEquals(AlarmSaveResult.EXACT_ALARM_BLOCKED, result)
     }
 
     @Test
     fun `scheduleAlarm reports failure when repository cannot store alarm`() = runTest {
         val draft = sampleAlarmDraft(label = "Wake")
-        coEvery { clockRepository.createAlarm(draft) } returns null
+        coEvery { clockRepository.createAlarm(draft) } returns SchedulingResult.SchedulingFailed(null)
         val viewModel = SidePanelViewModel(clockRepository)
         var result: AlarmSaveResult? = null
 
         viewModel.scheduleAlarm(draft) { result = it }
         advanceUntilIdle()
 
-        assertEquals(AlarmSaveResult.FAILED, result)
+        assertEquals(AlarmSaveResult.FAILED(null), result)
     }
 
     @Test
     fun `scheduleTimer returns true when repository accepts timer`() = runTest {
-        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns ClockTimer(
+        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns SchedulingResult.Success(ClockTimer(
             id = "timer-1",
             triggerAtMillis = 5_000L,
             label = "Tea",
             createdAtMillis = 1_000L,
             durationMs = 60_000L,
             startedAtMillis = 2_000L,
-        )
+        ))
         val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryScheduleTimer(60_000L, "Tea")
 
-        assertEquals(true, result)
+        assertEquals(AlarmSaveResult.STORED, result)
     }
 
     @Test
@@ -105,14 +106,14 @@ class SidePanelViewModelTest {
             startedAtMillis = 2_000L,
             completedAtMillis = 5_000L,
         )
-        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns timer
+        coEvery { clockRepository.scheduleTimer(60_000L, "Tea") } returns SchedulingResult.Success(timer)
         val viewModel = SidePanelViewModel(clockRepository)
-        var success: Boolean? = null
+        var result: AlarmSaveResult? = null
 
-        viewModel.restartTimer(timer) { success = it }
+        viewModel.restartTimer(timer) { result = it }
         advanceUntilIdle()
 
-        assertEquals(true, success)
+        assertEquals(AlarmSaveResult.STORED, result)
         coVerify(exactly = 1) { clockRepository.scheduleTimer(60_000L, "Tea") }
     }
 
@@ -163,12 +164,12 @@ class SidePanelViewModelTest {
     fun `editAlarm returns false when repository rejects update`() = runTest {
         val alarm = sampleAlarm()
         val draft = sampleAlarmDraft(label = "Updated")
-        coEvery { clockRepository.updateAlarm(alarm.id, draft) } returns null
+        coEvery { clockRepository.updateAlarm(alarm.id, draft) } returns SchedulingResult.ExactAlarmBlocked
         val viewModel = SidePanelViewModel(clockRepository)
 
         val result = viewModel.tryEditAlarm(alarm, draft)
 
-        assertEquals(false, result)
+        assertEquals(AlarmSaveResult.EXACT_ALARM_BLOCKED, result)
     }
 
     @Test

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/SidePanelViewModelTest.kt
@@ -92,7 +92,7 @@ class SidePanelViewModelTest {
 
         val result = viewModel.tryScheduleTimer(60_000L, "Tea")
 
-        assertEquals(AlarmSaveResult.STORED, result)
+        assertEquals(AlarmSaveResult.STORED(), result)
     }
 
     @Test
@@ -113,7 +113,7 @@ class SidePanelViewModelTest {
         viewModel.restartTimer(timer) { result = it }
         advanceUntilIdle()
 
-        assertEquals(AlarmSaveResult.STORED, result)
+        assertEquals(AlarmSaveResult.STORED(), result)
         coVerify(exactly = 1) { clockRepository.scheduleTimer(60_000L, "Tea") }
     }
 


### PR DESCRIPTION
Closes #1165

## Summary

Replace the opaque nullable-return scheduling API with a capability-aware `SchedulingResult<T>` model so callers can distinguish exact-alarm, notification, full-screen, boot-restore, and ordinary scheduling failures — and offer contextual repair.

## Production changes

### Core model (`core/memory/clock/ClockModels.kt`)
- `SchedulingResult<T>` with `Success(data, warnings)`, `ExactAlarmBlocked`, `NotificationBlocked`, `SchedulingFailed(message)`
- `SchedulingWarning` enum: `FULL_SCREEN_INTENT_UNAVAILABLE`, `BOOT_RESTORE_LIMITED`
- `ClockPlatformState.bootRestoreLimited`

### Repository (`ClockRepositoryImpl.kt`)
- **Full event-set result-aware**: `scheduleAlarmEvents()` schedules primary + secondary events in a loop; on any failure, rolls back already-scheduled events and returns the failure.
- **Update rollback checked**: `updateAlarm()` checks platform readiness before cancelling existing. If replace fails and restore also fails, returns `SchedulingFailed` with clear message.
- `createAlarm()`, `updateAlarm()`, `scheduleTimer()` return `SchedulingResult` with warnings.

### UI (`feature/settings/`)
- `AlarmSaveResult.STORED(warnings)` preserves warnings into Clock UI.
- `List<SchedulingWarning>.toWarningMessage()` renders user-facing warning text.
- Screens show full-screen and boot-restore warnings.

### Skill layer (`NativeIntentHandler.kt`)
- `setAlarm()` / `setTimer()` include warning text in success messages. Timer mixed-duration copy fixed.

## Regression tests added

### Repository scheduling/rollback (`ClockRepositorySchedulingTest.kt` — 3 tests)
- Pre-alarm failure → primary rolled back, DB not written.
- Update replacement failure → old schedule restored.
- Update restore failure → clear `SchedulingFailed` with "Manual intervention" message.

### UI warning propagation (`AlarmSaveResultTest.kt` — 11 tests)
- `toAlarmSaveResult()` mapping for all `SchedulingResult` variants.
- `toWarningMessage()` rendering.

### Timer copy (`NativeIntentHandlerTest.kt`)
- 90 seconds → `"Timer set for 1 min 30 sec."`.

### Existing tests updated
- `ClockRepositoryImplTest.kt`: `scheduler.schedule` mocked in setUp; existing createAlarm tests unwrap `SchedulingResult.Success.data`.
- `AlarmSaveResult` converted from 2-value enum to sealed class; all when blocks updated for exhaustive matching.

## CI note

`:core:memory:testDebugUnitTest` is now included in `.github/workflows/ci.yml`. CI run `2771` on head `1f70e23926d1eb6d0813e7fab0beda95144c25a5` is green, and Docs Drift run `411` is green.

All tests pass locally with the full command:
```
./gradlew :core:memory:testDebugUnitTest :core:skills:testDebugUnitTest :feature:chat:testDebugUnitTest :app:testDebugUnitTest :feature:settings:testDebugUnitTest --no-daemon
BUILD SUCCESSFUL in 18s
```