### PR TITLE
fix(#1377): classify missing email fixture cleanly

### DIFF
--- a/scripts/adb_harness/device.py
+++ b/scripts/adb_harness/device.py
@@ -562,6 +562,14 @@ FAMILY_CONTACTS: dict[str, str] = {
 }
 
 
+_EMAIL_ACCOUNT_PATTERN = re.compile(
+    r"Account \{name=[^,}@]+@[^,}]+, type=[^,}]+\}"
+)
+
+# Deterministic contacts referenced by contacts:email_contact_seed test cases.
+EMAIL_FIXTURE_CONTACTS = ("John", "Sarah", "Nick")
+
+
 def _extract_raw_contact_id(adb_output: str) -> str | None:
     """Extract the raw contact _id from a content insert result.
 
@@ -636,6 +644,31 @@ def check_contact_family_fixture() -> bool:
         "--projection", "display_name",
     )
     return any(n in output for n in FAMILY_CONTACTS)
+
+
+def check_email_fixture() -> bool:
+    """Return whether the email fixture has account and contact evidence.
+
+    This is only a preflight heuristic: it requires an email-shaped account
+    plus each deterministic fixture contact, but does not prove that an email
+    client or sender is available to the assistant.
+    """
+    account_dump = run_adb("shell", "dumpsys", "account")
+    if not _EMAIL_ACCOUNT_PATTERN.search(account_dump):
+        return False
+
+    for name in EMAIL_FIXTURE_CONTACTS:
+        contact_dump = run_adb(
+            "shell", "content", "query",
+            "--uri", f"content://com.android.contacts/contacts/filter/{name}",
+            "--projection", "display_name",
+        )
+        if not re.search(
+            rf"\bdisplay_name={re.escape(name)}(?:,|$)",
+            contact_dump,
+        ):
+            return False
+    return True
 
 
 def dismiss_notifications() -> None:

--- a/scripts/adb_harness/runners.py
+++ b/scripts/adb_harness/runners.py
@@ -47,6 +47,7 @@ from adb_harness.device import (
     capture_fresh_logcat,
     check_oracle,
     check_logcat_stream,
+    check_email_fixture,
     cleanup_clock_alerts,
     cleanup_side_effects,
     clear_logcat,
@@ -88,6 +89,31 @@ from adb_harness.reporting import (
 
 # Module-level fixture state — set during isolated warmup, read during test execution
 _isolated_known_missing: frozenset[str] = frozenset()
+
+
+def _known_missing_fixtures(
+    family_contacts_available: bool,
+    email_account_available: bool,
+) -> frozenset[str]:
+    """Build explicit fixture state from independent preflight checks."""
+    missing: set[str] = set()
+    if not family_contacts_available:
+        missing.add("contacts:family_seed")
+    if not email_account_available:
+        missing.add("contacts:email_contact_seed")
+    return frozenset(missing)
+
+
+def _mark_missing_fixture_xfail(
+    result: TestResult,
+    known_missing_fixtures: frozenset[str],
+) -> None:
+    """Mark a failed case as expected only when its exact fixture is unavailable."""
+    if result.fixture in known_missing_fixtures and not is_clean_pass(result):
+        result.xfail = True
+        result.xfail_reason = (
+            f"fixture_missing: required fixture '{result.fixture}' is unavailable"
+        )
 
 def _parse_tool_marker(marker: str | None) -> dict[str, str]:
     """Parse a key=value-style marker string into a dict.
@@ -795,7 +821,14 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
     print("  [init] Setting up family contact fixture ...", end=" ", flush=True)
     family_ok = setup_contact_family_fixture()
     print("done" if family_ok else "WARNING — contact seeding failed, fixture_missing may apply")
-    known_missing_fixtures: frozenset[str] = frozenset() if family_ok else frozenset(["contacts:family_seed", "contacts:email_contact_seed"])
+    print("  [init] Checking email account/contact fixture ...", end=" ", flush=True)
+    email_account_ok = check_email_fixture()
+    print(
+        "present (heuristic only)"
+        if email_account_ok
+        else "WARNING — no account/contact evidence; email fixture_missing may apply"
+    )
+    known_missing_fixtures = _known_missing_fixtures(family_ok, email_account_ok)
 
     # ── Orchestrator warmup: wait for MiniLM phrase vectors to be fully built ──
     # Clear logcat first so we don't match a stale "Ready:" from a previous app run.
@@ -1103,6 +1136,8 @@ def run_tests(dry_run: bool = False, post_pr: bool = False, start_phase: str | N
                 allowed_intent_observed=allowed_intent_observed,
                 expect_llm_fallthrough=tc.expect_llm_fallthrough,
             )
+            _mark_missing_fixture_xfail(result, known_missing_fixtures)
+            result.status = derive_status(result)
             result.failure_bucket = derive_failure_bucket(result, known_missing_fixtures)
             phase_results.append(result)
             results.append(result)
@@ -1549,8 +1584,15 @@ def _isolated_warmup(serial: str | None = None, model_readiness: bool = False,
     print("  [init] Setting up family contact fixture ...", end=" ", flush=True)
     family_ok = setup_contact_family_fixture()
     print("done" if family_ok else "WARNING — contact seeding failed, fixture_missing may apply")
+    print("  [init] Checking email account/contact fixture ...", end=" ", flush=True)
+    email_account_ok = check_email_fixture()
+    print(
+        "present (heuristic only)"
+        if email_account_ok
+        else "WARNING — no account/contact evidence; email fixture_missing may apply"
+    )
     global _isolated_known_missing
-    _isolated_known_missing = frozenset() if family_ok else frozenset(["contacts:family_seed", "contacts:email_contact_seed"])
+    _isolated_known_missing = _known_missing_fixtures(family_ok, email_account_ok)
 
     # Warm up MiniLM classifier
     clear_logcat()
@@ -1777,6 +1819,7 @@ def _execute_isolated_test(tc: TestCase, phase_name: str, index: int,
         allowed_intent_observed=allowed_intent_observed,
         expect_llm_fallthrough=tc.expect_llm_fallthrough,
     )
+    _mark_missing_fixture_xfail(result, _isolated_known_missing)
     result.status = derive_status(result)
     result.failure_bucket = derive_failure_bucket(result, _isolated_known_missing)
 

--- a/scripts/tests/test_cleanup_failure.py
+++ b/scripts/tests/test_cleanup_failure.py
@@ -308,6 +308,8 @@ class RunnerCleanupFailureTest(unittest.TestCase):
              patch("adb_harness.runners.start_keepalive"), \
              patch("adb_harness.runners.stop_keepalive"), \
              patch("adb_harness.runners.setup_contact_alias_fixture"), \
+             patch("adb_harness.runners.setup_contact_family_fixture", return_value=True), \
+             patch("adb_harness.runners.check_email_fixture", return_value=False), \
              patch("adb_harness.runners.teardown_contact_alias_fixture"), \
              patch("adb_harness.runners.check_oracle", return_value=True), \
              patch("adb_harness.runners.check_logcat_stream", return_value=True), \
@@ -353,6 +355,8 @@ class RunnerCleanupFailureTest(unittest.TestCase):
              patch("adb_harness.runners.start_keepalive"), \
              patch("adb_harness.runners.stop_keepalive"), \
              patch("adb_harness.runners.setup_contact_alias_fixture"), \
+             patch("adb_harness.runners.setup_contact_family_fixture", return_value=True), \
+             patch("adb_harness.runners.check_email_fixture", return_value=False), \
              patch("adb_harness.runners.teardown_contact_alias_fixture"), \
              patch("adb_harness.runners.check_oracle", return_value=True), \
              patch("adb_harness.runners.check_logcat_stream", return_value=True), \

--- a/scripts/tests/test_email_fixture.py
+++ b/scripts/tests/test_email_fixture.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Unit tests for email-account fixture detection and classification (#1377)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_DIR = HERE.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from adb_harness.device import check_email_fixture
+from adb_harness.models import TestResult, derive_failure_bucket, derive_status
+from adb_harness.runners import _known_missing_fixtures, _mark_missing_fixture_xfail
+
+
+class EmailFixtureDetectionTest(unittest.TestCase):
+    """`dumpsys account` plus deterministic-contact parsing is conservative."""
+
+    def test_account_and_all_fixture_contacts_are_available(self) -> None:
+        def adb_output(*args: str) -> str:
+            if args == ("shell", "dumpsys", "account"):
+                return "Accounts:\n  Account {name=test@example.com, type=com.google}\n"
+            name = args[4].rsplit("/", 1)[-1]
+            return f"Row: 0 display_name={name}\n"
+
+        with patch("adb_harness.device.run_adb", side_effect=adb_output):
+            self.assertTrue(check_email_fixture())
+
+    def test_no_account_evidence_is_unavailable(self) -> None:
+        """Empty or unsuccessful dumpsys output is unavailable, not an exception."""
+        with patch("adb_harness.device.run_adb", return_value="Accounts: 0\n"):
+            self.assertFalse(check_email_fixture())
+
+    def test_missing_fixture_contact_is_unavailable(self) -> None:
+        """Generic device accounts cannot substitute for a deterministic contact."""
+        def adb_output(*args: str) -> str:
+            if args == ("shell", "dumpsys", "account"):
+                return "Account {name=test@example.com, type=com.google}\n"
+            return ""
+
+        with patch("adb_harness.device.run_adb", side_effect=adb_output):
+            self.assertFalse(check_email_fixture())
+
+    def test_partial_contact_match_is_not_fixture_evidence(self) -> None:
+        """Contact-provider substring matches must not satisfy an exact fixture name."""
+        def adb_output(*args: str) -> str:
+            if args == ("shell", "dumpsys", "account"):
+                return "Account {name=test@example.com, type=com.google}\n"
+            return "Row: 0 display_name=John Smith\n"
+
+        with patch("adb_harness.device.run_adb", side_effect=adb_output):
+            self.assertFalse(check_email_fixture())
+
+
+class EmailFixtureClassificationTest(unittest.TestCase):
+    """Unavailable email accounts produce an xfail fixture bucket, never a pass."""
+
+    def _email_result(self, *, actual_intent: str, intent_passed: bool) -> TestResult:
+        return TestResult(
+            index=1,
+            message="send an email to John",
+            expect_intent="send_email",
+            actual_intent=actual_intent,
+            expect_params=None,
+            actual_params={},
+            intent_passed=intent_passed,
+            params_passed=True,
+            param_failures=[],
+            xfail=False,
+            reply_warn=None,
+            log_check_warn=None,
+            fixture="contacts:email_contact_seed",
+        )
+
+    def test_missing_email_fixture_marks_wrong_tool_as_xfail(self) -> None:
+        """Calendar fallthrough remains a failure, classified as unavailable fixture."""
+        result = self._email_result(
+            actual_intent="create_calendar_event",
+            intent_passed=False,
+        )
+        missing = _known_missing_fixtures(True, False)
+
+        _mark_missing_fixture_xfail(result, missing)
+
+        self.assertTrue(result.xfail)
+        self.assertEqual(result.xfail_reason, "fixture_missing: required fixture 'contacts:email_contact_seed' is unavailable")
+        self.assertEqual(derive_status(result), "xfail")
+        self.assertEqual(derive_failure_bucket(result, missing), "fixture_missing")
+
+    def test_missing_email_fixture_does_not_downgrade_a_clean_pass(self) -> None:
+        """A successful route stays a pass even when account availability is unknown."""
+        result = self._email_result(actual_intent="send_email", intent_passed=True)
+        missing = _known_missing_fixtures(True, False)
+
+        _mark_missing_fixture_xfail(result, missing)
+
+        self.assertFalse(result.xfail)
+        self.assertEqual(derive_status(result), "pass")
+        self.assertIsNone(derive_failure_bucket(result, missing))
+
+    def test_other_missing_fixture_does_not_xfail_email_failure(self) -> None:
+        """Fixture status is exact: family-contact absence cannot mask email routing."""
+        result = self._email_result(
+            actual_intent="create_calendar_event",
+            intent_passed=False,
+        )
+        missing = _known_missing_fixtures(False, True)
+
+        _mark_missing_fixture_xfail(result, missing)
+
+        self.assertFalse(result.xfail)
+        self.assertEqual(derive_status(result), "fail")
+        self.assertEqual(derive_failure_bucket(result, missing), "wrong_tool")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_warmup_recovery.py
+++ b/scripts/tests/test_warmup_recovery.py
@@ -65,6 +65,8 @@ def _warmup_with(
         patch("adb_harness.runners.start_keepalive"), \
         patch("adb_harness.runners.stop_keepalive"), \
         patch("adb_harness.runners.setup_contact_alias_fixture"), \
+        patch("adb_harness.runners.setup_contact_family_fixture", return_value=True), \
+        patch("adb_harness.runners.check_email_fixture", return_value=False), \
         patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
         patch("adb_harness.runners.check_logcat_stream", stream_mock), \
         patch("adb_harness.runners.logcat_restart", return_value=restart_succeeds), \
@@ -83,6 +85,17 @@ class WarmupHealthyTest(unittest.TestCase):
         """Stream healthy + oracle healthy → warmup succeeds (0)."""
         rc = _warmup_with(stream_healthy=True, oracle_healthy=True)
         self.assertEqual(rc, 0)
+
+    def test_missing_email_account_is_persisted_for_isolated_cases(self) -> None:
+        """Isolated warmup records email fixture absence for later classification."""
+        self.assertEqual(_warmup_with(), 0)
+
+        from adb_harness.runners import _isolated_known_missing
+
+        self.assertEqual(
+            _isolated_known_missing,
+            frozenset(["contacts:email_contact_seed"]),
+        )
 
 
 class WarmupStreamRecoveryTest(unittest.TestCase):
@@ -108,10 +121,11 @@ class WarmupStreamRecoveryTest(unittest.TestCase):
             patch("adb_harness.runners.logcat_start"), \
             patch("adb_harness.runners.clear_logcat"), \
             patch("adb_harness.runners.read_logcat", return_value=_WARMED_LOGCAT), \
-            patch("adb_harness.runners.run_adb", return_value=""), \
             patch("adb_harness.runners.start_keepalive"), \
             patch("adb_harness.runners.stop_keepalive"), \
             patch("adb_harness.runners.setup_contact_alias_fixture"), \
+            patch("adb_harness.runners.setup_contact_family_fixture", return_value=True), \
+            patch("adb_harness.runners.check_email_fixture", return_value=False), \
             patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
             patch("adb_harness.runners.check_logcat_stream", stream_mock), \
             patch("adb_harness.runners.logcat_restart", return_value=True), \
@@ -153,10 +167,11 @@ class WarmupOracleFailTest(unittest.TestCase):
             patch("adb_harness.runners.logcat_start"), \
             patch("adb_harness.runners.clear_logcat"), \
             patch("adb_harness.runners.read_logcat", return_value=_WARMED_LOGCAT), \
-            patch("adb_harness.runners.run_adb", return_value=""), \
             patch("adb_harness.runners.start_keepalive"), \
             patch("adb_harness.runners.stop_keepalive"), \
             patch("adb_harness.runners.setup_contact_alias_fixture"), \
+            patch("adb_harness.runners.setup_contact_family_fixture", return_value=True), \
+            patch("adb_harness.runners.check_email_fixture", return_value=False), \
             patch("adb_harness.runners.cleanup_clock_alerts", return_value=True), \
             patch("adb_harness.runners.check_logcat_stream", stream_mock), \
             patch("adb_harness.runners.logcat_restart", return_value=True), \


### PR DESCRIPTION
Closes #1377

## Scope
- Detect a usable email fixture from `dumpsys account` plus exact deterministic fixture-contact evidence.
- Keep this as a preflight heuristic; it does not claim email sending is available.
- Mark only failed cases whose exact fixture is known unavailable as `xfail` with the `fixture_missing` bucket.
- Preserve clean passes: `create_calendar_event` is never accepted as an email pass, and working `send_email` slot-fill cases remain passes.

## Verification
- `python3 -m unittest scripts.tests.test_email_fixture scripts.tests.test_false_positive scripts.tests.test_warmup_recovery scripts.tests.test_cleanup_failure -v` — 64 passed.
- S21 USB `--case send_an_email_to_john_about_the_project_update,email_sarah_the_meeting_notes` — 0 pass, 0 fail, 2 xfail; both bucketed `fixture_missing`.
- S21 USB `--phases slot_fill` — 14/14 pass.

No product routing or account-configuration changes.