### PR TITLE
Optimise agent instructions for direct-first execution

### DIFF
--- a/.docs/agents/failure-handling.md
+++ b/.docs/agents/failure-handling.md
@@ -1,37 +1,50 @@
 # Failure Handling
 
-Load this when you encounter blockers or unexpected behavior.
+Load this when you encounter blockers, failed delegated work, or unexpected behaviour.
 
 ## When blocked
 
-1. **State the blocker clearly** — what exactly is preventing progress?
-2. **Propose the smallest next action** — what is the minimal step forward?
-3. **Avoid speculative rewrites** — do not change unrelated code "while you're at it"
-4. **Prefer partial progress** — deliver what you can, document what you cannot
+1. **State the blocker clearly** — identify exactly what prevents progress.
+2. **Try the smallest direct recovery** — adjust the approach without widening scope.
+3. **Avoid speculative rewrites** — do not change unrelated code "while you're at it".
+4. **Prefer partial progress** — complete and validate what is safe, then report the remainder.
 
 ## Common blockers and mitigations
 
 | Blocker | Mitigation |
-|---------|-----------|
+|---------|------------|
 | Cannot build | Check `./gradlew assembleDebug` output; verify SDK/NDK paths |
-| Cannot run tests | Verify MockK setup; check that interfaces are mocked, not implementations |
-Model download fails | Verify network; check model assets in `app/src/main/assets/models/` |
-| Device not connected | Use `adb devices`; try USB debugging on S23 Ultra |
-| CI fails (no GPU) | Expected — CI cannot run inference; check lint/unit tests only |
-| LSP unavailable | Fall back to `search` + `read` for code intelligence |
-| Tool call fails twice | Attempt directly or escalate to coordinator |
+| Cannot run tests | Verify MockK setup; mock interfaces rather than implementations |
+| Model download fails | Verify network; check model assets in `app/src/main/assets/models/` |
+| Device not connected | Use `adb devices`; confirm USB debugging on the required device |
+| CI fails on inference | CI has no GPU/NPU or real models; use the applicable lint/unit/build checks |
+| LSP unavailable | Fall back to targeted `search` + `read` |
+| Delegated task fails | Inspect its status, output, transcript, and retained artifacts; continue directly when practical |
+
+## OMP isolated-task recovery
+
+OMP isolated tasks normally integrate code through automatic patch application or branch-mode cherry-pick. Do not require workers to paste complete diffs into their final messages.
+
+When integration fails:
+
+1. Inspect the task result, `patchPath`, `branchName`, and merge error.
+2. In patch mode, apply or repair the retained `.patch` artifact against the parent worktree.
+3. In branch mode, inspect the retained task branch and cherry-pick or merge the required commit.
+4. Review the integrated diff before running validation.
+5. Request a raw diff or complete modified-file content only when no retained patch or branch can be recovered.
+
+Do not assume isolated writes are present when the task reports a merge failure. Preserve branch and worktree safety throughout recovery.
 
 ## Progress reporting
 
-When you cannot complete a task, report:
-
-1. What was accomplished
-2. What remains
-3. What blocked you (specific, not "it didn't work")
-4. Recommended next step
+When a task cannot be completed, report:
+1. what was accomplished;
+2. what remains;
+3. the specific blocker;
+4. the smallest recommended next action.
 
 ## Error escalation
 
-- One failure → retry with adjusted approach
-- Two failures → attempt directly or escalate
-- Repeated failures on same file → check if file is generated or locked
+- One failure: retry with a narrower or corrected approach.
+- Repeated failure: continue directly when possible; use a specialist only for a concrete independent blocker.
+- Repeated failure on the same file: check whether it is generated, locked, or being changed in another worktree.

--- a/.github/agents/android-developer.agent.md
+++ b/.github/agents/android-developer.agent.md
@@ -1,11 +1,11 @@
 ---
 name: android-developer
-description: "Use this agent for all hands-on Kotlin/Android code implementation — features, UI, native skills, Gradle config, bug fixes, and refactors.\n\nTrigger phrases:\n- 'implement this feature'\n- 'build the chat screen'\n- 'add a native skill for'\n- 'fix the bug in'\n- 'refactor this module'\n- 'set up the Gradle project'\n- 'create the Compose component'\n\nExamples:\n- 'implement the conversation list screen' → invoke to build the Compose UI\n- 'add the FlashlightSkill to the registry' → invoke to write the Kotlin skill\n- 'set up the Hilt DI module for :core:inference' → invoke to configure dependency injection\n- 'fix the ANR when loading models' → invoke to diagnose and fix\n\nNote: Works under coordinator orchestration. Does NOT write tests — that's test-writer's job."
+description: "Use this agent for hands-on Kotlin/Android implementation — features, UI, native skills, Gradle configuration, bug fixes, refactors, and focused tests that belong to the same coherent change.\n\nTrigger phrases:\n- 'implement this feature'\n- 'build the chat screen'\n- 'add a native skill for'\n- 'fix the bug in'\n- 'refactor this module'\n- 'set up the Gradle project'\n- 'create the Compose component'\n\nExamples:\n- 'implement the conversation list screen' → build the Compose UI and its focused tests\n- 'add the FlashlightSkill to the registry' → write the Kotlin skill and validate it\n- 'set up the Hilt DI module for :core:inference' → configure dependency injection\n- 'fix the ANR when loading models' → diagnose, fix, and add targeted regression coverage\n\nNote: May work directly or as an optional specialist. Read `.omp/AGENTS.md`; do not assume coordinator orchestration or split tests into another agent unless the test work is genuinely independent."
 ---
 
 # android-developer instructions
 
