### PR TITLE
feat(#1330): add permission scenario runner

### DIFF
--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -11,8 +11,32 @@ and the device setup guide in [`docs/adb-testing.md`](./adb-testing.md).
 | Unit tests | Gradle + JUnit 5 + MockK | Core Kotlin logic, routing, parsing, repositories, presenters | `./gradlew testDebugUnitTest` |
 | Instrumented UI tests | Gradle + Compose/AndroidX test | Compose UI and connected-device Android tests, including S21 `permission_flows` | `./gradlew connectedDebugAndroidTest` |
 | Device regression harness | `adb` + Python | End-to-end intent routing, profile extraction, and on-device chat/action flows | `python3 scripts/adb_skill_test.py` |
+| Permission scenario runner | `adb` + Python | Physical-device permission journeys with step traces, screenshots, focused logcat, and UX-friction counters | `python3 scripts/run_permission_scenarios.py --device-id s21-exynos --scenarios …` |
 | Evidence generators | Python | Convert CI/connected outputs into #1113 normalised evidence | `python3 scripts/generate_permission_flow_evidence.py` |
 
+## Permission scenario runner
+
+The first-slice permission runner lives at [`scripts/run_permission_scenarios.py`](../scripts/run_permission_scenarios.py).
+It is a **local physical-device** runner for permission journeys that cross the app / Android
+boundary. It is **not CI evidence** and it does **not** auto-post GitHub comments or publish
+durable evidence in this first slice.
+
+Use it when you need:
+
+- Android runtime permission dialogs
+- Android Settings repair round-trips
+- app resume after external permission changes
+- screenshots and reviewer-friendly step traces
+- UX-friction counters on a real device
+
+Policy:
+
+- **S21 first** (`s21-exynos`)
+- **Do not use the S23U by default**
+- if no S21 / ADB device is available, stop on on-device validation rather than faking success
+
+See [`docs/testing/permission-scenario-runner.md`](./testing/permission-scenario-runner.md) for
+the command shape, output layout, and scope boundaries.
 ## ADB regression harness
 
 The main device automation entry point is [`scripts/adb_skill_test.py`](../scripts/adb_skill_test.py).

--- a/docs/testing/permission-scenario-runner.md
+++ b/docs/testing/permission-scenario-runner.md
@@ -1,0 +1,124 @@
+# Permission scenario runner
+
+Status: **First slice / local-only**  
+Issue: **#1330**
+
+## Purpose
+
+`scripts/run_permission_scenarios.py` is a deterministic physical-device runner for
+permission-sensitive user journeys that cross the app / Android boundary.
+
+It complements existing test layers:
+
+- **Compose / JVM tests** — rendering, state transitions, copy, callbacks
+- **Connected Android tests** — app + UiAutomator smoke coverage for known flows
+- **ADB skill harness** (`scripts/adb_skill_test.py`) — end-to-end routing and action flows
+- **Permission scenario runner** — reviewer-facing on-device permission journeys with
+  screenshots, step tracing, UX-friction counters, and focused logcat
+
+This runner is **not CI evidence**. It is **local physical-device evidence** only.
+
+## Device policy
+
+- **Default target:** S21 (`s21-exynos`)
+- **Do not use the S23U by default.** It is a targeted/reference device only when a
+  device-specific follow-up explicitly requires it.
+- If no S21 / ADB device is available, do not fake coverage. Capture the blocker and
+  stop the on-device validation step.
+
+## Scope in the first slice
+
+Implemented now:
+
+- deterministic scenario selection by ID
+- ADB-driven permission-state setup
+- explicit step trace with expected / actual / duration
+- local screenshots at declared checkpoints
+- focused per-scenario logcat capture (started from the current device timestamp, not the full ring buffer)
+- rich local `result.json`
+- PR/issue-comment-ready `summary.md`
+- schema-shaped derived `evidence.json` for downstream tooling experiments
+- initial scenarios:
+  - `mic_denied_enable_hey_jandal` — currently reports **blocked** on S21 when Jandal is not already the default assistant
+  - `mic_revoke_while_hey_jandal_enabled` — currently reports **blocked** on S21 when Jandal is not already the default assistant
+  - `weather_location_denied`
+
+Intentionally **not** implemented yet:
+
+- sticky GitHub comment posting
+- copying results into `test-results/`
+- dashboard publishing
+- S23U automation mode
+- special-access flows like DND / write-settings / exact alarms
+- video capture, screenshot diffing, or runtime-planned steps
+
+## Output layout
+
+Each run creates a timestamped directory under `scripts/test-reports/permissions/`:
+
+```text
+scripts/test-reports/permissions/<timestamp>/
+  result.json
+  evidence.json
+  summary.md
+  logcat.txt
+  screenshots/
+    01-...
+    02-...
+```
+
+### Output files
+
+- `result.json` — rich local run report with per-step trace, UX metrics, and artifact paths
+- `evidence.json` — narrower schema-shaped projection derived from the raw run
+- `evidence.json` intentionally omits scenarios that ended `blocked` / `skipped`, because the
+  current shared schema can represent pass/fail but not environment-prerequisite blockers without
+  misreporting them as product failures
+- `summary.md` — concise Markdown suitable for PR or issue comments
+- `logcat.txt` — focused app/crash logcat grouped by scenario, filtered to the active app process
+- `screenshots/` — explicit checkpoint screenshots only
+
+## Running the first slice
+
+```bash
+ANDROID_SERIAL=<S21_SERIAL> python3 scripts/run_permission_scenarios.py \
+  --device-id s21-exynos \
+  --serial "$ANDROID_SERIAL" \
+  --scenarios mic_denied_enable_hey_jandal,mic_revoke_while_hey_jandal_enabled,weather_location_denied \
+  --out-dir scripts/test-reports/permissions
+```
+
+List available scenarios:
+
+```bash
+python3 scripts/run_permission_scenarios.py \
+  --device-id s21-exynos \
+  --scenarios mic_denied_enable_hey_jandal \
+  --list-scenarios
+```
+
+## When to use this runner
+
+Use this runner when the regression depends on:
+
+- Android runtime permission dialogs
+- Android Settings repair hops
+- app resume after external permission changes
+- screenshot evidence for reviewer confidence
+- UX-friction counting on a real device
+
+Prefer other test layers when you only need:
+
+- composable rendering / copy verification
+- callback wiring
+- ViewModel state transitions
+- deterministic app-internal logic with no OS boundary
+- CI-safe checks
+
+## Privacy / evidence guardrails
+
+- Capture screenshots **only** at declared checkpoints tied to the scenario.
+- Keep runs on fresh, deterministic test state where practical.
+- Capture focused logcat only; do not collect or publish large raw device logs by default.
+- The runner writes **local** artifacts only. It does **not** auto-post GitHub comments and
+  does **not** publish durable evidence unless a separate workflow is invoked later.

--- a/docs/testing/permission-scenario-runner.md
+++ b/docs/testing/permission-scenario-runner.md
@@ -34,10 +34,10 @@ Implemented now:
 - ADB-driven permission-state setup
 - explicit step trace with expected / actual / duration
 - local screenshots at declared checkpoints
-- focused per-scenario logcat capture (started from the current device timestamp, not the full ring buffer)
+- focused per-scenario logcat capture from the latest PID-filtered app/crash lines, not the full ring buffer
 - rich local `result.json`
 - PR/issue-comment-ready `summary.md`
-- schema-shaped derived `evidence.json` for downstream tooling experiments
+- schema-compatible derived `evidence.json` for downstream tooling experiments, marked with explicit non-inference model metadata (`not_applicable` / `permission_scenario_runner` / `adb`)
 - initial scenarios:
   - `mic_denied_enable_hey_jandal` — currently reports **blocked** on S21 when Jandal is not already the default assistant
   - `mic_revoke_while_hey_jandal_enabled` — currently reports **blocked** on S21 when Jandal is not already the default assistant
@@ -70,7 +70,8 @@ scripts/test-reports/permissions/<timestamp>/
 ### Output files
 
 - `result.json` — rich local run report with per-step trace, UX metrics, and artifact paths
-- `evidence.json` — narrower schema-shaped projection derived from the raw run
+- `evidence.json` — narrower schema-compatible projection derived from the raw run, with explicit
+  non-inference model metadata because permission scenarios do not execute LiteRT/model inference
 - `evidence.json` intentionally omits scenarios that ended `blocked` / `skipped`, because the
   current shared schema can represent pass/fail but not environment-prerequisite blockers without
   misreporting them as product failures

--- a/scripts/permission_scenario_defs.py
+++ b/scripts/permission_scenario_defs.py
@@ -1,0 +1,171 @@
+"""Declarative scenario definitions for scripts/run_permission_scenarios.py."""
+
+from __future__ import annotations
+
+DEFAULT_UX_THRESHOLDS = {
+    "max_steps": 8,
+    "max_user_taps": 5,
+    "max_settings_hops": 1,
+    "max_duration_seconds": 30,
+    "max_back_presses": 2,
+    "fail_on_manual_intervention": True,
+}
+
+SCENARIOS: list[dict[str, object]] = [
+    {
+        "id": "mic_denied_enable_hey_jandal",
+        "title": "Enable Hey Jandal with microphone denied",
+        "capability": "wake_word",
+        "tags": ["permissions", "microphone", "wake_word"],
+        "steps": [
+            {
+                "id": "reset_microphone_prompt_state",
+                "action": "set_permission_state",
+                "permission": "android.permission.RECORD_AUDIO",
+                "state": "prompt",
+                "expected": "Microphone permission reset to promptable denied state",
+            },
+            {
+                "id": "launch_app",
+                "action": "launch_main",
+                "expected": "Kernel AI app returns to foreground",
+                "screenshot": True,
+            },
+            {
+                "id": "open_settings",
+                "action": "tap_visible",
+                "target": {"content_desc": "Settings"},
+                "expected": "Settings screen opens",
+                "expected_visible": ["Settings"],
+                "screenshot": True,
+            },
+            {
+                "id": "open_voice_settings",
+                "action": "tap_visible",
+                "target": {"text": "Voice"},
+                "expected": "Voice settings opens",
+                "expected_visible": ["Hey Jandal", 'Listen for "Hey Jandal"'],
+                "blocked_if_visible": {
+                    "texts": ["Set Jandal as default assistant first for reliable background mic access"],
+                    "reason": "S21 requires Jandal to be the default assistant before the Hey Jandal toggle becomes actionable.",
+                },
+                "screenshot": True,
+            },
+            {
+                "id": "try_enable_hey_jandal",
+                "action": "tap_visible",
+                "target": {"text": 'Listen for "Hey Jandal"'},
+                "expected": "Android microphone permission prompt appears",
+                "expected_any_visible": ["Allow", "While using the app", "Only this time", "Don't allow", "Deny"],
+                "screenshot": True,
+            },
+            {
+                "id": "deny_microphone_prompt",
+                "action": "tap_visible",
+                "target": {"any_text": ["Don't allow", "Deny", "No thanks", "Cancel"]},
+                "expected": "Permission prompt is denied and app remains usable",
+                "expected_visible": ['Listen for "Hey Jandal"'],
+                "expected_not_visible": ["Microphone permission is blocked"],
+                "screenshot": True,
+            },
+        ],
+    },
+    {
+        "id": "mic_revoke_while_hey_jandal_enabled",
+        "title": "Revoke microphone while Hey Jandal is enabled",
+        "capability": "wake_word",
+        "tags": ["permissions", "microphone", "wake_word", "durability"],
+        "steps": [
+            {
+                "id": "grant_microphone",
+                "action": "set_permission_state",
+                "permission": "android.permission.RECORD_AUDIO",
+                "state": "granted",
+                "expected": "Microphone permission granted",
+            },
+            {
+                "id": "launch_app",
+                "action": "launch_main",
+                "expected": "Kernel AI app returns to foreground",
+            },
+            {
+                "id": "open_settings",
+                "action": "tap_visible",
+                "target": {"content_desc": "Settings"},
+                "expected": "Settings screen opens",
+                "expected_visible": ["Settings"],
+            },
+            {
+                "id": "open_voice_settings",
+                "action": "tap_visible",
+                "target": {"text": "Voice"},
+                "expected": "Voice settings opens",
+                "expected_visible": ["Hey Jandal", 'Listen for "Hey Jandal"'],
+                "blocked_if_visible": {
+                    "texts": ["Set Jandal as default assistant first for reliable background mic access"],
+                    "reason": "S21 requires Jandal to be the default assistant before the Hey Jandal toggle can be enabled for revoke/resume validation.",
+                },
+                "screenshot": True,
+            },
+            {
+                "id": "enable_hey_jandal",
+                "action": "tap_visible",
+                "target": {"text": 'Listen for "Hey Jandal"'},
+                "expected": "Hey Jandal remains visible after enabling",
+                "expected_visible": ['Listen for "Hey Jandal"'],
+                "screenshot": True,
+            },
+            {
+                "id": "revoke_microphone_externally",
+                "action": "set_permission_state",
+                "permission": "android.permission.RECORD_AUDIO",
+                "state": "revoked",
+                "expected": "Microphone permission revoked externally",
+            },
+            {
+                "id": "background_app",
+                "action": "press_home",
+                "expected": "App is backgrounded",
+            },
+            {
+                "id": "resume_app",
+                "action": "launch_main",
+                "expected": "Voice screen resumes and shows durable repair UX",
+                "expected_visible": ["Microphone access was removed", "Open Microphone permission settings"],
+                "screenshot": True,
+            },
+        ],
+    },
+    {
+        "id": "weather_location_denied",
+        "title": "Weather request with location denied uses fallback UX",
+        "capability": "weather_current_location",
+        "tags": ["permissions", "location", "weather"],
+        "steps": [
+            {
+                "id": "reset_location_prompt_state",
+                "action": "set_permission_state",
+                "permission": "android.permission.ACCESS_COARSE_LOCATION",
+                "state": "prompt",
+                "also_apply": ["android.permission.ACCESS_FINE_LOCATION"],
+                "expected": "Location permissions reset to promptable denied state",
+            },
+            {
+                "id": "launch_weather_query",
+                "action": "launch_quick_action",
+                "query": "what's the weather",
+                "expected": "Weather permission dialog appears",
+                "expected_visible": ["Use your location for local weather?", "Use my location", "Use a named location"],
+                "screenshot": True,
+            },
+            {
+                "id": "choose_named_location",
+                "action": "tap_visible",
+                "target": {"text": "Use a named location"},
+                "expected": "Fallback guidance appears instead of forcing location access",
+                "expected_visible": ['Type a place name in the quick command bar, like "weather in Tokyo".'],
+                "screenshot": True,
+            },
+        ],
+    },
+]

--- a/scripts/run_permission_scenarios.py
+++ b/scripts/run_permission_scenarios.py
@@ -1,0 +1,1028 @@
+#!/usr/bin/env python3
+"""Run deterministic on-device permission scenarios with local evidence output.
+
+First slice for issue #1330:
+- deterministic ADB-driven execution only
+- local report output only; no publishing, PR comments, or durable evidence upload
+- S21-first physical validation
+- data-driven scenario definitions loaded from Python constants
+
+The runner writes a rich local report (`result.json`, `summary.md`, `logcat.txt`, screenshots)
+and a lightweight schema-compatible `evidence.json` derived from the richer output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from permission_scenario_defs import DEFAULT_UX_THRESHOLDS, SCENARIOS
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent
+REPO = "NickMonrad/kernel-ai-assistant"
+SCHEMA_VERSION = "1.0"
+SUITE = "permission_scenarios"
+APP_PACKAGE = "com.kernel.ai.debug"
+MAIN_ACTIVITY = "com.kernel.ai.MainActivity"
+UI_DUMP_REMOTE_PATH = "/sdcard/permission-runner-ui.xml"
+
+SETTINGS_PACKAGE_PREFIX = "com.android.settings"
+LOGCAT_TAG_SPECS = [
+    "KernelAI:D",
+    "AndroidRuntime:E",
+    "System.err:W",
+]
+
+
+class RunnerError(RuntimeError):
+    """Base runner error."""
+
+
+class DeviceUnavailable(RunnerError):
+    """ADB device or serial mismatch."""
+
+
+class StepFailure(RunnerError):
+    """Scenario step failed."""
+
+
+class ScenarioBlocked(RunnerError):
+    """Scenario cannot proceed deterministically on the current device state."""
+
+
+@dataclass(slots=True)
+class UiNode:
+    text: str
+    content_desc: str
+    resource_id: str
+    bounds: tuple[int, int, int, int] | None
+    clickable: bool
+    package: str
+
+    @property
+    def center(self) -> tuple[int, int] | None:
+        if self.bounds is None:
+            return None
+        left, top, right, bottom = self.bounds
+        return ((left + right) // 2, (top + bottom) // 2)
+
+
+@dataclass(slots=True)
+class StepTrace:
+    index: int
+    id: str
+    action: str
+    expected: str
+    actual: str
+    result: str
+    duration_ms: int
+    screenshot: str | None = None
+    screenshot_error: str | None = None
+    debug: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ScenarioResult:
+    schema_version: str
+    source: str
+    suite: str
+    scenario_id: str
+    scenario_title: str
+    timestamp: str
+    repo: str
+    branch: str | None
+    commit: str | None
+    pr: int | None
+    device: dict[str, Any]
+    functional_result: str
+    ux_result: str
+    step_count: int
+    tap_count: int
+    settings_hops: int
+    back_presses: int
+    duration_seconds: float
+    manual_intervention_required: bool
+    steps: list[StepTrace]
+    artifacts: dict[str, Any]
+    ux_warnings: list[str] = field(default_factory=list)
+    blocked_reason: str | None = None
+
+
+@dataclass(slots=True)
+class RunResult:
+    schema_version: str
+    source: str
+    suite: str
+    timestamp: str
+    repo: str
+    branch: str | None
+    commit: str | None
+    pr: int | None
+    run_id: str
+    device: dict[str, Any]
+    thresholds: dict[str, Any]
+    summary: dict[str, Any]
+    scenarios: list[ScenarioResult]
+    artifacts: dict[str, Any]
+
+
+class AdbClient:
+    def __init__(self, serial: str | None) -> None:
+        self.serial = serial
+
+    def _base_cmd(self) -> list[str]:
+        cmd = ["adb"]
+        if self.serial:
+            cmd.extend(["-s", self.serial])
+        return cmd
+
+    def run(
+        self,
+        *args: str,
+        timeout: float = 30.0,
+        check: bool = True,
+        text: bool = True,
+        input_text: str | bytes | None = None,
+    ) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+        cmd = self._base_cmd() + list(args)
+        result = subprocess.run(
+            cmd,
+            input=input_text,
+            capture_output=True,
+            text=text,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            stderr = result.stderr.strip() if isinstance(result.stderr, str) else (result.stderr or b"").decode(errors="replace").strip()
+            stdout = result.stdout.strip() if isinstance(result.stdout, str) else (result.stdout or b"").decode(errors="replace").strip()
+            detail = stderr or stdout or f"exit {result.returncode}"
+            raise RunnerError(f"ADB command failed: {' '.join(cmd)} :: {detail}")
+        return result
+
+    def shell(self, command: str, timeout: float = 30.0, check: bool = True) -> str:
+        result = self.run("shell", command, timeout=timeout, check=check, text=True)
+        assert isinstance(result.stdout, str)
+        return result.stdout.strip()
+
+    def shell_bool(self, command: str, timeout: float = 30.0) -> bool:
+        try:
+            self.shell(command, timeout=timeout, check=True)
+        except RunnerError:
+            return False
+        return True
+
+    def exec_out(self, *args: str, timeout: float = 30.0) -> bytes:
+        result = self.run("exec-out", *args, timeout=timeout, check=True, text=False)
+        assert isinstance(result.stdout, bytes)
+        return result.stdout
+
+    def ensure_device_available(self) -> None:
+        result = self.run("devices", timeout=10, check=True, text=True)
+        assert isinstance(result.stdout, str)
+        lines = [line.strip() for line in result.stdout.splitlines()[1:] if line.strip()]
+        if not lines:
+            raise DeviceUnavailable("No adb devices attached")
+        if self.serial and not any(line.startswith(f"{self.serial}\tdevice") for line in lines):
+            raise DeviceUnavailable(
+                f"Requested serial {self.serial!r} not in adb devices output: {lines}"
+            )
+
+    def current_package(self) -> str:
+        output = self.shell("dumpsys activity activities", timeout=20)
+        match = re.search(r"topResumedActivity=.*? ([^/\s]+)/", output)
+        if match:
+            return match.group(1)
+        return self.shell("dumpsys window windows | grep mCurrentFocus", timeout=20, check=False) or ""
+
+
+class LogcatCapture:
+    USER_RE = re.compile(r"(HuggingFaceAuthManager: restored auth=[^,]+, user=)(\S+)")
+
+    def __init__(self, adb: AdbClient) -> None:
+        self._adb = adb
+
+    def start(self) -> None:
+        return
+
+    def stop(self, pid: str | None) -> list[str]:
+        if not pid:
+            return ["<logcat capture skipped: app pid unavailable>"]
+        cmd = ["logcat", "--pid", pid, "-d", "-t", "200", "-v", "threadtime", "-s", *LOGCAT_TAG_SPECS]
+        result = self._adb.run(*cmd, timeout=30, check=False, text=True)
+        stdout = result.stdout if isinstance(result.stdout, str) else (result.stdout or b"").decode("utf-8", errors="replace")
+        if not stdout.strip():
+            return ["<no matching app logcat lines captured>"]
+        return [self._redact(line) for line in stdout.splitlines()]
+
+    def _redact(self, line: str) -> str:
+        return self.USER_RE.sub(r"\1<redacted>", line)
+
+
+class UiAutomatorView:
+    BOUNDS_RE = re.compile(r"\[(\d+),(\d+)]\[(\d+),(\d+)]")
+
+    def __init__(self, adb: AdbClient) -> None:
+        self._adb = adb
+
+    def dump_nodes(self, timeout: float = 15.0) -> list[UiNode]:
+        self._adb.shell(f"uiautomator dump {UI_DUMP_REMOTE_PATH}", timeout=timeout)
+        xml_text = self._adb.exec_out("cat", UI_DUMP_REMOTE_PATH, timeout=timeout).decode("utf-8", errors="replace")
+        return self._parse_nodes(xml_text)
+
+    def _parse_nodes(self, xml_text: str) -> list[UiNode]:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as exc:
+            raise RunnerError(f"Could not parse UI dump XML: {exc}") from exc
+        nodes: list[UiNode] = []
+        for el in root.iter("node"):
+            nodes.append(
+                UiNode(
+                    text=(el.attrib.get("text") or "").strip(),
+                    content_desc=(el.attrib.get("content-desc") or "").strip(),
+                    resource_id=(el.attrib.get("resource-id") or "").strip(),
+                    bounds=self._parse_bounds(el.attrib.get("bounds")),
+                    clickable=(el.attrib.get("clickable") == "true"),
+                    package=(el.attrib.get("package") or "").strip(),
+                )
+            )
+        return nodes
+
+    def _parse_bounds(self, raw: str | None) -> tuple[int, int, int, int] | None:
+        if not raw:
+            return None
+        match = self.BOUNDS_RE.fullmatch(raw)
+        if not match:
+            return None
+        return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+class ScenarioRunner:
+    def __init__(
+        self,
+        adb: AdbClient,
+        device: dict[str, Any],
+        branch: str | None,
+        commit: str | None,
+        pr: int | None,
+        run_dir: Path,
+        thresholds: dict[str, Any],
+    ) -> None:
+        self.adb = adb
+        self.device = device
+        self.branch = branch
+        self.commit = commit
+        self.pr = pr
+        self.run_dir = run_dir
+        self.thresholds = thresholds
+        self.ui = UiAutomatorView(adb)
+        self.screenshots_dir = run_dir / "screenshots"
+        self.screenshots_dir.mkdir(parents=True, exist_ok=True)
+        self.logcat_path = run_dir / "logcat.txt"
+
+    def wake_and_home(self) -> None:
+        self.adb.shell("input keyevent KEYCODE_WAKEUP", timeout=10, check=False)
+        time.sleep(0.5)
+        self.adb.shell("input swipe 540 2200 540 500 500", timeout=10, check=False)
+        time.sleep(1.0)
+        self.adb.shell("input keyevent KEYCODE_HOME", timeout=10, check=False)
+        time.sleep(1.0)
+
+    def run_scenario(self, scenario: dict[str, Any]) -> ScenarioResult:
+        started = time.monotonic()
+        steps: list[StepTrace] = []
+        tap_count = 0
+        settings_hops = 0
+        back_presses = 0
+        self.wake_and_home()
+        self.adb.shell(f"am force-stop {APP_PACKAGE}", timeout=20, check=False)
+        time.sleep(1.0)
+        manual_intervention_required = False
+        logcat_capture = LogcatCapture(self.adb)
+        scenario_timestamp = now_iso()
+        current_pid: str | None = None
+        logcat_capture.start()
+        functional_result = "pass"
+        blocked_reason: str | None = None
+        try:
+            for index, step in enumerate(scenario.get("steps", []), start=1):
+                step_started = time.monotonic()
+                action = step["action"]
+                expected = step.get("expected", action)
+                screenshot_error: str | None = None
+                debug: dict[str, Any] = {}
+                actual = ""
+                try:
+                    actual, delta = self._execute_step(step)
+                    tap_count += delta.get("tap_count", 0)
+                    settings_hops += delta.get("settings_hops", 0)
+                    back_presses += delta.get("back_presses", 0)
+                    manual_intervention_required = manual_intervention_required or delta.get("manual_intervention_required", False)
+                    current_pid = (delta.get("current_pid") or current_pid) if isinstance(delta.get("current_pid"), str) else current_pid
+                    self._apply_expectations(step)
+                    result = "pass"
+                except ScenarioBlocked as exc:
+                    functional_result = "blocked"
+                    blocked_reason = str(exc)
+                    actual = str(exc)
+                    result = "blocked"
+                except StepFailure as exc:
+                    functional_result = "fail"
+                    actual = str(exc)
+                    result = "fail"
+                duration_ms = int((time.monotonic() - step_started) * 1000)
+                screenshot_path = None
+                if step.get("screenshot"):
+                    screenshot_path, screenshot_error = self._capture_screenshot(
+                        scenario_id=scenario["id"],
+                        step_index=index,
+                        step_id=step["id"],
+                    )
+                if functional_result != "pass":
+                    debug.update(self._collect_debug_state())
+                steps.append(
+                    StepTrace(
+                        index=index,
+                        id=step["id"],
+                        action=action,
+                        expected=expected,
+                        actual=actual or "ok",
+                        result=result,
+                        duration_ms=duration_ms,
+                        screenshot=screenshot_path,
+                        screenshot_error=screenshot_error,
+                        debug=debug,
+                    )
+                )
+                if functional_result != "pass":
+                    break
+        finally:
+            scenario_lines = logcat_capture.stop(current_pid)
+            self._append_scenario_logcat(scenario["id"], scenario_lines)
+
+        duration_seconds = round(time.monotonic() - started, 2)
+        ux_result, ux_warnings = self._evaluate_ux(
+            functional_result=functional_result,
+            step_count=len(steps),
+            tap_count=tap_count,
+            settings_hops=settings_hops,
+            back_presses=back_presses,
+            duration_seconds=duration_seconds,
+            manual_intervention_required=manual_intervention_required,
+        )
+        artifacts = {
+            "screenshots": [trace.screenshot for trace in steps if trace.screenshot],
+            "logcat": relpath(self.logcat_path, self.run_dir),
+            "raw_json": "result.json",
+            "summary": "summary.md",
+            "evidence": "evidence.json",
+        }
+        return ScenarioResult(
+            schema_version=SCHEMA_VERSION,
+            source="on_device",
+            suite=SUITE,
+            scenario_id=scenario["id"],
+            scenario_title=scenario["title"],
+            timestamp=scenario_timestamp,
+            repo=REPO,
+            branch=self.branch,
+            commit=self.commit,
+            pr=self.pr,
+            device=self.device,
+            functional_result=functional_result,
+            ux_result=ux_result,
+            step_count=len(steps),
+            tap_count=tap_count,
+            settings_hops=settings_hops,
+            back_presses=back_presses,
+            duration_seconds=duration_seconds,
+            manual_intervention_required=manual_intervention_required,
+            steps=steps,
+            artifacts=artifacts,
+            ux_warnings=ux_warnings,
+            blocked_reason=blocked_reason,
+        )
+
+    def _execute_step(self, step: dict[str, Any]) -> tuple[str, dict[str, int | bool]]:
+        action = step["action"]
+        if action == "set_permission_state":
+            permissions = [step["permission"], *step.get("also_apply", [])]
+            state = step["state"]
+            for permission in permissions:
+                self._set_permission_state(permission, state)
+            return f"Permissions set to {state}: {', '.join(permissions)}", {}
+        if action == "launch_main":
+            self.wake_and_home()
+            self.adb.shell(f"am start -W -n {APP_PACKAGE}/{MAIN_ACTIVITY}", timeout=45)
+            self._wait_for_package(APP_PACKAGE, timeout_seconds=20)
+            return "MainActivity launched", {"current_pid": self._current_pid() or ""}
+        if action == "launch_quick_action":
+            self.wake_and_home()
+            query = step["query"]
+            encoded = uri_encode(query)
+            command = (
+                f"am start -W -S -n {APP_PACKAGE}/{MAIN_ACTIVITY} "
+                f"--es quick_action_input_encoded {encoded} --ez quick_action_is_voice false"
+            )
+            self.adb.shell(command, timeout=45)
+            self._wait_for_package(APP_PACKAGE, timeout_seconds=20)
+            return f"Quick action launched: {query}", {"current_pid": self._current_pid() or ""}
+        if action == "tap_visible":
+            node = self._find_target(step["target"], timeout_seconds=step.get("timeout_seconds", 8))
+            center = node.center
+            if center is None:
+                raise StepFailure(f"Visible target has no tappable bounds: {step['target']}")
+            x, y = center
+            self.adb.shell(f"input tap {x} {y}", timeout=10)
+            time.sleep(0.8)
+            deltas = {"tap_count": 1}
+            if self._current_package().startswith(SETTINGS_PACKAGE_PREFIX):
+                deltas["settings_hops"] = 1
+            return f"Tapped target {describe_target(step['target'])}", deltas
+        if action == "press_home":
+            self.adb.shell("input keyevent KEYCODE_HOME", timeout=10)
+            time.sleep(0.5)
+            return "Pressed HOME", {}
+        if action == "press_back":
+            self.adb.shell("input keyevent KEYCODE_BACK", timeout=10)
+            time.sleep(0.5)
+            return "Pressed BACK", {"back_presses": 1}
+        raise StepFailure(f"Unsupported action: {action}")
+
+    def _apply_expectations(self, step: dict[str, Any]) -> None:
+        timeout_seconds = float(step.get("timeout_seconds", 8))
+        for text in step.get("expected_visible", []):
+            if not self._wait_for_text(text, timeout_seconds=timeout_seconds):
+                raise StepFailure(f"Expected text not visible: {text}")
+        any_visible = step.get("expected_any_visible", [])
+        if any_visible and not self._wait_for_any_text(any_visible, timeout_seconds=timeout_seconds):
+            raise StepFailure(f"Expected one of {any_visible!r} to be visible")
+        blocked_marker = step.get("blocked_if_visible")
+        if blocked_marker:
+            texts = blocked_marker.get("texts", [])
+            if texts and self._wait_for_any_text(texts, timeout_seconds=1.0):
+                raise ScenarioBlocked(blocked_marker.get("reason", f"Blocked by visible prerequisite: {texts!r}"))
+        for text in step.get("expected_not_visible", []):
+            if self._is_text_visible(text, timeout_seconds=1.0):
+                raise StepFailure(f"Unexpected text visible: {text}")
+
+    def _set_permission_state(self, permission: str, state: str) -> None:
+        if state == "granted":
+            self.adb.shell(f"pm grant {APP_PACKAGE} {permission}")
+            self.adb.shell(
+                f"pm clear-permission-flags {APP_PACKAGE} {permission} user-set user-fixed",
+                check=False,
+            )
+            return
+        if state == "revoked":
+            self.adb.shell(f"pm revoke {APP_PACKAGE} {permission}", check=False)
+            self.adb.shell(
+                f"pm clear-permission-flags {APP_PACKAGE} {permission} user-set user-fixed",
+                check=False,
+            )
+            return
+        if state == "prompt":
+            self.adb.shell(f"pm revoke {APP_PACKAGE} {permission}", check=False)
+            self.adb.shell(
+                f"pm clear-permission-flags {APP_PACKAGE} {permission} user-set user-fixed",
+                check=False,
+            )
+            return
+        if state == "blocked":
+            self.adb.shell(f"pm revoke {APP_PACKAGE} {permission}", check=False)
+            self.adb.shell(
+                f"pm set-permission-flags {APP_PACKAGE} {permission} user-set user-fixed",
+                check=False,
+            )
+            return
+        raise StepFailure(f"Unsupported permission state: {state}")
+
+    def _find_target(self, target: dict[str, Any], timeout_seconds: float) -> UiNode:
+        deadline = time.monotonic() + timeout_seconds
+        last_nodes: list[UiNode] = []
+        while time.monotonic() < deadline:
+            nodes = self.ui.dump_nodes()
+            last_nodes = nodes
+            if match := find_matching_node(nodes, target):
+                return match
+            time.sleep(0.5)
+        raise StepFailure(
+            f"Target not visible within {timeout_seconds}s: {describe_target(target)}; "
+            f"visible sample={visible_sample(last_nodes)}"
+        )
+
+    def _wait_for_text(self, text: str, timeout_seconds: float) -> bool:
+        return self._wait_for_any_text([text], timeout_seconds=timeout_seconds, exact=True)
+
+    def _wait_for_any_text(self, texts: Iterable[str], timeout_seconds: float, exact: bool = True) -> bool:
+        wanted = list(texts)
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            nodes = self.ui.dump_nodes()
+            for node in nodes:
+                haystacks = [node.text, node.content_desc]
+                for needle in wanted:
+                    if exact:
+                        if needle in haystacks:
+                            return True
+                    elif any(needle in hay for hay in haystacks if hay):
+                        return True
+            time.sleep(0.5)
+        return False
+
+    def _is_text_visible(self, text: str, timeout_seconds: float) -> bool:
+        return self._wait_for_any_text([text], timeout_seconds=timeout_seconds, exact=True)
+
+    def _wait_for_package(self, package_name: str, timeout_seconds: float) -> None:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            current = self._current_package()
+            if current == package_name:
+                return
+            time.sleep(0.5)
+        raise StepFailure(f"Expected package {package_name} in foreground; saw {self._current_package()!r}")
+
+    def _current_package(self) -> str:
+        output = self.adb.shell("dumpsys activity activities", timeout=20, check=False)
+        for pattern in (
+            r"topResumedActivity=.*? ([^/\s]+)/",
+            r"mResumedActivity:.*? ([^/\s]+)/",
+        ):
+            match = re.search(pattern, output)
+            if match:
+                return match.group(1)
+        window = self.adb.shell("dumpsys window windows", timeout=20, check=False)
+        match = re.search(r"mCurrentFocus=.*? ([^/\s]+)/", window)
+        if match:
+            return match.group(1)
+        return ""
+
+    def _current_pid(self) -> str | None:
+        raw = self.adb.shell(f"pidof {APP_PACKAGE}", timeout=10, check=False).strip()
+        if not raw:
+            return None
+        return raw.split()[0]
+
+    def _collect_debug_state(self) -> dict[str, Any]:
+        focused_window = self.adb.shell("dumpsys window windows", timeout=20, check=False)
+        resumed_activity = self.adb.shell("dumpsys activity activities", timeout=20, check=False)
+        return {
+            "current_package": self._current_package(),
+            "focused_window": first_matching_line(focused_window, ["mCurrentFocus", "mFocusedApp"]),
+            "resumed_activity": first_matching_line(resumed_activity, ["topResumedActivity", "mResumedActivity", "ResumedActivity"]),
+        }
+
+    def _capture_screenshot(self, scenario_id: str, step_index: int, step_id: str) -> tuple[str | None, str | None]:
+        filename = f"{step_index:02d}-{slugify(scenario_id)}-{slugify(step_id)}.png"
+        destination = self.screenshots_dir / filename
+        try:
+            png = self.adb.exec_out("screencap", "-p", timeout=30)
+            destination.write_bytes(png)
+            return relpath(destination, self.run_dir), None
+        except Exception as exc:
+            return None, str(exc)
+
+    def _append_scenario_logcat(self, scenario_id: str, lines: list[str]) -> None:
+        with self.logcat_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"===== {scenario_id} =====\n")
+            if lines:
+                handle.write("\n".join(lines))
+                handle.write("\n")
+            else:
+                handle.write("<no captured logcat lines>\n")
+            handle.write("\n")
+
+    def _evaluate_ux(
+        self,
+        *,
+        functional_result: str,
+        step_count: int,
+        tap_count: int,
+        settings_hops: int,
+        back_presses: int,
+        duration_seconds: float,
+        manual_intervention_required: bool,
+    ) -> tuple[str, list[str]]:
+        if functional_result in {"blocked", "skipped"}:
+            return "not_assessed", []
+        warnings: list[str] = []
+        if step_count > self.thresholds["max_steps"]:
+            warnings.append(f"steps {step_count} > {self.thresholds['max_steps']}")
+        if tap_count > self.thresholds["max_user_taps"]:
+            warnings.append(f"taps {tap_count} > {self.thresholds['max_user_taps']}")
+        if settings_hops > self.thresholds["max_settings_hops"]:
+            warnings.append(f"settings hops {settings_hops} > {self.thresholds['max_settings_hops']}")
+        if duration_seconds > self.thresholds["max_duration_seconds"]:
+            warnings.append(
+                f"duration {duration_seconds:.1f}s > {self.thresholds['max_duration_seconds']}s"
+            )
+        if back_presses > self.thresholds["max_back_presses"]:
+            warnings.append(f"back presses {back_presses} > {self.thresholds['max_back_presses']}")
+        if manual_intervention_required and self.thresholds["fail_on_manual_intervention"]:
+            warnings.append("manual intervention required")
+        if functional_result == "fail":
+            return "fail", warnings
+        if warnings:
+            return "warning", warnings
+        return "pass", []
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run deterministic permission scenarios on a physical Android device")
+    parser.add_argument("--device-id", required=True, help="Device registry ID from scripts/testdata/devices.yaml")
+    parser.add_argument("--serial", default=os.environ.get("ANDROID_SERIAL"), help="ADB serial to target")
+    parser.add_argument(
+        "--scenarios",
+        required=True,
+        help="Comma-separated scenario IDs, e.g. mic_denied_enable_hey_jandal,weather_location_denied",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=str(HERE / "test-reports" / "permissions"),
+        help="Parent directory for timestamped local reports",
+    )
+    parser.add_argument("--pr", type=int, default=None, help="Optional PR number for report metadata")
+    parser.add_argument("--branch", default=None, help="Override git branch metadata")
+    parser.add_argument("--commit", default=None, help="Override git commit metadata")
+    parser.add_argument("--list-scenarios", action="store_true", help="List available scenarios and exit")
+    return parser.parse_args(argv)
+
+
+def load_devices() -> dict[str, dict[str, Any]]:
+    sys.path.insert(0, str(HERE))
+    from summarise_test_report import load_devices as load_devices_impl
+
+    return load_devices_impl()
+
+
+def resolve_device(device_id: str, serial: str | None) -> dict[str, Any]:
+    devices = load_devices()
+    if device_id not in devices:
+        known = ", ".join(sorted(devices))
+        raise RunnerError(f"Unknown --device-id {device_id!r}; valid IDs: {known}")
+    entry = dict(devices[device_id])
+    return {
+        "id": device_id,
+        "serial": serial,
+        "label": entry.get("label", device_id),
+        "manufacturer": entry.get("manufacturer", "Unknown"),
+        "model": entry.get("model", "Unknown"),
+        "soc": entry.get("soc", "Unknown"),
+        "tier": entry.get("tier", "tracked"),
+        "android_api": entry.get("android_api"),
+        "execution": entry.get("execution", "physical"),
+    }
+
+
+def load_scenarios() -> list[dict[str, Any]]:
+    return [dict(scenario) for scenario in SCENARIOS]
+
+
+def select_scenarios(selected_ids: list[str]) -> list[dict[str, Any]]:
+    scenarios = {scenario["id"]: scenario for scenario in load_scenarios()}
+    missing = [scenario_id for scenario_id in selected_ids if scenario_id not in scenarios]
+    if missing:
+        raise RunnerError(f"Unknown scenario IDs: {', '.join(missing)}")
+    return [scenarios[scenario_id] for scenario_id in selected_ids]
+
+def detect_git_metadata(branch_override: str | None, commit_override: str | None) -> tuple[str | None, str | None]:
+    branch = branch_override or git_output("git branch --show-current")
+    commit = commit_override or git_output("git rev-parse HEAD")
+    return branch or None, commit or None
+
+
+def git_output(command: str) -> str | None:
+    try:
+        result = subprocess.run(
+            shlex.split(command),
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except Exception:
+        return None
+    return result.stdout.strip() or None
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def build_run_result(
+    *,
+    timestamp: str,
+    run_id: str,
+    branch: str | None,
+    commit: str | None,
+    pr: int | None,
+    device: dict[str, Any],
+    thresholds: dict[str, Any],
+    scenarios: list[ScenarioResult],
+) -> RunResult:
+    summary = {
+        "total": len(scenarios),
+        "functional": count_by(s.functional_result for s in scenarios),
+        "ux": count_by(s.ux_result for s in scenarios),
+        "example_report": "summary.md",
+    }
+    return RunResult(
+        schema_version=SCHEMA_VERSION,
+        source="on_device",
+        suite=SUITE,
+        timestamp=timestamp,
+        repo=REPO,
+        branch=branch,
+        commit=commit,
+        pr=pr,
+        run_id=run_id,
+        device=device,
+        thresholds=thresholds,
+        summary=summary,
+        scenarios=scenarios,
+        artifacts={
+            "raw_json": "result.json",
+            "summary": "summary.md",
+            "logcat": "logcat.txt",
+            "evidence": "evidence.json",
+            "screenshots_dir": "screenshots",
+        },
+    )
+
+
+def to_evidence(run_result: RunResult) -> dict[str, Any]:
+    cases = []
+    for scenario in run_result.scenarios:
+        if scenario.functional_result not in {"pass", "fail"}:
+            continue
+        failures: list[str] = []
+        if scenario.functional_result != "pass":
+            failures.extend(
+                step.actual for step in scenario.steps if step.result in {"fail", "blocked", "skipped"}
+            )
+        cases.append(
+            {
+                "name": scenario.scenario_id,
+                "passed": scenario.functional_result == "pass",
+                "expected_tool": None,
+                "actual_tool": None,
+                "expected_result_mode": "success",
+                "actual_result_mode": "success" if scenario.functional_result == "pass" else "unknown",
+                "chip_present": False,
+                "skill_result_present": False,
+                "message_saved": False,
+                "retry_seen": False,
+                "slot_fill_seen": False,
+                "failure_category": map_failure_category(scenario.functional_result),
+                "failures": failures,
+            }
+        )
+    passed = sum(1 for case in cases if case["passed"])
+    failed = len(cases) - passed
+    evidence_device = dict(run_result.device)
+    evidence_device["serial"] = None
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": "on_device",
+        "suite": SUITE,
+        "timestamp": run_result.timestamp,
+        "repo": REPO,
+        "branch": run_result.branch,
+        "commit": run_result.commit,
+        "pr": run_result.pr,
+        "release": None,
+        "run_id": run_result.run_id,
+        "device": evidence_device,
+        "model": {"name": None, "runtime": None, "backend": None},
+        "summary": {
+            "total": len(cases),
+            "passed": passed,
+            "failed": failed,
+            "pass_rate": round((passed / len(cases)) if cases else 0.0, 3),
+        },
+        "cases": cases,
+    }
+
+
+def map_failure_category(functional_result: str) -> str | None:
+    if functional_result == "pass":
+        return None
+    if functional_result == "blocked":
+        return "device_environment_error"
+    return "harness_error"
+
+
+def write_summary(run_result: RunResult, path: Path) -> str:
+    lines = [
+        "# Permission scenario evidence",
+        "",
+        f"**Source:** `{run_result.source}`",
+        f"**Suite:** `{run_result.suite}`",
+        f"**Device:** {run_result.device['label']} ({run_result.device['manufacturer']}, `{run_result.device['id']}`)",
+        f"**Commit:** `{short_sha(run_result.commit)}`" if run_result.commit else "**Commit:** unknown",
+        f"**Branch:** `{run_result.branch}`" if run_result.branch else "**Branch:** unknown",
+        f"**Run ID:** `{run_result.run_id}`",
+        "",
+        "| Scenario | Functional | UX | Steps | Taps | Settings hops | Back | Duration |",
+        "|---|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for scenario in run_result.scenarios:
+        lines.append(
+            "| {title} | {functional} | {ux} | {steps} | {taps} | {settings} | {back} | {duration:.1f}s |".format(
+                title=scenario.scenario_title,
+                functional=scenario.functional_result,
+                ux=scenario.ux_result,
+                steps=scenario.step_count,
+                taps=scenario.tap_count,
+                settings=scenario.settings_hops,
+                back=scenario.back_presses,
+                duration=scenario.duration_seconds,
+            )
+        )
+    lines.extend([
+        "",
+        "## Artifacts",
+        "",
+        f"- Raw report: `{run_result.artifacts['raw_json']}`",
+        f"- Schema evidence: `{run_result.artifacts['evidence']}`",
+        f"- Logcat: `{run_result.artifacts['logcat']}`",
+        f"- Screenshots: `{run_result.artifacts['screenshots_dir']}/`",
+        "",
+    ])
+    for scenario in run_result.scenarios:
+        lines.append(f"## {scenario.scenario_title}")
+        lines.append("")
+        lines.append(f"- Scenario ID: `{scenario.scenario_id}`")
+        lines.append(f"- Functional result: `{scenario.functional_result}`")
+        lines.append(f"- UX result: `{scenario.ux_result}`")
+        if scenario.blocked_reason:
+            lines.append(f"- Blocked reason: {scenario.blocked_reason}")
+        if scenario.ux_warnings:
+            lines.append(f"- UX warnings: {', '.join(scenario.ux_warnings)}")
+        lines.append("- Steps:")
+        for step in scenario.steps:
+            screenshot = f" (`{step.screenshot}`)" if step.screenshot else ""
+            lines.append(
+                f"  - {step.index:02d}. `{step.id}` — {step.result}: {step.actual}{screenshot}"
+            )
+        lines.append("")
+    summary = "\n".join(lines).rstrip() + "\n"
+    path.write_text(summary, encoding="utf-8")
+    return summary
+
+
+def visible_sample(nodes: list[UiNode], limit: int = 8) -> list[str]:
+    sample: list[str] = []
+    for node in nodes:
+        for value in (node.text, node.content_desc):
+            if value and value not in sample:
+                sample.append(value)
+                if len(sample) >= limit:
+                    return sample
+    return sample
+
+
+def find_matching_node(nodes: list[UiNode], target: dict[str, Any]) -> UiNode | None:
+    text = target.get("text")
+    if text:
+        for node in nodes:
+            if node.text == text or node.content_desc == text:
+                return node
+    contains = target.get("text_contains")
+    if contains:
+        for node in nodes:
+            if contains in node.text or contains in node.content_desc:
+                return node
+    content_desc = target.get("content_desc")
+    if content_desc:
+        for node in nodes:
+            if node.content_desc == content_desc:
+                return node
+    resource_id = target.get("resource_id")
+    if resource_id:
+        for node in nodes:
+            if node.resource_id == resource_id:
+                return node
+    any_text = target.get("any_text")
+    if any_text:
+        for option in any_text:
+            for node in nodes:
+                if node.text == option or node.content_desc == option:
+                    return node
+    return None
+
+
+def describe_target(target: dict[str, Any]) -> str:
+    for key in ("text", "text_contains", "content_desc", "resource_id", "any_text"):
+        if key in target:
+            return f"{key}={target[key]!r}"
+    return repr(target)
+
+
+def first_matching_line(text: str, needles: list[str]) -> str:
+    for line in text.splitlines():
+        if any(needle in line for needle in needles):
+            return line.strip()
+    return "<not found>"
+
+
+def uri_encode(value: str) -> str:
+    from urllib.parse import quote
+
+    return quote(value, safe="")
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "step"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def short_sha(sha: str | None) -> str:
+    return sha[:7] if sha else "unknown"
+
+
+def relpath(path: Path, base: Path) -> str:
+    return str(path.relative_to(base))
+
+
+def count_by(values: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def list_scenarios() -> None:
+    for scenario in load_scenarios():
+        print(f"{scenario['id']}: {scenario['title']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.list_scenarios:
+        list_scenarios()
+        return 0
+    selected_ids = [item.strip() for item in args.scenarios.split(",") if item.strip()]
+    if not selected_ids:
+        raise RunnerError("At least one scenario ID is required")
+    adb = AdbClient(args.serial)
+    adb.ensure_device_available()
+    device = resolve_device(args.device_id, args.serial)
+    branch, commit = detect_git_metadata(args.branch, args.commit)
+    timestamp = now_iso()
+    timestamp_path = timestamp.replace(":", "-")
+    run_dir = Path(args.out_dir) / timestamp_path
+    run_dir.mkdir(parents=True, exist_ok=True)
+    runner = ScenarioRunner(
+        adb=adb,
+        device=device,
+        branch=branch,
+        commit=commit,
+        pr=args.pr,
+        run_dir=run_dir,
+        thresholds=dict(DEFAULT_UX_THRESHOLDS),
+    )
+    scenarios = [runner.run_scenario(scenario) for scenario in select_scenarios(selected_ids)]
+    run_id = f"on_device-{timestamp_path}-{args.device_id}"
+    run_result = build_run_result(
+        timestamp=timestamp,
+        run_id=run_id,
+        branch=branch,
+        commit=commit,
+        pr=args.pr,
+        device=device,
+        thresholds=dict(DEFAULT_UX_THRESHOLDS),
+        scenarios=scenarios,
+    )
+    write_json(run_dir / "result.json", asdict(run_result))
+    write_json(run_dir / "evidence.json", to_evidence(run_result))
+    write_summary(run_result, run_dir / "summary.md")
+    print(f"Permission scenario report: {run_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DeviceUnavailable as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    except RunnerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/run_permission_scenarios.py
+++ b/scripts/run_permission_scenarios.py
@@ -8,7 +8,8 @@ First slice for issue #1330:
 - data-driven scenario definitions loaded from Python constants
 
 The runner writes a rich local report (`result.json`, `summary.md`, `logcat.txt`, screenshots)
-and a lightweight schema-compatible `evidence.json` derived from the richer output.
+and a lightweight schema-compatible `evidence.json` derived from the richer output, using
+explicit non-inference model metadata for permission-only scenarios.
 """
 
 from __future__ import annotations
@@ -44,6 +45,12 @@ LOGCAT_TAG_SPECS = [
     "AndroidRuntime:E",
     "System.err:W",
 ]
+
+NON_INFERENCE_MODEL = {
+    "name": "not_applicable",
+    "runtime": "permission_scenario_runner",
+    "backend": "adb",
+}
 
 
 class RunnerError(RuntimeError):
@@ -806,7 +813,7 @@ def to_evidence(run_result: RunResult) -> dict[str, Any]:
         "release": None,
         "run_id": run_result.run_id,
         "device": evidence_device,
-        "model": {"name": None, "runtime": None, "backend": None},
+        "model": dict(NON_INFERENCE_MODEL),
         "summary": {
             "total": len(cases),
             "passed": passed,
@@ -857,7 +864,7 @@ def write_summary(run_result: RunResult, path: Path) -> str:
         "## Artifacts",
         "",
         f"- Raw report: `{run_result.artifacts['raw_json']}`",
-        f"- Schema evidence: `{run_result.artifacts['evidence']}`",
+        f"- Schema-compatible evidence: `{run_result.artifacts['evidence']}`",
         f"- Logcat: `{run_result.artifacts['logcat']}`",
         f"- Screenshots: `{run_result.artifacts['screenshots_dir']}/`",
         "",

--- a/scripts/tests/test_run_permission_scenarios.py
+++ b/scripts/tests/test_run_permission_scenarios.py
@@ -95,6 +95,9 @@ class PermissionScenarioRunnerTest(unittest.TestCase):
         self.assertEqual(1, len(evidence["cases"]))
         self.assertEqual("weather_location_denied", evidence["cases"][0]["name"])
         self.assertEqual([], evidence["cases"][0]["failures"])
+        self.assertEqual("not_applicable", evidence["model"]["name"])
+        self.assertEqual("permission_scenario_runner", evidence["model"]["runtime"])
+        self.assertEqual("adb", evidence["model"]["backend"])
 
     def test_write_summary_includes_artifacts_and_table(self) -> None:
         scenario = permission_runner.ScenarioResult(
@@ -165,7 +168,7 @@ class PermissionScenarioRunnerTest(unittest.TestCase):
 
         self.assertIn("| Scenario | Functional | UX | Steps |", markdown)
         self.assertIn("Enable Hey Jandal with microphone denied", markdown)
-        self.assertIn("Schema evidence", markdown)
+        self.assertIn("Schema-compatible evidence", markdown)
         self.assertEqual(markdown, written)
 
     def test_build_run_result_counts_functional_and_ux_outcomes(self) -> None:

--- a/scripts/tests/test_run_permission_scenarios.py
+++ b/scripts/tests/test_run_permission_scenarios.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Tests for run_permission_scenarios.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from dataclasses import asdict
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import run_permission_scenarios as permission_runner
+
+
+class PermissionScenarioRunnerTest(unittest.TestCase):
+    def test_select_scenarios_returns_requested_order(self) -> None:
+        selected = permission_runner.select_scenarios(
+            [
+                "weather_location_denied",
+                "mic_denied_enable_hey_jandal",
+            ]
+        )
+
+        self.assertEqual(
+            ["weather_location_denied", "mic_denied_enable_hey_jandal"],
+            [scenario["id"] for scenario in selected],
+        )
+
+    def test_select_scenarios_rejects_unknown_ids(self) -> None:
+        with self.assertRaises(permission_runner.RunnerError):
+            permission_runner.select_scenarios(["missing_scenario"])
+
+    def test_to_evidence_projects_rich_report_into_schema_shape(self) -> None:
+        scenario = permission_runner.ScenarioResult(
+            schema_version="1.0",
+            source="on_device",
+            suite="permission_scenarios",
+            scenario_id="weather_location_denied",
+            scenario_title="Weather request with location denied uses fallback UX",
+            timestamp="2026-06-29T00:00:00Z",
+            repo="NickMonrad/kernel-ai-assistant",
+            branch="feature/test",
+            commit="a" * 40,
+            pr=1330,
+            device={"id": "s21-exynos", "execution": "physical"},
+            functional_result="pass",
+            ux_result="warning",
+            step_count=3,
+            tap_count=2,
+            settings_hops=0,
+            back_presses=0,
+            duration_seconds=12.5,
+            manual_intervention_required=False,
+            steps=[
+                permission_runner.StepTrace(
+                    index=1,
+                    id="launch_weather_query",
+                    action="launch_quick_action",
+                    expected="Weather permission dialog appears",
+                    actual="Quick action launched",
+                    result="pass",
+                    duration_ms=1200,
+                    screenshot="screenshots/01-weather.png",
+                )
+            ],
+            artifacts={"raw_json": "result.json"},
+            ux_warnings=["steps 9 > 8"],
+        )
+        run_result = permission_runner.RunResult(
+            schema_version="1.0",
+            source="on_device",
+            suite="permission_scenarios",
+            timestamp="2026-06-29T00:00:00Z",
+            repo="NickMonrad/kernel-ai-assistant",
+            branch="feature/test",
+            commit="a" * 40,
+            pr=1330,
+            run_id="on_device-2026-06-29T00-00-00Z-s21-exynos",
+            device={"id": "s21-exynos", "execution": "physical"},
+            thresholds=dict(permission_runner.DEFAULT_UX_THRESHOLDS),
+            summary={"total": 1},
+            scenarios=[scenario],
+            artifacts={"raw_json": "result.json", "evidence": "evidence.json", "logcat": "logcat.txt", "screenshots_dir": "screenshots"},
+        )
+
+        evidence = permission_runner.to_evidence(run_result)
+
+        self.assertEqual("permission_scenarios", evidence["suite"])
+        self.assertEqual(1, evidence["summary"]["passed"])
+        self.assertEqual(1, len(evidence["cases"]))
+        self.assertEqual("weather_location_denied", evidence["cases"][0]["name"])
+        self.assertEqual([], evidence["cases"][0]["failures"])
+
+    def test_write_summary_includes_artifacts_and_table(self) -> None:
+        scenario = permission_runner.ScenarioResult(
+            schema_version="1.0",
+            source="on_device",
+            suite="permission_scenarios",
+            scenario_id="mic_denied_enable_hey_jandal",
+            scenario_title="Enable Hey Jandal with microphone denied",
+            timestamp="2026-06-29T00:00:00Z",
+            repo="NickMonrad/kernel-ai-assistant",
+            branch="feature/test",
+            commit="b" * 40,
+            pr=1330,
+            device={"id": "s21-exynos", "execution": "physical", "label": "S21", "manufacturer": "Samsung", "model": "SM-G991B"},
+            functional_result="blocked",
+            ux_result="not_assessed",
+            step_count=2,
+            tap_count=1,
+            settings_hops=0,
+            back_presses=0,
+            duration_seconds=5.1,
+            manual_intervention_required=False,
+            steps=[
+                permission_runner.StepTrace(
+                    index=1,
+                    id="launch_app",
+                    action="launch_main",
+                    expected="Jandal opens on the main screen",
+                    actual="MainActivity launched",
+                    result="pass",
+                    duration_ms=700,
+                ),
+                permission_runner.StepTrace(
+                    index=2,
+                    id="open_voice_settings",
+                    action="tap_visible",
+                    expected="Voice settings opens",
+                    actual="Target not visible",
+                    result="blocked",
+                    duration_ms=1800,
+                    screenshot="screenshots/02-open-voice.png",
+                ),
+            ],
+            artifacts={"raw_json": "result.json", "summary": "summary.md", "evidence": "evidence.json", "logcat": "logcat.txt", "screenshots": ["screenshots/02-open-voice.png"]},
+            blocked_reason="Target not visible",
+        )
+        run_result = permission_runner.RunResult(
+            schema_version="1.0",
+            source="on_device",
+            suite="permission_scenarios",
+            timestamp="2026-06-29T00:00:00Z",
+            repo="NickMonrad/kernel-ai-assistant",
+            branch="feature/test",
+            commit="b" * 40,
+            pr=1330,
+            run_id="on_device-2026-06-29T00-00-00Z-s21-exynos",
+            device={"id": "s21-exynos", "label": "S21", "manufacturer": "Samsung", "model": "SM-G991B", "execution": "physical"},
+            thresholds=dict(permission_runner.DEFAULT_UX_THRESHOLDS),
+            summary={"total": 1},
+            scenarios=[scenario],
+            artifacts={"raw_json": "result.json", "evidence": "evidence.json", "logcat": "logcat.txt", "screenshots_dir": "screenshots"},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.md"
+            markdown = permission_runner.write_summary(run_result, path)
+            written = path.read_text(encoding="utf-8")
+
+        self.assertIn("| Scenario | Functional | UX | Steps |", markdown)
+        self.assertIn("Enable Hey Jandal with microphone denied", markdown)
+        self.assertIn("Schema evidence", markdown)
+        self.assertEqual(markdown, written)
+
+    def test_build_run_result_counts_functional_and_ux_outcomes(self) -> None:
+        scenarios = [
+            permission_runner.ScenarioResult(
+                schema_version="1.0",
+                source="on_device",
+                suite="permission_scenarios",
+                scenario_id="a",
+                scenario_title="A",
+                timestamp="2026-06-29T00:00:00Z",
+                repo="NickMonrad/kernel-ai-assistant",
+                branch="feature/test",
+                commit="c" * 40,
+                pr=None,
+                device={"id": "s21-exynos", "execution": "physical"},
+                functional_result="pass",
+                ux_result="pass",
+                step_count=1,
+                tap_count=0,
+                settings_hops=0,
+                back_presses=0,
+                duration_seconds=1.0,
+                manual_intervention_required=False,
+                steps=[],
+                artifacts={},
+            ),
+            permission_runner.ScenarioResult(
+                schema_version="1.0",
+                source="on_device",
+                suite="permission_scenarios",
+                scenario_id="b",
+                scenario_title="B",
+                timestamp="2026-06-29T00:00:00Z",
+                repo="NickMonrad/kernel-ai-assistant",
+                branch="feature/test",
+                commit="c" * 40,
+                pr=None,
+                device={"id": "s21-exynos", "execution": "physical"},
+                functional_result="blocked",
+                ux_result="not_assessed",
+                step_count=1,
+                tap_count=0,
+                settings_hops=0,
+                back_presses=0,
+                duration_seconds=1.0,
+                manual_intervention_required=False,
+                steps=[],
+                artifacts={},
+                blocked_reason="device state",
+            ),
+        ]
+
+        run_result = permission_runner.build_run_result(
+            timestamp="2026-06-29T00:00:00Z",
+            run_id="on_device-2026-06-29T00-00-00Z-s21-exynos",
+            branch="feature/test",
+            commit="c" * 40,
+            pr=None,
+            device={"id": "s21-exynos", "execution": "physical"},
+            thresholds=dict(permission_runner.DEFAULT_UX_THRESHOLDS),
+            scenarios=scenarios,
+        )
+
+        self.assertEqual({"pass": 1, "blocked": 1}, run_result.summary["functional"])
+        self.assertEqual({"pass": 1, "not_assessed": 1}, run_result.summary["ux"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1330

## Summary
- add a first-slice deterministic on-device permission scenario runner at `scripts/run_permission_scenarios.py`
- add declarative scenario definitions, raw/local report generation, schema-compatible evidence projection, and Markdown summary output
- document when to use the runner vs connected tests / Compose tests / the ADB skill harness

## What this first slice does
- runs selected permission scenarios against a physical device over ADB
- writes local artifacts under `scripts/test-reports/permissions/<timestamp>/`
  - `result.json`
  - `evidence.json`
  - `summary.md`
  - `logcat.txt`
  - `screenshots/`
- separates functional result from UX result in the raw report
- writes `evidence.json` in the current shared evidence shape, with explicit non-inference model metadata for permission scenarios:
  - `name: "not_applicable"`
  - `runtime: "permission_scenario_runner"`
  - `backend: "adb"`
- omits `blocked` / `skipped` scenarios from `evidence.json` so device/setup blockers are not misreported as product failures
- captures the latest focused PID-filtered app/crash logcat lines per scenario instead of claiming timestamp-bounded capture
- redacts auth usernames in captured logcat

## What this first slice does not do
- no GitHub comment posting
- no durable evidence publishing to `test-results`
- no S23U mode
- no LLM-driven runtime planning
- no product permission UX changes

## Commands run
- `adb devices`
- `python3 -m py_compile scripts/run_permission_scenarios.py scripts/permission_scenario_defs.py`
- `python3 -m unittest scripts.tests.test_run_permission_scenarios scripts.tests.test_generate_permission_flow_evidence`
- `./gradlew testDebugUnitTest --no-daemon`
- `ANDROID_SERIAL=R5CR605B71K python3 scripts/run_permission_scenarios.py --device-id s21-exynos --serial R5CR605B71K --scenarios mic_denied_enable_hey_jandal,mic_revoke_while_hey_jandal_enabled,weather_location_denied --out-dir scripts/test-reports/permissions`
- `ANDROID_SERIAL=R5CR605B71K python3 scripts/run_permission_scenarios.py --device-id s21-exynos --serial R5CR605B71K --scenarios mic_denied_enable_hey_jandal,mic_revoke_while_hey_jandal_enabled,weather_location_denied --out-dir scripts/test-reports/permissions` (rerun after the schema/logcat fix)

## S21 result
S21 only. No S23U used.

Latest local report:
- `scripts/test-reports/permissions/2026-06-30T08-48-39Z/summary.md`

Observed results:
- `weather_location_denied` → `functional=pass`, `ux=pass`
- `mic_denied_enable_hey_jandal` → `blocked`
- `mic_revoke_while_hey_jandal_enabled` → `blocked`

The two mic scenarios currently block on an S21 prerequisite outside the runner’s control:
- Voice settings shows `Set Jandal as default assistant first for reliable background mic access`
- the Hey Jandal toggle is not actionable until Jandal is already the default assistant on that device

That blocker is reported explicitly in `result.json` / `summary.md`. It is omitted from `evidence.json` so the schema-shaped pass/fail artifact does not mislabel the blocked prerequisite as a product failure.

## Example summary snippet
```md
| Scenario | Functional | UX | Steps | Taps | Settings hops | Back | Duration |
|---|---|---|---:|---:|---:|---:|---:|
| Enable Hey Jandal with microphone denied | blocked | not_assessed | 4 | 2 | 0 | 0 | 26.4s |
| Revoke microphone while Hey Jandal is enabled | blocked | not_assessed | 4 | 2 | 0 | 0 | 24.7s |
| Weather request with location denied uses fallback UX | pass | pass | 3 | 1 | 0 | 0 | 22.3s |
```

## Notes
- local-only evidence generation; no GitHub evidence comments are posted automatically
- `evidence.json` now uses explicit non-inference model metadata so `source: on_device` remains schema-compatible for this permission-only runner
- physical-device evidence is labeled `on_device`, distinct from CI
- no product permission UX behaviour changed in this PR
