### PR TITLE
test(#1407): add structured target event journal for wake, STT, cue, handoff and re-arm

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,75 +115,6 @@ tasks.register("verifyAcousticStimulusReleaseIsolation") {
             "Release manifest package must be com.kernel.ai"
         }
 
-tasks.register("verifyTargetEventJournalReleaseIsolation") {
-    dependsOn("assembleDebug", "assembleRelease", "bundleRelease")
-    doLast {
-        val buildDirectory = layout.buildDirectory.get().asFile
-        val manifests = buildDirectory.walkTopDown()
-            .filter { it.isFile && it.name == "AndroidManifest.xml" }
-            .toList()
-        fun mergedManifest(variant: String): File = manifests.firstOrNull { file ->
-            file.path.contains("/$variant/") && file.path.contains("merged")
-        } ?: error("Merged $variant manifest not found")
-
-        val debugManifest = mergedManifest("debug").readText()
-        val releaseManifest = mergedManifest("release").readText()
-        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" in debugManifest) {
-            "Debug manifest must contain TargetEventJournalReceiver"
-        }
-        check("GET_JOURNAL_SEQUENCE" in debugManifest)
-        check("WAIT_FOR_JOURNAL_EVENT" in debugManifest)
-        check("GET_JOURNAL_SNAPSHOT" in debugManifest)
-        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" !in releaseManifest) {
-            "Release manifest must NOT contain TargetEventJournalReceiver"
-        }
-        check("GET_JOURNAL_SEQUENCE" !in releaseManifest)
-        check("WAIT_FOR_JOURNAL_EVENT" !in releaseManifest)
-        check("GET_JOURNAL_SNAPSHOT" !in releaseManifest)
-        check("package=\"com.kernel.ai\"" in releaseManifest)
-
-        val artifacts = listOf(
-            buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
-            buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),
-            buildDirectory.resolve("outputs/bundle/release/app-release.aab"),
-        )
-        artifacts.forEach { artifact ->
-            check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
-            ZipFile(artifact).use { zip ->
-                val names = zip.entries().asSequence().map { it.name }.toList()
-                val debugClassPresent = names.any {
-                    "TargetEventJournalReceiver" in it || "AcousticEventJournal" in it
-                }
-                if (artifact.name.contains("debug")) {
-                    check(debugClassPresent) {
-                        "TargetEventJournalReceiver/AcousticEventJournal missing from debug artifact"
-                    }
-                } else {
-                    check(!debugClassPresent) {
-                        "TargetEventJournalReceiver/AcousticEventJournal present in release artifact"
-                    }
-                }
-
-                val hasJournalPackage = names.any { "com/kernel/ai/debug/journal" in it }
-                if (artifact.name.contains("release")) {
-                    check(!hasJournalPackage) {
-                        "Debug journal package found in release artifact: ${artifact.name}"
-                    }
-                }
-            }
-        }
-
-        val releaseApk = buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk")
-        ZipFile(releaseApk).use { zip ->
-            val releaseNames = zip.entries().asSequence().map { it.name }.toList()
-            check(releaseNames.any { "AcousticJournalBridge" in it }) {
-                "AcousticJournalBridge must be present in release (production no-op interface)"
-            }
-        }
-    }
-}
-
-
         val artifacts = listOf(
             buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
             buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),
@@ -198,11 +129,10 @@ tasks.register("verifyTargetEventJournalReleaseIsolation") {
                 }
                 val helperBytes = zip.entries().asSequence()
                     .filter { !it.isDirectory }
