### PR TITLE
test(#1142): add S21 wake-word battery retest evidence

### DIFF
--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -574,8 +574,8 @@ class OnnxWakeWordDetector @Inject constructor(
                     // High-confidence fast path — activate immediately.
                     confidence >= highThreshold -> {
                         Log.i(TAG, "WakeWordDetector: detected (high confidence=$confidence)")
-                        diagnostics?.recordHighConfidenceActivation()
                         if (running.compareAndSet(true, false)) {
+                            diagnostics?.recordHighConfidenceActivation()
                             onDetected()
                         }
                     }
@@ -588,8 +588,8 @@ class OnnxWakeWordDetector @Inject constructor(
                         diagnostics?.recordVerifierResult(verified)
                         if (verified) {
                             Log.i(TAG, "WakeWordDetector: STT verification passed — activating")
-                            diagnostics?.recordVerifiedActivation()
                             if (running.compareAndSet(true, false)) {
+                                diagnostics?.recordVerifiedActivation()
                                 onDetected()
                             }
                         } else {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -21,9 +21,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "KernelAI"
+private const val DIAGNOSTIC_TAG = "WakeWordDiag"
+
+internal fun isWakeWordDiagnosticLoggingEnabled(): Boolean =
+    Log.isLoggable(DIAGNOSTIC_TAG, Log.DEBUG)
 
 /**
- * Diagnostic summaries are only emitted when the tag's DEBUG level is enabled.
+ * Diagnostic summaries are only emitted when the dedicated tag's DEBUG level is enabled.
  * Checking at this cadence keeps the production detector hot loop allocation-free.
  */
 private const val DIAGNOSTIC_REPORT_INTERVAL_MILLIS = 15 * 60 * 1_000L
@@ -315,7 +319,7 @@ class OnnxWakeWordDetector @Inject constructor(
         var melsSession: OrtSession? = null
         var embedSession: OrtSession? = null
         var classSession: OrtSession? = null
-        val diagnosticsEnabled = Log.isLoggable(TAG, Log.DEBUG)
+        val diagnosticsEnabled = isWakeWordDiagnosticLoggingEnabled()
         val diagnostics = if (diagnosticsEnabled) WakeWordDiagnosticCounters() else null
         val diagnosticsStartedAt = if (diagnosticsEnabled) SystemClock.elapsedRealtime() else 0L
         var lastDiagnosticReportElapsedMillis = 0L
@@ -508,7 +512,7 @@ class OnnxWakeWordDetector @Inject constructor(
                 if (diagnostics != null && chunkCount % DIAGNOSTIC_REPORT_CHECK_FRAMES == 0L) {
                     val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
                     if (elapsedMillis - lastDiagnosticReportElapsedMillis >= DIAGNOSTIC_REPORT_INTERVAL_MILLIS) {
-                        Log.d(TAG, formatDiagnosticSummary(diagnostics.snapshot(elapsedMillis), nnapiStatus))
+                        Log.d(DIAGNOSTIC_TAG, formatDiagnosticSummary(diagnostics.snapshot(elapsedMillis), nnapiStatus))
                         lastDiagnosticReportElapsedMillis = elapsedMillis
                     }
                 }
@@ -616,7 +620,7 @@ class OnnxWakeWordDetector @Inject constructor(
             running.set(false)
             diagnostics?.let {
                 val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
-                Log.d(TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
+                Log.d(DIAGNOSTIC_TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
             }
         }
     }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -8,6 +8,7 @@ import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.annotation.SuppressLint
+import android.os.SystemClock
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
@@ -20,6 +21,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "KernelAI"
+
+/**
+ * Diagnostic summaries are only emitted when the tag's DEBUG level is enabled.
+ * Checking at this cadence keeps the production detector hot loop allocation-free.
+ */
+private const val DIAGNOSTIC_REPORT_INTERVAL_MILLIS = 15 * 60 * 1_000L
+private const val DIAGNOSTIC_REPORT_CHECK_FRAMES = 128L
 
 // ── Audio parameters ─────────────────────────────────────────────────────────
 /** openWakeWord requires 16 kHz, mono, 16-bit PCM — non-negotiable. */
@@ -307,10 +315,11 @@ class OnnxWakeWordDetector @Inject constructor(
         var melsSession: OrtSession? = null
         var embedSession: OrtSession? = null
         var classSession: OrtSession? = null
-        // Diagnostics counters for final log
-        var inferenceCount = 0L
-        var gatedFramesSkipped = 0L
-        var minRms = 0.0
+        val diagnosticsEnabled = Log.isLoggable(TAG, Log.DEBUG)
+        val diagnostics = if (diagnosticsEnabled) WakeWordDiagnosticCounters() else null
+        val diagnosticsStartedAt = if (diagnosticsEnabled) SystemClock.elapsedRealtime() else 0L
+        var lastDiagnosticReportElapsedMillis = 0L
+        var nnapiStatus = "not_requested"
 
         try {
             val env = OrtEnvironment.getEnvironment()
@@ -319,8 +328,16 @@ class OnnxWakeWordDetector @Inject constructor(
             }
             embedOptions = OrtSession.SessionOptions().apply {
                 setIntraOpNumThreads(1)
-                runCatching { addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED)) }
-                    .onFailure { Log.w(TAG, "WakeWordDetector: NNAPI EP unavailable, using CPU", it) }
+            }
+            val nnapiConfigured = runCatching {
+                embedOptions!!.addNnapi(EnumSet.of(NNAPIFlags.CPU_DISABLED))
+            }.onFailure {
+                Log.w(TAG, "WakeWordDetector: NNAPI EP configuration failed; embedding session will use CPU", it)
+            }.isSuccess
+            nnapiStatus = if (nnapiConfigured) {
+                "requested_cpu_disabled"
+            } else {
+                "configuration_failed_cpu_session"
             }
 
             melsSession = runCatching { env.createSession(bytes.melspectrogram, cpuOptions!!) }
@@ -329,13 +346,19 @@ class OnnxWakeWordDetector @Inject constructor(
                 .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load embedding_model.onnx", e); null }
             classSession = runCatching { env.createSession(bytes.classifier, cpuOptions!!) }
                 .getOrElse { e -> Log.e(TAG, "WakeWordDetector: failed to load hey_jandal.onnx", e); null }
+            nnapiStatus = when {
+                embedSession == null && nnapiConfigured -> "session_create_failed_after_nnapi_request"
+                embedSession == null -> "cpu_session_create_failed"
+                nnapiConfigured -> "session_created_nnapi_requested_assignment_unverified"
+                else -> "cpu_session_created"
+            }
 
             if (melsSession == null || embedSession == null || classSession == null) {
                 Log.e(TAG, "WakeWordDetector: one or more ONNX sessions failed to load")
                 return
 
             }
-            Log.i(TAG, "WakeWordDetector: models loaded (embedding: NNAPI CPU_DISABLED, mel+classifier: CPU)")
+            Log.i(TAG, "WakeWordDetector: models loaded (embedding provider=$nnapiStatus; mel+classifier: CPU)")
 
 
             // Resolve ONNX node names once at startup.
@@ -389,6 +412,7 @@ class OnnxWakeWordDetector @Inject constructor(
                     }
                 }
                 if (totalRead < FRAME_SAMPLES) continue
+                diagnostics?.recordAudioFrame()
                 chunkCount++
                 val rms = calculateRms(chunk)
 
@@ -408,9 +432,6 @@ class OnnxWakeWordDetector @Inject constructor(
                     if (pcmFilled < VERIFY_RING_SAMPLES) pcmFilled += FRAME_SAMPLES
                 }
 
-                // ── Silence baseline ───────────────────────────────────────────────
-                // Track the minimum observed RMS for diagnostic logging.
-                if (minRms <= 0.0 || rms < minRms) minRms = rms
 
                 // ── Fast-open / slow-close voice detection ───────────────────────
                 // Fast-open: a single frame above threshold immediately resets the
@@ -452,6 +473,7 @@ class OnnxWakeWordDetector @Inject constructor(
                 }
                 // Input:  [1, 1280] float32 PCM
                 // Output: [1, 1, 5, 32] mel spectrogram patch (5 rows × 32 bins per chunk)
+                diagnostics?.recordStage1Execution()
                 val melRows: FloatArray = OnnxTensor.createTensor(
                     env,
                     FloatBuffer.wrap(framePcm),
@@ -483,23 +505,20 @@ class OnnxWakeWordDetector @Inject constructor(
                 }
                 if (melRowsFilled < MEL_RING_SIZE) continue
 
+                if (diagnostics != null && chunkCount % DIAGNOSTIC_REPORT_CHECK_FRAMES == 0L) {
+                    val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
+                    if (elapsedMillis - lastDiagnosticReportElapsedMillis >= DIAGNOSTIC_REPORT_INTERVAL_MILLIS) {
+                        Log.d(TAG, formatDiagnosticSummary(diagnostics.snapshot(elapsedMillis), nnapiStatus))
+                        lastDiagnosticReportElapsedMillis = elapsedMillis
+                    }
+                }
+
                 // ── Gating: skip embedding + classifier when confirmed-silent ─────
                 if (silenceFrames > silenceHangoverFrames &&
                     chunkCount % maxSilenceSkipFrames.toLong() != 0L) {
-                    gatedFramesSkipped++
+                    diagnostics?.recordSilenceGateSkip()
                     wasGated = true
                     continue  // wake word not expected — skip expensive Stage 2/3
-                }
-                // Log mic activity every ~8s (only when Stage 2/3 runs).
-                if (chunkCount % 100 == 0) {
-                    Log.d(
-                        TAG,
-                        "WakeWordDetector: alive chunk=$chunkCount rms=${"%.1f".format(rms)} " +
-                            "base=${"%.1f".format(minRms)} " +
-                            "thresh=$silenceRmsThreshold isVoiced=$isFrameVoiced " +
-                            "silenceFrames=$silenceFrames melFilled=$melRowsFilled " +
-                            "embAcc=$embFramesAccumulated ongoingSkips=$gatedFramesSkipped",
-                    )
                 }
 
                 // ── Stage 2: embedding backbone ───────────────────────────────────────
@@ -510,6 +529,7 @@ class OnnxWakeWordDetector @Inject constructor(
                 // passing the same flat array with shape [1, 76, 32, 1] — the channel is implicit
                 // (every element maps to exactly one channel-1 position).
                 melRing.copyInto(embedInput4D)
+                diagnostics?.recordStage2Execution()
                 val embedding: FloatArray = OnnxTensor.createTensor(
                     env,
                     FloatBuffer.wrap(embedInput4D),
@@ -536,6 +556,7 @@ class OnnxWakeWordDetector @Inject constructor(
                     embeddingRing[frameIdx].copyInto(windowFlat, f * EMBEDDING_DIM)
                 }
 
+                diagnostics?.recordStage3Execution()
                 val confidence: Float = OnnxTensor.createTensor(
                     env,
                     FloatBuffer.wrap(windowFlat),
@@ -546,17 +567,14 @@ class OnnxWakeWordDetector @Inject constructor(
                         ((t.value as Array<*>)[0] as FloatArray)[0]
                     }
                 }
-                inferenceCount++
-                // Log every inference during first 5s, then every ~1s (every 12 inferences).
-                if (inferenceCount <= 20 || inferenceCount % 12 == 0L) {
-                    Log.d(TAG, "WakeWordDetector: inference #$inferenceCount confidence=${"%.4f".format(confidence)}")
-                }
+                // Stage 3 count is retained in low-frequency diagnostics; avoid per-second logs.
 
 
                 when {
                     // High-confidence fast path — activate immediately.
                     confidence >= highThreshold -> {
                         Log.i(TAG, "WakeWordDetector: detected (high confidence=$confidence)")
+                        diagnostics?.recordHighConfidenceActivation()
                         if (running.compareAndSet(true, false)) {
                             onDetected()
                         }
@@ -566,8 +584,11 @@ class OnnxWakeWordDetector @Inject constructor(
                     verifyWindow != null && confidence >= lowThreshold -> {
                         Log.d(TAG, "WakeWordDetector: low-threshold crossing (confidence=$confidence) — verifying")
                         val snapshot = extractPcmSnapshot(pcmRing, pcmRingHead, pcmFilled)
-                        if (verifyWindow(snapshot)) {
+                        val verified = verifyWindow(snapshot)
+                        diagnostics?.recordVerifierResult(verified)
+                        if (verified) {
                             Log.i(TAG, "WakeWordDetector: STT verification passed — activating")
+                            diagnostics?.recordVerifiedActivation()
                             if (running.compareAndSet(true, false)) {
                                 onDetected()
                             }
@@ -593,10 +614,35 @@ class OnnxWakeWordDetector @Inject constructor(
             cpuOptions?.close()
             embedOptions?.close()
             running.set(false)
-            Log.d(TAG, "WakeWordDetector: detection loop exited — " +
-                "inferences=$inferenceCount gatedSkips=$gatedFramesSkipped " +
-                "finalMinRms=${"%.1f".format(minRms)}")
+            diagnostics?.let {
+                val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
+                Log.d(TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
+            }
         }
+    }
+
+    private fun formatDiagnosticSummary(
+        snapshot: WakeWordDiagnosticSnapshot,
+        nnapiStatus: String,
+        final: Boolean = false,
+    ): String = buildString {
+        append("WakeWordDetector: diagnostics")
+        if (final) append(" final")
+        append(" elapsedMs=").append(snapshot.elapsedMillis)
+        append(" audioFrames=").append(snapshot.audioFrames)
+        append(" stage1=").append(snapshot.stage1Executions)
+        append(" stage2=").append(snapshot.stage2Executions)
+        append(" stage3=").append(snapshot.stage3Executions)
+        append(" stage2PerHour=").append(snapshot.stage2ExecutionsPerHour())
+        append(" stage3PerHour=").append(snapshot.stage3ExecutionsPerHour())
+        append(" silenceSkips=").append(snapshot.silenceGateSkips)
+        append(" silenceSkipRatio=").append(snapshot.silenceGateSkipRatio)
+        append(" verifier=").append(snapshot.verifierInvocations)
+        append(" verifierPasses=").append(snapshot.verifierPasses)
+        append(" verifierRejects=").append(snapshot.verifierRejects)
+        append(" highActivations=").append(snapshot.highConfidenceActivations)
+        append(" verifiedActivations=").append(snapshot.verifiedActivations)
+        append(" embeddingProvider=").append(nnapiStatus)
     }
 
     /**

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordDiagnosticCounters.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordDiagnosticCounters.kt
@@ -1,0 +1,91 @@
+package com.kernel.ai.core.voice
+
+/**
+ * Per-detector-run counters for low-frequency wake-word diagnostics.
+ *
+ * The detector updates primitive fields only; callers create a [WakeWordDiagnosticSnapshot]
+ * only when emitting a periodic or shutdown summary. This keeps the AudioRecord hot loop
+ * allocation-free while allowing controlled battery tests to derive inference cadence and
+ * silence-gate effectiveness.
+ */
+internal class WakeWordDiagnosticCounters {
+    var audioFrames: Long = 0
+        private set
+    var stage1Executions: Long = 0
+        private set
+    var stage2Executions: Long = 0
+        private set
+    var stage3Executions: Long = 0
+        private set
+    var silenceGateSkips: Long = 0
+        private set
+    var verifierInvocations: Long = 0
+        private set
+    var verifierPasses: Long = 0
+        private set
+    var verifierRejects: Long = 0
+        private set
+    var highConfidenceActivations: Long = 0
+        private set
+    var verifiedActivations: Long = 0
+        private set
+
+    fun recordAudioFrame() { audioFrames++ }
+    fun recordStage1Execution() { stage1Executions++ }
+    fun recordStage2Execution() { stage2Executions++ }
+    fun recordStage3Execution() { stage3Executions++ }
+    fun recordSilenceGateSkip() { silenceGateSkips++ }
+    fun recordVerifierResult(passed: Boolean) {
+        verifierInvocations++
+        if (passed) verifierPasses++ else verifierRejects++
+    }
+    fun recordHighConfidenceActivation() { highConfidenceActivations++ }
+    fun recordVerifiedActivation() { verifiedActivations++ }
+
+    fun snapshot(elapsedMillis: Long): WakeWordDiagnosticSnapshot = WakeWordDiagnosticSnapshot(
+        elapsedMillis = elapsedMillis.coerceAtLeast(0L),
+        audioFrames = audioFrames,
+        stage1Executions = stage1Executions,
+        stage2Executions = stage2Executions,
+        stage3Executions = stage3Executions,
+        silenceGateSkips = silenceGateSkips,
+        verifierInvocations = verifierInvocations,
+        verifierPasses = verifierPasses,
+        verifierRejects = verifierRejects,
+        highConfidenceActivations = highConfidenceActivations,
+        verifiedActivations = verifiedActivations,
+    )
+}
+
+internal data class WakeWordDiagnosticSnapshot(
+    val elapsedMillis: Long,
+    val audioFrames: Long,
+    val stage1Executions: Long,
+    val stage2Executions: Long,
+    val stage3Executions: Long,
+    val silenceGateSkips: Long,
+    val verifierInvocations: Long,
+    val verifierPasses: Long,
+    val verifierRejects: Long,
+    val highConfidenceActivations: Long,
+    val verifiedActivations: Long,
+) {
+    val stage23EligibleFrames: Long
+        get() = stage2Executions + silenceGateSkips
+
+    val silenceGateSkipRatio: Double
+        get() = stage23EligibleFrames.takeIf { it > 0L }
+            ?.let { silenceGateSkips.toDouble() / it }
+            ?: 0.0
+
+    fun stage2ExecutionsPerHour(): Double = executionsPerHour(stage2Executions)
+
+    fun stage3ExecutionsPerHour(): Double = executionsPerHour(stage3Executions)
+
+    fun verifierInvocationsPerHour(): Double = executionsPerHour(verifierInvocations)
+
+    private fun executionsPerHour(executions: Long): Double {
+        if (elapsedMillis <= 0L) return 0.0
+        return executions.toDouble() * 3_600_000.0 / elapsedMillis
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDiagnosticCountersTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDiagnosticCountersTest.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WakeWordDiagnosticCountersTest {
+    @Test
+    fun `snapshot reports stage counters and silence gate ratio`() {
+        val counters = WakeWordDiagnosticCounters()
+        repeat(20) { counters.recordAudioFrame() }
+        repeat(20) { counters.recordStage1Execution() }
+        repeat(5) { counters.recordStage2Execution() }
+        repeat(3) { counters.recordStage3Execution() }
+        repeat(15) { counters.recordSilenceGateSkip() }
+
+        val snapshot = counters.snapshot(elapsedMillis = 3_600_000L)
+
+        assertEquals(20, snapshot.audioFrames)
+        assertEquals(20, snapshot.stage1Executions)
+        assertEquals(5, snapshot.stage2Executions)
+        assertEquals(3, snapshot.stage3Executions)
+        assertEquals(20, snapshot.stage23EligibleFrames)
+        assertEquals(0.75, snapshot.silenceGateSkipRatio)
+        assertEquals(5.0, snapshot.stage2ExecutionsPerHour())
+        assertEquals(3.0, snapshot.stage3ExecutionsPerHour())
+    }
+
+    @Test
+    fun `snapshot reports verifier outcomes and activation paths`() {
+        val counters = WakeWordDiagnosticCounters()
+        counters.recordVerifierResult(passed = true)
+        counters.recordVerifierResult(passed = false)
+        counters.recordHighConfidenceActivation()
+        counters.recordVerifiedActivation()
+
+        val snapshot = counters.snapshot(elapsedMillis = 1_800_000L)
+
+        assertEquals(2, snapshot.verifierInvocations)
+        assertEquals(1, snapshot.verifierPasses)
+        assertEquals(1, snapshot.verifierRejects)
+        assertEquals(1, snapshot.highConfidenceActivations)
+        assertEquals(1, snapshot.verifiedActivations)
+        assertEquals(4.0, snapshot.verifierInvocationsPerHour())
+    }
+
+    @Test
+    fun `zero elapsed snapshot avoids invalid rates`() {
+        val counters = WakeWordDiagnosticCounters()
+
+        val snapshot = counters.snapshot(elapsedMillis = 0L)
+
+        assertEquals(0.0, snapshot.silenceGateSkipRatio)
+        assertEquals(0.0, snapshot.stage2ExecutionsPerHour())
+        assertEquals(0.0, snapshot.stage3ExecutionsPerHour())
+        assertEquals(0.0, snapshot.verifierInvocationsPerHour())
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDiagnosticCountersTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDiagnosticCountersTest.kt
@@ -1,9 +1,32 @@
 package com.kernel.ai.core.voice
 
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class WakeWordDiagnosticCountersTest {
+
+    @Test
+    fun `diagnostics only enable from dedicated debug tag`() {
+        mockkStatic(Log::class)
+        try {
+            every { Log.isLoggable(any<String>(), any<Int>()) } returns false
+            every { Log.isLoggable("WakeWordDiag", Log.DEBUG) } returns true
+
+            assertTrue(isWakeWordDiagnosticLoggingEnabled())
+
+            verify(exactly = 1) { Log.isLoggable("WakeWordDiag", Log.DEBUG) }
+            verify(exactly = 0) { Log.isLoggable("KernelAI", Log.DEBUG) }
+        } finally {
+            unmockkStatic(Log::class)
+        }
+    }
+
     @Test
     fun `snapshot reports stage counters and silence gate ratio`() {
         val counters = WakeWordDiagnosticCounters()

--- a/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
+++ b/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
@@ -1,7 +1,7 @@
 # Wake-word battery retest — S21 — 2026-07-10
 
 **Issue:** #1142  
-**Result:** **Clearly excessive battery drain; follow-up required.**  
+**Result:** **Clearly excessive observed whole-device drain; comparative follow-up required.**  
 **Test source:** physical device, controlled idle window; no raw device logs are committed.
 
 ## Scope and build
@@ -23,7 +23,7 @@ The test followed [the repeatable battery procedure](wake-word-battery-test.md).
 - The operator visibly enabled **Listen for Hey Jandal** and a local-only screenshot confirmed the control state before the run.
 - `WakeWordService` was present before the official start.
 - A pre-test locked-screen spoken wake plus command passed.
-- Debug-gated, 15-minute `WakeWordDetector: diagnostics` logging was enabled before the detector started.
+- Debug-gated, 15-minute `WakeWordDetector: diagnostics` logging was enabled before the detector started. This completed run used the pre-fix diagnostic-tag configuration; #1392 changes future runs to the dedicated `WakeWordDiag` tag and no raw log output is retained here.
 - Wireless ADB was tested while USB was attached, then the charger and USB cable were physically removed.
 - The official start was rejected once while the screen was still on. The accepted run began only after the display reported off.
 
@@ -81,7 +81,7 @@ The first summary was emitted after detector startup but after the official test
 - The diagnostic provider status was `session_created_nnapi_requested_assignment_unverified`.
 - **NNAPI classification: inconclusive.** This proves only that NNAPI with `CPU_DISABLED` was requested and a session was created. It does not establish node assignment or accelerator execution. No native ONNX Runtime provider-assignment evidence was captured.
 - Mel and classifier execution are CPU by design. No CPU-utilisation sample was collected; detector cadence is the available workload proxy.
-- `batterystats --checkin` provided no package-attributed record for the debug app in this run. Per-app battery attribution and app-specific wakelock attribution are therefore **unavailable**, not zero.
+- `batterystats --checkin` provided no package-attributed record for the debug app in this run. Per-app battery attribution and app-specific wakelock attribution are therefore **unavailable**, not zero. No same-device wake-word-disabled control was performed.
 - `dumpsys power` showed the device dozing at both boundaries. `dumpsys meminfo` did not return a parsed package-PSS row, so no memory comparison is claimed.
 - No raw logcat, ADB serial, wireless endpoint, pairing code, account name, or screenshot is included in this repository evidence.
 
@@ -93,6 +93,6 @@ No audible cue was heard on the retry, so the operator had to guess when to spea
 
 ## Outcome and next step
 
-A 24-point loss in 4.013 hours while discharging, screen-off, dozing/idle, without intentional interactions is **clearly excessive** for an always-on default-assistant wake path. The current app-managed `AudioRecord` plus ONNX implementation is not supported by this evidence as a reasonable default-on v0.1 launch path.
+A 24-point loss in 4.013 hours while the tested configuration was discharging, screen-off, dozing/idle, and without intentional interactions is **clearly unacceptable for retaining that configuration as a default-on launch experience without further comparative evidence**. The enabled wake path, continuous detector workload, and excessive whole-device drain are strongly correlated in this run. The run does **not** isolate Jandal's exact battery share or prove that `AudioRecord` plus ONNX caused all observed drain: package attribution, app-specific wakelock attribution, and a same-device wake-word-disabled baseline are absent.
 
-No speculative performance tuning was added in this retest. [Issue #1391](https://github.com/NickMonrad/kernel-ai-assistant/issues/1391) will investigate the measured idle Stage 2/3 cadence, reproducible CPU-only versus NNAPI-requested behavior, and the post-idle cue/reliability observation before any release-default decision. Android Sound Trigger/DSP integration remains unproven for a normal third-party application; this result does not establish a usable OEM or privileged DSP path.
+No speculative performance tuning was added in this retest. [Issue #1391](https://github.com/NickMonrad/kernel-ai-assistant/issues/1391) requires a matched wake-word-disabled control before a firm causal or release-default conclusion, then investigates the measured idle Stage 2/3 cadence, reproducible CPU-only versus NNAPI-requested behavior, provider-assignment evidence, and the post-idle cue/reliability observation. Android Sound Trigger/DSP integration remains unproven for a normal third-party application; this result does not establish a usable OEM or privileged DSP path.

--- a/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
+++ b/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
@@ -1,0 +1,98 @@
+# Wake-word battery retest — S21 — 2026-07-10
+
+**Issue:** #1142  
+**Result:** **Clearly excessive battery drain; follow-up required.**  
+**Test source:** physical device, controlled idle window; no raw device logs are committed.
+
+## Scope and build
+
+| Field | Value |
+| --- | --- |
+| Device | Samsung SM-G991B (S21), Exynos 2100 |
+| Android | 15 / API 35 |
+| App | In-place debug install, version 0.1.0 (version code 1) |
+| Diagnostic source commit | `34e3ea1a40dd513b955baefdcbb4d58690441d5b` |
+| Wake pipeline | Bundled openWakeWord ONNX mel, embedding, and classifier models |
+| Verification model | Local Vosk storage was present; no verifier invocation occurred during the idle window |
+| Connectivity | Normal network connectivity retained; wireless ADB stayed reachable without disclosing the endpoint |
+
+The test followed [the repeatable battery procedure](wake-word-battery-test.md). The app was installed with `adb install -r`; no uninstall, data clearing, model removal, forced downgrade, or charging was used.
+
+## Preconditions
+
+- The operator visibly enabled **Listen for Hey Jandal** and a local-only screenshot confirmed the control state before the run.
+- `WakeWordService` was present before the official start.
+- A pre-test locked-screen spoken wake plus command passed.
+- Debug-gated, 15-minute `WakeWordDetector: diagnostics` logging was enabled before the detector started.
+- Wireless ADB was tested while USB was attached, then the charger and USB cable were physically removed.
+- The official start was rejected once while the screen was still on. The accepted run began only after the display reported off.
+
+## Controlled window
+
+| Field | Start | End |
+| --- | --- | --- |
+| UTC timestamp | 2026-07-10 10:00:31 | 2026-07-10 14:01:19 |
+| Elapsed | — | 14,448 s / 4 h 00 m 48 s |
+| Battery | 95% | 71% |
+| Battery delta | — | -24 percentage points / **5.98 percentage points per hour** |
+| Battery temperature | 31.1 °C | 25.4 °C |
+| External power | AC=false, USB=false, wireless=false | AC=false, USB=false, wireless=false |
+| Battery status | Discharging | Discharging |
+| Wake-word service | Active | Active |
+| Wakefulness | Dozing | Dozing |
+| Device idle state | `INACTIVE` | `IDLE` |
+
+The operator turned the display off and left the device untouched. `deviceidle` reported `mScreenOn=false` at accepted start and end. It reported `mScreenLocked=false`; therefore the automated system field is not treated as proof of lock state. There were **zero intentional voice interactions** during the measured window and no continuous log stream or ADB polling.
+
+## Supplemental unplugged continuation
+
+At 2026-07-10 20:35:03 UTC, after the official end and the post-test smoke interaction, one additional S21 snapshot recorded 32% battery, still discharging with all external-power fields false. `WakeWordService` was active; the device was Dozing with `mScreenOn=false` and `mLightState=IDLE`.
+
+This is **not** a second controlled measurement: it includes the post-test interaction and its intervening conditions were not controlled. It nevertheless records a further 39-point decrease over 23,623 s / 6 h 33 m 43 s (5.94 percentage points/hour). It is reported only as corroborating context, not combined with the official four-hour result or used for an S23U comparison.
+
+## Detector cadence and gating
+
+The detector remained continuous across setup and the test; counters are detector-lifetime counters, not resettable per test window. The latest 15-minute diagnostic summary at the end reported:
+
+| Metric | Value |
+| --- | ---: |
+| Detector uptime represented by summary | 15,319,116 ms / 4.26 h |
+| Audio frames / Stage 1 executions | 191,488 / 191,488 |
+| Stage 2 executions | 27,803 (6,533.7/h over detector uptime) |
+| Stage 3 executions | 26,213 (6,160.1/h over detector uptime) |
+| Silence-gate skips | 163,669 (85.48% of audio frames) |
+| Verifier invocations / passes / rejects during idle | 0 / 0 / 0 |
+| High-confidence / verified activations during idle | 0 / 0 |
+
+To reduce setup-period contamination, the delta between the first diagnostic summary emitted after the official start and the final summary covers 11,714,562 ms / 3.254 h:
+
+| Metric | Delta / observed cadence |
+| --- | ---: |
+| Audio frames / Stage 1 executions | 146,432 / 146,432 |
+| Stage 2 executions | 14,161 / **4,351.8 per hour** |
+| Stage 3 executions | 13,801 / **4,241.2 per hour** |
+| Silence-gate skips | 132,271 / **90.33%** of audio frames |
+| Verifier invocations / activations | 0 / 0 |
+
+The first summary was emitted after detector startup but after the official test began, so this delta is a conservative partial-window cadence measurement; it is not substituted for the exact four-hour battery duration.
+
+## Accelerator, attribution, and resource evidence
+
+- The diagnostic provider status was `session_created_nnapi_requested_assignment_unverified`.
+- **NNAPI classification: inconclusive.** This proves only that NNAPI with `CPU_DISABLED` was requested and a session was created. It does not establish node assignment or accelerator execution. No native ONNX Runtime provider-assignment evidence was captured.
+- Mel and classifier execution are CPU by design. No CPU-utilisation sample was collected; detector cadence is the available workload proxy.
+- `batterystats --checkin` provided no package-attributed record for the debug app in this run. Per-app battery attribution and app-specific wakelock attribution are therefore **unavailable**, not zero.
+- `dumpsys power` showed the device dozing at both boundaries. `dumpsys meminfo` did not return a parsed package-PSS row, so no memory comparison is claimed.
+- No raw logcat, ADB serial, wireless endpoint, pairing code, account name, or screenshot is included in this repository evidence.
+
+## Post-test wake smoke
+
+After end-state capture, the operator attempted a separate locked-screen **Hey Jandal** plus **what time is it** interaction. The first attempt appeared to fail. After waking and re-locking the device, a retry passed.
+
+No audible cue was heard on the retry, so the operator had to guess when to speak the command. Current volume or audio-routing state may explain the missing cue, but that cause is unverified. The filtered logs for the initial attempt showed one high-confidence detector event and one verifier rejection, with no detector error and `WakeWordService` still active. This records a cue/reliability observation, not a proven detector failure, and it is separate from the idle-window counters.
+
+## Outcome and next step
+
+A 24-point loss in 4.013 hours while discharging, screen-off, dozing/idle, without intentional interactions is **clearly excessive** for an always-on default-assistant wake path. The current app-managed `AudioRecord` plus ONNX implementation is not supported by this evidence as a reasonable default-on v0.1 launch path.
+
+No speculative performance tuning was added in this retest. [Issue #1391](https://github.com/NickMonrad/kernel-ai-assistant/issues/1391) will investigate the measured idle Stage 2/3 cadence, reproducible CPU-only versus NNAPI-requested behavior, and the post-idle cue/reliability observation before any release-default decision. Android Sound Trigger/DSP integration remains unproven for a normal third-party application; this result does not establish a usable OEM or privileged DSP path.

--- a/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
+++ b/docs/testing/wake-word-battery-retest-s21-2026-07-10.md
@@ -1,7 +1,7 @@
 # Wake-word battery retest — S21 — 2026-07-10
 
-**Issue:** #1142  
-**Result:** **Clearly excessive observed whole-device drain; comparative follow-up required.**  
+**Issue:** #1142<br>
+**Result:** **Clearly excessive observed whole-device drain; comparative follow-up required.**<br>
 **Test source:** physical device, controlled idle window; no raw device logs are committed.
 
 ## Scope and build

--- a/docs/testing/wake-word-battery-test.md
+++ b/docs/testing/wake-word-battery-test.md
@@ -1,0 +1,120 @@
+# Wake-word battery test procedure
+
+This procedure captures a controlled, **unplugged** real-device idle measurement for the Hey Jandal foreground service. It is designed for a normal, non-root Android device and intentionally uses start/end snapshots rather than continuous ADB polling.
+
+> **Privacy:** Never put an ADB serial number, Wi-Fi address, pairing code, account name, or raw unfiltered logcat into a committed report, issue, or PR. Identify the device by sanitized model, chipset, and Android version only.
+
+## Preconditions
+
+- Use the approved physical device and an in-place debug install: `adb install -r app/build/outputs/apk/debug/app-debug.apk`.
+- Do **not** uninstall the application, clear app data, or remove model storage.
+- Confirm the wake-word ONNX assets and the selected STT model are still present after installation.
+- Confirm **Listen for Hey Jandal** is visibly enabled in Jandal's Voice settings, then capture a local screenshot. Do not commit the screenshot unless it has been reviewed for private content.
+- Confirm the wake-word foreground service is running with `adb shell dumpsys activity services com.kernel.ai.debug`.
+- Set the diagnostic log tag before starting the detector. The detector emits a low-frequency summary every 15 minutes and when it stops only while this tag is DEBUG:
+
+```bash
+adb shell setprop log.tag.KernelAI DEBUG
+```
+
+- Perform one locked-screen spoken `Hey Jandal` activation before the measured window. Confirm activation and no crash. Record it as a **pre-test smoke activation**, not as idle-window activity.
+
+## Build and in-place install
+
+```bash
+./gradlew :app:assembleDebug
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb shell dumpsys package com.kernel.ai.debug | grep versionName
+adb shell find /sdcard/Android/data/com.kernel.ai.debug/files -maxdepth 4 -type f
+```
+
+Record the Git commit and app version. The model-file listing is inspection-only; do not include account files or private paths in the report.
+
+## Wireless ADB before unplugging
+
+Establish and test a wireless connection while USB is still attached. Either use Android's **Wireless debugging** pairing UI or the established USB-to-TCP handoff below. Do not publish the IP address, port, or pairing code.
+
+```bash
+adb tcpip 5555
+adb shell ip -f inet addr show wlan0
+adb connect <private-device-ip>:5555
+adb devices
+```
+
+Run one harmless command through the wireless transport before unplugging:
+
+```bash
+adb shell dumpsys battery
+```
+
+Do not leave `adb logcat` streaming or poll the device during the idle window.
+
+## Controlled start
+
+After the operator physically unplugs both charger and USB cable, wait several minutes, then collect the official start state. Do not start the timer until all charging fields are false and the battery is discharging.
+
+```bash
+adb shell dumpsys battery
+adb shell dumpsys power
+adb shell dumpsys deviceidle
+adb shell dumpsys activity services com.kernel.ai.debug
+adb shell dumpsys batterystats --reset
+adb shell dumpsys batterystats com.kernel.ai.debug
+adb logcat -d -v threadtime -s KernelAI:D '*:S'
+```
+
+Record locally:
+
+- local start timestamp and battery percentage;
+- `AC powered`, `USB powered`, and `Wireless powered` values; battery status; charging state;
+- screen-off / locked confirmation;
+- Wi-Fi or cellular network state and whether wireless ADB remained connected;
+- device-idle / doze state and app wake-word service state;
+- app version and Git commit;
+- sanitized device model, chipset, Android version;
+- selected wake-word and STT models;
+- the pre-test smoke activation count (separate from measured activity);
+- that batterystats was reset immediately before the controlled run.
+
+The start battery level must be captured **after** install, settings verification, smoke activation, wireless setup, physical unplugging, and service re-verification.
+
+## Four-hour idle window
+
+For at least four continuous hours:
+
+- keep the device physically unplugged and discharging;
+- leave Hey Jandal enabled, the service active, screen off, and device locked;
+- retain normal network connectivity;
+- make no intentional voice interaction and do not actively use Jandal;
+- do not run high-frequency ADB polling or a continuous log stream.
+
+Invalidate and restart the run if charging resumes, the service stops, the device reboots, Jandal crashes, the wake-word model becomes unavailable, or a material interaction occurs. Record a minor unavoidable interaction with timestamp, reason, and duration; assess conservatively whether idle conditions remain valid.
+
+## Controlled end and analysis
+
+At the four-hour mark, record the end timestamp before unnecessary interaction, then collect:
+
+```bash
+adb shell dumpsys battery
+adb shell dumpsys batterystats com.kernel.ai.debug
+adb shell dumpsys power
+adb shell dumpsys deviceidle
+adb shell dumpsys activity services com.kernel.ai.debug
+adb shell dumpsys meminfo com.kernel.ai.debug
+adb logcat -d -v threadtime -s KernelAI:D '*:S'
+```
+
+The relevant low-frequency `WakeWordDetector: diagnostics` lines contain:
+
+- audio frames and Stage 1/2/3 execution counts;
+- Stage 2/3 execution cadence per hour;
+- silence-gate skips and skip ratio;
+- verifier invocations, passes, and rejects;
+- high-confidence and verifier-confirmed activations;
+- NNAPI request/session status.
+
+Interpret provider status carefully: `session_created_nnapi_requested_assignment_unverified` proves only that NNAPI was requested with `CPU_DISABLED` and the session was created. It does **not** prove node assignment or actual accelerator execution. Classify NNAPI as `inconclusive` unless native ONNX Runtime logs directly establish assignment/execution; classify configuration failure as CPU fallback only when the detector reports that outcome.
+
+Calculate and report exact elapsed time, percentage points consumed, percentage points per hour, Stage 2/3 executions per hour, silence-gate skip ratio, verifier statistics, activation counts, service continuity, batterystats attribution, wakelock observations, and NNAPI classification. Note battery-level granularity, radio/network activity, battery age/calibration, temperature, and other system services as measurement limits.
+
+After collecting end evidence, perform one final spoken locked-screen `Hey Jandal` activation. Record it as a **post-test smoke activation**, separately from idle-window activity.

--- a/docs/testing/wake-word-battery-test.md
+++ b/docs/testing/wake-word-battery-test.md
@@ -11,11 +11,13 @@ This procedure captures a controlled, **unplugged** real-device idle measurement
 - Confirm the wake-word ONNX assets and the selected STT model are still present after installation.
 - Confirm **Listen for Hey Jandal** is visibly enabled in Jandal's Voice settings, then capture a local screenshot. Do not commit the screenshot unless it has been reviewed for private content.
 - Confirm the wake-word foreground service is running with `adb shell dumpsys activity services com.kernel.ai.debug`.
-- Set the diagnostic log tag before starting the detector. The detector emits a low-frequency summary every 15 minutes and when it stops only while this tag is DEBUG:
+- Set the dedicated diagnostic log tag before starting the detector. The detector emits a low-frequency summary every 15 minutes and when it stops only while this tag is DEBUG:
 
 ```bash
-adb shell setprop log.tag.KernelAI DEBUG
+adb shell setprop log.tag.WakeWordDiag DEBUG
 ```
+
+  `Log.isLoggable` is evaluated when a detector run begins. Stop and re-arm or otherwise restart the detector after changing this property; changing it does not enable diagnostics for an already-running detector.
 
 - Perform one locked-screen spoken `Hey Jandal` activation before the measured window. Confirm activation and no crash. Record it as a **pre-test smoke activation**, not as idle-window activity.
 
@@ -60,7 +62,7 @@ adb shell dumpsys deviceidle
 adb shell dumpsys activity services com.kernel.ai.debug
 adb shell dumpsys batterystats --reset
 adb shell dumpsys batterystats com.kernel.ai.debug
-adb logcat -d -v threadtime -s KernelAI:D '*:S' | grep -F "WakeWordDetector: diagnostics"
+adb logcat -d -v threadtime -s WakeWordDiag:D '*:S'
 ```
 
 Record locally:
@@ -101,10 +103,10 @@ adb shell dumpsys power
 adb shell dumpsys deviceidle
 adb shell dumpsys activity services com.kernel.ai.debug
 adb shell dumpsys meminfo com.kernel.ai.debug
-adb logcat -d -v threadtime -s KernelAI:D '*:S' | grep -F "WakeWordDetector: diagnostics"
+adb logcat -d -v threadtime -s WakeWordDiag:D '*:S'
 ```
 
-The `KernelAI` tag can include routed transcripts during spoken smoke checks. Never redirect, retain, attach, or share its unfiltered output. Extract only `WakeWordDetector: diagnostics` lines, then record their aggregate fields in the report; redact any accidental non-diagnostic line before it leaves the local terminal.
+`WakeWordDiag` is reserved for aggregate `WakeWordDetector: diagnostics` summaries. Retain only the summary fields needed by the report; do not attach raw device logs.
 
 The relevant low-frequency `WakeWordDetector: diagnostics` lines contain:
 
@@ -120,3 +122,13 @@ Interpret provider status carefully: `session_created_nnapi_requested_assignment
 Calculate and report exact elapsed time, percentage points consumed, percentage points per hour, Stage 2/3 executions per hour, silence-gate skip ratio, verifier statistics, activation counts, service continuity, batterystats attribution, wakelock observations, and NNAPI classification. Note battery-level granularity, radio/network activity, battery age/calibration, temperature, and other system services as measurement limits.
 
 After collecting end evidence, perform one final spoken locked-screen `Hey Jandal` activation. Record it as a **post-test smoke activation**, separately from idle-window activity.
+
+## Cleanup
+
+After the final capture, restore the dedicated diagnostic tag:
+
+```bash
+adb shell setprop log.tag.WakeWordDiag INFO
+```
+
+Stop and re-arm or restart the detector after restoring the property if it will continue running. Its current run retains the DEBUG decision made when it started.

--- a/docs/testing/wake-word-battery-test.md
+++ b/docs/testing/wake-word-battery-test.md
@@ -60,7 +60,7 @@ adb shell dumpsys deviceidle
 adb shell dumpsys activity services com.kernel.ai.debug
 adb shell dumpsys batterystats --reset
 adb shell dumpsys batterystats com.kernel.ai.debug
-adb logcat -d -v threadtime -s KernelAI:D '*:S'
+adb logcat -d -v threadtime -s KernelAI:D '*:S' | grep -F "WakeWordDetector: diagnostics"
 ```
 
 Record locally:
@@ -101,8 +101,10 @@ adb shell dumpsys power
 adb shell dumpsys deviceidle
 adb shell dumpsys activity services com.kernel.ai.debug
 adb shell dumpsys meminfo com.kernel.ai.debug
-adb logcat -d -v threadtime -s KernelAI:D '*:S'
+adb logcat -d -v threadtime -s KernelAI:D '*:S' | grep -F "WakeWordDetector: diagnostics"
 ```
+
+The `KernelAI` tag can include routed transcripts during spoken smoke checks. Never redirect, retain, attach, or share its unfiltered output. Extract only `WakeWordDetector: diagnostics` lines, then record their aggregate fields in the report; redact any accidental non-diagnostic line before it leaves the local terminal.
 
 The relevant low-frequency `WakeWordDetector: diagnostics` lines contain:
 


### PR DESCRIPTION
## Scope

- Adds debug-gated, 15-minute wake-word cadence counters and conservative NNAPI request-status wording.
- Routes diagnostic enablement and summaries exclusively through `WakeWordDiag`; existing operational `KernelAI` logging is unchanged.
- Adds focused counter/tag tests, a repeatable unplugged real-device procedure, and sanitized S21 evidence for #1142.
- Adds no wake-word threshold, cadence, or speculative performance change.

## Controlled whole-device result

- Samsung S21 official window: 4 h 00 m 48 s, 95% → 71%, **24 percentage points / 5.98 percentage points per hour**.
- The enabled configuration had the wake-word service active, display off, Dozing/IDLE, normal connectivity, and no intentional interactions.
- Quiet partial-window cadence: Stage 2 **4,351.8/h**, Stage 3 **4,241.2/h**, silence skips **90.33%**.
- This is a serious launch-risk signal: retaining the tested configuration as default-on is unacceptable without comparative evidence.

## Attribution boundary

The run demonstrates a strong correlation between the enabled wake path, continuous detector workload, and excessive **whole-device** drain. It does **not** isolate Jandal's exact battery share or prove that `AudioRecord` plus ONNX caused all observed drain: package-level battery attribution, app-specific wakelock attribution, and a same-device wake-word-disabled control are absent.

NNAPI assignment remains **inconclusive**. `CPU_DISABLED` was requested and an embedding session was created, but no native ONNX Runtime node-assignment/execution evidence proves accelerator offload.

## Diagnostic privacy and follow-up

- Future runs enable `WakeWordDiag` with `adb shell setprop log.tag.WakeWordDiag DEBUG`, collect only that tag, and restore `INFO` after the run. The detector must be restarted/re-armed after either property change because the DEBUG decision is latched per detector run.
- #1391 now carries `launch:blocking` and the v1.0 launch milestone. It requires a matched same-S21, four-hour, wake-word-disabled control before current NNAPI-requested, CPU-only, or later candidate comparisons can support a causal or release-default conclusion.
- The original completed-run report transparently notes it used the pre-fix diagnostic-tag configuration; no raw logs were retained or committed.

## Verification

- `:core:voice:testDebugUnitTest` — passed.
- `:core:voice:lintDebug` — passed.
- `:app:assembleDebug` — passed.
- Final diff reviewed: no raw device endpoint, serial, account detail, screenshot, raw logcat, detector threshold, or cadence change.

PR #1392 satisfies #1142's measurement/evidence work. #1142 remains open until this corrected evidence PR merges; remediation and launch-blocking tracking are in #1391. Relates to #65. Does not close either issue.