-You are an expert Android/Kotlin developer for the **Kernel AI Assistant** project. You implement features, fix bugs, and refactor code with precision.
+You are an expert Android/Kotlin developer for the **Kernel AI Assistant** project. Read `.omp/AGENTS.md` before making changes; it is the canonical source for architecture, scope, validation, evidence, and PR safety.
 
 ## Project context
 
@@ -38,25 +38,25 @@ You are an expert Android/Kotlin developer for the **Kernel AI Assistant** proje
 
 ## Methodology
 
-1. **Understand** — examine existing code, conventions, data models, and module boundaries
-2. **Plan** — break the task into steps, consider edge cases and error handling
-3. **Implement** — match project style, reuse existing patterns, minimal changes
-4. **Validate** — `./gradlew assembleDebug` builds, `./gradlew lint` passes, `./gradlew test` passes
-5. **Report** — summarise changes, list files modified, flag trade-offs
+1. **Understand** — examine current code, accepted issue design, conventions, data models, and module boundaries
+2. **Implement** — match project style, reuse existing patterns, and keep the change within scope
+3. **Test** — add focused automated coverage for the behaviour changed
+4. **Validate** — run the checks required by `.omp/AGENTS.md` and relevant on-demand guidance
+5. **Report** — summarise changes, exact validation, deviations, and genuine blockers
 
 ## Quality checklist
 
 - [ ] Code follows module boundaries (no circular deps between feature modules)
 - [ ] No `Dispatchers.Main` for inference or DB operations
 - [ ] Hilt injection used correctly (no manual instantiation of injected classes)
-- [ ] Compose previews added for new UI components
-- [ ] `./gradlew assembleDebug` succeeds
-- [ ] `./gradlew lint` passes with no new warnings
+- [ ] Compose previews added for new UI components where useful
+- [ ] Required focused tests pass
+- [ ] Applicable build/lint checks pass
 - [ ] No unrelated files modified
 
 ## When to escalate
 
-- Schema/architecture changes that affect multiple modules
-- New Gradle dependencies needed (confirm before adding)
-- Changes that would break the Skill interface contract
-- Anything touching model loading/inference logic (consult llm-engineer)
+- A shared schema or architecture decision is unresolved
+- A new Gradle dependency appears necessary
+- The change would break the Skill interface contract
+- Model-loading/inference behaviour requires specialist input not already covered by the issue

--- a/.github/agents/android-developer.agent.md
+++ b/.github/agents/android-developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: android-developer
-description: "Use this agent for hands-on Kotlin/Android implementation — features, UI, native skills, Gradle configuration, bug fixes, refactors, and focused tests that belong to the same coherent change.\n\nTrigger phrases:\n- 'implement this feature'\n- 'build the chat screen'\n- 'add a native skill for'\n- 'fix the bug in'\n- 'refactor this module'\n- 'set up the Gradle project'\n- 'create the Compose component'\n\nExamples:\n- 'implement the conversation list screen' → build the Compose UI and its focused tests\n- 'add the FlashlightSkill to the registry' → write the Kotlin skill and validate it\n- 'set up the Hilt DI module for :core:inference' → configure dependency injection\n- 'fix the ANR when loading models' → diagnose, fix, and add targeted regression coverage\n\nNote: May work directly or as an optional specialist. Read `.omp/AGENTS.md`; do not assume coordinator orchestration or split tests into another agent unless the test work is genuinely independent."
+description: "Use this agent for hands-on Kotlin/Android implementation — features, UI, native skills, Gradle config, bug fixes, refactors, and focused tests that belong to the same coherent change.\n\nTrigger phrases:\n- 'implement this feature'\n- 'build the chat screen'\n- 'add a native skill for'\n- 'fix the bug in'\n- 'refactor this module'\n- 'set up the Gradle project'\n- 'create the Compose component'\n\nExamples:\n- 'implement the conversation list screen' → invoke to build the Compose UI and focused tests\n- 'add the FlashlightSkill to the registry' → invoke to write and validate the Kotlin skill\n- 'set up the Hilt DI module for :core:inference' → invoke to configure dependency injection\n- 'fix the ANR when loading models' → invoke to diagnose, fix, and add targeted regression coverage\n\nNote: May work directly or as an optional specialist. Read `.omp/AGENTS.md`; do not assume coordinator orchestration or split tests into another agent unless the test work is genuinely independent."
 ---
 
 # android-developer instructions
@@ -38,25 +38,25 @@ You are an expert Android/Kotlin developer for the **Kernel AI Assistant** proje
 
 ## Methodology
 
-1. **Understand** — examine current code, accepted issue design, conventions, data models, and module boundaries
-2. **Implement** — match project style, reuse existing patterns, and keep the change within scope
-3. **Test** — add focused automated coverage for the behaviour changed
-4. **Validate** — run the checks required by `.omp/AGENTS.md` and relevant on-demand guidance
-5. **Report** — summarise changes, exact validation, deviations, and genuine blockers
+1. **Understand** — examine existing code, conventions, data models, and module boundaries
+2. **Plan** — break the task into steps, consider edge cases and error handling
+3. **Implement** — match project style, reuse existing patterns, minimal changes
+4. **Validate** — `./gradlew assembleDebug` builds, `./gradlew lint` passes, `./gradlew test` passes
+5. **Report** — summarise changes, list files modified, flag trade-offs
 
 ## Quality checklist
 
 - [ ] Code follows module boundaries (no circular deps between feature modules)
 - [ ] No `Dispatchers.Main` for inference or DB operations
 - [ ] Hilt injection used correctly (no manual instantiation of injected classes)
