### PR TITLE
[codex] Clarify test harness docs authority

### DIFF
--- a/.docs/agents/review-gates-test-harness.md
+++ b/.docs/agents/review-gates-test-harness.md
@@ -1,5 +1,14 @@
 # Review Gate: Test Harness
 
+> **Purpose:** This is a PR review gate and evidence checklist for test harness changes.
+> It is not the operational runbook or the evidence schema source of truth.
+>
+> **Current run commands:** `docs/automated-testing.md`
+>
+> **Evidence schema contract:** `docs/testing/test-evidence-schema.md`
+>
+> **Target and draft test design:** `docs/testing/automated-test-specification.md`
+
 ## When This Gate Applies
 
 This gate applies when the PR touches:

--- a/docs/SPEC_INDEX.md
+++ b/docs/SPEC_INDEX.md
@@ -51,7 +51,7 @@ These documents explain how to run, inspect, or verify something. They should po
 
 | Path | Scope |
 |---|---|
-| `docs/automated-testing.md` | Current automated testing commands, report shapes, and harness operations. |
+| `docs/automated-testing.md` | Current operational entrypoint for automated testing commands, report shapes, and harness operations. |
 | `docs/adb-testing.md` | ADB setup, device setup, logcat filters, and manual device commands. |
 | `.docs/agents/test-evidence-workflow.md` | Evidence publishing workflow for agents. |
 | `.docs/agents/validation.md` | Validation hierarchy and CI constraints. |
@@ -64,7 +64,7 @@ Review gates define evidence and review expectations for PRs. They are not produ
 | Path | Scope |
 |---|---|
 | `.docs/agents/review-gates-permissions.md` | Permission PR evidence and review checklist. |
-| `.docs/agents/review-gates-test-harness.md` | Test harness and evidence PR checklist. |
+| `.docs/agents/review-gates-test-harness.md` | Test harness PR review and evidence checklist. It is not the runbook or evidence schema source of truth. |
 | `.docs/agents/review-gates-navigation-ui.md` | Navigation and UI PR checklist. |
 | `.docs/agents/review-gates-voice.md` | Voice, STT, TTS, VAD, and wake-word review gate. |
 | `.docs/agents/review-gates-litert.md` | LiteRT and model-runtime review gate. |
@@ -77,8 +77,8 @@ Research docs are useful context. Treat them as draft or historical unless they 
 | Path | Scope |
 |---|---|
 | `docs/research/` | Technical research, design exploration, and feature-specific draft specs. |
-| `docs/testing/automated-test-specification.md` | Deeper test design and target coverage. Some sections are implemented; some remain draft. |
-| `docs/testing/harness-metrics-dashboard-design.md` | Dashboard design and staged follow-up work. |
+| `docs/testing/automated-test-specification.md` | Target and draft test design. Sections marked implemented can be treated as implemented references; use `docs/automated-testing.md` for current run commands. |
+| `docs/testing/harness-metrics-dashboard-design.md` | Dashboard metrics design plus implemented/staged status. Use `docs/testing/test-evidence-schema.md` for the evidence schema contract. |
 
 ### Evidence schemas
 
@@ -86,7 +86,7 @@ Evidence schemas are contracts for generated artifacts. Update schema docs and c
 
 | Path | Scope |
 |---|---|
-| `docs/testing/test-evidence-schema.md` | Normalised evidence schema for CI, physical device runs, dashboards, and PR summaries. |
+| `docs/testing/test-evidence-schema.md` | Authoritative normalised evidence schema for CI, physical device runs, dashboards, and PR summaries. Consumers must tolerate missing optional fields from older evidence. |
 
 ### Roadmap and status docs
 

--- a/docs/testing/harness-metrics-dashboard-design.md
+++ b/docs/testing/harness-metrics-dashboard-design.md
@@ -5,6 +5,14 @@ Parent: #1219
 Implements: #1224
 PR: #1237
 
+> **Authority:** This document records dashboard design, implemented dashboard metrics, and staged follow-up work. It is not the current harness runbook and it does not define the evidence schema contract.
+>
+> **Evidence schema contract:** [`test-evidence-schema.md`](./test-evidence-schema.md)
+>
+> **Current run commands:** [`../automated-testing.md`](../automated-testing.md)
+>
+> **Review gate:** [`.docs/agents/review-gates-test-harness.md`](../../.docs/agents/review-gates-test-harness.md)
+
 ---
 
 ## 1. Goal

--- a/docs/testing/test-evidence-schema.md
+++ b/docs/testing/test-evidence-schema.md
@@ -1,8 +1,16 @@
 # Normalised Test Evidence Schema
 