-                    .flatMap { entry ->
-                        zip.getInputStream(entry).use { input -> sequenceOf(input.readBytes()) }
-                    }
-                    .any { bytes ->
-                        val text = bytes.toString(Charsets.ISO_8859_1)
+                    .any { entry ->
+                        val text = zip.getInputStream(entry).use { input ->
+                            input.readBytes().toString(Charsets.ISO_8859_1)
+                        }
                         "AcousticStimulusReceiver" in text ||
                             "com/kernel/ai/debug/acoustic" in text
                     }
@@ -210,6 +140,77 @@ tasks.register("verifyTargetEventJournalReleaseIsolation") {
                     check(!helperBytes) { "Debug acoustic helper packaged in ${artifact.name}" }
                 } else {
                     check(helperBytes) { "Debug acoustic helper missing from ${artifact.name}" }
+                }
+            }
+        }
+    }
+}
+
+tasks.register("verifyTargetEventJournalReleaseIsolation") {
+    dependsOn("assembleDebug", "assembleRelease", "bundleRelease")
+    doLast {
+        val buildDirectory = layout.buildDirectory.get().asFile
+        val manifests = buildDirectory.walkTopDown()
+            .filter { it.isFile && it.name == "AndroidManifest.xml" }
+            .toList()
+        fun mergedManifest(variant: String): File = manifests.firstOrNull { file ->
+            file.path.contains("/$variant/") && file.path.contains("merged")
+        } ?: error("Merged $variant manifest not found")
+
+        val debugManifest = mergedManifest("debug").readText()
+        val releaseManifest = mergedManifest("release").readText()
+        val journalActions = listOf(
+            "GET_JOURNAL_SEQUENCE",
+            "WAIT_FOR_JOURNAL_EVENT",
+            "GET_JOURNAL_SNAPSHOT",
+        )
+        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" in debugManifest) {
+            "Debug manifest must contain TargetEventJournalReceiver"
+        }
+        journalActions.forEach { action ->
+            check(action in debugManifest) { "Debug manifest must contain $action" }
+        }
+        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" !in releaseManifest) {
+            "Release manifest must NOT contain TargetEventJournalReceiver"
+        }
+        journalActions.forEach { action ->
+            check(action !in releaseManifest) { "Release manifest must NOT contain $action" }
+        }
+        check("package=\"com.kernel.ai\"" in releaseManifest)
+
+        val artifacts = listOf(
+            buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
+            buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),
+            buildDirectory.resolve("outputs/bundle/release/app-release.aab"),
+        )
+        val debugMarkers = listOf(
+            "TargetEventJournalReceiver",
+            "com/kernel/ai/debug/journal",
+            "AcousticEventJournal",
+        )
+        artifacts.forEach { artifact ->
+            check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
+            ZipFile(artifact).use { zip ->
+                val dexText = zip.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.endsWith(".dex") }
+                    .map { entry ->
+                        zip.getInputStream(entry).use { input ->
+                            input.readBytes().toString(Charsets.ISO_8859_1)
+                        }
+                    }
+                    .toList()
+                check(dexText.isNotEmpty()) { "No DEX payload found in ${artifact.name}" }
+                val containsDebugJournal = dexText.any { text ->
+                    debugMarkers.any { marker -> marker in text }
+                }
+                if (artifact.name.contains("debug")) {
+                    check(containsDebugJournal) {
+                        "Debug journal implementation missing from ${artifact.name}"
+                    }
+                } else {
+                    check(!containsDebugJournal) {
+                        "Debug journal implementation present in ${artifact.name}"
+                    }
                 }
             }
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,21 +159,21 @@ tasks.register("verifyTargetEventJournalReleaseIsolation") {
 
         val debugManifest = mergedManifest("debug").readText()
         val releaseManifest = mergedManifest("release").readText()
-        val journalActions = listOf(
+        val journalBroadcastActions = listOf(
             "GET_JOURNAL_SEQUENCE",
-            "WAIT_FOR_JOURNAL_EVENT",
             "GET_JOURNAL_SNAPSHOT",
         )
-        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" in debugManifest) {
-            "Debug manifest must contain TargetEventJournalReceiver"
+        val journalComponents = listOf(
+            "com.kernel.ai.debug.journal.TargetEventJournalReceiver",
+            "com.kernel.ai.debug.journal.TargetEventJournalProvider",
+            "com.kernel.ai.debug.target-event-journal",
+        )
+        journalComponents.forEach { component ->
+            check(component in debugManifest) { "Debug manifest must contain $component" }
+            check(component !in releaseManifest) { "Release manifest must NOT contain $component" }
         }
-        journalActions.forEach { action ->
+        journalBroadcastActions.forEach { action ->
             check(action in debugManifest) { "Debug manifest must contain $action" }
-        }
-        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" !in releaseManifest) {
-            "Release manifest must NOT contain TargetEventJournalReceiver"
-        }
-        journalActions.forEach { action ->
             check(action !in releaseManifest) { "Release manifest must NOT contain $action" }
         }
         check("package=\"com.kernel.ai\"" in releaseManifest)
@@ -185,6 +185,7 @@ tasks.register("verifyTargetEventJournalReleaseIsolation") {
         )
         val debugMarkers = listOf(
             "TargetEventJournalReceiver",
+            "TargetEventJournalProvider",
             "com/kernel/ai/debug/journal",
             "AcousticEventJournal",
         )

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,75 @@ tasks.register("verifyAcousticStimulusReleaseIsolation") {
             "Release manifest package must be com.kernel.ai"
         }
 
+tasks.register("verifyTargetEventJournalReleaseIsolation") {
+    dependsOn("assembleDebug", "assembleRelease", "bundleRelease")
+    doLast {
+        val buildDirectory = layout.buildDirectory.get().asFile
+        val manifests = buildDirectory.walkTopDown()
+            .filter { it.isFile && it.name == "AndroidManifest.xml" }
+            .toList()
+        fun mergedManifest(variant: String): File = manifests.firstOrNull { file ->
+            file.path.contains("/$variant/") && file.path.contains("merged")
+        } ?: error("Merged $variant manifest not found")
+
+        val debugManifest = mergedManifest("debug").readText()
+        val releaseManifest = mergedManifest("release").readText()
+        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" in debugManifest) {
+            "Debug manifest must contain TargetEventJournalReceiver"
+        }
+        check("GET_JOURNAL_SEQUENCE" in debugManifest)
+        check("WAIT_FOR_JOURNAL_EVENT" in debugManifest)
+        check("GET_JOURNAL_SNAPSHOT" in debugManifest)
+        check("com.kernel.ai.debug.journal.TargetEventJournalReceiver" !in releaseManifest) {
+            "Release manifest must NOT contain TargetEventJournalReceiver"
+        }
+        check("GET_JOURNAL_SEQUENCE" !in releaseManifest)
+        check("WAIT_FOR_JOURNAL_EVENT" !in releaseManifest)
+        check("GET_JOURNAL_SNAPSHOT" !in releaseManifest)
+        check("package=\"com.kernel.ai\"" in releaseManifest)
+
+        val artifacts = listOf(
+            buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
+            buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),
+            buildDirectory.resolve("outputs/bundle/release/app-release.aab"),
+        )
+        artifacts.forEach { artifact ->
+            check(artifact.isFile) { "Missing artifact: ${artifact.path}" }
+            ZipFile(artifact).use { zip ->
+                val names = zip.entries().asSequence().map { it.name }.toList()
+                val debugClassPresent = names.any {
+                    "TargetEventJournalReceiver" in it || "AcousticEventJournal" in it
+                }
+                if (artifact.name.contains("debug")) {
+                    check(debugClassPresent) {
+                        "TargetEventJournalReceiver/AcousticEventJournal missing from debug artifact"
+                    }
+                } else {
+                    check(!debugClassPresent) {
+                        "TargetEventJournalReceiver/AcousticEventJournal present in release artifact"
+                    }
+                }
+
+                val hasJournalPackage = names.any { "com/kernel/ai/debug/journal" in it }
+                if (artifact.name.contains("release")) {
+                    check(!hasJournalPackage) {
+                        "Debug journal package found in release artifact: ${artifact.name}"
+                    }
+                }
+            }
+        }
+
+        val releaseApk = buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk")
+        ZipFile(releaseApk).use { zip ->
+            val releaseNames = zip.entries().asSequence().map { it.name }.toList()
+            check(releaseNames.any { "AcousticJournalBridge" in it }) {
+                "AcousticJournalBridge must be present in release (production no-op interface)"
+            }
+        }
+    }
+}
+
+
         val artifacts = listOf(
             buildDirectory.resolve("outputs/apk/debug/app-debug.apk"),
             buildDirectory.resolve("outputs/apk/release/app-release-unsigned.apk"),

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -35,10 +35,13 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE" />
-                <action android:name="com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT" />
                 <action android:name="com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT" />
             </intent-filter>
         </receiver>
+        <provider
+            android:name="com.kernel.ai.debug.journal.TargetEventJournalProvider"
+            android:authorities="com.kernel.ai.debug.target-event-journal"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -30,6 +30,15 @@
                 <action android:name="com.kernel.ai.debug.action.PLAY_ACOUSTIC_STIMULUS" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name="com.kernel.ai.debug.journal.TargetEventJournalReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE" />
+                <action android:name="com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT" />
+                <action android:name="com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
@@ -3,6 +3,7 @@ package com.kernel.ai.debug.journal
 import com.kernel.ai.core.voice.AcousticEvent
 import com.kernel.ai.core.voice.AcousticEventRecorder
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 data class AcousticJournalSnapshot(
     val lowestSequence: Long,
@@ -10,6 +11,43 @@ data class AcousticJournalSnapshot(
     val overflowed: Boolean,
     val events: List<AcousticEvent>,
 )
+
+sealed interface AcousticEventWaitResult {
+    data class Found(val event: AcousticEvent) : AcousticEventWaitResult
+    object TimedOut : AcousticEventWaitResult
+    object Cancelled : AcousticEventWaitResult
+}
+
+class AcousticEventWaitCancellation {
+    private val cancelled = AtomicBoolean(false)
+
+    val isCancelled: Boolean get() = cancelled.get()
+
+    internal fun cancel(): Boolean = cancelled.compareAndSet(false, true)
+}
+
+internal class AcousticEventWaitRegistration(
+    val cancellation: AcousticEventWaitCancellation = AcousticEventWaitCancellation(),
+) {
+    private val state = AtomicReference(State.ACTIVE)
+
+    fun cancel(): Boolean = state.compareAndSet(State.ACTIVE, State.CANCELLED)
+
+    fun resolve(result: AcousticEventWaitResult): AcousticEventWaitResult =
+        if (state.compareAndSet(State.ACTIVE, State.COMPLETED)) {
+            result
+        } else if (state.get() == State.CANCELLED) {
+            AcousticEventWaitResult.Cancelled
+        } else {
+            result
+        }
+
+    private enum class State {
+        ACTIVE,
+        CANCELLED,
+        COMPLETED,
+    }
+}
 
 /**
  * Bounded ring-buffer event journal for structured target-side diagnostics.
@@ -25,6 +63,7 @@ data class AcousticJournalSnapshot(
  * **Overflow:** when the journal is full the oldest event is silently
  * replaced and [overflowed] is set to true.
  */
+
 class AcousticEventJournal(
     val journalCapacity: Int = DEFAULT_CAPACITY,
 ) : AcousticEventRecorder {
@@ -71,18 +110,27 @@ class AcousticEventJournal(
         sinceSequence: Long,
         eventType: String,
         timeoutMs: Long,
-    ): AcousticEvent? {
-        snapshotSince(sinceSequence).events.firstOrNull { it.type == eventType }?.let { return it }
+        cancellation: AcousticEventWaitCancellation = AcousticEventWaitCancellation(),
+    ): AcousticEventWaitResult {
         val deadline = System.nanoTime() / 1_000_000 + timeoutMs
         synchronized(lock) {
             while (true) {
-                val remaining = deadline - System.nanoTime() / 1_000_000
-                if (remaining <= 0) return null
+                if (cancellation.isCancelled) return AcousticEventWaitResult.Cancelled
                 reconstructOrdered()
                     .firstOrNull { it.sequence > sinceSequence && it.type == eventType }
-                    ?.let { return it }
-                (lock as java.lang.Object).wait(remaining.coerceAtMost(500L))
+                    ?.let { return AcousticEventWaitResult.Found(it) }
+                val remaining = deadline - System.nanoTime() / 1_000_000
+                if (remaining <= 0) return AcousticEventWaitResult.TimedOut
+                (lock as java.lang.Object).wait(remaining)
             }
+        }
+    }
+
+    fun cancelWait(cancellation: AcousticEventWaitCancellation): Boolean {
+        synchronized(lock) {
+            val changed = cancellation.cancel()
+            if (changed) (lock as java.lang.Object).notifyAll()
+            return changed
         }
     }
 

--- a/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
@@ -1,13 +1,15 @@
 package com.kernel.ai.debug.journal
 
-import android.os.SystemClock
 import com.kernel.ai.core.voice.AcousticEvent
 import com.kernel.ai.core.voice.AcousticEventRecorder
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
 
-private const val TAG = "TargetJournal"
+data class AcousticJournalSnapshot(
+    val lowestSequence: Long,
+    val highestSequence: Long,
+    val overflowed: Boolean,
+    val events: List<AcousticEvent>,
+)
 
 /**
  * Bounded ring-buffer event journal for structured target-side diagnostics.
@@ -36,10 +38,8 @@ class AcousticEventJournal(
     /** True if at least one event was evicted due to capacity. */
     val overflowed: Boolean get() = _overflowed.get()
 
-    fun allocateGenerationId(): Long = generationCounter.incrementAndGet()
-    fun allocateSessionId(): Long = sessionCounter.incrementAndGet()
     private var localMaxSequence: Long = 0
-    val currentSequence: Long get() = localMaxSequence
+    val currentSequence: Long get() = synchronized(lock) { localMaxSequence }
 
     override fun record(event: AcousticEvent) {
         synchronized(lock) {
@@ -57,16 +57,14 @@ class AcousticEventJournal(
         }
     }
 
-    fun snapshotSince(sinceSequence: Long): List<AcousticEvent> {
-        val ordered: List<AcousticEvent>
-        synchronized(lock) {
-            ordered = if (count == 0) emptyList() else reconstructOrdered()
-        }
-        if (ordered.isEmpty()) return emptyList()
-        if (sinceSequence >= ordered.last().sequence) return emptyList()
-        val startIdx = ordered.indexOfFirst { it.sequence > sinceSequence }
-        if (startIdx < 0) return emptyList()
-        return ordered.subList(startIdx, ordered.size)
+    fun snapshotSince(sinceSequence: Long): AcousticJournalSnapshot = synchronized(lock) {
+        val ordered = reconstructOrdered()
+        AcousticJournalSnapshot(
+            lowestSequence = ordered.firstOrNull()?.sequence ?: 0L,
+            highestSequence = localMaxSequence,
+            overflowed = _overflowed.get(),
+            events = ordered.filter { it.sequence > sinceSequence },
+        )
     }
 
     fun waitForEvent(
@@ -74,7 +72,7 @@ class AcousticEventJournal(
         eventType: String,
         timeoutMs: Long,
     ): AcousticEvent? {
-        snapshotSince(sinceSequence).firstOrNull { it.type == eventType }?.let { return it }
+        snapshotSince(sinceSequence).events.firstOrNull { it.type == eventType }?.let { return it }
         val deadline = System.nanoTime() / 1_000_000 + timeoutMs
         synchronized(lock) {
             while (true) {
@@ -103,6 +101,7 @@ class AcousticEventJournal(
                 ring[i]?.let { result.add(it) }
             }
         }
+        result.sortBy(AcousticEvent::sequence)
         return result
     }
 
@@ -111,5 +110,3 @@ class AcousticEventJournal(
     }
 }
 
-private val generationCounter = AtomicLong(0)
-private val sessionCounter = AtomicLong(0)

--- a/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/AcousticEventJournal.kt
@@ -1,0 +1,115 @@
+package com.kernel.ai.debug.journal
+
+import android.os.SystemClock
+import com.kernel.ai.core.voice.AcousticEvent
+import com.kernel.ai.core.voice.AcousticEventRecorder
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+private const val TAG = "TargetJournal"
+
+/**
+ * Bounded ring-buffer event journal for structured target-side diagnostics.
+ *
+ * Capacity of 256 covers the expected ~20–30 events per trial across
+ * multiple trials (recently armed, 30s idle, 2min idle) plus diagnostic
+ * overhead from service/error events, without unbounded growth.
+ *
+ * **Thread safety:** all mutating operations use [synchronized] on the
+ * journal instance.  Recording is low-volume and transition-based, never
+ * per-frame, so contention is negligible.
+ *
+ * **Overflow:** when the journal is full the oldest event is silently
+ * replaced and [overflowed] is set to true.
+ */
+class AcousticEventJournal(
+    val journalCapacity: Int = DEFAULT_CAPACITY,
+) : AcousticEventRecorder {
+
+    private val ring: Array<AcousticEvent?> = arrayOfNulls<AcousticEvent>(journalCapacity)
+    private var writeIndex = 0
+    private var count = 0
+    private val _overflowed = AtomicBoolean(false)
+    private val lock = Any()
+
+    /** True if at least one event was evicted due to capacity. */
+    val overflowed: Boolean get() = _overflowed.get()
+
+    fun allocateGenerationId(): Long = generationCounter.incrementAndGet()
+    fun allocateSessionId(): Long = sessionCounter.incrementAndGet()
+    private var localMaxSequence: Long = 0
+    val currentSequence: Long get() = localMaxSequence
+
+    override fun record(event: AcousticEvent) {
+        synchronized(lock) {
+            val idx = if (count < journalCapacity) {
+                count++
+                writeIndex
+            } else {
+                _overflowed.set(true)
+                writeIndex
+            }
+            ring[idx] = event
+            writeIndex = (idx + 1) % journalCapacity
+            if (event.sequence > localMaxSequence) localMaxSequence = event.sequence
+            (lock as java.lang.Object).notifyAll()
+        }
+    }
+
+    fun snapshotSince(sinceSequence: Long): List<AcousticEvent> {
+        val ordered: List<AcousticEvent>
+        synchronized(lock) {
+            ordered = if (count == 0) emptyList() else reconstructOrdered()
+        }
+        if (ordered.isEmpty()) return emptyList()
+        if (sinceSequence >= ordered.last().sequence) return emptyList()
+        val startIdx = ordered.indexOfFirst { it.sequence > sinceSequence }
+        if (startIdx < 0) return emptyList()
+        return ordered.subList(startIdx, ordered.size)
+    }
+
+    fun waitForEvent(
+        sinceSequence: Long,
+        eventType: String,
+        timeoutMs: Long,
+    ): AcousticEvent? {
+        snapshotSince(sinceSequence).firstOrNull { it.type == eventType }?.let { return it }
+        val deadline = System.nanoTime() / 1_000_000 + timeoutMs
+        synchronized(lock) {
+            while (true) {
+                val remaining = deadline - System.nanoTime() / 1_000_000
+                if (remaining <= 0) return null
+                reconstructOrdered()
+                    .firstOrNull { it.sequence > sinceSequence && it.type == eventType }
+                    ?.let { return it }
+                (lock as java.lang.Object).wait(remaining.coerceAtMost(500L))
+            }
+        }
+    }
+
+    private fun reconstructOrdered(): List<AcousticEvent> {
+        if (count == 0) return emptyList()
+        val result = ArrayList<AcousticEvent>(count)
+        if (count < journalCapacity) {
+            for (i in 0 until count) {
+                ring[i]?.let { result.add(it) }
+            }
+        } else {
+            for (i in writeIndex until journalCapacity) {
+                ring[i]?.let { result.add(it) }
+            }
+            for (i in 0 until writeIndex) {
+                ring[i]?.let { result.add(it) }
+            }
+        }
+        return result
+    }
+
+    companion object {
+        const val DEFAULT_CAPACITY = 256
+    }
+}
+
+private val generationCounter = AtomicLong(0)
+private val sessionCounter = AtomicLong(0)

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalContract.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalContract.kt
@@ -1,61 +1,91 @@
 package com.kernel.ai.debug.journal
 
+import com.kernel.ai.core.voice.AcousticEventType
+
 /**
  * Debug-only ADB contract for the target event journal.
  *
- * Three actions:
+ * The concurrent machine interface is exposed through `ContentProvider.call` at
+ * [PROVIDER_AUTHORITY]. `GET_JOURNAL_SEQUENCE` returns the highest sequence as
+ * decimal result data. `GET_JOURNAL_SNAPSHOT` accepts optional `since_sequence`
+ * (default 0) and returns the exact envelope
+ * `{"lowestSequence":Long,"highestSequence":Long,"overflowed":Boolean,"events":[Event...]}`.
  *
- * 1. `GET_SEQUENCE` — returns the current highest sequence number as
- *    `result_data`.  Zero means the journal is empty.
+ * `WAIT_FOR_JOURNAL_EVENT` requires `request_id` and `event_type`; it accepts
+ * optional `since_sequence` and `timeout_ms`. `request_id` is 1–64 ASCII
+ * letters, digits, `.`, `_`, or `-`, and must be unique among active waits.
  *
- * 2. `WAIT_FOR_JOURNAL_EVENT` — waits up to `timeout_ms` for an event of
- *    type `event_type` that was recorded after `since_sequence`.
- *    Result code 0 = found, 1 = timeout, 2 = error.
- *    `result_data` contains the matching event as a compact JSON line when
- *    found, or an error description when not.
+ * `CANCEL_JOURNAL_WAIT` requires the same `request_id`. A successful cancellation
+ * and the cancelled wait both return code 3 with `cancelled:<request_id>`.
  *
- * 3. `GET_JOURNAL_SNAPSHOT` — returns all events with sequence >
- *    `since_sequence` as a JSON array (one object per line).
- *    Always succeeds; `result_data` is the JSON array (possibly empty `[]`).
- *    Result code is always 0.
+ * Result codes: 0 success/event found, 1 timeout, 2 deterministic argument or
+ * endpoint error, 3 cancelled. Timeouts default to 15 000 ms and must be within
+ * the inclusive 500–60 000 ms range. Waits use journal notifications, not polling.
  *
- * ## Timeout semantics
+ * Stable argument errors are:
+ * `argument_error:missing_request_id`, `argument_error:invalid_request_id`,
+ * `argument_error:duplicate_request_id`, `argument_error:unknown_request_id`,
+ * `argument_error:negative_since_sequence`, `argument_error:missing_event_type`,
+ * `argument_error:invalid_event_type`, and `argument_error:invalid_timeout_ms`.
  *
- * The receiver checks once synchronously, then enters a bounded `wait` / poll
- * loop on the journal's intrinsic lock.  The supplied `timeout_ms` is the
- * maximum wall-clock time the receiver will block.  The default is 15 000 ms
- * and the minimum is 500 ms.
- *
- * ## Response format
- *
- * Events are serialised as compact JSON with the fields:
- * - `s` — sequence (Long)
- * - `m` — monotonicMs (Long)
- * - `w` — wallClockMs (Long, 0 if absent)
- * - `t` — type (String)
- * - `g` — generationId (Long, 0 if absent)
- * - `i` — sessionId (Long, 0 if absent)
- * - `d` — metadata (JSON object, empty `{}` if absent)
- *
- * Example: `{"s":1,"m":123456789,"w":1705300000000,"t":"STT_READY","g":1,"i":1,"d":{}}`
+ * Events use compact fields `s` sequence, `m` monotonic ms, `w` wall-clock ms,
+ * `t` type, `g` generation ID, `i` session ID, and `d` metadata.
  */
 internal object TargetEventJournalContract {
     const val ACTION_GET_SEQUENCE = "com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE"
-    const val ACTION_WAIT_FOR_EVENT = "com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT"
     const val ACTION_GET_SNAPSHOT = "com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT"
 
+    const val PROVIDER_AUTHORITY = "com.kernel.ai.debug.target-event-journal"
+    const val PROVIDER_URI = "content://$PROVIDER_AUTHORITY"
+    const val METHOD_GET_SEQUENCE = "GET_JOURNAL_SEQUENCE"
+    const val METHOD_WAIT_FOR_EVENT = "WAIT_FOR_JOURNAL_EVENT"
+    const val METHOD_CANCEL_WAIT = "CANCEL_JOURNAL_WAIT"
+    const val METHOD_GET_SNAPSHOT = "GET_JOURNAL_SNAPSHOT"
+
+    const val EXTRA_REQUEST_ID = "request_id"
     const val EXTRA_SINCE_SEQUENCE = "since_sequence"
     const val EXTRA_EVENT_TYPE = "event_type"
     const val EXTRA_TIMEOUT_MS = "timeout_ms"
+    const val RESULT_CODE = "result_code"
+    const val RESULT_DATA = "result_data"
 
     const val RESULT_OK = 0
     const val RESULT_TIMEOUT = 1
     const val RESULT_ERROR = 2
+    const val RESULT_CANCELLED = 3
 
     const val DEFAULT_TIMEOUT_MS = 15_000L
     const val MIN_TIMEOUT_MS = 500L
+    const val MAX_TIMEOUT_MS = 60_000L
 
-    /** Maps Long? → clamped timeout. */
-    fun clampTimeout(ms: Long?): Long =
-        (ms ?: DEFAULT_TIMEOUT_MS).coerceAtLeast(MIN_TIMEOUT_MS)
+    const val ERROR_MISSING_REQUEST_ID = "argument_error:missing_request_id"
+    const val ERROR_INVALID_REQUEST_ID = "argument_error:invalid_request_id"
+    const val ERROR_DUPLICATE_REQUEST_ID = "argument_error:duplicate_request_id"
+    const val ERROR_UNKNOWN_REQUEST_ID = "argument_error:unknown_request_id"
+    const val ERROR_NEGATIVE_SINCE_SEQUENCE = "argument_error:negative_since_sequence"
+    const val ERROR_MISSING_EVENT_TYPE = "argument_error:missing_event_type"
+    const val ERROR_INVALID_EVENT_TYPE = "argument_error:invalid_event_type"
+    const val ERROR_INVALID_TIMEOUT = "argument_error:invalid_timeout_ms"
+    const val ERROR_ENDPOINT_BUSY = "endpoint_busy"
+    const val ERROR_ENDPOINT = "endpoint_error"
+
+    private val requestIdPattern = Regex("[A-Za-z0-9._-]{1,64}")
+
+    fun requestIdError(requestId: String?): String? = when {
+        requestId.isNullOrBlank() -> ERROR_MISSING_REQUEST_ID
+        !requestIdPattern.matches(requestId) -> ERROR_INVALID_REQUEST_ID
+        else -> null
+    }
+
+    fun sinceSequenceError(sequence: Long): String? =
+        ERROR_NEGATIVE_SINCE_SEQUENCE.takeIf { sequence < 0L }
+
+    fun eventTypeError(eventType: String?): String? = when {
+        eventType.isNullOrBlank() -> ERROR_MISSING_EVENT_TYPE
+        eventType !in AcousticEventType.ALL -> ERROR_INVALID_EVENT_TYPE
+        else -> null
+    }
+
+    fun timeoutError(timeoutMs: Long): String? =
+        ERROR_INVALID_TIMEOUT.takeIf { timeoutMs !in MIN_TIMEOUT_MS..MAX_TIMEOUT_MS }
 }

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalContract.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalContract.kt
@@ -1,0 +1,61 @@
+package com.kernel.ai.debug.journal
+
+/**
+ * Debug-only ADB contract for the target event journal.
+ *
+ * Three actions:
+ *
+ * 1. `GET_SEQUENCE` — returns the current highest sequence number as
+ *    `result_data`.  Zero means the journal is empty.
+ *
+ * 2. `WAIT_FOR_JOURNAL_EVENT` — waits up to `timeout_ms` for an event of
+ *    type `event_type` that was recorded after `since_sequence`.
+ *    Result code 0 = found, 1 = timeout, 2 = error.
+ *    `result_data` contains the matching event as a compact JSON line when
+ *    found, or an error description when not.
+ *
+ * 3. `GET_JOURNAL_SNAPSHOT` — returns all events with sequence >
+ *    `since_sequence` as a JSON array (one object per line).
+ *    Always succeeds; `result_data` is the JSON array (possibly empty `[]`).
+ *    Result code is always 0.
+ *
+ * ## Timeout semantics
+ *
+ * The receiver checks once synchronously, then enters a bounded `wait` / poll
+ * loop on the journal's intrinsic lock.  The supplied `timeout_ms` is the
+ * maximum wall-clock time the receiver will block.  The default is 15 000 ms
+ * and the minimum is 500 ms.
+ *
+ * ## Response format
+ *
+ * Events are serialised as compact JSON with the fields:
+ * - `s` — sequence (Long)
+ * - `m` — monotonicMs (Long)
+ * - `w` — wallClockMs (Long, 0 if absent)
+ * - `t` — type (String)
+ * - `g` — generationId (Long, 0 if absent)
+ * - `i` — sessionId (Long, 0 if absent)
+ * - `d` — metadata (JSON object, empty `{}` if absent)
+ *
+ * Example: `{"s":1,"m":123456789,"w":1705300000000,"t":"STT_READY","g":1,"i":1,"d":{}}`
+ */
+internal object TargetEventJournalContract {
+    const val ACTION_GET_SEQUENCE = "com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE"
+    const val ACTION_WAIT_FOR_EVENT = "com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT"
+    const val ACTION_GET_SNAPSHOT = "com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT"
+
+    const val EXTRA_SINCE_SEQUENCE = "since_sequence"
+    const val EXTRA_EVENT_TYPE = "event_type"
+    const val EXTRA_TIMEOUT_MS = "timeout_ms"
+
+    const val RESULT_OK = 0
+    const val RESULT_TIMEOUT = 1
+    const val RESULT_ERROR = 2
+
+    const val DEFAULT_TIMEOUT_MS = 15_000L
+    const val MIN_TIMEOUT_MS = 500L
+
+    /** Maps Long? → clamped timeout. */
+    fun clampTimeout(ms: Long?): Long =
+        (ms ?: DEFAULT_TIMEOUT_MS).coerceAtLeast(MIN_TIMEOUT_MS)
+}

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalEndpoint.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalEndpoint.kt
@@ -1,0 +1,167 @@
+package com.kernel.ai.debug.journal
+
+import android.util.Log
+import com.kernel.ai.core.voice.AcousticJournalBridge
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+internal data class TargetEventJournalResponse(
+    val code: Int,
+    val data: String,
+)
+
+/** Shared implementation for the debug-only target journal machine interfaces. */
+internal object TargetEventJournalEndpoint {
+    private const val TAG = "TargetJournalEndpoint"
+    private const val WAIT_WORKER_COUNT = 4
+
+    private val waitExecutor = ThreadPoolExecutor(
+        WAIT_WORKER_COUNT,
+        WAIT_WORKER_COUNT,
+        0L,
+        TimeUnit.MILLISECONDS,
+        SynchronousQueue(),
+        { task -> Thread(task, "target-journal-wait").also { it.isDaemon = true } },
+        ThreadPoolExecutor.AbortPolicy(),
+    )
+    private val activeWaits = ConcurrentHashMap<String, AcousticEventWaitRegistration>()
+    private val reservationLock = Any()
+
+    @Volatile
+    private var journal: AcousticEventJournal? = null
+
+    fun sequence(): TargetEventJournalResponse = success(lazyJournal().currentSequence.toString())
+
+    fun snapshot(sinceSequence: Long): TargetEventJournalResponse {
+        TargetEventJournalContract.sinceSequenceError(sinceSequence)?.let {
+            return error(it)
+        }
+        return success(AcousticJournalJson.serialiseSnapshot(lazyJournal().snapshotSince(sinceSequence)))
+    }
+
+    fun waitForEvent(
+        requestId: String?,
+        sinceSequence: Long,
+        eventType: String?,
+        timeoutMs: Long,
+    ): TargetEventJournalResponse {
+        val argumentError = TargetEventJournalContract.requestIdError(requestId)
+            ?: TargetEventJournalContract.sinceSequenceError(sinceSequence)
+            ?: TargetEventJournalContract.eventTypeError(eventType)
+            ?: TargetEventJournalContract.timeoutError(timeoutMs)
+        if (argumentError != null) return error(argumentError)
+
+        val stableRequestId = requireNotNull(requestId)
+        val stableEventType = requireNotNull(eventType)
+        val registration = AcousticEventWaitRegistration()
+        val reservationError = synchronized(reservationLock) {
+            when {
+                activeWaits.containsKey(stableRequestId) ->
+                    TargetEventJournalContract.ERROR_DUPLICATE_REQUEST_ID
+                activeWaits.size >= WAIT_WORKER_COUNT ->
+                    TargetEventJournalContract.ERROR_ENDPOINT_BUSY
+                else -> {
+                    activeWaits[stableRequestId] = registration
+                    null
+                }
+            }
+        }
+        if (reservationError != null) return error(reservationError)
+
+        val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        var task: java.util.concurrent.Future<TargetEventJournalResponse>? = null
+        return try {
+            val submitted = waitExecutor.submit<TargetEventJournalResponse> {
+                val remainingMs = TimeUnit.NANOSECONDS.toMillis(
+                    (deadlineNanos - System.nanoTime()).coerceAtLeast(0L),
+                )
+                when (
+                    val result = registration.resolve(
+                        lazyJournal().waitForEvent(
+                            sinceSequence = sinceSequence,
+                            eventType = stableEventType,
+                            timeoutMs = remainingMs,
+                            cancellation = registration.cancellation,
+                        ),
+                    )
+                ) {
+                    is AcousticEventWaitResult.Found -> success(
+                        AcousticJournalJson.serialiseEvent(result.event),
+                    )
+                    AcousticEventWaitResult.TimedOut -> TargetEventJournalResponse(
+                        TargetEventJournalContract.RESULT_TIMEOUT,
+                        "timeout:$stableRequestId:${timeoutMs}ms",
+                    )
+                    AcousticEventWaitResult.Cancelled -> cancelled(stableRequestId)
+                }
+            }
+            task = submitted
+            submitted.get(timeoutMs + WAIT_COMPLETION_GRACE_MS, TimeUnit.MILLISECONDS)
+        } catch (_: RejectedExecutionException) {
+            error(TargetEventJournalContract.ERROR_ENDPOINT_BUSY)
+        } catch (failure: Exception) {
+            registration.cancel()
+            lazyJournal().cancelWait(registration.cancellation)
+            task?.cancel(true)
+            if (failure is InterruptedException) Thread.currentThread().interrupt()
+            Log.e(TAG, "wait_error", failure)
+            error(TargetEventJournalContract.ERROR_ENDPOINT)
+        } finally {
+            synchronized(reservationLock) {
+                activeWaits.remove(stableRequestId, registration)
+            }
+        }
+    }
+
+    fun cancelWait(requestId: String?): TargetEventJournalResponse {
+        TargetEventJournalContract.requestIdError(requestId)?.let {
+            return error(it)
+        }
+        val stableRequestId = requireNotNull(requestId)
+        val registration = activeWaits[stableRequestId]
+        if (registration == null || !registration.cancel()) {
+            return error(TargetEventJournalContract.ERROR_UNKNOWN_REQUEST_ID)
+        }
+        lazyJournal().cancelWait(registration.cancellation)
+        return cancelled(stableRequestId)
+    }
+
+    private fun success(data: String) = TargetEventJournalResponse(
+        TargetEventJournalContract.RESULT_OK,
+        data,
+    )
+
+    private fun error(data: String) = TargetEventJournalResponse(
+        TargetEventJournalContract.RESULT_ERROR,
+        data,
+    )
+
+    private fun cancelled(requestId: String) = TargetEventJournalResponse(
+        TargetEventJournalContract.RESULT_CANCELLED,
+        "cancelled:$requestId",
+    )
+
+    internal fun replaceJournalForTest(replacement: AcousticEventJournal) {
+        check(activeWaits.isEmpty())
+        synchronized(this) {
+            journal = replacement
+            AcousticJournalBridge.install(replacement)
+        }
+    }
+
+    internal fun activeWaitCountForTest(): Int = activeWaits.size
+
+    /** Creates and installs the process-local journal on first access. */
+    private fun lazyJournal(): AcousticEventJournal = journal ?: synchronized(this) {
+        journal ?: AcousticEventJournal().also {
+            journal = it
+            AcousticJournalBridge.install(it)
+            Log.i(TAG, "journal installed (capacity=${it.journalCapacity})")
+        }
+    }
+
+    private const val WAIT_COMPLETION_GRACE_MS = 1_000L
+}

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalProvider.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalProvider.kt
@@ -1,0 +1,76 @@
+package com.kernel.ai.debug.journal
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+
+/**
+ * Debug-only concurrent ADB endpoint for bounded journal waits and control calls.
+ *
+ * Content-provider calls execute on Binder threads rather than Android's serial ordered-
+ * broadcast queue. Independent waits can therefore remain open while snapshot, sequence,
+ * and cancellation calls complete promptly, without a BroadcastReceiver ANR deadline.
+ */
+class TargetEventJournalProvider : ContentProvider() {
+    override fun onCreate(): Boolean {
+        TargetEventJournalEndpoint.sequence()
+        return true
+    }
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+        val response = when (method) {
+            TargetEventJournalContract.METHOD_GET_SEQUENCE -> TargetEventJournalEndpoint.sequence()
+            TargetEventJournalContract.METHOD_GET_SNAPSHOT -> TargetEventJournalEndpoint.snapshot(
+                extras.longExtra(TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L),
+            )
+            TargetEventJournalContract.METHOD_WAIT_FOR_EVENT -> TargetEventJournalEndpoint.waitForEvent(
+                requestId = extras?.getString(TargetEventJournalContract.EXTRA_REQUEST_ID),
+                sinceSequence = extras.longExtra(TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L),
+                eventType = extras?.getString(TargetEventJournalContract.EXTRA_EVENT_TYPE),
+                timeoutMs = extras.longExtra(
+                    TargetEventJournalContract.EXTRA_TIMEOUT_MS,
+                    TargetEventJournalContract.DEFAULT_TIMEOUT_MS,
+                ),
+            )
+            TargetEventJournalContract.METHOD_CANCEL_WAIT -> TargetEventJournalEndpoint.cancelWait(
+                extras?.getString(TargetEventJournalContract.EXTRA_REQUEST_ID),
+            )
+            else -> TargetEventJournalResponse(
+                TargetEventJournalContract.RESULT_ERROR,
+                "unknown_method:$method",
+            )
+        }
+        return Bundle(2).apply {
+            putInt(TargetEventJournalContract.RESULT_CODE, response.code)
+            putString(TargetEventJournalContract.RESULT_DATA, response.data)
+        }
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = throw UnsupportedOperationException("Use ContentProvider.call")
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? =
+        throw UnsupportedOperationException("Use ContentProvider.call")
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        throw UnsupportedOperationException("Use ContentProvider.call")
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = throw UnsupportedOperationException("Use ContentProvider.call")
+
+    private fun Bundle?.longExtra(key: String, defaultValue: Long): Long =
+        if (this?.containsKey(key) == true) getLong(key) else defaultValue
+}

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
@@ -1,0 +1,182 @@
+package com.kernel.ai.debug.journal
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.AcousticJournalBridge
+import java.util.concurrent.Executors
+
+private const val TAG = "TargetJournalReceiver"
+
+/**
+ * Debug-only ADB endpoint for the structured target event journal.
+ *
+ * ## Lifecycle
+ *
+ * The receiver lazily creates and installs a [BoundedAcousticEventJournal] on
+ * its first invocation.  The journal is shared with production hooks via
+ * [AcousticJournalBridge].
+ *
+ * ## Invocation (examples)
+ *
+ * ```sh
+ * # Get current highest sequence
+ * adb shell am broadcast \
+ *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+ *   -a com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE
+ *
+ * # Wait for STT_READY, timeout 10 seconds
+ * adb shell am broadcast \
+ *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+ *   -a com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT \
+ *   --el since_sequence 5 \
+ *   --es event_type STT_READY \
+ *   --el timeout_ms 10000
+ *
+ * # Get snapshot since sequence 5
+ * adb shell am broadcast \
+ *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+ *   -a com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT \
+ *   --el since_sequence 5
+ * ```
+ *
+ * ## Thread safety
+ *
+ * All three actions are executed on the receiver's single-threaded executor
+ * so they are serialised with respect to each other.  Journal recording
+ * happens on production threads (detector, service, main) and synchronises
+ * on the journal's intrinsic lock.
+ */
+class TargetEventJournalReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        executor.execute {
+            try {
+                handle(intent, pendingResult)
+            } catch (e: Exception) {
+                Log.e(TAG, "receiver_error", e)
+                pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
+                pendingResult.setResultData("receiver_error: ${e.message}")
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun handle(
+        intent: Intent,
+        pendingResult: BroadcastReceiver.PendingResult,
+    ) {
+        val journal = lazyJournal()
+
+        when (intent.action) {
+            TargetEventJournalContract.ACTION_GET_SEQUENCE -> {
+                val seq = journal.currentSequence
+                pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
+                pendingResult.setResultData(seq.toString())
+                pendingResult.finish()
+            }
+
+            TargetEventJournalContract.ACTION_WAIT_FOR_EVENT -> {
+                val sinceSeq = intent.getLongExtra(
+                    TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L,
+                )
+                val eventType = intent.getStringExtra(
+                    TargetEventJournalContract.EXTRA_EVENT_TYPE,
+                )
+                val timeoutMs = TargetEventJournalContract.clampTimeout(
+                    intent.getLongExtra(
+                        TargetEventJournalContract.EXTRA_TIMEOUT_MS,
+                        TargetEventJournalContract.DEFAULT_TIMEOUT_MS,
+                    ),
+                )
+
+                if (eventType.isNullOrBlank()) {
+                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
+                    pendingResult.setResultData("event_type is required")
+                    pendingResult.finish()
+                    return
+                }
+
+                val event = journal.waitForEvent(sinceSeq, eventType, timeoutMs)
+                if (event != null) {
+                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
+                    pendingResult.setResultData(serialiseEvent(event))
+                } else {
+                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_TIMEOUT)
+                    pendingResult.setResultData(
+                        "timeout after ${timeoutMs}ms waiting for $eventType since seq $sinceSeq"
+                    )
+                }
+                pendingResult.finish()
+            }
+
+            TargetEventJournalContract.ACTION_GET_SNAPSHOT -> {
+                val sinceSeq = intent.getLongExtra(
+                    TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L,
+                )
+                val events = journal.snapshotSince(sinceSeq)
+                val json = events.joinToString(separator = "\n", prefix = "[", postfix = "]") {
+                    serialiseEvent(it)
+                }
+                pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
+                pendingResult.setResultData(json)
+                pendingResult.finish()
+            }
+
+            else -> {
+                pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
+                pendingResult.setResultData("unknown_action: ${intent.action}")
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        private val executor = Executors.newSingleThreadExecutor { r ->
+            Thread(r, "target-journal-receiver").also { it.isDaemon = true }
+        }
+
+        @Volatile
+        private var journal: AcousticEventJournal? = null
+
+        /**
+         * Creates and installs the journal on first access.
+         * Thread-safe: at most one journal is ever created.
+         */
+        private fun lazyJournal(): AcousticEventJournal {
+            return journal ?: synchronized(this) {
+                journal ?: AcousticEventJournal().also {
+                    journal = it
+                    AcousticJournalBridge.install(it)
+                    Log.i(TAG, "journal installed (capacity=${it.journalCapacity})")
+                }
+            }
+        }
+
+        /** Compact JSON serialisation of an [AcousticEvent]. */
+        private fun serialiseEvent(event: com.kernel.ai.core.voice.AcousticEvent): String {
+            val metaJson = if (event.metadata.isEmpty()) "{}" else {
+                event.metadata.entries.joinToString(
+                    separator = ",",
+                    prefix = "{",
+                    postfix = "}",
+                ) { (k, v) ->
+                    "\"${escapeJson(k)}\":\"${escapeJson(v)}\""
+                }
+            }
+            return """{"s":${event.sequence},"m":${event.monotonicMs},"w":${event.wallClockMs},"t":"${escapeJson(event.type)}","g":${event.generationId},"i":${event.sessionId},"d":$metaJson}"""
+        }
+
+        private fun escapeJson(s: String): String =
+            s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+    }
+}

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
@@ -3,158 +3,54 @@ package com.kernel.ai.debug.journal
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
-import com.kernel.ai.core.voice.AcousticEventType
-import com.kernel.ai.core.voice.AcousticJournalBridge
 import java.util.concurrent.Executors
 
-private const val TAG = "TargetJournalReceiver"
-
 /**
- * Debug-only ADB endpoint for the structured target event journal.
+ * Legacy debug-only ordered-broadcast endpoint for non-blocking journal reads.
  *
- * ## Lifecycle
- *
- * The receiver lazily creates and installs a [BoundedAcousticEventJournal] on
- * its first invocation.  The journal is shared with production hooks via
- * [AcousticJournalBridge].
- *
- * ## Invocation (examples)
- *
- * ```sh
- * # Get current highest sequence
- * adb shell am broadcast \
- *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
- *   -a com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE
- *
- * # Wait for STT_READY, timeout 10 seconds
- * adb shell am broadcast \
- *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
- *   -a com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT \
- *   --el since_sequence 5 \
- *   --es event_type STT_READY \
- *   --el timeout_ms 10000
- *
- * # Get snapshot since sequence 5
- * adb shell am broadcast \
- *   -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
- *   -a com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT \
- *   --el since_sequence 5
- * ```
- *
- * ## Thread safety
- *
- * All three actions are executed on the receiver's single-threaded executor
- * so they are serialised with respect to each other.  Journal recording
- * happens on production threads (detector, service, main) and synchronises
- * on the journal's intrinsic lock.
+ * Android serialises ordered broadcasts and imposes a receiver completion deadline, so
+ * bounded waits and cancellation use [TargetEventJournalProvider]. Keeping waits out of
+ * this receiver prevents one open wait from blocking every later control request.
  */
 class TargetEventJournalReceiver : BroadcastReceiver() {
-
     override fun onReceive(context: Context, intent: Intent) {
         val pendingResult = goAsync()
-        executor.execute {
-            try {
-                handle(intent, pendingResult)
-            } catch (e: Exception) {
-                Log.e(TAG, "receiver_error", e)
-                pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
-                pendingResult.setResultData("receiver_error")
-                pendingResult.finish()
-            }
-        }
-    }
-
-    private fun handle(
-        intent: Intent,
-        pendingResult: BroadcastReceiver.PendingResult,
-    ) {
-        val journal = lazyJournal()
-
-        when (intent.action) {
-            TargetEventJournalContract.ACTION_GET_SEQUENCE -> {
-                val seq = journal.currentSequence
-                pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
-                pendingResult.setResultData(seq.toString())
-                pendingResult.finish()
-            }
-
-            TargetEventJournalContract.ACTION_WAIT_FOR_EVENT -> {
-                val sinceSeq = intent.getLongExtra(
-                    TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L,
-                )
-                val eventType = intent.getStringExtra(
-                    TargetEventJournalContract.EXTRA_EVENT_TYPE,
-                )
-                val timeoutMs = TargetEventJournalContract.clampTimeout(
-                    intent.getLongExtra(
-                        TargetEventJournalContract.EXTRA_TIMEOUT_MS,
-                        TargetEventJournalContract.DEFAULT_TIMEOUT_MS,
-                    ),
-                )
-
-                if (eventType.isNullOrBlank()) {
-                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
-                    pendingResult.setResultData("event_type is required")
-                    pendingResult.finish()
-                    return
-                }
-
-                val event = journal.waitForEvent(sinceSeq, eventType, timeoutMs)
-                if (event != null) {
-                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
-                    pendingResult.setResultData(AcousticJournalJson.serialiseEvent(event))
-                } else {
-                    pendingResult.setResultCode(TargetEventJournalContract.RESULT_TIMEOUT)
-                    pendingResult.setResultData(
-                        "timeout after ${timeoutMs}ms waiting for $eventType since seq $sinceSeq"
+        controlExecutor.execute {
+            val response = runCatching {
+                when (intent.action) {
+                    TargetEventJournalContract.ACTION_GET_SEQUENCE ->
+                        TargetEventJournalEndpoint.sequence()
+                    TargetEventJournalContract.ACTION_GET_SNAPSHOT ->
+                        TargetEventJournalEndpoint.snapshot(
+                            intent.getLongExtra(
+                                TargetEventJournalContract.EXTRA_SINCE_SEQUENCE,
+                                0L,
+                            ),
+                        )
+                    else -> TargetEventJournalResponse(
+                        TargetEventJournalContract.RESULT_ERROR,
+                        "use_content_provider:${intent.action}",
                     )
                 }
-                pendingResult.finish()
-            }
-
-            TargetEventJournalContract.ACTION_GET_SNAPSHOT -> {
-                val sinceSeq = intent.getLongExtra(
-                    TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L,
+            }.getOrElse {
+                Log.e(TAG, "receiver_error", it)
+                TargetEventJournalResponse(
+                    TargetEventJournalContract.RESULT_ERROR,
+                    TargetEventJournalContract.ERROR_ENDPOINT,
                 )
-                val snapshot = journal.snapshotSince(sinceSeq)
-                pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
-                pendingResult.setResultData(AcousticJournalJson.serialiseSnapshot(snapshot))
-                pendingResult.finish()
             }
-
-            else -> {
-                pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
-                pendingResult.setResultData("unknown_action: ${intent.action}")
-                pendingResult.finish()
-            }
+            pendingResult.setResultCode(response.code)
+            pendingResult.setResultData(response.data)
+            pendingResult.finish()
         }
     }
 
-    companion object {
-        private val executor = Executors.newSingleThreadExecutor { r ->
-            Thread(r, "target-journal-receiver").also { it.isDaemon = true }
+    private companion object {
+        const val TAG = "TargetJournalReceiver"
+        val controlExecutor = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "target-journal-control").also { it.isDaemon = true }
         }
-
-        @Volatile
-        private var journal: AcousticEventJournal? = null
-
-        /**
-         * Creates and installs the journal on first access.
-         * Thread-safe: at most one journal is ever created.
-         */
-        private fun lazyJournal(): AcousticEventJournal {
-            return journal ?: synchronized(this) {
-                journal ?: AcousticEventJournal().also {
-                    journal = it
-                    AcousticJournalBridge.install(it)
-                    Log.i(TAG, "journal installed (capacity=${it.journalCapacity})")
-                }
-            }
-        }
-
     }
 }
 

--- a/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/journal/TargetEventJournalReceiver.kt
@@ -61,7 +61,7 @@ class TargetEventJournalReceiver : BroadcastReceiver() {
             } catch (e: Exception) {
                 Log.e(TAG, "receiver_error", e)
                 pendingResult.setResultCode(TargetEventJournalContract.RESULT_ERROR)
-                pendingResult.setResultData("receiver_error: ${e.message}")
+                pendingResult.setResultData("receiver_error")
                 pendingResult.finish()
             }
         }
@@ -105,7 +105,7 @@ class TargetEventJournalReceiver : BroadcastReceiver() {
                 val event = journal.waitForEvent(sinceSeq, eventType, timeoutMs)
                 if (event != null) {
                     pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
-                    pendingResult.setResultData(serialiseEvent(event))
+                    pendingResult.setResultData(AcousticJournalJson.serialiseEvent(event))
                 } else {
                     pendingResult.setResultCode(TargetEventJournalContract.RESULT_TIMEOUT)
                     pendingResult.setResultData(
@@ -119,12 +119,9 @@ class TargetEventJournalReceiver : BroadcastReceiver() {
                 val sinceSeq = intent.getLongExtra(
                     TargetEventJournalContract.EXTRA_SINCE_SEQUENCE, 0L,
                 )
-                val events = journal.snapshotSince(sinceSeq)
-                val json = events.joinToString(separator = "\n", prefix = "[", postfix = "]") {
-                    serialiseEvent(it)
-                }
+                val snapshot = journal.snapshotSince(sinceSeq)
                 pendingResult.setResultCode(TargetEventJournalContract.RESULT_OK)
-                pendingResult.setResultData(json)
+                pendingResult.setResultData(AcousticJournalJson.serialiseSnapshot(snapshot))
                 pendingResult.finish()
             }
 
@@ -158,25 +155,51 @@ class TargetEventJournalReceiver : BroadcastReceiver() {
             }
         }
 
-        /** Compact JSON serialisation of an [AcousticEvent]. */
-        private fun serialiseEvent(event: com.kernel.ai.core.voice.AcousticEvent): String {
-            val metaJson = if (event.metadata.isEmpty()) "{}" else {
-                event.metadata.entries.joinToString(
-                    separator = ",",
-                    prefix = "{",
-                    postfix = "}",
-                ) { (k, v) ->
-                    "\"${escapeJson(k)}\":\"${escapeJson(v)}\""
-                }
+    }
+}
+
+internal object AcousticJournalJson {
+    fun serialiseSnapshot(snapshot: AcousticJournalSnapshot): String =
+        buildString {
+            append("""{"lowestSequence":${snapshot.lowestSequence},"highestSequence":${snapshot.highestSequence},"overflowed":${snapshot.overflowed},"events":[""")
+            snapshot.events.forEachIndexed { index, event ->
+                if (index > 0) append(',')
+                append(serialiseEvent(event))
             }
-            return """{"s":${event.sequence},"m":${event.monotonicMs},"w":${event.wallClockMs},"t":"${escapeJson(event.type)}","g":${event.generationId},"i":${event.sessionId},"d":$metaJson}"""
+            append("]}")
         }
 
-        private fun escapeJson(s: String): String =
-            s.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t")
+    fun serialiseEvent(event: com.kernel.ai.core.voice.AcousticEvent): String {
+        val metaJson = if (event.metadata.isEmpty()) "{}" else {
+            event.metadata.entries.joinToString(
+                separator = ",",
+                prefix = "{",
+                postfix = "}",
+            ) { (key, value) ->
+                "\"${escapeJson(key)}\":\"${escapeJson(value)}\""
+            }
+        }
+        return """{"s":${event.sequence},"m":${event.monotonicMs},"w":${event.wallClockMs},"t":"${escapeJson(event.type)}","g":${event.generationId},"i":${event.sessionId},"d":$metaJson}"""
     }
+
+    private fun escapeJson(value: String): String =
+        buildString(value.length) {
+            value.forEach { character ->
+                when (character) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\b' -> append("\\b")
+                    '\u000C' -> append("\\f")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    '\t' -> append("\\t")
+                    else -> if (character.code < 0x20) {
+                        append("\\u")
+                        append(character.code.toString(16).padStart(4, '0'))
+                    } else {
+                        append(character)
+                    }
+                }
+            }
+        }
 }

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -577,6 +577,8 @@ class ClockAlertService : Service() {
                 refreshForeground()
             }
 
+            is VoiceInputEvent.SpeechDetected -> Unit
+
             is VoiceInputEvent.PartialTranscript -> Unit
 
             is VoiceInputEvent.Transcript -> {

--- a/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
+++ b/app/src/main/java/com/kernel/ai/alarm/ClockAlertService.kt
@@ -561,7 +561,7 @@ class ClockAlertService : Service() {
         refreshForeground()
         serviceScope.launch {
             when (val result = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)) {
-                VoiceInputStartResult.Started -> Unit
+                is VoiceInputStartResult.Started -> Unit
                 is VoiceInputStartResult.Unavailable -> finishVoiceCapture(
                     result.message.ifBlank { "Voice commands are unavailable right now." },
                 )

--- a/app/src/main/java/com/kernel/ai/assistant/WakeSessionJournal.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeSessionJournal.kt
@@ -1,0 +1,57 @@
+package com.kernel.ai.assistant
+
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.AcousticJournalBridge
+
+/** Emits one correlated wake-session stream with exactly one terminal event. */
+internal class WakeSessionJournal(
+    private val generationId: Long,
+    private val sessionId: Long,
+    private val emit: (
+        type: String,
+        generationId: Long,
+        sessionId: Long,
+        metadata: () -> Map<String, String>,
+    ) -> Unit = { type, generationId, sessionId, metadata ->
+        AcousticJournalBridge.record(type, generationId, sessionId, metadata = metadata)
+    },
+) {
+    private var started = false
+    private var terminal = false
+
+    @Synchronized
+    fun start() {
+        check(!started) { "Wake session already started" }
+        started = true
+        emit(AcousticEventType.VOICE_SESSION_STARTED, generationId, sessionId, EMPTY_METADATA)
+    }
+
+    @Synchronized
+    fun record(
+        type: String,
+        metadata: () -> Map<String, String> = EMPTY_METADATA,
+    ) {
+        if (!started || terminal) return
+        emit(type, generationId, sessionId, metadata)
+    }
+
+    @Synchronized
+    fun complete(): Boolean = finish(AcousticEventType.SESSION_COMPLETED, EMPTY_METADATA)
+
+    @Synchronized
+    fun cancel(category: String): Boolean = finish(
+        AcousticEventType.SESSION_CANCELLED,
+        { mapOf("category" to category) },
+    )
+
+    private fun finish(type: String, metadata: () -> Map<String, String>): Boolean {
+        if (!started || terminal) return false
+        terminal = true
+        emit(type, generationId, sessionId, metadata)
+        return true
+    }
+
+    private companion object {
+        val EMPTY_METADATA: () -> Map<String, String> = { emptyMap() }
+    }
+}

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -33,9 +33,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 import javax.inject.Inject
@@ -176,137 +175,141 @@ class WakeWordService : Service() {
             journal.start()
             var completed = false
             var cancellationCategory = "stt_no_final_result"
-            val progressCollector = launch(start = CoroutineStart.UNDISPATCHED) {
-                voiceInputController.events.collect { event ->
-                    if (!event.isWakeSessionEvent()) return@collect
-                    when (event) {
-                        is VoiceInputEvent.SpeechDetected -> journal.record(
-                            AcousticEventType.STT_SPEECH_DETECTED,
-                        )
-                        is VoiceInputEvent.PartialTranscript -> journal.record(
-                            AcousticEventType.STT_PARTIAL,
-                            metadata = { mapOf("length" to event.text.length.toString()) },
-                        )
-                        else -> Unit
-                    }
-                }
-            }
 
             try {
                 var transcript: String? = null
                 for (attempt in 1..2) {
-                    val startupEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
-                        voiceInputController.events.first {
-                            it.isWakeSessionEvent() && (
+                    val attemptEvents = Channel<VoiceInputEvent>(capacity = Channel.BUFFERED)
+                    val attemptCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+                        voiceInputController.events.collect(attemptEvents::send)
+                    }
+                    try {
+                        journal.record(
+                            AcousticEventType.STT_START_REQUESTED,
+                            metadata = { mapOf("attempt" to attempt.toString()) },
+                        )
+                        val startResult = voiceInputController.startListening(
+                            VoiceCaptureMode.AlertCommand,
+                        )
+                        if (startResult !is VoiceInputStartResult.Started) {
+                            cancellationCategory = "stt_unavailable"
+                            journal.record(
+                                AcousticEventType.STT_ERROR,
+                                metadata = { mapOf("category" to "stt_unavailable") },
+                            )
+                            Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
+                            val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
+                            if (!message.isNullOrBlank()) showWakeWordError(message)
+                            break
+                        }
+
+                        val captureSessionId = startResult.captureSessionId
+                        suspend fun awaitAttemptEvent(
+                            isTerminal: (VoiceInputEvent) -> Boolean,
+                        ): VoiceInputEvent {
+                            while (true) {
+                                val event = attemptEvents.receive()
+                                if (!event.isWakeSessionEvent(captureSessionId)) continue
+                                when (event) {
+                                    is VoiceInputEvent.SpeechDetected -> journal.record(
+                                        AcousticEventType.STT_SPEECH_DETECTED,
+                                    )
+                                    is VoiceInputEvent.PartialTranscript -> journal.record(
+                                        AcousticEventType.STT_PARTIAL,
+                                        metadata = {
+                                            mapOf("length" to event.text.length.toString())
+                                        },
+                                    )
+                                    else -> Unit
+                                }
+                                if (isTerminal(event)) return event
+                            }
+                        }
+
+                        val startupEvent = try {
+                            awaitAttemptEvent {
                                 it is VoiceInputEvent.ListeningStarted ||
                                     it is VoiceInputEvent.Transcript ||
                                     it is VoiceInputEvent.Error ||
                                     it is VoiceInputEvent.ListeningStopped
-                                )
-                        }
-                    }
-                    val terminalEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
-                        voiceInputController.events.first {
-                            it.isWakeSessionEvent() && (
-                                it is VoiceInputEvent.Transcript ||
-                                    it is VoiceInputEvent.Error ||
-                                    it is VoiceInputEvent.ListeningStopped
-                                )
-                        }
-                    }
-                    journal.record(
-                        AcousticEventType.STT_START_REQUESTED,
-                        metadata = { mapOf("attempt" to attempt.toString()) },
-                    )
-                    val startResult = voiceInputController.startListening(
-                        VoiceCaptureMode.AlertCommand,
-                    )
-                    if (startResult !is VoiceInputStartResult.Started) {
-                        startupEventDeferred.cancel()
-                        terminalEventDeferred.cancel()
-                        cancellationCategory = "stt_unavailable"
-                        journal.record(
-                            AcousticEventType.STT_ERROR,
-                            metadata = { mapOf("category" to "stt_unavailable") },
-                        )
-                        Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
-                        val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
-                        if (!message.isNullOrBlank()) showWakeWordError(message)
-                        break
-                    }
-
-                    val startupEvent = try {
-                        startupEventDeferred.await()
-                    } catch (e: CancellationException) {
-                        terminalEventDeferred.cancel()
-                        throw e
-                    } catch (e: Exception) {
-                        terminalEventDeferred.cancel()
-                        cancellationCategory = "startup_collection_failed"
-                        Log.w(TAG, "WakeWordService: startup event collection failed (attempt $attempt)", e)
-                        break
-                    }
-
-                    if (startupEvent is VoiceInputEvent.ListeningStarted) {
-                        journal.record(AcousticEventType.STT_READY)
-                    }
-
-                    val terminalEvent = when (startupEvent) {
-                        is VoiceInputEvent.ListeningStarted -> {
-                            if (attempt == 1) {
-                                journal.record(
-                                    AcousticEventType.CUE_REQUESTED,
-                                    metadata = { mapOf("force_audible" to "true") },
-                                )
-                                cuePlayer.playCue(forceAudible = true)
                             }
-                            try {
-                                terminalEventDeferred.await()
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Exception) {
-                                cancellationCategory = "transcript_collection_failed"
-                                Log.w(
-                                    TAG,
-                                    "WakeWordService: transcript collection failed (attempt $attempt)",
-                                    e,
-                                )
-                                break
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            cancellationCategory = "startup_collection_failed"
+                            Log.w(
+                                TAG,
+                                "WakeWordService: startup event collection failed (attempt $attempt)",
+                                e,
+                            )
+                            break
+                        }
+
+                        if (startupEvent is VoiceInputEvent.ListeningStarted) {
+                            journal.record(AcousticEventType.STT_READY)
+                        }
+
+                        val terminalEvent = when (startupEvent) {
+                            is VoiceInputEvent.ListeningStarted -> {
+                                if (attempt == 1) {
+                                    journal.record(
+                                        AcousticEventType.CUE_REQUESTED,
+                                        metadata = { mapOf("force_audible" to "true") },
+                                    )
+                                    cuePlayer.playCue(forceAudible = true)
+                                }
+                                try {
+                                    awaitAttemptEvent {
+                                        it is VoiceInputEvent.Transcript ||
+                                            it is VoiceInputEvent.Error ||
+                                            it is VoiceInputEvent.ListeningStopped
+                                    }
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    cancellationCategory = "transcript_collection_failed"
+                                    Log.w(
+                                        TAG,
+                                        "WakeWordService: transcript collection failed (attempt $attempt)",
+                                        e,
+                                    )
+                                    break
+                                }
                             }
+                            else -> startupEvent
                         }
-                        else -> {
-                            terminalEventDeferred.cancel()
-                            startupEvent
-                        }
-                    }
 
-                    val text = (terminalEvent as? VoiceInputEvent.Transcript)?.text
-                    if (!text.isNullOrBlank()) {
-                        journal.record(
-                            AcousticEventType.STT_FINAL,
-                            metadata = { mapOf("length" to text.length.toString()) },
-                        )
-                        transcript = text
-                        break
-                    }
-
-                    if (terminalEvent is VoiceInputEvent.Error) {
-                        journal.record(
-                            AcousticEventType.STT_ERROR,
-                            metadata = { mapOf("category" to "stt_recognition_failed") },
-                        )
-                        if (attempt == 2 && terminalEvent.message.isNotBlank()) {
-                            showWakeWordError(terminalEvent.message)
+                        val text = (terminalEvent as? VoiceInputEvent.Transcript)?.text
+                        if (!text.isNullOrBlank()) {
+                            journal.record(
+                                AcousticEventType.STT_FINAL,
+                                metadata = { mapOf("length" to text.length.toString()) },
+                            )
+                            transcript = text
+                            break
                         }
-                        cancellationCategory = "stt_recognition_failed"
-                    } else {
-                        cancellationCategory = "stt_stopped_without_result"
+
+                        if (terminalEvent is VoiceInputEvent.Error) {
+                            journal.record(
+                                AcousticEventType.STT_ERROR,
+                                metadata = { mapOf("category" to "stt_recognition_failed") },
+                            )
+                            if (attempt == 2 && terminalEvent.message.isNotBlank()) {
+                                showWakeWordError(terminalEvent.message)
+                            }
+                            cancellationCategory = "stt_recognition_failed"
+                        } else {
+                            cancellationCategory = "stt_stopped_without_result"
+                        }
+                        Log.w(
+                            TAG,
+                            "WakeWordService: no transcript on attempt $attempt ($terminalEvent)" +
+                                if (attempt < 2) " — retrying" else "",
+                        )
+                    } finally {
+                        attemptCollector.cancel()
+                        attemptEvents.cancel()
                     }
-                    Log.w(
-                        TAG,
-                        "WakeWordService: no transcript on attempt $attempt ($terminalEvent)" +
-                            if (attempt < 2) " — retrying" else "",
-                    )
                 }
 
                 if (transcript != null) {
@@ -337,7 +340,6 @@ class WakeWordService : Service() {
                 cancellationCategory = "session_failed"
                 Log.e(TAG, "WakeWordService: wake session failed", e)
             } finally {
-                progressCollector.cancel()
                 if (completed) {
                     journal.complete()
                 } else {
@@ -524,5 +526,5 @@ class WakeWordService : Service() {
     }
 }
 
-internal fun VoiceInputEvent.isWakeSessionEvent(): Boolean =
-    mode == VoiceCaptureMode.AlertCommand
+internal fun VoiceInputEvent.isWakeSessionEvent(captureSessionId: Long): Boolean =
+    mode == VoiceCaptureMode.AlertCommand && this.captureSessionId == captureSessionId

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -14,6 +14,8 @@ import android.widget.Toast
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.kernel.ai.MainActivity
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.AcousticJournalBridge
 import com.kernel.ai.core.voice.containsWakePhrase
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
@@ -132,6 +134,22 @@ class WakeWordService : Service() {
                         Log.i(TAG, "WakeWordService: re-arming after voice session (${event.mode})")
                         rearmDetector()
                     }
+
+                    is VoiceInputEvent.PartialTranscript -> {
+                        // Record partial presence without exposing transcript text.
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.STT_PARTIAL,
+                            metadata = mapOf("length" to event.text.length.toString()),
+                        )
+                    }
+
+                    is VoiceInputEvent.Error -> {
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.STT_ERROR,
+                            metadata = mapOf("error" to (event.message.take(200))),
+                        )
+                    }
+
                     else -> Unit
                 }
             }
@@ -154,12 +172,14 @@ class WakeWordService : Service() {
 
 
     private fun handleDetection() {
+        val sessionId = AcousticJournalBridge.allocateSessionId()
         serviceScope.launch {
             isHandlingDetection = true
+            AcousticJournalBridge.record(
+                type = AcousticEventType.VOICE_SESSION_STARTED,
+                sessionId = sessionId,
+            )
             try {
-                // Attempt STT up to twice (#790: 1 retry on silence/error after wake word).
-                // The observer's ListeningStopped handler is suppressed while isHandlingDetection
-                // is true, so re-arm is always done explicitly at the end of this function.
                 var transcript: String? = null
                 for (attempt in 1..2) {
                     val startupEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
@@ -177,6 +197,11 @@ class WakeWordService : Service() {
                                 || it is VoiceInputEvent.ListeningStopped
                         }
                     }
+                    AcousticJournalBridge.record(
+                        type = AcousticEventType.STT_START_REQUESTED,
+                        sessionId = sessionId,
+                        metadata = mapOf("attempt" to attempt.toString()),
+                    )
                     val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
                     if (startResult !is VoiceInputStartResult.Started) {
                         startupEventDeferred.cancel()
@@ -184,6 +209,11 @@ class WakeWordService : Service() {
                         Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
                         val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
                         if (!message.isNullOrBlank()) showWakeWordError(message)
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.SESSION_CANCELLED,
+                            sessionId = sessionId,
+                            metadata = mapOf("reason" to "stt_unavailable", "message" to (message?.take(200) ?: "")),
+                        )
                         break
                     }
 
@@ -192,19 +222,40 @@ class WakeWordService : Service() {
                     } catch (e: Exception) {
                         terminalEventDeferred.cancel()
                         Log.w(TAG, "WakeWordService: startup event collection failed (attempt $attempt)", e)
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.SESSION_CANCELLED,
+                            sessionId = sessionId,
+                            metadata = mapOf("reason" to "startup_collection_failed"),
+                        )
                         break
+                    }
+
+                    if (startupEvent is VoiceInputEvent.ListeningStarted) {
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.STT_READY,
+                            sessionId = sessionId,
+                        )
                     }
 
                     val terminalEvent = when (startupEvent) {
                         is VoiceInputEvent.ListeningStarted -> {
-                            // Play the cue only after the recognizer reports it is actually ready
-                            // for speech, so users can start speaking on the bloop without losing
-                            // the start of the command on slower devices.
-                            if (attempt == 1) cuePlayer.playCue(forceAudible = true)
+                            if (attempt == 1) {
+                                AcousticJournalBridge.record(
+                                    type = AcousticEventType.CUE_REQUESTED,
+                                    sessionId = sessionId,
+                                    metadata = mapOf("force_audible" to "true"),
+                                )
+                                cuePlayer.playCue(forceAudible = true)
+                            }
                             try {
                                 terminalEventDeferred.await()
                             } catch (e: Exception) {
                                 Log.w(TAG, "WakeWordService: transcript collection failed (attempt $attempt)", e)
+                                AcousticJournalBridge.record(
+                                    type = AcousticEventType.SESSION_CANCELLED,
+                                    sessionId = sessionId,
+                                    metadata = mapOf("reason" to "transcript_collection_failed"),
+                                )
                                 break
                             }
                         }
@@ -232,12 +283,14 @@ class WakeWordService : Service() {
                     routeTranscript(transcript)
                 }
             } finally {
-                // Always clear the flag and re-arm before returning. The observer is gated on
-                // isHandlingDetection so we are the sole caller of rearmDetector() here.
                 isHandlingDetection = false
                 rearmDetector()
             }
         }
+        AcousticJournalBridge.record(
+            type = AcousticEventType.SESSION_COMPLETED,
+            sessionId = sessionId,
+        )
     }
 
     private fun showWakeWordError(message: String) {
@@ -255,8 +308,15 @@ class WakeWordService : Service() {
             Log.w(TAG, "WakeWordService: RECORD_AUDIO not granted — not re-arming detector")
             return
         }
+        val generationId = AcousticJournalBridge.allocateGenerationId()
         wakeWordDetector.start(
-            onDetected = { handleDetection() },
+            onDetected = {
+                AcousticJournalBridge.record(
+                    type = AcousticEventType.WAKE_CALLBACK_INVOKED,
+                    generationId = generationId,
+                )
+                handleDetection()
+            },
             verifyWindow = { pcm ->
                 try {
                     kotlinx.coroutines.runBlocking {
@@ -267,6 +327,10 @@ class WakeWordService : Service() {
                     false
                 }
             },
+        )
+        AcousticJournalBridge.record(
+            type = AcousticEventType.DETECTOR_REARMED,
+            generationId = generationId,
         )
     }
 

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -27,6 +27,7 @@ import com.kernel.ai.core.voice.WakeWordHandoff
 import com.kernel.ai.feature.widget.EXTRA_PREFILLED_TRANSCRIPT
 import com.kernel.ai.feature.widget.VoiceCommandActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineStart
@@ -99,6 +100,10 @@ class WakeWordService : Service() {
                 != android.content.pm.PackageManager.PERMISSION_GRANTED) {
             Log.w(TAG, "WakeWordService: RECORD_AUDIO not granted — refusing to start")
             stopSelf(startId)
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "record_audio_permission_missing") },
+            )
             return START_NOT_STICKY
         }
 
@@ -106,6 +111,10 @@ class WakeWordService : Service() {
 
         if (!wakeWordDetector.isAvailable) {
             Log.i(TAG, "WakeWordService: model not yet available (#984) — stopping")
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "wake_model_unavailable") },
+            )
             stopSelf(startId)
             return START_NOT_STICKY
         }
@@ -135,22 +144,11 @@ class WakeWordService : Service() {
                         rearmDetector()
                     }
 
-                    is VoiceInputEvent.PartialTranscript -> {
-                        // Record partial presence without exposing transcript text.
-                        AcousticJournalBridge.record(
-                            type = AcousticEventType.STT_PARTIAL,
-                            metadata = mapOf("length" to event.text.length.toString()),
-                        )
-                    }
-
-                    is VoiceInputEvent.Error -> {
-                        AcousticJournalBridge.record(
-                            type = AcousticEventType.STT_ERROR,
-                            metadata = mapOf("error" to (event.message.take(200))),
-                        )
-                    }
-
-                    else -> Unit
+                    is VoiceInputEvent.SpeechDetected,
+                    is VoiceInputEvent.PartialTranscript,
+                    is VoiceInputEvent.Transcript,
+                    is VoiceInputEvent.Error,
+                    -> Unit
                 }
             }
         }
@@ -171,90 +169,107 @@ class WakeWordService : Service() {
 
 
 
-    private fun handleDetection() {
-        val sessionId = AcousticJournalBridge.allocateSessionId()
+    private fun handleDetection(generationId: Long, sessionId: Long) {
         serviceScope.launch {
             isHandlingDetection = true
-            AcousticJournalBridge.record(
-                type = AcousticEventType.VOICE_SESSION_STARTED,
-                sessionId = sessionId,
-            )
+            val journal = WakeSessionJournal(generationId, sessionId)
+            journal.start()
+            var completed = false
+            var cancellationCategory = "stt_no_final_result"
+            val progressCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+                voiceInputController.events.collect { event ->
+                    if (!event.isWakeSessionEvent()) return@collect
+                    when (event) {
+                        is VoiceInputEvent.SpeechDetected -> journal.record(
+                            AcousticEventType.STT_SPEECH_DETECTED,
+                        )
+                        is VoiceInputEvent.PartialTranscript -> journal.record(
+                            AcousticEventType.STT_PARTIAL,
+                            metadata = { mapOf("length" to event.text.length.toString()) },
+                        )
+                        else -> Unit
+                    }
+                }
+            }
+
             try {
                 var transcript: String? = null
                 for (attempt in 1..2) {
                     val startupEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
                         voiceInputController.events.first {
-                            it is VoiceInputEvent.ListeningStarted
-                                || it is VoiceInputEvent.Transcript
-                                || it is VoiceInputEvent.Error
-                                || it is VoiceInputEvent.ListeningStopped
+                            it.isWakeSessionEvent() && (
+                                it is VoiceInputEvent.ListeningStarted ||
+                                    it is VoiceInputEvent.Transcript ||
+                                    it is VoiceInputEvent.Error ||
+                                    it is VoiceInputEvent.ListeningStopped
+                                )
                         }
                     }
                     val terminalEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
                         voiceInputController.events.first {
-                            it is VoiceInputEvent.Transcript
-                                || it is VoiceInputEvent.Error
-                                || it is VoiceInputEvent.ListeningStopped
+                            it.isWakeSessionEvent() && (
+                                it is VoiceInputEvent.Transcript ||
+                                    it is VoiceInputEvent.Error ||
+                                    it is VoiceInputEvent.ListeningStopped
+                                )
                         }
                     }
-                    AcousticJournalBridge.record(
-                        type = AcousticEventType.STT_START_REQUESTED,
-                        sessionId = sessionId,
-                        metadata = mapOf("attempt" to attempt.toString()),
+                    journal.record(
+                        AcousticEventType.STT_START_REQUESTED,
+                        metadata = { mapOf("attempt" to attempt.toString()) },
                     )
-                    val startResult = voiceInputController.startListening(VoiceCaptureMode.AlertCommand)
+                    val startResult = voiceInputController.startListening(
+                        VoiceCaptureMode.AlertCommand,
+                    )
                     if (startResult !is VoiceInputStartResult.Started) {
                         startupEventDeferred.cancel()
                         terminalEventDeferred.cancel()
+                        cancellationCategory = "stt_unavailable"
+                        journal.record(
+                            AcousticEventType.STT_ERROR,
+                            metadata = { mapOf("category" to "stt_unavailable") },
+                        )
                         Log.w(TAG, "WakeWordService: STT unavailable after detection — $startResult")
                         val message = (startResult as? VoiceInputStartResult.Unavailable)?.message
                         if (!message.isNullOrBlank()) showWakeWordError(message)
-                        AcousticJournalBridge.record(
-                            type = AcousticEventType.SESSION_CANCELLED,
-                            sessionId = sessionId,
-                            metadata = mapOf("reason" to "stt_unavailable", "message" to (message?.take(200) ?: "")),
-                        )
                         break
                     }
 
                     val startupEvent = try {
                         startupEventDeferred.await()
+                    } catch (e: CancellationException) {
+                        terminalEventDeferred.cancel()
+                        throw e
                     } catch (e: Exception) {
                         terminalEventDeferred.cancel()
+                        cancellationCategory = "startup_collection_failed"
                         Log.w(TAG, "WakeWordService: startup event collection failed (attempt $attempt)", e)
-                        AcousticJournalBridge.record(
-                            type = AcousticEventType.SESSION_CANCELLED,
-                            sessionId = sessionId,
-                            metadata = mapOf("reason" to "startup_collection_failed"),
-                        )
                         break
                     }
 
                     if (startupEvent is VoiceInputEvent.ListeningStarted) {
-                        AcousticJournalBridge.record(
-                            type = AcousticEventType.STT_READY,
-                            sessionId = sessionId,
-                        )
+                        journal.record(AcousticEventType.STT_READY)
                     }
 
                     val terminalEvent = when (startupEvent) {
                         is VoiceInputEvent.ListeningStarted -> {
                             if (attempt == 1) {
-                                AcousticJournalBridge.record(
-                                    type = AcousticEventType.CUE_REQUESTED,
-                                    sessionId = sessionId,
-                                    metadata = mapOf("force_audible" to "true"),
+                                journal.record(
+                                    AcousticEventType.CUE_REQUESTED,
+                                    metadata = { mapOf("force_audible" to "true") },
                                 )
                                 cuePlayer.playCue(forceAudible = true)
                             }
                             try {
                                 terminalEventDeferred.await()
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
-                                Log.w(TAG, "WakeWordService: transcript collection failed (attempt $attempt)", e)
-                                AcousticJournalBridge.record(
-                                    type = AcousticEventType.SESSION_CANCELLED,
-                                    sessionId = sessionId,
-                                    metadata = mapOf("reason" to "transcript_collection_failed"),
+                                cancellationCategory = "transcript_collection_failed"
+                                Log.w(
+                                    TAG,
+                                    "WakeWordService: transcript collection failed (attempt $attempt)",
+                                    e,
                                 )
                                 break
                             }
@@ -267,30 +282,71 @@ class WakeWordService : Service() {
 
                     val text = (terminalEvent as? VoiceInputEvent.Transcript)?.text
                     if (!text.isNullOrBlank()) {
+                        journal.record(
+                            AcousticEventType.STT_FINAL,
+                            metadata = { mapOf("length" to text.length.toString()) },
+                        )
                         transcript = text
                         break
                     }
-                    val errorMessage = (terminalEvent as? VoiceInputEvent.Error)?.message
-                    if (!errorMessage.isNullOrBlank() && attempt == 2) {
-                        showWakeWordError(errorMessage)
+
+                    if (terminalEvent is VoiceInputEvent.Error) {
+                        journal.record(
+                            AcousticEventType.STT_ERROR,
+                            metadata = { mapOf("category" to "stt_recognition_failed") },
+                        )
+                        if (attempt == 2 && terminalEvent.message.isNotBlank()) {
+                            showWakeWordError(terminalEvent.message)
+                        }
+                        cancellationCategory = "stt_recognition_failed"
+                    } else {
+                        cancellationCategory = "stt_stopped_without_result"
                     }
-                    Log.w(TAG, "WakeWordService: no transcript on attempt $attempt ($terminalEvent)" +
-                        if (attempt < 2) " — retrying" else "")
+                    Log.w(
+                        TAG,
+                        "WakeWordService: no transcript on attempt $attempt ($terminalEvent)" +
+                            if (attempt < 2) " — retrying" else "",
+                    )
                 }
 
                 if (transcript != null) {
-                    Log.d(TAG, "WakeWordService: routing transcript=\"$transcript\"")
-                    routeTranscript(transcript)
+                    Log.d(TAG, "WakeWordService: routing final transcript")
+                    if (routeTranscript(transcript)) {
+                        journal.record(
+                            AcousticEventType.COMMAND_ROUTING_RESULT,
+                            metadata = { mapOf("outcome" to "handed_off") },
+                        )
+                        completed = true
+                    } else {
+                        journal.record(
+                            AcousticEventType.COMMAND_ROUTING_RESULT,
+                            metadata = {
+                                mapOf(
+                                    "outcome" to "failed",
+                                    "category" to "route_activity_failed",
+                                )
+                            },
+                        )
+                        cancellationCategory = "route_activity_failed"
+                    }
                 }
+            } catch (e: CancellationException) {
+                cancellationCategory = "session_cancelled"
+                throw e
+            } catch (e: Exception) {
+                cancellationCategory = "session_failed"
+                Log.e(TAG, "WakeWordService: wake session failed", e)
             } finally {
+                progressCollector.cancel()
+                if (completed) {
+                    journal.complete()
+                } else {
+                    journal.cancel(cancellationCategory)
+                }
                 isHandlingDetection = false
                 rearmDetector()
             }
         }
-        AcousticJournalBridge.record(
-            type = AcousticEventType.SESSION_COMPLETED,
-            sessionId = sessionId,
-        )
     }
 
     private fun showWakeWordError(message: String) {
@@ -302,20 +358,33 @@ class WakeWordService : Service() {
 
     /** Re-arms [wakeWordDetector] with the standard callbacks. */
     private fun rearmDetector() {
-        if (!wakeWordDetector.isAvailable) return
+        if (!wakeWordDetector.isAvailable) {
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "wake_model_unavailable") },
+            )
+            return
+        }
         if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.RECORD_AUDIO)
                 != android.content.pm.PackageManager.PERMISSION_GRANTED) {
             Log.w(TAG, "WakeWordService: RECORD_AUDIO not granted — not re-arming detector")
+            AcousticJournalBridge.record(
+                type = AcousticEventType.SERVICE_ERROR,
+                metadata = { mapOf("category" to "record_audio_permission_missing") },
+            )
             return
         }
         val generationId = AcousticJournalBridge.allocateGenerationId()
         wakeWordDetector.start(
+            generationId = generationId,
             onDetected = {
+                val sessionId = AcousticJournalBridge.allocateSessionId()
                 AcousticJournalBridge.record(
                     type = AcousticEventType.WAKE_CALLBACK_INVOKED,
                     generationId = generationId,
+                    sessionId = sessionId,
                 )
-                handleDetection()
+                handleDetection(generationId, sessionId)
             },
             verifyWindow = { pcm ->
                 try {
@@ -334,24 +403,27 @@ class WakeWordService : Service() {
         )
     }
 
-    private fun routeTranscript(transcript: String) {
+    private fun routeTranscript(transcript: String): Boolean {
         // Set the in-process authorisation token before launching the activity.
         // VoiceCommandActivity checks this field and clears it on read — external callers
         // cannot set it, so they cannot inject transcripts even though the activity is exported.
         WakeWordHandoff.pendingTranscript = transcript
-        try {
+        return try {
             startActivity(
                 Intent(this, VoiceCommandActivity::class.java).apply {
                     putExtra(EXTRA_PREFILLED_TRANSCRIPT, transcript)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
             )
+            true
         } catch (e: Exception) {
             // Clear the token if startActivity failed so it doesn't linger.
             WakeWordHandoff.pendingTranscript = null
             Log.e(TAG, "WakeWordService: failed to launch VoiceCommandActivity", e)
+            false
         }
     }
+
 
     // ── Notification ───────────────────────────────────────────────────────────
 
@@ -451,3 +523,6 @@ class WakeWordService : Service() {
         }
     }
 }
+
+internal fun VoiceInputEvent.isWakeSessionEvent(): Boolean =
+    mode == VoiceCaptureMode.AlertCommand

--- a/app/src/test/java/com/kernel/ai/assistant/WakeSessionJournalTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeSessionJournalTest.kt
@@ -77,26 +77,29 @@ class WakeSessionJournalTest {
     }
 
     @Test
-    fun `only alert command events belong to the active wake session`() {
+    fun `only matching alert command capture belongs to active wake session`() {
+        val captureSessionId = 73L
         val wakeEvents = listOf(
-            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand),
-            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.AlertCommand),
-            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.AlertCommand, "partial"),
-            VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "final"),
-            VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "error"),
-            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.AlertCommand),
+            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId),
+            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.AlertCommand, captureSessionId),
+            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.AlertCommand, "partial", captureSessionId),
+            VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "final", captureSessionId),
+            VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "error", captureSessionId),
+            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.AlertCommand, captureSessionId),
         )
         val unrelatedEvents = listOf(
-            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command),
-            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.SlotReply),
-            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.Command, "private"),
-            VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "private"),
-            VoiceInputEvent.Error(VoiceCaptureMode.Command, "private"),
-            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.SlotReply),
+            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId - 1),
+            VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "wrong capture", captureSessionId + 1),
+            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command, captureSessionId),
+            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.SlotReply, captureSessionId),
+            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.Command, "private", captureSessionId),
+            VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "private", captureSessionId),
+            VoiceInputEvent.Error(VoiceCaptureMode.Command, "private", captureSessionId),
+            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.SlotReply, captureSessionId),
         )
 