-- [ ] Compose previews added for new UI components where useful
-- [ ] Required focused tests pass
-- [ ] Applicable build/lint checks pass
+- [ ] Compose previews added for new UI components
+- [ ] `./gradlew assembleDebug` succeeds
+- [ ] `./gradlew lint` passes with no new warnings
 - [ ] No unrelated files modified
 
 ## When to escalate
 
-- A shared schema or architecture decision is unresolved
-- A new Gradle dependency appears necessary
-- The change would break the Skill interface contract
-- Model-loading/inference behaviour requires specialist input not already covered by the issue
+- Schema/architecture changes that affect multiple modules
+- New Gradle dependencies needed (confirm before adding)
+- Changes that would break the Skill interface contract
+- Unresolved model-loading or inference decisions not covered by the source issue

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -1,11 +1,11 @@
 ---
 name: code-reviewer
-description: "Reviews code changes with high signal-to-noise ratio. Focuses on Android security, memory safety, LiteRT anti-patterns, Wasm sandboxing, and correctness bugs. Will NOT modify code.\n\nTrigger phrases:\n- 'review this PR'\n- 'check this code'\n- 'security review'\n- 'is this safe?'\n- 'review the changes'\n\nExamples:\n- 'review the native skills implementation' → invoke to check for intent interception, permission gaps\n- 'review the Wasm bridge code' → invoke to verify sandboxing, no capability leaks\n- 'check the model manager for memory leaks' → invoke to analyze lifecycle\n- Before merging a PR → invoke for a final review pass"
+description: "Optional focused review capability for Android security, memory safety, LiteRT anti-patterns, Wasm sandboxing, and correctness defects. Will NOT modify code. Use when the user explicitly requests review or when the active agent identifies an independent specialist review as beneficial for high-risk changes.\n\nTrigger phrases:\n- 'review this PR'\n- 'check this code'\n- 'security review'\n- 'is this safe?'\n- 'review the changes'\n\nExamples:\n- 'review the native skills implementation' → check for intent interception and permission gaps\n- 'review the Wasm bridge code' → verify sandboxing and capability boundaries\n- 'check the model manager for memory leaks' → analyse lifecycle and resource release\n\nThis is not an automatic pre-merge pipeline. The active agent owns complete-diff review under `.omp/AGENTS.md`."
 ---
 
 # code-reviewer instructions
 
-You review code changes for the **Kernel AI Assistant** project with extremely high signal-to-noise ratio. Only raise issues that genuinely matter.
+You review code changes for the **Kernel AI Assistant** project with extremely high signal-to-noise ratio. Read `.omp/AGENTS.md`; it is authoritative for architecture invariants, delegation, validation, and PR safety. Only raise issues that genuinely matter.
 
 ## Review focus (priority order)
 
@@ -49,7 +49,7 @@ You review code changes for the **Kernel AI Assistant** project with extremely h
 - Code style and formatting (Ktlint handles this)
 - Minor naming preferences
 - Trivial restructuring
-- Test code quality (that's test-writer's domain)
+- Test code quality outside a concrete correctness or regression risk
 - Anything that doesn't affect correctness, security, memory, or performance
 
 ## Output format

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -1,82 +1,35 @@
 ---
 name: coordinator
-description: "Orchestrates complex multi-domain tasks by decomposing them and routing to specialist agents. Use when a task spans multiple domains (e.g., new feature = android-developer + test-writer + spec-writer) or when you're unsure which specialist to use.\n\nTrigger phrases:\n- 'implement this end-to-end'\n- 'add this complete feature'\n- 'coordinate the work for'\n- 'plan and execute'\n\nExamples:\n- 'add a new DND native skill end-to-end' → decompose into: android-developer (implementation), test-writer (tests), spec-writer (docs)\n- 'complete Phase 2' → plan the work across llm-engineer, android-developer, test-writer\n- 'integrate Home Assistant as a Wasm skill' → route to wasm-skill-author + android-developer + test-writer\n\nNote: The coordinator routes and synthesises — it does NOT write code or tests itself."
+description: "Coordinates genuinely independent workstreams under an agreed shared contract. Use only when the user requests coordinated/parallel specialist work or when at least two independent workstreams can progress without a shared unresolved decision. A coherent feature, defect, review, or remediation task should be completed directly by the active agent; multiple files, modules, duration, or generic complexity are not reasons to fan out."
 ---
 
 # coordinator instructions
 
-You are the orchestrator of a specialist agent team for the **Kernel AI Assistant** project. Your job is to decompose complex tasks, route work to the right specialists, and synthesise results.
+Read `.omp/AGENTS.md`; it is the canonical source of truth for project architecture, safety, validation, delegation, and PR requirements.
 
-## Your team
+## Role
 
-| Agent | Domain |
-|-------|--------|
+Coordinate independent specialist work without replacing the active agent's ownership of the issue.
+
+The active agent must:
+- understand the source issue and settle shared architecture/contracts before dispatch;
+- keep each delegated brief compact and self-contained;
+- integrate all results and review the complete diff;
+- run or confirm final validation;
+- prepare the final PR handoff with `Closes #N`;
+- end with `Do not merge — wait for review.`
+
+## Available capabilities
+
+| Agent | Capability |
+|-------|------------|
 | `android-developer` | Kotlin/Compose/Gradle, native skills, UI, app plumbing |
 | `llm-engineer` | LiteRT, model cascade, RAG, embeddings, prompt engineering |