-Status: **Design / Draft**  
-Parent: #1113 — GitHub-native test evidence dashboard for CI and on-device results  
-Implements: #1115 — Define normalised test result schema and device registry  
+Status: **Authoritative schema contract for normalised test evidence**
+Parent: #1113 — GitHub-native test evidence dashboard for CI and on-device results
+Implements: #1115 — Define normalised test result schema and device registry
+
+> **Authority:** This document defines the durable normalised evidence shape consumed by dashboards, PR summaries, release snapshots, and regression analysis. Producers and consumers should remain backward-compatible when optional fields are missing.
+>
+> **Current run commands:** [`../automated-testing.md`](../automated-testing.md)
+>
+> **Target and draft test design:** [`automated-test-specification.md`](./automated-test-specification.md)
+>
+> **Dashboard design:** [`harness-metrics-dashboard-design.md`](./harness-metrics-dashboard-design.md)
 
 ---
 
@@ -258,7 +266,7 @@ For CI runs that do not execute any model, set to:
 
 ### Suggested mapping from raw harness markers
 
-The normalisation script (to be implemented in #1116) should map raw harness fields to these categories as follows:
+Producer implementation can vary by suite, but normalised evidence should map raw harness fields to these categories as follows when those raw fields are available:
 
 - No `native_tool_marker` AND no `legacy_tool_marker` → **`model_tool_generation_miss`** (model didn't produce a tool call)
 - Tool called but `chip_text` is null → **`missing_marker`** (chip marker)
@@ -272,12 +280,7 @@ The normalisation script (to be implemented in #1116) should map raw harness fie
 
 ### Field transformation table
 
-The normaliser (to be implemented in #1116) should map raw `llm_tools` report fields
-(from `save_llm_tools_report()` in `scripts/adb_skill_test.py`) to normalised fields
-as shown below. Fields marked "not stored" are consumed during categorisation but do
-not appear in the normalised output. Fields marked "(derived)" are computed from
-multiple raw fields or harness configuration — the raw report does not contain them
-directly.
+Normalisers should map raw `llm_tools` report fields (from `save_llm_tools_report()` in `scripts/adb_skill_test.py`) to normalised fields as shown below. Fields marked "not stored" are consumed during categorisation but do not appear in the normalised output. Fields marked "(derived)" are computed from multiple raw fields or harness configuration — the raw report does not contain them directly.
 
 | Raw field | Normalised field | Transformation |
 |---|---|---|
@@ -408,11 +411,17 @@ These invariants MUST hold for every normalised report. The normalisation script
 - `source == "ci"` → `device.execution == "github_hosted_runner"`, `device.tier == "ci"`, all model fields `null`.
 - `source == "on_device"` → `device.execution == "physical"`, model fields are non-null (name, runtime, backend each non-null).
 
-## 8. Related documents
+## 8. Compatibility rule
+
+Consumers must tolerate missing optional fields from older evidence records and render unknown or empty values instead of crashing. Breaking changes require a `schema_version` bump, compatibility notes, and corresponding updates to dashboard builders, normalisers, and review-gate guidance.
+
+## 9. Related documents
 
 - `scripts/testdata/devices.yaml` — device registry consumed by normalisation scripts
 - `scripts/testdata/test_evidence.schema.json` — machine-verifiable JSON Schema
-- `docs/testing/automated-testing.md` — test harness documentation
+- `docs/automated-testing.md` — current operational run commands and report inspection
+- `docs/testing/automated-test-specification.md` — target and draft test design
+- `docs/testing/harness-metrics-dashboard-design.md` — dashboard metrics design and staged work
 - `docs/testing/llm-tools-harness.md` — `llm_tools` test details
 - [Issue #1115](https://github.com/NickMonrad/kernel-ai-assistant/issues/1115) — this issue
 - [Issue #1113](https://github.com/NickMonrad/kernel-ai-assistant/issues/1113) — parent epic


### PR DESCRIPTION
## Summary

Refs #1337.

This is a small docs-only pass to clarify which test harness documents are authoritative, operational, draft/design, or review-gate material.

Changes:

- Update `docs/SPEC_INDEX.md` to clarify test harness doc roles.
- Clarify `.docs/agents/review-gates-test-harness.md` as a PR review/evidence checklist, not the runbook or schema source of truth.
- Clarify `docs/testing/test-evidence-schema.md` as the authoritative normalised evidence schema contract, including a compatibility rule for older evidence records.
- Clarify `docs/testing/harness-metrics-dashboard-design.md` as dashboard design plus implemented/staged status, not the schema contract or runbook.

## Notes

`docs/automated-testing.md` already states it is the current automation overview and operational entrypoint, and `docs/testing/automated-test-specification.md` already states it is design/draft with implemented sections called out. I avoided extra churn there and clarified those roles from the spec index and linked docs instead.

## Validation

Docs-only change. No Android build or device testing run.

Manual compare checked:

- 4 files changed
- no app/harness code changed
- only status, authority, and cross-link text updated

# Do not merge until Nick reviews.