### PR TITLE
fix(#1374): use PermissionOverlayDialog + sendPointerSync for real backdrop tap on S21

### DIFF
--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -1,48 +1,29 @@
 package com.kernel.ai.feature.chat
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import android.os.SystemClock
+import android.view.MotionEvent
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kernel.ai.core.ui.permissions.PermissionDialogAction
+import com.kernel.ai.core.ui.permissions.PermissionOverlayDialog
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-
 /**
- * Instrumented Compose UI tests for the DND special-access AlertDialog.
+ * Instrumented Compose UI tests for the DND special-access dialog.
  *
- * The dialog is rendered inline in [ActionsScreen] (via PermissionOverlayDialog →
- * BasicAlertDialog). This test verifies the dialog rendering and CTA callbacks
- * in isolation using a test wrapper that replicates the same conditional dialog
- * structure. The wrapper uses [Dialog] directly (matching BasicAlertDialog's pattern)
- * rather than AlertDialog so the scrim has an explicit test tag for backdrop tap.
+ * The dialog is rendered in production via [PermissionOverlayDialog] →
+ * BasicAlertDialog. This test uses [PermissionOverlayDialog] exactly as
+ * [ActionsScreen] does.
  *
  * OS-boundary notes:
  *   - The "Open DND access settings" CTA triggers [ActionsViewModel.onDndOpenSettings],
@@ -57,11 +38,10 @@ import org.junit.Test
  *     stable third-party helper exists for this.
  *   - The lifecycle resume path (ON_RESUME → onDndResumeCheck) is tested at the
  *     ViewModel unit-test layer (retry-with-grant and blocked-without-grant).
- *   - Backdrop tap: tested via a test-tagged scrim Box with clickable(onClick = onDismiss).
- *     Compose Dialog windows have a known limitation where performTouchInput { click() }
- *     on the dialog root does not reliably reach the scrim Surface (coordinate-system
- *     mismatch for separate Dialog windows). Using performClick() on a test-tagged
- *     scrim node exercises the same semantic action (onClick → onDismissRequest).
+ *   - Backdrop tap: uses [Instrumentation.sendPointerSync] with real MotionEvent
+ *     injection rather than Compose [performTouchInput], because Compose touch
+ *     injection does not reliably reach the scrim Surface inside Compose Dialog
+ *     windows (coordinate-system mismatch between activity and dialog views).
  */
 class ActionsDndDialogTest {
 
@@ -219,19 +199,19 @@ class ActionsDndDialogTest {
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
             .assertIsDisplayed()
         assertFalse("Dismiss should not have been called before interaction", dismissCalled)
-        // Find the fill-sized scrim Box in the unmerged semantics tree and click it.
-        // The Box has clickable(onClick = onDismiss) which adds OnClick semantics.
-        // On S21 the dialog window is ~960×900 px — the scrim fills this area.
-        // Buttons are <60k px², so area > 100k uniquely matches the scrim.
-        composeTestRule.onNode(
-            hasClickAction().and(
-                SemanticsMatcher("dialogScrim") { node ->
-                    val area = node.boundsInRoot.width * node.boundsInRoot.height
-                    area > 100_000f
-                }
-            ),
-            useUnmergedTree = true,
-        ).performClick()
+        // Tap the dialog scrim via real MotionEvent injection through the
+        // Android input pipeline (not Compose performTouchInput, which has
+        // coordinate-system issues with Compose Dialog windows).
+        // BasicAlertDialog's scrim Surface fills the dialog window; tapping
+        // the left-edge area (50px from left, 200px from top) lands on the
+        // scrim (outside the centered card) and triggers onDismissRequest.
+        val downTime = SystemClock.uptimeMillis()
+        InstrumentationRegistry.getInstrumentation().sendPointerSync(
+            MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, 50f, 200f, 0)
+        )
+        InstrumentationRegistry.getInstrumentation().sendPointerSync(
+            MotionEvent.obtain(downTime, downTime + 50, MotionEvent.ACTION_UP, 50f, 200f, 0)
+        )
         composeTestRule.waitForIdle()
         assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
@@ -239,16 +219,15 @@ class ActionsDndDialogTest {
     }
 
     // ── Test wrapper composable ────────────────────────────────────────────────
-
     /**
-     * Replicates the exact dialog structure from [ActionsScreen] which uses
-     * PermissionOverlayDialog → BasicAlertDialog.
+     * Wraps [PermissionOverlayDialog] with the same DND-specific title, body,
+     * and actions that [ActionsScreen] uses, driven by test-controllable state.
      *
-     * Unlike the Material3 AlertDialog convenience API, this wrapper uses [Dialog]
-     * directly so the scrim layer has an explicit [testTag]("dialog_scrim") for
-     * ComposeUI test access. The behavior is identical: a clickable fill-size scrim
-     * triggers [onDismiss] when tapped outside the centered card.
+     * @param dndState The DND permission state. Dialog shown when non-null.
+     * @param onOpenSettings Called when "Open DND access settings" is tapped.
+     * @param onDismiss Called when dismiss is triggered (scrim, back, "Not now").
      */
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     private fun DndDialogContent(
         dndState: MutableState<ActionsViewModel.DndState?>,
@@ -256,67 +235,34 @@ class ActionsDndDialogTest {
         onDismiss: () -> Unit,
     ) {
         dndState.value?.let { state ->
-            Dialog(
+            PermissionOverlayDialog(
+                title = if (state.isAccessBlocked) {
+                    "Jandal still needs Do Not Disturb access"
+                } else {
+                    "Allow Jandal to control Do Not Disturb?"
+                },
+                body = if (state.isAccessBlocked) {
+                    "Grant Do Not Disturb access in Android settings, " +
+                        "then return to Jandal to continue."
+                } else {
+                    "Android requires special access before Jandal can " +
+                        "turn Do Not Disturb on or off."
+                },
+                actions = listOf(
+                    PermissionDialogAction(
+                        label = "Open DND access settings",
+                        testTag = "permission_dialog_dnd_open_settings",
+                        onClick = onOpenSettings,
+                    ),
+                    PermissionDialogAction(
+                        label = "Not now",
+                        testTag = "permission_dialog_dnd_not_now",
+                        onClick = onDismiss,
+                    ),
+                ),
+                dialogTestTag = "permission_dialog_dnd",
                 onDismissRequest = onDismiss,
-                properties = DialogProperties(usePlatformDefaultWidth = true),
-            ) {
-                // Scrim — fill-sized clickable Box inside the Dialog.
-                // clickable(onClick = onDismiss) adds OnClick semantics to the Box.
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = onDismiss,
-                        ),
-                ) {
-                    // Card — centered, same surface styling as BasicAlertDialog
-                    Surface(
-                        modifier = Modifier
-                            .wrapContentSize()
-                            .align(Alignment.Center),
-                        shape = MaterialTheme.shapes.extraLarge,
-                        color = MaterialTheme.colorScheme.surface,
-                        tonalElevation = 6.dp,
-                    ) {
-                        Column(modifier = Modifier.padding(24.dp)) {
-                            Text(
-                                text = if (state.isAccessBlocked) {
-                                    "Jandal still needs Do Not Disturb access"
-                                } else {
-                                    "Allow Jandal to control Do Not Disturb?"
-                                },
-                                style = MaterialTheme.typography.headlineSmall,
-                            )
-                            Text(
-                                text = if (state.isAccessBlocked) {
-                                    "Grant Do Not Disturb access in Android settings, " +
-                                        "then return to Jandal to continue."
-                                } else {
-                                    "Android requires special access before Jandal can " +
-                                        "turn Do Not Disturb on or off."
-                                },
-                                modifier = Modifier.padding(top = 16.dp),
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 24.dp),
-                                horizontalArrangement = Arrangement.End,
-                            ) {
-                                TextButton(onClick = onDismiss) {
-                                    Text("Not now")
-                                }
-                                TextButton(onClick = onOpenSettings) {
-                                    Text("Open DND access settings")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            )
         }
     }
 }

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -1,18 +1,35 @@
 package com.kernel.ai.feature.chat
 
-import android.view.KeyEvent
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -21,9 +38,11 @@ import org.junit.Test
 /**
  * Instrumented Compose UI tests for the DND special-access AlertDialog.
  *
- * The dialog is rendered inline in [ActionsScreen] (lines 615–650 of ActionsScreen.kt).
- * This test verifies the dialog rendering and CTA callbacks in isolation using a
- * test wrapper that replicates the same conditional [AlertDialog] structure.
+ * The dialog is rendered inline in [ActionsScreen] (via PermissionOverlayDialog →
+ * BasicAlertDialog). This test verifies the dialog rendering and CTA callbacks
+ * in isolation using a test wrapper that replicates the same conditional dialog
+ * structure. The wrapper uses [Dialog] directly (matching BasicAlertDialog's pattern)
+ * rather than AlertDialog so the scrim has an explicit test tag for backdrop tap.
  *
  * OS-boundary notes:
  *   - The "Open DND access settings" CTA triggers [ActionsViewModel.onDndOpenSettings],
@@ -38,6 +57,11 @@ import org.junit.Test
  *     stable third-party helper exists for this.
  *   - The lifecycle resume path (ON_RESUME → onDndResumeCheck) is tested at the
  *     ViewModel unit-test layer (retry-with-grant and blocked-without-grant).
+ *   - Backdrop tap: tested via a test-tagged scrim Box with clickable(onClick = onDismiss).
+ *     Compose Dialog windows have a known limitation where performTouchInput { click() }
+ *     on the dialog root does not reliably reach the scrim Surface (coordinate-system
+ *     mismatch for separate Dialog windows). Using performClick() on a test-tagged
+ *     scrim node exercises the same semantic action (onClick → onDismissRequest).
  */
 class ActionsDndDialogTest {
 
@@ -195,13 +219,20 @@ class ActionsDndDialogTest {
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
             .assertIsDisplayed()
         assertFalse("Dismiss should not have been called before interaction", dismissCalled)
-
-        // Dismiss the dialog via back button — triggers the AlertDialog's
-        // onDismissRequest on all Android devices.
-        InstrumentationRegistry.getInstrumentation()
-            .sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+        // Find the fill-sized scrim Box in the unmerged semantics tree and click it.
+        // The Box has clickable(onClick = onDismiss) which adds OnClick semantics.
+        // On S21 the dialog window is ~960×900 px — the scrim fills this area.
+        // Buttons are <60k px², so area > 100k uniquely matches the scrim.
+        composeTestRule.onNode(
+            hasClickAction().and(
+                SemanticsMatcher("dialogScrim") { node ->
+                    val area = node.boundsInRoot.width * node.boundsInRoot.height
+                    area > 100_000f
+                }
+            ),
+            useUnmergedTree = true,
+        ).performClick()
         composeTestRule.waitForIdle()
-
         assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")
             .assertIsNotDisplayed()
@@ -210,10 +241,13 @@ class ActionsDndDialogTest {
     // ── Test wrapper composable ────────────────────────────────────────────────
 
     /**
-     * Replicates the exact [AlertDialog] structure from [ActionsScreen] lines 615–650.
+     * Replicates the exact dialog structure from [ActionsScreen] which uses
+     * PermissionOverlayDialog → BasicAlertDialog.
      *
-     * Kept as a local composable so the test mirrors the production rendering
-     * without depending on the full [ActionsViewModel] or lifecycle infrastructure.
+     * Unlike the Material3 AlertDialog convenience API, this wrapper uses [Dialog]
+     * directly so the scrim layer has an explicit [testTag]("dialog_scrim") for
+     * ComposeUI test access. The behavior is identical: a clickable fill-size scrim
+     * triggers [onDismiss] when tapped outside the centered card.
      */
     @Composable
     private fun DndDialogContent(
@@ -222,39 +256,67 @@ class ActionsDndDialogTest {
         onDismiss: () -> Unit,
     ) {
         dndState.value?.let { state ->
-            AlertDialog(
+            Dialog(
                 onDismissRequest = onDismiss,
-                title = {
-                    Text(
-                        if (state.isAccessBlocked) {
-                            "Jandal still needs Do Not Disturb access"
-                        } else {
-                            "Allow Jandal to control Do Not Disturb?"
-                        },
-                    )
-                },
-                text = {
-                    Text(
-                        if (state.isAccessBlocked) {
-                            "Grant Do Not Disturb access in Android settings, " +
-                                "then return to Jandal to continue."
-                        } else {
-                            "Android requires special access before Jandal can " +
-                                "turn Do Not Disturb on or off."
-                        },
-                    )
-                },
-                confirmButton = {
-                    TextButton(onClick = onOpenSettings) {
-                        Text("Open DND access settings")
+                properties = DialogProperties(usePlatformDefaultWidth = true),
+            ) {
+                // Scrim — fill-sized clickable Box inside the Dialog.
+                // clickable(onClick = onDismiss) adds OnClick semantics to the Box.
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = onDismiss,
+                        ),
+                ) {
+                    // Card — centered, same surface styling as BasicAlertDialog
+                    Surface(
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .align(Alignment.Center),
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.surface,
+                        tonalElevation = 6.dp,
+                    ) {
+                        Column(modifier = Modifier.padding(24.dp)) {
+                            Text(
+                                text = if (state.isAccessBlocked) {
+                                    "Jandal still needs Do Not Disturb access"
+                                } else {
+                                    "Allow Jandal to control Do Not Disturb?"
+                                },
+                                style = MaterialTheme.typography.headlineSmall,
+                            )
+                            Text(
+                                text = if (state.isAccessBlocked) {
+                                    "Grant Do Not Disturb access in Android settings, " +
+                                        "then return to Jandal to continue."
+                                } else {
+                                    "Android requires special access before Jandal can " +
+                                        "turn Do Not Disturb on or off."
+                                },
+                                modifier = Modifier.padding(top = 16.dp),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 24.dp),
+                                horizontalArrangement = Arrangement.End,
+                            ) {
+                                TextButton(onClick = onDismiss) {
+                                    Text("Not now")
+                                }
+                                TextButton(onClick = onOpenSettings) {
+                                    Text("Open DND access settings")
+                                }
+                            }
+                        }
                     }
-                },
-                dismissButton = {
-                    TextButton(onClick = onDismiss) {
-                        Text("Not now")
-                    }
-                },
-            )
+                }
+            }
         }
     }
 }

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsDndDialogTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.chat
 
+import android.view.KeyEvent
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -11,10 +12,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.click
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -198,11 +196,11 @@ class ActionsDndDialogTest {
             .assertIsDisplayed()
         assertFalse("Dismiss should not have been called before interaction", dismissCalled)
 
-        // Click outside the dialog (top-left corner of the screen on the scrim)
-        // to trigger AlertDialog's onDismissRequest.
-        composeTestRule.onRoot().performTouchInput {
-            click(position = Offset(0f, 0f))
-        }
+        // Dismiss the dialog via back button — triggers the AlertDialog's
+        // onDismissRequest on all Android devices.
+        InstrumentationRegistry.getInstrumentation()
+            .sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+        composeTestRule.waitForIdle()
 
         assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
         composeTestRule.onNodeWithText("Allow Jandal to control Do Not Disturb?")

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
@@ -1,47 +1,29 @@
 package com.kernel.ai.feature.chat
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import android.os.SystemClock
+import android.view.MotionEvent
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kernel.ai.core.ui.permissions.PermissionDialogAction
+import com.kernel.ai.core.ui.permissions.PermissionOverlayDialog
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 /**
- * Instrumented Compose UI tests for the write-settings special-access AlertDialog.
+ * Instrumented Compose UI tests for the write-settings special-access dialog.
  *
- * The dialog is rendered inline in [ActionsScreen] (via PermissionOverlayDialog →
- * BasicAlertDialog). This test verifies the dialog rendering and CTA callbacks
- * in isolation using a test wrapper that replicates the same conditional dialog
- * structure. The wrapper uses [Dialog] directly (matching BasicAlertDialog's pattern)
- * rather than AlertDialog so the scrim has an explicit test tag for backdrop tap.
+ * The dialog is rendered in production via [PermissionOverlayDialog] →
+ * BasicAlertDialog. This test uses [PermissionOverlayDialog] exactly as
+ * [ActionsScreen] does.
  *
  * OS-boundary notes:
  *   - The "Open settings access" CTA triggers [ActionsViewModel.onWriteSettingsOpenSettings],
@@ -54,11 +36,10 @@ import org.junit.Test
  *     manual smoke test.
  *   - Full grant/revoke automation (toggling WRITE_SETTINGS) is OEM-specific
  *     and inherently unstable across Samsung One UI vs AOSP.
- *   - Backdrop tap: tested via a test-tagged scrim Box with clickable(onClick = onDismiss).
- *     Compose Dialog windows have a known limitation where performTouchInput { click() }
- *     on the dialog root does not reliably reach the scrim Surface (coordinate-system
- *     mismatch for separate Dialog windows). Using performClick() on a test-tagged
- *     scrim node exercises the same semantic action (onClick → onDismissRequest).
+ *   - Backdrop tap: uses [Instrumentation.sendPointerSync] with real MotionEvent
+ *     injection rather than Compose [performTouchInput], because Compose touch
+ *     injection does not reliably reach the scrim Surface inside Compose Dialog
+ *     windows (coordinate-system mismatch between activity and dialog views).
  */
 class ActionsWriteSettingsDialogTest {
 
@@ -224,38 +205,37 @@ class ActionsWriteSettingsDialogTest {
                 onDismiss = { dismissCalled = true; writeSettingsState.value = null },
             )
         }
-
-        // Find the fill-sized scrim Box in the unmerged semantics tree and click it.
-        // The Box has clickable(onClick = onDismiss) which adds OnClick semantics.
-        // On S21 the dialog window is ~960×900 px — the scrim fills this area.
-        // Buttons are <60k px², so area > 100k uniquely matches the scrim.
-        composeTestRule.onNode(
-            hasClickAction().and(
-                SemanticsMatcher("dialogScrim") { node ->
-                    val area = node.boundsInRoot.width * node.boundsInRoot.height
-                    area > 100_000f
-                }
-            ),
-            useUnmergedTree = true,
-        ).performClick()
         composeTestRule.waitForIdle()
-
-        assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
         composeTestRule.onNodeWithText("Allow Jandal to modify system settings?")
-            .assertIsNotDisplayed()
+            .assertIsDisplayed()
+        assertFalse("Dismiss should not have been called before interaction", dismissCalled)
+
+        // Tap the dialog scrim via real MotionEvent injection through the
+        // Android input pipeline (not Compose performTouchInput, which has
+        // coordinate-system issues with Compose Dialog windows).
+        // BasicAlertDialog's scrim Surface fills the dialog window; tapping
+        // the left-edge area (50px from left, 200px from top) lands on the
+        // scrim (outside the centered card) and triggers onDismissRequest.
+        val downTime = SystemClock.uptimeMillis()
+        InstrumentationRegistry.getInstrumentation().sendPointerSync(
+            MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, 50f, 200f, 0)
+        )
+        InstrumentationRegistry.getInstrumentation().sendPointerSync(
+            MotionEvent.obtain(downTime, downTime + 50, MotionEvent.ACTION_UP, 50f, 200f, 0)
+        )
+        composeTestRule.waitForIdle()
     }
 
     // ── Test wrapper composable ────────────────────────────────────────────────
-
     /**
-     * Replicates the exact dialog structure from [ActionsScreen] which uses
-     * PermissionOverlayDialog → BasicAlertDialog.
+     * Wraps [PermissionOverlayDialog] with the same settings-specific title, body,
+     * and actions that [ActionsScreen] uses, driven by test-controllable state.
      *
-     * Unlike the Material3 AlertDialog convenience API, this wrapper uses [Dialog]
-     * directly so the scrim layer has an explicit [testTag]("dialog_scrim") for
-     * ComposeUI test access. The behavior is identical: a clickable fill-size scrim
-     * triggers [onDismiss] when tapped outside the centered card.
+     * @param writeSettingsState The write-settings permission state. Dialog shown when non-null.
+     * @param onOpenSettings Called when "Open settings access" is tapped.
+     * @param onDismiss Called when dismiss is triggered (scrim, back, "Not now").
      */
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     private fun WriteSettingsDialogContent(
         writeSettingsState: MutableState<ActionsViewModel.WriteSettingsState?>,
@@ -263,66 +243,34 @@ class ActionsWriteSettingsDialogTest {
         onDismiss: () -> Unit,
     ) {
         writeSettingsState.value?.let { state ->
-            Dialog(
+            PermissionOverlayDialog(
+                title = if (state.isAccessBlocked) {
+                    "Jandal still needs settings access"
+                } else {
+                    "Allow Jandal to modify system settings?"
+                },
+                body = if (state.isAccessBlocked) {
+                    "Jandal still does not have access to modify " +
+                        "system settings."
+                } else {
+                    "Android requires special access before Jandal can " +
+                        "change settings such as screen brightness."
+                },
+                actions = listOf(
+                    PermissionDialogAction(
+                        label = "Open settings access",
+                        testTag = "permission_dialog_write_settings_open_settings",
+                        onClick = onOpenSettings,
+                    ),
+                    PermissionDialogAction(
+                        label = "Not now",
+                        testTag = "permission_dialog_write_settings_not_now",
+                        onClick = onDismiss,
+                    ),
+                ),
+                dialogTestTag = "permission_dialog_write_settings",
                 onDismissRequest = onDismiss,
-                properties = DialogProperties(usePlatformDefaultWidth = true),
-            ) {
-                // Scrim — fill-sized clickable Box inside the Dialog.
-                // clickable(onClick = onDismiss) adds OnClick semantics to the Box.
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = onDismiss,
-                        ),
-                ) {
-                    // Card — centered, same surface styling as BasicAlertDialog
-                    Surface(
-                        modifier = Modifier
-                            .wrapContentSize()
-                            .align(Alignment.Center),
-                        shape = MaterialTheme.shapes.extraLarge,
-                        color = MaterialTheme.colorScheme.surface,
-                        tonalElevation = 6.dp,
-                    ) {
-                        Column(modifier = Modifier.padding(24.dp)) {
-                            Text(
-                                text = if (state.isAccessBlocked) {
-                                    "Jandal still needs settings access"
-                                } else {
-                                    "Allow Jandal to modify system settings?"
-                                },
-                                style = MaterialTheme.typography.headlineSmall,
-                            )
-                            Text(
-                                text = if (state.isAccessBlocked) {
-                                    "Jandal still does not have access to modify system settings."
-                                } else {
-                                    "Android requires special access before Jandal can " +
-                                        "change settings such as screen brightness."
-                                },
-                                modifier = Modifier.padding(top = 16.dp),
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 24.dp),
-                                horizontalArrangement = Arrangement.End,
-                            ) {
-                                TextButton(onClick = onDismiss) {
-                                    Text("Not now")
-                                }
-                                TextButton(onClick = onOpenSettings) {
-                                    Text("Open settings access")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            )
         }
     }
 }

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
@@ -224,6 +224,9 @@ class ActionsWriteSettingsDialogTest {
             MotionEvent.obtain(downTime, downTime + 50, MotionEvent.ACTION_UP, 50f, 200f, 0)
         )
         composeTestRule.waitForIdle()
+        assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
+        composeTestRule.onNodeWithText("Allow Jandal to modify system settings?")
+            .assertIsNotDisplayed()
     }
 
     // ── Test wrapper composable ────────────────────────────────────────────────

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
@@ -1,18 +1,35 @@
 package com.kernel.ai.feature.chat
 
-import android.view.KeyEvent
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -20,9 +37,11 @@ import org.junit.Test
 /**
  * Instrumented Compose UI tests for the write-settings special-access AlertDialog.
  *
- * The dialog is rendered inline in [ActionsScreen]. This test verifies the dialog
- * rendering and CTA callbacks in isolation using a test wrapper that replicates
- * the same conditional [AlertDialog] structure.
+ * The dialog is rendered inline in [ActionsScreen] (via PermissionOverlayDialog →
+ * BasicAlertDialog). This test verifies the dialog rendering and CTA callbacks
+ * in isolation using a test wrapper that replicates the same conditional dialog
+ * structure. The wrapper uses [Dialog] directly (matching BasicAlertDialog's pattern)
+ * rather than AlertDialog so the scrim has an explicit test tag for backdrop tap.
  *
  * OS-boundary notes:
  *   - The "Open settings access" CTA triggers [ActionsViewModel.onWriteSettingsOpenSettings],
@@ -31,13 +50,15 @@ import org.junit.Test
  *     handled in [ActionsScreen]'s LaunchedEffect event collector via
  *     [android.content.Context.startActivity]. This final OS call is not directly
  *     verified at the Compose UI layer — it is covered by the ViewModel unit test
- *     (`write settings open settings emits OpenWriteSettings event`) and by manual
- *     smoke test.
- *   - Full grant/revoke automation (toggling the write-settings switch) is
- *     OEM-specific and may be unstable across Samsung One UI vs AOSP — no stable
- *     third-party helper exists for this.
- *   - The lifecycle resume path (ON_RESUME → onWriteSettingsResumeCheck) is tested
- *     at the ViewModel unit-test layer (retry-with-grant and blocked-without-grant).
+ *     (`write settings open settings emits OpenWriteSettings event`) and by
+ *     manual smoke test.
+ *   - Full grant/revoke automation (toggling WRITE_SETTINGS) is OEM-specific
+ *     and inherently unstable across Samsung One UI vs AOSP.
+ *   - Backdrop tap: tested via a test-tagged scrim Box with clickable(onClick = onDismiss).
+ *     Compose Dialog windows have a known limitation where performTouchInput { click() }
+ *     on the dialog root does not reliably reach the scrim Surface (coordinate-system
+ *     mismatch for separate Dialog windows). Using performClick() on a test-tagged
+ *     scrim node exercises the same semantic action (onClick → onDismissRequest).
  */
 class ActionsWriteSettingsDialogTest {
 
@@ -204,15 +225,19 @@ class ActionsWriteSettingsDialogTest {
             )
         }
 
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Allow Jandal to modify system settings?")
-            .assertIsDisplayed()
-        assertFalse("Dismiss should not have been called before interaction", dismissCalled)
-
-        // Dismiss the dialog via back button — triggers the AlertDialog's
-        // onDismissRequest on all Android devices.
-        InstrumentationRegistry.getInstrumentation()
-            .sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+        // Find the fill-sized scrim Box in the unmerged semantics tree and click it.
+        // The Box has clickable(onClick = onDismiss) which adds OnClick semantics.
+        // On S21 the dialog window is ~960×900 px — the scrim fills this area.
+        // Buttons are <60k px², so area > 100k uniquely matches the scrim.
+        composeTestRule.onNode(
+            hasClickAction().and(
+                SemanticsMatcher("dialogScrim") { node ->
+                    val area = node.boundsInRoot.width * node.boundsInRoot.height
+                    area > 100_000f
+                }
+            ),
+            useUnmergedTree = true,
+        ).performClick()
         composeTestRule.waitForIdle()
 
         assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
@@ -223,10 +248,13 @@ class ActionsWriteSettingsDialogTest {
     // ── Test wrapper composable ────────────────────────────────────────────────
 
     /**
-     * Replicates the exact [AlertDialog] structure from [ActionsScreen].
+     * Replicates the exact dialog structure from [ActionsScreen] which uses
+     * PermissionOverlayDialog → BasicAlertDialog.
      *
-     * Kept as a local composable so the test mirrors the production rendering
-     * without depending on the full [ActionsViewModel] or lifecycle infrastructure.
+     * Unlike the Material3 AlertDialog convenience API, this wrapper uses [Dialog]
+     * directly so the scrim layer has an explicit [testTag]("dialog_scrim") for
+     * ComposeUI test access. The behavior is identical: a clickable fill-size scrim
+     * triggers [onDismiss] when tapped outside the centered card.
      */
     @Composable
     private fun WriteSettingsDialogContent(
@@ -235,38 +263,66 @@ class ActionsWriteSettingsDialogTest {
         onDismiss: () -> Unit,
     ) {
         writeSettingsState.value?.let { state ->
-            AlertDialog(
+            Dialog(
                 onDismissRequest = onDismiss,
-                title = {
-                    Text(
-                        if (state.isAccessBlocked) {
-                            "Jandal still needs settings access"
-                        } else {
-                            "Allow Jandal to modify system settings?"
-                        },
-                    )
-                },
-                text = {
-                    Text(
-                        if (state.isAccessBlocked) {
-                            "Jandal still does not have access to modify system settings."
-                        } else {
-                            "Android requires special access before Jandal can " +
-                                "change settings such as screen brightness."
-                        },
-                    )
-                },
-                confirmButton = {
-                    TextButton(onClick = onOpenSettings) {
-                        Text("Open settings access")
+                properties = DialogProperties(usePlatformDefaultWidth = true),
+            ) {
+                // Scrim — fill-sized clickable Box inside the Dialog.
+                // clickable(onClick = onDismiss) adds OnClick semantics to the Box.
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = onDismiss,
+                        ),
+                ) {
+                    // Card — centered, same surface styling as BasicAlertDialog
+                    Surface(
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .align(Alignment.Center),
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = MaterialTheme.colorScheme.surface,
+                        tonalElevation = 6.dp,
+                    ) {
+                        Column(modifier = Modifier.padding(24.dp)) {
+                            Text(
+                                text = if (state.isAccessBlocked) {
+                                    "Jandal still needs settings access"
+                                } else {
+                                    "Allow Jandal to modify system settings?"
+                                },
+                                style = MaterialTheme.typography.headlineSmall,
+                            )
+                            Text(
+                                text = if (state.isAccessBlocked) {
+                                    "Jandal still does not have access to modify system settings."
+                                } else {
+                                    "Android requires special access before Jandal can " +
+                                        "change settings such as screen brightness."
+                                },
+                                modifier = Modifier.padding(top = 16.dp),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 24.dp),
+                                horizontalArrangement = Arrangement.End,
+                            ) {
+                                TextButton(onClick = onDismiss) {
+                                    Text("Not now")
+                                }
+                                TextButton(onClick = onOpenSettings) {
+                                    Text("Open settings access")
+                                }
+                            }
+                        }
                     }
-                },
-                dismissButton = {
-                    TextButton(onClick = onDismiss) {
-                        Text("Not now")
-                    }
-                },
-            )
+                }
+            }
         }
     }
 }

--- a/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
+++ b/feature/chat/src/androidTest/java/com/kernel/ai/feature/chat/ActionsWriteSettingsDialogTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.feature.chat
 
+import android.view.KeyEvent
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -11,15 +12,11 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.click
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-
 /**
  * Instrumented Compose UI tests for the write-settings special-access AlertDialog.
  *
@@ -212,11 +209,11 @@ class ActionsWriteSettingsDialogTest {
             .assertIsDisplayed()
         assertFalse("Dismiss should not have been called before interaction", dismissCalled)
 
-        // Click outside the dialog (top-left corner of the screen on the scrim)
-        // to trigger AlertDialog's onDismissRequest.
-        composeTestRule.onRoot().performTouchInput {
-            click(position = Offset(0f, 0f))
-        }
+        // Dismiss the dialog via back button — triggers the AlertDialog's
+        // onDismissRequest on all Android devices.
+        InstrumentationRegistry.getInstrumentation()
+            .sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+        composeTestRule.waitForIdle()
 
         assertTrue("Backdrop dismiss should trigger dismiss callback", dismissCalled)
         composeTestRule.onNodeWithText("Allow Jandal to modify system settings?")


### PR DESCRIPTION
## Summary

Fixes #1374 — S21 dialog backdrop tap fails with `isRoot` 2-node mismatch in `ActionsDndDialogTest.dialogDismissesViaBackdropTap` and `ActionsWriteSettingsDialogTest.dialogDismissesViaBackdropTap`.

## Root cause

`composeTestRule.onRoot().performTouchInput { click(Offset(0f, 0f)) }` fails on S21 because:
1. `isRoot()` matches 2 Compose semantic nodes — a zero-size activity root and a full-screen dialog window root.
2. Even with a custom `isRoot().and(nonEmptyBounds)` matcher, `performTouchInput { click(...) }` does not reliably reach the scrim clickable handler inside Compose Dialog windows. Compose's `InjectedPointerInputFilter` has a coordinate-system mismatch where touch events are injected relative to the activity's view rather than the dialog window's view.

## Changes

Both test files (ActionsDndDialogTest + ActionsWriteSettingsDialogTest):

### Test wrapper → Production composable

Replaced the custom `Dialog { Box(fillMaxSize, clickable) { Card { ... } } }` wrapper with the actual production composable `PermissionOverlayDialog`.

Before: Custom `Dialog` with manual scrim `Box` to make the scrim clickable via `hasClickAction()` semantics.

After: `PermissionOverlayDialog(title, body, actions, onDismissRequest = onDismiss)` — matches exactly what `ActionsScreen.kt` uses.

### Backdrop tap → Real MotionEvent injection

**Before:**
```kotlin
composeTestRule.onNode(
    hasClickAction().and(SemanticsMatcher(···) { area > 100k }),
    useUnmergedTree = true
).performClick()
```

**After:**
```kotlin
val downTime = SystemClock.uptimeMillis()
InstrumentationRegistry.getInstrumentation().sendPointerSync(
    MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, 50f, 200f, 0)
)
InstrumentationRegistry.getInstrumentation().sendPointerSync(
    MotionEvent.obtain(downTime, downTime + 50, MotionEvent.ACTION_UP, 50f, 200f, 0)
)
```

`Instrumentation.sendPointerSync` sends events through the Android input pipeline (window manager → correct Dialog window → Compose hit-test → scrim Surface → clickable(onClick = onDismiss) → onDismissRequest). This bypasses Compose's `InjectedPointerInputFilter` coordinate issue because real MotionEvents are dispatched by the system's window manager, which correctly routes them to the topmost window at the given coordinates.

The coordinates (50px from left, 200px from top) are on the dialog left-edge scrim area — outside the centered dialog card — on all modern phones (1080×2400 S21, 1440×3088 S23U, 1080×2340 Pixel).

### WriteSettings test: restored preconditions

The backdrop test now starts with `waitForIdle()`, asserts the dialog title is displayed, and asserts `dismissCalled == false` before clicking the scrim — matching the DnD test pattern.

## Validation

### S21 (serial `R5CR605B71K`)

```
./gradlew :feature:chat:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=\
  com.kernel.ai.feature.chat.ActionsDndDialogTest,\
  com.kernel.ai.feature.chat.ActionsWriteSettingsDialogTest \
  --no-daemon
```

→ **14/14 pass, BUILD SUCCESSFUL**

### Full chat connected suite

```
./gradlew :feature:chat:connectedDebugAndroidTest --no-daemon
```

→ **BUILD SUCCESSFUL** (30 tests)

### JVM unit tests

```
./gradlew testDebugUnitTest --no-daemon
```

→ **BUILD SUCCESSFUL**

## Scope

- Test-only fix in two files (+124/−230 lines overall — mostly removing verbose custom wrapper code)
- No production code changes
- Matches the exact production composable path: `PermissionOverlayDialog → BasicAlertDialog → Dialog`
- Known Compose limitation documented: `sendPointerSync` used instead of `performTouchInput` because Compose's touch injection does not reliably reach Dialog window scrim surfaces
- Git status shows only the two modified test files. No generated artifacts are staged.