-        assertTrue(wakeEvents.all(VoiceInputEvent::isWakeSessionEvent))
-        assertFalse(unrelatedEvents.any(VoiceInputEvent::isWakeSessionEvent))
+        assertTrue(wakeEvents.all { it.isWakeSessionEvent(captureSessionId) })
+        assertFalse(unrelatedEvents.any { it.isWakeSessionEvent(captureSessionId) })
     }
 
     private fun journal(events: MutableList<RecordedEvent>) = WakeSessionJournal(

--- a/app/src/test/java/com/kernel/ai/assistant/WakeSessionJournalTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeSessionJournalTest.kt
@@ -1,0 +1,116 @@
+package com.kernel.ai.assistant
+
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WakeSessionJournalTest {
+    @Test
+    fun `session emits one correlated ordered lifecycle`() {
+        val events = mutableListOf<RecordedEvent>()
+        val journal = journal(events)
+
+        journal.start()
+        journal.record(
+            AcousticEventType.STT_START_REQUESTED,
+            metadata = { mapOf("attempt" to "1") },
+        )
+        journal.record(AcousticEventType.STT_READY)
+        assertTrue(journal.complete())
+
+        assertEquals(
+            listOf(
+                AcousticEventType.VOICE_SESSION_STARTED,
+                AcousticEventType.STT_START_REQUESTED,
+                AcousticEventType.STT_READY,
+                AcousticEventType.SESSION_COMPLETED,
+            ),
+            events.map(RecordedEvent::type),
+        )
+        assertTrue(events.all { it.generationId == 41L && it.sessionId == 73L })
+        assertEquals(mapOf("attempt" to "1"), events[1].metadata)
+    }
+
+    @Test
+    fun `first terminal wins and post-terminal events are ignored`() {
+        val events = mutableListOf<RecordedEvent>()
+        var lateMetadataCalls = 0
+        val journal = journal(events)
+
+        journal.start()
+        assertTrue(journal.cancel("stt_unavailable"))
+        assertFalse(journal.complete())
+        assertFalse(journal.cancel("second_terminal"))
+        journal.record(AcousticEventType.STT_READY) {
+            lateMetadataCalls += 1
+            mapOf("unexpected" to "value")
+        }
+
+        assertEquals(
+            listOf(
+                AcousticEventType.VOICE_SESSION_STARTED,
+                AcousticEventType.SESSION_CANCELLED,
+            ),
+            events.map(RecordedEvent::type),
+        )
+        assertEquals(mapOf("category" to "stt_unavailable"), events.last().metadata)
+        assertEquals(0, lateMetadataCalls)
+    }
+
+    @Test
+    fun `session must start once before recording or finishing`() {
+        val events = mutableListOf<RecordedEvent>()
+        val journal = journal(events)
+
+        journal.record(AcousticEventType.STT_READY)
+        assertFalse(journal.complete())
+        assertFalse(journal.cancel("not_started"))
+        journal.start()
+
+        assertThrows(IllegalStateException::class.java) { journal.start() }
+        assertEquals(listOf(AcousticEventType.VOICE_SESSION_STARTED), events.map(RecordedEvent::type))
+    }
+
+    @Test
+    fun `only alert command events belong to the active wake session`() {
+        val wakeEvents = listOf(
+            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand),
+            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.AlertCommand),
+            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.AlertCommand, "partial"),
+            VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "final"),
+            VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "error"),
+            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.AlertCommand),
+        )
+        val unrelatedEvents = listOf(
+            VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command),
+            VoiceInputEvent.SpeechDetected(VoiceCaptureMode.SlotReply),
+            VoiceInputEvent.PartialTranscript(VoiceCaptureMode.Command, "private"),
+            VoiceInputEvent.Transcript(VoiceCaptureMode.SlotReply, "private"),
+            VoiceInputEvent.Error(VoiceCaptureMode.Command, "private"),
+            VoiceInputEvent.ListeningStopped(VoiceCaptureMode.SlotReply),
+        )
+
+        assertTrue(wakeEvents.all(VoiceInputEvent::isWakeSessionEvent))
+        assertFalse(unrelatedEvents.any(VoiceInputEvent::isWakeSessionEvent))
+    }
+
+    private fun journal(events: MutableList<RecordedEvent>) = WakeSessionJournal(
+        generationId = 41L,
+        sessionId = 73L,
+        emit = { type, generationId, sessionId, metadata ->
+            events += RecordedEvent(type, generationId, sessionId, metadata())
+        },
+    )
+
+    private data class RecordedEvent(
+        val type: String,
+        val generationId: Long,
+        val sessionId: Long,
+        val metadata: Map<String, String>,
+    )
+}

