### PR TITLE
fix(#1375): avoid oracle probe text collision with warmup query

### DIFF
--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -360,7 +360,7 @@ def logcat_restart() -> bool:
 # ═══════════════════════════════════════════════════════════════════════
 
 _ORACLE_PROBES: list[tuple[str, str, str, str]] = [
-    ("get_time", "what time is it", "get_time", "NativeIntentHandler.handle: intent=get_time"),
+    ("get_time", "what's the current time", "get_time", "NativeIntentHandler.handle: intent=get_time"),
 ]
 
 

--- a/scripts/tests/test_logcat_boundary.py
+++ b/scripts/tests/test_logcat_boundary.py
@@ -21,8 +21,7 @@ HERE = Path(__file__).resolve().parent
 SCRIPT_DIR = HERE.parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from adb_harness.device import _filter_lines_after_boundary
-
+from adb_harness.device import _filter_lines_after_boundary, _ORACLE_PROBES
 BOUNDARY = "__ADB_HARNESS_BOUNDARY_test__"
 
 STALE_LINE = "D/KernelAI(12345): NativeIntentHandler.handle: intent=get_time"
@@ -130,6 +129,43 @@ class DuplicateLinesAcrossBoundaryTest(unittest.TestCase):
         result = _filter_lines_after_boundary(text, BOUNDARY)
         self.assertIn(self.DUP_LINE, result)
         self.assertIn(FRESH_LINE, result)
+
+
+class OracleProbeNotIdenticalToWarmupTest(unittest.TestCase):
+    """Oracle probe text must differ from the common warmup query to avoid dedup."""
+
+    WARMUP_TEXT = "what time is it"
+    MAX_PROBES = 10
+
+    def test_probe_list_not_empty(self) -> None:
+        self.assertGreater(len(_ORACLE_PROBES), 0)
+
+    def test_each_probe_has_four_elements(self) -> None:
+        for i, probe in enumerate(_ORACLE_PROBES):
+            with self.subTest(probe_index=i):
+                self.assertEqual(len(probe), 4)
+
+    def test_probe_differs_from_warmup_text(self) -> None:
+        for i, (label, prompt, intent, marker) in enumerate(_ORACLE_PROBES):
+            with self.subTest(probe_index=i, label=label):
+                self.assertNotEqual(
+                    prompt, self.WARMUP_TEXT,
+                    f"Oracle probe {i} ({label!r}) uses warmup text {self.WARMUP_TEXT!r} "
+                    f"— app may deduplicate the second identical query. "
+                    f"Use different phrasing so the oracle can detect a fresh intent dispatch.",
+                )
+
+    def test_probe_expects_native_intent_handler(self) -> None:
+        for i, (label, prompt, intent, marker) in enumerate(_ORACLE_PROBES):
+            with self.subTest(probe_index=i, label=label):
+                self.assertIn(
+                    "NativeIntentHandler.handle", marker,
+                    f"Oracle probe {i} ({label!r}) expected marker should reference "
+                    f"NativeIntentHandler.handle",
+                )
+
+    def test_probe_list_not_excessive(self) -> None:
+        self.assertLessEqual(len(_ORACLE_PROBES), self.MAX_PROBES)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The ADB harness oracle probe always fails after the warmup phase because both use identical `chat_input` text (`"what time is it"`). The app's ChatViewModel deduplicates consecutive identical chat_input queries — the oracle's probe is silently dropped, producing zero logcat output. The harness concludes ORACLE_UNHEALTHY and aborts.

This blocked validation of #1379 (stale ring-buffer fix) on S21.

## Diagnosis

Evidence from investigation:
- Using `"what time is it"` for warmup then same for oracle → 0 logcat lines → ORACLE_UNHEALTHY
- Using `"what time is it"` for warmup then `"set timer for 5 seconds"` → `NativeIntentHandler.handle: intent=set_timer` ✅
- Using `"what time is it"` for warmup then `"what's the current time"` → `NativeIntentHandler.handle: intent=get_time` ✅

The root cause is **not** ADB, logcat, HF sign-in, or Android 15 FGS — it's the app-level dedup of identical consecutive chat_input.

## Change

`scripts/adb_harness/device.py`:
- Oracle probe text: `"what time is it"` → `"what's the current time"`
- Expected marker unchanged: `NativeIntentHandler.handle: intent=get_time`
- Both trigger the same QIR→get_time→NativeIntentHandler pipeline

`scripts/tests/test_logcat_boundary.py`:
- 5 new tests validating oracle probe invariants:
  - Non-empty list
  - Each probe is a 4-element tuple
  - Probe text differs from warmup text `"what time is it"`
  - Expected marker contains `NativeIntentHandler.handle`
  - List not excessive (≤10)

## Validation

Oracle check against warm S21: ✅ passed (11.7s)

Phase results (cumulative mode):

| Phase | Pass | Fail | XFail |
|---|---:|---:|---|
| slot_fill | 3 | 11 | 0 |
| orchestrator_recovery | 5 | 2 | 3 |

- **Zero stale `get_time` contamination** — #1379 validated
- All 11 slot_fill failures show `NO_MATCH` (correct: no intent dispatched after slot-fill)
- Remaining failures are genuine product routing issues tracked under #1375

Refs #1375