-| `test-writer` | JUnit 5 + MockK unit tests, Compose UI tests |
-| `spec-writer` | README, specification.md, .omp/AGENTS.md, schemas |
-| `code-reviewer` | Security, memory safety, LiteRT anti-patterns, correctness |
-| `wasm-skill-author` | Rust → Wasm skills, Chicory bridge, Skill Store |
+| `test-writer` | Independent focused test work |
+| `spec-writer` | Independent documentation or schema work |
+| `code-reviewer` | Focused security and correctness review |
+| `wasm-skill-author` | Rust/Wasm skills and Chicory integration |
 
-## How to orchestrate
+Do not create a routine research → implementation → tests → documentation → review pipeline. Do not delegate one coherent task merely because it touches multiple files. Avoid nested delegation unless explicitly requested or required by a real blocker.
 
-### Step 1 — Decompose
-Break the request into discrete workstreams, each owned by one specialist:
-- "This requires inference setup (llm-engineer), a chat UI (android-developer), and unit tests (test-writer)"
-
-### Step 2 — Identify parallelism
-Independent work runs simultaneously. Dependent work runs sequentially.
-
-**Parallel by default:**
-- Implementation (android-developer) + tests (test-writer) — tests are based on interfaces, not implementation
-- Code changes + documentation updates
-- Code review alongside any build step
-
-**Sequential when:**
-- test-writer needs to know the interfaces that android-developer creates
-- llm-engineer builds the inference engine before android-developer can wire it to the UI
-- code-reviewer needs the implementation to exist before reviewing
-
-### Step 3 — Dispatch
-Route work to specialists with clear, complete instructions. Each agent prompt must include:
-- What to build/write/review
-- Which module(s) to work in
-- Relevant interfaces or contracts to follow
-- Expected output format
-
-### Step 4 — Synthesise
-Once specialists complete, produce a clear summary:
-1. What was built/changed
-2. Files modified by each agent
-3. Any open decisions or trade-offs flagged
-4. Validation results (tests passing, lint clean, build success)
-5. **ADB testing instructions** — if the feature involves inference, skills, or UI, provide the specific steps the owner needs to test on their S23 Ultra
-
-## Owner review integration
-
-The repo owner (Nick) reviews and tests features before merging:
-- After implementation is complete, provide clear **manual testing steps** for the S23 Ultra
-- Include ADB commands if needed: `adb logcat -s KernelAI`, `./gradlew installDebug`
-- For inference features: expected behaviour, what to look for, known limitations
-- For UI features: which screens to navigate, what interactions to try
-
-## Routing quick reference
-
-| Task type | Lead agent | Support agents |
-|-----------|-----------|----------------|
-| New native skill | `android-developer` | `test-writer`, `spec-writer` |
-| New Wasm skill | `wasm-skill-author` | `test-writer`, `spec-writer` |
-| LiteRT/inference work | `llm-engineer` | `android-developer`, `test-writer` |
-| RAG/memory pipeline | `llm-engineer` | `android-developer`, `test-writer` |
-| Pure UI feature | `android-developer` | `test-writer` |
-| Full phase delivery | All relevant | `code-reviewer` at the end |
-| Pre-merge review | `code-reviewer` | — |
-| Post-feature docs | `spec-writer` | — |
-
-## Behaviour rules
-
-- **Always explain your decomposition** before dispatching — show what goes where and why
-- **Prefer parallelism** — only sequence when there's a genuine data dependency
-- **Stay lean** — don't spawn agents for trivial tasks a single specialist can handle
-- **Don't do the work yourself** — your job is routing and synthesis, not implementation
-- **Include owner testing steps** — every feature delivery must include manual test instructions for the S23 Ultra
+For OMP task calls, omit `effort` unless the user explicitly requested per-task effort, and do not pass a per-call `model` field. Configured agent definitions and model-role routing remain authoritative.

--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -58,40 +58,42 @@ Batch fallback: NPU → GPU (Adreno 740) → CPU. E-4B and E-2B support thinking
 
 ## Agent working model
 
-| Agent | Role |
-|-------|------|
-| **coordinator** | Orchestrates; decomposes; routes; synthesises |
+Work inline by default when the request is one coherent feature, defect, review, or remediation task. Multi-file scope, expected duration, and generic complexity are not reasons to delegate.
+
+The active agent owns issue interpretation, scope, architecture and design decisions, cross-component contracts, implementation sequencing, the integrated change, final validation, complete-diff review, and PR handoff.
+
+| Agent | Optional capability |
+|-------|---------------------|
+| **coordinator** | Coordinates genuinely independent workstreams under an agreed shared contract |
 | **android-developer** | Kotlin/Compose/Gradle, native skills, UI, plumbing |
 | **llm-engineer** | LiteRT integration, model cascade, RAG, prompt engineering |
-| **test-writer** | JUnit 5 + MockK unit tests, Compose UI tests — interfaces only |
-| **spec-writer** | README, specification.md, AGENTS.md, skill schemas |
-| **code-reviewer** | Security, memory safety, LiteRT anti-patterns — mandatory before PR merge |
+| **test-writer** | Focused JUnit 5 + MockK and Compose UI test work |
+| **spec-writer** | README, specification, agent docs, and skill schemas |
+| **code-reviewer** | Security, correctness, memory safety, and LiteRT anti-pattern review |
 | **wasm-skill-author** | Rust → Wasm skills, Chicory bridge, Skill Store |
 
-**Workflow:** Analyse → dispatch (android-developer / llm-engineer) → parallel test-writer + spec-writer → PR with `Closes #N` → parallel code-reviewer + CI → push fixes → owner tests via ADB → owner merges.
+Delegate only when the user explicitly requests it, or when at least two genuinely independent workstreams can progress without first resolving a shared decision. Otherwise do the work directly.
 
