### PR TITLE
fix(#1375): filter stale ring-buffer markers in capture_fresh_logcat with boundary delimiter

### DIFF
--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -231,6 +231,21 @@ def read_logcat_all() -> str:
     return logcat_snapshot()
 
 
+def _filter_lines_after_boundary(text: str, boundary: str) -> str:
+    """Return only lines after the last occurrence of *boundary* in *text*.
+
+    If *boundary* is not found (should not happen under normal operation),
+    returns the full text prefixed with ``__BOUNDARY_NOT_FOUND__`` as a
+    structured diagnostic so callers can detect the condition.
+    """
+    idx = text.rfind(boundary)
+    if idx < 0:
+        return f"__BOUNDARY_NOT_FOUND__{text}"
+    after = text[idx + len(boundary):]
+    nl = after.find("\n")
+    return after[nl + 1:] if nl >= 0 else ""
+
+
 def capture_fresh_logcat(
     action: Callable[[], None],
     timeout: float = WAIT_SECONDS,
@@ -294,25 +309,14 @@ def capture_fresh_logcat(
             time.sleep(poll_interval)
             drain()
             text = "\n".join(accumulated)
-            idx = text.rfind(boundary)
-            if idx >= 0:
-                after = text[idx + len(boundary):]
-                nl = after.find("\n")
-                filtered = after[nl + 1:] if nl >= 0 else after
-            else:
-                filtered = text
+            filtered = _filter_lines_after_boundary(text, boundary)
             if expected and expected in filtered:
                 break
             if keep_foreground:
                 _tap_keepalive()
         drain()
         text = "\n".join(accumulated)
-        idx = text.rfind(boundary)
-        if idx >= 0:
-            after = text[idx + len(boundary):]
-            nl = after.find("\n")
-            return after[nl + 1:] if nl >= 0 else after
-        return text
+        return _filter_lines_after_boundary(text, boundary)
     finally:
         try:
             proc.terminate()

--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -14,6 +14,7 @@ import shlex
 import subprocess
 import sys
 import threading
+import uuid
 import time
 
 from adb_harness.config import (
@@ -239,10 +240,16 @@ def capture_fresh_logcat(
 ) -> str:
     """Capture only log lines produced after *action* starts.
 
-    Starts a fresh bounded logcat subprocess, runs *action*, then accumulates
-    only lines emitted during the current observation window. This avoids stale
-    ring-buffer matches and avoids dependence on the long-running stream.
+    Emits a unique boundary marker to logcat before the action, then filters
+    the captured output to only include lines after that marker. This prevents
+    stale ring-buffer matches (e.g. a warmup oracle probe) from contaminating
+    the result for tests whose action does not emit a NATIVE_INTENT marker.
     """
+    # Emit a unique boundary marker so we can discard stale ring-buffer lines.
+    boundary = f"__ADB_HARNESS_BOUNDARY_{uuid.uuid4().hex[:16]}__"
+    run_adb("shell", "log", "-t", "KernelAI", "-p", "i", boundary)
+    time.sleep(0.1)
+
     proc = subprocess.Popen(
         build_adb_cmd(*_LOGCAT_STREAM_ARGS),
         stdout=subprocess.PIPE,
@@ -286,13 +293,26 @@ def capture_fresh_logcat(
         while time.time() < deadline:
             time.sleep(poll_interval)
             drain()
-            combined = "\n".join(accumulated)
-            if expected and expected in combined:
+            text = "\n".join(accumulated)
+            idx = text.rfind(boundary)
+            if idx >= 0:
+                after = text[idx + len(boundary):]
+                nl = after.find("\n")
+                filtered = after[nl + 1:] if nl >= 0 else after
+            else:
+                filtered = text
+            if expected and expected in filtered:
                 break
             if keep_foreground:
                 _tap_keepalive()
         drain()
-        return "\n".join(accumulated)
+        text = "\n".join(accumulated)
+        idx = text.rfind(boundary)
+        if idx >= 0:
+            after = text[idx + len(boundary):]
+            nl = after.find("\n")
+            return after[nl + 1:] if nl >= 0 else after
+        return text
     finally:
         try:
             proc.terminate()

--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -235,12 +235,12 @@ def _filter_lines_after_boundary(text: str, boundary: str) -> str:
     """Return only lines after the last occurrence of *boundary* in *text*.
 
     If *boundary* is not found (should not happen under normal operation),
-    returns the full text prefixed with ``__BOUNDARY_NOT_FOUND__`` as a
-    structured diagnostic so callers can detect the condition.
+    returns ``__BOUNDARY_NOT_FOUND__`` so the ``expected`` check in the polling
+    loop cannot match against stale ring-buffer content.
     """
     idx = text.rfind(boundary)
     if idx < 0:
-        return f"__BOUNDARY_NOT_FOUND__{text}"
+        return "__BOUNDARY_NOT_FOUND__"
     after = text[idx + len(boundary):]
     nl = after.find("\n")
     return after[nl + 1:] if nl >= 0 else ""
@@ -290,7 +290,7 @@ def capture_fresh_logcat(
     time.sleep(0.2)
 
     accumulated: list[str] = []
-    seen: set[str] = set()
+
 
     def drain() -> None:
         with lock:
@@ -298,8 +298,7 @@ def capture_fresh_logcat(
             buffer.clear()
         for line in snapshot:
             line = line.strip()
-            if line and line not in seen:
-                seen.add(line)
+            if line:
                 accumulated.append(line)
 
     try:

--- a/scripts/tests/test_logcat_boundary.py
+++ b/scripts/tests/test_logcat_boundary.py
@@ -87,18 +87,49 @@ class BoundaryAtEndReturnsEmptyTest(unittest.TestCase):
 
 
 class BoundaryAbsentReturnsDiagnosticTest(unittest.TestCase):
-    """Missing boundary prepends ``__BOUNDARY_NOT_FOUND__``."""
+    """Missing boundary returns ``__BOUNDARY_NOT_FOUND__`` without stale text."""
 
-    def test_no_boundary_diagnostic_prefixed(self) -> None:
+    def test_no_boundary_diagnostic_only(self) -> None:
+        """Result is exactly ``__BOUNDARY_NOT_FOUND__``, no stale text appended."""
         text = f"{STALE_LINE}\n"
         result = _filter_lines_after_boundary(text, BOUNDARY)
-        self.assertTrue(result.startswith("__BOUNDARY_NOT_FOUND__"))
-        self.assertIn(STALE_LINE, result)
+        self.assertEqual(result, "__BOUNDARY_NOT_FOUND__")
 
     def test_no_boundary_on_empty_text(self) -> None:
         result = _filter_lines_after_boundary("", BOUNDARY)
         self.assertEqual(result, "__BOUNDARY_NOT_FOUND__")
 
+
+class BoundaryAbsentExpectedNotMatchedTest(unittest.TestCase):
+    """When boundary is absent, ``expected`` marker must not match stale text."""
+
+    def test_expected_not_found_in_stale_when_boundary_absent(self) -> None:
+        stale_text = (
+            f"some unrelated line\n"
+            f"{STALE_LINE}\n"
+            f"more noise\n"
+        )
+        result = _filter_lines_after_boundary(stale_text, BOUNDARY)
+        self.assertEqual(result, "__BOUNDARY_NOT_FOUND__")
+        # The stale marker must NOT appear in the filtered output
+        self.assertNotIn("get_time", result)
+
+
+class DuplicateLinesAcrossBoundaryTest(unittest.TestCase):
+    """Identical lines before and after boundary both preserved after filter."""
+
+    DUP_LINE = "D/KernelAI(12345): SomeRepeatingMarker: intent=xyzzy"
+
+    def test_fresh_copy_preserved_after_filter(self) -> None:
+        text = (
+            f"{self.DUP_LINE}\n"
+            f"{BOUNDARY}\n"
+            f"{self.DUP_LINE}\n"
+            f"{FRESH_LINE}\n"
+        )
+        result = _filter_lines_after_boundary(text, BOUNDARY)
+        self.assertIn(self.DUP_LINE, result)
+        self.assertIn(FRESH_LINE, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_logcat_boundary.py
+++ b/scripts/tests/test_logcat_boundary.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for ``_filter_lines_after_boundary`` — the logcat boundary-filtering
+helper that prevents stale ring-buffer markers from contaminating harness
+test results.
+
+Coverage:
+- boundary present, stale lines before it → only post-boundary lines returned
+- multiple boundary markers → last boundary wins
+- boundary at end of text, no following lines → empty string
+- boundary present, no trailing newline → empty string
+- boundary absent → ``__BOUNDARY_NOT_FOUND__`` diagnostic prefix
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from adb_harness.device import _filter_lines_after_boundary
+
+BOUNDARY = "__ADB_HARNESS_BOUNDARY_test__"
+
+STALE_LINE = "D/KernelAI(12345): NativeIntentHandler.handle: intent=get_time"
+FRESH_LINE = "D/KernelAI(12345): ActionsViewModel: NeedsSlot for \"set an alarm\""
+
+TEXT_WITH_STALE = (
+    f"line before the warmup\n"
+    f"{STALE_LINE}\n"
+    f"{BOUNDARY}\n"
+    f"{FRESH_LINE}\n"
+)
+
+TEXT_MULTIPLE_BOUNDARIES = (
+    f"{STALE_LINE}\n"
+    f"{BOUNDARY}\n"
+    f"middle line that will be dropped\n"
+    f"{BOUNDARY}\n"
+    f"{FRESH_LINE}\n"
+)
+
+
+class BoundaryPresentFiltersStaleTest(unittest.TestCase):
+    """Stale lines before the boundary are discarded."""
+
+    def test_stale_lines_dropped(self) -> None:
+        result = _filter_lines_after_boundary(TEXT_WITH_STALE, BOUNDARY)
+        self.assertIn(FRESH_LINE, result)
+        self.assertNotIn(STALE_LINE, result)
+
+    def test_fresh_lines_kept(self) -> None:
+        result = _filter_lines_after_boundary(TEXT_WITH_STALE, BOUNDARY)
+        self.assertEqual(result.rstrip("\n"), FRESH_LINE)
+
+
+class MultipleBoundariesUsesLastTest(unittest.TestCase):
+    """When multiple boundary markers exist, content after the last one is kept."""
+
+    def test_last_boundary_wins(self) -> None:
+        result = _filter_lines_after_boundary(
+            TEXT_MULTIPLE_BOUNDARIES, BOUNDARY
+        )
+        self.assertIn(FRESH_LINE, result)
+        self.assertNotIn(STALE_LINE, result)
+        self.assertNotIn("middle line that will be dropped", result)
+
+
+class BoundaryAtEndReturnsEmptyTest(unittest.TestCase):
+    """Boundary as the final text yields an empty string."""
+
+    def test_boundary_at_end_no_newline(self) -> None:
+        result = _filter_lines_after_boundary(f"{BOUNDARY}", BOUNDARY)
+        self.assertEqual(result, "")
+
+    def test_boundary_with_newline_no_following(self) -> None:
+        result = _filter_lines_after_boundary(f"{BOUNDARY}\n", BOUNDARY)
+        self.assertEqual(result, "")
+
+    def test_stale_lines_then_boundary_no_following(self) -> None:
+        text = f"{STALE_LINE}\n{BOUNDARY}"
+        result = _filter_lines_after_boundary(text, BOUNDARY)
+        self.assertEqual(result, "")
+
+
+class BoundaryAbsentReturnsDiagnosticTest(unittest.TestCase):
+    """Missing boundary prepends ``__BOUNDARY_NOT_FOUND__``."""
+
+    def test_no_boundary_diagnostic_prefixed(self) -> None:
+        text = f"{STALE_LINE}\n"
+        result = _filter_lines_after_boundary(text, BOUNDARY)
+        self.assertTrue(result.startswith("__BOUNDARY_NOT_FOUND__"))
+        self.assertIn(STALE_LINE, result)
+
+    def test_no_boundary_on_empty_text(self) -> None:
+        result = _filter_lines_after_boundary("", BOUNDARY)
+        self.assertEqual(result, "__BOUNDARY_NOT_FOUND__")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

Test harness `extract_intent()` reads stale `NativeIntentHandler.handle` markers from the logcat ring buffer. Each phase starts with a warmup oracle probe (`"what time is it" → get_time`), and `capture_fresh_logcat()` starts a new `adb logcat` subprocess that reads the **entire kernel ring-buffer backlog**. Since bare slot-fill queries ("set an alarm", "open an app") route through QIR and return `NeedsSlot`, they do **not** emit a `NativeIntentHandler.handle` marker. The harness then finds the stale `get_time` marker from warmup and reports a false failure.

This also causes a contamination chain: when a passing test emits its own marker (e.g., `add_to_list`), it becomes the new stale match for subsequent tests — explaining why some tests showed `add_to_list` instead of `get_time`.

## Fix

### Boundary filtering helper — `_filter_lines_after_boundary()`

Extracted into `scripts/adb_harness/device.py`:

1. Emit a unique boundary marker via `adb shell log -t KernelAI __ADB_HARNESS_BOUNDARY_<uuid>__` **before** starting the fresh logcat subprocess.
2. After collection, locate the last occurrence of the boundary marker in the captured output and return only lines **after** that marker, discarding all stale ring-buffer content.

Used in both the polling loop (`expected` break check) and the final return path — no duplication.

### Fail-closed diagnostic (harness trust)

If the boundary marker is absent from the captured output, returns plain `__BOUNDARY_NOT_FOUND__` — **no stale text appended**. This prevents the `expected` check in the polling loop from matching against stale ring-buffer content before the boundary marker arrives.

### Removed `seen` de-dupe (harness trust)

Removed the per-session global `seen` set from `drain()`. Since `buffer.clear()` already prevents per-drain duplicates, a global de-dupe could cause a fresh post-boundary line to be discarded when an identical stale pre-boundary line had already been seen — producing a false `NO_MATCH`.

## Unit tests — `scripts/tests/test_logcat_boundary.py`

10 tests across 5 boundary conditions:

| Condition | Coverage |
|---|---|
| Boundary present, stale before it | Stale lines dropped, fresh lines kept |
| Multiple boundary markers | Last boundary wins |
| Boundary at end, no following content | Empty string returned |
| Boundary absent | Returns exact `__BOUNDARY_NOT_FOUND__` with no stale text |
| Boundary absent + expected in stale text | Expected marker NOT matched (fail-closed) |
| Duplicate line before and after boundary | Fresh copy preserved after filter |

```bash
python3 -m unittest discover -s scripts/tests -p "test_logcat_boundary.py" -v
# 10/10 OK
```

## Before / After

### slot_fill (14 tests)

| # | Query | Before | After | Notes |
|---|---|---|---|---|
| 1 | "set an alarm" | ✗ got get_time (stale) | ✗ NO_MATCH | Intent not dispatched after slot-fill (pre-existing) |
| 2 | "set a timer" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 3 | "open an app" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 4 | "navigate" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 5 | "find nearby" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 6 | "send a message" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 7 | "send an email" | ✗ got get_time (stale) | ✗ NO_MATCH | Same |
| 8 | "add to my list" | ✗ got get_time | ✗ got get_time | **Genuine** product routing bug (unchanged) |
| 9 | "add eggs to my shopping list" | ✅ PASS | ✅ PASS | — |
| 10 | "add to my list" | ✗ got get_time | ✗ got get_time | **Genuine** product routing bug (unchanged) |
| 11 | "send a message" (multi) | ✗ got get_time (stale) | ✗ NO_MATCH | Same as #6 |
| 12 | "send an email" (multi) | ✗ got get_time (stale) | ✗ NO_MATCH | Same as #7 |
| 13 | "set a timer" (invalid) | ✗ slot_fill_invalid_reply (stale) | ✅ PASS | **Fixed** — no more stale marker contamination |
| 14 | "set an alarm" (invalid) | ✗ slot_fill_invalid_reply (stale) | ✅ PASS | **Fixed** |

### orchestrator_recovery (10 tests)

| # | Query | Before | After | Notes |
|---|---|---|---|---|
| 1 | create_calendar_event | ✗ got get_time (stale) | ✅ PASS | **Fixed** |
| 2 | create_calendar_event | ✗ got get_time (stale) | ✅ PASS | **Fixed** |
| 3 | get_weather | ✗ got get_time (stale) | ✅ PASS | **Fixed** |
| 4 | send_sms | ✗ xfail | ✗ xfail | Expected |
| 5 | xyzzy_unknown | ✗ got get_time (stale) | ✗ harness_or_logcat_issue | Genuine gap (no NotActionable marker) |
| 6 | play_youtube | ✗ got get_time (stale) | ✗ harness_or_logcat_issue | Genuine gap (no NotActionable marker) |
| 7 | create_calendar_event | ✗ got get_time (stale) | ✅ PASS | **Fixed** |
| 8 | create_calendar_event | ✗ got get_time (stale) | ✅ PASS | **Fixed** |
| 9 | send_sms | ✗ xfail | ✗ xfail | Expected |
| 10 | save_memory | ✗ xfail | ✗ xfail | Expected |

### Summary

| Phase | Before (pass/fail/xfail) | After (pass/fail/xfail) | Change |
|---|---|---|---|
| slot_fill | 2 / 12 / 0 | 3 / 11 / 0 | +1 pass, -1 stale |
| orchestrator_recovery | 0 / 7 / 3 | 5 / 2 / 3 | **+5 pass**, -5 stale |
| **Total** | **2 / 19 / 3** | **8 / 13 / 3** | **+6 pass** |

## Commands run

```bash
# Reproduction and validation
python3 scripts/adb_skill_test.py --serial R5CR605B71K --phases slot_fill,orchestrator_recovery --iso

# Unit tests for boundary filtering helper
python3 -m unittest discover -s scripts/tests -p "test_logcat_boundary.py" -v
# 10/10 OK

# Existing harness unit tests unaffected
python3 -m unittest discover -s scripts/tests -p "test_warmup_recovery.py" -v
# 6/6 OK
```

## Report paths

- Pre-fix: `scripts/test-reports/2026-07-06T06-15-24Z_isolated_slot_fill.json`
- Post-fix: `/home/lokhor/.omp/wt/issue-1375/scripts/test-reports/2026-07-06T06-32-09Z_isolated_slot_fill.json`
- Post-fix: `/home/lokhor/.omp/wt/issue-1375/scripts/test-reports/2026-07-06T06-32-09Z_isolated_orchestrator_recovery.json`

## Remaining failures

The following failures are **not** harness contamination — they are pre-existing product behaviour:

- **slot_fill tests 1-7, 11-12**: Intent not dispatched after slot-fill completion. Shown as `NO_MATCH`.
- **slot_fill tests 8, 10**: "add to my list" slot-fill dispatches `get_time` instead of `add_to_list`. Shown as `got get_time` with `query_type=time` params.
- **orchestrator tests 5, 6**: `xyzzy_unknown` and `play_youtube` do not emit `RecoveryOrchestrator.NotActionable` — QIR may reject these before the orchestrator runs.

These are tracked under the broader #1375 bucket. They are not regressions from this change.

## #1376 / #1377 relationship

This fix only addresses the harness logcat-contamination dimension of #1375. It does not fix #1376 (Explicit Wikipedia queries bypass Gemma tool-call path via QIR shortcut) or #1377 (S21 email fixture/setup gap — email queries routed to create_calendar_event). Those remain separate and unaffected by this change.

Refs #1375