### PR TITLE
test(voice): add debug acoustic stimulus source (#1406)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ scripts/private-battery-runs/
 !scripts/testdata/
 !scripts/testdata/fixtures/
 !scripts/testdata/fixtures/*
+scripts/private-acoustic-fixtures/
+scripts/private-acoustic-runs/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.time.Instant
+import java.util.zip.ZipFile
 
 plugins {
     alias(libs.plugins.android.application)
@@ -89,6 +90,63 @@ android {
         }
     }
 }
+
+tasks.register("verifyAcousticStimulusReleaseIsolation") {
+    dependsOn("assembleDebug", "assembleRelease", "bundleRelease")
+    doLast {
+        val buildDirectory = layout.buildDirectory.get().asFile
+        val manifests = buildDirectory.walkTopDown()
+            .filter { it.isFile && it.name == "AndroidManifest.xml" }
+            .toList()
+        fun mergedManifest(variant: String): File = manifests.firstOrNull { file ->
+            file.path.contains("/$variant/") && file.path.contains("merged")
+        } ?: error("Merged $variant manifest not found")
+
+        val debugManifest = mergedManifest("debug").readText()
+        val releaseManifest = mergedManifest("release").readText()
+        check("package=\"com.kernel.ai.debug\"" in debugManifest) {
+            "Debug manifest package must be com.kernel.ai.debug"
+        }
+        check("com.kernel.ai.debug.acoustic.AcousticStimulusReceiver" in debugManifest)
+        check("com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS" in debugManifest)
+        check("com.kernel.ai.debug.acoustic.AcousticStimulusReceiver" !in releaseManifest)
+        check("com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS" !in releaseManifest)
+        check("package=\"com.kernel.ai\"" in releaseManifest) {
+            "Release manifest package must be com.kernel.ai"
+        }
+
+        val artifacts = listOf(
+            buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
+            buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),
+            buildDirectory.resolve("outputs/bundle/release/app-release.aab"),
+        )
+        artifacts.forEach { artifact ->
+            check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
+            ZipFile(artifact).use { zip ->
+                val names = zip.entries().asSequence().map { it.name }.toList()
+                check(names.none { it.endsWith(".wav", ignoreCase = true) }) {
+                    "WAV fixture packaged in ${artifact.name}"
+                }
+                val helperBytes = zip.entries().asSequence()
+                    .filter { !it.isDirectory }
+                    .flatMap { entry ->
+                        zip.getInputStream(entry).use { input -> sequenceOf(input.readBytes()) }
+                    }
+                    .any { bytes ->
+                        val text = bytes.toString(Charsets.ISO_8859_1)
+                        "AcousticStimulusReceiver" in text ||
+                            "com/kernel/ai/debug/acoustic" in text
+                    }
+                if (artifact.name.contains("release")) {
+                    check(!helperBytes) { "Debug acoustic helper packaged in ${artifact.name}" }
+                } else {
+                    check(helperBytes) { "Debug acoustic helper missing from ${artifact.name}" }
+                }
+            }
+        }
+    }
+}
+
 
 dependencies {
     implementation(project(":core:inference"))

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -23,6 +23,13 @@
                     android:pathPrefix="/callback" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name="com.kernel.ai.debug.acoustic.AcousticStimulusReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusContract.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusContract.kt
@@ -1,0 +1,126 @@
+package com.kernel.ai.debug.acoustic
+
+import android.content.Intent
+import android.os.Bundle
+import java.util.Locale
+
+internal object AcousticStimulusContract {
+    const val ACTION_PLAY = "com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS"
+    const val EXTRA_TRIAL_ID = "trial_id"
+    const val EXTRA_FIXTURE_ID = "fixture_id"
+    const val EXTRA_VOLUME_INDEX = "volume_index"
+    const val EXTRA_PLAYER_GAIN = "player_gain"
+    const val EXTRA_FIXTURE_PATH = "fixture_path"
+
+    const val RESULT_OK = 0
+    const val RESULT_REJECTED = 1
+    const val RESULT_FAILED = 2
+
+    const val MAX_TRIAL_ID_LENGTH = 128
+    const val MAX_FIXTURE_ID_LENGTH = 64
+    const val MIN_PLAYER_GAIN = 0.1f
+    const val MAX_PLAYER_GAIN = 1.0f
+    const val HARD_TIMEOUT_MS = 7_000L
+
+    val acceptedExtras: Set<String> = setOf(
+        EXTRA_TRIAL_ID,
+        EXTRA_FIXTURE_ID,
+        EXTRA_VOLUME_INDEX,
+        EXTRA_PLAYER_GAIN,
+    )
+}
+
+data class StimulusInvocation(
+    val trialId: String,
+    val fixtureId: String,
+    val volumeIndex: Int,
+    val playerGain: Float,
+)
+
+data class InvalidInvocation(
+    val category: String,
+    val trialId: String?,
+    val fixtureId: String?,
+)
+
+sealed interface InvocationParseResult {
+    data class Valid(val invocation: StimulusInvocation) : InvocationParseResult
+    data class Invalid(val error: InvalidInvocation) : InvocationParseResult
+}
+
+internal object InvocationParser {
+    private val trialIdPattern = Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+    private val fixtureIdPattern = Regex("[a-z0-9][a-z0-9_-]{0,63}")
+
+    fun parse(intent: Intent): InvocationParseResult {
+        val extras = intent.extras
+        val values = extras?.keySet()?.associateWith { extras.get(it) } ?: emptyMap()
+        return parse(intent.action, values)
+    }
+
+    fun parse(action: String?, values: Map<String, Any?>): InvocationParseResult {
+        if (action != AcousticStimulusContract.ACTION_PLAY) {
+            return invalid("invalid_action", values[AcousticStimulusContract.EXTRA_TRIAL_ID] as? String)
+        }
+        val unsupportedKey = values.keys.firstOrNull { it !in AcousticStimulusContract.acceptedExtras }
+        if (unsupportedKey != null) {
+            val category = if (unsupportedKey == AcousticStimulusContract.EXTRA_FIXTURE_PATH) {
+                "arbitrary_path_not_allowed"
+            } else {
+                "unsupported_extra"
+            }
+            return invalid(category, values[AcousticStimulusContract.EXTRA_TRIAL_ID] as? String)
+        }
+        if (!values.containsKey(AcousticStimulusContract.EXTRA_TRIAL_ID)) {
+            return invalid("missing_trial_id", null)
+        }
+        val trialId = values[AcousticStimulusContract.EXTRA_TRIAL_ID] as? String
+        if (trialId == null || trialId.length !in 1..AcousticStimulusContract.MAX_TRIAL_ID_LENGTH ||
+            !trialIdPattern.matches(trialId)
+        ) {
+            return invalid("malformed_trial_id", trialId)
+        }
+        if (!values.containsKey(AcousticStimulusContract.EXTRA_FIXTURE_ID)) {
+            return invalid("missing_fixture_id", trialId)
+        }
+        val fixtureId = values[AcousticStimulusContract.EXTRA_FIXTURE_ID] as? String
+        if (fixtureId == null || fixtureId.isBlank()) {
+            return invalid("missing_fixture_id", trialId)
+        }
+        if (fixtureId.contains('/') || fixtureId.contains('\\') || fixtureId.contains("..")) {
+            return invalid("arbitrary_path_not_allowed", trialId, fixtureId)
+        }
+        if (fixtureId.length !in 1..AcousticStimulusContract.MAX_FIXTURE_ID_LENGTH ||
+            !fixtureIdPattern.matches(fixtureId)
+        ) {
+            return invalid("malformed_fixture_id", trialId, fixtureId)
+        }
+        val rawVolume = values[AcousticStimulusContract.EXTRA_VOLUME_INDEX]
+        if (rawVolume !is Int) {
+            return invalid("missing_or_malformed_volume_index", trialId, fixtureId)
+        }
+        if (rawVolume < 1) {
+            return invalid("unsafe_volume_index", trialId, fixtureId)
+        }
+        val gain = when {
+            !values.containsKey(AcousticStimulusContract.EXTRA_PLAYER_GAIN) ->
+                AcousticStimulusContract.MAX_PLAYER_GAIN
+            values[AcousticStimulusContract.EXTRA_PLAYER_GAIN] !is Number ->
+                return invalid("malformed_player_gain", trialId, fixtureId)
+            else -> (values[AcousticStimulusContract.EXTRA_PLAYER_GAIN] as Number).toFloat()
+        }
+        if (!gain.isFinite() || gain !in AcousticStimulusContract.MIN_PLAYER_GAIN..AcousticStimulusContract.MAX_PLAYER_GAIN) {
+            return invalid("unsafe_player_gain", trialId, fixtureId)
+        }
+        return InvocationParseResult.Valid(
+            StimulusInvocation(trialId, fixtureId, rawVolume, gain),
+        )
+    }
+
+    private fun invalid(category: String, trialId: String?, fixtureId: String? = null) =
+        InvocationParseResult.Invalid(InvalidInvocation(category, trialId, fixtureId))
+
+    private fun Bundle.stringValue(key: String): String? = get(key) as? String
+}
+
+internal fun String.sha256Normalised(): String = lowercase(Locale.US)

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusEngine.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusEngine.kt
@@ -75,6 +75,9 @@ internal data class StimulusEvent(
     val name: String,
     val monotonicMs: Long,
     val wallClockMs: Long,
+    val cleanupSuccess: Boolean? = null,
+    val exactRestorationVerified: Boolean? = null,
+    val errorCategory: String? = null,
 )
 
 internal data class StimulusResult(
@@ -103,6 +106,8 @@ internal data class StimulusResult(
     val cleanupSuccess: Boolean,
     val exactRestorationVerified: Boolean,
     val events: List<StimulusEvent>,
+    val playbackErrorCategory: String? = null,
+    val evidencePersistenceFailed: Boolean = false,
 ) {
     fun toJson(): JSONObject = JSONObject().apply {
         put("schema_version", RESULT_SCHEMA_VERSION)
@@ -126,6 +131,8 @@ internal data class StimulusResult(
         put("focus_result", focusResult)
         put("completion_status", completionStatus)
         putOpt("error_category", errorCategory)
+        putOpt("playback_error_category", playbackErrorCategory)
+        put("evidence_persistence_failed", evidencePersistenceFailed)
         put("timeout", timeout)
         put("overlap_rejected", overlapRejected)
         put("cleanup_success", cleanupSuccess)
@@ -137,6 +144,9 @@ internal data class StimulusResult(
                         put("name", event.name)
                         put("monotonic_ms", event.monotonicMs)
                         put("wall_clock_ms", event.wallClockMs)
+                        putOpt("cleanup_success", event.cleanupSuccess)
+                        putOpt("exact_restoration_verified", event.exactRestorationVerified)
+                        putOpt("error_category", event.errorCategory)
                     },
                 )
             }
@@ -220,13 +230,29 @@ internal class AcousticStimulusEngine(
         }
     }
 
-    private fun deliver(result: StimulusResult, finish: (StimulusResult) -> Unit) {
-        try {
+    private fun deliver(
+        result: StimulusResult,
+        finish: (StimulusResult) -> Unit,
+        releaseGate: Boolean = false,
+    ) {
+        val externallyReturned = try {
             resultWriter.write(result)
+            result
         } catch (error: Exception) {
-            Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "result_write_failed", error)
+            runCatching {
+                Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "result_write_failed", error)
+            }
+            result.copy(
+                completionStatus = "invalid",
+                errorCategory = "result_write_failed",
+                playbackErrorCategory = result.playbackErrorCategory ?: result.errorCategory,
+                evidencePersistenceFailed = true,
+            )
+        }
+        try {
+            finish(externallyReturned)
         } finally {
-            finish(result)
+            if (releaseGate) PlaybackGate.release()
         }
     }
 
@@ -388,8 +414,20 @@ internal class AcousticStimulusEngine(
 
         fun isComplete(): Boolean = completed
 
-        fun record(name: String) {
-            val event = StimulusEvent(name, time.monotonicMs(), time.wallClockMs())
+        fun record(
+            name: String,
+            cleanupSuccess: Boolean? = null,
+            exactRestorationVerified: Boolean? = null,
+            errorCategory: String? = null,
+        ) {
+            val event = StimulusEvent(
+                name = name,
+                monotonicMs = time.monotonicMs(),
+                wallClockMs = time.wallClockMs(),
+                cleanupSuccess = cleanupSuccess,
+                exactRestorationVerified = exactRestorationVerified,
+                errorCategory = errorCategory,
+            )
             events += event
             try {
                 eventLogger.event(event, invocation.trialId, invocation.fixtureId)
@@ -453,6 +491,12 @@ internal class AcousticStimulusEngine(
                     cleanupError = cleanupError ?: "volume_restoration_failed"
                 }
             }
+            record(
+                name = "cleanup_completed",
+                cleanupSuccess = cleanupSuccess,
+                exactRestorationVerified = exactRestorationVerified,
+                errorCategory = cleanupError,
+            )
             val result = StimulusResult(
                 trialId = invocation.trialId,
                 fixtureId = invocation.fixtureId,
@@ -479,9 +523,9 @@ internal class AcousticStimulusEngine(
                 cleanupSuccess = cleanupSuccess,
                 exactRestorationVerified = exactRestorationVerified,
                 events = events.toList(),
+                playbackErrorCategory = errorCategory.takeIf { cleanupError != null },
             )
-            PlaybackGate.release()
-            deliver(result, finish)
+            deliver(result, finish, releaseGate = true)
         }
     }
 }
@@ -610,6 +654,9 @@ internal object AndroidStimulusEventLogger : StimulusEventLogger {
             put("fixture_id", fixtureId)
             put("monotonic_ms", result.monotonicMs)
             put("wall_clock_ms", result.wallClockMs)
+            putOpt("cleanup_success", result.cleanupSuccess)
+            putOpt("exact_restoration_verified", result.exactRestorationVerified)
+            putOpt("error_category", result.errorCategory)
         }
         Log.i(ACOUSTIC_STIMULUS_LOG_TAG, json.toString())
     }

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusEngine.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusEngine.kt
@@ -1,0 +1,616 @@
+package com.kernel.ai.debug.acoustic
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioDeviceInfo
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaPlayer
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.FileInputStream
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal const val ACOUSTIC_STIMULUS_LOG_TAG = "AcousticStimulus"
+private const val RESULT_SCHEMA_VERSION = 1
+private const val STREAM = AudioManager.STREAM_MUSIC
+
+internal val STIMULUS_AUDIO_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
+    .setUsage(AudioAttributes.USAGE_MEDIA)
+    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+    .build()
+
+enum class OutputRoute {
+    BUILT_IN_SPEAKER,
+    EXTERNAL_BLUETOOTH,
+    OTHER,
+    UNKNOWN,
+}
+
+data class AudioSnapshot(
+    val volumeBefore: Int,
+    val maximumVolume: Int,
+    val routeBefore: OutputRoute,
+)
+
+interface FocusHandle
+
+sealed interface FocusRequestResult {
+    data class Granted(val handle: FocusHandle) : FocusRequestResult
+    data class Denied(val reason: String = "request_denied") : FocusRequestResult
+}
+
+internal interface StimulusAudioController {
+    fun snapshot(): AudioSnapshot
+    fun currentRoute(): OutputRoute
+    fun setMediaVolume(volume: Int)
+    fun currentMediaVolume(): Int
+    fun requestFocus(): FocusRequestResult
+    fun abandonFocus(handle: FocusHandle)
+}
+
+internal interface StimulusPlayer {
+    fun setGain(gain: Float)
+    fun setDataSource(fileDescriptor: FileDescriptor)
+    fun setOnPreparedListener(listener: () -> Unit)
+    fun setOnCompletionListener(listener: () -> Unit)
+    fun setOnErrorListener(listener: (what: Int, extra: Int) -> Unit)
+    fun prepareAsync()
+    fun start()
+    fun release()
+}
+
+internal fun interface StimulusPlayerFactory {
+    fun create(): StimulusPlayer
+}
+
+internal data class StimulusEvent(
+    val name: String,
+    val monotonicMs: Long,
+    val wallClockMs: Long,
+)
+
+internal data class StimulusResult(
+    val trialId: String?,
+    val fixtureId: String?,
+    val fixtureSha256: String?,
+    val fixtureDurationMs: Long?,
+    val requestWallClockMs: Long,
+    val requestMonotonicMs: Long,
+    val prepareMonotonicMs: Long?,
+    val playbackStartMonotonicMs: Long?,
+    val completionMonotonicMs: Long?,
+    val cleanupMonotonicMs: Long?,
+    val volumeBefore: Int?,
+    val requestedVolume: Int?,
+    val appliedVolume: Int?,
+    val maximumVolume: Int?,
+    val restoredVolume: Int?,
+    val outputRouteBefore: OutputRoute?,
+    val outputRouteDuring: OutputRoute?,
+    val focusResult: String,
+    val completionStatus: String,
+    val errorCategory: String?,
+    val timeout: Boolean,
+    val overlapRejected: Boolean,
+    val cleanupSuccess: Boolean,
+    val exactRestorationVerified: Boolean,
+    val events: List<StimulusEvent>,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("schema_version", RESULT_SCHEMA_VERSION)
+        putOpt("trial_id", trialId)
+        putOpt("fixture_id", fixtureId)
+        putOpt("fixture_sha256", fixtureSha256)
+        putOpt("fixture_duration_ms", fixtureDurationMs)
+        put("request_wall_clock_ms", requestWallClockMs)
+        put("request_monotonic_ms", requestMonotonicMs)
+        putOpt("prepare_monotonic_ms", prepareMonotonicMs)
+        putOpt("playback_start_monotonic_ms", playbackStartMonotonicMs)
+        putOpt("completion_monotonic_ms", completionMonotonicMs)
+        putOpt("cleanup_monotonic_ms", cleanupMonotonicMs)
+        putOpt("volume_before", volumeBefore)
+        putOpt("requested_volume", requestedVolume)
+        putOpt("applied_volume", appliedVolume)
+        putOpt("maximum_volume", maximumVolume)
+        putOpt("restored_volume", restoredVolume)
+        putOpt("output_route_before", outputRouteBefore?.name)
+        putOpt("output_route_during", outputRouteDuring?.name)
+        put("focus_result", focusResult)
+        put("completion_status", completionStatus)
+        putOpt("error_category", errorCategory)
+        put("timeout", timeout)
+        put("overlap_rejected", overlapRejected)
+        put("cleanup_success", cleanupSuccess)
+        put("exact_restoration_verified", exactRestorationVerified)
+        put("events", JSONArray().apply {
+            events.forEach { event ->
+                put(
+                    JSONObject().apply {
+                        put("name", event.name)
+                        put("monotonic_ms", event.monotonicMs)
+                        put("wall_clock_ms", event.wallClockMs)
+                    },
+                )
+            }
+        })
+    }
+}
+
+internal fun interface StimulusClock {
+    fun wallClockMs(): Long
+}
+
+internal interface StimulusTimeSource {
+    fun wallClockMs(): Long
+    fun monotonicMs(): Long
+}
+
+internal object SystemStimulusTimeSource : StimulusTimeSource {
+    override fun wallClockMs(): Long = System.currentTimeMillis()
+    override fun monotonicMs(): Long = SystemClock.elapsedRealtime()
+}
+
+internal interface StimulusCancellation {
+    fun cancel()
+}
+
+internal interface StimulusScheduler {
+    fun schedule(delayMs: Long, action: () -> Unit): StimulusCancellation
+}
+
+internal interface StimulusResultWriter {
+    fun write(result: StimulusResult)
+}
+
+internal fun interface StimulusEventLogger {
+    fun event(result: StimulusEvent, trialId: String?, fixtureId: String?)
+}
+
+internal object PlaybackGate {
+    private val inProgress = AtomicBoolean(false)
+
+    fun tryAcquire(): Boolean = inProgress.compareAndSet(false, true)
+    fun release() {
+        inProgress.set(false)
+    }
+}
+
+internal class AcousticStimulusEngine(
+    private val fixtures: FixtureSource,
+    private val audio: StimulusAudioController,
+    private val playerFactory: StimulusPlayerFactory,
+    private val scheduler: StimulusScheduler,
+    private val time: StimulusTimeSource,
+    private val resultWriter: StimulusResultWriter,
+    private val eventLogger: StimulusEventLogger,
+) {
+    fun handle(
+        parsed: InvocationParseResult,
+        finish: (StimulusResult) -> Unit,
+    ) {
+        val requestWallClockMs = time.wallClockMs()
+        val requestMonotonicMs = time.monotonicMs()
+        when (parsed) {
+            is InvocationParseResult.Invalid -> {
+                val error = parsed.error
+                val result = invalidResult(
+                    trialId = error.trialId,
+                    fixtureId = error.fixtureId,
+                    requestWallClockMs = requestWallClockMs,
+                    requestMonotonicMs = requestMonotonicMs,
+                    errorCategory = error.category,
+                    overlapRejected = false,
+                )
+                deliver(result, finish)
+            }
+            is InvocationParseResult.Valid -> start(
+                parsed.invocation,
+                requestWallClockMs,
+                requestMonotonicMs,
+                finish,
+            )
+        }
+    }
+
+    private fun deliver(result: StimulusResult, finish: (StimulusResult) -> Unit) {
+        try {
+            resultWriter.write(result)
+        } catch (error: Exception) {
+            Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "result_write_failed", error)
+        } finally {
+            finish(result)
+        }
+    }
+
+    private fun start(
+        invocation: StimulusInvocation,
+        requestWallClockMs: Long,
+        requestMonotonicMs: Long,
+        finish: (StimulusResult) -> Unit,
+    ) {
+        if (!PlaybackGate.tryAcquire()) {
+            val result = invalidResult(
+                trialId = invocation.trialId,
+                fixtureId = invocation.fixtureId,
+                requestWallClockMs = requestWallClockMs,
+                requestMonotonicMs = requestMonotonicMs,
+                errorCategory = "overlap_rejected",
+                overlapRejected = true,
+            )
+            deliver(result, finish)
+            return
+        }
+        val state = SessionState(invocation, requestWallClockMs, requestMonotonicMs, finish)
+        try {
+            state.timeout = scheduler.schedule(AcousticStimulusContract.HARD_TIMEOUT_MS) {
+                state.complete("timeout", "playback_timeout", timedOut = true)
+            }
+            val resolved = fixtures.resolveAndValidate(invocation.fixtureId)
+            state.fixture = resolved
+            if (state.isComplete()) return
+            state.snapshot = audio.snapshot()
+            if (state.snapshot!!.routeBefore != OutputRoute.BUILT_IN_SPEAKER) {
+                state.complete("rejected", "invalid_output_route")
+                return
+            }
+            if (invocation.volumeIndex !in 1..state.snapshot!!.maximumVolume) {
+                state.complete("rejected", "unsafe_volume_index")
+                return
+            }
+            state.requestedVolume = invocation.volumeIndex
+            audio.setMediaVolume(invocation.volumeIndex)
+            state.appliedVolume = audio.currentMediaVolume()
+            if (state.appliedVolume != invocation.volumeIndex) {
+                state.complete("rejected", "volume_apply_failed")
+                return
+            }
+            when (val focus = audio.requestFocus()) {
+                is FocusRequestResult.Denied -> {
+                    state.focusResult = "denied:${focus.reason}"
+                    state.complete("rejected", "audio_focus_denied")
+                    return
+                }
+                is FocusRequestResult.Granted -> {
+                    state.focusHandle = focus.handle
+                    state.focusResult = "granted"
+                }
+            }
+            if (audio.currentRoute() != OutputRoute.BUILT_IN_SPEAKER) {
+                state.complete("rejected", "invalid_output_route")
+                return
+            }
+            state.source = fixtures.openFixture(resolved)
+            state.player = playerFactory.create()
+            state.player!!.setGain(invocation.playerGain)
+            state.player!!.setOnPreparedListener {
+                if (state.isComplete()) return@setOnPreparedListener
+                state.record("prepared")
+                state.prepareMonotonicMs = time.monotonicMs()
+                val routeValid = try {
+                    audio.currentRoute() == OutputRoute.BUILT_IN_SPEAKER
+                } catch (_: Exception) {
+                    false
+                }
+                if (!routeValid) {
+                    state.complete("rejected", "invalid_output_route")
+                    return@setOnPreparedListener
+                }
+                try {
+                    state.player!!.start()
+                    state.record("started")
+                    state.playbackStartMonotonicMs = time.monotonicMs()
+                } catch (_: Exception) {
+                    state.complete("failed", "playback_start_failed")
+                }
+            }
+            state.player!!.setOnCompletionListener {
+                state.complete("completed", null)
+            }
+            state.player!!.setOnErrorListener { _, _ ->
+                state.complete("failed", "playback_error")
+            }
+            state.player!!.setDataSource(state.source!!.fd)
+            state.player!!.prepareAsync()
+        } catch (error: FixtureValidationException) {
+            state.complete("rejected", error.category)
+        } catch (_: SecurityException) {
+            state.complete("failed", "audio_state_access_failed")
+        } catch (_: Exception) {
+            state.complete("failed", "prepare_failed")
+        }
+    }
+
+    private fun invalidResult(
+        trialId: String?,
+        fixtureId: String?,
+        requestWallClockMs: Long,
+        requestMonotonicMs: Long,
+        errorCategory: String,
+        overlapRejected: Boolean,
+    ): StimulusResult = StimulusResult(
+        trialId = trialId,
+        fixtureId = fixtureId,
+        fixtureSha256 = null,
+        fixtureDurationMs = null,
+        requestWallClockMs = requestWallClockMs,
+        requestMonotonicMs = requestMonotonicMs,
+        prepareMonotonicMs = null,
+        playbackStartMonotonicMs = null,
+        completionMonotonicMs = requestMonotonicMs,
+        cleanupMonotonicMs = requestMonotonicMs,
+        volumeBefore = null,
+        requestedVolume = null,
+        appliedVolume = null,
+        maximumVolume = null,
+        restoredVolume = null,
+        outputRouteBefore = null,
+        outputRouteDuring = null,
+        focusResult = "not_requested",
+        completionStatus = "rejected",
+        errorCategory = errorCategory,
+        timeout = false,
+        overlapRejected = overlapRejected,
+        cleanupSuccess = true,
+        exactRestorationVerified = true,
+        events = emptyList(),
+    )
+
+    private inner class SessionState(
+        private val invocation: StimulusInvocation,
+        private val requestWallClockMs: Long,
+        private val requestMonotonicMs: Long,
+        private val finish: (StimulusResult) -> Unit,
+    ) {
+        var fixture: ResolvedFixture? = null
+        var snapshot: AudioSnapshot? = null
+        var requestedVolume: Int? = null
+        var appliedVolume: Int? = null
+        var restoredVolume: Int? = null
+        var focusHandle: FocusHandle? = null
+        var focusResult: String = "not_requested"
+        var source: FileInputStream? = null
+        var player: StimulusPlayer? = null
+        var timeout: StimulusCancellation? = null
+        var prepareMonotonicMs: Long? = null
+        var playbackStartMonotonicMs: Long? = null
+        var outputRouteDuring: OutputRoute? = null
+        private val events = mutableListOf<StimulusEvent>()
+        @Volatile
+        private var completed = false
+
+        fun isComplete(): Boolean = completed
+
+        fun record(name: String) {
+            val event = StimulusEvent(name, time.monotonicMs(), time.wallClockMs())
+            events += event
+            try {
+                eventLogger.event(event, invocation.trialId, invocation.fixtureId)
+            } catch (error: Exception) {
+                Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "event_log_failed", error)
+            }
+        }
+
+        @Synchronized
+        fun complete(status: String, errorCategory: String?, timedOut: Boolean = false) {
+            if (completed) return
+            completed = true
+            timeout?.cancel()
+            val completionMonotonicMs = time.monotonicMs()
+            var cleanupSuccess = true
+            var exactRestorationVerified = true
+            var cleanupError: String? = null
+            record(if (timedOut) "timeout" else if (errorCategory == null) "completed" else "error")
+            val capturedSnapshot = snapshot
+            if (capturedSnapshot != null) {
+                outputRouteDuring = try {
+                    audio.currentRoute()
+                } catch (_: Exception) {
+                    cleanupSuccess = false
+                    cleanupError = "output_route_unavailable"
+                    OutputRoute.UNKNOWN
+                }
+            }
+            try {
+                player?.release()
+            } catch (_: Exception) {
+                cleanupSuccess = false
+                cleanupError = "player_release_failed"
+            }
+            try {
+                source?.close()
+            } catch (_: Exception) {
+                cleanupSuccess = false
+                cleanupError = cleanupError ?: "fixture_fd_close_failed"
+            }
+            focusHandle?.let { handle ->
+                try {
+                    audio.abandonFocus(handle)
+                } catch (_: Exception) {
+                    cleanupSuccess = false
+                    cleanupError = cleanupError ?: "audio_focus_abandon_failed"
+                }
+            }
+            if (capturedSnapshot != null) {
+                try {
+                    audio.setMediaVolume(capturedSnapshot.volumeBefore)
+                    restoredVolume = audio.currentMediaVolume()
+                    exactRestorationVerified = restoredVolume == capturedSnapshot.volumeBefore
+                    if (!exactRestorationVerified) {
+                        cleanupSuccess = false
+                        cleanupError = cleanupError ?: "volume_restoration_failed"
+                    }
+                } catch (_: Exception) {
+                    cleanupSuccess = false
+                    exactRestorationVerified = false
+                    cleanupError = cleanupError ?: "volume_restoration_failed"
+                }
+            }
+            val result = StimulusResult(
+                trialId = invocation.trialId,
+                fixtureId = invocation.fixtureId,
+                fixtureSha256 = fixture?.metadata?.sha256,
+                fixtureDurationMs = fixture?.metadata?.durationMs,
+                requestWallClockMs = requestWallClockMs,
+                requestMonotonicMs = requestMonotonicMs,
+                prepareMonotonicMs = prepareMonotonicMs,
+                playbackStartMonotonicMs = playbackStartMonotonicMs,
+                completionMonotonicMs = completionMonotonicMs,
+                cleanupMonotonicMs = time.monotonicMs(),
+                volumeBefore = capturedSnapshot?.volumeBefore,
+                requestedVolume = requestedVolume,
+                appliedVolume = appliedVolume,
+                maximumVolume = capturedSnapshot?.maximumVolume,
+                restoredVolume = restoredVolume,
+                outputRouteBefore = capturedSnapshot?.routeBefore,
+                outputRouteDuring = outputRouteDuring,
+                focusResult = focusResult,
+                completionStatus = if (cleanupError == null) status else "invalid",
+                errorCategory = cleanupError ?: errorCategory,
+                timeout = timedOut,
+                overlapRejected = false,
+                cleanupSuccess = cleanupSuccess,
+                exactRestorationVerified = exactRestorationVerified,
+                events = events.toList(),
+            )
+            PlaybackGate.release()
+            deliver(result, finish)
+        }
+    }
+}
+
+internal class AndroidMediaPlayerFactory : StimulusPlayerFactory {
+    override fun create(): StimulusPlayer = AndroidStimulusPlayer(MediaPlayer().apply {
+        setAudioAttributes(STIMULUS_AUDIO_ATTRIBUTES)
+    })
+}
+
+private class AndroidStimulusPlayer(private val player: MediaPlayer) : StimulusPlayer {
+    override fun setGain(gain: Float) = player.setVolume(gain, gain)
+    override fun setDataSource(fileDescriptor: FileDescriptor) = player.setDataSource(fileDescriptor)
+    override fun setOnPreparedListener(listener: () -> Unit) {
+        player.setOnPreparedListener { listener() }
+    }
+    override fun setOnCompletionListener(listener: () -> Unit) {
+        player.setOnCompletionListener { listener() }
+    }
+    override fun setOnErrorListener(listener: (what: Int, extra: Int) -> Unit) {
+        player.setOnErrorListener { _, what, extra ->
+            listener(what, extra)
+            true
+        }
+    }
+    override fun prepareAsync() = player.prepareAsync()
+    override fun start() = player.start()
+    override fun release() = player.release()
+}
+
+internal class AndroidStimulusAudioController(
+    context: Context,
+) : StimulusAudioController {
+    private val audioManager = context.getSystemService(AudioManager::class.java)
+
+    override fun snapshot(): AudioSnapshot = AudioSnapshot(
+        volumeBefore = audioManager.getStreamVolume(STREAM),
+        maximumVolume = audioManager.getStreamMaxVolume(STREAM),
+        routeBefore = currentRoute(),
+    )
+
+    override fun currentRoute(): OutputRoute {
+        val devices = try {
+            audioManager.getAudioDevicesForAttributes(STIMULUS_AUDIO_ATTRIBUTES)
+        } catch (_: SecurityException) {
+            return OutputRoute.UNKNOWN
+        }
+        if (devices.isEmpty()) return OutputRoute.UNKNOWN
+        if (devices.any { it.type in BLUETOOTH_OUTPUT_TYPES }) return OutputRoute.EXTERNAL_BLUETOOTH
+        return if (devices.all { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }) {
+            OutputRoute.BUILT_IN_SPEAKER
+        } else {
+            OutputRoute.OTHER
+        }
+    }
+
+    override fun setMediaVolume(volume: Int) = audioManager.setStreamVolume(STREAM, volume, 0)
+    override fun currentMediaVolume(): Int = audioManager.getStreamVolume(STREAM)
+
+    override fun requestFocus(): FocusRequestResult {
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(STIMULUS_AUDIO_ATTRIBUTES)
+            .setOnAudioFocusChangeListener { }
+            .setWillPauseWhenDucked(false)
+            .build()
+        val result = audioManager.requestAudioFocus(request)
+        return if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            FocusRequestResult.Granted(AndroidFocusHandle(request))
+        } else {
+            FocusRequestResult.Denied(result.toString())
+        }
+    }
+
+    override fun abandonFocus(handle: FocusHandle) {
+        audioManager.abandonAudioFocusRequest((handle as AndroidFocusHandle).request)
+    }
+
+    private data class AndroidFocusHandle(val request: AudioFocusRequest) : FocusHandle
+
+    companion object {
+        private val BLUETOOTH_OUTPUT_TYPES = setOf(
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            AudioDeviceInfo.TYPE_BLE_HEADSET,
+            AudioDeviceInfo.TYPE_BLE_SPEAKER,
+        )
+    }
+}
+
+internal class HandlerStimulusScheduler(
+    private val handler: Handler = Handler(Looper.getMainLooper()),
+) : StimulusScheduler {
+    override fun schedule(delayMs: Long, action: () -> Unit): StimulusCancellation {
+        val runnable = Runnable(action)
+        handler.postDelayed(runnable, delayMs)
+        return object : StimulusCancellation {
+            override fun cancel() {
+                handler.removeCallbacks(runnable)
+            }
+        }
+    }
+}
+
+internal class AndroidStimulusResultWriter(
+    private val context: Context,
+) : StimulusResultWriter {
+    override fun write(result: StimulusResult) {
+        val directory = AcousticFixtureStorage.resultDirectory(context).apply { mkdirs() }
+        val safeId = result.trialId?.takeIf { it.matches(Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,127}")) }
+            ?: "invalid-${result.requestMonotonicMs}"
+        val destination = File(directory, "$safeId.json")
+        val temporary = File(directory, "$safeId.json.tmp")
+        FileOutputStream(temporary).use { output ->
+            output.write(result.toJson().toString(2).toByteArray(Charsets.UTF_8))
+            output.fd.sync()
+        }
+        check(temporary.renameTo(destination)) { "result_write_failed" }
+    }
+}
+
+internal object AndroidStimulusEventLogger : StimulusEventLogger {
+    override fun event(result: StimulusEvent, trialId: String?, fixtureId: String?) {
+        val json = JSONObject().apply {
+            put("event", result.name)
+            put("trial_id", trialId)
+            put("fixture_id", fixtureId)
+            put("monotonic_ms", result.monotonicMs)
+            put("wall_clock_ms", result.wallClockMs)
+        }
+        Log.i(ACOUSTIC_STIMULUS_LOG_TAG, json.toString())
+    }
+}

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusFixtures.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusFixtures.kt
@@ -1,0 +1,258 @@
+package com.kernel.ai.debug.acoustic
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.io.RandomAccessFile
+import java.security.MessageDigest
+
+internal const val MAX_FIXTURE_DURATION_MS = 5_000L
+private const val SAMPLE_RATE_HZ = 48_000
+private const val CHANNEL_COUNT = 1
+private const val BITS_PER_SAMPLE = 16
+private const val BYTES_PER_SECOND = SAMPLE_RATE_HZ * CHANNEL_COUNT * BITS_PER_SAMPLE / 8
+private const val MAX_DATA_BYTES = BYTES_PER_SECOND * (MAX_FIXTURE_DURATION_MS / 1_000)
+private const val MAX_FILE_BYTES = MAX_DATA_BYTES + 4_096L
+
+internal object AcousticFixtureStorage {
+    const val DIRECTORY_NAME = "acoustic-fixtures"
+    const val MANIFEST_FILE_NAME = "manifest.json"
+    const val RESULTS_DIRECTORY_NAME = "acoustic-stimulus-results"
+
+    fun fixtureDirectory(context: Context): File = File(context.filesDir, DIRECTORY_NAME)
+    fun manifestFile(context: Context): File = File(fixtureDirectory(context), MANIFEST_FILE_NAME)
+    fun resultDirectory(context: Context): File = File(context.filesDir, RESULTS_DIRECTORY_NAME)
+}
+
+data class FixtureManifest(
+    val schemaVersion: Int,
+    val fixtures: List<FixtureEntry>,
+)
+
+data class FixtureEntry(
+    val fixtureId: String,
+    val fileName: String,
+    val sha256: String,
+    val durationMs: Long,
+)
+
+data class ResolvedFixture(
+    val entry: FixtureEntry,
+    val file: File,
+    val metadata: WavMetadata,
+)
+
+class FixtureValidationException(val category: String) : Exception(category)
+
+fun interface FixtureManifestReader {
+    fun read(file: File): FixtureManifest
+}
+
+internal class JsonFixtureManifestReader : FixtureManifestReader {
+    override fun read(file: File): FixtureManifest {
+        if (!file.isFile || file.length() == 0L) {
+            throw FixtureValidationException("fixture_manifest_missing")
+        }
+        val root = try {
+            JSONObject(file.readText(Charsets.UTF_8))
+        } catch (_: Exception) {
+            throw FixtureValidationException("fixture_manifest_invalid")
+        }
+        val schemaVersion = root.optInt("schema_version", -1)
+        val array = root.optJSONArray("fixtures")
+        if (schemaVersion != 1 || array == null) {
+            throw FixtureValidationException("fixture_manifest_invalid")
+        }
+        val fixtures = mutableListOf<FixtureEntry>()
+        for (index in 0 until array.length()) {
+            val entry = array.optJSONObject(index)
+                ?: throw FixtureValidationException("fixture_manifest_invalid")
+            val fixtureId = entry.optString("fixture_id", "")
+            val fileName = entry.optString("file_name", "")
+            val sha256 = entry.optString("sha256", "").sha256Normalised()
+            val durationMs = entry.optLong("duration_ms", -1L)
+            if (!isManifestId(fixtureId) || fileName.isBlank() ||
+                !isSha256(sha256) || durationMs <= 0L || durationMs > MAX_FIXTURE_DURATION_MS
+            ) {
+                throw FixtureValidationException("fixture_manifest_invalid")
+            }
+            if (fixtures.any { it.fixtureId == fixtureId }) {
+                throw FixtureValidationException("fixture_manifest_invalid")
+            }
+            fixtures += FixtureEntry(fixtureId, fileName, sha256, durationMs)
+        }
+        return FixtureManifest(schemaVersion, fixtures)
+    }
+}
+
+internal interface FixtureSource {
+    fun resolveAndValidate(fixtureId: String): ResolvedFixture
+    fun openFixture(fixture: ResolvedFixture): java.io.FileInputStream
+}
+
+
+internal class FileFixtureRepository(
+    private val fixtureDirectory: File,
+    private val manifestReader: FixtureManifestReader = JsonFixtureManifestReader(),
+) : FixtureSource {
+    override fun resolveAndValidate(fixtureId: String): ResolvedFixture {
+        val manifest = try {
+            manifestReader.read(File(fixtureDirectory, AcousticFixtureStorage.MANIFEST_FILE_NAME))
+        } catch (error: FixtureValidationException) {
+            throw error
+        } catch (_: Exception) {
+            throw FixtureValidationException("fixture_manifest_invalid")
+        }
+        val entry = manifest.fixtures.firstOrNull { it.fixtureId == fixtureId }
+            ?: throw FixtureValidationException("unknown_fixture")
+        if (!isSafeFileName(entry.fileName)) {
+            throw FixtureValidationException("arbitrary_path_not_allowed")
+        }
+        val root = fixtureDirectory.canonicalFile
+        val file = File(root, entry.fileName).canonicalFile
+        if (file.parentFile != root) {
+            throw FixtureValidationException("arbitrary_path_not_allowed")
+        }
+        if (!file.isFile) {
+            throw FixtureValidationException("fixture_missing")
+        }
+        if (file.length() == 0L) {
+            throw FixtureValidationException("fixture_empty")
+        }
+        if (file.length() > MAX_FILE_BYTES) {
+            throw FixtureValidationException("fixture_duration_not_supported")
+        }
+        val metadata = try {
+            WavValidator.validate(file)
+        } catch (error: FixtureValidationException) {
+            throw error
+        } catch (_: Exception) {
+            throw FixtureValidationException("malformed_wav")
+        }
+        if (metadata.durationMs > MAX_FIXTURE_DURATION_MS) {
+            throw FixtureValidationException("fixture_duration_not_supported")
+        }
+        if (metadata.sha256 != entry.sha256 || metadata.durationMs != entry.durationMs) {
+            throw FixtureValidationException("fixture_hash_or_metadata_mismatch")
+        }
+        return ResolvedFixture(entry, file, metadata)
+    }
+
+    override fun openFixture(fixture: ResolvedFixture): java.io.FileInputStream =
+        java.io.FileInputStream(fixture.file)
+}
+
+data class WavMetadata(
+    val sha256: String,
+    val durationMs: Long,
+    val dataBytes: Long,
+    val sampleRateHz: Int,
+    val channels: Int,
+    val bitsPerSample: Int,
+)
+
+internal object WavValidator {
+    fun validate(file: File): WavMetadata {
+        if (file.length() == 0L) throw FixtureValidationException("fixture_empty")
+        val parsed = RandomAccessFile(file, "r").use { raf -> parse(raf) }
+        val digest = MessageDigest.getInstance("SHA-256")
+        java.io.FileInputStream(file).use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                digest.update(buffer, 0, count)
+            }
+        }
+        return parsed.copy(sha256 = digest.digest().toHex())
+    }
+
+    private fun parse(raf: RandomAccessFile): WavMetadata {
+        val length = raf.length()
+        if (length < 12L || readAscii(raf, 4) != "RIFF") {
+            throw FixtureValidationException("malformed_wav")
+        }
+        val riffSize = readUInt32(raf)
+        if (riffSize < 4L || riffSize + 8L > length || readAscii(raf, 4) != "WAVE") {
+            throw FixtureValidationException("malformed_wav")
+        }
+        var fmtSeen = false
+        var dataBytes = -1L
+        var sampleRate = 0
+        var channels = 0
+        var bits = 0
+        while (raf.filePointer + 8L <= length) {
+            val chunkId = readAscii(raf, 4)
+            val chunkSize = readUInt32(raf)
+            val chunkStart = raf.filePointer
+            val chunkEnd = chunkStart + chunkSize
+            if (chunkEnd < chunkStart || chunkEnd > length) {
+                throw FixtureValidationException("malformed_wav")
+            }
+            when (chunkId) {
+                "fmt " -> {
+                    if (chunkSize < 16L) throw FixtureValidationException("malformed_wav")
+                    val format = readUInt16(raf)
+                    channels = readUInt16(raf)
+                    sampleRate = readUInt32(raf).toInt()
+                    readUInt32(raf)
+                    val blockAlign = readUInt16(raf)
+                    bits = readUInt16(raf)
+                    if (format != 1 || channels != CHANNEL_COUNT || sampleRate != SAMPLE_RATE_HZ ||
+                        bits != BITS_PER_SAMPLE || blockAlign != 2
+                    ) {
+                        throw FixtureValidationException("unsupported_wav_format")
+                    }
+                    fmtSeen = true
+                }
+                "data" -> {
+                    if (dataBytes >= 0L) throw FixtureValidationException("malformed_wav")
+                    dataBytes = chunkSize
+                }
+            }
+            raf.seek(chunkEnd + (chunkSize and 1L))
+        }
+        if (!fmtSeen) throw FixtureValidationException("malformed_wav")
+        if (dataBytes <= 0L) throw FixtureValidationException("fixture_empty")
+        if (dataBytes > MAX_DATA_BYTES) throw FixtureValidationException("fixture_duration_not_supported")
+        if (dataBytes % 2L != 0L) throw FixtureValidationException("malformed_wav")
+        val durationMs = dataBytes * 1_000L / BYTES_PER_SECOND
+        if (durationMs <= 0L) throw FixtureValidationException("fixture_empty")
+        if (durationMs > MAX_FIXTURE_DURATION_MS) throw FixtureValidationException("fixture_duration_not_supported")
+        return WavMetadata(
+            sha256 = "",
+            durationMs = durationMs,
+            dataBytes = dataBytes,
+            sampleRateHz = sampleRate,
+            channels = channels,
+            bitsPerSample = bits,
+        )
+    }
+
+    private fun readAscii(raf: RandomAccessFile, count: Int): String {
+        val bytes = ByteArray(count)
+        raf.readFully(bytes)
+        return bytes.toString(Charsets.US_ASCII)
+    }
+
+    private fun readUInt16(raf: RandomAccessFile): Int =
+        raf.readUnsignedByte() or (raf.readUnsignedByte() shl 8)
+
+    private fun readUInt32(raf: RandomAccessFile): Long =
+        (raf.readUnsignedByte().toLong()) or
+            (raf.readUnsignedByte().toLong() shl 8) or
+            (raf.readUnsignedByte().toLong() shl 16) or
+            (raf.readUnsignedByte().toLong() shl 24)
+}
+
+private fun isManifestId(value: String): Boolean =
+    value.length in 1..AcousticStimulusContract.MAX_FIXTURE_ID_LENGTH &&
+        Regex("[a-z0-9][a-z0-9_-]{0,63}").matches(value)
+
+private fun isSafeFileName(value: String): Boolean =
+    value.isNotBlank() && value == File(value).name && value != "." && value != ".."
+
+private fun isSha256(value: String): Boolean = value.matches(Regex("[0-9a-f]{64}"))
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusReceiver.kt
@@ -1,0 +1,68 @@
+package com.kernel.ai.debug.acoustic
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * Debug-only source playback endpoint. Invoke explicitly against com.kernel.ai.debug.
+ */
+class AcousticStimulusReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+        try {
+            Handler(Looper.getMainLooper()).post {
+                try {
+                    val parsed = if (!isExplicitReceiverInvocation(appContext, intent)) {
+                        InvocationParseResult.Invalid(
+                            InvalidInvocation("explicit_component_required", null, null),
+                        )
+                    } else {
+                        InvocationParser.parse(intent)
+                    }
+                    createEngine(appContext).handle(parsed) { result ->
+                        pendingResult.setResultCode(
+                            when {
+                                result.completionStatus == "completed" && result.errorCategory == null ->
+                                    AcousticStimulusContract.RESULT_OK
+                                result.overlapRejected || result.completionStatus == "rejected" ->
+                                    AcousticStimulusContract.RESULT_REJECTED
+                                else -> AcousticStimulusContract.RESULT_FAILED
+                            },
+                        )
+                        pendingResult.setResultData(result.errorCategory ?: result.completionStatus)
+                        pendingResult.finish()
+                    }
+                } catch (error: Exception) {
+                    Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "receiver_failed", error)
+                    pendingResult.setResultCode(AcousticStimulusContract.RESULT_FAILED)
+                    pendingResult.setResultData("receiver_failed")
+                    pendingResult.finish()
+                }
+            }
+        } catch (error: Exception) {
+            Log.e(ACOUSTIC_STIMULUS_LOG_TAG, "receiver_dispatch_failed", error)
+            pendingResult.setResultCode(AcousticStimulusContract.RESULT_FAILED)
+            pendingResult.setResultData("receiver_dispatch_failed")
+            pendingResult.finish()
+        }
+    }
+
+    private fun isExplicitReceiverInvocation(context: Context, intent: Intent): Boolean =
+        intent.component?.packageName == context.packageName &&
+            intent.component?.className == AcousticStimulusReceiver::class.java.name
+
+    private fun createEngine(context: Context): AcousticStimulusEngine = AcousticStimulusEngine(
+        fixtures = FileFixtureRepository(AcousticFixtureStorage.fixtureDirectory(context)),
+        audio = AndroidStimulusAudioController(context),
+        playerFactory = AndroidMediaPlayerFactory(),
+        scheduler = HandlerStimulusScheduler(),
+        time = SystemStimulusTimeSource,
+        resultWriter = AndroidStimulusResultWriter(context),
+        eventLogger = AndroidStimulusEventLogger,
+    )
+}