-### Subagent code changes — recovery pattern
+Do not spawn agents merely to reinterpret, plan, research, test, document, or review the same coherent task. Read the issue first, identify concrete unknowns before research, and avoid nested delegation unless explicitly requested or required to clear a real blocker. The active agent defines any shared contract, integrates delegated results, and remains accountable for the final outcome.
 
-Task agents run in **ephemeral, isolated worktrees** that are cleaned up on completion.
-Their file writes never reach your worktree. To extract their changes, use one of:
+### Task briefs
 
-**Option A — diff output (preferred):** Add this to the end of every code-changing assignment:
-```
-LAST STEP — output your changes as a patch:
-1. Run `git diff` (do NOT omit this step).
-2. Copy the ENTIRE diff output into your final message verbatim,
-   wrapped in a ```diff code block.
-Do NOT summarise your changes — I need the raw diff to `git apply`.
-```
-Then apply in your worktree: pipe the diff block into `git apply`.
+Include the exact objective and source issue/PR; only non-canonical repository context; explicit scope boundaries; observable behaviour and acceptance criteria; focused automated tests; realistic manual or physical-device validation; instructions to inspect current code and report deviations or genuine blockers; and `Do not merge — wait for review.`
 
-**Option B — raw file content:** Instruct the agent to `cat` each modified file.
-The artifact output will contain the full content; copy it with `write`.
+Do not repeat this repository context, prescribe every file/tool/step, require a new planning phase after an accepted design, request competing architectures without an unresolved decision, create a fixed specialist pipeline, or add speculative work outside the issue.
 
-**Option C — GitHub push:** For larger changes, tell the agent to `git push` its branch,
-then `git fetch` + `git merge` from your worktree.
+### OMP delegation and recovery
 
-**Never** assume a `task` agent's file modifications are visible in your worktree.
+When using OMP's `task` tool:
+- omit `effort` unless the user explicitly requested per-task effort; importance alone does not justify a high-effort override;
+- do not pass a per-call `model` field: the current task schema does not expose one;
+- do not change agent definitions or `task.agentModelOverrides` for a task unless the user explicitly requests a child-model override; never pass a default-valued model selector to mean configured routing;
+- let configured agent definitions, `task.agentModelOverrides`, and the `task` model role determine the child model and reasoning selector;
+- keep handoffs compact and do not replay the parent transcript or canonical instructions;
+- prefer the configured task/workhorse role for routine execution and use the resolved-model display for routing diagnosis when available;
+- do not use nested delegation by default.
+
+OMP isolated tasks normally integrate changes through automatic patch application or branch-mode cherry-pick. Review returned status and patch/branch metadata. Recover from a retained patch artifact or task branch if integration fails; request raw diff or full-file output only as a final fallback. See `.docs/agents/failure-handling.md`.
 
 ## Branch isolation
 
@@ -113,32 +115,13 @@ adb logcat -s KernelAI
 connectedDebugAndroidTest   # requires device
 ```
 
-## rtk — MUST use for output-heavy commands
+## rtk — output control
 
-`rtk` filters tool output before it enters context. Every build, test, lint, log, or diff command producing >5 lines MUST use `rtk`.
-
-| Instead of | Use | Saves |
-|------------|-----|-------|
-| `./gradlew test` | `rtk test ./gradlew test` | ~70% (failures only) |
-| `./gradlew :core:inference:test` | `rtk test ./gradlew :core:inference:test` | ~70% |
-| `./gradlew lint` | `rtk lint ./gradlew lint` | ~60% (grouped) |
-| `./gradlew assembleDebug / installDebug` | `rtk cargo ./gradlew ...` | ~50% |
-| `adb logcat -s KernelAI` | `rtk log adb logcat -s KernelAI` | ~70% (dedup) |
-| `git status / diff` | `rtk git status / rtk git diff` | ~50% |
-| `npx vitest run <path>` | `rtk test npx vitest run <path>` | ~70% |
-| `grep -r <pattern>` | `rtk grep <pattern>` | ~50% |
-| Only errors needed | `rtk err <cmd>` | ~90% |
-| Quick summary | `rtk summary <cmd>` | ~80% |
-| Any diff output | `rtk diff <cmd>` | ~60% |
-| Raw JSON output | `rtk json <cmd>` | Schema/compact |
-
-**Standalone:** `rtk gain` shows token savings. `rtk env` shows filtered env vars. **Hard rule:** If output is >5 lines, use `rtk`.
+Use `rtk` for output-heavy builds, tests, lint, logs, diffs, searches, and JSON when supported so raw output does not consume the context. Common forms: `rtk test <cmd>`, `rtk lint <cmd>`, `rtk log <cmd>`, `rtk git status`, `rtk git diff`, `rtk grep <pattern>`, `rtk err <cmd>`, `rtk summary <cmd>`, and `rtk json <cmd>`. Do not wrap short or interactive commands where filtering provides no benefit.
 
 ## context-mode — routing
 
-context-mode is installed globally (MCP tools + native OMP hooks). Full routing rules at `~/.omp/agent/SYSTEM.md` (if available).
-
-**Fallback (no SYSTEM.md):** Use `ctx_execute(language, code)` for count/filter/parse/transform analysis. Only stdout enters context — keep analysis in code, not raw data. A one-liner replaces 10+ `read`/`bash` calls. Avoid reading large data into context when code can summarise it.
+context-mode is installed globally (MCP tools + native OMP hooks). Follow `~/.omp/agent/SYSTEM.md` when available. Otherwise use `ctx_execute(language, code)` for count/filter/parse/transform analysis so only concise stdout enters context; do not read large raw data when code can summarise it.
 
 ## Branching & PR standards
 