--- a/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
@@ -1,0 +1,339 @@
+package com.kernel.ai.debug.journal
+
+import com.kernel.ai.core.voice.AcousticEvent
+import com.kernel.ai.core.voice.AcousticEventType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.system.measureNanoTime
+
+class AcousticEventJournalTest {
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private fun event(sequence: Long, type: String = "TEST"): AcousticEvent =
+        AcousticEvent(
+            sequence = sequence,
+            monotonicMs = sequence * 1000L,
+            wallClockMs = 0L,
+            type = type,
+        )
+
+    private var testSequenceCounter = 1L
+
+    private fun AcousticEventJournal.recordN(n: Int, type: String = "TEST") {
+        for (i in 1..n) {
+            record(event(sequence = testSequenceCounter++, type = type))
+        }
+    }
+
+    // ── Ordered recording ───────────────────────────────────────────────────────
+
+    @Test
+    fun `ordered recording preserves insertion order`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "A"))
+        journal.record(event(2, "B"))
+        journal.record(event(3, "C"))
+
+        val snapshot = journal.snapshotSince(0)
+        assertEquals(3, snapshot.size)
+        assertEquals("A", snapshot[0].type)
+        assertEquals("B", snapshot[1].type)
+        assertEquals("C", snapshot[2].type)
+    }
+
+    // ── Monotonic sequence numbers ──────────────────────────────────────────────
+
+    @Test
+    fun `sequence numbers increase monotonically`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        for (i in 1..100) {
+            journal.record(event(i.toLong()))
+        }
+        assertEquals(100, journal.currentSequence)
+    }
+
+    // ── Monotonic timestamps ────────────────────────────────────────────────────
+
+    @Test
+    fun `timestamps increase monotonically`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1))
+        Thread.sleep(1)
+        journal.record(event(2))
+        Thread.sleep(1)
+        journal.record(event(3))
+
+        val snapshot = journal.snapshotSince(0)
+        assertTrue(snapshot[0].monotonicMs <= snapshot[1].monotonicMs)
+        assertTrue(snapshot[1].monotonicMs <= snapshot[2].monotonicMs)
+    }
+
+    // ── Generation and session correlation ──────────────────────────────────────
+
+    @Test
+    fun `generation and session correlation identifiers are recorded`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        val genId = journal.allocateGenerationId()
+        val sessId = journal.allocateSessionId()
+        journal.record(event(1).copy(generationId = genId, sessionId = sessId))
+
+        val snapshot = journal.snapshotSince(0)
+        assertEquals(1, snapshot.size)
+        assertEquals(genId, snapshot[0].generationId)
+        assertEquals(sessId, snapshot[0].sessionId)
+    }
+
+    // ── Bounded capacity ────────────────────────────────────────────────────────
+
+    @Test
+    fun `journal has bounded capacity`() {
+        val journal = AcousticEventJournal(journalCapacity = 4)
+        journal.recordN(6)  // 6 events into capacity 4
+
+        assertEquals(4, journal.snapshotSince(0).size)
+        assertTrue(journal.overflowed)
+    }
+
+    // ── Oldest-event eviction ───────────────────────────────────────────────────
+
+    @Test
+    fun `oldest event is evicted when capacity exceeded`() {
+        val journal = AcousticEventJournal(journalCapacity = 4)
+        // Fill with events 1-4
+        for (i in 1..4) journal.record(event(i.toLong(), "E$i"))
+        // Add event 5 — 1 is evicted
+        journal.record(event(5L, "E5"))
+
+        val snapshot = journal.snapshotSince(0)
+        assertEquals(4, snapshot.size)
+        // E1 should be gone; oldest is now E2
+        assertEquals("E2", snapshot[0].type)
+        assertEquals("E5", snapshot[3].type)
+    }
+
+    // ── Explicit overflow/truncation ────────────────────────────────────────────
+
+    @Test
+    fun `overflow flag is set when events are evicted`() {
+        val journal = AcousticEventJournal(journalCapacity = 2)
+        assertFalse(journal.overflowed)
+        journal.record(event(1))
+        journal.record(event(2))
+        assertFalse(journal.overflowed)
+        journal.record(event(3)) // triggers eviction
+        assertTrue(journal.overflowed)
+    }
+
+    // ── Snapshot-since semantics ────────────────────────────────────────────────
+
+    @Test
+    fun `snapshotSince returns only events with sequence greater than`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "A"))
+        journal.record(event(2, "B"))
+        journal.record(event(3, "C"))
+        journal.record(event(4, "D"))
+
+        val since2 = journal.snapshotSince(2)
+        assertEquals(2, since2.size)
+        assertEquals("C", since2[0].type)
+        assertEquals("D", since2[1].type)
+    }
+
+    @Test
+    fun `snapshotSince returns empty when since equals current`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "A"))
+        journal.record(event(2, "B"))
+
+        val snapshot = journal.snapshotSince(2)
+        assertTrue(snapshot.isEmpty())
+    }
+
+    @Test
+    fun `snapshotSince returns empty for empty journal`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        assertTrue(journal.snapshotSince(0).isEmpty())
+    }
+
+    @Test
+    fun `snapshotSince handles overflow correctly`() {
+        val journal = AcousticEventJournal(journalCapacity = 4)
+        for (i in 1..6) journal.record(event(i.toLong(), "E$i"))
+
+        // After overflow: events 3,4,5,6 are in the journal (capacity 4)
+        val snapshot = journal.snapshotSince(0)
+        assertEquals(4, snapshot.size)
+        assertEquals("E3", snapshot[0].type)
+
+        // snapshotSince(4) should return E5, E6
+        val since4 = journal.snapshotSince(4)
+        assertEquals(2, since4.size)
+        assertEquals("E5", since4[0].type)
+        assertEquals("E6", since4[1].type)
+    }
+
+    // ── Wait before event ───────────────────────────────────────────────────────
+
+    @Test
+    fun `waitForEvent returns event that occurs after wait begins`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "PRE"))
+
+        val waiter = Thread {
+            Thread.sleep(50)
+            journal.record(event(2, "TARGET"))
+        }
+        waiter.start()
+
+        val result = journal.waitForEvent(sinceSequence = 1, eventType = "TARGET", timeoutMs = 2000)
+        assertNotNull(result)
+        assertEquals("TARGET", result?.type)
+        waiter.join()
+    }
+
+    // ── Event before wait / late subscriber ─────────────────────────────────────
+
+    @Test
+    fun `waitForEvent returns immediately when event already present`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "PRE"))
+        journal.record(event(2, "TARGET"))
+
+        val result = journal.waitForEvent(sinceSequence = 0, eventType = "TARGET", timeoutMs = 500)
+        assertNotNull(result)
+        assertEquals("TARGET", result?.type)
+    }
+
+    // ── Timeout ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `waitForEvent returns null on timeout`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "PRE"))
+
+        val start = System.nanoTime()
+        val result = journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 200)
+        val elapsed = measureNanoTime { } // not used for assertion, just reference
+        assertNull(result)
+    }
+
+    @Test
+    fun `waitForEvent respects timeout lower bound`() {
+        // Verify that a very short timeout still returns null when event never arrives
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "PRE"))
+
+        val start = System.nanoTime()
+        val result = journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 50)
+        assertNull(result)
+    }
+
+    // ── Cancellation ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `waitForEvent can be interrupted`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "PRE"))
+
+        val waiter = Thread {
+            journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 10_000)
+        }
+        waiter.start()
+        Thread.sleep(100) // let waiter enter the wait loop
+        waiter.interrupt()
+        waiter.join(2000)
+        assertFalse(waiter.isAlive)
+    }
+
+    // ── Concurrent waits ────────────────────────────────────────────────────────
+
+    @Test
+    fun `multiple concurrent waits both resolve on matching event`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+
+        val results = arrayOfNulls<AcousticEvent?>(2)
+        val threads = List(2) { idx ->
+            Thread {
+                results[idx] = journal.waitForEvent(
+                    sinceSequence = 0, eventType = "TARGET", timeoutMs = 2000,
+                )
+            }
+        }
+        threads.forEach { it.start() }
+        Thread.sleep(100)
+
+        journal.record(event(1, "TARGET"))
+        threads.forEach { it.join(2000) }
+
+        assertNotNull(results[0])
+        assertNotNull(results[1])
+    }
+
+    // ── Unsupported event filters ───────────────────────────────────────────────
+
+    @Test
+    fun `waitForEvent with non-matching event type returns null on timeout`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(event(1, "A"))
+        journal.record(event(2, "B"))
+
+        val result = journal.waitForEvent(sinceSequence = 0, eventType = "C", timeoutMs = 100)
+        assertNull(result)
+    }
+
+    // ── Privacy-safe serialisation ─────────────────────────────────────────────
+
+    @Test
+    fun `event metadata does not contain private fields`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        journal.record(
+            event(1, "STT_PARTIAL").copy(
+                metadata = mapOf("length" to "42"),
+            )
+        )
+
+        val snapshot = journal.snapshotSince(0)
+        assertEquals(1, snapshot.size)
+        val meta = snapshot[0].metadata
+        assertEquals("42", meta["length"])
+        // No transcript text, audio, or private fields
+        assertNull(meta["text"])
+        assertNull(meta["audio"])
+        assertNull(meta["path"])
+        assertNull(meta["selector"])
+    }
+
+    // ── Reset or boundary semantics ─────────────────────────────────────────────
+
+    @Test
+    fun `empty journal after creation`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        assertEquals(0, journal.currentSequence)
+        assertFalse(journal.overflowed)
+        assertTrue(journal.snapshotSince(0).isEmpty())
+    }
+
+    // ── Performance: bounded capacity does not degrade ──────────────────────────
+
+    @Test
+    fun `recording at capacity does not throw`() {
+        val journal = AcousticEventJournal(journalCapacity = 256)
+        // Fill and overflow
+        for (i in 1..300) journal.record(event(i.toLong()))
+        assertTrue(journal.overflowed)
+        assertEquals(256, journal.snapshotSince(0).size)
+    }
+
+    // ── Default capacity ────────────────────────────────────────────────────────
+
+    @Test
+    fun `default capacity is 256`() {
+        assertEquals(256, AcousticEventJournal.DEFAULT_CAPACITY)
+    }
+}

--- a/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
@@ -4,6 +4,7 @@ import com.kernel.ai.core.voice.AcousticEvent
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -89,8 +90,8 @@ class AcousticEventJournalTest {
 
         val result = journal.waitForEvent(0, "TARGET", 500)
 
-        assertNotNull(result)
-        assertEquals(2L, result?.sequence)
+        assertTrue(result is AcousticEventWaitResult.Found)
+        assertEquals(2L, (result as AcousticEventWaitResult.Found).event.sequence)
     }
 
     @Test
@@ -105,14 +106,20 @@ class AcousticEventJournalTest {
         val result = journal.waitForEvent(1, "TARGET", 2_000)
 
         writer.join()
-        assertEquals("TARGET", result?.type)
+        assertEquals(
+            "TARGET",
+            (result as AcousticEventWaitResult.Found).event.type,
+        )
     }
 
     @Test
     fun `wait timeout is bounded and returns null`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
         val elapsed = measureTimeMillis {
-            assertNull(journal.waitForEvent(0, "NEVER", 50))
+            assertEquals(
+                AcousticEventWaitResult.TimedOut,
+                journal.waitForEvent(0, "NEVER", 50),
+            )
         }
 
         assertTrue(elapsed >= 40, "wait returned too early: ${elapsed}ms")