--- a/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusReceiver.kt
@@ -7,6 +7,16 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 
+internal fun acousticStimulusResultCode(result: StimulusResult): Int = when {
+    result.completionStatus == "completed" &&
+        result.errorCategory == null &&
+        !result.evidencePersistenceFailed ->
+        AcousticStimulusContract.RESULT_OK
+    result.overlapRejected || result.completionStatus == "rejected" ->
+        AcousticStimulusContract.RESULT_REJECTED
+    else -> AcousticStimulusContract.RESULT_FAILED
+}
+
 /**
  * Debug-only source playback endpoint. Invoke explicitly against com.kernel.ai.debug.
  */
@@ -25,15 +35,7 @@ class AcousticStimulusReceiver : BroadcastReceiver() {
                         InvocationParser.parse(intent)
                     }
                     createEngine(appContext).handle(parsed) { result ->
-                        pendingResult.setResultCode(
-                            when {
-                                result.completionStatus == "completed" && result.errorCategory == null ->
-                                    AcousticStimulusContract.RESULT_OK
-                                result.overlapRejected || result.completionStatus == "rejected" ->
-                                    AcousticStimulusContract.RESULT_REJECTED
-                                else -> AcousticStimulusContract.RESULT_FAILED
-                            },
-                        )
+                        pendingResult.setResultCode(acousticStimulusResultCode(result))
                         pendingResult.setResultData(result.errorCategory ?: result.completionStatus)
                         pendingResult.finish()
                     }

