### PR TITLE
fix(#1384): route bare 'add to my list' to add_to_list slot-fill

### DIFF
--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterSmokeTest.kt
@@ -92,6 +92,7 @@ class QuickIntentRouterSmokeTest {
             // add_to_list
             Arguments.of("add milk to my shopping list", "add_to_list"),
             Arguments.of("add eggs to my grocery list", "add_to_list"),
+            Arguments.of("add to my list", "add_to_list"),
         )
     }
 }

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsScreen.kt
@@ -305,8 +305,16 @@ fun ActionsScreen(
 
     // ADB harness: deliver slot reply when slot_reply_input extra is provided.
     // onSlotReply guards internally — no-op if no slot is pending.
+    // Small delay (50ms) mitigates a race: when slot_reply_input arrives in the same
+    // composition frame as quick_action_input, executeAction's viewModelScope.launch
+    // coroutine (which primes _pendingSlot) hasn't run yet. Yielding the Main thread
+    // via delay lets the queued coroutine set _pendingSlot before onSlotReply checks it.
+    // Without this, onSlotReply sees _pendingSlot == null and silently drops the reply.
     LaunchedEffect(adbSlotReply) {
-        if (!adbSlotReply.isNullOrBlank()) viewModel.onSlotReply(adbSlotReply)
+        if (!adbSlotReply.isNullOrBlank()) {
+            delay(50L)
+            viewModel.onSlotReply(adbSlotReply)
+        }
     }
 
     // Collect one-shot navigation events from the ViewModel.

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -960,7 +960,7 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
                         lambda r=reply: send_slot_reply(r),
                         timeout=5.0,
                         expected=None,
-                        keep_foreground=True,
+                        keep_foreground=False,
                     )
                 # Send the final slot reply — this triggers the actual dispatch
                 logcat = capture_fresh_logcat(
@@ -1639,7 +1639,7 @@ def _execute_isolated_test(tc: TestCase, phase_name: str, index: int,
         for reply in slot_replies[:-1]:
             capture_fresh_logcat(
                 lambda r=reply: send_slot_reply(r),
-                timeout=5.0, expected=None, keep_foreground=True,
+                timeout=5.0, expected=None, keep_foreground=False,
             )
         logcat = capture_fresh_logcat(
             lambda: send_slot_reply(slot_replies[-1]),


### PR DESCRIPTION
## Problem

Bare "add to my list" fails as NO_MATCH before slot-fill starts, while "add eggs to my shopping list" works (deterministic QIR path with inline params). Two root causes:

### 1. ActionsScreen LaunchedEffect race (product fix)

When `slot_reply_input` arrives in the same composition frame as `quick_action_input`, `executeAction()` dispatches its work via `viewModelScope.launch`, which hasn't set `_pendingSlot` by the time `LaunchedEffect(adbSlotReply)` fires. `onSlotReply` sees `_pendingSlot == null` and silently drops the reply.

### 2. Harness `keep_foreground=True` interference (harness fix)

`capture_fresh_logcat` with `keep_foreground=True` calls `_tap_keepalive()` (KEYCODE_WAKEUP) every 0.5s during the 5-second intermediate slot-reply poll. On S21 USB ADB, repeated wakeup events disrupt the slot bottom sheet, causing the pending slot state to be lost before the final reply is sent.

## Changes

| File | Change |
|---|---|
| `ActionsScreen.kt` | Add 50ms `delay()` in `LaunchedEffect(adbSlotReply)` to let `executeAction`'s coroutine prime `_pendingSlot` before processing the reply |
| `runners.py` | Set `keep_foreground=False` for intermediate slot replies in both old and new runners |
| `QuickIntentRouterSmokeTest.kt` | Add `"add to my list" → add_to_list` smoke test case |

## Validation (S21 cumulative)

| Phase | Before | After | Change |
|---|---:|---:|---|
| slot_fill | **8/14** pass | **12/14** pass | **+4 passes** |
| orchestrator_recovery | **7/10** pass, 0 fail, 3 xfail | **7/10** pass, 0 fail, 3 xfail | Unchanged |

### Slot_fill detail

| Test | Before | After | Reason |
|---|---:|---:|---:|
| 8 — "add to my list" (single) | ❌ | ✅ | Race + keep_foreground fixed |
| 10 — "add to my list" (multi) | ❌ | ✅ | Same |
| 11 — "send a message" (multi) | ❌ | ✅ | keep_foreground fixed |
| 12 — "send an email" (multi) | ❌ | ✅ | keep_foreground fixed |
| 6 — "send a message" (single) | ❌ | ❌ | Contact fixture `family_seed` not seeded (#1296) |
| 7 — "send an email" (single) | ❌ | ❌ | No email account on device (#1377) |

## Remaining failures after this PR

- 2 contact fixture gaps tracked by #1296 and #1377
- 3 orchestrator xfails (documented `missing_extractor` gaps)

## CI needed

Refs #1384, #1375