@@ -132,6 +139,139 @@ class AcousticEventJournalTest {
         waiter.join(2_000)
 
         assertFalse(waiter.isAlive)
+    }
+
+    @Test
+    fun `two waits for different events complete independently`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        val first = AtomicReference<AcousticEventWaitResult>()
+        val second = AtomicReference<AcousticEventWaitResult>()
+        val ready = CountDownLatch(2)
+        val firstWaiter = Thread {
+            ready.countDown()
+            first.set(journal.waitForEvent(0, "FIRST", 2_000))
+        }
+        val secondWaiter = Thread {
+            ready.countDown()
+            second.set(journal.waitForEvent(0, "SECOND", 2_000))
+        }
+        firstWaiter.start()
+        secondWaiter.start()
+        ready.await()
+
+        journal.record(event(1, "SECOND"))
+        journal.record(event(2, "FIRST"))
+        firstWaiter.join(2_000)
+        secondWaiter.join(2_000)
+
+        assertEquals(
+            "FIRST",
+            (first.get() as AcousticEventWaitResult.Found).event.type,
+        )
+        assertEquals(
+            "SECOND",
+            (second.get() as AcousticEventWaitResult.Found).event.type,
+        )
+    }
+
+    @Test
+    fun `snapshot and sequence remain responsive during active waits`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        val cancellation = AcousticEventWaitCancellation()
+        val waiter = Thread {
+            journal.waitForEvent(0, "NEVER", 10_000, cancellation)
+        }
+        waiter.start()
+        Thread.sleep(50)
+
+        journal.record(event(1, "OTHER"))
+        assertEquals(1L, journal.currentSequence)
+        assertEquals(listOf("OTHER"), journal.snapshotSince(0).events.map { it.type })
+        assertTrue(journal.cancelWait(cancellation))
+        waiter.join(2_000)
+        assertFalse(waiter.isAlive)
+    }
+
+    @Test
+    fun `cancellation wakes wait promptly and wins before a later event`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        val cancellation = AcousticEventWaitCancellation()
+        val result = AtomicReference<AcousticEventWaitResult>()
+        val waiter = Thread {
+            result.set(journal.waitForEvent(0, "TARGET", 10_000, cancellation))
+        }
+        waiter.start()
+        Thread.sleep(50)
+
+        val elapsed = measureTimeMillis {
+            assertTrue(journal.cancelWait(cancellation))
+            journal.record(event(1, "TARGET"))
+            waiter.join(2_000)
+        }
+
+        assertEquals(AcousticEventWaitResult.Cancelled, result.get())
+        assertTrue(elapsed < 1_000, "cancellation was not prompt: ${elapsed}ms")
+        assertFalse(journal.cancelWait(cancellation))
+    }
+
+    @Test
+    fun `request keyed cancellation wins deterministically over a concurrent event`() {
+        val registration = AcousticEventWaitRegistration()
+        val found = AcousticEventWaitResult.Found(event(1, "TARGET"))
+
+        assertTrue(registration.cancel())
+        assertEquals(AcousticEventWaitResult.Cancelled, registration.resolve(found))
+        assertFalse(registration.cancel())
+    }
+
+    @Test
+    fun `completed wait rejects late cancellation`() {
+        val registration = AcousticEventWaitRegistration()
+        val found = AcousticEventWaitResult.Found(event(1, "TARGET"))
+
+        assertEquals(found, registration.resolve(found))
+        assertFalse(registration.cancel())
+    }
+
+    @Test
+    fun `contract rejects malformed arguments and timeout bounds`() {
+        assertEquals(
+            TargetEventJournalContract.ERROR_MISSING_REQUEST_ID,
+            TargetEventJournalContract.requestIdError(null),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_INVALID_REQUEST_ID,
+            TargetEventJournalContract.requestIdError("bad id"),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_NEGATIVE_SINCE_SEQUENCE,
+            TargetEventJournalContract.sinceSequenceError(-1),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_MISSING_EVENT_TYPE,
+            TargetEventJournalContract.eventTypeError(null),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_INVALID_EVENT_TYPE,
+            TargetEventJournalContract.eventTypeError("NOT_AN_EVENT"),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_INVALID_TIMEOUT,
+            TargetEventJournalContract.timeoutError(
+                TargetEventJournalContract.MIN_TIMEOUT_MS - 1,
+            ),
+        )
+        assertEquals(
+            TargetEventJournalContract.ERROR_INVALID_TIMEOUT,
+            TargetEventJournalContract.timeoutError(
+                TargetEventJournalContract.MAX_TIMEOUT_MS + 1,
+            ),
+        )
+        assertNull(
+            TargetEventJournalContract.timeoutError(
+                TargetEventJournalContract.MAX_TIMEOUT_MS,
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/journal/AcousticEventJournalTest.kt
@@ -1,339 +1,215 @@
 package com.kernel.ai.debug.journal
 
 import com.kernel.ai.core.voice.AcousticEvent
-import com.kernel.ai.core.voice.AcousticEventType
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicLong
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.system.measureNanoTime
+import kotlin.system.measureTimeMillis
 
 class AcousticEventJournalTest {
 
-    // ── Helpers ─────────────────────────────────────────────────────────────────
-
-    private fun event(sequence: Long, type: String = "TEST"): AcousticEvent =
-        AcousticEvent(
-            sequence = sequence,
-            monotonicMs = sequence * 1000L,
-            wallClockMs = 0L,
-            type = type,
-        )
-
-    private var testSequenceCounter = 1L
-
-    private fun AcousticEventJournal.recordN(n: Int, type: String = "TEST") {
-        for (i in 1..n) {
-            record(event(sequence = testSequenceCounter++, type = type))
-        }
-    }
-
-    // ── Ordered recording ───────────────────────────────────────────────────────
+    private fun event(
+        sequence: Long,
+        type: String = "TEST",
+        generationId: Long = 0,
+        sessionId: Long = 0,
+        metadata: Map<String, String> = emptyMap(),
+    ): AcousticEvent = AcousticEvent(
+        sequence = sequence,
+        monotonicMs = sequence * 1000L,
+        wallClockMs = sequence * 2000L,
+        type = type,
+        generationId = generationId,
+        sessionId = sessionId,
+        metadata = metadata,
+    )
 
     @Test
-    fun `ordered recording preserves insertion order`() {
+    fun `snapshot is ordered and uses strict greater-than filtering`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "A"))
-        journal.record(event(2, "B"))
         journal.record(event(3, "C"))
-
-        val snapshot = journal.snapshotSince(0)
-        assertEquals(3, snapshot.size)
-        assertEquals("A", snapshot[0].type)
-        assertEquals("B", snapshot[1].type)
-        assertEquals("C", snapshot[2].type)
-    }
-
-    // ── Monotonic sequence numbers ──────────────────────────────────────────────
-
-    @Test
-    fun `sequence numbers increase monotonically`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        for (i in 1..100) {
-            journal.record(event(i.toLong()))
-        }
-        assertEquals(100, journal.currentSequence)
-    }
-
-    // ── Monotonic timestamps ────────────────────────────────────────────────────
-
-    @Test
-    fun `timestamps increase monotonically`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1))
-        Thread.sleep(1)
-        journal.record(event(2))
-        Thread.sleep(1)
-        journal.record(event(3))
-
-        val snapshot = journal.snapshotSince(0)
-        assertTrue(snapshot[0].monotonicMs <= snapshot[1].monotonicMs)
-        assertTrue(snapshot[1].monotonicMs <= snapshot[2].monotonicMs)
-    }
-
-    // ── Generation and session correlation ──────────────────────────────────────
-
-    @Test
-    fun `generation and session correlation identifiers are recorded`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        val genId = journal.allocateGenerationId()
-        val sessId = journal.allocateSessionId()
-        journal.record(event(1).copy(generationId = genId, sessionId = sessId))
-
-        val snapshot = journal.snapshotSince(0)
-        assertEquals(1, snapshot.size)
-        assertEquals(genId, snapshot[0].generationId)
-        assertEquals(sessId, snapshot[0].sessionId)
-    }
-
-    // ── Bounded capacity ────────────────────────────────────────────────────────
-
-    @Test
-    fun `journal has bounded capacity`() {
-        val journal = AcousticEventJournal(journalCapacity = 4)
-        journal.recordN(6)  // 6 events into capacity 4
-
-        assertEquals(4, journal.snapshotSince(0).size)
-        assertTrue(journal.overflowed)
-    }
-
-    // ── Oldest-event eviction ───────────────────────────────────────────────────
-
-    @Test
-    fun `oldest event is evicted when capacity exceeded`() {
-        val journal = AcousticEventJournal(journalCapacity = 4)
-        // Fill with events 1-4
-        for (i in 1..4) journal.record(event(i.toLong(), "E$i"))
-        // Add event 5 — 1 is evicted
-        journal.record(event(5L, "E5"))
-
-        val snapshot = journal.snapshotSince(0)
-        assertEquals(4, snapshot.size)
-        // E1 should be gone; oldest is now E2
-        assertEquals("E2", snapshot[0].type)
-        assertEquals("E5", snapshot[3].type)
-    }
-
-    // ── Explicit overflow/truncation ────────────────────────────────────────────
-
-    @Test
-    fun `overflow flag is set when events are evicted`() {
-        val journal = AcousticEventJournal(journalCapacity = 2)
-        assertFalse(journal.overflowed)
-        journal.record(event(1))
-        journal.record(event(2))
-        assertFalse(journal.overflowed)
-        journal.record(event(3)) // triggers eviction
-        assertTrue(journal.overflowed)
-    }
-
-    // ── Snapshot-since semantics ────────────────────────────────────────────────
-
-    @Test
-    fun `snapshotSince returns only events with sequence greater than`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "A"))
-        journal.record(event(2, "B"))
-        journal.record(event(3, "C"))
-        journal.record(event(4, "D"))
-
-        val since2 = journal.snapshotSince(2)
-        assertEquals(2, since2.size)
-        assertEquals("C", since2[0].type)
-        assertEquals("D", since2[1].type)
-    }
-
-    @Test
-    fun `snapshotSince returns empty when since equals current`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
         journal.record(event(1, "A"))
         journal.record(event(2, "B"))
 
-        val snapshot = journal.snapshotSince(2)
-        assertTrue(snapshot.isEmpty())
+        val snapshot = journal.snapshotSince(1)
+
+        assertEquals(listOf(2L, 3L), snapshot.events.map { it.sequence })
+        assertEquals(1L, snapshot.lowestSequence)
+        assertEquals(3L, snapshot.highestSequence)
+        assertFalse(snapshot.overflowed)
+        assertTrue(journal.snapshotSince(3).events.isEmpty())
     }
 
     @Test
-    fun `snapshotSince returns empty for empty journal`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        assertTrue(journal.snapshotSince(0).isEmpty())
+    fun `empty snapshot has explicit zero bounds`() {
+        val snapshot = AcousticEventJournal(journalCapacity = 16).snapshotSince(0)
+
+        assertEquals(0L, snapshot.lowestSequence)
+        assertEquals(0L, snapshot.highestSequence)
+        assertFalse(snapshot.overflowed)
+        assertTrue(snapshot.events.isEmpty())
     }
 
     @Test
-    fun `snapshotSince handles overflow correctly`() {
+    fun `overflow reports retained bounds and evicts oldest arrivals`() {
         val journal = AcousticEventJournal(journalCapacity = 4)
-        for (i in 1..6) journal.record(event(i.toLong(), "E$i"))
+        for (sequence in 1L..6L) journal.record(event(sequence, "E$sequence"))
 
-        // After overflow: events 3,4,5,6 are in the journal (capacity 4)
         val snapshot = journal.snapshotSince(0)
-        assertEquals(4, snapshot.size)
-        assertEquals("E3", snapshot[0].type)
 
-        // snapshotSince(4) should return E5, E6
-        val since4 = journal.snapshotSince(4)
-        assertEquals(2, since4.size)
-        assertEquals("E5", since4[0].type)
-        assertEquals("E6", since4[1].type)
+        assertEquals(listOf(3L, 4L, 5L, 6L), snapshot.events.map { it.sequence })
+        assertEquals(3L, snapshot.lowestSequence)
+        assertEquals(6L, snapshot.highestSequence)
+        assertTrue(snapshot.overflowed)
+        assertEquals(6L, journal.currentSequence)
     }
 
-    // ── Wait before event ───────────────────────────────────────────────────────
-
     @Test
-    fun `waitForEvent returns event that occurs after wait begins`() {
+    fun `correlation identifiers are preserved without journal allocation`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "PRE"))
+        journal.record(event(1, generationId = 41, sessionId = 73))
 
-        val waiter = Thread {
-            Thread.sleep(50)
-            journal.record(event(2, "TARGET"))
-        }
-        waiter.start()
+        val recorded = journal.snapshotSince(0).events.single()
 
-        val result = journal.waitForEvent(sinceSequence = 1, eventType = "TARGET", timeoutMs = 2000)
-        assertNotNull(result)
-        assertEquals("TARGET", result?.type)
-        waiter.join()
+        assertEquals(41L, recorded.generationId)
+        assertEquals(73L, recorded.sessionId)
     }
 
-    // ── Event before wait / late subscriber ─────────────────────────────────────
-
     @Test
-    fun `waitForEvent returns immediately when event already present`() {
+    fun `wait returns an already recorded event`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
         journal.record(event(1, "PRE"))
         journal.record(event(2, "TARGET"))
 
-        val result = journal.waitForEvent(sinceSequence = 0, eventType = "TARGET", timeoutMs = 500)
+        val result = journal.waitForEvent(0, "TARGET", 500)
+
         assertNotNull(result)
+        assertEquals(2L, result?.sequence)
+    }
+
+    @Test
+    fun `wait observes an event recorded after subscription`() {
+        val journal = AcousticEventJournal(journalCapacity = 16)
+        val writer = Thread {
+            Thread.sleep(50)
+            journal.record(event(2, "TARGET"))
+        }
+        writer.start()
+
+        val result = journal.waitForEvent(1, "TARGET", 2_000)
+
+        writer.join()
         assertEquals("TARGET", result?.type)
     }
 
-    // ── Timeout ─────────────────────────────────────────────────────────────────
-
     @Test
-    fun `waitForEvent returns null on timeout`() {
+    fun `wait timeout is bounded and returns null`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "PRE"))
+        val elapsed = measureTimeMillis {
+            assertNull(journal.waitForEvent(0, "NEVER", 50))
+        }
 
-        val start = System.nanoTime()
-        val result = journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 200)
-        val elapsed = measureNanoTime { } // not used for assertion, just reference
-        assertNull(result)
+        assertTrue(elapsed >= 40, "wait returned too early: ${elapsed}ms")
+        assertTrue(elapsed < 1_000, "wait exceeded bounded tolerance: ${elapsed}ms")
     }
 
     @Test
-    fun `waitForEvent respects timeout lower bound`() {
-        // Verify that a very short timeout still returns null when event never arrives
+    fun `wait can be interrupted`() {
         val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "PRE"))
-
-        val start = System.nanoTime()
-        val result = journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 50)
-        assertNull(result)
-    }
-
-    // ── Cancellation ────────────────────────────────────────────────────────────
-
-    @Test
-    fun `waitForEvent can be interrupted`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "PRE"))
-
         val waiter = Thread {
-            journal.waitForEvent(sinceSequence = 1, eventType = "NEVER", timeoutMs = 10_000)
+            runCatching { journal.waitForEvent(0, "NEVER", 10_000) }
         }
         waiter.start()
-        Thread.sleep(100) // let waiter enter the wait loop
+        Thread.sleep(100)
+
         waiter.interrupt()
-        waiter.join(2000)
+        waiter.join(2_000)
+
         assertFalse(waiter.isAlive)
     }
 
-    // ── Concurrent waits ────────────────────────────────────────────────────────
-
     @Test
-    fun `multiple concurrent waits both resolve on matching event`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-
-        val results = arrayOfNulls<AcousticEvent?>(2)
-        val threads = List(2) { idx ->
+    fun `concurrent record and snapshot preserve a coherent sequence envelope`() {
+        val journal = AcousticEventJournal(journalCapacity = 512)
+        val sequence = AtomicLong()
+        val start = CountDownLatch(1)
+        val failures = ConcurrentLinkedQueue<Throwable>()
+        val writers = List(4) {
             Thread {
-                results[idx] = journal.waitForEvent(
-                    sinceSequence = 0, eventType = "TARGET", timeoutMs = 2000,
-                )
+                start.await()
+                repeat(100) {
+                    runCatching {
+                        journal.record(event(sequence.incrementAndGet()))
+                    }.onFailure(failures::add)
+                }
             }
         }
-        threads.forEach { it.start() }
-        Thread.sleep(100)
-
-        journal.record(event(1, "TARGET"))
-        threads.forEach { it.join(2000) }
-
-        assertNotNull(results[0])
-        assertNotNull(results[1])
-    }
-
-    // ── Unsupported event filters ───────────────────────────────────────────────
-
-    @Test
-    fun `waitForEvent with non-matching event type returns null on timeout`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(event(1, "A"))
-        journal.record(event(2, "B"))
-
-        val result = journal.waitForEvent(sinceSequence = 0, eventType = "C", timeoutMs = 100)
-        assertNull(result)
-    }
-
-    // ── Privacy-safe serialisation ─────────────────────────────────────────────
-
-    @Test
-    fun `event metadata does not contain private fields`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        journal.record(
-            event(1, "STT_PARTIAL").copy(
-                metadata = mapOf("length" to "42"),
-            )
-        )
+        val reader = Thread {
+            start.await()
+            while (writers.any(Thread::isAlive)) {
+                runCatching {
+                    val snapshot = journal.snapshotSince(0)
+                    assertTrue(snapshot.events.zipWithNext().all { (a, b) ->
+                        a.sequence < b.sequence
+                    })
+                    assertTrue(snapshot.highestSequence >= snapshot.events.lastOrNull()?.sequence ?: 0L)
+                }.onFailure(failures::add)
+            }
+        }
+        writers.forEach(Thread::start)
+        reader.start()
+        start.countDown()
+        writers.forEach { it.join(2_000) }
+        reader.join(2_000)
 
         val snapshot = journal.snapshotSince(0)
-        assertEquals(1, snapshot.size)
-        val meta = snapshot[0].metadata
-        assertEquals("42", meta["length"])
-        // No transcript text, audio, or private fields
-        assertNull(meta["text"])
-        assertNull(meta["audio"])
-        assertNull(meta["path"])
-        assertNull(meta["selector"])
+        assertTrue(failures.isEmpty(), failures.joinToString())
+        assertEquals(400, snapshot.events.size)
+        assertEquals(400L, snapshot.highestSequence)
+        assertEquals((1L..400L).toList(), snapshot.events.map { it.sequence })
     }
 
-    // ── Reset or boundary semantics ─────────────────────────────────────────────
-
     @Test
-    fun `empty journal after creation`() {
-        val journal = AcousticEventJournal(journalCapacity = 16)
-        assertEquals(0, journal.currentSequence)
-        assertFalse(journal.overflowed)
-        assertTrue(journal.snapshotSince(0).isEmpty())
+    fun `snapshot JSON has exact valid envelope and privacy-safe event fields`() {
+        val snapshot = AcousticJournalSnapshot(
+            lowestSequence = 7,
+            highestSequence = 9,
+            overflowed = true,
+            events = listOf(
+                event(
+                    sequence = 9,
+                    type = "STT_PARTIAL",
+                    generationId = 11,
+                    sessionId = 13,
+                    metadata = linkedMapOf("length" to "42", "escaped" to "\"\n"),
+                ),
+            ),
+        )
+
+        val json = AcousticJournalJson.serialiseSnapshot(snapshot)
+
+        assertEquals(
+            """{"lowestSequence":7,"highestSequence":9,"overflowed":true,"events":[{"s":9,"m":9000,"w":18000,"t":"STT_PARTIAL","g":11,"i":13,"d":{"length":"42","escaped":"\"\n"}}]}""",
+            json,
+        )
+        assertFalse(json.contains("text"))
+        assertFalse(json.contains("audio"))
+        assertFalse(json.contains("path"))
     }
 
-    // ── Performance: bounded capacity does not degrade ──────────────────────────
-
     @Test
-    fun `recording at capacity does not throw`() {
-        val journal = AcousticEventJournal(journalCapacity = 256)
-        // Fill and overflow
-        for (i in 1..300) journal.record(event(i.toLong()))
-        assertTrue(journal.overflowed)
-        assertEquals(256, journal.snapshotSince(0).size)
-    }
+    fun `recording remains bounded at default capacity`() {
+        val journal = AcousticEventJournal()
+        for (sequence in 1L..300L) journal.record(event(sequence))
 
-    // ── Default capacity ────────────────────────────────────────────────────────
-
-    @Test
-    fun `default capacity is 256`() {
+        assertEquals(256, journal.snapshotSince(0).events.size)
         assertEquals(256, AcousticEventJournal.DEFAULT_CAPACITY)
+        assertTrue(journal.overflowed)
     }
 }

--- a/app/src/test/java/com/kernel/ai/debug/journal/TargetEventJournalEndpointTest.kt
+++ b/app/src/test/java/com/kernel/ai/debug/journal/TargetEventJournalEndpointTest.kt
@@ -1,0 +1,131 @@
+package com.kernel.ai.debug.journal
+
+import com.kernel.ai.core.voice.AcousticEvent
+import com.kernel.ai.core.voice.AcousticEventType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class TargetEventJournalEndpointTest {
+    private lateinit var journal: AcousticEventJournal
+    private val callers = Executors.newFixedThreadPool(2)
+
+    @BeforeEach
+    fun setUp() {
+        journal = AcousticEventJournal()
+        TargetEventJournalEndpoint.replaceJournalForTest(journal)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        callers.shutdownNow()
+    }
+
+    @Test
+    fun `independent waits leave control calls responsive and cancel exactly one request`() {
+        val cancelledWait = callers.submit<TargetEventJournalResponse> {
+            TargetEventJournalEndpoint.waitForEvent(
+                requestId = "cancel-me",
+                sinceSequence = 0L,
+                eventType = AcousticEventType.DETECTOR_REARMED,
+                timeoutMs = 5_000L,
+            )
+        }
+        val foundWait = callers.submit<TargetEventJournalResponse> {
+            TargetEventJournalEndpoint.waitForEvent(
+                requestId = "find-me",
+                sinceSequence = 0L,
+                eventType = AcousticEventType.STT_READY,
+                timeoutMs = 5_000L,
+            )
+        }
+
+        assertEquals("0", TargetEventJournalEndpoint.sequence().data)
+        assertEquals(TargetEventJournalContract.RESULT_OK, TargetEventJournalEndpoint.snapshot(0L).code)
+
+        val cancellation = awaitSuccessfulCancellation("cancel-me")
+        assertEquals("cancelled:cancel-me", cancellation.data)
+
+        journal.record(
+            AcousticEvent(
+                sequence = 1L,
+                monotonicMs = 10L,
+                type = AcousticEventType.STT_READY,
+                generationId = 2L,
+                sessionId = 3L,
+            ),
+        )
+
+        assertEquals(
+            TargetEventJournalContract.RESULT_CANCELLED,
+            cancelledWait.get(1L, TimeUnit.SECONDS).code,
+        )
+        val found = foundWait.get(1L, TimeUnit.SECONDS)
+        assertEquals(TargetEventJournalContract.RESULT_OK, found.code)
+        assertTrue(found.data.contains("\"t\":\"STT_READY\""))
+        assertEquals(
+            TargetEventJournalContract.ERROR_UNKNOWN_REQUEST_ID,
+            TargetEventJournalEndpoint.cancelWait("cancel-me").data,
+        )
+    }
+
+    @Test
+    fun `fifth wait fails fast without consuming control capacity`() {
+        val saturatedCallers = Executors.newFixedThreadPool(4)
+        val requestIds = (1..4).map { "wait-$it" }
+        try {
+            val waits = requestIds.map { requestId ->
+                saturatedCallers.submit<TargetEventJournalResponse> {
+                    TargetEventJournalEndpoint.waitForEvent(
+                        requestId = requestId,
+                        sinceSequence = 0L,
+                        eventType = AcousticEventType.STT_READY,
+                        timeoutMs = 5_000L,
+                    )
+                }
+            }
+            awaitActiveWaitCount(4)
+
+            val busy = TargetEventJournalEndpoint.waitForEvent(
+                requestId = "wait-5",
+                sinceSequence = 0L,
+                eventType = AcousticEventType.STT_READY,
+                timeoutMs = 5_000L,
+            )
+
+            assertEquals(TargetEventJournalContract.RESULT_ERROR, busy.code)
+            assertEquals(TargetEventJournalContract.ERROR_ENDPOINT_BUSY, busy.data)
+            assertEquals(TargetEventJournalContract.RESULT_OK, TargetEventJournalEndpoint.sequence().code)
+            requestIds.forEach { assertEquals(3, TargetEventJournalEndpoint.cancelWait(it).code) }
+            waits.forEach {
+                assertEquals(
+                    TargetEventJournalContract.RESULT_CANCELLED,
+                    it.get(1L, TimeUnit.SECONDS).code,
+                )
+            }
+        } finally {
+            saturatedCallers.shutdownNow()
+        }
+    }
+
+    private fun awaitActiveWaitCount(expected: Int) {
+        repeat(1_000) {
+            if (TargetEventJournalEndpoint.activeWaitCountForTest() == expected) return
+            Thread.sleep(1L)
+        }
+        error("Expected $expected active waits")
+    }
+
+    private fun awaitSuccessfulCancellation(requestId: String): TargetEventJournalResponse {
+        repeat(1_000) {
+            val response = TargetEventJournalEndpoint.cancelWait(requestId)
+            if (response.code == TargetEventJournalContract.RESULT_CANCELLED) return response
+            Thread.sleep(1L)
+        }
+        error("Wait registration was not visible")
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
@@ -33,6 +33,9 @@ object AcousticEventType {
     /** First voiced frame detected after a period of silence-gating. */
     const val VOICED_FRAME_AFTER_SILENCE = "VOICED_FRAME_AFTER_SILENCE"
 
+    /** Stage 2 embedding execution resumed after silence gating. */
+    const val STAGE2_RESUMED = "STAGE2_RESUMED"
+
     /** Stage 3 classifier ready after embedding ring history filled. */
     const val STAGE3_READY = "STAGE3_READY"
 
@@ -69,19 +72,25 @@ object AcousticEventType {
     /** STT produced a partial result.  Metadata: "length" (character count). */
     const val STT_PARTIAL = "STT_PARTIAL"
 
-    /** STT produced an error.  Metadata: "error". */
+    /** STT produced a final result. Metadata: "length" (character count). */
+    const val STT_FINAL = "STT_FINAL"
+
+    /** STT produced an error. Metadata: stable "category". */
     const val STT_ERROR = "STT_ERROR"
+
+    /** Command handoff result. Metadata: "outcome" and optional stable "category". */
+    const val COMMAND_ROUTING_RESULT = "COMMAND_ROUTING_RESULT"
 
     /** Voice session completed normally. */
     const val SESSION_COMPLETED = "SESSION_COMPLETED"
 
-    /** Voice session was cancelled.  Metadata: "reason". */
+    /** Voice session was cancelled. Metadata: stable "category". */
     const val SESSION_CANCELLED = "SESSION_CANCELLED"
 
     /** Detector was re-armed with a new generation. */
     const val DETECTOR_REARMED = "DETECTOR_REARMED"
 
-    /** Service loss or detector error.  Metadata: "error". */
+    /** Service loss. Metadata: stable "category". */
     const val SERVICE_ERROR = "SERVICE_ERROR"
 
     /** Detector-level error (ONNX session, AudioRecord, etc.). */

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
@@ -1,0 +1,89 @@
+package com.kernel.ai.core.voice
+
+/**
+ * Structured debug-only event for the target event journal.
+ *
+ * Each event carries a monotonically increasing sequence number, a monotonic
+ * timestamp (elapsedRealtime), an optional wall-clock timestamp for operator
+ * diagnostics, and correlation identifiers that let the runner group events
+ * by detector generation and voice session.
+ *
+ * [metadata] contains only small structured, privacy-safe scalar values.
+ * Never include transcript text, audio samples, file paths, account data,
+ * device selectors, service endpoints, model paths or exception dumps.
+ */
+data class AcousticEvent(
+    val sequence: Long,
+    val monotonicMs: Long,
+    val wallClockMs: Long = 0L,
+    val type: String,
+    val generationId: Long = 0L,
+    val sessionId: Long = 0L,
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+/** Canonical event type strings emitted by the journal. */
+object AcousticEventType {
+    /** A new detector generation started. */
+    const val DETECTOR_GENERATION_STARTED = "DETECTOR_GENERATION_STARTED"
+
+    /** Silence gate became active (Stage 2/3 suppressed). */
+    const val SILENCE_GATE_ENTERED = "SILENCE_GATE_ENTERED"
+
+    /** First voiced frame detected after a period of silence-gating. */
+    const val VOICED_FRAME_AFTER_SILENCE = "VOICED_FRAME_AFTER_SILENCE"
+
+    /** Stage 3 classifier ready after embedding ring history filled. */
+    const val STAGE3_READY = "STAGE3_READY"
+
+    /**
+     * An activation candidate was produced at or above the low threshold.
+     * Metadata includes "confidence" and "mode" ("high" or "low").
+     */
+    const val ACTIVATION_CANDIDATE = "ACTIVATION_CANDIDATE"
+
+    /**
+     * Activation verified by STT (low-threshold path succeeded) or by
+     * high-confidence fast path.  Metadata includes "mode".
+     */
+    const val VERIFIED_ACTIVATION = "VERIFIED_ACTIVATION"
+
+    /** Wake callback invoked in WakeWordService. */
+    const val WAKE_CALLBACK_INVOKED = "WAKE_CALLBACK_INVOKED"
+
+    /** Voice/assistant session has started. */
+    const val VOICE_SESSION_STARTED = "VOICE_SESSION_STARTED"
+
+    /** STT start has been requested. */
+    const val STT_START_REQUESTED = "STT_START_REQUESTED"
+
+    /** STT recogniser reported readiness / ListeningStarted. */
+    const val STT_READY = "STT_READY"
+
+    /** Start-listening cue was requested. Metadata: "force_audible". */
+    const val CUE_REQUESTED = "CUE_REQUESTED"
+
+    /** STT detected speech.  No transcript content exposed. */
+    const val STT_SPEECH_DETECTED = "STT_SPEECH_DETECTED"
+
+    /** STT produced a partial result.  Metadata: "length" (character count). */
+    const val STT_PARTIAL = "STT_PARTIAL"
+
+    /** STT produced an error.  Metadata: "error". */
+    const val STT_ERROR = "STT_ERROR"
+
+    /** Voice session completed normally. */
+    const val SESSION_COMPLETED = "SESSION_COMPLETED"
+
+    /** Voice session was cancelled.  Metadata: "reason". */
+    const val SESSION_CANCELLED = "SESSION_CANCELLED"
+
+    /** Detector was re-armed with a new generation. */
+    const val DETECTOR_REARMED = "DETECTOR_REARMED"
+
+    /** Service loss or detector error.  Metadata: "error". */
+    const val SERVICE_ERROR = "SERVICE_ERROR"
+
+    /** Detector-level error (ONNX session, AudioRecord, etc.). */
+    const val DETECTOR_ERROR = "DETECTOR_ERROR"
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEvent.kt
@@ -95,4 +95,29 @@ object AcousticEventType {
 
     /** Detector-level error (ONNX session, AudioRecord, etc.). */
     const val DETECTOR_ERROR = "DETECTOR_ERROR"
+
+    val ALL: Set<String> = setOf(
+        DETECTOR_GENERATION_STARTED,
+        SILENCE_GATE_ENTERED,
+        VOICED_FRAME_AFTER_SILENCE,
+        STAGE2_RESUMED,
+        STAGE3_READY,
+        ACTIVATION_CANDIDATE,
+        VERIFIED_ACTIVATION,
+        WAKE_CALLBACK_INVOKED,
+        VOICE_SESSION_STARTED,
+        STT_START_REQUESTED,
+        STT_READY,
+        CUE_REQUESTED,
+        STT_SPEECH_DETECTED,
+        STT_PARTIAL,
+        STT_FINAL,
+        STT_ERROR,
+        COMMAND_ROUTING_RESULT,
+        SESSION_COMPLETED,
+        SESSION_CANCELLED,
+        DETECTOR_REARMED,
+        SERVICE_ERROR,
+        DETECTOR_ERROR,
+    )
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEventRecorder.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEventRecorder.kt
@@ -58,22 +58,25 @@ object AcousticJournalBridge {
         type: String,
         generationId: Long = 0L,
         sessionId: Long = 0L,
-        metadata: Map<String, String> = emptyMap(),
         sequenceProvider: SequenceProvider = AtomicSequenceProvider,
+        metadata: () -> Map<String, String> = EMPTY_METADATA,
     ) {
-        val seq = sequenceProvider.nextSequence()
-        current().record(
+        val target = recorder
+        if (target === AcousticEventRecorder.NoOp) return
+        target.record(
             AcousticEvent(
-                sequence = seq,
+                sequence = sequenceProvider.nextSequence(),
                 monotonicMs = SystemClock.elapsedRealtime(),
                 wallClockMs = System.currentTimeMillis(),
                 type = type,
                 generationId = generationId,
                 sessionId = sessionId,
-                metadata = metadata,
+                metadata = metadata(),
             )
         )
     }
+
+    private val EMPTY_METADATA: () -> Map<String, String> = { emptyMap() }
 }
 
 /**

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEventRecorder.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/AcousticEventRecorder.kt
@@ -1,0 +1,92 @@
+package com.kernel.ai.core.voice
+
+import android.os.SystemClock
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Narrow recorder interface for production-side journal hooks.
+ *
+ * Production code calls [record] at well-defined state transitions.  The
+ * default [NoOp] implementation is used in release builds or when no debug
+ * journal has been installed.  The actual bounded journal, storage and
+ * machine-interface components live in the debug source set and are wired
+ * through [AcousticJournalBridge].
+ *
+ * Recordings are low-volume and transition-based — never per-frame or
+ * per-inference-step.
+ */
+fun interface AcousticEventRecorder {
+    fun record(event: AcousticEvent)
+
+    companion object {
+        val NoOp: AcousticEventRecorder = AcousticEventRecorder { /* no-op */ }
+    }
+}
+
+/**
+ * Static bridge that connects production-side hooks to the debug-only journal.
+ *
+ * In debug builds [install] is called early (e.g. from the debug receiver)
+ * to wire the real bounded journal.  In release builds the [NoOp] default
+ * remains active — the bridge adds no detectable surface or allocation path.
+ */
+object AcousticJournalBridge {
+    @Volatile
+    private var recorder: AcousticEventRecorder = AcousticEventRecorder.NoOp
+
+    private val generationCounter = AtomicLong(0)
+    private val sessionCounter = AtomicLong(0)
+
+    /** Allocates the next monotonically increasing detector generation ID. */
+    fun allocateGenerationId(): Long = generationCounter.incrementAndGet()
+
+    /** Allocates the next monotonically increasing voice session ID. */
+    fun allocateSessionId(): Long = sessionCounter.incrementAndGet()
+
+    fun install(recorder: AcousticEventRecorder) {
+        this.recorder = recorder
+    }
+
+    fun current(): AcousticEventRecorder = recorder
+
+    /**
+     * Convenience factory: creates an [AcousticEvent] with the next
+     * available sequence number from a supplied [SequenceProvider] and
+     * records it through [current].
+     */
+    fun record(
+        type: String,
+        generationId: Long = 0L,
+        sessionId: Long = 0L,
+        metadata: Map<String, String> = emptyMap(),
+        sequenceProvider: SequenceProvider = AtomicSequenceProvider,
+    ) {
+        val seq = sequenceProvider.nextSequence()
+        current().record(
+            AcousticEvent(
+                sequence = seq,
+                monotonicMs = SystemClock.elapsedRealtime(),
+                wallClockMs = System.currentTimeMillis(),
+                type = type,
+                generationId = generationId,
+                sessionId = sessionId,
+                metadata = metadata,
+            )
+        )
+    }
+}
+
+/**
+ * Provides monotonically increasing sequence numbers for [AcousticEvent].
+ *
+ * The [AtomicSequenceProvider] default is safe for concurrent use across
+ * multiple threads (detector thread, main thread, broadcast receiver).
+ */
+fun interface SequenceProvider {
+    fun nextSequence(): Long
+}
+
+object AtomicSequenceProvider : SequenceProvider {
+    private val counter = AtomicLong(0)
+    override fun nextSequence(): Long = counter.incrementAndGet()
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -126,7 +126,6 @@ class NativeAndroidVoiceInputController @Inject constructor(
     private var startupFallbackJob: Job? = null
 
 
-    private var nextSessionId: Long = 0L
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         return withContext(Dispatchers.Main.immediate) {
@@ -151,7 +150,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
 
             try {
                 requestAudioFocus()
-                val sessionId = ++nextSessionId
+                val sessionId = VoiceCaptureSessionIds.allocate()
                 currentMode = mode
                 activeSessionId = sessionId
                 val startBackend = initialRecognizerBackend(mode)
@@ -187,7 +186,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         throw startEx
                     }
                 }
-                VoiceInputStartResult.Started
+                VoiceInputStartResult.Started(sessionId)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start Android native voice capture", e)
                 stopListeningInternal(emitStopped = false)
@@ -210,6 +209,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         }
 
         val mode = currentMode
+        val sessionId = activeSessionId
         val recognizer = speechRecognizer
         startupFallbackJob?.cancel()
         startupFallbackJob = null
@@ -225,7 +225,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         releaseAudioFocus()
 
         if (emitStopped && mode != null) {
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
         }
     }
 
@@ -376,10 +376,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 _events.tryEmit(
                     VoiceInputEvent.Error(
                         mode = mode,
+                        captureSessionId = sessionId,
                         message = "Android speech recognition stopped responding before it returned a result.",
                     ),
                 )
-                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
                 stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
             }
         }
@@ -395,7 +396,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             cancelStartupFallback()
             resetSessionWatchdog()
             Log.i(TAG, "Android native STT ready: sessionId=$sessionId mode=$mode backend=$backend")
-            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode, sessionId))
         }
 
         override fun onBeginningOfSpeech() {
@@ -403,7 +404,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             heardSpeech = true
             resetSessionWatchdog()
             Log.d(TAG, "Android native STT speech began: sessionId=$sessionId mode=$mode backend=$backend")
-            _events.tryEmit(VoiceInputEvent.SpeechDetected(mode))
+            _events.tryEmit(VoiceInputEvent.SpeechDetected(mode, sessionId))
         }
 
         override fun onRmsChanged(rmsdB: Float) = Unit
@@ -448,10 +449,11 @@ class NativeAndroidVoiceInputController @Inject constructor(
             _events.tryEmit(
                 VoiceInputEvent.Error(
                     mode = mode,
+                    captureSessionId = sessionId,
                     message = mapError(error, availability),
                 ),
             )
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
             stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
         }
 
@@ -470,13 +472,20 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 _events.tryEmit(
                     VoiceInputEvent.Error(
                         mode = mode,
+                        captureSessionId = sessionId,
                         message = "I didn't catch anything from Android speech recognition.",
                     ),
                 )
             } else {
-                _events.tryEmit(VoiceInputEvent.Transcript(mode = mode, text = transcript))
+                _events.tryEmit(
+                    VoiceInputEvent.Transcript(
+                        mode = mode,
+                        text = transcript,
+                        captureSessionId = sessionId,
+                    ),
+                )
             }
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
             stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
         }
 
@@ -490,7 +499,13 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     TAG,
                     "Android native STT partial: sessionId=$sessionId mode=$mode transcript='$transcript'",
                 )