--- a/app/src/test/java/com/kernel/ai/debug/acoustic/AcousticStimulusTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/acoustic/AcousticStimulusTest.kt
@@ -112,7 +112,7 @@ class AcousticStimulusTest {
     }
 
     @Test
-    fun `valid playback emits prepared started completed and restores exact volume`() {
+    fun `valid playback emits prepared started completed cleanup and restores exact volume`() {
         val audio = FakeAudio()
         val player = FakePlayer()
         val logger = RecordingLogger()
@@ -126,7 +126,12 @@ class AcousticStimulusTest {
 
         assertEquals("completed", result?.completionStatus)
         assertNull(result?.errorCategory)
-        assertEquals(listOf("prepared", "started", "completed"), logger.events.map { it.name })
+        assertEquals(
+            listOf("prepared", "started", "completed", "cleanup_completed"),
+            logger.events.map { it.name },
+        )
+        assertTrue(result?.events?.last()?.cleanupSuccess == true)
+        assertTrue(result?.events?.last()?.exactRestorationVerified == true)
         assertEquals(4, result?.volumeBefore)
         assertEquals(7, result?.requestedVolume)
         assertEquals(7, result?.appliedVolume)
@@ -146,40 +151,104 @@ class AcousticStimulusTest {
         )
         cases.forEach { (audio, player, category) ->
             val writer = RecordingWriter()
-            val engine = testEngine(audio, player, writer, RecordingLogger())
+            val logger = RecordingLogger()
+            val engine = testEngine(audio, player, writer, logger)
             var result: StimulusResult? = null
             engine.handle(InvocationParseResult.Valid(invocation())) { result = it }
             assertEquals(category, result?.errorCategory)
+            assertEquals("cleanup_completed", result?.events?.last()?.name)
             assertEquals(4, result?.restoredVolume)
             assertTrue(result?.exactRestorationVerified == true)
             assertEquals(if (category == "prepare_failed") 1 else 0, player.releaseCount)
             assertEquals(if (category == "prepare_failed") 1 else 0, audio.abandonCount)
-            PlaybackGate.release()
         }
 
         val errorAudio = FakeAudio()
         val errorPlayer = FakePlayer()
         val errorWriter = RecordingWriter()
-        val errorEngine = testEngine(errorAudio, errorPlayer, errorWriter, RecordingLogger())
+        val errorLogger = RecordingLogger()
+        val errorEngine = testEngine(errorAudio, errorPlayer, errorWriter, errorLogger)
         var errorResult: StimulusResult? = null
         errorEngine.handle(InvocationParseResult.Valid(invocation())) { errorResult = it }
         errorPlayer.triggerPrepared()
         errorPlayer.triggerError()
         assertEquals("playback_error", errorResult?.errorCategory)
+        assertEquals(
+            listOf("prepared", "started", "error", "cleanup_completed"),
+            errorLogger.events.map { it.name },
+        )
         assertEquals(4, errorResult?.restoredVolume)
-        PlaybackGate.release()
 
         val timeoutAudio = FakeAudio()
         val timeoutPlayer = FakePlayer()
         val timeoutScheduler = RecordingScheduler()
         val timeoutWriter = RecordingWriter()
-        val timeoutEngine = testEngine(timeoutAudio, timeoutPlayer, timeoutWriter, RecordingLogger(), timeoutScheduler)
+        val timeoutLogger = RecordingLogger()
+        val timeoutEngine = testEngine(timeoutAudio, timeoutPlayer, timeoutWriter, timeoutLogger, timeoutScheduler)
         var timeoutResult: StimulusResult? = null
         timeoutEngine.handle(InvocationParseResult.Valid(invocation())) { timeoutResult = it }
         timeoutScheduler.fire()
         assertEquals("playback_timeout", timeoutResult?.errorCategory)
         assertTrue(timeoutResult?.timeout == true)
+        assertEquals(
+            listOf("timeout", "cleanup_completed"),
+            timeoutLogger.events.map { it.name },
+        )
         assertEquals(4, timeoutResult?.restoredVolume)
+    }
+
+    @Test
+    fun `result writer failure returns failed outcome and releases playback gate`() {
+        val audio = FakeAudio()
+        val player = FakePlayer()
+        var result: StimulusResult? = null
+        testEngine(audio, player, ThrowingWriter(), RecordingLogger())
+            .handle(InvocationParseResult.Valid(invocation())) { result = it }
+        player.triggerPrepared()
+        player.triggerCompletion()
+
+        assertEquals("invalid", result?.completionStatus)
+        assertEquals("result_write_failed", result?.errorCategory)
+        assertNull(result?.playbackErrorCategory)
+        assertTrue(result?.evidencePersistenceFailed == true)
+        assertTrue(result?.cleanupSuccess == true)
+        assertEquals(
+            listOf("prepared", "started", "completed", "cleanup_completed"),
+            result?.events?.map { it.name },
+        )
+        assertEquals(
+            AcousticStimulusContract.RESULT_FAILED,
+            acousticStimulusResultCode(result!!),
+        )
+        assertTrue(
+            result?.completionStatus != "completed" ||
+                acousticStimulusResultCode(result!!) != AcousticStimulusContract.RESULT_OK,
+        )
+        assertTrue(PlaybackGate.tryAcquire())
+        PlaybackGate.release()
+    }
+
+    @Test
+    fun `playback start failure releases resources restores volume and releases gate`() {
+        val audio = FakeAudio()
+        val player = FakePlayer(startThrows = true)
+        val logger = RecordingLogger()
+        var result: StimulusResult? = null
+        testEngine(audio, player, RecordingWriter(), logger)
+            .handle(InvocationParseResult.Valid(invocation())) { result = it }
+        player.triggerPrepared()
+
+        assertEquals("playback_start_failed", result?.errorCategory)
+        assertEquals(1, player.releaseCount)
+        assertEquals(1, audio.abandonCount)
+        assertEquals(4, result?.restoredVolume)
+        assertTrue(result?.exactRestorationVerified == true)
+        assertEquals(
+            listOf("prepared", "error", "cleanup_completed"),
+            logger.events.map { it.name },
+        )
+        assertTrue(PlaybackGate.tryAcquire())
+        PlaybackGate.release()
     }
 
     @Test
@@ -228,6 +297,27 @@ class AcousticStimulusTest {
         assertEquals("volume_restoration_failed", result?.errorCategory)
         assertFalse(result?.cleanupSuccess == true)
         assertFalse(result?.exactRestorationVerified == true)
+    }
+
+    @Test
+    fun `cleanup failure preserves original playback failure`() {
+        val audio = FakeAudio(restorationFails = true)
+        val player = FakePlayer()
+        val logger = RecordingLogger()
+        var result: StimulusResult? = null
+        testEngine(audio, player, RecordingWriter(), logger)
+            .handle(InvocationParseResult.Valid(invocation())) { result = it }
+        player.triggerPrepared()
+        player.triggerError()
+
+        assertEquals("invalid", result?.completionStatus)
+        assertEquals("volume_restoration_failed", result?.errorCategory)
+        assertEquals("playback_error", result?.playbackErrorCategory)
+        assertFalse(result?.cleanupSuccess == true)
+        assertFalse(result?.exactRestorationVerified == true)
+        assertEquals("cleanup_completed", result?.events?.last()?.name)
+        assertFalse(result?.events?.last()?.cleanupSuccess == true)
+        assertEquals("volume_restoration_failed", result?.events?.last()?.errorCategory)
     }
 
     @Test
@@ -288,7 +378,7 @@ class AcousticStimulusTest {
     private fun testEngine(
         audio: FakeAudio,
         player: FakePlayer,
-        writer: RecordingWriter,
+        writer: StimulusResultWriter,
         logger: RecordingLogger,
         scheduler: RecordingScheduler = RecordingScheduler(),
     ) = AcousticStimulusEngine(
@@ -361,6 +451,7 @@ class AcousticStimulusTest {
 
     private class FakePlayer(
         private val prepareThrows: Boolean = false,
+        private val startThrows: Boolean = false,
     ) : StimulusPlayer {
         private var prepared: (() -> Unit)? = null
         private var completion: (() -> Unit)? = null
@@ -375,7 +466,10 @@ class AcousticStimulusTest {
         override fun prepareAsync() {
             if (prepareThrows) throw IllegalStateException("prepare")
         }
-        override fun start() { started = true }
+        override fun start() {
+            if (startThrows) throw IllegalStateException("start")
+            started = true
+        }
         override fun release() { releaseCount++ }
         fun triggerPrepared() { prepared?.invoke() }
         fun triggerCompletion() { completion?.invoke() }
@@ -394,6 +488,12 @@ class AcousticStimulusTest {
     private class RecordingWriter : StimulusResultWriter {
         val results = mutableListOf<StimulusResult>()
         override fun write(result: StimulusResult) { results += result }
+    }
+
+    private class ThrowingWriter : StimulusResultWriter {
+        override fun write(result: StimulusResult) {
+            throw IllegalStateException("writer")
+        }
     }
 
     private class RecordingLogger : StimulusEventLogger {

--- a/app/src/test/java/com/kernel/ai/debug/acoustic/AcousticStimulusTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/acoustic/AcousticStimulusTest.kt
@@ -1,0 +1,403 @@
+package com.kernel.ai.debug.acoustic
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AcousticStimulusTest {
+    @AfterEach
+    fun releasePlaybackGate() {
+        PlaybackGate.release()
+    }
+
+    @Test
+    fun `valid invocation accepts bounded contract`() {
+        val result = InvocationParser.parse(
+            AcousticStimulusContract.ACTION_PLAY,
+            mapOf(
+                "trial_id" to "smoke-001",
+                "fixture_id" to "natural_wake",
+                "volume_index" to 7,
+                "player_gain" to 1.0f,
+            ),
+        )
+
+        assertEquals(
+            InvocationParseResult.Valid(StimulusInvocation("smoke-001", "natural_wake", 7, 1.0f)),
+            result,
+        )
+    }
+
+    @Test
+    fun `invocation parser rejects malformed ids paths and unsafe bounds`() {
+        assertError(mapOf("fixture_id" to "natural_wake", "volume_index" to 7), "missing_trial_id")
+        assertError(mapOf("trial_id" to "bad id", "fixture_id" to "natural_wake", "volume_index" to 7), "malformed_trial_id")
+        assertError(mapOf("trial_id" to "t1", "volume_index" to 7), "missing_fixture_id")
+        assertError(mapOf("trial_id" to "t1", "fixture_id" to "../secret", "volume_index" to 7), "arbitrary_path_not_allowed")
+        assertError(mapOf("trial_id" to "t1", "fixture_id" to "natural_wake", "volume_index" to -1), "unsafe_volume_index")
+        assertError(mapOf("trial_id" to "t1", "fixture_id" to "natural_wake", "volume_index" to 7, "player_gain" to 1.1f), "unsafe_player_gain")
+        assertError(mapOf("trial_id" to "t1", "fixture_id" to "natural_wake", "volume_index" to 7, "fixture_path" to "/sdcard/x.wav"), "arbitrary_path_not_allowed")
+    }
+
+    @Test
+    fun `invocation parser rejects wrong action unknown extras and malformed types`() {
+        val values = mapOf("trial_id" to "t1", "fixture_id" to "natural_wake", "volume_index" to 7)
+        assertError(values, "invalid_action", action = "other.action")
+        assertError(values + ("extra" to true), "unsupported_extra")
+        assertError(values + ("volume_index" to "7"), "missing_or_malformed_volume_index")
+        assertError(values + ("player_gain" to "1.0"), "malformed_player_gain")
+    }
+
+    @Test
+    fun `fixture repository only resolves app private allowlisted files`() {
+        val root = Files.createTempDirectory("acoustic-fixtures-").toFile()
+        val file = File(root, "natural_wake.wav")
+        writeWav(file, dataBytes = 96_000)
+        val metadata = WavValidator.validate(file)
+        val repository = FileFixtureRepository(root) { _ ->
+            FixtureManifest(1, listOf(FixtureEntry("natural_wake", file.name, metadata.sha256, metadata.durationMs)))
+        }
+
+        val resolved = repository.resolveAndValidate("natural_wake")
+        assertEquals(file.canonicalFile, resolved.file)
+        assertEquals(metadata.sha256, resolved.metadata.sha256)
+        assertThrowsCategory("unknown_fixture") { repository.resolveAndValidate("other") }
+        assertThrowsCategory("fixture_missing") {
+            FileFixtureRepository(root) { _ ->
+                FixtureManifest(1, listOf(FixtureEntry("missing", "missing.wav", metadata.sha256, metadata.durationMs)))
+            }.resolveAndValidate("missing")
+        }
+        assertThrowsCategory("arbitrary_path_not_allowed") {
+            FileFixtureRepository(root) { _ ->
+                FixtureManifest(1, listOf(FixtureEntry("escape", "../escape.wav", metadata.sha256, metadata.durationMs)))
+            }.resolveAndValidate("escape")
+        }
+        assertThrowsCategory("fixture_hash_or_metadata_mismatch") {
+            FileFixtureRepository(root) { _ ->
+                FixtureManifest(
+                    1,
+                    listOf(FixtureEntry("natural_wake", file.name, "0".repeat(64), metadata.durationMs)),
+                )
+            }.resolveAndValidate("natural_wake")
+        }
+    }
+
+    @Test
+    fun `wav validator rejects malformed unsupported over duration and empty fixtures`() {
+        val malformed = File.createTempFile("malformed-", ".wav")
+        malformed.writeBytes("not-wave".toByteArray())
+        assertThrowsCategory("malformed_wav") { WavValidator.validate(malformed) }
+
+        val unsupported = File.createTempFile("unsupported-", ".wav")
+        writeWav(unsupported, dataBytes = 96_000, channels = 2)
+        assertThrowsCategory("unsupported_wav_format") { WavValidator.validate(unsupported) }
+
+        val tooLong = File.createTempFile("too-long-", ".wav")
+        writeWav(tooLong, dataBytes = 480_002)
+        assertThrowsCategory("fixture_duration_not_supported") { WavValidator.validate(tooLong) }
+
+        val empty = File.createTempFile("empty-", ".wav")
+        assertThrowsCategory("fixture_empty") { WavValidator.validate(empty) }
+    }
+
+    @Test
+    fun `valid playback emits prepared started completed and restores exact volume`() {
+        val audio = FakeAudio()
+        val player = FakePlayer()
+        val logger = RecordingLogger()
+        val writer = RecordingWriter()
+        val engine = testEngine(audio, player, writer, logger)
+        var result: StimulusResult? = null
+
+        engine.handle(InvocationParseResult.Valid(invocation())) { result = it }
+        player.triggerPrepared()
+        player.triggerCompletion()
+
+        assertEquals("completed", result?.completionStatus)
+        assertNull(result?.errorCategory)
+        assertEquals(listOf("prepared", "started", "completed"), logger.events.map { it.name })
+        assertEquals(4, result?.volumeBefore)
+        assertEquals(7, result?.requestedVolume)
+        assertEquals(7, result?.appliedVolume)
+        assertEquals(4, result?.restoredVolume)
+        assertTrue(result?.cleanupSuccess == true)
+        assertTrue(result?.exactRestorationVerified == true)
+        assertEquals(1, player.releaseCount)
+        assertEquals(1, audio.abandonCount)
+    }
+
+    @Test
+    fun `invalid route focus failure preparation error playback error and timeout all clean up`() {
+        val cases = listOf(
+            Triple(FakeAudio(route = OutputRoute.EXTERNAL_BLUETOOTH), FakePlayer(), "invalid_output_route"),
+            Triple(FakeAudio(focusGranted = false), FakePlayer(), "audio_focus_denied"),
+            Triple(FakeAudio(), FakePlayer(prepareThrows = true), "prepare_failed"),
+        )
+        cases.forEach { (audio, player, category) ->
+            val writer = RecordingWriter()
+            val engine = testEngine(audio, player, writer, RecordingLogger())
+            var result: StimulusResult? = null
+            engine.handle(InvocationParseResult.Valid(invocation())) { result = it }
+            assertEquals(category, result?.errorCategory)
+            assertEquals(4, result?.restoredVolume)
+            assertTrue(result?.exactRestorationVerified == true)
+            assertEquals(if (category == "prepare_failed") 1 else 0, player.releaseCount)
+            assertEquals(if (category == "prepare_failed") 1 else 0, audio.abandonCount)
+            PlaybackGate.release()
+        }
+
+        val errorAudio = FakeAudio()
+        val errorPlayer = FakePlayer()
+        val errorWriter = RecordingWriter()
+        val errorEngine = testEngine(errorAudio, errorPlayer, errorWriter, RecordingLogger())
+        var errorResult: StimulusResult? = null
+        errorEngine.handle(InvocationParseResult.Valid(invocation())) { errorResult = it }
+        errorPlayer.triggerPrepared()
+        errorPlayer.triggerError()
+        assertEquals("playback_error", errorResult?.errorCategory)
+        assertEquals(4, errorResult?.restoredVolume)
+        PlaybackGate.release()
+
+        val timeoutAudio = FakeAudio()
+        val timeoutPlayer = FakePlayer()
+        val timeoutScheduler = RecordingScheduler()
+        val timeoutWriter = RecordingWriter()
+        val timeoutEngine = testEngine(timeoutAudio, timeoutPlayer, timeoutWriter, RecordingLogger(), timeoutScheduler)
+        var timeoutResult: StimulusResult? = null
+        timeoutEngine.handle(InvocationParseResult.Valid(invocation())) { timeoutResult = it }
+        timeoutScheduler.fire()
+        assertEquals("playback_timeout", timeoutResult?.errorCategory)
+        assertTrue(timeoutResult?.timeout == true)
+        assertEquals(4, timeoutResult?.restoredVolume)
+    }
+
+    @Test
+    fun `overlapping request is rejected without changing volume`() {
+        val firstAudio = FakeAudio()
+        val firstPlayer = FakePlayer()
+        val firstEngine = testEngine(firstAudio, firstPlayer, RecordingWriter(), RecordingLogger())
+        firstEngine.handle(InvocationParseResult.Valid(invocation("first"))) {}
+
+        val secondAudio = FakeAudio()
+        var secondResult: StimulusResult? = null
+        testEngine(secondAudio, FakePlayer(), RecordingWriter(), RecordingLogger())
+            .handle(InvocationParseResult.Valid(invocation("second"))) { secondResult = it }
+
+        assertEquals("overlap_rejected", secondResult?.errorCategory)
+        assertTrue(secondResult?.overlapRejected == true)
+        assertEquals(0, secondAudio.setVolumeCount)
+    }
+
+    @Test
+    fun `volume above device maximum is rejected before playback`() {
+        val audio = FakeAudio()
+        var result: StimulusResult? = null
+        testEngine(audio, FakePlayer(), RecordingWriter(), RecordingLogger())
+            .handle(
+                InvocationParseResult.Valid(StimulusInvocation("trial-high-volume", "natural_wake", 16, 1.0f)),
+            ) { result = it }
+
+        assertEquals("unsafe_volume_index", result?.errorCategory)
+        assertEquals(1, audio.setVolumeCount)
+        assertEquals(4, result?.restoredVolume)
+    }
+
+    @Test
+    fun `cleanup failure invalidates an otherwise completed attempt`() {
+        val audio = FakeAudio(restorationFails = true)
+        val player = FakePlayer()
+        val writer = RecordingWriter()
+        var result: StimulusResult? = null
+        testEngine(audio, player, writer, RecordingLogger())
+            .handle(InvocationParseResult.Valid(invocation())) { result = it }
+        player.triggerPrepared()
+        player.triggerCompletion()
+
+        assertEquals("invalid", result?.completionStatus)
+        assertEquals("volume_restoration_failed", result?.errorCategory)
+        assertFalse(result?.cleanupSuccess == true)
+        assertFalse(result?.exactRestorationVerified == true)
+    }
+
+    @Test
+    fun `structured result contains required source evidence`() {
+        val result = StimulusResult(
+            trialId = "trial-1",
+            fixtureId = "natural_wake",
+            fixtureSha256 = "a".repeat(64),
+            fixtureDurationMs = 1_000,
+            requestWallClockMs = 10,
+            requestMonotonicMs = 20,
+            prepareMonotonicMs = 21,
+            playbackStartMonotonicMs = 22,
+            completionMonotonicMs = 23,
+            cleanupMonotonicMs = 24,
+            volumeBefore = 4,
+            requestedVolume = 7,
+            appliedVolume = 7,
+            maximumVolume = 15,
+            restoredVolume = 4,
+            outputRouteBefore = OutputRoute.BUILT_IN_SPEAKER,
+            outputRouteDuring = OutputRoute.BUILT_IN_SPEAKER,
+            focusResult = "granted",
+            completionStatus = "completed",
+            errorCategory = null,
+            timeout = false,
+            overlapRejected = false,
+            cleanupSuccess = true,
+            exactRestorationVerified = true,
+            events = listOf(StimulusEvent("started", 22, 12)),
+        )
+        assertEquals("trial-1", result.trialId)
+        assertEquals("natural_wake", result.fixtureId)
+        assertEquals(64, result.fixtureSha256?.length)
+        assertEquals(4, result.volumeBefore)
+        assertEquals("BUILT_IN_SPEAKER", result.outputRouteDuring?.name)
+        assertTrue(result.exactRestorationVerified)
+        assertEquals("started", result.events.single().name)
+    }
+
+    private fun assertError(values: Map<String, Any?>, category: String, action: String = AcousticStimulusContract.ACTION_PLAY) {
+        val result = InvocationParser.parse(action, values) as InvocationParseResult.Invalid
+        assertEquals(category, result.error.category)
+    }
+
+    private fun assertThrowsCategory(category: String, action: () -> Unit) {
+        try {
+            action()
+            throw AssertionError("expected $category")
+        } catch (error: FixtureValidationException) {
+            assertEquals(category, error.category)
+        }
+    }
+
+    private fun invocation(trialId: String = "trial-1") =
+        StimulusInvocation(trialId, "natural_wake", 7, 1.0f)
+
+    private fun testEngine(
+        audio: FakeAudio,
+        player: FakePlayer,
+        writer: RecordingWriter,
+        logger: RecordingLogger,
+        scheduler: RecordingScheduler = RecordingScheduler(),
+    ) = AcousticStimulusEngine(
+        fixtures = FakeFixtureSource(),
+        audio = audio,
+        playerFactory = StimulusPlayerFactory { player },
+        scheduler = scheduler,
+        time = IncrementingTimeSource(),
+        resultWriter = writer,
+        eventLogger = logger,
+    )
+
+    private fun writeWav(
+        file: File,
+        dataBytes: Int,
+        channels: Int = 1,
+        sampleRate: Int = 48_000,
+        bits: Int = 16,
+    ) {
+        FileOutputStream(file).use { output ->
+            val riffSize = 36 + dataBytes
+            fun text(value: String) = output.write(value.toByteArray(Charsets.US_ASCII))
+            fun u16(value: Int) = output.write(ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort(value.toShort()).array())
+            fun u32(value: Int) = output.write(ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array())
+            text("RIFF"); u32(riffSize); text("WAVE")
+            text("fmt "); u32(16); u16(1); u16(channels); u32(sampleRate)
+            u32(sampleRate * channels * bits / 8); u16(channels * bits / 8); u16(bits)
+            text("data"); u32(dataBytes)
+            output.write(ByteArray(dataBytes))
+        }
+    }
+
+    private class IncrementingTimeSource : StimulusTimeSource {
+        private val next = AtomicInteger(1_000)
+        override fun wallClockMs(): Long = next.incrementAndGet().toLong()
+        override fun monotonicMs(): Long = next.incrementAndGet().toLong()
+    }
+
+    private class FakeFixtureSource : FixtureSource {
+        private val file = File.createTempFile("fixture-", ".wav").apply { writeBytes(byteArrayOf(1)) }
+        private val metadata = WavMetadata("b".repeat(64), 1_000, 96_000, 48_000, 1, 16)
+        private val resolved = ResolvedFixture(FixtureEntry("natural_wake", "natural_wake.wav", metadata.sha256, metadata.durationMs), file, metadata)
+        override fun resolveAndValidate(fixtureId: String): ResolvedFixture {
+            if (fixtureId != "natural_wake") throw FixtureValidationException("unknown_fixture")
+            return resolved
+        }
+        override fun openFixture(fixture: ResolvedFixture): FileInputStream = FileInputStream(fixture.file)
+    }
+
+    private class FakeAudio(
+        private val route: OutputRoute = OutputRoute.BUILT_IN_SPEAKER,
+        val focusGranted: Boolean = true,
+        private val restorationFails: Boolean = false,
+    ) : StimulusAudioController {
+        var volume = 4
+        var setVolumeCount = 0
+        var abandonCount = 0
+        override fun snapshot() = AudioSnapshot(volume, 15, route)
+        override fun currentRoute() = route
+        override fun setMediaVolume(volume: Int) {
+            setVolumeCount++
+            this.volume = if (restorationFails && volume == 4) 5 else volume
+        }
+        override fun currentMediaVolume() = volume
+        override fun requestFocus(): FocusRequestResult =
+            if (focusGranted) FocusRequestResult.Granted(object : FocusHandle {})
+            else FocusRequestResult.Denied()
+        override fun abandonFocus(handle: FocusHandle) { abandonCount++ }
+    }
+
+    private class FakePlayer(
+        private val prepareThrows: Boolean = false,
+    ) : StimulusPlayer {
+        private var prepared: (() -> Unit)? = null
+        private var completion: (() -> Unit)? = null
+        private var error: ((Int, Int) -> Unit)? = null
+        var releaseCount = 0
+        var started = false
+        override fun setGain(gain: Float) = Unit
+        override fun setDataSource(fileDescriptor: java.io.FileDescriptor) = Unit
+        override fun setOnPreparedListener(listener: () -> Unit) { prepared = listener }
+        override fun setOnCompletionListener(listener: () -> Unit) { completion = listener }
+        override fun setOnErrorListener(listener: (what: Int, extra: Int) -> Unit) { error = listener }
+        override fun prepareAsync() {
+            if (prepareThrows) throw IllegalStateException("prepare")
+        }
+        override fun start() { started = true }
+        override fun release() { releaseCount++ }
+        fun triggerPrepared() { prepared?.invoke() }
+        fun triggerCompletion() { completion?.invoke() }
+        fun triggerError() { error?.invoke(1, 2) }
+    }
+
+    private class RecordingScheduler : StimulusScheduler {
+        var action: (() -> Unit)? = null
+        override fun schedule(delayMs: Long, action: () -> Unit): StimulusCancellation {
+            this.action = action
+            return object : StimulusCancellation { override fun cancel() = Unit }
+        }
+        fun fire() { action?.invoke() }
+    }
+
+    private class RecordingWriter : StimulusResultWriter {
+        val results = mutableListOf<StimulusResult>()
+        override fun write(result: StimulusResult) { results += result }
+    }
+
+    private class RecordingLogger : StimulusEventLogger {
+        val events = mutableListOf<StimulusEvent>()
+        override fun event(result: StimulusEvent, trialId: String?, fixtureId: String?) { events += result }
+    }
+}

--- a/docs/testing/acoustic-stimulus-source.md
+++ b/docs/testing/acoustic-stimulus-source.md
@@ -1,0 +1,103 @@
+# Debug acoustic stimulus source
+
+The source endpoint exists only in the debug application (`com.kernel.ai.debug`). It
+plays an approved app-private WAV fixture through the source device's built-in
+speaker. It does not schedule trials or change wake-word behaviour.
+
+## Invocation
+
+Use an ADB alias, not a serial number or other private selector, and target the
+receiver explicitly:
+
+```sh
+adb -s "$JANDAL_S23U_SOURCE" shell am broadcast \
+  -n com.kernel.ai.debug/com.kernel.ai.debug.acoustic.AcousticStimulusReceiver \
+  -a com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS \
+  --es trial_id smoke-001 \
+  --es fixture_id natural_wake \
+  --ei volume_index 7 \
+  --ef player_gain 1.0
+```
+
+The receiver accepts only `trial_id`, `fixture_id`, `volume_index` and optional
+`player_gain`. Trial IDs are opaque bounded identifiers. Fixture IDs are
+allowlisted manifest IDs; paths and path-like IDs are rejected. Volume is an
+integer from 1 through the source media-stream maximum. Player gain is bounded to
+`0.1..1.0`, with `1.0` as the normal value. A request must use the debug package
+and receiver component explicitly.
+
+Each request writes a private JSON result below the app's private
+`files/acoustic-stimulus-results/` directory and emits only structured events
+under the `AcousticStimulus` log tag. The result contains fixture hash and timing,
+route, focus, volume, completion/error, timeout, overlap and cleanup fields. It
+never contains a host path, device selector or audio bytes.
+
+## Approved fixture contract
+
+The fixture directory is app-private:
+
+```text
+files/acoustic-fixtures/
+  manifest.json
+  <allowlisted-file>.wav
+```
+
+`manifest.json` has this shape (the hash and duration must describe the exact
+file installed):
+
+```json
+{
+  "schema_version": 1,
+  "fixtures": [
+    {
+      "fixture_id": "natural_wake",
+      "file_name": "natural_wake.wav",
+      "sha256": "<64 lowercase hex characters>",
+      "duration_ms": 1250
+    }
+  ]
+}
+```
+
+WAV files must be RIFF/WAVE, signed linear PCM, 16-bit little-endian, mono,
+48 kHz, non-empty and no longer than five seconds. The helper validates the WAV
+header, duration, manifest hash and manifest duration before opening a file
+descriptor. It rejects malformed/unsupported WAV, missing or unknown fixtures,
+empty files, over-duration files and hash/metadata mismatches. Private natural
+and voice-cloned recordings remain outside Git and are never placed in an APK or
+AAB.
+
+## Safe local installation
+
+Install an approved fixture and its manifest only after reviewing their private
+provenance and hash. The temporary files are made readable solely so `run-as`
+can copy them into the app UID's private directory; remove them after copying.
+
+```sh
+export SOURCE_ALIAS="$JANDAL_S23U_SOURCE"
+export FIXTURE_FILE="$HOME/private-acoustic-fixtures/natural_wake.wav"
+export MANIFEST_FILE="$HOME/private-acoustic-fixtures/manifest.json"
+
+adb -s "$SOURCE_ALIAS" shell run-as com.kernel.ai.debug mkdir -p files/acoustic-fixtures
+adb -s "$SOURCE_ALIAS" push "$FIXTURE_FILE" /data/local/tmp/acoustic-natural_wake.wav
+adb -s "$SOURCE_ALIAS" push "$MANIFEST_FILE" /data/local/tmp/acoustic-manifest.json
+adb -s "$SOURCE_ALIAS" shell chmod 644 /data/local/tmp/acoustic-natural_wake.wav /data/local/tmp/acoustic-manifest.json
+adb -s "$SOURCE_ALIAS" shell run-as com.kernel.ai.debug cp /data/local/tmp/acoustic-natural_wake.wav files/acoustic-fixtures/natural_wake.wav
+adb -s "$SOURCE_ALIAS" shell run-as com.kernel.ai.debug cp /data/local/tmp/acoustic-manifest.json files/acoustic-fixtures/manifest.json
+adb -s "$SOURCE_ALIAS" shell rm /data/local/tmp/acoustic-natural_wake.wav /data/local/tmp/acoustic-manifest.json
+```
+
+Do not use `adb push` directly into the application data directory, add fixture
+files to a source/resource directory, or reuse wake-model training audio.
+
+## Lifecycle and safety
+
+Playback uses `MediaPlayer` and `goAsync()` with a seven-second hard timeout.
+The helper snapshots only media volume and the current output route, verifies a
+built-in speaker route, requests transient media focus, opens the validated WAV
+through a file descriptor, and emits prepared/started/completed/error events.
+Every completion, preparation error, player error, timeout or partial failure
+releases the player, closes the descriptor, abandons focus, restores the exact
+original media volume and verifies that restoration. A restoration or cleanup
+failure makes the result invalid. Concurrent requests are rejected without
+mutating audio state.

--- a/docs/testing/acoustic-stimulus-source.md
+++ b/docs/testing/acoustic-stimulus-source.md
@@ -29,8 +29,12 @@ and receiver component explicitly.
 Each request writes a private JSON result below the app's private
 `files/acoustic-stimulus-results/` directory and emits only structured events
 under the `AcousticStimulus` log tag. The result contains fixture hash and timing,
-route, focus, volume, completion/error, timeout, overlap and cleanup fields. It
-never contains a host path, device selector or audio bytes.
+route, focus, volume, completion/error, timeout, overlap and cleanup fields,
+including a final `cleanup_completed` event with restoration status. If result
+persistence fails, the externally returned outcome is invalid with
+`result_write_failed`; playback/cleanup status remains visible in the returned
+evidence even though the evidence file was not persisted.
+It never contains a host path, device selector or audio bytes.
 
 ## Approved fixture contract
 
@@ -91,13 +95,13 @@ Do not use `adb push` directly into the application data directory, add fixture
 files to a source/resource directory, or reuse wake-model training audio.
 
 ## Lifecycle and safety
-
 Playback uses `MediaPlayer` and `goAsync()` with a seven-second hard timeout.
 The helper snapshots only media volume and the current output route, verifies a
 built-in speaker route, requests transient media focus, opens the validated WAV
 through a file descriptor, and emits prepared/started/completed/error events.
-Every completion, preparation error, player error, timeout or partial failure
-releases the player, closes the descriptor, abandons focus, restores the exact
-original media volume and verifies that restoration. A restoration or cleanup
-failure makes the result invalid. Concurrent requests are rejected without
-mutating audio state.
+After player release, descriptor close, focus abandonment, volume restoration and
+restoration verification it emits the final `cleanup_completed` event. Every
+completion, preparation error, player error, timeout or partial failure releases
+resources and restores the exact original media volume. A restoration or cleanup
+failure makes the result invalid while preserving the original playback error.
+Concurrent requests are rejected without mutating audio state.


### PR DESCRIPTION
DO NOT MERGE - WAIT FOR REVIEW

## Architecture
- Added a debug-only exported `AcousticStimulusReceiver` with an explicit ADB component/action contract.
- Uses `goAsync()`, a seven-second hard timeout, platform `MediaPlayer`, transient media focus, built-in-speaker route checks, and a single cleanup path.
- Resolves only manifest-allowlisted fixtures from app-private storage, validates RIFF/WAVE signed PCM 16-bit little-endian mono 48 kHz audio, duration, manifest metadata, and SHA-256 before opening the fixture file descriptor.
- Records structured private JSON results and narrow `AcousticStimulus` events with wall-clock and monotonic timestamps.
- Passes `result=0 data="completed"` back to the broadcast caller on success.
- Uses `runCatching` to guard the `resultWriter.write()` error-log path in unit-test environments where `android.util.Log.e` is not mocked.

## Changed files
- `app/src/debug/AndroidManifest.xml`
- `app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusContract.kt`
- `app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusFixtures.kt`
- `app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusEngine.kt`
- `app/src/debug/java/com/kernel/ai/debug/acoustic/AcousticStimulusReceiver.kt`
- `app/src/test/java/com/kernel/ai/debug/acoustic/AcousticStimulusTest.kt`
- `app/build.gradle.kts`
- `docs/testing/acoustic-stimulus-source.md`
- `.gitignore`

## Invocation and fixture installation
```sh
adb -s "$JANDAL_S23U_SOURCE" shell am broadcast \
  -n com.kernel.ai.debug/com.kernel.ai.debug.acoustic.AcousticStimulusReceiver \
  -a com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS \
  --es trial_id smoke-001 \
  --es fixture_id natural_wake \
  --ei volume_index 7 \
  --ef player_gain 1.0
```

The accepted extras are only `trial_id`, `fixture_id`, `volume_index`, and optional `player_gain`. Fixtures are installed into `files/acoustic-fixtures/` with a manifest through the documented `run-as`/temporary-file process in `docs/testing/acoustic-stimulus-source.md`. No fixture audio or private device data is tracked.

## WAV contract
RIFF/WAVE; signed linear PCM; 16-bit little-endian; mono; 48 kHz; non-empty; no longer than five seconds. The manifest records the allowlisted ID, file name, SHA-256, and duration. Paths, traversal, unknown IDs, malformed/unsupported WAV, over-duration files, empty files, and hash/metadata mismatches are rejected deterministically.

## Lifecycle and restoration
The receiver validates first, snapshots media volume and route, verifies the built-in speaker, applies and verifies the bounded media volume, requests transient focus, opens the validated fixture by file descriptor, prepares/starts `MediaPlayer`, and records prepared/started/completion/error events. Completion, player error, preparation failure, timeout, and partial initialization all release the player, close the descriptor, abandon focus, restore the exact original media volume, verify restoration, write the result, and finish the pending broadcast. A final `cleanup_completed` event records cleanup and restoration verification. Cleanup or exact-restoration failure marks the result invalid while preserving the original playback error. If result persistence fails, the broadcast receives `result_write_failed` with an invalid result and evidence-persistence marker; playback and cleanup status is retained in that returned result. Concurrent requests are rejected without changing audio state.

## Release isolation
`verifyAcousticStimulusReleaseIsolation` checks the merged debug/release manifests and the debug APK, release APK, and release AAB. It proves the debug receiver/action are present only in the debug manifest, release package identity remains `com.kernel.ai`, the helper is absent from release APK/AAB contents, and no WAV fixture is packaged in any inspected artifact.

## Automated validation
- `./gradlew :app:testDebugUnitTest` — passed; 968 tests.
- `./gradlew lintDebug` — passed.
- `./gradlew verifyAcousticStimulusReleaseIsolation` — passed.
- Added coverage for result-writer failure and gate release, cleanup-event ordering, playback-start failure, cleanup failure preserving the original playback error, and the final cleanup evidence fields.

## Physical feasibility checkpoint
Performed on physical S23 Ultra (SM-S918B, ADB Wi-Fi) as source and S21 (SM-G991B, USB) as target.

### Fixture
- ID: `natural_wake`
- SHA-256: `c144131efde247fafd1cef6a86d88408f871f4c264eb574d4dcf7d5f1aa72d45`
- Format: RIFF/WAVE PCM 16-bit mono 48 kHz, 1.984 s
- Validated: format, channels, sample rate, bit depth, duration ≤5 s, SHA-256 match, manifest duration match
- Host-local private fixture directory (`$HOME/private-acoustic-fixtures/`); not committed or exposed.

### Approved test parameters
- **Fixed volume index:** 7 (~47% of hardware maximum 15)
- **Player gain:** 1.0
- **Placement:** side-by-side on desk, ~30 cm separation, screens facing same direction
- **Audibility preflight:** Fixture clearly audible through S23U built-in speaker at this volume; no clipping or distortion observed
- **Pre-flight trial:** `preflight-audibility-001` — completed, cleanup success, exact restoration verified
- **S23U audio route:** Built-in speaker before and during all trials; no Bluetooth/USB/headset active

### Natural wake trial results (all at volume index 7, player gain 1.0)

| Trial | Target idle | Completion | Vol applied/max | Route | Focus | Volume restored | Cleanup | Wake outcome |
|---|---|---|---|---|---|---|---|---|
| chk-1406-r1 | Recently armed | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-r2 | Recently armed | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-r3 | Recently armed | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-i1 | 30s idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-i2 | 30s idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-i3 | 30s idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-m1 | 2min idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-m2 | 2min idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |
| chk-1406-m3 | 2min idle | completed | 7/15 | BUILT_IN_SPEAKER | granted | 6 (exact) | success | No detection |

All 9 natural wake trials completed with full structured JSON evidence persisted to `files/acoustic-stimulus-results/`. Common per-trial attributes verified from persisted JSON:
- `fixture_sha256`, `fixture_duration_ms` present and correct
- `request_wall_clock_ms`, `prepare_monotonic_ms`, `playback_start_monotonic_ms`, `completion_monotonic_ms`, `cleanup_monotonic_ms` recorded
- `volume_before: 6`, `applied_volume: 7`, `maximum_volume: 15`, `restored_volume: 6`
- `output_route_before` and `output_route_during`: `BUILT_IN_SPEAKER`
- `focus_result: granted`
- `timeout: false`, `overlap_rejected: false`, `evidence_persistence_failed: false`
- `cleanup_success: true`, `exact_restoration_verified: true`
- lifecycle events: `prepared` → `started` → `completed` → `cleanup_completed`

### Target (S21) evidence
- WakeWordService confirmed running (`dumpsys activity services` — foreground service with `isForeground=true`)
- `OnnxWakeWordDetector` confirmed active: models loaded (embedding provider NNAPI, mel+classifier CPU); `AudioRecord` capturing at 16 kHz mono; 3-stage openWakeWord pipeline processing frames
- `WakeWordDiag` diagnostic logging enabled via `setprop log.tag.WakeWordDiag DEBUG`
- No `Log.i` `WakeWordDetector: detected` or `Log.d` low-threshold crossing message appeared in the KernelAI log during or after any of the 9 trials
- No `WakeWordDiag` periodic summary emitted yet (the 15-minute report interval has not elapsed since the last logcat clear)
- **Mic/gate observability gap:** The `OnnxWakeWordDetector` has an integrated silence gate (RMS threshold 300, 5 s hangover, 1 s max silence skip). When gated, Stage 2/3 inference is skipped. The detector produces no per-second confidence or gate-status log — the only observable signal is a detection event or the 15-minute `WakeWordDiag` summary. No bounded temporary diagnostic was added in this PR. The structured target journal from issue #1407 would close this gap.
- **Conclusion:** The acoustic source produced audibly clear playback through the S23U built-in speaker for all 9 trials. The S21 WakeWordService was armed and processing audio throughout. No wake event occurred — this is a target-side acoustic-coupling or model-sensitivity outcome, not a source-side defect.

### Qwen wake-sample trial
**Not performed.** No Qwen acoustic fixture (`$HOME/private-acoustic-fixtures/`) is available. The directory contains only the private `natural_wake` fixture. A Qwen wake fixture would need to be created per the approved provenance rules and placed alongside the existing manifest before this trial can be executed. This is a fixture-gap blocker, not a code defect.

### Command-handoff trial
**Not performed.** No separate short command fixture (e.g. "What time is it?") is available. This fixture does not exist in `$HOME/private-acoustic-fixtures/` and has no entry in the existing manifest. Until a command fixture is created per the approved design, the command-handoff trial cannot proceed. This is a fixture-gap blocker, not a code defect.

### Suitability classifications
- **Natural wake fixture (`natural_wake.wav`):** Source playback suitability verified. The fixture plays correctly through the S23U built-in speaker, all lifecycle events complete, and structured evidence is persisted. Target-wake suitability is **not demonstrated** in this bounded session (zero detections across 9 trials at volume index 7, ~30 cm separation). The source component itself operates correctly.
- **Qwen wake fixture:** Not evaluated — fixture does not exist.
- **Qwen command fixture:** Not evaluated — fixture does not exist.

### Remaining blocker
The source component (debug acoustic stimulus receiver/engine) is complete and validated. The physical feasibility checkpoint demonstrated reliable source playback but did not produce S21 wake-word detection. The remaining gaps before this PR can close #1406 are:
1. **No Qwen wake fixture available** — needed for the Qwen wake-sample trial required by #1403
2. **No command fixture available** — needed for the command-handoff trial
3. **Target-side mic/gate observability gap** — the current `WakeWordDiag` only emits one summary every 15 minutes; per-second confidence, gate-status, or frame-RMS logging would help diagnose whether the playback is reaching the detector's Stage 2/3 path or being suppressed by the silence gate
4. **No wake-word detection demonstrated** — even at max volume (trial chk-1406-003) in earlier exploratory testing, no S21 detection occurred; the source component is not defective but the end-to-end acoustic coupling + model sensitivity has not been validated

These are fixture-gap and observability-gap blockers, not source-component defects. No production thresholds, models, silence-gate behaviour, or wake service lifecycle were changed.

Closes #1406

DO NOT MERGE - WAIT FOR REVIEW