### PR TITLE
fix(#1365): harden S21 non-permission sweep harness

### DIFF
--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenThinkBubbleTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenThinkBubbleTest.kt
@@ -23,8 +23,8 @@ class ChatScreenThinkBubbleTest {
         composeTestRule.setContent {
             // MessageBubble is private; replicate the relevant composable tree
             // by invoking the same composables from ChatScreen.kt.
-            // We use the internal helper below to render the bubble standalone.
-            MessageBubbleTestWrapper(message = message, showThinkingProcess = showThinkingProcess)
+            // Use the shared fixture below to render the bubble standalone.
+            MessageBubbleFixture(message = message, showThinkingProcess = showThinkingProcess)
         }
     }
 

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -21,7 +21,7 @@ class ChatScreenToolChipTest {
 
     private fun setContent(message: ChatMessage) {
         composeTestRule.setContent {
-            MessageBubbleTestWrapper(message = message)
+            MessageBubbleFixture(message = message)
         }
     }
 

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/MessageBubbleFixture.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/MessageBubbleFixture.kt
@@ -37,12 +37,14 @@ import com.kernel.ai.feature.chat.model.ChatMessage
 import com.kernel.ai.feature.chat.model.ToolCallInfo
 
 /**
- * A standalone composable that mirrors the think-bubble and tool-chip portions of
- * [ChatScreen]'s private `MessageBubble` so that instrumented tests can exercise
+ * A standalone fixture that mirrors the think-bubble and tool-chip portions of
+ * [ChatScreen]'s private `MessageBubble` so instrumented tests can exercise
  * them without depending on the full chat screen (which requires a ViewModel + Hilt).
+ *
+ * This is a reusable composable fixture, not an AndroidTest entry point.
  */
 @Composable
-fun MessageBubbleTestWrapper(
+fun MessageBubbleFixture(
     message: ChatMessage,
     showThinkingProcess: Boolean = true,
 ) {

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/AlarmDialogFixture.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/AlarmDialogFixture.kt
@@ -20,11 +20,13 @@ import androidx.compose.ui.unit.dp
 /**
  * Renders the label-step of the alarm create/edit dialog in isolation for testing.
  * The production dialog is a multi-step flow (date → time → label) which cannot
- * easily be driven through Espresso without a device calendar. This wrapper skips
+ * easily be driven through Espresso without a device calendar. This fixture skips
  * directly to the label step so we can verify tag presence, input, and callbacks.
+ *
+ * This is a reusable composable fixture, not an AndroidTest entry point.
  */
 @Composable
-fun AlarmDialogTestWrapper(
+fun AlarmDialogFixture(
     label: String,
     onLabelChange: (String) -> Unit,
     onConfirm: (label: String?) -> Unit,

--- a/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ScheduledAlarmsDialogTest.kt
+++ b/feature/settings/src/androidTest/java/com/kernel/ai/feature/settings/ScheduledAlarmsDialogTest.kt
@@ -62,7 +62,7 @@ class ScheduledAlarmsDialogTest {
             }
 
             if (showDialog) {
-                AlarmDialogTestWrapper(
+                AlarmDialogFixture(
                     label = label,
                     onLabelChange = { label = it },
                     onConfirm = { confirmed ->

--- a/scripts/adb_harness/config.py
+++ b/scripts/adb_harness/config.py
@@ -39,11 +39,8 @@ DIRECT_REPLY_PATTERN = re.compile(r"DirectReply:\s*(.*)")
 LLM_TOOLS_ASSISTANT_REPLY_PATTERN = re.compile(r"llm_tools_assistant_reply:\s*(.*)")
 MARKER_TIMEOUT_PATTERN = re.compile(r"llm_tools_response_ready|llm_tools_native_handler_started")
 SLOT_FILL_MARKERS = re.compile(r"NeedsSlot|ConfirmationFastPath:")
-PROFILE_LLM_PATTERN = re.compile(r"ProfileExtraction\s+method=llm")
-PROFILE_FALLBACK_PATTERN = re.compile(
-    r"ProfileExtraction\s+method=regex|"
-    r"ProfileExtraction\s+method=fallback"
-)
+PROFILE_LLM_PATTERN = re.compile(r"Profile LLM extraction succeeded")
+PROFILE_FALLBACK_PATTERN = re.compile(r"Profile regex fallback")
 PROFILE_RESULT_PATTERN = re.compile(r"llm_tools_skill_result:\s*({.*})")
 
 # ── Timeouts (overridable via env vars) ──

--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -767,9 +767,14 @@ def extract_profile_result(logcat_output: str) -> dict[str, str | None]:
     """Parse profile extraction method and structured fields from logcat."""
     used_llm = bool(PROFILE_LLM_PATTERN.search(logcat_output))
     used_fallback = bool(PROFILE_FALLBACK_PATTERN.search(logcat_output))
-    name_match = re.search(r"^KernelAI: name:\s*(.+)$", logcat_output, flags=re.MULTILINE)
-    role_match = re.search(r"^KernelAI: role:\s*(.+)$", logcat_output, flags=re.MULTILINE)
-    location_match = re.search(r"^KernelAI: location:\s*(.+)$", logcat_output, flags=re.MULTILINE)
+    # The app logs YAML field names (name:, role:, location:) as the log message
+    # content via Log.d("KernelAI", ...), so we match the field name after any
+    # logcat prefix content.  The prefix comes from logcat -v brief
+    # ("D/KernelAI(PID): ") and is not part of the message.
+    # Using $ with MULTILINE anchors to end-of-line; . doesn't cross \n.
+    name_match = re.search(r"name:\s*(.+)$", logcat_output, flags=re.MULTILINE)
+    role_match = re.search(r"role:\s*(.+)$", logcat_output, flags=re.MULTILINE)
+    location_match = re.search(r"location:\s*(.+)$", logcat_output, flags=re.MULTILINE)
     return {
         "method": "llm" if used_llm else ("regex" if used_fallback else None),
         "name": name_match.group(1).strip() if name_match else None,

--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -25,6 +25,8 @@ from adb_harness.config import (
     NATIVE_INTENT_PATTERN,
     PARAM_EXTRACT_PATTERN,
     PACKAGE,
+    PROFILE_FALLBACK_PATTERN,
+    PROFILE_LLM_PATTERN,
     WAIT_SECONDS,
     LLM_TOOLS_ASSISTANT_REPLY_PATTERN,
 )
@@ -765,9 +767,9 @@ def extract_profile_result(logcat_output: str) -> dict[str, str | None]:
     """Parse profile extraction method and structured fields from logcat."""
     used_llm = bool(PROFILE_LLM_PATTERN.search(logcat_output))
     used_fallback = bool(PROFILE_FALLBACK_PATTERN.search(logcat_output))
-    name_match = re.search(r"KernelAI: name:\s*(.+)", logcat_output)
-    role_match = re.search(r"KernelAI: role:\s*(.+)", logcat_output)
-    location_match = re.search(r"KernelAI: location:\s*(.+)", logcat_output)
+    name_match = re.search(r"^KernelAI: name:\s*(.+)$", logcat_output, flags=re.MULTILINE)
+    role_match = re.search(r"^KernelAI: role:\s*(.+)$", logcat_output, flags=re.MULTILINE)
+    location_match = re.search(r"^KernelAI: location:\s*(.+)$", logcat_output, flags=re.MULTILINE)
     return {
         "method": "llm" if used_llm else ("regex" if used_fallback else None),
         "name": name_match.group(1).strip() if name_match else None,

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -52,6 +52,7 @@ from adb_harness.device import (
     clear_logcat,
     dismiss_notifications,
     extract_intent,
+    extract_profile_result,
     extract_reply,
     check_params,
     logcat_start,
@@ -156,6 +157,25 @@ def _poll_for_all_markers(
     return results, accumulated
 def _clear_conversation() -> None:
     """Force-stop the app to clear conversation state and model caches."""
+    run_adb("shell", "am", "force-stop", PACKAGE)
+    time.sleep(1)
+
+def _reset_app_process(reason: str) -> None:
+    """Return to launcher, dismiss overlays, and force-stop the app.
+
+    Safe isolation for suite and phase boundaries: preserves app data and
+    downloaded models while clearing foreground UI and in-process routing state.
+    """
+    print(f"  [reset] {reason} — returning HOME, dismissing overlays, force-stopping app")
+    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    time.sleep(0.2)
+    run_adb("shell", "input", "keyevent", "KEYCODE_HOME")
+    time.sleep(0.5)
+    dismiss_notifications()
+    run_adb("shell", "input", "keyevent", "KEYCODE_BACK")
+    time.sleep(0.2)
+    run_adb("shell", "input", "keyevent", "KEYCODE_BACK")
+    time.sleep(0.2)
     run_adb("shell", "am", "force-stop", PACKAGE)
     time.sleep(1)
 
@@ -648,7 +668,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
         if cumulative_reset_interval is not None:
             print(f"  Cumulative reset interval: {cumulative_reset_interval} tests (opt-in)")
         else:
-            print("  Cumulative mode: true cumulative (no periodic force-stop)")
+            print("  Cumulative mode: no periodic force-stop; safe phase-boundary reset between phases")
         print(f"  Selected: {len(selected_tests)} / {total_tests}")
         print(f"  Not selected: {not_selected}")
         print(f"  Total: {len(selected_tests)} test cases"
@@ -715,10 +735,11 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
     run_adb("shell", "settings", "put", "system", "screen_off_timeout", "2147483647")
     start_keepalive()
 
-    # Warm up: send a dummy query to trigger model load, wait for NativeIntentHandler to fire.
+    # Warm up: start from a clean launcher/app state, then send a dummy query to
+    # trigger model load and wait for NativeIntentHandler to fire.
     # Cold starts (or post-OOM reloads) can take 90-120s; poll for 120s before giving up.
     print("  [init] Warming up model (this takes ~30s on first run) ...", end=" ", flush=True)
-    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    _reset_app_process("suite preflight warmup")
     run_adb("shell", "am", "start", "-n", ACTIVITY)
     time.sleep(3)
     clear_logcat()
@@ -893,6 +914,11 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
         phase_group = list(phase_group_iter)
         phase_start = time.time()
         phase_results: list[TestResult] = []
+        if results:
+            print(f"  [phase-reset] Preparing clean boundary before phase '{phase_name}' ...")
+            _reset_app_process(f"between phases → {phase_name}")
+            clear_logcat()
+            time.sleep(1)
 
         for _phase_idx, _case_idx, tc in phase_group:
             global_index = len(results) + 1  # 1-based, runs only over selected tests
@@ -1309,9 +1335,13 @@ def run_profile_tests(dry_run: bool = False) -> int:
     print("=" * 70)
     print()
 
-    # Warm up: send a chat message and wait for the inference engine to load
-    print("  Warming up engine ...", end=" ", flush=True)
+    # Warm up: reset to a clean launcher/app state, then send a chat message and
+    # wait for the inference engine to load.
+    print("  Resetting app state ...", end=" ", flush=True)
+    _reset_app_process("profile preflight")
     clear_logcat()
+    print("done")
+    print("  Warming up engine ...", end=" ", flush=True)
     send_text("hello")
     warm_start = time.time()
     warmed = False
@@ -1332,9 +1362,19 @@ def run_profile_tests(dry_run: bool = False) -> int:
         send_profile(tc.profile_text)
         time.sleep(PROFILE_WAIT_SECONDS)
         logcat = read_logcat_all()
-        extracted = extract_profile_result(logcat)
+        harness_error: str | None = None
+        try:
+            extracted = extract_profile_result(logcat)
+        except Exception as exc:
+            harness_error = f"profile extraction parse error: {exc}"
+            extracted = {
+                "method": "HARNESS_ERROR",
+                "name": None,
+                "role": None,
+                "location": None,
+            }
 
-        passed = True
+        passed = harness_error is None
         if tc.expect_name and extracted["name"] != tc.expect_name:
             passed = False
         if tc.expect_role_contains and (
@@ -1347,7 +1387,7 @@ def run_profile_tests(dry_run: bool = False) -> int:
         ):
             passed = False
 
-        results.append(TestResult(
+        result = TestResult(
             index=i,
             message=tc.name,
             expect_intent=tc.name,
@@ -1359,10 +1399,16 @@ def run_profile_tests(dry_run: bool = False) -> int:
             param_failures=[],
             xfail=False,
             reply_warn=None,
-            log_check_warn=None,
-        ))
+            log_check_warn=harness_error,
+        )
+        result.status = derive_status(result)
+        result.failure_bucket = derive_failure_bucket(result)
+        results.append(result)
         method_tag = f"[{extracted['method'] or 'NO_LOG'}]"
-        print("✓" if passed else "✗", method_tag)
+        if harness_error is not None:
+            print("✗", method_tag, f"[{harness_error}]")
+        else:
+            print("✓" if passed else "✗", method_tag)
 
     # Summary
     print()
@@ -1443,9 +1489,9 @@ def _isolated_warmup(serial: str | None = None, model_readiness: bool = False,
     run_adb("shell", "settings", "put", "system", "screen_off_timeout", "2147483647")
     start_keepalive()
 
-    # Warm up model
+    # Warm up model from a clean launcher/app state.
     print("  [init] Warming up model (this takes ~30s on first run) ...", end=" ", flush=True)
-    run_adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+    _reset_app_process("isolated phase warmup")
     run_adb("shell", "am", "start", "-n", ACTIVITY)
     time.sleep(3)
     clear_logcat()

--- a/scripts/tests/test_harness_cumulative_semantics.py
+++ b/scripts/tests/test_harness_cumulative_semantics.py
@@ -3,7 +3,7 @@
 
 Verifies:
 - Default cumulative mode (--cumulative-reset-interval not set) does NOT
-  force-stop between test cases — suitable for reproducing #1293.
+  force-stop between test cases, but does advertise a safe reset between phases.
 - --cumulative-reset-interval N triggers force-stop every N tests.
 - --iso (phase-isolated) mode force-stops between phases (unchanged).
 
@@ -57,12 +57,12 @@ class HarnessCumulativeSemanticsTest(unittest.TestCase):
     # ── Default cumulative mode (no --cumulative-reset-interval) ──
 
     def test_default_cumulative_no_periodic_reset(self) -> None:
-        """Default cumulative mode must state true cumulative in dry-run output."""
+        """Default cumulative mode must advertise no periodic resets."""
         output = self._run_dry()
         self.assertIn(
-            "Cumulative mode: true cumulative (no periodic force-stop)",
+            "Cumulative mode: no periodic force-stop; safe phase-boundary reset between phases",
             output,
-            "Default cumulative mode should advertise no force-stop",
+            "Default cumulative mode should advertise the new safe boundary reset",
         )
         # Also verify no reset interval is mentioned
         self.assertNotIn(

--- a/scripts/tests/test_profile_harness.py
+++ b/scripts/tests/test_profile_harness.py
@@ -25,12 +25,13 @@ import adb_harness.runners as runners  # noqa: E402
 
 
 class ProfileParserTest(unittest.TestCase):
-    def test_extract_profile_result_parses_method_and_fields(self) -> None:
+    def test_extract_profile_result_parses_simple_lines(self) -> None:
+        """Simplified lines containing just the log message (no logcat prefix)."""
         logcat = (
-            "KernelAI: ProfileExtraction method=llm\n"
-            "KernelAI: name: Nick\n"
-            "KernelAI: role: Developer\n"
-            "KernelAI: location: Wellington\n"
+            "Profile LLM extraction succeeded\n"
+            "name: Nick\n"
+            "role: Developer\n"
+            "location: Wellington\n"
         )
 
         parsed = device.extract_profile_result(logcat)
@@ -44,6 +45,59 @@ class ProfileParserTest(unittest.TestCase):
             },
             parsed,
         )
+
+    def test_extract_profile_result_parses_logcat_brief_lines(self) -> None:
+        """Real logcat -v brief format as produced by adb logcat -v brief."""
+        logcat = (
+            "D/KernelAI(12345): Profile LLM extraction succeeded\n"
+            "D/KernelAI(12345): name: Nick\n"
+            "D/KernelAI(12345): role: Developer\n"
+            "D/KernelAI(12345): location: Wellington\n"
+        )
+
+        parsed = device.extract_profile_result(logcat)
+
+        self.assertEqual(
+            {
+                "method": "llm",
+                "name": "Nick",
+                "role": "Developer",
+                "location": "Wellington",
+            },
+            parsed,
+        )
+
+    def test_extract_profile_result_parses_logcat_brief_fallback(self) -> None:
+        """Regex fallback path with logcat -v brief lines."""
+        logcat = (
+            "D/KernelAI(12345): Profile LLM extraction skipped — engine not ready\n"
+            "D/KernelAI(12345): Profile regex fallback\n"
+            "D/KernelAI(12345): name: Alex\n"
+            "D/KernelAI(12345): role: software engineer\n"
+            "D/KernelAI(12345): location: Sydney, Australia\n"
+        )
+
+        parsed = device.extract_profile_result(logcat)
+
+        self.assertEqual(
+            {
+                "method": "regex",
+                "name": "Alex",
+                "role": "software engineer",
+                "location": "Sydney, Australia",
+            },
+            parsed,
+        )
+
+    def test_extract_profile_result_handles_missing_fields(self) -> None:
+        """Partial output returns None for missing fields, not crash."""
+        logcat = "Profile regex fallback\nname: Sam\n"
+        parsed = device.extract_profile_result(logcat)
+        self.assertEqual("regex", parsed["method"])
+        self.assertEqual("Sam", parsed["name"])
+        self.assertIsNone(parsed["role"])
+        self.assertIsNone(parsed["location"])
+
 
 
 class ProfileHarnessTest(unittest.TestCase):

--- a/scripts/tests/test_profile_harness.py
+++ b/scripts/tests/test_profile_harness.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for profile extraction harness reliability fixes.
+
+Covers:
+- run_profile_tests imports and uses extract_profile_result successfully
+- parser failures become structured harness failures instead of Python crashes
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from adb_harness import device  # noqa: E402
+from adb_harness.models import ProfileTestCase  # noqa: E402
+import adb_harness.runners as runners  # noqa: E402
+
+
+
+class ProfileParserTest(unittest.TestCase):
+    def test_extract_profile_result_parses_method_and_fields(self) -> None:
+        logcat = (
+            "KernelAI: ProfileExtraction method=llm\n"
+            "KernelAI: name: Nick\n"
+            "KernelAI: role: Developer\n"
+            "KernelAI: location: Wellington\n"
+        )
+
+        parsed = device.extract_profile_result(logcat)
+
+        self.assertEqual(
+            {
+                "method": "llm",
+                "name": "Nick",
+                "role": "Developer",
+                "location": "Wellington",
+            },
+            parsed,
+        )
+
+
+class ProfileHarnessTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.script = SCRIPT_DIR / "adb_skill_test.py"
+        if not cls.script.is_file():
+            raise FileNotFoundError(f"Test script not found: {cls.script}")
+
+    def _patch_common(self, cases: list[ProfileTestCase]) -> ExitStack:
+        stack = ExitStack()
+        stack.enter_context(patch("adb_harness.runners.os.path.isfile", return_value=True))
+        stack.enter_context(patch.object(runners, "PROFILE_TEST_CASES", cases))
+        stack.enter_context(patch.object(runners, "logcat_start"))
+        stack.enter_context(patch.object(runners, "clear_logcat"))
+        stack.enter_context(patch.object(runners, "send_text"))
+        stack.enter_context(patch.object(runners, "send_profile"))
+        stack.enter_context(patch.object(runners, "_reset_app_process"))
+        stack.enter_context(patch.object(runners, "analyse_results"))
+        stack.enter_context(patch.object(runners.time, "sleep", return_value=None))
+        stack.enter_context(
+            patch.object(
+                runners,
+                "read_logcat_all",
+                side_effect=["Generation complete", "KernelAI: name: Nick"],
+            )
+        )
+        return stack
+
+    def test_run_profile_tests_saves_successful_result(self) -> None:
+        cases = [
+            ProfileTestCase(
+                name="simple_profile",
+                profile_text="Name: Nick",
+                expect_name="Nick",
+            )
+        ]
+        with self._patch_common(cases) as stack:
+            save_report = stack.enter_context(
+                patch.object(runners, "save_report", return_value=Path("/tmp/profile.json"))
+            )
+            stack.enter_context(
+                patch.object(
+                    runners,
+                    "extract_profile_result",
+                    return_value={
+                        "method": "regex",
+                        "name": "Nick",
+                        "role": None,
+                        "location": None,
+                    },
+                )
+            )
+
+            rc = runners.run_profile_tests()
+
+        self.assertEqual(0, rc)
+        saved_results = save_report.call_args.args[0]
+        self.assertEqual(1, len(saved_results))
+        result = saved_results[0]
+        self.assertEqual("regex", result.actual_intent)
+        self.assertEqual("pass", result.status)
+        self.assertIsNone(result.log_check_warn)
+
+    def test_run_profile_tests_reports_parser_failure_without_crashing(self) -> None:
+        cases = [
+            ProfileTestCase(
+                name="broken_profile",
+                profile_text="Name: Nick",
+                expect_name="Nick",
+            )
+        ]
+        with self._patch_common(cases) as stack:
+            save_report = stack.enter_context(
+                patch.object(runners, "save_report", return_value=Path("/tmp/profile.json"))
+            )
+            stack.enter_context(
+                patch.object(
+                    runners,
+                    "extract_profile_result",
+                    side_effect=RuntimeError("boom"),
+                )
+            )
+
+            rc = runners.run_profile_tests()
+
+        self.assertEqual(1, rc)
+        saved_results = save_report.call_args.args[0]
+        self.assertEqual(1, len(saved_results))
+        result = saved_results[0]
+        self.assertEqual("HARNESS_ERROR", result.actual_intent)
+        self.assertEqual("fail", result.status)
+        self.assertIn("profile extraction parse error: boom", result.log_check_warn or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Triages #1365 S21 non-permission automation sweep blockers identified after the full permissions suite (24/24 pass) completed at `8c9658ce` on `main`.

## Original evidence

- Sweep report: `scripts/test-reports/automation-sweep/2026-07-02-s21-non-permission-sweep.md`
- Commit under test: `8c9658ce`

## Changes

- Fix profile parser patterns to match actual app logcat output: the app logs YAML field names (`name:`, `role:`, `location:`) as message content via `Log.d("KernelAI", ...)`, and logcat `-v brief` prefixes lines with `D/KernelAI(PID): `. Updated `PROFILE_LLM_PATTERN`, `PROFILE_FALLBACK_PATTERN`, and field extraction regexes to parse real S21 logcat lines correctly.
- Add profile harness unit coverage: 6 tests covering simplified, `-v brief`, fallback, and missing-fields formats; plus 2 runner integration tests for structured failure handling.
- Import harden profile extraction parsing so `scripts/adb_skill_test.py --profile` reports structured failures instead of crashing.
- Rename AndroidTest-only composable helpers from `*TestWrapper` to `*Fixture` (`MessageBubbleFixture`, `AlarmDialogFixture`) so they are no longer discoverable as fake test entry points.
- Add safe suite/phase boundary app resets in the ADB harness to return HOME, dismiss overlays, and force-stop the app without clearing data or models.
- Update cumulative-mode dry-run semantics to document the new safe phase-boundary reset.

## Before / after

| Area | Before | After | Classification |
|---|---|---|---|
| profile harness `extract_profile_result` | Python crash (`NameError` — missing import, then parser globals, then regex anchor mismatch with real logcat) | **3/3 pass on S21** (`scripts/test-reports/2026-07-02T22-24-34Z_profile.json`) — correctly parses `D/KernelAI(…): name: Nick` etc | **fixed harness bug** — patterns now match actual app logcat `-v brief` YAML format |
| wrapper-class AndroidTest loader | `MessageBubbleTestWrapper` / `AlarmDialogTestWrapper` targeted as classes and failed to load | helpers renamed to `MessageBubbleFixture` / `AlarmDialogFixture`; `ScheduledAlarmsDialogTest` rerun passes | fixed stale invocation |
| connected UI chat/settings/clock | sweep reported failures mixed with wrapper-loader noise | reruns still fail in `ClockSettingsActionUiTest` (3), `ChatScreenToolChipTest` (3), `ClockSurfaceTabsTest` (1), `ClockSurfaceContentTest` (2), `StopwatchDashboardTest` (1) after wrapper fix | remaining **product/test follow-up**, not wrapper noise |
| core-memory AndroidTest | 6 failures in migration / repository assertions | rerun still fails with missing Room migration `50 -> 51`, meal-history assertion mismatch, SQLite `NOT NULL` migration failure | remaining **product follow-up** |
| S21 ADB contamination/stuck-mode | later cumulative phases collapsed into repeated wrong intents | added safe suite/phase resets; rerun of `slot_fill,orchestrator_recovery,false_positives` now aborts `ORACLE_UNHEALTHY` with 0 logcat lines instead of producing contaminated evidence | reduced false evidence risk; remaining **harness/setup blocker** |

## Validation

### Off-device

```
python3 -m py_compile scripts/*.py
python3 -m unittest scripts.tests.test_profile_harness scripts.tests.test_harness_cumulative_semantics
python3 -m unittest discover scripts/tests
./gradlew testDebugUnitTest --no-daemon
```

### S21 rerun evidence

| Field | Value |
|---|---|
| Device | Samsung Galaxy S21 SM-G991B |
| Serial | R5CR605B71K |
| Android API | 35 |
| Commit under test | `0b61a7b6` |
| Profile report | `scripts/test-reports/2026-07-02T22-24-34Z_profile.json` |

**Suites re-run after fix:**

- **Profile harness** (`--profile`): **3/3 pass** — all three profile cases correctly parsed from real `-v brief` logcat YAML output with method=`regex`, name, role, and location fields extracted.
- **Fixture-backed connected AndroidTest**: `ScheduledAlarmsDialogTest` passes (wrapper-loader blocker confirmed fixed).
- **Failing connected test reruns** (product follow-up, no fix attempted here):
  - `ChatScreenToolChipTest`: 3 failures (Wellington, Forecast, duplicate surfaced link node)
  - `ClockSettingsActionUiTest`: 3 failures (Timer sound, missing `0`, click callback)
  - `ClockSurfaceTabsTest`, `ClockSurfaceContentTest`, `StopwatchDashboardTest`: 4 failures total
  - `:core:memory:connectedDebugAndroidTest`: 6 failures (migration 50→51, meal-history, SQLite NOT NULL)
- **ADB phase-isolated rerun** (`slot_fill,orchestrator_recovery,false_positives`): now aborts `ORACLE_UNHEALTHY` with 0 logcat lines (remaining harness/setup blocker).

### Generated artifacts

All generated reports are local only under `scripts/test-reports/**`. `git status --short` is clean — no staged or committed generated artifacts.

## Recommended follow-ups

- **Profile harness:** no follow-up needed — 3/3 pass on S21.
- **S21 ADB oracle/logcat health** for late-phase non-permission subsets: file a separate harness/setup issue.
- **Open product/test fixes** for chat/settings/clock/core-memory AndroidTest regressions (not harness issues).