-                _events.tryEmit(VoiceInputEvent.PartialTranscript(mode = mode, text = transcript))
+                _events.tryEmit(
+                    VoiceInputEvent.PartialTranscript(
+                        mode = mode,
+                        text = transcript,
+                        captureSessionId = sessionId,
+                    ),
+                )
             }
         }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -403,6 +403,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
             heardSpeech = true
             resetSessionWatchdog()
             Log.d(TAG, "Android native STT speech began: sessionId=$sessionId mode=$mode backend=$backend")
+            _events.tryEmit(VoiceInputEvent.SpeechDetected(mode))
         }
 
         override fun onRmsChanged(rmsdB: Float) = Unit

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -27,6 +27,38 @@ internal fun isWakeWordDiagnosticLoggingEnabled(): Boolean =
     Log.isLoggable(DIAGNOSTIC_TAG, Log.DEBUG)
 
 /**
+ * Transition state for silence-gate journal events.
+ *
+ * Periodic full-inference frames do not leave the gate. Only a voiced frame does,
+ * and the first Stage 2 execution after that voiced exit emits the resume event.
+ */
+internal class SilenceGateTransitionState {
+    var isGated: Boolean = false
+        private set
+
+    private var stage2ResumePending = false
+
+    fun enter(): Boolean {
+        if (isGated) return false
+        isGated = true
+        return true
+    }
+
+    fun onVoicedFrame(): Boolean {
+        if (!isGated) return false
+        isGated = false
+        stage2ResumePending = true
+        return true
+    }
+
+    fun onStage2Execution(): Boolean {
+        if (!stage2ResumePending) return false
+        stage2ResumePending = false
+        return true
+    }
+}
+
+/**
  * Diagnostic summaries are only emitted when the dedicated tag's DEBUG level is enabled.
  * Checking at this cadence keeps the production detector hot loop allocation-free.
  */
