### PR TITLE
fix(#1389): handle unavailable email and parse subjects

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -3248,9 +3248,9 @@ class QuickIntentRouter(
             intentName = "send_email",
             regex = Regex(
                 """^(?:send\s+(?:an?\s+)?email|email)\s+(?:to\s+)?(.+?)""" +
-                    """(?:\s+(?:about|regarding|re|subject:?)\s+(.+?))?""" +
+                    """(?:\s+(?:about|regarding|re|subject:?|with\s+subject:?)\s+(.+?))?""" +
                     """(?:\s+(?:that)\s+(.+?))?""" +
-                    """(?:\s+(?:body|message|saying|containing)\s+(.+))?$""",
+                    """(?:\s+(?:and\s+)?(?:body|message|saying|containing)\s+(.+))?$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/natives/NativeIntentHandler.kt
@@ -366,7 +366,10 @@ class NativeIntentHandler @Inject constructor(
                 SkillResult.Success("Email composer opened. Couldn't prefill recipient for $contact.")
             }
         } catch (e: ActivityNotFoundException) {
-            SkillResult.Failure("send_email", "No email app available")
+            SkillResult.Failure(
+                "send_email",
+                "I can't send email from this device yet. Set up an email app and account, then try again.",
+            )
         }
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -1833,6 +1833,19 @@ class QuickIntentRouterTest {
             assertEquals(expectedSubject, needsSlot.intent.params["subject"], "subject for '$input'")
             assertEquals("body", needsSlot.missingSlot.name, "missing slot for '$input'")
         }
+
+        @Test
+        fun `should exclude body delimiter from explicit email subject`() {
+            val result = regexOnlyRouter.route(
+                "send an email to Nick with subject Test and body Hello",
+            )
+
+            assertRegexMatch(result, "send_email", "explicit subject and body")
+            val intent = (result as QuickIntentRouter.RouteResult.RegexMatch).intent
+            assertEquals("Nick", intent.params["contact"])
+            assertEquals("Test", intent.params["subject"])
+            assertEquals("Hello", intent.params["body"])
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/natives/NativeIntentHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.kernel.ai.core.skills.natives
 
+import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -587,6 +588,24 @@ class NativeIntentHandlerTest {
 
         assertEquals(SkillResult.Success("Email composer opened to susan@example.com."), result)
         verify(exactly = 0) { context.checkSelfPermission(android.Manifest.permission.READ_CONTACTS) }
+    }
+
+    @Test
+    fun `send_email explains unavailable email app`() {
+        every { context.startActivity(any()) } throws ActivityNotFoundException()
+
+        val result = handleIntent(
+            "send_email",
+            mapOf("contact" to "susan@example.com", "subject" to "Hello", "body" to "World"),
+        )
+
+        assertEquals(
+            SkillResult.Failure(
+                "send_email",
+                "I can't send email from this device yet. Set up an email app and account, then try again.",
+            ),
+            result,
+        )
     }
 
     @Test

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -1805,7 +1805,7 @@ class ChatViewModel @Inject constructor(
                                 }
                             }
                             is SkillResult.Failure -> {
-                                if (!inferenceEngine.isReady.value) {
+                                if (skillResult.skillName == "send_email" || !inferenceEngine.isReady.value) {
                                     appendAssistantMessage(
                                         convId,
                                         skillResult.error,
@@ -2144,10 +2144,10 @@ class ChatViewModel @Inject constructor(
                         }
                         is com.kernel.ai.core.skills.SkillResult.Failure -> {
                             // #1313: deterministic regex-matched native routes are terminal even on
-                            // failure — show the error directly and skip E4B to prevent the model
-                            // from overwriting with a stale tool call (e.g. play_netflix after a
-                            // play_plex app-not-installed failure).
-                            if (routeResult is QuickIntentRouter.RouteResult.RegexMatch) {
+                            // failure. Email failures are also terminal because retrying through E4B
+                            // can invoke an unrelated tool instead of showing the email limitation.
+                            if (routeResult is QuickIntentRouter.RouteResult.RegexMatch ||
+                                skillResult.skillName == "send_email") {
                                 appendAssistantMessage(
                                     convId,
                                     skillResult.error,
@@ -2248,7 +2248,7 @@ class ChatViewModel @Inject constructor(
                             return@launch
                         }
                         is SkillResult.Failure -> {
-                            if (!inferenceEngine.isReady.value) {
+                            if (skillResult.skillName == "send_email" || !inferenceEngine.isReady.value) {
                                 appendAssistantMessage(convId, skillResult.error, shouldIndex = false, spokenSummary = skillResult.error)
                                 return@launch
                             }
@@ -3093,7 +3093,12 @@ class ChatViewModel @Inject constructor(
                     resultText = result.error,
                     isSuccess = false,
                 )
-                Pair(toolCall, "I tried to do that but something went wrong: ${result.error}")
+                val response = if (result.skillName == "send_email") {
+                    result.error
+                } else {
+                    "I tried to do that but something went wrong: ${result.error}"
+                }
+                Pair(toolCall, response)
             }
             is SkillResult.CapabilityRequired -> null
             is SkillResult.ParseError, is SkillResult.UnknownSkill -> null


### PR DESCRIPTION
Closes #1389

## Changes
- Show a clear, terminal email setup limitation when no mail composer is available, preventing unrelated fallback actions.
- Preserve explicit subject/body boundaries for email requests such as `with subject Test and body Hello`.
- Add regression coverage for both unavailable-composer handling and subject/body parsing.

## Verification
- `:core:skills:testDebugUnitTest --tests com.kernel.ai.core.skills.natives.NativeIntentHandlerTest`
- `:core:skills:testDebugUnitTest --tests com.kernel.ai.core.skills.QuickIntentRouterTest`
- `:feature:chat:testDebugUnitTest --tests com.kernel.ai.feature.chat.ChatViewModelQuickIntentRouterTest`
- S21 USB manual verification: composer showed subject `Test` and body `Hello`.