### PR TITLE
feat(#1344): publish permission scenario evidence

### DIFF
--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -12,14 +12,15 @@ and the device setup guide in [`docs/adb-testing.md`](./adb-testing.md).
 | Instrumented UI tests | Gradle + Compose/AndroidX test | Compose UI and connected-device Android tests, including S21 `permission_flows` | `./gradlew connectedDebugAndroidTest` |
 | Device regression harness | `adb` + Python | End-to-end intent routing, profile extraction, and on-device chat/action flows | `python3 scripts/adb_skill_test.py` |
 | Permission scenario runner | `adb` + Python | Physical-device permission journeys with step traces, screenshots, focused logcat, and UX-friction counters | `python3 scripts/run_permission_scenarios.py --device-id s21-exynos --scenarios …` |
+| Permission report publisher | Python + `gh` | Explicitly publish an existing permission report bundle to `test-results` and one sticky PR comment | `python3 scripts/publish_permission_scenario_report.py --report-dir … --pr … --commit … --device-id s21-exynos` |
 | Evidence generators | Python | Convert CI/connected outputs into #1113 normalised evidence | `python3 scripts/generate_permission_flow_evidence.py` |
 
 ## Permission scenario runner
 
 The first-slice permission runner lives at [`scripts/run_permission_scenarios.py`](../scripts/run_permission_scenarios.py).
 It is a **local physical-device** runner for permission journeys that cross the app / Android
-boundary. It is **not CI evidence** and it does **not** auto-post GitHub comments or publish
-durable evidence in this first slice.
+boundary. It stays local-only by default: it does **not** auto-post GitHub comments or publish
+durable evidence unless you explicitly run the publisher step.
 
 Use it when you need:
 
@@ -36,7 +37,7 @@ Policy:
 - if no S21 / ADB device is available, stop on on-device validation rather than faking success
 
 See [`docs/testing/permission-scenario-runner.md`](./testing/permission-scenario-runner.md) for
-the command shape, output layout, and scope boundaries.
+the local run command, explicit publish flow, stale-report protections, and artifact layout.
 ## ADB regression harness
 
 The main device automation entry point is [`scripts/adb_skill_test.py`](../scripts/adb_skill_test.py).

--- a/docs/testing/permission-scenario-runner.md
+++ b/docs/testing/permission-scenario-runner.md
@@ -45,9 +45,8 @@ Implemented now:
 
 Intentionally **not** implemented yet:
 
-- sticky GitHub comment posting
-- copying results into `test-results/`
-- dashboard publishing
+- automatic publish side effects during local scenario execution
+- CI merge-gate enforcement for permission scenarios
 - S23U automation mode
 - special-access flows like DND / write-settings / exact alarms
 - video capture, screenshot diffing, or runtime-planned steps
@@ -79,7 +78,7 @@ scripts/test-reports/permissions/<timestamp>/
 - `logcat.txt` — focused app/crash logcat grouped by scenario, filtered to the active app process
 - `screenshots/` — explicit checkpoint screenshots only
 
-## Running the first slice
+## Running locally
 
 ```bash
 ANDROID_SERIAL=<S21_SERIAL> python3 scripts/run_permission_scenarios.py \
@@ -97,6 +96,59 @@ python3 scripts/run_permission_scenarios.py \
   --scenarios mic_denied_enable_hey_jandal \
   --list-scenarios
 ```
+
+## Publishing evidence explicitly
+
+Publishing is a **separate explicit step**. The runner stays local-only unless you invoke
+[`scripts/publish_permission_scenario_report.py`](../../scripts/publish_permission_scenario_report.py).
+
+```bash
+python3 scripts/publish_permission_scenario_report.py \
+  --report-dir scripts/test-reports/permissions/<timestamp> \
+  --pr <PR_NUMBER> \
+  --commit <EXPECTED_HEAD_SHA> \
+  --device-id s21-exynos
+```
+
+What the publisher does:
+
+- validates `result.json`, `evidence.json`, `summary.md`, and available artifacts
+- requires `source == on_device` and `device.execution == physical`
+- refuses stale publication by default if:
+  - the report commit does not match `--commit`, or
+  - the live PR head SHA does not match `--commit`
+- updates one sticky PR comment in place via marker
+  `<!-- jandal-permission-scenario-evidence -->`
+- publishes schema-valid evidence and reviewer artifacts separately so the dashboard only ingests
+  `evidence.json`
+
+Override only for recovery cases:
+
+```bash
+python3 scripts/publish_permission_scenario_report.py \
+  --report-dir scripts/test-reports/permissions/<timestamp> \
+  --pr <PR_NUMBER> \
+  --commit <EXPECTED_HEAD_SHA> \
+  --device-id s21-exynos \
+  --allow-stale-report
+```
+
+### Published layout
+
+```text
+results/pr/<PR>/on_device/permissions/<device>/<timestamp>/
+  evidence.json
+
+artifacts/pr/<PR>/permissions/<device>/<timestamp>/
+  result.json
+  summary.md
+  logcat-redacted.txt
+  screenshots/
+```
+
+This split is deliberate: the dashboard recursively ingests `results/**/*.json`, so only the
+schema-compatible `evidence.json` lives under `results/`. The richer reviewer bundle lives under
+`artifacts/` on the same `test-results` branch.
 
 ## When to use this runner
 

--- a/scripts/publish_permission_scenario_report.py
+++ b/scripts/publish_permission_scenario_report.py
@@ -185,7 +185,7 @@ def validate_report_dir(report_dir: Path) -> ReportBundle:
     evidence = load_json(evidence_path)
     screenshots: list[Path] = []
     if screenshots_dir.is_dir():
-        screenshots = sorted(path for path in screenshots_dir.iterdir() if path.is_file())
+        screenshots_dir = screenshots_dir
     else:
         screenshots_dir = None
     referenced_screenshots = sorted({
@@ -204,6 +204,7 @@ def validate_report_dir(report_dir: Path) -> ReportBundle:
             raise PublishError(
                 "Report references missing screenshot artifact(s): " + ", ".join(missing_shots)
             )
+        screenshots = [report_dir / relpath for relpath in referenced_screenshots]
     if not logcat_path.is_file():
         logcat_path = None
     return ReportBundle(
@@ -272,6 +273,18 @@ def ensure_schema_compatible_evidence(bundle: ReportBundle) -> None:
         raise PublishError(f"evidence.json failed schema validation:\n{joined}")
 
 
+def ensure_no_serial_values(payload: Any, label: str, path: str = "$") -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            current = f"{path}.{key}"
+            if key == "serial" and value is not None:
+                raise PublishError(f"{label} contains non-null serial at {current}")
+            ensure_no_serial_values(value, label, current)
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            ensure_no_serial_values(value, label, f"{path}[{index}]")
+
+
 def ensure_evidence_matches_result(bundle: ReportBundle) -> None:
     scenarios = bundle.result.get("scenarios", [])
     pass_fail = [scenario for scenario in scenarios if scenario.get("functional_result") in {"pass", "fail"}]
@@ -309,13 +322,23 @@ def bundle_commit(bundle: ReportBundle) -> str:
     return commit
 
 
-def build_public_result(bundle: ReportBundle) -> dict[str, Any]:
+def build_public_result(bundle: ReportBundle, pr: int) -> dict[str, Any]:
     public_result = json.loads(json.dumps(bundle.result))
+    public_result["pr"] = pr
     public_result.setdefault("device", {})["serial"] = None
     for scenario in public_result.get("scenarios", []):
         if isinstance(scenario, dict):
+            scenario["pr"] = pr
             scenario.setdefault("device", {})["serial"] = None
+    ensure_no_serial_values(public_result, "public result.json")
     return public_result
+
+
+def build_public_evidence(bundle: ReportBundle, pr: int) -> dict[str, Any]:
+    public_evidence = json.loads(json.dumps(bundle.evidence))
+    public_evidence["pr"] = pr
+    ensure_no_serial_values(public_evidence, "public evidence.json")
+    return public_evidence
 
 
 def timestamp_slug(bundle: ReportBundle) -> str:
@@ -342,11 +365,13 @@ def build_published_paths(bundle: ReportBundle, pr: int, device_id: str) -> Publ
     )
 
 
-def prepare_publish_mapping(bundle: ReportBundle, published: PublishedPaths, scratch_dir: Path) -> dict[Path, str]:
+def prepare_publish_mapping(bundle: ReportBundle, published: PublishedPaths, scratch_dir: Path, pr: int) -> dict[Path, str]:
     public_result_path = scratch_dir / "result.json"
-    public_result_path.write_text(json.dumps(build_public_result(bundle), indent=2) + "\n", encoding="utf-8")
+    public_result_path.write_text(json.dumps(build_public_result(bundle, pr), indent=2) + "\n", encoding="utf-8")
+    public_evidence_path = scratch_dir / "evidence.json"
+    public_evidence_path.write_text(json.dumps(build_public_evidence(bundle, pr), indent=2) + "\n", encoding="utf-8")
     mapping: dict[Path, str] = {
-        bundle.evidence_path: published.evidence,
+        public_evidence_path: published.evidence,
         bundle.summary_path: published.summary,
         public_result_path: published.result,
     }
@@ -462,6 +487,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     bundle = validate_report_dir(args.report_dir)
     ensure_schema_compatible_evidence(bundle)
+    ensure_no_serial_values(bundle.evidence, "evidence.json")
     ensure_evidence_matches_result(bundle)
     github = GitHubClient(args.repo)
     pr_head_sha = github.get_pr_head_sha(args.pr)
@@ -469,7 +495,7 @@ def main(argv: list[str] | None = None) -> int:
     existing_comment_id = github.find_sticky_comment_id(args.pr, STICKY_MARKER)
     published = build_published_paths(bundle, args.pr, args.device_id)
     with tempfile.TemporaryDirectory(prefix="permission-publish-") as scratch:
-        mapping = prepare_publish_mapping(bundle, published, Path(scratch))
+        mapping = prepare_publish_mapping(bundle, published, Path(scratch), args.pr)
         comment_body = build_comment_body(bundle, published, args)
         action = choose_comment_action(existing_comment_id)
         print_publish_plan(mapping, comment_body, action, args)

--- a/scripts/publish_permission_scenario_report.py
+++ b/scripts/publish_permission_scenario_report.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Publish a local permission scenario report bundle to test-results and a sticky PR comment.
+
+This script is intentionally separate from ``run_permission_scenarios.py``.
+Local scenario execution remains side-effect free; publication is an explicit follow-up step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import publish_test_evidence as publish_helpers
+
+HERE = Path(__file__).resolve().parent
+REPO = "NickMonrad/kernel-ai-assistant"
+STICKY_MARKER = "<!-- jandal-permission-scenario-evidence -->"
+LOGCAT_REDACTION_RE = re.compile(r"(HuggingFaceAuthManager: restored auth=[^,]+, user=)(\S+)")
+MAX_PUBLISHED_LOGCAT_LINES = 200
+MAX_PUBLISHED_LOGCAT_BYTES = 64 * 1024
+
+
+class PublishError(RuntimeError):
+    """Base error for validation or publish failures."""
+
+
+@dataclass(slots=True)
+class ReportBundle:
+    report_dir: Path
+    result_path: Path
+    evidence_path: Path
+    summary_path: Path
+    logcat_path: Path | None
+    screenshots_dir: Path | None
+    result: dict[str, Any]
+    evidence: dict[str, Any]
+    screenshots: list[Path]
+
+
+@dataclass(slots=True)
+class PublishedPaths:
+    results_base: str
+    artifacts_base: str
+    evidence: str
+    result: str
+    summary: str
+    logcat: str | None
+    screenshots_dir: str | None
+    screenshots: list[str]
+
+
+class GitHubClient:
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def _run(self, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+        cmd = ["gh", *args]
+        try:
+            return subprocess.run(
+                cmd,
+                input=input_text,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except FileNotFoundError as exc:
+            raise PublishError("gh CLI is not installed or not on PATH") from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.strip() if exc.stderr else ""
+            raise PublishError(f"gh command failed: {' '.join(cmd)}\n{stderr}".rstrip()) from exc
+
+    def get_pr_head_sha(self, pr: int) -> str:
+        result = self._run(
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            self.repo,
+            "--json",
+            "headRefOid",
+            "--jq",
+            ".headRefOid",
+        )
+        head = result.stdout.strip()
+        if not head:
+            raise PublishError(f"Could not resolve PR #{pr} head SHA")
+        return head
+
+    def find_sticky_comment_id(self, pr: int, marker: str) -> int | None:
+        result = self._run(
+            "api",
+            f"repos/{self.repo}/issues/{pr}/comments?per_page=100",
+            "--jq",
+            f"[.[] | select(.body | startswith(\"{marker}\"))][0].id // empty",
+        )
+        raw = result.stdout.strip()
+        return int(raw) if raw else None
+
+    def upsert_comment(self, pr: int, marker: str, body: str) -> str:
+        comment_id = self.find_sticky_comment_id(pr, marker)
+        payload = json.dumps({"body": body})
+        if comment_id is None:
+            self._run(
+                "api",
+                f"repos/{self.repo}/issues/{pr}/comments",
+                "-X",
+                "POST",
+                "--input",
+                "-",
+                input_text=payload,
+            )
+            return "created"
+        self._run(
+            "api",
+            f"repos/{self.repo}/issues/comments/{comment_id}",
+            "-X",
+            "PATCH",
+            "--input",
+            "-",
+            input_text=payload,
+        )
+        return "updated"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish an existing permission scenario report to test-results and a sticky PR comment."
+    )
+    parser.add_argument("--report-dir", type=Path, required=True, help="Local report directory from run_permission_scenarios.py")
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number to publish against")
+    parser.add_argument("--commit", required=True, help="Expected 40-character head SHA for the report and PR")
+    parser.add_argument("--device-id", required=True, help="Expected device ID from devices.yaml and result.json")
+    parser.add_argument("--target-branch", default=publish_helpers.DEFAULT_TARGET_BRANCH, help="Target branch for published artifacts")
+    parser.add_argument("--repo", default=REPO, help="GitHub repo in owner/name form")
+    parser.add_argument("--repo-url", default=None, help="Explicit git remote URL for test-results push")
+    parser.add_argument("--allow-stale-report", action="store_true", help="Override report/PR head staleness checks for recovery-only use")
+    parser.add_argument("--dry-run", action="store_true", help="Print the publish plan and sticky comment without pushing or posting")
+    args = parser.parse_args(argv)
+    if args.target_branch.lower() in {"main", "master"}:
+        parser.error("--target-branch must not be a default branch")
+    if len(args.commit) != 40:
+        parser.error("--commit must be a full 40-character SHA")
+    if "../" in args.target_branch or args.target_branch.startswith("/"):
+        parser.error("--target-branch must be a plain branch name")
+    publish_helpers._validate_path_segment(args.device_id, "--device-id")
+    return args
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PublishError(f"Required file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PublishError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PublishError(f"Expected JSON object in {path}, got {type(data).__name__}")
+    return data
+
+
+def validate_report_dir(report_dir: Path) -> ReportBundle:
+    if not report_dir.is_dir():
+        raise PublishError(f"Report directory not found: {report_dir}")
+    result_path = report_dir / "result.json"
+    evidence_path = report_dir / "evidence.json"
+    summary_path = report_dir / "summary.md"
+    logcat_path = report_dir / "logcat.txt"
+    screenshots_dir = report_dir / "screenshots"
+    missing = [
+        str(path.name)
+        for path in (result_path, evidence_path, summary_path)
+        if not path.is_file()
+    ]
+    if missing:
+        raise PublishError(f"Report directory missing required file(s): {', '.join(missing)}")
+    result = load_json(result_path)
+    evidence = load_json(evidence_path)
+    screenshots: list[Path] = []
+    if screenshots_dir.is_dir():
+        screenshots = sorted(path for path in screenshots_dir.iterdir() if path.is_file())
+    else:
+        screenshots_dir = None
+    referenced_screenshots = sorted({
+        str(step.get("screenshot"))
+        for scenario in result.get("scenarios", [])
+        for step in scenario.get("steps", [])
+        if step.get("screenshot")
+    })
+    if referenced_screenshots and screenshots_dir is None:
+        raise PublishError("Report references screenshots but screenshots/ directory is missing")
+    if screenshots_dir is not None:
+        missing_shots = [
+            relpath for relpath in referenced_screenshots if not (report_dir / relpath).is_file()
+        ]
+        if missing_shots:
+            raise PublishError(
+                "Report references missing screenshot artifact(s): " + ", ".join(missing_shots)
+            )
+    if not logcat_path.is_file():
+        logcat_path = None
+    return ReportBundle(
+        report_dir=report_dir,
+        result_path=result_path,
+        evidence_path=evidence_path,
+        summary_path=summary_path,
+        logcat_path=logcat_path,
+        screenshots_dir=screenshots_dir,
+        result=result,
+        evidence=evidence,
+        screenshots=screenshots,
+    )
+
+
+def validate_report_metadata(bundle: ReportBundle, args: argparse.Namespace, pr_head_sha: str | None) -> None:
+    result = bundle.result
+    evidence = bundle.evidence
+    if result.get("source") != "on_device":
+        raise PublishError(f"result.json source must be 'on_device', got {result.get('source')!r}")
+    if evidence.get("source") != "on_device":
+        raise PublishError(f"evidence.json source must be 'on_device', got {evidence.get('source')!r}")
+    if result.get("suite") != "permission_scenarios":
+        raise PublishError(f"result.json suite must be 'permission_scenarios', got {result.get('suite')!r}")
+    if evidence.get("suite") != "permission_scenarios":
+        raise PublishError(f"evidence.json suite must be 'permission_scenarios', got {evidence.get('suite')!r}")
+    if result.get("device", {}).get("execution") != "physical":
+        raise PublishError("result.json device.execution must be 'physical'")
+    if evidence.get("device", {}).get("execution") != "physical":
+        raise PublishError("evidence.json device.execution must be 'physical'")
+    if result.get("device", {}).get("id") != args.device_id:
+        raise PublishError(
+            f"result.json device.id {result.get('device', {}).get('id')!r} != --device-id {args.device_id!r}"
+        )
+    if evidence.get("device", {}).get("id") != args.device_id:
+        raise PublishError(
+            f"evidence.json device.id {evidence.get('device', {}).get('id')!r} != --device-id {args.device_id!r}"
+        )
+    result_commit = result.get("commit")
+    evidence_commit = evidence.get("commit")
+    if not result_commit or not evidence_commit:
+        raise PublishError("Both result.json and evidence.json must include commit metadata")
+    if result_commit != evidence_commit:
+        raise PublishError(f"Report commit mismatch inside bundle: result.json={result_commit} evidence.json={evidence_commit}")
+    report_pr = result.get("pr")
+    evidence_pr = evidence.get("pr")
+    if report_pr is not None and report_pr != args.pr and not args.allow_stale_report:
+        raise PublishError(f"result.json pr {report_pr!r} != --pr {args.pr}. Use --allow-stale-report to override.")
+    if evidence_pr is not None and evidence_pr != args.pr and not args.allow_stale_report:
+        raise PublishError(f"evidence.json pr {evidence_pr!r} != --pr {args.pr}. Use --allow-stale-report to override.")
+    if not args.allow_stale_report and result_commit != args.commit:
+        raise PublishError(
+            f"Report commit {result_commit} != --commit {args.commit}. Use --allow-stale-report to override."
+        )
+    if pr_head_sha and not args.allow_stale_report and pr_head_sha != args.commit:
+        raise PublishError(
+            f"PR #{args.pr} head SHA {pr_head_sha} != --commit {args.commit}. Use --allow-stale-report to override."
+        )
+
+
+def ensure_schema_compatible_evidence(bundle: ReportBundle) -> None:
+    schema = publish_helpers._load_schema(HERE / "testdata" / "test_evidence.schema.json")
+    errors = publish_helpers._validate_evidence(bundle.evidence, schema)
+    if errors:
+        joined = "\n".join(f"  - {error}" for error in errors)
+        raise PublishError(f"evidence.json failed schema validation:\n{joined}")
+
+
+def ensure_evidence_matches_result(bundle: ReportBundle) -> None:
+    scenarios = bundle.result.get("scenarios", [])
+    pass_fail = [scenario for scenario in scenarios if scenario.get("functional_result") in {"pass", "fail"}]
+    evidence_cases = bundle.evidence.get("cases", [])
+    scenario_ids = [scenario.get("scenario_id") for scenario in pass_fail]
+    evidence_ids = [case.get("name") for case in evidence_cases]
+    if scenario_ids != evidence_ids:
+        raise PublishError(
+            "evidence.json cases do not match pass/fail scenarios from result.json: "
+            f"{scenario_ids!r} != {evidence_ids!r}"
+        )
+
+
+def sanitize_logcat_for_publish(logcat_path: Path) -> str:
+    text = logcat_path.read_text(encoding="utf-8")
+    redacted = LOGCAT_REDACTION_RE.sub(r"\1<redacted>", text)
+    lines = redacted.splitlines()
+    if len(lines) > MAX_PUBLISHED_LOGCAT_LINES:
+        lines = lines[-MAX_PUBLISHED_LOGCAT_LINES:]
+        lines.insert(0, f"[truncated to last {MAX_PUBLISHED_LOGCAT_LINES} lines for publication]")
+    sanitized = "\n".join(lines).strip() + "\n"
+    encoded = sanitized.encode("utf-8")
+    if len(encoded) > MAX_PUBLISHED_LOGCAT_BYTES:
+        sanitized = encoded[-MAX_PUBLISHED_LOGCAT_BYTES:].decode("utf-8", errors="ignore")
+        sanitized = (
+            f"[truncated to last {MAX_PUBLISHED_LOGCAT_BYTES} bytes for publication]\n{sanitized.lstrip()}"
+        )
+    return sanitized
+
+
+def build_public_result(bundle: ReportBundle) -> dict[str, Any]:
+    public_result = json.loads(json.dumps(bundle.result))
+    public_result.setdefault("device", {})["serial"] = None
+    return public_result
+
+
+def timestamp_slug(bundle: ReportBundle) -> str:
+    timestamp = bundle.result.get("timestamp") or bundle.evidence.get("timestamp")
+    if not isinstance(timestamp, str) or not timestamp:
+        raise PublishError("Report timestamp missing from result.json/evidence.json")
+    return timestamp.replace(":", "-")
+
+
+def build_published_paths(bundle: ReportBundle, pr: int, device_id: str) -> PublishedPaths:
+    stamp = timestamp_slug(bundle)
+    results_base = f"results/pr/{pr}/on_device/permissions/{device_id}/{stamp}"
+    artifacts_base = f"artifacts/pr/{pr}/permissions/{device_id}/{stamp}"
+    screenshots_dir = f"{artifacts_base}/screenshots" if bundle.screenshots else None
+    return PublishedPaths(
+        results_base=results_base,
+        artifacts_base=artifacts_base,
+        evidence=f"{results_base}/evidence.json",
+        result=f"{artifacts_base}/result.json",
+        summary=f"{artifacts_base}/summary.md",
+        logcat=f"{artifacts_base}/logcat-redacted.txt" if bundle.logcat_path else None,
+        screenshots_dir=screenshots_dir,
+        screenshots=[f"{artifacts_base}/screenshots/{shot.name}" for shot in bundle.screenshots],
+    )
+
+
+def prepare_publish_mapping(bundle: ReportBundle, published: PublishedPaths, scratch_dir: Path) -> dict[Path, str]:
+    public_result_path = scratch_dir / "result.json"
+    public_result_path.write_text(json.dumps(build_public_result(bundle), indent=2) + "\n", encoding="utf-8")
+    mapping: dict[Path, str] = {
+        bundle.evidence_path: published.evidence,
+        bundle.summary_path: published.summary,
+        public_result_path: published.result,
+    }
+    if bundle.logcat_path is not None and published.logcat is not None:
+        sanitized_path = scratch_dir / "logcat-redacted.txt"
+        sanitized_path.write_text(sanitize_logcat_for_publish(bundle.logcat_path), encoding="utf-8")
+        mapping[sanitized_path] = published.logcat
+    for shot, dest in zip(bundle.screenshots, published.screenshots):
+        mapping[shot] = dest
+    return mapping
+
+
+def quote_path(value: str) -> str:
+    return quote(value, safe="/")
+
+
+def blob_url(repo: str, branch: str, relpath: str) -> str:
+    return f"https://github.com/{repo}/blob/{quote(branch, safe='')}/{quote_path(relpath)}"
+
+
+def tree_url(repo: str, branch: str, relpath: str) -> str:
+    return f"https://github.com/{repo}/tree/{quote(branch, safe='')}/{quote_path(relpath)}"
+
+
+def build_comment_body(bundle: ReportBundle, published: PublishedPaths, args: argparse.Namespace) -> str:
+    result = bundle.result
+    scenarios = result.get("scenarios", [])
+    lines = [
+        STICKY_MARKER,
+        "",
+        "## Permission scenario evidence",
+        "",
+        f"**Source:** `{result.get('source', 'unknown')}`  ",
+        f"**Device:** {result.get('device', {}).get('label', 'Unknown')} (`{args.device_id}`)  ",
+        f"**Commit:** `{args.commit[:12]}`  ",
+        f"**Report timestamp:** `{result.get('timestamp', 'unknown')}`",
+        "",
+        "| Scenario | Functional | UX | Steps | Taps | Settings | Back | Duration | Blocked reason |",
+        "|---|---|---|---:|---:|---:|---:|---:|---|",
+    ]
+    blocked_lines: list[str] = []
+    for scenario in scenarios:
+        title = scenario.get("scenario_title") or scenario.get("scenario_id") or "unknown"
+        blocked_reason = scenario.get("blocked_reason") or "—"
+        lines.append(
+            "| {title} | {functional} | {ux} | {steps} | {taps} | {settings} | {back} | {duration:.1f}s | {blocked} |".format(
+                title=str(title).replace("|", "\\|"),
+                functional=scenario.get("functional_result", "unknown"),
+                ux=scenario.get("ux_result", "unknown"),
+                steps=scenario.get("step_count", 0),
+                taps=scenario.get("tap_count", 0),
+                settings=scenario.get("settings_hops", 0),
+                back=scenario.get("back_presses", 0),
+                duration=float(scenario.get("duration_seconds", 0.0)),
+                blocked=str(blocked_reason).replace("|", "\\|") if blocked_reason else "—",
+            )
+        )
+        if scenario.get("functional_result") in {"blocked", "skipped"} and scenario.get("blocked_reason"):
+            blocked_lines.append(f"- `{scenario.get('scenario_id', 'unknown')}` — {scenario['blocked_reason']}")
+    lines.extend([
+        "",
+        "### Published artifacts",
+        "",
+        f"- [Schema-compatible evidence]({blob_url(args.repo, args.target_branch, published.evidence)})",
+        f"- [Rich summary]({blob_url(args.repo, args.target_branch, published.summary)})",
+        f"- [Public raw result JSON]({blob_url(args.repo, args.target_branch, published.result)})",
+    ])
+    if published.logcat:
+        lines.append(f"- [Focused redacted logcat]({blob_url(args.repo, args.target_branch, published.logcat)})")
+    else:
+        lines.append("- Focused redacted logcat: unavailable")
+    if published.screenshots_dir:
+        lines.append(f"- [Screenshots]({tree_url(args.repo, args.target_branch, published.screenshots_dir)})")
+    else:
+        lines.append("- Screenshots: unavailable")
+    if blocked_lines:
+        lines.extend(["", "### Blocked scenarios", "", *blocked_lines])
+    lines.extend([
+        "",
+        "> This comment is updated in place when the permission scenario publisher is re-run for the same PR.",
+        "> Blocked/skipped scenarios remain visible here, but only pass/fail cases are projected into schema evidence.",
+    ])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def choose_comment_action(existing_comment_id: int | None) -> str:
+    return "update" if existing_comment_id is not None else "create"
+
+
+def commit_message(pr: int, commit: str, device_id: str) -> str:
+    return f"test-results: add permission evidence for PR #{pr} {device_id} @ {commit[:12]}"
+
+
+def print_publish_plan(mapping: dict[Path, str], comment_body: str, action: str, args: argparse.Namespace) -> None:
+    print(f"PR:             #{args.pr}")
+    print(f"Commit:         {args.commit}")
+    print(f"Device:         {args.device_id}")
+    print(f"Target branch:  {args.target_branch}")
+    print(f"Dry run:        {args.dry_run}")
+    print(f"Sticky comment: {action}")
+    print(f"Stale override: {args.allow_stale_report}")
+    print("")
+    for local, dest in sorted(mapping.items(), key=lambda item: item[1]):
+        print(f"  {local} -> {dest}")
+    print("\n--- Sticky comment preview ---\n")
+    print(comment_body)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    bundle = validate_report_dir(args.report_dir)
+    ensure_schema_compatible_evidence(bundle)
+    ensure_evidence_matches_result(bundle)
+    github = GitHubClient(args.repo)
+    pr_head_sha = github.get_pr_head_sha(args.pr)
+    validate_report_metadata(bundle, args, pr_head_sha)
+    existing_comment_id = github.find_sticky_comment_id(args.pr, STICKY_MARKER)
+    published = build_published_paths(bundle, args.pr, args.device_id)
+    with tempfile.TemporaryDirectory(prefix="permission-publish-") as scratch:
+        mapping = prepare_publish_mapping(bundle, published, Path(scratch))
+        comment_body = build_comment_body(bundle, published, args)
+        action = choose_comment_action(existing_comment_id)
+        print_publish_plan(mapping, comment_body, action, args)
+        publish_helpers._check_git_available()
+        if args.dry_run:
+            return 0
+        repo_url = args.repo_url or publish_helpers._get_remote_url()
+        publish_helpers._publish_to_branch(
+            mapping=mapping,
+            target_branch=args.target_branch,
+            commit_msg=commit_message(args.pr, args.commit, args.device_id),
+            repo_url=repo_url,
+            dry_run=False,
+        )
+        comment_action = github.upsert_comment(args.pr, STICKY_MARKER, comment_body)
+        print(f"Sticky comment {comment_action} on PR #{args.pr}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PublishError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/publish_permission_scenario_report.py
+++ b/scripts/publish_permission_scenario_report.py
@@ -302,9 +302,19 @@ def sanitize_logcat_for_publish(logcat_path: Path) -> str:
     return sanitized
 
 
+def bundle_commit(bundle: ReportBundle) -> str:
+    commit = bundle.result.get("commit") or bundle.evidence.get("commit")
+    if not isinstance(commit, str) or not commit:
+        raise PublishError("Report commit missing from result.json/evidence.json")
+    return commit
+
+
 def build_public_result(bundle: ReportBundle) -> dict[str, Any]:
     public_result = json.loads(json.dumps(bundle.result))
     public_result.setdefault("device", {})["serial"] = None
+    for scenario in public_result.get("scenarios", []):
+        if isinstance(scenario, dict):
+            scenario.setdefault("device", {})["serial"] = None
     return public_result
 
 
@@ -364,6 +374,7 @@ def tree_url(repo: str, branch: str, relpath: str) -> str:
 def build_comment_body(bundle: ReportBundle, published: PublishedPaths, args: argparse.Namespace) -> str:
     result = bundle.result
     scenarios = result.get("scenarios", [])
+    report_commit = bundle_commit(bundle)
     lines = [
         STICKY_MARKER,
         "",
@@ -371,7 +382,7 @@ def build_comment_body(bundle: ReportBundle, published: PublishedPaths, args: ar
         "",
         f"**Source:** `{result.get('source', 'unknown')}`  ",
         f"**Device:** {result.get('device', {}).get('label', 'Unknown')} (`{args.device_id}`)  ",
-        f"**Commit:** `{args.commit[:12]}`  ",
+        f"**Commit:** `{report_commit[:12]}`  ",
         f"**Report timestamp:** `{result.get('timestamp', 'unknown')}`",
         "",
         "| Scenario | Functional | UX | Steps | Taps | Settings | Back | Duration | Blocked reason |",
@@ -412,6 +423,8 @@ def build_comment_body(bundle: ReportBundle, published: PublishedPaths, args: ar
         lines.append(f"- [Screenshots]({tree_url(args.repo, args.target_branch, published.screenshots_dir)})")
     else:
         lines.append("- Screenshots: unavailable")
+    if args.allow_stale_report and report_commit != args.commit:
+        lines.extend(["", f"> Override used: report commit `{report_commit[:12]}` published against requested head `{args.commit[:12]}`."])
     if blocked_lines:
         lines.extend(["", "### Blocked scenarios", "", *blocked_lines])
     lines.extend([
@@ -432,7 +445,7 @@ def commit_message(pr: int, commit: str, device_id: str) -> str:
 
 def print_publish_plan(mapping: dict[Path, str], comment_body: str, action: str, args: argparse.Namespace) -> None:
     print(f"PR:             #{args.pr}")
-    print(f"Commit:         {args.commit}")
+    print(f"Expected head:  {args.commit}")
     print(f"Device:         {args.device_id}")
     print(f"Target branch:  {args.target_branch}")
     print(f"Dry run:        {args.dry_run}")
@@ -467,7 +480,7 @@ def main(argv: list[str] | None = None) -> int:
         publish_helpers._publish_to_branch(
             mapping=mapping,
             target_branch=args.target_branch,
-            commit_msg=commit_message(args.pr, args.commit, args.device_id),
+            commit_msg=commit_message(args.pr, bundle_commit(bundle), args.device_id),
             repo_url=repo_url,
             dry_run=False,
         )

--- a/scripts/tests/test_publish_permission_scenario_report.py
+++ b/scripts/tests/test_publish_permission_scenario_report.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Tests for publish_permission_scenario_report.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import publish_permission_scenario_report as publisher
+
+
+def sample_result(commit: str = "a" * 40, pr: int | None = None) -> dict:
+    return {
+        "schema_version": "1.0",
+        "source": "on_device",
+        "suite": "permission_scenarios",
+        "timestamp": "2026-06-30T08:48:39Z",
+        "repo": "NickMonrad/kernel-ai-assistant",
+        "branch": "feature/1344-permission-report-publisher",
+        "commit": commit,
+        "pr": pr,
+        "run_id": "on_device-2026-06-30T08-48-39Z-s21-exynos",
+        "device": {
+            "id": "s21-exynos",
+            "serial": "R5CR605B71K",
+            "label": "S21",
+            "manufacturer": "Samsung",
+            "model": "SM-G991B",
+            "soc": "Exynos 2100",
+            "tier": "tracked",
+            "android_api": 35,
+            "execution": "physical",
+        },
+        "thresholds": {
+            "max_steps": 8,
+            "max_user_taps": 5,
+            "max_settings_hops": 1,
+            "max_duration_seconds": 30,
+            "max_back_presses": 2,
+            "fail_on_manual_intervention": True,
+        },
+        "summary": {
+            "total": 2,
+            "functional": {"pass": 1, "blocked": 1},
+            "ux": {"pass": 1, "not_assessed": 1},
+            "example_report": "summary.md",
+        },
+        "scenarios": [
+            {
+                "schema_version": "1.0",
+                "source": "on_device",
+                "suite": "permission_scenarios",
+                "scenario_id": "weather_location_denied",
+                "scenario_title": "Weather request with location denied uses fallback UX",
+                "timestamp": "2026-06-30T08:48:39Z",
+                "repo": "NickMonrad/kernel-ai-assistant",
+                "branch": "feature/1344-permission-report-publisher",
+                "commit": commit,
+                "pr": pr,
+                "device": {"id": "s21-exynos", "execution": "physical"},
+                "functional_result": "pass",
+                "ux_result": "pass",
+                "step_count": 3,
+                "tap_count": 2,
+                "settings_hops": 0,
+                "back_presses": 0,
+                "duration_seconds": 12.5,
+                "manual_intervention_required": False,
+                "steps": [
+                    {
+                        "index": 1,
+                        "id": "launch",
+                        "action": "launch_main",
+                        "expected": "app visible",
+                        "actual": "app visible",
+                        "result": "pass",
+                        "duration_ms": 1200,
+                        "screenshot": "screenshots/01-weather.png",
+                        "screenshot_error": None,
+                        "debug": {},
+                    }
+                ],
+                "artifacts": {},
+                "ux_warnings": [],
+                "blocked_reason": None,
+            },
+            {
+                "schema_version": "1.0",
+                "source": "on_device",
+                "suite": "permission_scenarios",
+                "scenario_id": "mic_denied_enable_hey_jandal",
+                "scenario_title": "Enable Hey Jandal with microphone denied",
+                "timestamp": "2026-06-30T08:48:39Z",
+                "repo": "NickMonrad/kernel-ai-assistant",
+                "branch": "feature/1344-permission-report-publisher",
+                "commit": commit,
+                "pr": pr,
+                "device": {"id": "s21-exynos", "execution": "physical"},
+                "functional_result": "blocked",
+                "ux_result": "not_assessed",
+                "step_count": 4,
+                "tap_count": 1,
+                "settings_hops": 1,
+                "back_presses": 0,
+                "duration_seconds": 8.2,
+                "manual_intervention_required": False,
+                "steps": [
+                    {
+                        "index": 1,
+                        "id": "open_voice",
+                        "action": "tap_visible",
+                        "expected": "Voice settings opens",
+                        "actual": "Set Jandal as default assistant first for reliable background mic access",
+                        "result": "blocked",
+                        "duration_ms": 400,
+                        "screenshot": "screenshots/02-mic.png",
+                        "screenshot_error": None,
+                        "debug": {},
+                    }
+                ],
+                "artifacts": {},
+                "ux_warnings": [],
+                "blocked_reason": "Set Jandal as default assistant first for reliable background mic access",
+            },
+        ],
+        "artifacts": {
+            "raw_json": "result.json",
+            "summary": "summary.md",
+            "logcat": "logcat.txt",
+            "evidence": "evidence.json",
+            "screenshots_dir": "screenshots",
+        },
+    }
+
+
+def sample_evidence(commit: str = "a" * 40, pr: int | None = None) -> dict:
+    return {
+        "schema_version": "1.0",
+        "source": "on_device",
+        "suite": "permission_scenarios",
+        "timestamp": "2026-06-30T08:48:39Z",
+        "repo": "NickMonrad/kernel-ai-assistant",
+        "branch": "feature/1344-permission-report-publisher",
+        "commit": commit,
+        "pr": pr,
+        "release": None,
+        "run_id": "on_device-2026-06-30T08-48-39Z-s21-exynos",
+        "device": {
+            "id": "s21-exynos",
+            "serial": None,
+            "label": "S21",
+            "manufacturer": "Samsung",
+            "model": "SM-G991B",
+            "soc": "Exynos 2100",
+            "tier": "tracked",
+            "android_api": 35,
+            "execution": "physical",
+        },
+        "model": {
+            "name": "not_applicable",
+            "runtime": "permission_scenario_runner",
+            "backend": "adb",
+        },
+        "summary": {"total": 1, "passed": 1, "failed": 0, "pass_rate": 1.0},
+        "cases": [
+            {
+                "name": "weather_location_denied",
+                "passed": True,
+                "expected_tool": None,
+                "actual_tool": None,
+                "expected_result_mode": "success",
+                "actual_result_mode": "success",
+                "chip_present": False,
+                "skill_result_present": False,
+                "message_saved": False,
+                "retry_seen": False,
+                "slot_fill_seen": False,
+                "failure_category": None,
+                "failures": [],
+            }
+        ],
+    }
+
+
+class PublishPermissionScenarioReportTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="publish_permission_")
+        self.root = Path(self.tmpdir.name)
+        self.report_dir = self.root / "2026-06-30T08-48-39Z"
+        self.report_dir.mkdir(parents=True)
+        self.screenshots_dir = self.report_dir / "screenshots"
+        self.screenshots_dir.mkdir()
+        (self.screenshots_dir / "01-weather.png").write_bytes(b"png")
+        (self.screenshots_dir / "02-mic.png").write_bytes(b"png")
+        (self.report_dir / "summary.md").write_text("# summary\n", encoding="utf-8")
+        (self.report_dir / "result.json").write_text(json.dumps(sample_result()) + "\n", encoding="utf-8")
+        (self.report_dir / "evidence.json").write_text(json.dumps(sample_evidence()) + "\n", encoding="utf-8")
+        (self.report_dir / "logcat.txt").write_text(
+            "KernelAI: ok\nHuggingFaceAuthManager: restored auth=true, user=nick@example.com\n",
+            encoding="utf-8",
+        )
+        self.args = argparse.Namespace(
+            report_dir=self.report_dir,
+            pr=1344,
+            commit="a" * 40,
+            device_id="s21-exynos",
+            target_branch="test-results",
+            repo="NickMonrad/kernel-ai-assistant",
+            repo_url=None,
+            allow_stale_report=False,
+            dry_run=True,
+        )
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_validate_report_dir_loads_optional_artifacts(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        self.assertEqual(bundle.result["suite"], "permission_scenarios")
+        self.assertEqual(bundle.evidence["summary"]["total"], 1)
+        self.assertEqual(len(bundle.screenshots), 2)
+        self.assertIsNotNone(bundle.logcat_path)
+
+    def test_validate_report_dir_requires_core_files(self) -> None:
+        (self.report_dir / "summary.md").unlink()
+        with self.assertRaisesRegex(publisher.PublishError, "summary.md"):
+            publisher.validate_report_dir(self.report_dir)
+
+    def test_validate_report_dir_rejects_missing_referenced_screenshot(self) -> None:
+        (self.screenshots_dir / "02-mic.png").unlink()
+        with self.assertRaisesRegex(publisher.PublishError, "missing screenshot"):
+            publisher.validate_report_dir(self.report_dir)
+
+    def test_validate_report_metadata_rejects_report_commit_mismatch(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        args = argparse.Namespace(**{**vars(self.args), "commit": "b" * 40})
+        with self.assertRaisesRegex(publisher.PublishError, "Report commit"):
+            publisher.validate_report_metadata(bundle, args, pr_head_sha="b" * 40)
+
+    def test_validate_report_metadata_rejects_pr_head_mismatch(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        with self.assertRaisesRegex(publisher.PublishError, "head SHA"):
+            publisher.validate_report_metadata(bundle, self.args, pr_head_sha="b" * 40)
+
+    def test_validate_report_metadata_allows_override_for_stale_report(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        args = argparse.Namespace(**{**vars(self.args), "allow_stale_report": True, "commit": "b" * 40})
+        publisher.validate_report_metadata(bundle, args, pr_head_sha="c" * 40)
+
+    def test_ensure_evidence_matches_result_accepts_blocked_omission(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        publisher.ensure_evidence_matches_result(bundle)
+
+    def test_build_public_result_nulls_device_serial(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        public_result = publisher.build_public_result(bundle)
+        self.assertIsNone(public_result["device"]["serial"])
+
+    def test_build_published_paths_uses_results_and_artifacts_layout(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
+        self.assertEqual(
+            published.evidence,
+            "results/pr/1344/on_device/permissions/s21-exynos/2026-06-30T08-48-39Z/evidence.json",
+        )
+        self.assertEqual(
+            published.result,
+            "artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/result.json",
+        )
+        self.assertEqual(
+            published.summary,
+            "artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/summary.md",
+        )
+        self.assertEqual(
+            published.screenshots_dir,
+            "artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/screenshots",
+        )
+
+    def test_sanitize_logcat_redacts_user(self) -> None:
+        text = publisher.sanitize_logcat_for_publish(self.report_dir / "logcat.txt")
+        self.assertIn("user=<redacted>", text)
+        self.assertNotIn("nick@example.com", text)
+
+    def test_build_comment_body_keeps_blocked_reason_visible(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
+        body = publisher.build_comment_body(bundle, published, self.args)
+        self.assertTrue(body.startswith(publisher.STICKY_MARKER))
+        self.assertIn("Weather request with location denied uses fallback UX", body)
+        self.assertIn("Enable Hey Jandal with microphone denied", body)
+        self.assertIn("Set Jandal as default assistant first for reliable background mic access", body)
+        self.assertIn("Blocked/skipped scenarios remain visible", body)
+        self.assertIn("Schema-compatible evidence", body)
+
+    def test_choose_comment_action(self) -> None:
+        self.assertEqual(publisher.choose_comment_action(None), "create")
+        self.assertEqual(publisher.choose_comment_action(42), "update")
+
+    def test_prepare_publish_mapping_uses_public_result_and_optional_logcat(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
+        with tempfile.TemporaryDirectory(prefix="publish_map_") as scratch:
+            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch))
+            public_result_path = next(path for path, dest in mapping.items() if dest == published.result)
+            public_result = json.loads(public_result_path.read_text(encoding="utf-8"))
+        self.assertIsNone(public_result["device"]["serial"])
+        self.assertIn("artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/logcat-redacted.txt", mapping.values())
+
+    def test_prepare_publish_mapping_excludes_missing_optional_artifacts(self) -> None:
+        (self.report_dir / "logcat.txt").unlink()
+        bundle = publisher.validate_report_dir(self.report_dir)
+        published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
+        with tempfile.TemporaryDirectory(prefix="publish_map_") as scratch:
+            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch))
+        self.assertNotIn("artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/logcat-redacted.txt", mapping.values())
+
+    @mock.patch.object(publisher.GitHubClient, "find_sticky_comment_id", return_value=123)
+    @mock.patch.object(publisher.GitHubClient, "get_pr_head_sha", return_value="a" * 40)
+    @mock.patch.object(publisher.publish_helpers, "_publish_to_branch")
+    @mock.patch.object(publisher.publish_helpers, "_check_git_available")
+    def test_main_dry_run_skips_publish_and_uses_update_action(
+        self,
+        _check_git_available: mock.Mock,
+        _publish_to_branch: mock.Mock,
+        _get_pr_head_sha: mock.Mock,
+        _find_comment: mock.Mock,
+    ) -> None:
+        rc = publisher.main(
+            [
+                "--report-dir",
+                str(self.report_dir),
+                "--pr",
+                "1344",
+                "--commit",
+                "a" * 40,
+                "--device-id",
+                "s21-exynos",
+                "--dry-run",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        _publish_to_branch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_publish_permission_scenario_report.py
+++ b/scripts/tests/test_publish_permission_scenario_report.py
@@ -66,7 +66,7 @@ def sample_result(commit: str = "a" * 40, pr: int | None = None) -> dict:
                 "branch": "feature/1344-permission-report-publisher",
                 "commit": commit,
                 "pr": pr,
-                "device": {"id": "s21-exynos", "execution": "physical"},
+                "device": {"id": "s21-exynos", "execution": "physical", "serial": "R5CR605B71K"},
                 "functional_result": "pass",
                 "ux_result": "pass",
                 "step_count": 3,
@@ -104,7 +104,7 @@ def sample_result(commit: str = "a" * 40, pr: int | None = None) -> dict:
                 "branch": "feature/1344-permission-report-publisher",
                 "commit": commit,
                 "pr": pr,
-                "device": {"id": "s21-exynos", "execution": "physical"},
+                "device": {"id": "s21-exynos", "execution": "physical", "serial": "R5CR605B71K"},
                 "functional_result": "blocked",
                 "ux_result": "not_assessed",
                 "step_count": 4,
@@ -264,6 +264,7 @@ class PublishPermissionScenarioReportTest(unittest.TestCase):
         bundle = publisher.validate_report_dir(self.report_dir)
         public_result = publisher.build_public_result(bundle)
         self.assertIsNone(public_result["device"]["serial"])
+        self.assertTrue(all(scenario["device"]["serial"] is None for scenario in public_result["scenarios"]))
 
     def test_build_published_paths_uses_results_and_artifacts_layout(self) -> None:
         bundle = publisher.validate_report_dir(self.report_dir)
@@ -300,6 +301,14 @@ class PublishPermissionScenarioReportTest(unittest.TestCase):
         self.assertIn("Set Jandal as default assistant first for reliable background mic access", body)
         self.assertIn("Blocked/skipped scenarios remain visible", body)
         self.assertIn("Schema-compatible evidence", body)
+
+    def test_build_comment_body_uses_report_commit_when_stale_override_enabled(self) -> None:
+        bundle = publisher.validate_report_dir(self.report_dir)
+        published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
+        args = argparse.Namespace(**{**vars(self.args), "allow_stale_report": True, "commit": "b" * 40})
+        body = publisher.build_comment_body(bundle, published, args)
+        self.assertIn("`aaaaaaaaaaaa`", body)
+        self.assertIn("requested head `bbbbbbbbbbbb`", body)
 
     def test_choose_comment_action(self) -> None:
         self.assertEqual(publisher.choose_comment_action(None), "create")

--- a/scripts/tests/test_publish_permission_scenario_report.py
+++ b/scripts/tests/test_publish_permission_scenario_report.py
@@ -262,9 +262,11 @@ class PublishPermissionScenarioReportTest(unittest.TestCase):
 
     def test_build_public_result_nulls_device_serial(self) -> None:
         bundle = publisher.validate_report_dir(self.report_dir)
-        public_result = publisher.build_public_result(bundle)
+        public_result = publisher.build_public_result(bundle, 1344)
+        self.assertEqual(public_result["pr"], 1344)
         self.assertIsNone(public_result["device"]["serial"])
         self.assertTrue(all(scenario["device"]["serial"] is None for scenario in public_result["scenarios"]))
+        self.assertTrue(all(scenario["pr"] == 1344 for scenario in public_result["scenarios"]))
 
     def test_build_published_paths_uses_results_and_artifacts_layout(self) -> None:
         bundle = publisher.validate_report_dir(self.report_dir)
@@ -318,10 +320,14 @@ class PublishPermissionScenarioReportTest(unittest.TestCase):
         bundle = publisher.validate_report_dir(self.report_dir)
         published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
         with tempfile.TemporaryDirectory(prefix="publish_map_") as scratch:
-            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch))
+            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch), 1344)
             public_result_path = next(path for path, dest in mapping.items() if dest == published.result)
             public_result = json.loads(public_result_path.read_text(encoding="utf-8"))
+            public_evidence_path = next(path for path, dest in mapping.items() if dest == published.evidence)
+            public_evidence = json.loads(public_evidence_path.read_text(encoding="utf-8"))
+        self.assertEqual(public_result["pr"], 1344)
         self.assertIsNone(public_result["device"]["serial"])
+        self.assertEqual(public_evidence["pr"], 1344)
         self.assertIn("artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/logcat-redacted.txt", mapping.values())
 
     def test_prepare_publish_mapping_excludes_missing_optional_artifacts(self) -> None:
@@ -329,7 +335,7 @@ class PublishPermissionScenarioReportTest(unittest.TestCase):
         bundle = publisher.validate_report_dir(self.report_dir)
         published = publisher.build_published_paths(bundle, 1344, "s21-exynos")
         with tempfile.TemporaryDirectory(prefix="publish_map_") as scratch:
-            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch))
+            mapping = publisher.prepare_publish_mapping(bundle, published, Path(scratch), 1344)
         self.assertNotIn("artifacts/pr/1344/permissions/s21-exynos/2026-06-30T08-48-39Z/logcat-redacted.txt", mapping.values())
 
     @mock.patch.object(publisher.GitHubClient, "find_sticky_comment_id", return_value=123)


### PR DESCRIPTION
## Summary
- add `scripts/publish_permission_scenario_report.py` as an explicit publisher for existing local permission scenario reports
- publish schema-compatible permission evidence under `results/pr/<PR>/on_device/permissions/<device>/<timestamp>/evidence.json` and richer reviewer artifacts under `artifacts/pr/<PR>/permissions/<device>/<timestamp>/...`
- add stale report / PR head mismatch protection, sticky PR comment generation, redacted logcat publication, and docs/tests for the explicit publish flow

Closes #1344

## What this does
- validates an existing local permission report bundle before publishing
- requires `--pr`, `--commit`, and `--device-id`
- refuses stale publication by default when the report commit or live PR head does not match `--commit`
- updates a single sticky PR comment via `<!-- jandal-permission-scenario-evidence -->`
- keeps blocked/skipped scenarios visible in the rich comment/report while leaving pass/fail-only schema evidence unchanged

## What this does not do
- does not auto-publish from `run_permission_scenarios.py`
- does not make permission publishing a CI merge gate
- does not change product permission UX
- does not use the S23U

## Commands run
- `python3 -m py_compile scripts/run_permission_scenarios.py scripts/permission_scenario_defs.py scripts/publish_permission_scenario_report.py`
- `python3 -m unittest scripts.tests.test_run_permission_scenarios scripts.tests.test_publish_permission_scenario_report`
- `./gradlew testDebugUnitTest --no-daemon`

## Validation result
- Python compile: ✅
- Python unit tests: ✅
- Gradle unit tests: ✅
- Live GitHub publishing: not exercised; publisher behavior was unit-tested and dry-run exercised in tests only

## Example publish layout
```text
results/pr/<PR>/on_device/permissions/<device>/<timestamp>/
  evidence.json

artifacts/pr/<PR>/permissions/<device>/<timestamp>/
  result.json
  summary.md
  logcat-redacted.txt
  screenshots/
```

## Example sticky comment snippet
```md
<!-- jandal-permission-scenario-evidence -->
## Permission scenario evidence

**Source:** `on_device`
**Device:** S21 (`s21-exynos`)
**Commit:** `<sha>`
```

## Notes
- stale report / PR-head mismatch protection is on by default; `--allow-stale-report` is recovery-only
- runner remains local-only unless `scripts/publish_permission_scenario_report.py` is explicitly invoked
- no product permission UX changes
- no S23U was used