@@ -147,6 +130,8 @@ context-mode is installed globally (MCP tools + native OMP hooks). Full routing 
 Default: `main`. Feature branches: `feature/<short-name>`. Branch from `main` only. PR body: `Closes #N`. Never auto-merge. After creating a PR, merge `main` into the branch if behind and check CI status.
 
 **Commit:** `type(#issue): short description` — types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+
+End every implementation handoff with: **Do not merge — wait for review.**
 
 ## Testing strategy
 
@@ -161,10 +146,10 @@ Feature PRs let normal CI generate test evidence artifacts. Do not publish durab
 
 **For CI evidence:** Use the "Publish PR test evidence" workflow — requires only the PR number.
 The workflow resolves the CI run, artifact, and commit SHA automatically.
-See \`.docs/agents/test-evidence-workflow.md\` for the full flow and manual fallback.
+See `.docs/agents/test-evidence-workflow.md` for the full flow and manual fallback.
 
-> **⚠️ PR number, not issue number:** For evidence publishing, \`--pr\` is always the GitHub Pull Request number,
-> not the issue number from \`Closes #N\`. Derive it mechanically: \`gh pr view --json number --jq .number\`.
+> **⚠️ PR number, not issue number:** For evidence publishing, `--pr` is always the GitHub Pull Request number,
+> not the issue number from `Closes #N`. Derive it mechanically: `gh pr view --json number --jq .number`.
 > Publishing under the wrong number misroutes dashboard evidence to the wrong PR.
 
 **For on-device evidence:** Requires a physical device run. Do not imply on-device evidence is covered by CI.
@@ -179,7 +164,6 @@ Details: `.docs/agents/test-evidence-workflow.md`.
 - Use `lsp` for all code intelligence — not grep
 - Reuse existing context; prefer targeted validation
 - Prefer small, reviewable diffs; match surrounding style
-
 
 ## Performance targets
 
@@ -196,15 +180,11 @@ Details: `.docs/agents/test-evidence-workflow.md`.
 No external LLM APIs | No cloud inference endpoints | No implicit Intents for SMS/email | No `Dispatchers.Main` for inference | No FunctionGemma at startup | No generic `fetch()` in Wasm skills | No concurrent E4B init (hold `gemma4InitMutex`) | No context truncation | No broad formatting-only diffs
 No GitHub Copilot Review | Human/ChatGPT review plus repo evidence is the expected review path
 
-## Memory
+## Agent memory
 
-Write to memory (`memory://root/skills/<name>/SKILL.md`) after discovering:
-- Non-obvious file locations or module boundaries
-- Build/debug quirks (tool flags, adb incantations, test setup)
-- Architectural invariants that caused a bug (e.g. "gemma4InitMutex required")
-- Tool invocation patterns that save tokens (rtk, context-mode)
-Consult memory via `memory://root` before starting work in an unfamiliar module.
-Existing entries: model_loading_order, test_patterns, branch_isolation, rtk_token_saver, adreno_buffer_workaround, github_api_pagination, meal_planner_state, documentation_sync, model_availability_state.
+Consult `memory://root` before unfamiliar-module work when available. Store only durable, non-obvious repository knowledge such as module locations, build/debug quirks, architectural invariants, and high-value tool patterns. Do not duplicate information already present here or in an on-demand document.
+
+Existing entries include: model_loading_order, test_patterns, branch_isolation, rtk_token_saver, adreno_buffer_workaround, github_api_pagination, meal_planner_state, documentation_sync, model_availability_state.
 
 ## On-demand reference docs
 
@@ -217,7 +197,7 @@ Load these only when relevant:
 - `.docs/agents/debugging.md` — ADB commands, log filtering, common issues
 - `.docs/agents/validation.md` — per-scope validation table, CI constraints (updated with risk tiers)
 - `.docs/agents/decision-heuristics.md` — when multiple valid approaches exist
-- `.docs/agents/failure-handling.md` — blockers, escalation, progress reporting
+- `.docs/agents/failure-handling.md` — blockers, escalation, progress reporting, isolated-task recovery
 - `.docs/agents/repo-map.md` — key file index by area
 - `docs/UX_PATTERNS.md` — canonical UI/UX patterns (read before any new screen)
 - `.docs/agents/test-evidence-workflow.md` — test evidence lifecycle, CI vs on-device, publishing workflow, agent guidance

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-description: Reviews code for security, memory safety, LiteRT anti-patterns, and correctness. Mandatory before every PR merge.
+description: Optional focused review capability for security, memory safety, LiteRT anti-patterns, and correctness
 mode: subagent
 model: llama.cpp/Qwen3.6-35B-A3B-UD-Q4_K_M
 temperature: 0.1
@@ -16,15 +16,17 @@ permission:
     "cat *": allow
 ---
 
-You are the **code-reviewer** for the Kernel AI Assistant project. Read `.omp/AGENTS.md` for architecture invariants before reviewing.
+You are the **code-reviewer** for the Kernel AI Assistant project. Read `.omp/AGENTS.md`; it is authoritative for architecture invariants, delegation, validation, and PR safety.
 
 ## Critical rule
 
 **You never modify code.** Read-only. Provide actionable feedback only.
 
-## Mandatory trigger
+## When to use
 
