### PR TITLE
fix(#1372): add logcat stream recovery and reorder preflight checks in isolated warmup

### DIFF
--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -318,6 +318,17 @@ def check_logcat_stream(timeout: float = 5.0) -> bool:
             return True
         time.sleep(0.5)
     return False
+def logcat_restart() -> bool:
+    """Restart the host-side logcat stream.
+
+    Stops the existing stream, starts a fresh one, and verifies it is
+    receiving new lines. Returns True if the restarted stream is healthy.
+    """
+    logcat_stop()
+    time.sleep(0.5)
+    logcat_start()
+    time.sleep(1)
+    return check_logcat_stream(timeout=5.0)
 
 
 

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -54,6 +54,7 @@ from adb_harness.device import (
     extract_intent,
     extract_profile_result,
     extract_reply,
+    logcat_restart,
     check_params,
     logcat_start,
     read_logcat,
@@ -1544,25 +1545,45 @@ def _isolated_warmup(serial: str | None = None, model_readiness: bool = False,
             warmed_ml = True
             break
 
-    # Oracle preflight
+    # Streaming logcat health check — run BEFORE oracle to detect
+    # dead-logcat conditions that would produce false ORACLE_UNHEALTHY.
+    print("  [stream] Verifying host-side logcat stream ...", end=" ", flush=True)
+    healthy = check_logcat_stream(timeout=5.0)
+    if healthy:
+        print("healthy")
+    else:
+        print("FAILED")
+        print("  [stream] Attempting logcat restart ...", end=" ", flush=True)
+        recovered = logcat_restart()
+        if recovered:
+            print("recovered")
+            print("  [stream] Re-verifying after restart ...", end=" ", flush=True)
+            healthy = check_logcat_stream(timeout=5.0)
+            if healthy:
+                print("healthy")
+            else:
+                print("FAILED — aborting")
+                stop_keepalive()
+                run_adb("shell", "svc", "power", "stayon", "false")
+                run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
+                return _STREAM_UNHEALTHY
+        else:
+            print("FAILED — aborting")
+            stop_keepalive()
+            run_adb("shell", "svc", "power", "stayon", "false")
+            run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
+            return _STREAM_UNHEALTHY
+
+    # Oracle preflight — logcat stream is confirmed healthy, so a failure here
+    # is a real app/inference issue, not a logcat-stream contamination.
     if not check_oracle(timeout=30.0):
         print()
-        print("  [oracle] ORACLE_UNHEALTHY — aborting")
+        print("  [oracle] ORACLE_UNHEALTHY — aborting (logcat stream was healthy)")
         stop_keepalive()
         run_adb("shell", "svc", "power", "stayon", "false")
         run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
         return _ORACLE_UNHEALTHY
 
-    # Streaming logcat health check
-    print("  [stream] Verifying host-side logcat stream ...", end=" ", flush=True)
-    healthy = check_logcat_stream(timeout=5.0)
-    print("healthy" if healthy else "STREAM_UNHEALTHY")
-    if not healthy:
-        print("  [stream] Logcat stream unhealthy — aborting.")
-        stop_keepalive()
-        run_adb("shell", "svc", "power", "stayon", "false")
-        run_adb("shell", "settings", "put", "system", "screen_off_timeout", "60000")
-        return _STREAM_UNHEALTHY
     print("ready" if warmed_ml else "timeout (proceeding anyway)")
 
     # Flush logcat residue before tests

--- a/scripts/tests/test_warmup_recovery.py
+++ b/scripts/tests/test_warmup_recovery.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Tests for isolated warmup recovery path (#1372).
+
+Covers warmup preflight ordering and logcat-stream recovery in
+``_isolated_warmup()``:
+
+- Stream healthy → oracle healthy → warmup succeeds (0)
+- Stream unhealthy → logcat_restart succeeds → re-verify healthy → 0
+- Stream unhealthy → restart succeeds → re-verify fails → _STREAM_UNHEALTHY (43)
+- Stream unhealthy → restart fails → _STREAM_UNHEALTHY (43)
+- Stream healthy → oracle unhealthy → _ORACLE_UNHEALTHY (42)
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# ── Helper: run _isolated_warmup with configurable mocks ──
+
+_WARMED_LOGCAT = (
+    "NativeIntentHandler.handle: intent=get_time\n"
+    "Ready:\n"
+)
+
+
+def _warmup_with(
+    *,
+    stream_healthy: bool = True,
+    restart_succeeds: bool = True,
+    oracle_healthy: bool = True,
+) -> int:
+    """Run ``_isolated_warmup()`` with mocked ADB/harness dependencies.
+
+    Args:
+        stream_healthy: return value from ``check_logcat_stream``
+        restart_succeeds: return value from ``logcat_restart``
+        oracle_healthy: return value from ``check_oracle``
+
+    Returns the exit code from ``_isolated_warmup()``.
+    """
+    stream_mock = MagicMock()
+    if stream_healthy:
+        stream_mock.return_value = True
+    elif restart_succeeds:
+        # Dead stream → restart → re-verify passes
+        stream_mock.side_effect = [False, True]
+    else:
+        # Dead stream → restart fails → re-verify never called
+        stream_mock.return_value = False
+
+    with \
+        patch("os.path.isfile", return_value=True), \
+        patch("time.sleep"), \
+        patch("adb_harness.runners.logcat_start"), \
+        patch("adb_harness.runners.clear_logcat"), \
+        patch("adb_harness.runners.read_logcat", return_value=_WARMED_LOGCAT), \
+        patch("adb_harness.runners.run_adb", return_value=""), \
+        patch("adb_harness.runners.start_keepalive"), \
+        patch("adb_harness.runners.stop_keepalive"), \
+        patch("adb_harness.runners.setup_contact_alias_fixture"), \
+        patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
+        patch("adb_harness.runners.check_logcat_stream", stream_mock), \
+        patch("adb_harness.runners.logcat_restart", return_value=restart_succeeds), \
+        patch("adb_harness.runners.check_oracle", return_value=oracle_healthy):
+        from adb_harness.runners import _isolated_warmup
+        return _isolated_warmup()
+
+
+# ── Test cases ──
+
+
+class WarmupHealthyTest(unittest.TestCase):
+    """Normal healthy warmup — no recovery needed."""
+
+    def test_stream_and_oracle_healthy_returns_0(self) -> None:
+        """Stream healthy + oracle healthy → warmup succeeds (0)."""
+        rc = _warmup_with(stream_healthy=True, oracle_healthy=True)
+        self.assertEqual(rc, 0)
+
+
+class WarmupStreamRecoveryTest(unittest.TestCase):
+    """Stream unhealthy → logcat_restart recovery paths."""
+
+    def test_restart_success_and_reverify_healthy_returns_0(self) -> None:
+        """Dead stream → restart ok → re-verify ok → warmup succeeds (0)."""
+        rc = _warmup_with(
+            stream_healthy=False,
+            restart_succeeds=True,
+            oracle_healthy=True,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_restart_success_but_reverify_fails_returns_43(self) -> None:
+        """Dead stream → restart ok → re-verify fails → _STREAM_UNHEALTHY (43)."""
+        # check_logcat_stream: False (dead), then False (re-verify fails)
+        stream_mock = MagicMock(side_effect=[False, False])
+
+        with \
+            patch("os.path.isfile", return_value=True), \
+            patch("time.sleep"), \
+            patch("adb_harness.runners.logcat_start"), \
+            patch("adb_harness.runners.clear_logcat"), \
+            patch("adb_harness.runners.read_logcat", return_value=_WARMED_LOGCAT), \
+            patch("adb_harness.runners.run_adb", return_value=""), \
+            patch("adb_harness.runners.start_keepalive"), \
+            patch("adb_harness.runners.stop_keepalive"), \
+            patch("adb_harness.runners.setup_contact_alias_fixture"), \
+            patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
+            patch("adb_harness.runners.check_logcat_stream", stream_mock), \
+            patch("adb_harness.runners.logcat_restart", return_value=True), \
+            patch("adb_harness.runners.check_oracle", return_value=True):
+            from adb_harness.runners import _isolated_warmup
+            rc = _isolated_warmup()
+
+        self.assertEqual(rc, 43)
+
+    def test_restart_fails_returns_43(self) -> None:
+        """Dead stream → restart fails → _STREAM_UNHEALTHY (43)."""
+        rc = _warmup_with(
+            stream_healthy=False,
+            restart_succeeds=False,
+        )
+        self.assertEqual(rc, 43)
+
+
+class WarmupOracleFailTest(unittest.TestCase):
+    """Stream healthy but oracle fails — no contaminated evidence emitted."""
+
+    def test_oracle_unhealthy_after_stream_healthy_returns_42(self) -> None:
+        """Stream healthy → oracle unhealthy → _ORACLE_UNHEALTHY (42)."""
+        rc = _warmup_with(stream_healthy=True, oracle_healthy=False)
+        self.assertEqual(rc, 42)
+
+    def test_oracle_unhealthy_message_says_logcat_stream_healthy(self) -> None:
+        """Oracle failure prints ``logcat stream was healthy`` diagnostic.
+
+        Verifies the diagnostic message distinguishes real app issues
+        from logcat-stream contamination.
+        """
+        stream_mock = MagicMock(return_value=True)
+        oracle_mock = MagicMock(return_value=False)
+
+        with \
+            patch("os.path.isfile", return_value=True), \
+            patch("time.sleep"), \
+            patch("adb_harness.runners.logcat_start"), \
+            patch("adb_harness.runners.clear_logcat"), \
+            patch("adb_harness.runners.read_logcat", return_value=_WARMED_LOGCAT), \
+            patch("adb_harness.runners.run_adb", return_value=""), \
+            patch("adb_harness.runners.start_keepalive"), \
+            patch("adb_harness.runners.stop_keepalive"), \
+            patch("adb_harness.runners.setup_contact_alias_fixture"), \
+            patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
+            patch("adb_harness.runners.check_logcat_stream", stream_mock), \
+            patch("adb_harness.runners.logcat_restart", return_value=True), \
+            patch("adb_harness.runners.check_oracle", oracle_mock), \
+            patch("builtins.print") as mock_print:
+            from adb_harness.runners import _isolated_warmup
+            _isolated_warmup()
+
+        # Assert that the oracle-failure message includes
+        # "logcat stream was healthy" — real app issue, not contamination
+        printed = [
+            call[0][0] for call in mock_print.call_args_list
+            if call[0] and "logcat stream was healthy" in str(call[0][0])
+        ]
+        self.assertGreaterEqual(
+            len(printed), 1,
+            "Expected oracle failure message to mention logcat stream was healthy"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1372 — S21 ADB oracle/logcat health blocks trustworthy full-sweep evidence.

**Root cause:** In `_isolated_warmup()`, the oracle preflight (`check_oracle()`) ran **before** the logcat stream health check (`check_logcat_stream()`). When the host-side logcat stream died between phase-isolated reruns, the oracle probe produced 0 logcat lines → `ORACLE_UNHEALTHY` → harness aborted with contaminated evidence indistinguishable from real app failures.

**Fix:** Reorder checks so logcat stream health is verified (and recovered if needed) **before** the oracle preflight. If stream recovery fails, the harness returns structured `_STREAM_UNHEALTHY` (43) — not contaminated product evidence.

## Changes

### `scripts/adb_harness/device.py` — `logcat_restart()` (new function)
- Stops the existing stream, starts a fresh one, and verifies it receives new lines
- Returns `True` if the restarted stream is healthy

### `scripts/adb_harness/runners.py` — `_isolated_warmup()` reordered
1. **Logcat stream check runs BEFORE oracle** — detects dead-logcat conditions early
2. On failure → `logcat_restart()` → re-verify → continue or `_STREAM_UNHEALTHY`
3. Oracle check now has a **confirmed-healthy logcat stream** — any failure is a real app issue
4. Oracle failure message includes `"logcat stream was healthy"` diagnostic

### `scripts/tests/test_warmup_recovery.py` (new — 6 tests, 100% pass)
- `test_stream_and_oracle_healthy_returns_0` — normal path
- `test_restart_success_and_reverify_healthy_returns_0` — recovery succeeds
- `test_restart_success_but_reverify_fails_returns_43` — restart ok but re-verify fails
- `test_restart_fails_returns_43` — restart fails outright
- `test_oracle_unhealthy_after_stream_healthy_returns_42` — oracle fail after healthy stream
- `test_oracle_unhealthy_message_says_logcat_stream_healthy` — diagnostic distinguishes real issue

## Validation

### Off-device

```bash
python3 -m py_compile scripts/adb_harness/device.py scripts/adb_harness/runners.py scripts/adb_skill_test.py
```
→ All scripts compile cleanly.

```bash
python3 -m unittest scripts/tests/test_warmup_recovery.py -v
```
→ 6/6 pass (all recovery paths exercised).

```bash
python3 -m unittest scripts/tests/test_cleanup_failure.py -v
```
→ 20/20 pass (existing mock tests still work with reordered warmup).

### Logcat kill/restart on S21 (`R5CR605B71K`)

Explicit kill-and-recover test:

| Step | Result |
|---|---|
| `stream1` | healthy |
| `logcat_pid` | 2806494 (killed) |
| `stream_after_kill` | **False** — correctly detects dead stream |
| `recovered` | **True** — `logcat_restart()` recovers |
| `stream_after_restart` | healthy |
| Oracle probe | ✅ marker found — pipeline healthy |

### Integrated path — previously failing rerun (`slot_fill, orchestrator_recovery, false_positives`)

```bash
python3 scripts/adb_skill_test.py --serial R5CR605B71K --iso \
  --phases slot_fill,orchestrator_recovery,false_positives
```

All 3 warmup preflights show `[stream] ... healthy` then `[oracle] ✅ marker found`:

```
PHASE 1/3: slot_fill
  [stream] Verifying host-side logcat stream ... healthy
  [oracle] ✅ marker found — observability pipeline healthy

PHASE 2/3: orchestrator_recovery
  [stream] Verifying host-side logcat stream ... healthy
  [oracle] ✅ marker found — observability pipeline healthy

PHASE 3/3: false_positives
  [stream] Verifying host-side logcat stream ... healthy
  [oracle] ✅ marker found — observability pipeline healthy
```

Combined summary (40 tests, 1082s):

```
Phase                 Tests   Pass   Fail  XFail
-------------------- ------ ------ ------ ------
slot_fill                14      2     12      0
orchestrator_recovery     10      0      7      3
false_positives          16      7      9      0
-------------------- ------ ------ ------ ------
TOTAL                    40      9     28      3
```

**No `ORACLE_UNHEALTHY` aborts. No `STREAM_UNHEALTHY` aborts. No harness/setup failures.** All failures are product/intent-routing failures — the harness correctly attributed them to the app.

### Coverage preserved
- Existing `check_oracle` and `check_logcat_stream` mocks in `test_cleanup_failure.py` — still pass (mocks return True regardless of ordering)
- `--dry-run` tests in `test_harness_cumulative_semantics.py` — unaffected (skip warmup entirely)
- False-positive status derivation tests — unchanged

## Scope

Harness/setup only — no app/product fixes. `#1372`'s broader recovery items (device online check, wake screen, HOME/overlay dismissal, force-stop/restart app) are intentionally **out of scope** for this PR because the `_reset_app_process()` + `_isolated_warmup()` sequence already handles these at the phase boundary. This PR only adds the missing **logcat-stream health check before oracle** with automatic restart, which was the root cause of the `ORACLE_UNHEALTHY` / 0-logcat contamination.

## Related issue
#1372 — S21 ADB oracle/logcat health blocks trustworthy full-sweep evidence
