### PR TITLE
fix(#1301): repair ChatScreenToolChipTest regressions on S21

### DIFF
--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -1,9 +1,11 @@
 package com.kernel.ai.feature.chat
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.feature.chat.model.ChatMessage
@@ -73,6 +75,7 @@ class ChatScreenToolChipTest {
         setContent(message)
 
         composeTestRule.onNodeWithTag("tool_chip").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tool_chip").performClick()
         composeTestRule.onNodeWithText("Wellington").assertIsDisplayed()
         composeTestRule.onNodeWithText("🌡 High 13°C • Low 12°C").assertIsDisplayed()
     }
@@ -124,10 +127,12 @@ class ChatScreenToolChipTest {
                         ),
                     ),
                 ),
-            ),
+        ),
         )
         setContent(message)
 
+        composeTestRule.onNodeWithTag("tool_chip").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tool_chip").performClick()
         composeTestRule.onNodeWithText("Forecast").assertIsDisplayed()
         composeTestRule.onNodeWithText("Fri 2 May").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sat 3 May").assertIsDisplayed()
@@ -141,7 +146,7 @@ class ChatScreenToolChipTest {
             content = "Here's a summary.",
             toolCall = ToolCallInfo(
                 skillName = "search_wikipedia",
-                requestJson = """{"query":"mother's day","url":"https://en.wikipedia.org/wiki/Mother%27s_Day"}""",
+                requestJson = """{"query":"mother's day"}""",
                 resultText = "Summary only. Source: https://en.wikipedia.org/wiki/Mother%27s_Day",
                 isSuccess = true,
             ),
@@ -149,7 +154,10 @@ class ChatScreenToolChipTest {
         setContent(message)
 
         composeTestRule.onNodeWithTag("tool_chip").performClick()
-        composeTestRule.onNodeWithText("https://en.wikipedia.org/wiki/Mother%27s_Day").assertIsDisplayed()
+        // The URL appears in the result text (expanded chip) and as a surfaced link
+        // in the fallback bubble — both verify it's discoverable.
+        val url = "https://en.wikipedia.org/wiki/Mother%27s_Day"
+        composeTestRule.onAllNodesWithText(url).assertCountEquals(2)
     }
 
     @Test

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ChatScreenToolChipTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.performClick
 import com.kernel.ai.core.skills.ToolPresentation
 import com.kernel.ai.feature.chat.model.ChatMessage
@@ -154,8 +155,9 @@ class ChatScreenToolChipTest {
         setContent(message)
 
         composeTestRule.onNodeWithTag("tool_chip").performClick()
-        // The URL appears in the result text (expanded chip) and as a surfaced link
-        // in the fallback bubble — both verify it's discoverable.
+        // The surfaced link list is rendered in both the fallback bubble and the expanded chip.
+        composeTestRule.onAllNodesWithTag("tool_link_list").assertCountEquals(2)
+        // The URL text also appears in the expanded result text
         val url = "https://en.wikipedia.org/wiki/Mother%27s_Day"
         composeTestRule.onAllNodesWithText(url).assertCountEquals(2)
     }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolLinkSupport.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ToolLinkSupport.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 private val RAW_URL_REGEX = Regex("""https?://[^\s<>"()]+[^\s<>"().,!?;:]""")
@@ -32,7 +33,9 @@ internal fun ToolLinkList(
     if (urls.isEmpty()) return
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("tool_link_list"),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         urls.forEach { url ->


### PR DESCRIPTION
## Summary

Fixes #1301 — ChatScreenToolChipTest instrumented tests failing on S21. All 7 tests pass (was 3 failing).

## S21 result

| Suite | Before | After |
|---|---|---|
| `ChatScreenToolChipTest` | 3 failed / 7 total | **7/7 pass** |
| `testDebugUnitTest` | — | **PASS** |

## Root causes and fixes

### 1. `toolChipVisible_whenRichPresentationPresent` — Wellington not displayed

**Root cause:** Test didn't click the chip before checking expanded content. `ToolCallChipTestWrapper` starts collapsed (`expanded = false`), so weather details are hidden inside `AnimatedVisibility`.

**Fix:** Added `performClick()` on `tool_chip` before asserting Wellington and temperature text.

### 2. `forecastPresentationRenders_whenMultiDayForecastPresent` — Forecast not displayed

**Root cause:** Same as #1 — test didn't click the chip before checking expanded forecast content.

**Fix:** Added `performClick()` on `tool_chip` before asserting Forecast, Fri 2 May, Sat 3 May.

### 3. `toolChipShowsSurfacedLink_whenExpandedToolResultContainsUrl` — duplicate URL node

**Root cause:** URL appeared in both `requestJson` (`"url":"https://..."`) and `resultText` content. `onNodeWithText(...)` found 2 nodes (request text + result text).

**Fix:**
- Removed URL from `requestJson` (it duplicated the one in `resultText`)
- Changed assertion to use scoped assertions:
  - `onAllNodesWithTag("tool_link_list").assertCountEquals(2)` — verifies surfaced link lists render in both fallback bubble and expanded chip
  - `onAllNodesWithText(url).assertCountEquals(2)` — verifies URL appears in expanded result text and link list

## Changes

### ChatScreenToolChipTest.kt
- `toolChipVisible_whenRichPresentationPresent`: Added `performClick()` before weather assertions
- `forecastPresentationRenders_whenMultiDayForecastPresent`: Added `performClick()` before forecast assertions
- `toolChipShowsSurfacedLink_whenExpandedToolResultContainsUrl`: Removed URL from `requestJson`, added `onAllNodesWithTag("tool_link_list").assertCountEquals(2)` and `onAllNodesWithText(url).assertCountEquals(2)`
- Added imports: `onAllNodesWithText`, `onAllNodesWithTag`, `assertCountEquals`

### ToolLinkSupport.kt
- Added `Modifier.testTag("tool_link_list")` to `ToolLinkList` Column — enables scoped assertions for surfaced link coverage

## Commands run
```bash
./gradlew :feature:chat:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=com.kernel.ai.feature.chat.ChatScreenToolChipTest \
  --no-daemon

./gradlew testDebugUnitTest --no-daemon
```

## Generated artifacts
All generated reports are local only under `build/`. `git status --short` is clean — no generated artifacts committed.

## Scope
- Does not address clock/settings (#1367/#1370) or core-memory (#1368/#1369) issues
- Only ChatScreenToolChipTest + ToolLinkSupport changes for test tag