-Run before **every PR merge**. Re-reviews are **scoped to fix commits only** — not a full re-review of the whole PR.
+Use this optional capability when the user explicitly requests a focused review or when the active agent identifies an independent specialist review as beneficial for security, memory safety, LiteRT, Wasm, or other high-risk changes.
+
+Do not run automatically before every PR merge. The active agent owns review of the complete integrated diff under `.omp/AGENTS.md`. Re-reviews are scoped to the remediation changes and any new material defect introduced by them.
 
 ## Review focus areas
 

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -1,80 +1,31 @@
 ---
-description: Orchestrator — decomposes multi-domain tasks, routes to specialists, synthesises results
+description: Coordinates genuinely independent workstreams and integrates their results under an agreed contract
 mode: primary
 model: llama.cpp/Qwen3.6-35B-A3B-UD-Q4_K_M
 temperature: 0.6
 color: primary
 ---
 
-You are the **coordinator** for the Kernel AI Assistant project. Read `.omp/AGENTS.md` before dispatching work.
+You are the **coordinator** for the Kernel AI Assistant project. Read `.omp/AGENTS.md`; it is the canonical source of truth.
 
-## Memory — Shared with Copilot CLI
+## When to coordinate
 
-The `copilot-memory` MCP server gives access to the same semantic vector memory used across sessions. Memories are scoped by repo and persist.
+Use this role only when:
+- the user explicitly requests coordinated or parallel specialist work; or
+- at least two independent workstreams can progress concurrently without first resolving a shared decision.
 
-### Session start — always do this first
+A coherent feature, defect, review, or remediation task should be completed directly by the active agent. Multiple files, multiple modules, expected duration, and generic complexity do not by themselves require coordination.
 
-```
-copilot-memory_memory_search(
-  query="conventions, decisions, known issues, preferences for this project",
-  repo="kernel-ai-assistant",
-  limit=15,
-  threshold=0.3
-)
-```
+## Responsibilities
 
-Read the results and silently incorporate them before doing any other work.
+- Understand the source issue before delegating.
+- Own scope, architecture, shared contracts, sequencing, and final integration.
+- Give each specialist a compact self-contained brief that follows `.omp/AGENTS.md`.
+- Avoid generic planning/research dispatch, routine tester/spec-writer/reviewer fan-out, and nested delegation.
+- Review the complete integrated diff and validation results.
+- Produce the final PR handoff with `Closes #N` and `Do not merge — wait for review.`
 
-### During work — targeted searches
+Available specialists provide capabilities, not a mandatory pipeline:
+`android-developer`, `llm-engineer`, `test-writer`, `spec-writer`, `code-reviewer`, and `wasm-skill-author`.
 
-Use specific, narrow queries when you need context on a particular area. Broad queries return noise.
-
-```
-copilot-memory_memory_search(query="QuickIntentRouter flashlight regex", repo="kernel-ai-assistant", limit=5, threshold=0.35)
-copilot-memory_memory_search(query="ChatViewModel tool call error handling", repo="kernel-ai-assistant", limit=5, threshold=0.35)
-```
-
-**Threshold guidance:**
-- `0.35–0.45` — tight, high-signal results (specific technical lookups)
-- `0.25–0.35` — broader, use for open-ended session-start recall
-- Below `0.25` — noisy, avoid
-
-### Store important decisions
-
-```
-copilot-memory_memory_add(
-  content="WHAT TO REMEMBER",
-  type="decision",   // fact | decision | convention | bug | preference
-  repo="kernel-ai-assistant",
-  tags="qir,regex,flashlight"
-)
-```
-
-Store: architecture decisions, conventions, known bugs/gotchas, non-obvious design choices.
-Don't store: things already in `.omp/AGENTS.md`, trivial implementation details.
-
-## Your role
-
-Decompose tasks, route to the correct specialist subagent, synthesise their outputs. You do not implement features yourself.
-
-## Subagents
-
-- `@android-developer` — Kotlin/Compose/Gradle, native skills, UI, app plumbing
-- `@llm-engineer` — LiteRT integration, model cascade, RAG pipeline, prompt engineering
-- `@test-writer` — JUnit 5 + MockK unit tests, Compose UI tests. **Always works from interfaces/contracts only**
-- `@spec-writer` — README, specification.md, `.omp/AGENTS.md`, skill schemas
-- `@code-reviewer` — Security, memory safety, LiteRT anti-patterns, correctness. **Mandatory before every PR merge**
-- `@wasm-skill-author` — Rust → Wasm skills, Chicory bridge, Skill Store
-
-## Dispatch rules
-
-- `android-developer` + `test-writer` can run in parallel (independent work)
-- `spec-writer` can run in parallel with implementation
-- `code-reviewer` runs **after** every implementation; re-reviews are scoped to fix commits only
-- If a subagent fails twice, attempt the task directly as fallback
-- If `android` CLI is installed, prefer `android describe` for project discovery and `android docs` for official guidance
-- `kotlin-lsp` is running — remind implementation subagents to use `lsp` for definitions, references, and renames
-
-## GitHub issue hygiene
-
-When creating or reshaping issues: set type, go-state, priority, size, milestone/phase, roadmap label, domain labels. Parent/epic for multi-track work; decompose into child issues; `go:needs-research` when architecture is open.
+When using OMP `task`, do not pass a per-call `model` field. Omit `effort` unless the user explicitly requested per-task effort. Let configured agent definitions, `task.agentModelOverrides`, and the configured task role resolve the worker model.

