### PR TITLE
fix(#1335): improve TTS response stop action contrast

### DIFF
--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -592,7 +593,12 @@ fun ActionsScreen(
                             color = MaterialTheme.colorScheme.onTertiaryContainer,
                             modifier = Modifier.weight(1f),
                         )
-                        TextButton(onClick = viewModel::stopVoiceOutput) {
+                        TextButton(
+                            onClick = viewModel::stopVoiceOutput,
+                            colors = ButtonDefaults.textButtonColors(
+                                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                            ),
+                        ) {
                             Text("Stop")
                         }
                     }


### PR DESCRIPTION
## Summary
- set the active `Stop` text button on the Actions speaking-response banner to use `onTertiaryContainer`
- keep the existing card layout and stop-TTS behaviour unchanged
- avoid the default pale button tint that looked disabled against the light blue speaking banner

Closes #1335.

## Validation
- `./gradlew :feature:chat:testDebugUnitTest`
- `./gradlew :feature:chat:assembleDebug`

## Results
- `:feature:chat:testDebugUnitTest` ✅
- `:feature:chat:assembleDebug` ✅

## Manual validation notes
- Connected device: Samsung SM-G991B / Android 15.
- I attempted an ADB-driven smoke path to capture the speaking banner, but the app cold-started into the on-device model loading surface instead of reaching the TTS response banner during this harness run.
- No before/after screenshot is attached from this session.
- Theme coverage by code path: the banner already uses `tertiaryContainer`; this change pins the active `Stop` action to the matching `onTertiaryContainer` content role and removes the washed-out default button tint risk across light/dark and dynamic colour schemes.

## Base branch confirmation
- Branched from latest `main` after `git pull --ff-only origin main` in a dedicated worktree.
- The pulled `main` fast-forwarded to `cccfa0ee` and already included merged PR #1340 content, including `feature/settings/src/main/java/com/kernel/ai/feature/settings/ClockVoiceFloatingActionButton.kt`.

## Notes
- Draft for review only. Do not merge without review.