### PR TITLE
fix(#1375): use adb logcat -d polling instead of continuous subprocess in capture_fresh_logcat

### DIFF
--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -259,47 +259,38 @@ def capture_fresh_logcat(
     the captured output to only include lines after that marker. This prevents
     stale ring-buffer matches (e.g. a warmup oracle probe) from contaminating
     the result for tests whose action does not emit a NATIVE_INTENT marker.
+
+    Uses ``adb logcat -d`` (dump-and-exit) polling instead of a continuous
+    subprocess to avoid ADB transport contention on S21 — multiple concurrent
+    ``adb logcat`` subprocesses (from both this function and the persistent
+    streaming logcat) cause the device-side logd to stop delivering lines
+    to the fresh subprocess.
     """
-    # Emit a unique boundary marker so we can discard stale ring-buffer lines.
+    accumulated: list[str] = []
+
+    def drain() -> None:
+        """Read and drain the device logcat ring buffer via ``adb logcat -d``."""
+        raw = run_adb(
+            "logcat", "-d", "-v", "brief",
+            "-s", f"{LOGCAT_TAG}:D",
+            "LiteRtInferenceEngine:I",
+            "MiniLMIntentClassifier:I",
+        )
+        if raw:
+            for line in raw.split("\n"):
+                stripped = line.strip()
+                if stripped:
+                    accumulated.append(stripped)
+
+    # Clear the device ring buffer before boundary + action so we only see
+    # fresh log output. This is safe on USB ADB.
+    run_adb("logcat", "-c")
+    time.sleep(0.2)
+
+    # Emit a unique boundary marker AFTER clearing so it appears fresh.
     boundary = f"__ADB_HARNESS_BOUNDARY_{uuid.uuid4().hex[:16]}__"
     run_adb("shell", "log", "-t", "KernelAI", "-p", "i", boundary)
     time.sleep(0.1)
-
-    proc = subprocess.Popen(
-        build_adb_cmd(*_LOGCAT_STREAM_ARGS),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        bufsize=1,
-    )
-    assert proc.stdout is not None
-
-    lock = threading.Lock()
-    buffer: list[str] = []
-
-    def reader() -> None:
-        try:
-            for line in proc.stdout:
-                with lock:
-                    buffer.append(line.rstrip("\n"))
-        except ValueError:
-            pass
-
-    reader_thread = threading.Thread(target=reader, daemon=True)
-    reader_thread.start()
-    time.sleep(0.2)
-
-    accumulated: list[str] = []
-
-
-    def drain() -> None:
-        with lock:
-            snapshot = list(buffer)
-            buffer.clear()
-        for line in snapshot:
-            line = line.strip()
-            if line:
-                accumulated.append(line)
 
     try:
         action()
@@ -313,16 +304,12 @@ def capture_fresh_logcat(
                 break
             if keep_foreground:
                 _tap_keepalive()
+        # Final drain to catch anything produced since the last poll
         drain()
         text = "\n".join(accumulated)
         return _filter_lines_after_boundary(text, boundary)
     finally:
-        try:
-            proc.terminate()
-            proc.wait(timeout=5)
-        except Exception:
-            proc.kill()
-            proc.wait(timeout=5)
+        pass
 
 def check_logcat_stream(timeout: float = 5.0) -> bool:
     """Verify the host-side streaming logcat buffer is receiving new lines.

--- a/scripts/tests/test_logcat_boundary.py
+++ b/scripts/tests/test_logcat_boundary.py
@@ -131,6 +131,69 @@ class DuplicateLinesAcrossBoundaryTest(unittest.TestCase):
         self.assertIn(FRESH_LINE, result)
 
 
+class MultiDrainPollingTest(unittest.TestCase):
+    """Simulates multiple ``adb logcat -d`` polls across the boundary.
+
+    Repeated ``capture_fresh_logcat`` drain() calls accumulate logcat
+    snapshots. Lines before the last boundary must be discarded by
+    ``_filter_lines_after_boundary`` even when multiple snapshots overlap.
+    """
+
+    def test_multi_drain_keeps_only_post_boundary(self) -> None:
+        """Lines from the first drain (pre-boundary) are dropped; second drain
+        (post-boundary) content is kept."""
+        boundary = "__ADB_HARNESS_BOUNDARY_abc123__"
+        stale_line = "D/KernelAI(123): get_time stale"
+        fresh_line = "D/KernelAI(123): NativeIntentHandler.handle: intent=set_timer"
+        # Simulate first drain: only stale lines before boundary was emitted
+        drain_1 = stale_line
+        # Simulate second drain: boundary + fresh action output
+        drain_2 = (
+            f"I/KernelAI(123): {boundary}\n"
+            f"{fresh_line}\n"
+        )
+        accumulated = "\n".join([drain_1, drain_2])
+        result = _filter_lines_after_boundary(accumulated, boundary)
+        self.assertIn(fresh_line, result)
+        self.assertNotIn(stale_line, result)
+
+    def test_multi_drain_overlap_no_duplicates(self) -> None:
+        """The same post-boundary line appearing in multiple drains appears
+        only once in the filtered output (``rfind`` ensures only the last
+        boundary matters, but content between boundaries is also dropped)."""
+        boundary = "__ADB_HARNESS_BOUNDARY_def456__"
+        fresh_line = "D/KernelAI(123): New log event"
+        # Drain 1 and drain 2 both contain the same fresh line after the boundary
+        drain_1 = f"I/KernelAI(123): {boundary}\n{fresh_line}\nD/KernelAI(123): extra_1\n"
+        drain_2 = f"I/KernelAI(123): {boundary}\n{fresh_line}\n"
+        accumulated = "\n".join([drain_1, drain_2])
+        result = _filter_lines_after_boundary(accumulated, boundary)
+        self.assertIn(fresh_line, result)
+        # The first boundary splits the text — content before it in drain_1
+        # (which is empty here) is dropped, but fresh_line from drain_1 is
+        # between the two boundaries, so it's also dropped. Only the last
+        # boundary's content survives.
+        self.assertNotIn("extra_1", result)
+
+    def test_multi_drain_boundary_in_first_drain(self) -> None:
+        """When the boundary appears in the first drain, later drains extend
+        the post-boundary window."""
+        boundary = "__ADB_HARNESS_BOUNDARY_ghi789__"
+        stale_1 = "D/KernelAI(123): old log"
+        fresh_1 = "D/KernelAI(123): Started processing"
+        fresh_2 = "D/KernelAI(123): Completed"
+        drain_1 = f"{stale_1}\nI/KernelAI(123): {boundary}\n{fresh_1}"
+        drain_2 = fresh_2
+        unchanged_us = "D/KernelAI(123): somewhere else"
+        drain_3 = unchanged_us
+        accumulated = "\n".join([drain_1, drain_2, drain_3])
+        result = _filter_lines_after_boundary(accumulated, boundary)
+        self.assertIn(fresh_1, result)
+        self.assertIn(fresh_2, result)
+        self.assertIn(unchanged_us, result)
+        self.assertNotIn(stale_1, result)
+
+
 class OracleProbeNotIdenticalToWarmupTest(unittest.TestCase):
     """Oracle probe text must differ from the common warmup query to avoid dedup."""
 


### PR DESCRIPTION
## Problem

`capture_fresh_logcat()` starts a continuous `adb logcat` subprocess via `subprocess.Popen` + reader thread to capture fresh log output. On S21 USB ADB, this subprocess competes with the persistent streaming logcat (`logcat_start()`) for the device's `logd` transport. The fresh subprocess receives 0–4 lines while the persistent stream gets everything, causing `capture_fresh_logcat` to miss expected markers.

This caused:

1. **slot_fill**: All single-slot positive tests (1–5) reported `NO_MATCH` — `NativeIntentHandler.handle` was being emitted by the app but never captured (3/14 pass).
2. **orchestrator_recovery**: Tests 19, 21 reported `harness_or_logcat_issue` — same root cause (2 `harness_or_logcat_issue` failures).
3. **Stale contamination**: The original #1379 boundary-marker fix was validated but could not be separated from the concurrent-logcat exhaustion.

All three issues shared the same root cause: continuous `adb logcat` subprocesses competing with the persistent stream on S21 ADB.

## Fix

Replace the `Popen`-based continuous subprocess + reader thread with a polling loop that calls **`adb logcat -d`** (dump-and-exit) each iteration.

```python
# Before: subprocess.Popen(adb logcat ...) + threading reader
proc = subprocess.Popen(build_adb_cmd(*_LOGCAT_STREAM_ARGS), ...)
# ... reader thread, drain(), proc.terminate()

# After: adb logcat -d in a polling loop
def drain():
    raw = run_adb("logcat", "-d", "-v", "brief", "-s", ...)
    # accumulate lines
```

Dump-mode is safe for concurrent readers — it opens a fresh ADB connection, reads the current ring buffer snapshot, and exits immediately. No persistent pipe to compete with the streaming logcat.

### `adb logcat -c` decision

`capture_fresh_logcat` clears the device ring buffer (`adb logcat -c`) before the boundary marker + action. This is required because:

- Without it, inference generates enough log output in 10–30 s to wrap the 256 KB ring buffer, evicting the boundary marker before the first poll
- Eviction causes `__BOUNDARY_NOT_FOUND__`, which breaks tests relying on `expect_log_contains` (orchestrator recovery NotActionable/AskConfirmation patterns)
- Without `-c`, orchestrator_recovery tests 19 and 21 regress to `harness_or_logcat_issue`

`adb logcat -c` is safe on USB ADB (the only transport used). The persistent streaming logcat subprocess survives the clear and continues accumulating fresh lines. On ADB-over-TLS or shared-device CI, clearing the ring buffer could disrupt concurrent readers, but this harness runs one device/session at a time.

## Validation

### Unit tests (boundary filtering, multi-drain polling, oracle invariants)

```sh
$ python3 -m unittest tests.test_logcat_boundary -v
```

<details>
<summary>18/18 tests pass (expand)</summary>

```
test_expected_not_found_in_stale_when_boundary_absent ... ok
test_no_boundary_diagnostic_only ... ok
test_no_boundary_on_empty_text ... ok
test_boundary_at_end_no_newline ... ok
test_boundary_with_newline_no_following ... ok
test_stale_lines_then_boundary_no_following ... ok
test_fresh_lines_kept ... ok
test_stale_lines_dropped ... ok
test_fresh_copy_preserved_after_filter ... ok
test_multi_drain_boundary_in_first_drain ... ok
test_multi_drain_keeps_only_post_boundary ... ok
test_multi_drain_overlap_no_duplicates ... ok
test_last_boundary_wins ... ok
test_each_probe_has_four_elements ... ok
test_probe_differs_from_warmup_text ... ok
test_probe_expects_native_intent_handler ... ok
test_probe_list_not_empty ... ok
test_probe_list_not_excessive ... ok
----------------------------------------------------------------------
Ran 18 tests in 0.001s
OK
```
</details>

New `MultiDrainPollingTest` cases (3):

| Test | What it covers |
|---|---|
| `test_multi_drain_keeps_only_post_boundary` | Pre-boundary drain content dropped, post-boundary kept |
| `test_multi_drain_overlap_no_duplicates` | Repeated snapshots across boundary don't reintroduce stale matches |
| `test_multi_drain_boundary_in_first_drain` | Subsequent drains extend post-boundary window correctly |

### Device validation (S21 cumulative)

```sh
$ python3 scripts/adb_skill_test.py --serial R5CR605B71K --phases slot_fill,orchestrator_recovery
```

| Metric | Before (continuous subprocess) | After (adb logcat -d polling) | Change |
|---|---:|---:|---|
| slot_fill pass | 3/14 | **8/14** | **+5 passes** |
| slot_fill harness failures | 11 harness/stale | **0** | **All eliminated** |
| orchestrator_recovery pass | 5/10 | **7/10** | **+2 passes** |
| orchestrator_recovery harness failures | 2 (`harness_or_logcat_issue`) | **0** | **All eliminated** |

S21 validation report: `scripts/test-reports/2026-07-07T23-18-38Z_skills.json`

### Remaining failures are genuine product routing gaps

All 6 slot_fill failures are `field_mismatch` — `NO_MATCH` returned instead of `send_sms`, `send_email`, or `add_to_list`. These require contact fixtures or list name normalization, neither of which is a harness issue.

Orchestrator_recovery has 0 real failures — all 3 xfails are documented `missing_extractor` gaps for `send_sms`, `save_memory`.

## Files changed

- `scripts/adb_harness/device.py` — `capture_fresh_logcat()` rewritten from continuous subprocess to `adb logcat -d` polling
- `scripts/tests/test_logcat_boundary.py` — 3 new `MultiDrainPollingTest` cases (18 tests total)

## CI status

- CI: ✅ green (run #28904120540)
- Docs Drift Check: ✅ green (run #28904120438)

Refs #1375 (does not close — remaining product routing gaps)