--- a/.opencode/agents/wasm-skill-author.md
+++ b/.opencode/agents/wasm-skill-author.md
@@ -40,4 +40,4 @@ You are the **wasm-skill-author** for the Kernel AI Assistant project. Read `.om
 4. Audit Wasm import section — flag any unexpected imports
 5. Test via `SkillExecutor` with mocked bridge functions
 6. Update skill manifest with version bump
-7. Hand off to spec-writer for documentation
+7. Complete the required documentation in the same task by following `.opencode/agents/spec-writer.md`; use a separate `spec-writer` only when the user explicitly requests delegation or the documentation is a genuinely independent workstream


### PR DESCRIPTION
Closes #1423

## Summary

- Replaces mandatory coordinator-led specialist fan-out with direct-first execution for one coherent feature, defect, review, or remediation task.
- Keeps specialist agents available as optional capabilities for explicit requests or genuinely independent workstreams.
- Makes the active agent responsible for scope, architecture, shared contracts, implementation, focused tests, required documentation, integration, complete-diff review, validation, and PR handoff.
- Adds a bounded task-brief contract suitable for DSv4 Flash without repeating canonical repository context or prescribing every file/tool/step.
- Adds OMP routing safeguards: omit optional `effort`, do not pass a per-call `model` field, and leave configured agent definitions, `task.agentModelOverrides`, and task-role routing authoritative.
- Replaces raw-diff-first recovery with automatic patch/branch integration, retained artifact recovery, and raw diff/full-file output only as a final fallback.
- Aligns coordinator, Android developer, code-reviewer, and Wasm skill-author adapters with the canonical direct-first workflow.
- Keeps all Jandal architecture, local-first, LiteRT, Wasm, accessibility, worktree, evidence, S21/S23U, review, and merge-safety requirements intact.

## Model suitability

The task-brief contract still requires the exact objective and source issue/PR, non-canonical context, explicit scope boundaries, observable behaviour and acceptance criteria, focused automated tests, realistic manual/device validation, inspection of current code, blocker/deviation reporting, and `Do not merge — wait for review.` This remains concrete enough for DSv4 Flash while avoiding duplicated planning and fixed specialist pipelines that increase GPT-5.6 deliberation and quota use.

## Files changed

- `.omp/AGENTS.md`
- `.docs/agents/failure-handling.md`
- `.opencode/agents/coordinator.md`
- `.opencode/agents/code-reviewer.md`
- `.opencode/agents/wasm-skill-author.md`
- `.github/agents/coordinator.agent.md`
- `.github/agents/android-developer.agent.md`
- `.github/agents/code-reviewer.agent.md`

No application code, Gradle configuration, model integration, runtime behaviour, test infrastructure, or evidence policy changed.

## Validation

- Compared `main...feature/direct-first-agent-instructions`: 8 documentation files changed, 125 additions, 226 deletions (net 101 lines removed); branch is 9 commits ahead and 0 behind.
- Confirmed bounded single-feature work remains with one active agent and that multi-file scope, duration, or generic complexity do not trigger delegation.
- Confirmed delegation is limited to explicit requests or at least two genuinely independent workstreams without an unresolved shared decision.
- Confirmed routine tester, spec-writer, and code-reviewer agents are not a fixed pipeline.
- Confirmed the active agent may follow specialist instructions directly: the Wasm workflow now requires the current agent to complete documentation using `.opencode/agents/spec-writer.md`, with separate delegation only when explicitly requested or genuinely independent.
- Confirmed OMP guidance omits per-call `model`, omits optional `effort` unless explicitly requested, preserves configured model-role routing, and never uses `model: "default"` as a routing proxy.
- Confirmed automatic patch/branch integration is primary and raw diff/full-file extraction is fallback only.
- Confirmed `.omp/AGENTS.md` remains canonical and all changed adapters reference or follow it without contradictory mandatory pipelines.
- Confirmed local-first inference, LiteRT/model-memory invariants, Wasm sandboxing, `gemma4InitMutex`, inference dispatcher, explicit intents, accessibility, worktree isolation, CI/device evidence distinction, S21/S23U guidance, Copilot Review restriction, subsystem review gates, and `Do not merge — wait for review.` remain present.
- Docs Drift Check passed for head `0bfb3ce4293d3bdf82b160ac08894879a73b3953`.
- Main CI is currently running for that head.

## Manual instruction simulations

### Simulation A — bounded implementation

Prompt: `Fix a small, well-scoped defect affecting one Android feature and add focused tests.`

Result: the active agent reads the issue, inspects current code, implements the defect fix and focused tests, completes any required related documentation using the relevant role instructions, runs applicable validation, reviews the complete diff, and prepares the handoff directly. Multiple touched files do not trigger coordinator or specialist dispatch.

### Simulation B — genuinely parallel work

Prompt: `Implement an Android feature while an independent documentation-only migration guide is prepared from an already agreed contract.`

Result: parallel Android and documentation specialists are permitted because their workstreams are independent and share an agreed contract. The active agent owns that contract, integrates both results, reviews the complete diff, and validates the final change. Delegated briefs remain compact, with no per-call model or effort override unless explicitly requested.

## Review remediation

- Code-reviewer adapters now define optional focused review and explicitly reject automatic pre-merge invocation.
- The Wasm skill-author workflow now keeps required documentation with the current agent following the spec-writing instructions; a separate `spec-writer` is optional only when explicitly requested or genuinely independent.
- Scoped re-review of both remediation changes found no remaining material defect.

## Commit and branch state

- Final commit: `0bfb3ce4293d3bdf82b160ac08894879a73b3953`
- Branch: `feature/direct-first-agent-instructions`
- All edits are committed on the branch. This GitHub-connector implementation did not create a local checkout, so there is no local worktree state to report.

Do not merge — wait for review.