@@ -334,7 +366,7 @@ class OnnxWakeWordDetector @Inject constructor(
         var nnapiStatus = "not_requested"
 
         // ── Target event journal tracking ──────────────────────────────────────
-        var wasPreviouslyGated = false
+        val silenceGateState = SilenceGateTransitionState()
         var emittedStage3Ready = false
 
         try {
@@ -477,9 +509,8 @@ class OnnxWakeWordDetector @Inject constructor(
                     // every frame even during gating), so the first speech frame
                     // already pre-fills it with speech mel data.
                     // Latency: 80ms + 16-frame ring fill (~1.3s) ≈ ~1.4s.
-                    if (wasGated) {
+                    if (silenceGateState.onVoicedFrame()) {
                         embFramesAccumulated = 0
-                        wasGated = false
                         emittedStage3Ready = false
                         AcousticJournalBridge.record(
                             type = AcousticEventType.VOICED_FRAME_AFTER_SILENCE,
@@ -550,14 +581,12 @@ class OnnxWakeWordDetector @Inject constructor(
                 if (silenceFrames > silenceHangoverFrames &&
                     chunkCount % maxSilenceSkipFrames.toLong() != 0L) {
                     diagnostics?.recordSilenceGateSkip()
-                    if (!wasPreviouslyGated) {
-                        wasPreviouslyGated = true
+                    if (silenceGateState.enter()) {
                         AcousticJournalBridge.record(
                             type = AcousticEventType.SILENCE_GATE_ENTERED,
                             generationId = generationId,
                         )
                     }
-                    wasGated = true
                     continue  // wake word not expected — skip expensive Stage 2/3
                 }
 
@@ -568,8 +597,7 @@ class OnnxWakeWordDetector @Inject constructor(
                 // melRing is already [76 × 32] row-major.  We reinterpret as [76 × 32 × 1] by
                 // passing the same flat array with shape [1, 76, 32, 1] — the channel is implicit
                 // (every element maps to exactly one channel-1 position).
-                if (wasPreviouslyGated) {
-                    wasPreviouslyGated = false
+                if (silenceGateState.onStage2Execution()) {
                     AcousticJournalBridge.record(
                         type = AcousticEventType.STAGE2_RESUMED,
                         generationId = generationId,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -325,6 +325,11 @@ class OnnxWakeWordDetector @Inject constructor(
         var lastDiagnosticReportElapsedMillis = 0L
         var nnapiStatus = "not_requested"
 
+        // ── Target event journal tracking ──────────────────────────────────────
+        val currentGenerationId = AcousticJournalBridge.allocateGenerationId()
+        var wasPreviouslyGated = false
+        var emittedStage3Ready = false
+
         try {
             val env = OrtEnvironment.getEnvironment()
             cpuOptions = OrtSession.SessionOptions().apply {
@@ -363,6 +368,11 @@ class OnnxWakeWordDetector @Inject constructor(
 
             }
             Log.i(TAG, "WakeWordDetector: models loaded (embedding provider=$nnapiStatus; mel+classifier: CPU)")
+
+            AcousticJournalBridge.record(
+                type = AcousticEventType.DETECTOR_GENERATION_STARTED,
+                generationId = currentGenerationId,
+            )
 
 
             // Resolve ONNX node names once at startup.
@@ -456,6 +466,12 @@ class OnnxWakeWordDetector @Inject constructor(
                     if (wasGated) {
                         embFramesAccumulated = 0
                         wasGated = false
+                        emittedStage3Ready = false
+                        wasPreviouslyGated = false
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.VOICED_FRAME_AFTER_SILENCE,
+                            generationId = currentGenerationId,
+                        )
                     }
                     silenceFrames = 0
                     voicedFrameStreak = 0
@@ -521,6 +537,13 @@ class OnnxWakeWordDetector @Inject constructor(
                 if (silenceFrames > silenceHangoverFrames &&
                     chunkCount % maxSilenceSkipFrames.toLong() != 0L) {
                     diagnostics?.recordSilenceGateSkip()
+                    if (!wasPreviouslyGated) {
+                        wasPreviouslyGated = true
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.SILENCE_GATE_ENTERED,
+                            generationId = currentGenerationId,
+                        )
+                    }
                     wasGated = true
                     continue  // wake word not expected — skip expensive Stage 2/3
                 }
@@ -551,6 +574,13 @@ class OnnxWakeWordDetector @Inject constructor(
                 embRingHead = (embRingHead + 1) % EMBEDDING_FRAMES
                 if (embFramesAccumulated < EMBEDDING_FRAMES) embFramesAccumulated++
                 if (embFramesAccumulated < EMBEDDING_FRAMES) continue
+                if (!emittedStage3Ready && embFramesAccumulated >= EMBEDDING_FRAMES) {
+                    emittedStage3Ready = true
+                    AcousticJournalBridge.record(
+                        type = AcousticEventType.STAGE3_READY,
+                        generationId = currentGenerationId,
+                    )
+                }
 
                 // ── Stage 3: classifier over the last 16 embedding frames ─────────────
                 // Input:  [1, 16, 96]
@@ -578,8 +608,18 @@ class OnnxWakeWordDetector @Inject constructor(
                     // High-confidence fast path — activate immediately.
                     confidence >= highThreshold -> {
                         Log.i(TAG, "WakeWordDetector: detected (high confidence=$confidence)")
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.ACTIVATION_CANDIDATE,
+                            generationId = currentGenerationId,
+                            metadata = mapOf("confidence" to confidence.toString(), "mode" to "high"),
+                        )
                         if (running.compareAndSet(true, false)) {
                             diagnostics?.recordHighConfidenceActivation()
+                            AcousticJournalBridge.record(
+                                type = AcousticEventType.VERIFIED_ACTIVATION,
+                                generationId = currentGenerationId,
+                                metadata = mapOf("mode" to "high"),
+                            )
                             onDetected()
                         }
                     }
@@ -587,6 +627,11 @@ class OnnxWakeWordDetector @Inject constructor(
                     // Secondary band — run STT verification if a verifier is wired.
                     verifyWindow != null && confidence >= lowThreshold -> {
                         Log.d(TAG, "WakeWordDetector: low-threshold crossing (confidence=$confidence) — verifying")
+                        AcousticJournalBridge.record(
+                            type = AcousticEventType.ACTIVATION_CANDIDATE,
+                            generationId = currentGenerationId,
+                            metadata = mapOf("confidence" to confidence.toString(), "mode" to "low"),
+                        )
                         val snapshot = extractPcmSnapshot(pcmRing, pcmRingHead, pcmFilled)
                         val verified = verifyWindow(snapshot)
                         diagnostics?.recordVerifierResult(verified)
@@ -594,6 +639,11 @@ class OnnxWakeWordDetector @Inject constructor(
                             Log.i(TAG, "WakeWordDetector: STT verification passed — activating")
                             if (running.compareAndSet(true, false)) {
                                 diagnostics?.recordVerifiedActivation()
+                                AcousticJournalBridge.record(
+                                    type = AcousticEventType.VERIFIED_ACTIVATION,
+                                    generationId = currentGenerationId,
+                                    metadata = mapOf("mode" to "low"),
+                                )
                                 onDetected()
                             }
                         } else {
@@ -608,6 +658,11 @@ class OnnxWakeWordDetector @Inject constructor(
             Thread.currentThread().interrupt()
         } catch (e: Exception) {
             Log.e(TAG, "WakeWordDetector: fatal error", e)
+            AcousticJournalBridge.record(
+                type = AcousticEventType.DETECTOR_ERROR,
+                generationId = currentGenerationId,
+                metadata = mapOf("error" to (e.message?.take(200) ?: "unknown")),
+            )
         } finally {
             activeAudioRecord = null
             runCatching { audioRecord.stop() }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -213,7 +213,11 @@ class OnnxWakeWordDetector @Inject constructor(
             ) == android.content.pm.PackageManager.PERMISSION_GRANTED
         }.getOrDefault(false)
     }
-    override fun start(onDetected: () -> Unit, verifyWindow: ((ShortArray) -> Boolean)?) {
+    override fun start(
+        generationId: Long,
+        onDetected: () -> Unit,
+        verifyWindow: ((ShortArray) -> Boolean)?,
+    ) {
         val bytes = modelBytes
         if (bytes == null) {
             Log.d(TAG, "WakeWordDetector: start() called but model(s) absent — no-op")
@@ -251,6 +255,7 @@ class OnnxWakeWordDetector @Inject constructor(
         detectionThread = Thread(
             {
                 runDetectionLoop(
+                    generationId = generationId,
                     bytes = bytes,
                     highThreshold = highThreshold,
                     lowThreshold = lowThreshold,
@@ -279,6 +284,7 @@ class OnnxWakeWordDetector @Inject constructor(
     @Suppress("LongMethod")
     @SuppressLint("MissingPermission")
     private fun runDetectionLoop(
+        generationId: Long,
         bytes: ModelBytes,
         highThreshold: Float,
         lowThreshold: Float,
@@ -302,11 +308,13 @@ class OnnxWakeWordDetector @Inject constructor(
         )
         } catch (e: Exception) {
             Log.e(TAG, "WakeWordDetector: AudioRecord construction failed", e)
+            recordDetectorError(generationId, "audio_record_construction_failed")
             running.set(false)
             return
         }
         if (audioRecord.state != AudioRecord.STATE_INITIALIZED) {
             Log.e(TAG, "WakeWordDetector: AudioRecord failed to initialise")
+            recordDetectorError(generationId, "audio_record_initialisation_failed")
             running.set(false)
             return
         }
@@ -326,7 +334,6 @@ class OnnxWakeWordDetector @Inject constructor(
         var nnapiStatus = "not_requested"
 
         // ── Target event journal tracking ──────────────────────────────────────
-        val currentGenerationId = AcousticJournalBridge.allocateGenerationId()
         var wasPreviouslyGated = false
         var emittedStage3Ready = false
 
@@ -364,14 +371,14 @@ class OnnxWakeWordDetector @Inject constructor(
 
             if (melsSession == null || embedSession == null || classSession == null) {
                 Log.e(TAG, "WakeWordDetector: one or more ONNX sessions failed to load")
+                recordDetectorError(generationId, "onnx_session_failed")
                 return
-
             }
             Log.i(TAG, "WakeWordDetector: models loaded (embedding provider=$nnapiStatus; mel+classifier: CPU)")
 
             AcousticJournalBridge.record(
                 type = AcousticEventType.DETECTOR_GENERATION_STARTED,
-                generationId = currentGenerationId,
+                generationId = generationId,
             )
 
 
@@ -403,7 +410,12 @@ class OnnxWakeWordDetector @Inject constructor(
             var voicedFrameStreak = 0
             var wasGated = false
             runCatching { audioRecord.startRecording() }
-                .onFailure { e -> Log.e(TAG, "WakeWordDetector: startRecording failed", e); running.set(false); return }
+                .onFailure { e ->
+                    Log.e(TAG, "WakeWordDetector: startRecording failed", e)
+                    recordDetectorError(generationId, "audio_record_start_failed")
+                    running.set(false)
+                    return
+                }
             Log.d(TAG, "WakeWordDetector: recording started")
             while (running.get() && !Thread.currentThread().isInterrupted) {
                 // Read exactly one 80ms frame; abort if AudioRecord signals an error.
@@ -413,6 +425,7 @@ class OnnxWakeWordDetector @Inject constructor(
                         audioRecord.read(chunk, totalRead, FRAME_SAMPLES - totalRead)
                     } catch (e: SecurityException) {
                         Log.e(TAG, "WakeWordDetector: permission revoked during read", e)
+                        recordDetectorError(generationId, "audio_record_permission_revoked")
                         running.set(false)
                         -1
                     }
@@ -420,6 +433,7 @@ class OnnxWakeWordDetector @Inject constructor(
                         read > 0 -> totalRead += read
                         read < 0 -> {
                             Log.e(TAG, "WakeWordDetector: AudioRecord.read() error $read — stopping")
+                            recordDetectorError(generationId, "audio_record_read_failed")
                             running.set(false)
                         }
                         // read == 0: no data yet, spin
@@ -467,10 +481,9 @@ class OnnxWakeWordDetector @Inject constructor(
                         embFramesAccumulated = 0
                         wasGated = false
                         emittedStage3Ready = false
-                        wasPreviouslyGated = false
                         AcousticJournalBridge.record(
                             type = AcousticEventType.VOICED_FRAME_AFTER_SILENCE,
-                            generationId = currentGenerationId,
+                            generationId = generationId,
                         )
                     }
                     silenceFrames = 0
@@ -541,7 +554,7 @@ class OnnxWakeWordDetector @Inject constructor(
                         wasPreviouslyGated = true
                         AcousticJournalBridge.record(
                             type = AcousticEventType.SILENCE_GATE_ENTERED,
-                            generationId = currentGenerationId,
+                            generationId = generationId,
                         )
                     }
                     wasGated = true
@@ -555,6 +568,13 @@ class OnnxWakeWordDetector @Inject constructor(
                 // melRing is already [76 × 32] row-major.  We reinterpret as [76 × 32 × 1] by
                 // passing the same flat array with shape [1, 76, 32, 1] — the channel is implicit
                 // (every element maps to exactly one channel-1 position).
+                if (wasPreviouslyGated) {
+                    wasPreviouslyGated = false
+                    AcousticJournalBridge.record(
+                        type = AcousticEventType.STAGE2_RESUMED,
+                        generationId = generationId,
+                    )
+                }
                 melRing.copyInto(embedInput4D)
                 diagnostics?.recordStage2Execution()
                 val embedding: FloatArray = OnnxTensor.createTensor(
@@ -578,7 +598,7 @@ class OnnxWakeWordDetector @Inject constructor(
                     emittedStage3Ready = true
                     AcousticJournalBridge.record(
                         type = AcousticEventType.STAGE3_READY,
-                        generationId = currentGenerationId,
+                        generationId = generationId,
                     )
                 }
 
@@ -610,15 +630,17 @@ class OnnxWakeWordDetector @Inject constructor(
                         Log.i(TAG, "WakeWordDetector: detected (high confidence=$confidence)")
                         AcousticJournalBridge.record(
                             type = AcousticEventType.ACTIVATION_CANDIDATE,
-                            generationId = currentGenerationId,
-                            metadata = mapOf("confidence" to confidence.toString(), "mode" to "high"),
+                            generationId = generationId,
+                            metadata = {
+                                mapOf("confidence" to confidence.toString(), "mode" to "high")
+                            },
                         )
                         if (running.compareAndSet(true, false)) {
                             diagnostics?.recordHighConfidenceActivation()
                             AcousticJournalBridge.record(
                                 type = AcousticEventType.VERIFIED_ACTIVATION,
-                                generationId = currentGenerationId,
-                                metadata = mapOf("mode" to "high"),
+                                generationId = generationId,
+                                metadata = { mapOf("mode" to "high") },
                             )
                             onDetected()
                         }
@@ -629,8 +651,10 @@ class OnnxWakeWordDetector @Inject constructor(
                         Log.d(TAG, "WakeWordDetector: low-threshold crossing (confidence=$confidence) — verifying")
                         AcousticJournalBridge.record(
                             type = AcousticEventType.ACTIVATION_CANDIDATE,
-                            generationId = currentGenerationId,
-                            metadata = mapOf("confidence" to confidence.toString(), "mode" to "low"),
+                            generationId = generationId,
+                            metadata = {
+                                mapOf("confidence" to confidence.toString(), "mode" to "low")
+                            },
                         )
                         val snapshot = extractPcmSnapshot(pcmRing, pcmRingHead, pcmFilled)
                         val verified = verifyWindow(snapshot)
@@ -641,8 +665,8 @@ class OnnxWakeWordDetector @Inject constructor(
                                 diagnostics?.recordVerifiedActivation()
                                 AcousticJournalBridge.record(
                                     type = AcousticEventType.VERIFIED_ACTIVATION,
-                                    generationId = currentGenerationId,
-                                    metadata = mapOf("mode" to "low"),
+                                    generationId = generationId,
+                                    metadata = { mapOf("mode" to "low") },
                                 )
                                 onDetected()
                             }
@@ -658,11 +682,7 @@ class OnnxWakeWordDetector @Inject constructor(
             Thread.currentThread().interrupt()
         } catch (e: Exception) {
             Log.e(TAG, "WakeWordDetector: fatal error", e)
-            AcousticJournalBridge.record(
-                type = AcousticEventType.DETECTOR_ERROR,
-                generationId = currentGenerationId,
-                metadata = mapOf("error" to (e.message?.take(200) ?: "unknown")),
-            )
+            recordDetectorError(generationId, "detector_runtime_failed")
         } finally {
             activeAudioRecord = null
             runCatching { audioRecord.stop() }
@@ -678,6 +698,14 @@ class OnnxWakeWordDetector @Inject constructor(
                 Log.d(DIAGNOSTIC_TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
             }
         }
+    }
+
+    private fun recordDetectorError(generationId: Long, category: String) {
+        AcousticJournalBridge.record(
+            type = AcousticEventType.DETECTOR_ERROR,
+            generationId = generationId,
+            metadata = { mapOf("category" to category) },
+        )
     }
 
     private fun formatDiagnosticSummary(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -165,19 +165,28 @@ class SherpaOnnxVoiceInputController @Inject constructor(
                 )
             }
 
+            val captureSessionId = VoiceCaptureSessionIds.allocate()
             isRecording = true
-            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode, captureSessionId))
 
             activeJob = recordingScope.launch {
                 try {
                     when (spec.recognizerKind) {
-                        SherpaSttModelSpec.RecognizerKind.Online -> onlineAudioLoop(ar, mode, rec, spec)
-                        SherpaSttModelSpec.RecognizerKind.Offline -> offlineAudioLoop(ar, mode, rec, spec)
+                        SherpaSttModelSpec.RecognizerKind.Online ->
+                            onlineAudioLoop(ar, mode, captureSessionId, rec, spec)
+                        SherpaSttModelSpec.RecognizerKind.Offline ->
+                            offlineAudioLoop(ar, mode, captureSessionId, rec, spec)
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Audio loop error", e)
-                    _events.tryEmit(VoiceInputEvent.Error(mode, e.message ?: "Voice input error"))
-                    _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                    _events.tryEmit(
+                        VoiceInputEvent.Error(
+                            mode,
+                            e.message ?: "Voice input error",
+                            captureSessionId,
+                        ),
+                    )
+                    _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
                 } finally {
                     stopAudioRecord(ar)
                     releaseAudioFocus()
@@ -185,7 +194,7 @@ class SherpaOnnxVoiceInputController @Inject constructor(
                 }
             }
 
-            VoiceInputStartResult.Started
+            VoiceInputStartResult.Started(captureSessionId)
         }
 
     override fun stopListening() {
@@ -206,6 +215,7 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     private fun onlineAudioLoop(
         ar: AudioRecord,
         mode: VoiceCaptureMode,
+        captureSessionId: Long,
         rec: Any,
         spec: SherpaSttModelSpec,
     ) {
@@ -236,12 +246,12 @@ class SherpaOnnxVoiceInputController @Inject constructor(
                 if (onlineMethods.isEndpoint!!.invoke(rec, stream) as Boolean) {
                     val text = signalEndAndDrainOnline(rec, stream)
                     if (text.isNotEmpty()) {
-                        _events.tryEmit(VoiceInputEvent.Transcript(mode, text))
+                        _events.tryEmit(VoiceInputEvent.Transcript(mode, text, captureSessionId))
                         lastPartial = ""
                     }
                     onlineMethods.reset!!.invoke(rec, stream)
                     if (text.isNotEmpty()) {
-                        _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                        _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
                         exitedFromLoop = true
                         isRecording = false
                         break
@@ -253,13 +263,17 @@ class SherpaOnnxVoiceInputController @Inject constructor(
                 if (System.currentTimeMillis() - started > LISTEN_TIMEOUT_MS) {
                     val text = signalEndAndDrainOnline(rec, stream)
                     if (text.isNotEmpty()) {
-                        _events.tryEmit(VoiceInputEvent.Transcript(mode, text))
+                        _events.tryEmit(VoiceInputEvent.Transcript(mode, text, captureSessionId))
                     } else {
                         _events.tryEmit(
-                            VoiceInputEvent.Error(mode, "I didn't catch anything — please try again.")
+                            VoiceInputEvent.Error(
+                                mode,
+                                "I didn't catch anything — please try again.",
+                                captureSessionId,
+                            ),
                         )
                     }
-                    _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                    _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
                     exitedFromLoop = true
                     isRecording = false
                     break
@@ -269,16 +283,16 @@ class SherpaOnnxVoiceInputController @Inject constructor(
                 val partial = resultTextOnline(rec, stream)
                 if (partial.isNotEmpty() && partial != lastPartial) {
                     lastPartial = partial
-                    _events.tryEmit(VoiceInputEvent.PartialTranscript(mode, partial))
+                    _events.tryEmit(VoiceInputEvent.PartialTranscript(mode, partial, captureSessionId))
                 }
             }
 
             if (!exitedFromLoop) {
                 val text = signalEndAndDrainOnline(rec, stream)
                 if (text.isNotEmpty()) {
-                    _events.tryEmit(VoiceInputEvent.Transcript(mode, text))
+                    _events.tryEmit(VoiceInputEvent.Transcript(mode, text, captureSessionId))
                 }
-                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
             }
         } finally {
             streamMethods.streamRelease!!.invoke(stream)
@@ -314,6 +328,7 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     private fun offlineAudioLoop(
         ar: AudioRecord,
         mode: VoiceCaptureMode,
+        captureSessionId: Long,
         rec: Any,
         spec: SherpaSttModelSpec,
     ) {
@@ -362,20 +377,28 @@ class SherpaOnnxVoiceInputController @Inject constructor(
 
                 val text = resultTextOffline(rec, stream)
                 if (text.isNotEmpty()) {
-                    _events.tryEmit(VoiceInputEvent.Transcript(mode, text))
+                    _events.tryEmit(VoiceInputEvent.Transcript(mode, text, captureSessionId))
                 } else {
                     _events.tryEmit(
-                        VoiceInputEvent.Error(mode, "I didn't catch anything — please try again.")
+                        VoiceInputEvent.Error(
+                            mode,
+                            "I didn't catch anything — please try again.",
+                            captureSessionId,
+                        ),
                     )
                 }
             } else {
                 _events.tryEmit(
-                    VoiceInputEvent.Error(mode, "I didn't catch anything — please try again.")
+                    VoiceInputEvent.Error(
+                        mode,
+                        "I didn't catch anything — please try again.",
+                        captureSessionId,
+                    ),
                 )
             }
         } finally {
             streamMethods.streamRelease!!.invoke(stream)
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
         }
     }
 

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
@@ -9,11 +9,17 @@ sealed interface VoiceInputStartResult {
 }
 
 sealed interface VoiceInputEvent {
-    data class ListeningStarted(val mode: VoiceCaptureMode) : VoiceInputEvent
-    data class PartialTranscript(val mode: VoiceCaptureMode, val text: String) : VoiceInputEvent
-    data class Transcript(val mode: VoiceCaptureMode, val text: String) : VoiceInputEvent
-    data class Error(val mode: VoiceCaptureMode, val message: String) : VoiceInputEvent
-    data class ListeningStopped(val mode: VoiceCaptureMode) : VoiceInputEvent
+    val mode: VoiceCaptureMode
+
+    data class ListeningStarted(override val mode: VoiceCaptureMode) : VoiceInputEvent
+    data class SpeechDetected(override val mode: VoiceCaptureMode) : VoiceInputEvent
+    data class PartialTranscript(
+        override val mode: VoiceCaptureMode,
+        val text: String,
+    ) : VoiceInputEvent
+    data class Transcript(override val mode: VoiceCaptureMode, val text: String) : VoiceInputEvent
+    data class Error(override val mode: VoiceCaptureMode, val message: String) : VoiceInputEvent
+    data class ListeningStopped(override val mode: VoiceCaptureMode) : VoiceInputEvent
 }
 
 interface VoiceInputController {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
@@ -2,24 +2,50 @@ package com.kernel.ai.core.voice
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import java.util.concurrent.atomic.AtomicLong
 
 sealed interface VoiceInputStartResult {
-    object Started : VoiceInputStartResult
+    data class Started(val captureSessionId: Long) : VoiceInputStartResult
     data class Unavailable(val message: String) : VoiceInputStartResult
+}
+
+internal object VoiceCaptureSessionIds {
+    private val nextId = AtomicLong()
+
+    fun allocate(): Long = nextId.incrementAndGet()
 }
 
 sealed interface VoiceInputEvent {
     val mode: VoiceCaptureMode
+    val captureSessionId: Long
 
-    data class ListeningStarted(override val mode: VoiceCaptureMode) : VoiceInputEvent
-    data class SpeechDetected(override val mode: VoiceCaptureMode) : VoiceInputEvent
+    data class ListeningStarted(
+        override val mode: VoiceCaptureMode,
+        override val captureSessionId: Long = 0L,
+    ) : VoiceInputEvent
+    data class SpeechDetected(
+        override val mode: VoiceCaptureMode,
+        override val captureSessionId: Long = 0L,
+    ) : VoiceInputEvent
     data class PartialTranscript(
         override val mode: VoiceCaptureMode,
         val text: String,
+        override val captureSessionId: Long = 0L,
     ) : VoiceInputEvent
-    data class Transcript(override val mode: VoiceCaptureMode, val text: String) : VoiceInputEvent
-    data class Error(override val mode: VoiceCaptureMode, val message: String) : VoiceInputEvent
-    data class ListeningStopped(override val mode: VoiceCaptureMode) : VoiceInputEvent
+    data class Transcript(
+        override val mode: VoiceCaptureMode,
+        val text: String,
+        override val captureSessionId: Long = 0L,
+    ) : VoiceInputEvent
+    data class Error(
+        override val mode: VoiceCaptureMode,
+        val message: String,
+        override val captureSessionId: Long = 0L,
+    ) : VoiceInputEvent
+    data class ListeningStopped(
+        override val mode: VoiceCaptureMode,
+        override val captureSessionId: Long = 0L,
+    ) : VoiceInputEvent
 }
 
 interface VoiceInputController {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoskOfflineVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoskOfflineVoiceInputController.kt
@@ -50,6 +50,9 @@ class VoskOfflineVoiceInputController @Inject constructor(
     @Volatile
     private var audioFocusRequest: AudioFocusRequest? = null
 
+    @Volatile
+    private var activeCaptureSessionId = 0L
+
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
         stopListening()
 
@@ -67,28 +70,39 @@ class VoskOfflineVoiceInputController @Inject constructor(
         return withContext(Dispatchers.Main.immediate) {
             try {
                 requestAudioFocus()
+                val captureSessionId = VoiceCaptureSessionIds.allocate()
+                activeCaptureSessionId = captureSessionId
                 val recognizer = Recognizer(installedModel, SAMPLE_RATE)
                 val service = SpeechService(recognizer, SAMPLE_RATE)
                 speechService = service
-                val listener = SessionRecognitionListener(mode)
+                val listener = SessionRecognitionListener(mode, captureSessionId)
                 if (!service.startListening(listener, LISTEN_TIMEOUT_MS)) {
                     service.shutdown()
                     speechService = null
                     releaseAudioFocus()
+                    activeCaptureSessionId = 0L
                     return@withContext VoiceInputStartResult.Unavailable(
                         "Voice capture is already active."
                     )
                 }
                 delay(STARTUP_SETTLE_MS)
-                _events.tryEmit(VoiceInputEvent.ListeningStarted(mode))
-                VoiceInputStartResult.Started
+                _events.tryEmit(VoiceInputEvent.ListeningStarted(mode, captureSessionId))
+                VoiceInputStartResult.Started(captureSessionId)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start Vosk voice capture", e)
                 speechService?.shutdown()
                 speechService = null
                 releaseAudioFocus()
-                _events.tryEmit(VoiceInputEvent.Error(mode, e.message ?: "Failed to start offline voice input."))
-                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                val captureSessionId = activeCaptureSessionId
+                _events.tryEmit(
+                    VoiceInputEvent.Error(
+                        mode,
+                        e.message ?: "Failed to start offline voice input.",
+                        captureSessionId,
+                    ),
+                )
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
+                activeCaptureSessionId = 0L
                 VoiceInputStartResult.Unavailable(
                     e.message ?: "Failed to start offline voice input."
                 )
@@ -97,7 +111,9 @@ class VoskOfflineVoiceInputController @Inject constructor(
     }
 
     override fun stopListening() {
-        val service = speechService ?: return
+        val service = speechService
+        activeCaptureSessionId = 0L
+        if (service == null) return
         service.stop()
         service.shutdown()
         speechService = null
@@ -136,6 +152,7 @@ class VoskOfflineVoiceInputController @Inject constructor(
 
     private inner class SessionRecognitionListener(
         private val mode: VoiceCaptureMode,
+        private val captureSessionId: Long,
     ) : RecognitionListener {
         private var completed = false
 
@@ -143,7 +160,13 @@ class VoskOfflineVoiceInputController @Inject constructor(
             if (completed) return
             val text = parsePartialTranscript(hypothesis)
             if (text.isNotBlank()) {
-                _events.tryEmit(VoiceInputEvent.PartialTranscript(mode = mode, text = text))
+                _events.tryEmit(
+                    VoiceInputEvent.PartialTranscript(
+                        mode = mode,
+                        text = text,
+                        captureSessionId = captureSessionId,
+                    ),
+                )
             }
         }
 
@@ -155,7 +178,7 @@ class VoskOfflineVoiceInputController @Inject constructor(
             completeWithTranscript(hypothesis)
             if (!completed) {
                 completed = true
-                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
                 speechService = null
             }
         }
@@ -167,10 +190,11 @@ class VoskOfflineVoiceInputController @Inject constructor(
             _events.tryEmit(
                 VoiceInputEvent.Error(
                     mode = mode,
+                    captureSessionId = captureSessionId,
                     message = exception.message ?: "Offline voice recognition failed.",
                 )
             )
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
             speechService = null
             releaseAudioFocus()
         }
@@ -181,10 +205,11 @@ class VoskOfflineVoiceInputController @Inject constructor(
             _events.tryEmit(
                 VoiceInputEvent.Error(
                     mode = mode,
+                    captureSessionId = captureSessionId,
                     message = "I didn't catch anything before listening timed out.",
                 )
             )
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
             speechService = null
             releaseAudioFocus()
         }
@@ -194,8 +219,14 @@ class VoskOfflineVoiceInputController @Inject constructor(
             val text = parseTranscript(hypothesis)
             if (text.isBlank()) return
             completed = true
-            _events.tryEmit(VoiceInputEvent.Transcript(mode = mode, text = text))
-            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode))
+            _events.tryEmit(
+                VoiceInputEvent.Transcript(
+                    mode = mode,
+                    text = text,
+                    captureSessionId = captureSessionId,
+                ),
+            )
+            _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, captureSessionId))
             stopListening()
         }
     }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordDetector.kt
@@ -33,6 +33,7 @@ interface WakeWordDetector {
      * [onDetected] is invoked on an unspecified background thread when confidence exceeds the
      * primary threshold (or the secondary threshold after [verifyWindow] confirms the phrase).
      *
+     * @param generationId   service-allocated ID shared by every event from this detector run
      * @param onDetected      called when the wake word is confirmed; runs on the detector thread
      * @param verifyWindow    optional secondary verification: receives the last ~3 s of raw 16kHz
      *                        PCM (as [ShortArray]) captured just before the LOW_THRESHOLD crossing.
@@ -43,7 +44,11 @@ interface WakeWordDetector {
      *
      * No-op if [isAvailable] is false.
      */
-    fun start(onDetected: () -> Unit, verifyWindow: ((ShortArray) -> Boolean)? = null)
+    fun start(
+        generationId: Long,
+        onDetected: () -> Unit,
+        verifyWindow: ((ShortArray) -> Boolean)? = null,
+    )
 
     /**
      * Stop detection and release AudioRecord resources.

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/AcousticJournalBridgeTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/AcousticJournalBridgeTest.kt
@@ -1,0 +1,59 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AcousticJournalBridgeTest {
+    @AfterEach
+    fun resetRecorder() {
+        AcousticJournalBridge.install(AcousticEventRecorder.NoOp)
+    }
+
+    @Test
+    fun `disabled bridge does not allocate sequence or metadata`() {
+        var sequenceCalls = 0
+        var metadataCalls = 0
+        AcousticJournalBridge.install(AcousticEventRecorder.NoOp)
+
+        AcousticJournalBridge.record(
+            type = AcousticEventType.DETECTOR_REARMED,
+            sequenceProvider = SequenceProvider {
+                sequenceCalls += 1
+                sequenceCalls.toLong()
+            },
+            metadata = {
+                metadataCalls += 1
+                mapOf("category" to "must_not_be_built")
+            },
+        )
+
+        assertEquals(0, sequenceCalls)
+        assertEquals(0, metadataCalls)
+    }
+
+    @Test
+    fun `enabled bridge evaluates sequence and metadata once`() {
+        val events = mutableListOf<AcousticEvent>()
+        var sequenceCalls = 0
+        var metadataCalls = 0
+        AcousticJournalBridge.install(events::add)
+
+        AcousticJournalBridge.record(
+            type = AcousticEventType.DETECTOR_REARMED,
+            sequenceProvider = SequenceProvider {
+                sequenceCalls += 1
+                17L
+            },
+            metadata = {
+                metadataCalls += 1
+                mapOf("category" to "enabled")
+            },
+        )
+
+        assertEquals(1, sequenceCalls)
+        assertEquals(1, metadataCalls)
+        assertEquals(17L, events.single().sequence)
+        assertEquals(mapOf("category" to "enabled"), events.single().metadata)
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -2,19 +2,28 @@ package com.kernel.ai.core.voice
 
 import android.content.Context
 import android.media.AudioManager
+import android.os.Bundle
+import android.speech.RecognitionListener
 import android.speech.SpeechRecognizer
 import io.mockk.every
 import io.mockk.coEvery
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -196,18 +205,25 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         // Arrange: on-device recognizer throws on startListening(); platform recognizer succeeds.
         val onDeviceRecognizer = mockk<SpeechRecognizer>(relaxed = true)
         val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val platformListener = slot<RecognitionListener>()
 
         every { recognitionSupport.createOnDeviceSpeechRecognizer() } returns onDeviceRecognizer
         every { recognitionSupport.createPlatformSpeechRecognizer() } returns platformRecognizer
+        every { platformRecognizer.setRecognitionListener(capture(platformListener)) } just runs
 
         every { onDeviceRecognizer.startListening(any()) } throws
             RuntimeException("on-device recognizer unavailable")
+        val nextEvent = async { controller.events.first() }
+        runCurrent()
 
         // Act
         val result = controller.startListening(VoiceCaptureMode.Command)
 
         // Assert: overall result is Started (platform succeeded)
-        assertEquals(VoiceInputStartResult.Started, result)
+        val started = result as VoiceInputStartResult.Started
+        assertTrue(started.captureSessionId > 0L)
+        platformListener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        assertEquals(started.captureSessionId, nextEvent.await().captureSessionId)
 
         // Platform recognizer was started
         verify(exactly = 1) { recognitionSupport.createPlatformSpeechRecognizer() }
@@ -216,6 +232,22 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         // Orphaned on-device recognizer was cleaned up before the retry
         verify(atLeast = 1) { onDeviceRecognizer.cancel() }
         verify(atLeast = 1) { onDeviceRecognizer.destroy() }
+    }
+
+    @Test
+    fun `separate logical starts receive distinct capture session identifiers`() = runTest {
+        val firstRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val secondRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        every { recognitionSupport.createOnDeviceSpeechRecognizer() } returnsMany
+            listOf(firstRecognizer, secondRecognizer)
+
+        val first = controller.startListening(VoiceCaptureMode.Command) as
+            VoiceInputStartResult.Started
+        val second = controller.startListening(VoiceCaptureMode.Command) as
+            VoiceInputStartResult.Started
+
+        assertTrue(first.captureSessionId > 0L)
+        assertTrue(second.captureSessionId > first.captureSessionId)
     }
 
     @Test

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
@@ -37,7 +37,8 @@ class SelectableVoiceInputControllerTest {
         every { voskOfflineVoiceInputController.stopListening() } just runs
         every { nativeAndroidVoiceInputController.stopListening() } just runs
         every { sherpaOnnxVoiceInputController.stopListening() } just runs
-        coEvery { nativeAndroidVoiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+        coEvery { nativeAndroidVoiceInputController.startListening(VoiceCaptureMode.Command) } returns
+            VoiceInputStartResult.Started(1L)
 
         val controller = SelectableVoiceInputController(
             voiceInputPreferences = voiceInputPreferences,
@@ -80,7 +81,7 @@ class SelectableVoiceInputControllerTest {
                     message = "startup failed",
                 ),
             )
-            VoiceInputStartResult.Started
+            VoiceInputStartResult.Started(1L)
         }
 
         val controller = SelectableVoiceInputController(

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordSilenceGateTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordSilenceGateTest.kt
@@ -26,4 +26,31 @@ class WakeWordSilenceGateTest {
     fun `default silence skip interval is one second`() {
         assertEquals(13, secondsToFrames(WAKE_WORD_MAX_SILENCE_SKIP_SECONDS))
     }
+
+    @Test
+    fun `prolonged silence enters once and periodic inference does not resume`() {
+        val state = SilenceGateTransitionState()
+
+        assertTrue(state.enter())
+        assertTrue(state.isGated)
+        assertEquals(false, state.enter())
+        assertEquals(false, state.onStage2Execution())
+        assertTrue(state.isGated)
+        assertEquals(false, state.enter())
+    }
+
+    @Test
+    fun `voiced exit resumes stage2 once then permits a new gate entry`() {
+        val state = SilenceGateTransitionState()
+        state.enter()
+
+        assertTrue(state.onVoicedFrame())
+        assertEquals(false, state.isGated)
+        assertEquals(false, state.onVoicedFrame())
+        assertTrue(state.onStage2Execution())
+        assertEquals(false, state.onStage2Execution())
+        assertTrue(state.enter())
+        assertTrue(state.isGated)
+        assertEquals(false, state.enter())
+    }
 }

--- a/docs/testing/acoustic-stimulus-source.md
+++ b/docs/testing/acoustic-stimulus-source.md
@@ -105,3 +105,152 @@ completion, preparation error, player error, timeout or partial failure releases
 resources and restores the exact original media volume. A restoration or cleanup
 failure makes the result invalid while preserving the original playback error.
 Concurrent requests are rejected without mutating audio state.
+
+## Target structured event journal
+
+The debug application (`com.kernel.ai.debug`) includes an additional receiver for
+structured diagnostics from the target device. It provides a bounded in-memory event
+journal, an event-driven bounded wait and a snapshot-since mechanism. It does not
+alter wake thresholds, models, provider selection, silence-gate semantics or
+production service behaviour.
+
+### Receiver actions
+
+```sh
+# Get the current highest sequence number (0 = journal empty)
+adb shell am broadcast \
+  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+  -a com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE
+
+# Wait up to 10 seconds for an STT_READY event after sequence 5
+adb shell am broadcast \
+  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+  -a com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT \
+  --el since_sequence 5 \
+  --es event_type STT_READY \
+  --el timeout_ms 10000
+
+# Retrieve the complete snapshot since sequence 5
+adb shell am broadcast \
+  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
+  -a com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT \
+  --el since_sequence 5
+```
+
+### Journal contract
+
+- Default capacity: **256 events** — covers the expected 20–30 events per trial
+  across a full idle-interval matrix plus diagnostic overhead.
+- Bounded ring buffer; oldest events are evicted when capacity is exceeded.
+- `overflowed` flag is set when eviction occurs.
+- Events carry a monotonically increasing **sequence number**, a **monotonic
+  timestamp** (elapsed-time since boot), an optional wall-clock timestamp for
+  operator diagnostics, a **generation ID** (detector (re-)start) and a **session
+  ID** (voice session), and a small structured metadata map.
+- No transcripts, audio samples, private file paths, device selectors, account
+  data, service endpoints, model paths or exception dumps are recorded.
+
+### Event vocabulary
+
+| Type | Description | Metadata |
+|---|---|---|
+| `DETECTOR_GENERATION_STARTED` | ONNX pipeline loaded and detector began | — |
+| `SILENCE_GATE_ENTERED` | Silence gate became active (Stage 2/3 suppressed) | — |
+| `VOICED_FRAME_AFTER_SILENCE` | First voiced frame detected after silence gating | — |
+| `STAGE3_READY` | Embedding ring filled; classifier active | — |
+| `ACTIVATION_CANDIDATE` | Confidence at or above low threshold | `confidence`, `mode` (high/low) |
+| `VERIFIED_ACTIVATION` | Activation confirmed by STT or high-confidence path | `mode` (high/low) |
+| `WAKE_CALLBACK_INVOKED` | WakeWordService callback entered | — |
+| `VOICE_SESSION_STARTED` | Assistant/voice session beginning | — |
+| `STT_START_REQUESTED` | Speech recogniser start called | `attempt` |
+| `STT_READY` | Recogniser reported readiness / ListeningStarted | — |
+| `CUE_REQUESTED` | Start-listening cue playback requested | `force_audible` |
+| `STT_PARTIAL` | Partial STT result (no transcript text) | `length` (chars) |
+| `STT_ERROR` | STT error | `error` |
+| `SESSION_COMPLETED` | Voice session ended normally | — |
+| `SESSION_CANCELLED` | Voice session cancelled | `reason` |
+| `DETECTOR_REARMED` | Detector re-armed after session end | — |
+| `DETECTOR_ERROR` | Fatal detector error (ONNX/AudioRecord) | `error` |
+
+### Snapshot-since contract
+
+`GET_JOURNAL_SNAPSHOT` with `since_sequence=N` returns all events whose
+sequence number is strictly greater than N, in chronological order. An empty
+array is returned when N equals or exceeds the current highest sequence.
+
+### Bounded wait contract
+
+`WAIT_FOR_JOURNAL_EVENT` provides event-driven synchronisation for the future
+paired runner. After source playback the runner opens one bounded wait for
+`STT_READY` / `ListeningStarted`. The receiver checks once synchronously, then
+enters a `wait`/`notify` loop on the journal's intrinsic lock.
+
+Timeouts:
+- Default: 15 seconds
+- Minimum: 500 ms
+
+Result codes: `0` = event found; `1` = timeout; `2` = error.
+
+### Response format
+
+Events are serialised as compact JSON:
+
+```json
+{"s":1,"m":123456789,"w":1705300000000,"t":"STT_READY","g":1,"i":1,"d":{}}
+```
+
+Fields: `s` sequence; `m` monotonic Ms; `w` wall-clock Ms; `t` type; `g`
+generation ID; `i` session ID; `d` metadata dict.
+
+### Target-idle invariant
+
+The journal interface preserves the target-idle invariant required by the design:
+no target polling, log streaming or state queries occur during the configured idle
+interval. One bounded wait opens only after source wake playback completes. Full
+evidence is retrieved after the trial via `GET_JOURNAL_SNAPSHOT`.
+
+### Release isolation
+
+The receiver, journal implementation and all debug actions are present only in
+debug builds. The production-side `AcousticJournalBridge` and
+`AcousticEventRecorder` no-op interface remain in the release APK/AAB as required
+for the production-code hooks.
+
+Verify with:
+
+```sh
+./gradlew verifyTargetEventJournalReleaseIsolation
+```
+
+## Production-source integration points
+
+### `OnnxWakeWordDetector` (`core/voice/src/main/`)
+
+Calls `AcousticJournalBridge.record(...)` at these transition points:
+- After models load: `DETECTOR_GENERATION_STARTED`
+- Silence gate activation: `SILENCE_GATE_ENTERED`
+- Voice onset after gating: `VOICED_FRAME_AFTER_SILENCE`
+- First classifier-ready frame: `STAGE3_READY`
+- At each confidence threshold crossing: `ACTIVATION_CANDIDATE`
+- After STT verification or high-confidence: `VERIFIED_ACTIVATION`
+- On fatal detector error: `DETECTOR_ERROR`
+
+### `WakeWordService` (`app/src/main/`)
+
+Calls `AcousticJournalBridge.record(...)` at these points:
+- `handleDetection()` start: `VOICE_SESSION_STARTED`, allocates session ID
+- Before `startListening()`: `STT_START_REQUESTED`
+- On `ListeningStarted` event: `STT_READY`
+- Before `cuePlayer.playCue()`: `CUE_REQUESTED`
+- On error/break paths: `SESSION_CANCELLED` with reason
+- After session end: `SESSION_COMPLETED`
+- In `rearmDetector()`: allocates generation ID, records `WAKE_CALLBACK_INVOKED`
+  (in the `onDetected` lambda) and `DETECTOR_REARMED`
+- On `VoiceInputEvent.PartialTranscript`: `STT_PARTIAL` (length only, no text)
+- On `VoiceInputEvent.Error`: `STT_ERROR`
+
+### `AcousticJournalBridge` (`core/voice/src/main/`)
+
+Thread-safe singleton bridge that connects production hooks to the debug-only
+journal. Defaults to `NoOp`. The debug `TargetEventJournalReceiver` installs the
+real journal on first invocation via `AcousticJournalBridge.install(...)`.

--- a/docs/testing/acoustic-stimulus-source.md
+++ b/docs/testing/acoustic-stimulus-source.md
@@ -108,34 +108,51 @@ Concurrent requests are rejected without mutating audio state.
 
 ## Target structured event journal
 
-The debug application (`com.kernel.ai.debug`) includes an additional receiver for
-structured diagnostics from the target device. It provides a bounded in-memory event
-journal, an event-driven bounded wait and a snapshot-since mechanism. It does not
-alter wake thresholds, models, provider selection, silence-gate semantics or
-production service behaviour.
+The debug application (`com.kernel.ai.debug`) includes a concurrent content-provider
+machine interface and a legacy read-only broadcast receiver for structured target
+diagnostics. The interface provides a bounded in-memory event journal, an event-driven
+bounded wait and a snapshot-since mechanism. It does not alter wake thresholds, models,
+provider selection, silence-gate semantics or production service behaviour.
 
-### Receiver actions
+### Provider calls
+
+Use `content call` for orchestration. Provider calls run on independent Binder threads;
+unlike ordered `am broadcast` delivery, one open wait cannot block a second wait or a
+control request, and waits are not subject to the BroadcastReceiver ANR deadline.
 
 ```sh
 # Get the current highest sequence number (0 = journal empty)
-adb shell am broadcast \
-  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
-  -a com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE
+adb shell content call \
+  --uri content://com.kernel.ai.debug.target-event-journal \
+  --method GET_JOURNAL_SEQUENCE
 
 # Wait up to 10 seconds for an STT_READY event after sequence 5
-adb shell am broadcast \
-  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
-  -a com.kernel.ai.debug.action.WAIT_FOR_JOURNAL_EVENT \
-  --el since_sequence 5 \
-  --es event_type STT_READY \
-  --el timeout_ms 10000
+adb shell content call \
+  --uri content://com.kernel.ai.debug.target-event-journal \
+  --method WAIT_FOR_JOURNAL_EVENT \
+  --extra request_id:s:trial-1 \
+  --extra since_sequence:l:5 \
+  --extra event_type:s:STT_READY \
+  --extra timeout_ms:l:10000
+
+# Cancel that exact wait without blocking sequence or snapshot requests
+adb shell content call \
+  --uri content://com.kernel.ai.debug.target-event-journal \
+  --method CANCEL_JOURNAL_WAIT \
+  --extra request_id:s:trial-1
 
 # Retrieve the complete snapshot since sequence 5
-adb shell am broadcast \
-  -n com.kernel.ai.debug/com.kernel.ai.debug.journal.TargetEventJournalReceiver \
-  -a com.kernel.ai.debug.action.GET_JOURNAL_SNAPSHOT \
-  --el since_sequence 5
+adb shell content call \
+  --uri content://com.kernel.ai.debug.target-event-journal \
+  --method GET_JOURNAL_SNAPSHOT \
+  --extra since_sequence:l:5
 ```
+
+For backwards-compatible manual reads, `GET_JOURNAL_SEQUENCE` and
+`GET_JOURNAL_SNAPSHOT` remain available on `TargetEventJournalReceiver`.
+Wait and cancellation requests intentionally are not broadcast actions: Android
+serialises ordered shell broadcasts, so a long-lived receiver would block control
+requests and could be killed at the receiver completion deadline.
 
 ### Journal contract
 
@@ -186,16 +203,27 @@ an empty journal uses zero for both. `overflowed` remains true after eviction.
 
 ### Bounded wait contract
 
-`WAIT_FOR_JOURNAL_EVENT` provides event-driven synchronisation for the future
-paired runner. After source playback the runner opens one bounded wait for
-`STT_READY` / `ListeningStarted`. The receiver checks once synchronously, then
-enters a `wait`/`notify` loop on the journal's intrinsic lock.
+`WAIT_FOR_JOURNAL_EVENT` is event-driven and requires a stable `request_id`
+plus a canonical `event_type`. Optional `since_sequence` defaults to zero and
+must be non-negative. Optional `timeout_ms` defaults to 15,000 ms and must be
+within the inclusive 500–60,000 ms range; invalid values are rejected rather
+than clamped. Request IDs are 1–64 ASCII letters, digits, `.`, `_`, or `-` and
+must be unique among active waits.
 
-Timeouts:
-- Default: 15 seconds
-- Minimum: 500 ms
+Up to four waits execute concurrently; additional waits fail immediately with
+`endpoint_busy` rather than occupying Binder threads needed by control calls.
+Independent Binder calls keep sequence, snapshot, validation, and cancellation
+responsive while waits are open. `CANCEL_JOURNAL_WAIT` requires a known active
+`request_id`; cancellation wakes that exact wait through the journal condition
+rather than polling.
 
-Result codes: `0` = event found; `1` = timeout; `2` = error.
+Each provider result is a Bundle with `result_code` and `result_data`.
+Result codes are `0` = success/event found, `1` = timeout, `2` = deterministic
+argument/endpoint error, and `3` = cancelled. Timeouts return
+`timeout:<request_id>:<timeout_ms>ms`; successful cancellation and the cancelled
+wait both return `cancelled:<request_id>`. Stable argument errors cover missing,
+invalid, duplicate, and unknown request IDs; negative sequences; missing or
+unknown event types; and out-of-range timeouts.
 
 ### Response format
 
@@ -224,9 +252,10 @@ evidence is retrieved after the trial via `GET_JOURNAL_SNAPSHOT`.
 
 ### Release isolation
 
-The receiver, journal implementation and all debug actions are present only in
-debug builds. Production hooks call the no-op `AcousticEventRecorder` through
-`AcousticJournalBridge`; release optimisation may inline or remove that no-op path.
+The provider, read-only receiver, journal implementation and all debug actions are
+present only in debug builds. Production hooks call the no-op
+`AcousticEventRecorder` through `AcousticJournalBridge`; release optimisation may
+inline or remove that no-op path.
 
 Verify with:
 
@@ -270,5 +299,6 @@ Calls `AcousticJournalBridge.record(...)` at these points:
 ### `AcousticJournalBridge` (`core/voice/src/main/`)
 
 Thread-safe singleton bridge that connects production hooks to the debug-only
-journal. Defaults to `NoOp`. The debug `TargetEventJournalReceiver` installs the
-real journal on first invocation via `AcousticJournalBridge.install(...)`.
+journal. Defaults to `NoOp`. The debug `TargetEventJournalProvider` installs the
+real journal when the debug process creates the provider; legacy read-only receiver
+calls delegate to the same endpoint and journal.

--- a/docs/testing/acoustic-stimulus-source.md
+++ b/docs/testing/acoustic-stimulus-source.md
@@ -157,6 +157,7 @@ adb shell am broadcast \
 | `DETECTOR_GENERATION_STARTED` | ONNX pipeline loaded and detector began | — |
 | `SILENCE_GATE_ENTERED` | Silence gate became active (Stage 2/3 suppressed) | — |
 | `VOICED_FRAME_AFTER_SILENCE` | First voiced frame detected after silence gating | — |
+| `STAGE2_RESUMED` | First Stage 2 execution after silence gating | — |
 | `STAGE3_READY` | Embedding ring filled; classifier active | — |
 | `ACTIVATION_CANDIDATE` | Confidence at or above low threshold | `confidence`, `mode` (high/low) |
 | `VERIFIED_ACTIVATION` | Activation confirmed by STT or high-confidence path | `mode` (high/low) |
@@ -165,18 +166,23 @@ adb shell am broadcast \
 | `STT_START_REQUESTED` | Speech recogniser start called | `attempt` |
 | `STT_READY` | Recogniser reported readiness / ListeningStarted | — |
 | `CUE_REQUESTED` | Start-listening cue playback requested | `force_audible` |
+| `STT_SPEECH_DETECTED` | Recogniser detected speech onset | — |
 | `STT_PARTIAL` | Partial STT result (no transcript text) | `length` (chars) |
-| `STT_ERROR` | STT error | `error` |
+| `STT_FINAL` | Final STT result (no transcript text) | `length` (chars) |
+| `STT_ERROR` | STT error | stable `category` |
+| `COMMAND_ROUTING_RESULT` | Final transcript handoff result | `outcome`, optional stable `category` |
 | `SESSION_COMPLETED` | Voice session ended normally | — |
-| `SESSION_CANCELLED` | Voice session cancelled | `reason` |
+| `SESSION_CANCELLED` | Voice session cancelled | stable `category` |
 | `DETECTOR_REARMED` | Detector re-armed after session end | — |
-| `DETECTOR_ERROR` | Fatal detector error (ONNX/AudioRecord) | `error` |
+| `SERVICE_ERROR` | Wake service cannot run or re-arm | stable `category` |
+| `DETECTOR_ERROR` | Fatal detector error (ONNX/AudioRecord) | stable `category` |
 
 ### Snapshot-since contract
 
-`GET_JOURNAL_SNAPSHOT` with `since_sequence=N` returns all events whose
-sequence number is strictly greater than N, in chronological order. An empty
-array is returned when N equals or exceeds the current highest sequence.
+`GET_JOURNAL_SNAPSHOT` with `since_sequence=N` returns an envelope whose
+`events` contain only sequence numbers strictly greater than N, in ascending
+order. `lowestSequence` and `highestSequence` describe the retained journal;
+an empty journal uses zero for both. `overflowed` remains true after eviction.
 
 ### Bounded wait contract
 
@@ -193,14 +199,21 @@ Result codes: `0` = event found; `1` = timeout; `2` = error.
 
 ### Response format
 
-Events are serialised as compact JSON:
+`WAIT_FOR_JOURNAL_EVENT` returns one compact event:
 
 ```json
 {"s":1,"m":123456789,"w":1705300000000,"t":"STT_READY","g":1,"i":1,"d":{}}
 ```
 
-Fields: `s` sequence; `m` monotonic Ms; `w` wall-clock Ms; `t` type; `g`
-generation ID; `i` session ID; `d` metadata dict.
+`GET_JOURNAL_SNAPSHOT` returns a deterministic envelope. Bounds describe the
+retained journal, while `events` contains only entries with `s > since_seq`:
+
+```json
+{"lowestSequence":1,"highestSequence":4,"overflowed":false,"events":[{"s":4,"m":123456789,"w":1705300000000,"t":"STT_READY","g":1,"i":1,"d":{}}]}
+```
+
+Event fields: `s` sequence; `m` monotonic ms; `w` wall-clock ms; `t` type; `g`
+generation ID; `i` session ID; `d` privacy-safe scalar metadata.
 
 ### Target-idle invariant
 
@@ -212,14 +225,13 @@ evidence is retrieved after the trial via `GET_JOURNAL_SNAPSHOT`.
 ### Release isolation
 
 The receiver, journal implementation and all debug actions are present only in
-debug builds. The production-side `AcousticJournalBridge` and
-`AcousticEventRecorder` no-op interface remain in the release APK/AAB as required
-for the production-code hooks.
+debug builds. Production hooks call the no-op `AcousticEventRecorder` through
+`AcousticJournalBridge`; release optimisation may inline or remove that no-op path.
 
 Verify with:
 
 ```sh
-./gradlew verifyTargetEventJournalReleaseIsolation
+./gradlew :app:verifyTargetEventJournalReleaseIsolation
 ```
 
 ## Production-source integration points
@@ -230,6 +242,7 @@ Calls `AcousticJournalBridge.record(...)` at these transition points:
 - After models load: `DETECTOR_GENERATION_STARTED`
 - Silence gate activation: `SILENCE_GATE_ENTERED`
 - Voice onset after gating: `VOICED_FRAME_AFTER_SILENCE`
+- First Stage 2 execution after gating: `STAGE2_RESUMED`
 - First classifier-ready frame: `STAGE3_READY`
 - At each confidence threshold crossing: `ACTIVATION_CANDIDATE`
 - After STT verification or high-confidence: `VERIFIED_ACTIVATION`
@@ -238,16 +251,21 @@ Calls `AcousticJournalBridge.record(...)` at these transition points:
 ### `WakeWordService` (`app/src/main/`)
 
 Calls `AcousticJournalBridge.record(...)` at these points:
-- `handleDetection()` start: `VOICE_SESSION_STARTED`, allocates session ID
+- In `rearmDetector()`: allocates the detector generation ID and passes it into
+  `WakeWordDetector.start()`
+- In the detector callback: allocates the session ID, then records
+  `WAKE_CALLBACK_INVOKED` with both correlation IDs
+- At `handleDetection()` start: `VOICE_SESSION_STARTED` with the same IDs
 - Before `startListening()`: `STT_START_REQUESTED`
-- On `ListeningStarted` event: `STT_READY`
+- On alert-command `ListeningStarted`: `STT_READY`
 - Before `cuePlayer.playCue()`: `CUE_REQUESTED`
-- On error/break paths: `SESSION_CANCELLED` with reason
-- After session end: `SESSION_COMPLETED`
-- In `rearmDetector()`: allocates generation ID, records `WAKE_CALLBACK_INVOKED`
-  (in the `onDetected` lambda) and `DETECTOR_REARMED`
-- On `VoiceInputEvent.PartialTranscript`: `STT_PARTIAL` (length only, no text)
-- On `VoiceInputEvent.Error`: `STT_ERROR`
+- On alert-command speech onset, partial and final results:
+  `STT_SPEECH_DETECTED`, `STT_PARTIAL` and `STT_FINAL` (lengths only; no text)
+- After command handoff: `COMMAND_ROUTING_RESULT`
+- Exactly one terminal event: `SESSION_COMPLETED` or `SESSION_CANCELLED`
+- After the terminal event: `DETECTOR_REARMED` for the next generation
+- On service, STT or detector loss: the corresponding error event with a stable
+  `category`; exception messages and transcript content are never metadata
 
 ### `AcousticJournalBridge` (`core/voice/src/main/`)
 

--- a/docs/testing/wake-word-acoustic-reliability-harness.md
+++ b/docs/testing/wake-word-acoustic-reliability-harness.md
@@ -667,6 +667,11 @@ Scope:
 
 Dependency: approved design. Can proceed in parallel with Slice B after event vocabulary review.
 
+Implemented Slice C contract details, including the exact snapshot envelope,
+bounded concurrent wait/cancellation actions, extras, result codes, validation
+errors, and timeout bounds, are maintained in
+[`acoustic-stimulus-source.md`](acoustic-stimulus-source.md#target-structured-event-journal).
+
 ### Slice D — evidence schema and dashboard
 
 **Title:** Add acoustic wake reliability evidence and dashboard support

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -383,6 +383,7 @@ class ActionsViewModel @Inject constructor(
                         // #791: Play the start-listening earcon now that the mic is truly open.
                         startListeningCuePlayer.playCue()
                     }
+                    is VoiceInputEvent.SpeechDetected -> Unit
                     is VoiceInputEvent.PartialTranscript -> {
                         if (!ownsVoiceCapture(event.mode)) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.mode, event.text)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -595,6 +595,7 @@ class ChatViewModel @Inject constructor(
                             .orEmpty()
                         _voiceCaptureState.value = VoiceCaptureState.Listening(currentTranscript)
                     }
+                    is VoiceInputEvent.SpeechDetected -> Unit
                     is VoiceInputEvent.PartialTranscript -> {
                         if (event.mode != VoiceCaptureMode.Command || !ownsCommandVoiceCapture()) return@collect
                         _voiceCaptureState.value = VoiceCaptureState.Listening(event.text)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ChatViewModel.kt
@@ -614,7 +614,7 @@ class ChatViewModel @Inject constructor(
                             Log.d(TAG, "ChatViewModel: voice error — silent retry $chatCommandVoiceRetryCount/1")
                             _voiceCaptureState.value = VoiceCaptureState.Preparing
                             when (val r = voiceInputController.startListening(VoiceCaptureMode.Command)) {
-                                VoiceInputStartResult.Started -> {
+                                is VoiceInputStartResult.Started -> {
                                     if (_voiceCaptureState.value == VoiceCaptureState.Preparing) {
                                         _voiceCaptureState.value = VoiceCaptureState.Listening()
                                     }
@@ -1203,7 +1203,7 @@ class ChatViewModel @Inject constructor(
             _error.value = null
             _voiceCaptureState.value = VoiceCaptureState.Preparing
             when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
-                VoiceInputStartResult.Started -> {
+                is VoiceInputStartResult.Started -> {
                     if (_voiceCaptureState.value == VoiceCaptureState.Preparing) {
                         _voiceCaptureState.value = VoiceCaptureState.Listening()
                     }
@@ -1230,7 +1230,7 @@ class ChatViewModel @Inject constructor(
             _error.value = null
             _voiceCaptureState.value = VoiceCaptureState.Preparing
             when (val result = voiceInputController.startListening(VoiceCaptureMode.Command)) {
-                VoiceInputStartResult.Started -> {
+                is VoiceInputStartResult.Started -> {
                     if (_voiceCaptureState.value == VoiceCaptureState.Preparing) {
                         _voiceCaptureState.value = VoiceCaptureState.Listening()
                     }

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelVoiceTest.kt
@@ -521,7 +521,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text message to my wife", InputMode.Voice)
         advanceUntilIdle()
@@ -549,7 +549,7 @@ class ActionsViewModelVoiceTest {
         val router = QuickIntentRouter()
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         val voiceViewModel = ActionsViewModel(
             quickIntentRouter = router,
@@ -605,7 +605,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text message to my wife", InputMode.Voice)
         advanceUntilIdle()
@@ -628,7 +628,7 @@ class ActionsViewModelVoiceTest {
     fun `partial transcript is surfaced while listening`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.startVoiceCommand()
         voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
@@ -678,7 +678,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text message to my wife", InputMode.Voice)
         advanceUntilIdle()
@@ -711,7 +711,7 @@ class ActionsViewModelVoiceTest {
     fun `listening stopped preserves transcript while processing`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.startVoiceCommand()
         voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
@@ -1026,7 +1026,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text message to my wife", InputMode.Voice)
         advanceUntilIdle()
@@ -2468,7 +2468,7 @@ class ActionsViewModelVoiceTest {
     fun `ListeningStarted event triggers start-listening cue player`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.startVoiceCommand()
         voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
@@ -2502,7 +2502,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text to Alice", InputMode.Voice)
         advanceUntilIdle()
@@ -2532,7 +2532,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a message to Bob", InputMode.Voice)
         advanceUntilIdle()
@@ -2629,7 +2629,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text to Carol", InputMode.Voice)
         advanceUntilIdle()
@@ -2662,7 +2662,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send an email to Dave", InputMode.Voice)
         advanceUntilIdle()
@@ -2693,7 +2693,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send an email to Eve", InputMode.Voice)
         advanceUntilIdle()
@@ -2713,7 +2713,7 @@ class ActionsViewModelVoiceTest {
     fun `idle command voice error retries once then surfaces error`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.startVoiceCommand()
         voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
@@ -2748,7 +2748,7 @@ class ActionsViewModelVoiceTest {
     fun `idle command retry budget resets on fresh startVoiceCommand call`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         // First session: exhaust retry budget.
         viewModel.startVoiceCommand()
@@ -2791,7 +2791,7 @@ class ActionsViewModelVoiceTest {
             )
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.executeAction("send a text to Dave", InputMode.Voice)
         advanceUntilIdle()
@@ -2885,7 +2885,7 @@ class ActionsViewModelVoiceTest {
                 )
             coEvery {
                 voiceInputController.startListening(VoiceCaptureMode.SlotReply)
-            } returns VoiceInputStartResult.Started
+            } returns VoiceInputStartResult.Started(1L)
 
             viewModel.executeAction("send a text message to my wife", InputMode.Voice)
             advanceUntilIdle()
@@ -3638,7 +3638,7 @@ class ActionsViewModelVoiceTest {
     fun `microphone resume check with grant retries voice action`() = runTest(dispatcher) {
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
 
         viewModel.onVoiceCaptureRequiresPermission(VoiceCaptureMode.Command)
         advanceUntilIdle()

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ChatViewModelVoiceTest.kt
@@ -181,7 +181,8 @@ class ChatViewModelVoiceTest {
         every { jandalPersona.personaMode } returns MutableStateFlow(PersonaMode.FULL)
         every { jandalPersona.currentPersonaMode } returns PersonaMode.FULL
         every { voiceInputController.events } returns voiceInputEvents
-        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns
+            VoiceInputStartResult.Started(1L)
         every { voiceInputController.stopListening() } just runs
         every { voiceOutputController.events } returns voiceOutputEvents
         coEvery { voiceOutputController.warmUp() } returns VoiceOutputResult.Spoken
@@ -840,7 +841,7 @@ class ChatViewModelVoiceTest {
         val viewModel = createViewModel()
         coEvery {
             voiceInputController.startListening(VoiceCaptureMode.Command)
-        } returns VoiceInputStartResult.Started
+        } returns VoiceInputStartResult.Started(1L)
         viewModel.startVoiceInput()
         runCurrent()
         voiceInputEvents.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command))
@@ -1109,7 +1110,8 @@ class ChatViewModelVoiceTest {
     
     @Test
     fun `mic repair resume with grant restarts one shot voice input`() = runTest(dispatcher) {
-        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns
+            VoiceInputStartResult.Started(1L)
         val viewModel = createViewModel()
         advanceUntilIdle()
         
@@ -1128,7 +1130,8 @@ class ChatViewModelVoiceTest {
     
     @Test
     fun `mic repair resume with grant restarts back and forth voice`() = runTest(dispatcher) {
-        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns VoiceInputStartResult.Started
+        coEvery { voiceInputController.startListening(VoiceCaptureMode.Command) } returns
+            VoiceInputStartResult.Started(1L)
         val viewModel = createViewModel()
         advanceUntilIdle()
         


### PR DESCRIPTION
DO NOT MERGE - WAIT FOR REVIEW

## Goal

Add the narrow target-side structured journal required by the approved wake-word acoustic reliability harness. The runner can synchronise on detector, wake, STT, cue, routing, terminal, and re-arm events without polling or streaming target logs during idle.

Closes #1407

## Existing-signal audit

| Required evidence | Existing signal | Result |
|---|---|---|
| STT readiness/error/partial/final/speech | `VoiceInputController.events` | Reused; alert-command mode only, text reduced to lengths |
| Detector gate/stage/candidate/verification | Logs and cumulative counters | Added structured transition events with one service-owned generation ID |
| Wake/session/terminal/re-arm | Service control flow | Added correlated generation/session events and exactly one terminal event |
| Command handoff | Implicit routing result | Added structured success/failure outcome |
| Target snapshot/wait | None | Added bounded debug-only ContentProvider endpoint plus read-only broadcast compatibility |

## Changes

- `AcousticJournalBridge` keeps the disabled path allocation-free: recorder identity is checked before sequence, clocks, or lazy metadata are evaluated.
- `WakeWordService` owns detector generation and voice-session IDs and accepts STT events only when their authoritative capture-session ID matches the active session.
- All STT backends preserve the same capture-session ID across fallback/retry attempts; stale events cannot be attached to a newer wake session.
- The wake-word silence gate is an explicit transition state machine: prolonged silence emits one entry, the first voiced frame emits one exit/resume, and later silence can enter again.
- `WakeSessionJournal` enforces start-once, one terminal event, and no post-terminal emission.
- `AcousticEventJournal.snapshotSince()` returns a deterministic envelope with retained bounds, overflow state, strictly ordered events, and strict `sequence > since` filtering under one lock.
- `TargetEventJournalProvider` exposes concurrent Binder calls for sequence, snapshot, wait, and exact request-ID cancellation. Four bounded waits may run concurrently; excess waits fail fast with `endpoint_busy`, leaving control capacity available.
- Long-lived ordered-broadcast waits were removed because Android serialises ordered receiver delivery and imposes a receiver deadline. The legacy receiver remains read-only for sequence/snapshot compatibility.
- `verifyTargetEventJournalReleaseIsolation` requires the receiver/provider in debug and forbids their manifest and DEX markers in release APK/AAB outputs.
- Documentation defines provider commands, result fields/codes, timeout and validation behaviour, envelope bounds, correlation lifecycle, privacy, and release isolation.

## Privacy and performance

- No transcripts, audio, private paths, account data, endpoints, device selectors, model paths, or exception text enter journal metadata.
- Transcript-derived events expose character length only; errors use stable categories.
- Disabled bridge tests prove sequence and metadata suppliers are not evaluated.
- The private wake fixture remains device-local and is not included in this branch or PR evidence.
- No wake thresholds, models, providers, STT selection, or service policy changed.

## Validation

Host:

- `./gradlew :core:voice:testDebugUnitTest` — PASS
- `./gradlew :app:testDebugUnitTest` — PASS
- focused endpoint, wake-session, silence-gate, capture-correlation, and chat voice tests — PASS
- `./gradlew :app:lintDebug` — PASS
- `./gradlew :app:assembleDebug` — PASS
- `./gradlew :app:assembleRelease :app:bundleRelease` — PASS
- `./gradlew :app:verifyTargetEventJournalReleaseIsolation` — PASS

S21 target (`SM-G991B`) with the reviewed debug APK:

- Two independent 60-second provider waits remained open while sequence and snapshot calls returned promptly.
- Cancelling one request returned stable result code 3 to both cancellation and blocked-wait callers; repeated cancellation returned stable unknown-request result code 2 without affecting the other wait.
- The device-local private wake fixture exercised the real detector callback and STT path. `STT_READY` was observed with `generationId=1`, `sessionId=1`; the correlated session ended once with stable category `stt_recognition_failed`, then `DETECTOR_REARMED` was observed for generation 2.
- Snapshot parsing confirmed retained bounds `[1,71]`, `overflowed=false`, 31 strictly ordered events, one correlated terminal for session 1, the generation-2 re-arm, and genuine idle `SILENCE_GATE_ENTERED` / `VOICED_FRAME_AFTER_SILENCE` / `STAGE2_RESUMED` transitions.

## Review remediation

The blocking review is addressed at the source: wait/control concurrency no longer depends on ordered broadcasts; request-keyed cancellation and fail-fast capacity have focused tests and S21 evidence; STT correlation uses authoritative capture IDs; silence events represent real transitions; snapshot/release/privacy contracts remain deterministic and tested.

DO NOT MERGE - WAIT FOR REVIEW