### PR TITLE
[codex] First cut shared Clock voice FAB

### DIFF
--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -434,6 +434,16 @@ navigation or executing any action.
   a follow-up.
 - Sub-feature favourite affordances in the Tools hub are not yet surfaced in the main tools
   list grid.
+
+#### 1.8g Clock action pattern
+
+- All Clock tabs use one consistent bottom-right voice FAB.
+- Tab-specific primary actions stay inside tab content or empty states:
+  - Timers: preset and custom timer actions live in the Timers card.
+  - Alarms: `New alarm` lives in the alarms content header or empty state.
+  - World Clock: `Add city` lives in the world clock content header or empty state.
+  - Stopwatch: `Start stopwatch` lives in the stopwatch card.
+- Avoid stacked FABs or duplicate primary actions unless there is a documented reason.
 ---
 
 ## 2. List / Collection Screens

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceContentTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockSurfaceContentTest.kt
@@ -1,0 +1,165 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.kernel.ai.core.memory.clock.AlarmRepeatRule
+import com.kernel.ai.core.memory.clock.ClockAlarm
+import com.kernel.ai.core.memory.clock.ClockStopwatch
+import com.kernel.ai.core.memory.clock.StopwatchStatus
+import com.kernel.ai.core.memory.clock.WorldClock
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+class ClockSurfaceContentTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun allClockTabsExposeSharedVoiceFab() {
+        ClockSurfaceTab.entries.forEach { tab ->
+            setClockSurfaceContent(selectedTab = tab)
+            composeTestRule.onNodeWithTag(CLOCK_VOICE_FAB_TEST_TAG).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun selectionModeHidesSharedVoiceFab() {
+        setClockSurfaceContent(
+            selectedTab = ClockSurfaceTab.ALARMS,
+            isInSelectionMode = true,
+            alarms = listOf(sampleAlarm()),
+        )
+
+        composeTestRule.onAllNodesWithTag(CLOCK_VOICE_FAB_TEST_TAG).assertCountEquals(0)
+    }
+
+    @Test
+    fun alarmsTabKeepsInContentNewAlarmActionWithoutBottomExtendedFab() {
+        setClockSurfaceContent(
+            selectedTab = ClockSurfaceTab.ALARMS,
+            alarms = listOf(sampleAlarm()),
+        )
+
+        composeTestRule.onNodeWithTag(CLOCK_VOICE_FAB_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText("New alarm").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("New Alarm").assertCountEquals(0)
+    }
+
+    @Test
+    fun worldClockTabKeepsInContentAddCityActionWithoutBottomExtendedFab() {
+        setClockSurfaceContent(
+            selectedTab = ClockSurfaceTab.WORLD_CLOCK,
+            worldClocks = listOf(sampleWorldClock()),
+        )
+
+        composeTestRule.onNodeWithTag(CLOCK_VOICE_FAB_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add city").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Add City").assertCountEquals(0)
+    }
+
+    @Test
+    fun timerAndStopwatchPrimaryActionsStayInsideContent() {
+        setClockSurfaceContent(selectedTab = ClockSurfaceTab.TIMERS)
+        composeTestRule.onNodeWithText("Custom timer").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+
+        setClockSurfaceContent(selectedTab = ClockSurfaceTab.STOPWATCH)
+        composeTestRule.onNodeWithText("Start stopwatch").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Start stopwatch").assertCountEquals(1)
+    }
+
+    private fun setClockSurfaceContent(
+        selectedTab: ClockSurfaceTab,
+        isInSelectionMode: Boolean = false,
+        alarms: List<ClockAlarm> = emptyList(),
+        worldClocks: List<WorldClock> = emptyList(),
+        stopwatch: ClockStopwatch = idleStopwatch(),
+    ) {
+        composeTestRule.setContent {
+            MaterialTheme {
+                Scaffold(
+                    floatingActionButton = {
+                        ClockScreenFloatingActionButton(
+                            isInSelectionMode = isInSelectionMode,
+                            onNavigateToVoiceActions = {},
+                        )
+                    },
+                ) { innerPadding ->
+                    ClockSurfaceContent(
+                        selectedTab = selectedTab,
+                        alarms = alarms,
+                        timers = emptyList(),
+                        recentCompletedTimers = emptyList(),
+                        stopwatch = stopwatch,
+                        worldClocks = worldClocks,
+                        nowMs = 1_710_000_000_000L,
+                        nowElapsedRealtimeMs = 5_000L,
+                        isInSelectionMode = isInSelectionMode,
+                        selectedIds = emptySet(),
+                        onTabSelected = {},
+                        onCreateCustomTimer = {},
+                        onPresetTimer = {},
+                        onTimerTap = {},
+                        onTimerLongPress = {},
+                        onCancelTimer = {},
+                        onRestartTimer = {},
+                        onDeleteCompletedTimer = {},
+                        onClearCompletedTimers = {},
+                        onNewAlarm = {},
+                        onAlarmTap = {},
+                        onAlarmLongPress = {},
+                        onDismissAlarm = {},
+                        onToggleAlarm = {},
+                        onStartStopwatch = {},
+                        onPauseStopwatch = {},
+                        onResumeStopwatch = {},
+                        onResetStopwatch = {},
+                        onLapStopwatch = {},
+                        onAddWorldClock = {},
+                        onMoveWorldClockUp = {},
+                        onMoveWorldClockDown = {},
+                        onRemoveWorldClock = {},
+                        modifier = androidx.compose.ui.Modifier.padding(innerPadding),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun sampleAlarm() = ClockAlarm(
+        id = "alarm-1",
+        label = "Wake up",
+        createdAtMillis = 1_710_000_000_000L,
+        enabled = true,
+        hour = 7,
+        minute = 30,
+        repeatRule = AlarmRepeatRule.OneOff(LocalDate.of(2026, 6, 30).toEpochDay()),
+        timeZoneId = ZoneId.systemDefault().id,
+        triggerAtMillis = 1_710_028_200_000L,
+    )
+
+    private fun sampleWorldClock() = WorldClock(
+        id = "wc-1",
+        zoneId = "Europe/Copenhagen",
+        displayName = "Copenhagen",
+        sortOrder = 0,
+        createdAtMillis = 1_710_000_000_000L,
+    )
+
+    private fun idleStopwatch() = ClockStopwatch(
+        id = "stopwatch-1",
+        status = StopwatchStatus.IDLE,
+        accumulatedElapsedMs = 0L,
+        updatedAtMillis = 1_710_000_000_000L,
+    )
+}

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockVoiceFloatingActionButtonTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ClockVoiceFloatingActionButtonTest.kt
@@ -1,0 +1,33 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ClockVoiceFloatingActionButtonTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun sharedClockVoiceFabIsVisibleAndClickable() {
+        var clickCount = 0
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                ClockVoiceFloatingActionButton(onClick = { clickCount++ })
+            }
+        }
+
+        composeTestRule.onNodeWithTag(CLOCK_VOICE_FAB_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Voice input").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(CLOCK_VOICE_FAB_TEST_TAG).performClick()
+
+        assertEquals(1, clickCount)
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/ClockVoiceFloatingActionButton.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/ClockVoiceFloatingActionButton.kt
@@ -1,0 +1,34 @@
+package com.kernel.ai.feature.settings
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+internal const val CLOCK_VOICE_FAB_TEST_TAG = "clock_voice_fab"
+
+/**
+ * Shared Clock voice action FAB.
+ *
+ * #1279 standardises the Clock floating action area so every Clock tab uses the
+ * same bottom-right voice affordance. Tab-specific primary actions stay inside
+ * the tab content or empty-state cards.
+ */
+@Composable
+internal fun ClockVoiceFloatingActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = modifier.testTag(CLOCK_VOICE_FAB_TEST_TAG),
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Icon(Icons.Default.Mic, contentDescription = "Voice input")
+    }
+}

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/SidePanelScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -39,9 +38,6 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -212,156 +208,88 @@ fun SidePanelScreen(
             }
         },
         floatingActionButton = {
-            if (!isInSelectionMode) {
-                when (selectedTab) {
-                    ClockSurfaceTab.ALARMS -> Column(
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        SmallFloatingActionButton(
-                            onClick = onNavigateToVoiceActions,
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        ) {
-                            Icon(Icons.Default.Mic, contentDescription = "Voice input")
-                        }
-                        ExtendedFloatingActionButton(
-                            text = { Text("New Alarm") },
-                            icon = { Icon(Icons.Default.Alarm, contentDescription = null) },
-                            onClick = { showCreateAlarmDialog = true },
-                        )
-                    }
-
-                    ClockSurfaceTab.WORLD_CLOCK -> Column(
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        SmallFloatingActionButton(
-                            onClick = onNavigateToVoiceActions,
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        ) {
-                            Icon(Icons.Default.Mic, contentDescription = "Voice input")
-                        }
-                        ExtendedFloatingActionButton(
-                            text = { Text("Add City") },
-                            icon = { Icon(Icons.Default.AccessTime, contentDescription = null) },
-                            onClick = { showAddWorldClockDialog = true },
-                        )
-                    }
-
-                    ClockSurfaceTab.TIMERS, ClockSurfaceTab.STOPWATCH -> FloatingActionButton(
-                        onClick = onNavigateToVoiceActions,
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    ) {
-                        Icon(Icons.Default.Mic, contentDescription = "Voice input")
-                    }
-                }
-            }
+            ClockScreenFloatingActionButton(
+                isInSelectionMode = isInSelectionMode,
+                onNavigateToVoiceActions = onNavigateToVoiceActions,
+            )
         },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-        ) {
-            ClockSurfaceTabs(
-                selectedTab = selectedTab,
-                onTabSelected = viewModel::setTab,
-            )
-
-
-            when (selectedTab) {
-                ClockSurfaceTab.TIMERS -> TimerDashboard(
-                    timers = timers,
-                    recentCompletedTimers = recentCompletedTimers,
-                    nowMs = nowMs,
-                    inSelectionMode = isInSelectionMode,
-                    selectedIds = selectedIds,
-                    onCreateCustomTimer = { showCreateTimerDialog = true },
-                    onPresetTimer = { durationMs ->
-                        viewModel.scheduleTimer(durationMs, null) { result ->
-                            onTimerScheduled(result)
-                        }
-                    },
-                    onTimerTap = { timer ->
-                        if (isInSelectionMode) viewModel.toggleSelection(timer.id) else pendingCancel = timer
-                    },
-                    onTimerLongPress = { timer ->
-                        if (!isInSelectionMode) viewModel.enterSelectionMode(timer.id)
-                    },
-                    onCancelTimer = { timer -> pendingCancel = timer },
-                    onRestartTimer = { timer ->
-                        viewModel.restartTimer(timer) { result ->
-                            onTimerScheduled(result)
-                        }
-                    },
-                    onDeleteCompletedTimer = { timer -> pendingDeleteCompleted = timer },
-                    onClearCompletedTimers = { pendingClearCompleted = true },
-                )
-
-                ClockSurfaceTab.ALARMS -> AlarmDashboard(
-                    alarms = alarms,
-                    inSelectionMode = isInSelectionMode,
-                    selectedIds = selectedIds,
-                    onNewAlarm = { showCreateAlarmDialog = true },
-                    onAlarmTap = { alarm ->
-                        if (isInSelectionMode) viewModel.toggleSelection(alarm.id) else editingAlarm = alarm
-                    },
-                    onAlarmLongPress = { alarm ->
-                        if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
-                    },
-                    onDismissAlarm = { alarm -> pendingDismiss = alarm },
-                    onToggleAlarm = { alarm ->
-                        viewModel.toggleEnabled(alarm) { success ->
-                            if (!success) schedulingError = "Couldn't update the alarm."
-                        }
-                    },
-                )
-
-                ClockSurfaceTab.STOPWATCH -> StopwatchDashboard(
-                    stopwatch = stopwatch,
+        ClockSurfaceContent(
+            selectedTab = selectedTab,
+            alarms = alarms,
+            timers = timers,
+            recentCompletedTimers = recentCompletedTimers,
+            stopwatch = stopwatch,
+            worldClocks = worldClocks,
+            nowMs = nowMs,
+            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+            isInSelectionMode = isInSelectionMode,
+            selectedIds = selectedIds,
+            onTabSelected = viewModel::setTab,
+            onCreateCustomTimer = { showCreateTimerDialog = true },
+            onPresetTimer = { durationMs ->
+                viewModel.scheduleTimer(durationMs, null) { result ->
+                    onTimerScheduled(result)
+                }
+            },
+            onTimerTap = { timer ->
+                if (isInSelectionMode) viewModel.toggleSelection(timer.id) else pendingCancel = timer
+            },
+            onTimerLongPress = { timer ->
+                if (!isInSelectionMode) viewModel.enterSelectionMode(timer.id)
+            },
+            onCancelTimer = { timer -> pendingCancel = timer },
+            onRestartTimer = { timer ->
+                viewModel.restartTimer(timer) { result ->
+                    onTimerScheduled(result)
+                }
+            },
+            onDeleteCompletedTimer = { timer -> pendingDeleteCompleted = timer },
+            onClearCompletedTimers = { pendingClearCompleted = true },
+            onNewAlarm = { showCreateAlarmDialog = true },
+            onAlarmTap = { alarm ->
+                if (isInSelectionMode) viewModel.toggleSelection(alarm.id) else editingAlarm = alarm
+            },
+            onAlarmLongPress = { alarm ->
+                if (!isInSelectionMode) viewModel.enterSelectionMode(alarm.id)
+            },
+            onDismissAlarm = { alarm -> pendingDismiss = alarm },
+            onToggleAlarm = { alarm ->
+                viewModel.toggleEnabled(alarm) { success ->
+                    if (!success) schedulingError = "Couldn't update the alarm."
+                }
+            },
+            onStartStopwatch = {
+                viewModel.startStopwatch(
+                    nowWallClockMillis = nowMs,
                     nowElapsedRealtimeMs = nowElapsedRealtimeMs,
-                    nowWallClockMs = nowMs,
-                    onStart = {
-                        viewModel.startStopwatch(
-                            nowWallClockMillis = nowMs,
-                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
-                        )
-                    },
-                    onPause = {
-                        viewModel.pauseStopwatch(
-                            nowWallClockMillis = nowMs,
-                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
-                        )
-                    },
-                    onResume = {
-                        viewModel.resumeStopwatch(
-                            nowWallClockMillis = nowMs,
-                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
-                        )
-                    },
-                    onReset = viewModel::resetStopwatch,
-                    onLap = {
-                        viewModel.recordStopwatchLap(
-                            nowWallClockMillis = nowMs,
-                            nowElapsedRealtimeMs = nowElapsedRealtimeMs,
-                        )
-                    },
                 )
-
-
-                ClockSurfaceTab.WORLD_CLOCK -> WorldClockDashboard(
-                    worldClocks = worldClocks,
-                    nowMs = nowMs,
-                    onAddWorldClock = { showAddWorldClockDialog = true },
-                    onMoveUp = { worldClock -> viewModel.moveWorldClock(worldClock, direction = -1) },
-                    onMoveDown = { worldClock -> viewModel.moveWorldClock(worldClock, direction = 1) },
-                    onRemove = { worldClock -> pendingRemoveWorldClock = worldClock },
+            },
+            onPauseStopwatch = {
+                viewModel.pauseStopwatch(
+                    nowWallClockMillis = nowMs,
+                    nowElapsedRealtimeMs = nowElapsedRealtimeMs,
                 )
-            }
-        }
+            },
+            onResumeStopwatch = {
+                viewModel.resumeStopwatch(
+                    nowWallClockMillis = nowMs,
+                    nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                )
+            },
+            onResetStopwatch = viewModel::resetStopwatch,
+            onLapStopwatch = {
+                viewModel.recordStopwatchLap(
+                    nowWallClockMillis = nowMs,
+                    nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                )
+            },
+            onAddWorldClock = { showAddWorldClockDialog = true },
+            onMoveWorldClockUp = { worldClock -> viewModel.moveWorldClock(worldClock, direction = -1) },
+            onMoveWorldClockDown = { worldClock -> viewModel.moveWorldClock(worldClock, direction = 1) },
+            onRemoveWorldClock = { worldClock -> pendingRemoveWorldClock = worldClock },
+            modifier = Modifier.padding(innerPadding),
+        )
     }
 
     pendingCancel?.let { timer ->
@@ -573,6 +501,116 @@ fun SidePanelScreen(
                 TextButton(onClick = { schedulingWarning = null }) { Text("OK") }
             },
         )
+    }
+}
+
+@Composable
+internal fun ClockScreenFloatingActionButton(
+    isInSelectionMode: Boolean,
+    onNavigateToVoiceActions: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!isInSelectionMode) {
+        ClockVoiceFloatingActionButton(
+            onClick = onNavigateToVoiceActions,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+internal fun ClockSurfaceContent(
+    selectedTab: ClockSurfaceTab,
+    alarms: List<ClockAlarm>,
+    timers: List<ClockTimer>,
+    recentCompletedTimers: List<ClockTimer>,
+    stopwatch: ClockStopwatch,
+    worldClocks: List<WorldClock>,
+    nowMs: Long,
+    nowElapsedRealtimeMs: Long,
+    isInSelectionMode: Boolean,
+    selectedIds: Set<String>,
+    onTabSelected: (ClockSurfaceTab) -> Unit,
+    onCreateCustomTimer: () -> Unit,
+    onPresetTimer: (Long) -> Unit,
+    onTimerTap: (ClockTimer) -> Unit,
+    onTimerLongPress: (ClockTimer) -> Unit,
+    onCancelTimer: (ClockTimer) -> Unit,
+    onRestartTimer: (ClockTimer) -> Unit,
+    onDeleteCompletedTimer: (ClockTimer) -> Unit,
+    onClearCompletedTimers: () -> Unit,
+    onNewAlarm: () -> Unit,
+    onAlarmTap: (ClockAlarm) -> Unit,
+    onAlarmLongPress: (ClockAlarm) -> Unit,
+    onDismissAlarm: (ClockAlarm) -> Unit,
+    onToggleAlarm: (ClockAlarm) -> Unit,
+    onStartStopwatch: () -> Unit,
+    onPauseStopwatch: () -> Unit,
+    onResumeStopwatch: () -> Unit,
+    onResetStopwatch: () -> Unit,
+    onLapStopwatch: () -> Unit,
+    onAddWorldClock: () -> Unit,
+    onMoveWorldClockUp: (WorldClock) -> Unit,
+    onMoveWorldClockDown: (WorldClock) -> Unit,
+    onRemoveWorldClock: (WorldClock) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        ClockSurfaceTabs(
+            selectedTab = selectedTab,
+            onTabSelected = onTabSelected,
+        )
+
+        when (selectedTab) {
+            ClockSurfaceTab.TIMERS -> TimerDashboard(
+                timers = timers,
+                recentCompletedTimers = recentCompletedTimers,
+                nowMs = nowMs,
+                inSelectionMode = isInSelectionMode,
+                selectedIds = selectedIds,
+                onCreateCustomTimer = onCreateCustomTimer,
+                onPresetTimer = onPresetTimer,
+                onTimerTap = onTimerTap,
+                onTimerLongPress = onTimerLongPress,
+                onCancelTimer = onCancelTimer,
+                onRestartTimer = onRestartTimer,
+                onDeleteCompletedTimer = onDeleteCompletedTimer,
+                onClearCompletedTimers = onClearCompletedTimers,
+            )
+
+            ClockSurfaceTab.ALARMS -> AlarmDashboard(
+                alarms = alarms,
+                inSelectionMode = isInSelectionMode,
+                selectedIds = selectedIds,
+                onNewAlarm = onNewAlarm,
+                onAlarmTap = onAlarmTap,
+                onAlarmLongPress = onAlarmLongPress,
+                onDismissAlarm = onDismissAlarm,
+                onToggleAlarm = onToggleAlarm,
+            )
+
+            ClockSurfaceTab.STOPWATCH -> StopwatchDashboard(
+                stopwatch = stopwatch,
+                nowElapsedRealtimeMs = nowElapsedRealtimeMs,
+                nowWallClockMs = nowMs,
+                onStart = onStartStopwatch,
+                onPause = onPauseStopwatch,
+                onResume = onResumeStopwatch,
+                onReset = onResetStopwatch,
+                onLap = onLapStopwatch,
+            )
+
+            ClockSurfaceTab.WORLD_CLOCK -> WorldClockDashboard(
+                worldClocks = worldClocks,
+                nowMs = nowMs,
+                onAddWorldClock = onAddWorldClock,
+                onMoveUp = onMoveWorldClockUp,
+                onMoveDown = onMoveWorldClockDown,
+                onRemove = onRemoveWorldClock,
+            )
+        }
     }
 }
 
@@ -1249,6 +1287,8 @@ private fun AlarmDashboard(
         item {
             SectionHeader(
                 title = "Alarms",
+                actionLabel = "New alarm",
+                onAction = onNewAlarm,
                 supportingText = alarms.firstOrNull()?.let { "Next: ${formatClockTime(it.triggerAtMillis)}" } ?: "",
             )
         }
@@ -1292,6 +1332,8 @@ private fun WorldClockDashboard(
         item {
             SectionHeader(
                 title = "World Clock",
+                actionLabel = "Add city",
+                onAction = onAddWorldClock,
                 supportingText = "Saved cities update live.",
             )
         }


### PR DESCRIPTION
## Summary

Closes #1279.

This PR completes the Clock FAB standardisation by using one shared voice-only bottom-right FAB across Timers, Alarms, World Clock, and Stopwatch.

Changes:

- replace the per-tab Scaffold FAB branch in `SidePanelScreen` with the shared `ClockVoiceFloatingActionButton` whenever selection mode is off;
- remove the old stacked bottom FABs for Alarms and World Clock;
- keep tab-specific primary actions inside tab content instead of the Scaffold FAB slot;
- add screen-level Compose coverage for the shared voice FAB and the in-content actions;
- document the Clock action pattern in `docs/UX_PATTERNS.md`.

## Chosen pattern

- one consistent bottom-right voice FAB on every Clock tab;
- Timers keep preset/custom timer actions in the Timers card;
- Alarms keep `New alarm` in the alarms header or empty state;
- World Clock keeps `Add city` in the world clock header or empty state;
- Stopwatch keeps `Start stopwatch` in the stopwatch card;
- no stacked FABs or duplicate primary actions without a documented reason.

## Visual summary

- **Timers** — bottom-right mic FAB; preset timer buttons and `Custom timer` stay in the Timers card.
- **Alarms** — bottom-right mic FAB; `New alarm` stays in the alarms header or empty state; no bottom stacked `New Alarm` FAB.
- **World Clock** — bottom-right mic FAB; `Add city` stays in the world clock header or empty state; no bottom stacked `Add City` FAB.
- **Stopwatch** — bottom-right mic FAB; `Start stopwatch` stays in the stopwatch card.

## Validation

- `./gradlew :feature:settings:compileDebugAndroidTestKotlin --no-daemon`
- `./gradlew lint --no-daemon`
- `./gradlew test --no-daemon`
- `./gradlew assembleDebug --no-daemon`
- `./gradlew :app:compileDebugAndroidTestKotlin --no-daemon`

## Notes

- PR stays draft.
- Do Not Merge – Wait for Review.
