### PR TITLE
fix(#1417): continue incomplete reminders deterministically

### DIFF
--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -718,7 +718,7 @@ class QuickIntentRouter(
         IntentPattern(
             intentName = "add_reminder",
             regex = Regex(
-                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+to\s+(.+?)\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|sat|sun|mon|tues?|wed|thurs?))\s*[.!?]*$""",
+                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+to\s+(.+?)\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$""",
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -627,65 +627,6 @@ class QuickIntentRouter(
             },
             requiredSlots = slotContract("add_reminder"),
         ),
-        // Imperative reminder requests without a schedule — retain the task and start slot-filling.
-        // Keep these after complete reminder matchers so explicit day/time requests still dispatch.
-        IntentPattern(
-            intentName = "add_reminder",
-            regex = Regex(
-                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+(?:to\s+(?!(?:get|wake)\s+up\b)|about\s+)(?!(?:.+\s+)?(?:today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$)(.+?)\s*[.!?]*$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
-            requiredSlots = slotContract("add_reminder"),
-        ),
-        IntentPattern(
-            intentName = "add_reminder",
-            regex = Regex(
-                """^(?:set|create|make)\s+(?:an?\s+)?reminder\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
-            requiredSlots = slotContract("add_reminder"),
-        ),
-        IntentPattern(
-            intentName = "add_reminder",
-            regex = Regex(
-                """^(?:don't|do not)\s+let\s+me\s+forget\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
-            requiredSlots = slotContract("add_reminder"),
-        ),
-        // "remind me to/about <task> on <day>" — needs time slot-fill
-        IntentPattern(
-            intentName = "add_reminder",
-            regex = Regex(
-                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+(?:to|about)\s+(.+?)\s+on\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ ->
-                mapOf(
-                    "item" to normalizeReminderItem(match.groupValues[1]),
-                    "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
-                )
-            },
-            requiredSlots = slotContract("add_reminder"),
-        ),
-        // "remind me to <task> <day>" (day without 'on') — dispatches directly; handler defaults time
-        IntentPattern(
-            intentName = "add_reminder",
-            regex = Regex(
-                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+to\s+(.+?)\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$""",
-                RegexOption.IGNORE_CASE,
-            ),
-            paramExtractor = { match, _ ->
-                mapOf(
-                    "item" to normalizeReminderItem(match.groupValues[1]),
-                    "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
-                )
-            },
-            requiredSlots = emptyMap(),
-        ),
         // "remind me to <task> at <time>" — time without explicit day (dispatches directly)
         IntentPattern(
             intentName = "add_reminder",
@@ -727,6 +668,94 @@ class QuickIntentRouter(
                 mapOf("item" to match.groupValues[2].trim()) + parseAlarmTime(match.groupValues[1].trim())
             },
             requiredSlots = emptyMap(),
+        ),
+        // "remind me <day> at <time> to <task>" — task-bearing reminder before time
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^remind\s+me\s+(today|tomorrow|tonight|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s+(?:at|by)\s+(.+?)\s+to\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to normalizeReminderItem(match.groupValues[3].trim()),
+                    "day" to normalizeDayName(match.groupValues[1].trim().lowercase()),
+                ) + parseAlarmTime(match.groupValues[2].trim())
+            },
+            requiredSlots = emptyMap(),
+        ),
+        // "set a reminder for <time> <day> to <task>" — task-bearing reminder
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:set|create|make)\s+(?:an?\s+)?reminder\s+(?:for|at)\s+(.+?)\s+(today|tomorrow|tonight|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s+to\s+(.+)""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to normalizeReminderItem(match.groupValues[3].trim()),
+                    "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
+                ) + parseAlarmTime(match.groupValues[1].trim())
+            },
+            requiredSlots = emptyMap(),
+        ),
+        // "remind me to/about <task> on <day>" — needs time slot-fill
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+(?:to|about)\s+(.+?)\s+on\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to normalizeReminderItem(match.groupValues[1]),
+                    "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
+                )
+            },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        // "remind me to <task> <day>" (day without 'on') — dispatches directly
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+to\s+(.+?)\s+(today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|sat|sun|mon|tues?|wed|thurs?))\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ ->
+                mapOf(
+                    "item" to normalizeReminderItem(match.groupValues[1]),
+                    "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
+                )
+            },
+            requiredSlots = emptyMap(),
+        ),
+        // Imperative reminder requests without a schedule — retain the task and start slot-filling.
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+(?:to\s+(?!(?:get|wake)\s+up\b)|about\s+)(?!(?:.+\s+)?(?:today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$)(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:set|create|make)\s+(?:an?\s+)?reminder\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:don't|do not)\s+let\s+me\s+forget\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
+            requiredSlots = slotContract("add_reminder"),
         ),
         IntentPattern(
             intentName = "set_alarm",

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/QuickIntentRouter.kt
@@ -269,6 +269,9 @@ class QuickIntentRouter(
         .takeIf { it.isNotBlank() }
         ?.takeUnless { it.lowercase() in placeholderItems }
 
+    private fun normalizeReminderItem(raw: String): String = raw.trim()
+        .replace(Regex("""^buying\b\s*""", RegexOption.IGNORE_CASE), "buy ")
+
     private fun normalizeImportantDateLabel(raw: String): String = raw.trim()
         .replace(Regex("""^(?:my|the)\s+""", RegexOption.IGNORE_CASE), "")
         .replace(Regex("""^(?:an?\s+)?important\s+(?:date|day)(?:\s+for)?\s+""", RegexOption.IGNORE_CASE), "")
@@ -613,7 +616,7 @@ class QuickIntentRouter(
                 RegexOption.IGNORE_CASE,
             ),
             paramExtractor = { match, _ ->
-                val item = match.groupValues[1].trim()
+                val item = normalizeReminderItem(match.groupValues[1])
                 val day = normalizeDayName(match.groupValues[2].trim().lowercase())
                 val timeParsed = parseAlarmTime(match.groupValues[3].trim())
                 buildMap {
@@ -622,6 +625,35 @@ class QuickIntentRouter(
                     putAll(timeParsed)
                 }
             },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        // Imperative reminder requests without a schedule — retain the task and start slot-filling.
+        // Keep these after complete reminder matchers so explicit day/time requests still dispatch.
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:(?:can|could|would)\s+you\s+|please\s+)?remind\s+me\s+(?:to\s+(?!(?:get|wake)\s+up\b)|about\s+)(?!(?:.+\s+)?(?:today|tomorrow|(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\s*[.!?]*$)(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:set|create|make)\s+(?:an?\s+)?reminder\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
+            requiredSlots = slotContract("add_reminder"),
+        ),
+        IntentPattern(
+            intentName = "add_reminder",
+            regex = Regex(
+                """^(?:don't|do not)\s+let\s+me\s+forget\s+(?:to|about)\s+(.+?)\s*[.!?]*$""",
+                RegexOption.IGNORE_CASE,
+            ),
+            paramExtractor = { match, _ -> mapOf("item" to normalizeReminderItem(match.groupValues[1])) },
             requiredSlots = slotContract("add_reminder"),
         ),
         // "remind me to/about <task> on <day>" — needs time slot-fill
@@ -633,7 +665,7 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ ->
                 mapOf(
-                    "item" to match.groupValues[1].trim(),
+                    "item" to normalizeReminderItem(match.groupValues[1]),
                     "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
                 )
             },
@@ -648,7 +680,7 @@ class QuickIntentRouter(
             ),
             paramExtractor = { match, _ ->
                 mapOf(
-                    "item" to match.groupValues[1].trim(),
+                    "item" to normalizeReminderItem(match.groupValues[1]),
                     "day" to normalizeDayName(match.groupValues[2].trim().lowercase()),
                 )
             },

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
@@ -72,7 +72,15 @@ class SlotFillerManager @Inject constructor(
         validationRegistry: SlotValidationRegistry = this.slotValidationRegistry,
     ): SlotFillResult {
         val pending = pendingRequests[conversationId] ?: return SlotFillResult.Cancelled
-        val normalizedMessage = normalizeSlotReply(message, pending.missingSlot.name)
+        val reminderSchedule = if (pending.intentName == "add_reminder") {
+            parseReminderScheduleReply(message)
+                .takeIf { it.containsKey(pending.missingSlot.name) }
+                ?: emptyMap()
+        } else {
+            emptyMap()
+        }
+        val normalizedMessage = reminderSchedule[pending.missingSlot.name]
+            ?: normalizeSlotReply(message, pending.missingSlot.name)
         if (normalizedMessage.isBlank()) {
             pendingRequests.remove(conversationId)
             recoveryConversations.remove(conversationId)
@@ -104,9 +112,12 @@ class SlotFillerManager @Inject constructor(
             return SlotFillResult.InvalidSlot(retryRequest)
         }
 
-        // Use corrected value if provided by validator
+        // Use corrected value if provided by validator. A reminder reply may also carry
+        // the other schedule slot, e.g. "tomorrow at 5 pm" fills both day and time.
         val finalValue = validationResult.correctedValue ?: normalizedMessage
-        val mergedParams = pending.existingParams + mapOf(pending.missingSlot.name to finalValue)
+        val mergedParams = pending.existingParams +
+            reminderSchedule +
+            mapOf(pending.missingSlot.name to finalValue)
         val nextMissingSlot = intentContractRegistry.nextMissingSlot(
             intentName = pending.intentName,
             params = mergedParams,

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotFillerManager.kt
@@ -74,10 +74,28 @@ class SlotFillerManager @Inject constructor(
         val pending = pendingRequests[conversationId] ?: return SlotFillResult.Cancelled
         val reminderSchedule = if (pending.intentName == "add_reminder") {
             parseReminderScheduleReply(message)
-                .takeIf { it.containsKey(pending.missingSlot.name) }
-                ?: emptyMap()
         } else {
             emptyMap()
+        }
+        if (pending.intentName == "add_reminder" &&
+            pending.missingSlot.name !in reminderSchedule &&
+            reminderSchedule.isNotEmpty()
+        ) {
+            val mergedParams = pending.existingParams + reminderSchedule
+            val nextMissingSlot = intentContractRegistry.nextMissingSlot(
+                intentName = pending.intentName,
+                params = mergedParams,
+            )
+            if (nextMissingSlot != null) {
+                val nextRequest = PendingSlotRequest(
+                    intentName = pending.intentName,
+                    existingParams = mergedParams,
+                    missingSlot = nextMissingSlot,
+                    isRecovery = pending.isRecovery,
+                )
+                pendingRequests[conversationId] = nextRequest
+                return SlotFillResult.NeedsMore(nextRequest)
+            }
         }
         val normalizedMessage = reminderSchedule[pending.missingSlot.name]
             ?: normalizeSlotReply(message, pending.missingSlot.name)

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
@@ -1,5 +1,7 @@
 package com.kernel.ai.core.skills.slot
 
+import com.kernel.ai.core.skills.QuickIntentRouter
+
 /**
  * Describes a required parameter that is missing from a matched intent, together with
  * a template for the clarifying question to ask the user.
@@ -28,6 +30,42 @@ fun normalizeSlotReply(text: String, slotName: String): String {
         "list_name" -> normalizeListSlotReply(trimmed)
         else -> trimmed
     }
+}
+
+/**
+ * Extracts any reminder schedule values present in one natural-language slot reply.
+ *
+ * A single reply can fill both `day` and `time` (for example, "tomorrow at 5 pm").
+ * Replies containing only one value return only that value so slot filling can prompt
+ * for the remaining schedule field.
+ */
+fun parseReminderScheduleReply(text: String): Map<String, String> {
+    val cleaned = text.trim().trimEnd('.', '!', '?')
+    if (cleaned.isBlank()) return emptyMap()
+
+    val params = linkedMapOf<String, String>()
+    val dayMatch = Regex(
+        """\b(today|tomorrow|tonight|monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun)\b""",
+        RegexOption.IGNORE_CASE,
+    ).find(cleaned)
+    if (dayMatch != null) {
+        params["day"] = normalizeReminderDay(dayMatch.groupValues[1])
+    }
+
+    QuickIntentRouter.parseAlarmTime(cleaned)["time"]?.let { params["time"] = it }
+    return params
+}
+
+private fun normalizeReminderDay(raw: String): String = when (raw.lowercase()) {
+    "tonight" -> "today"
+    "mon" -> "monday"
+    "tue", "tues" -> "tuesday"
+    "wed" -> "wednesday"
+    "thu", "thur", "thurs" -> "thursday"
+    "fri" -> "friday"
+    "sat" -> "saturday"
+    "sun" -> "sunday"
+    else -> raw.lowercase()
 }
 
 private fun normalizeTimeSlotReply(trimmed: String): String {

--- a/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
+++ b/core/skills/src/main/java/com/kernel/ai/core/skills/slot/SlotSpec.kt
@@ -45,7 +45,7 @@ fun parseReminderScheduleReply(text: String): Map<String, String> {
 
     val params = linkedMapOf<String, String>()
     val dayMatch = Regex(
-        """\b(today|tomorrow|tonight|monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun)\b""",
+        """\b((?:next\s+)?(?:today|tomorrow|tonight|monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tues?|wed|thurs?|fri|sat|sun))\b""",
         RegexOption.IGNORE_CASE,
     ).find(cleaned)
     if (dayMatch != null) {
@@ -56,16 +56,21 @@ fun parseReminderScheduleReply(text: String): Map<String, String> {
     return params
 }
 
-private fun normalizeReminderDay(raw: String): String = when (raw.lowercase()) {
-    "tonight" -> "today"
-    "mon" -> "monday"
-    "tue", "tues" -> "tuesday"
-    "wed" -> "wednesday"
-    "thu", "thur", "thurs" -> "thursday"
-    "fri" -> "friday"
-    "sat" -> "saturday"
-    "sun" -> "sunday"
-    else -> raw.lowercase()
+private fun normalizeReminderDay(raw: String): String {
+    val maybeNext = if (raw.startsWith("next ", ignoreCase = true)) "next " else ""
+    val day = raw.removePrefix("next ").removePrefix("Next ").lowercase()
+    val normalized = when (day) {
+        "tonight" -> "today"
+        "mon" -> "monday"
+        "tue", "tues" -> "tuesday"
+        "wed" -> "wednesday"
+        "thu", "thur", "thurs" -> "thursday"
+        "fri" -> "friday"
+        "sat" -> "saturday"
+        "sun" -> "sunday"
+        else -> day
+    }
+    return "$maybeNext$normalized"
 }
 
 private fun normalizeTimeSlotReply(trimmed: String): String {

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3937,6 +3937,78 @@ class QuickIntentRouterTest {
             val result = hybridRouter.route("remind me to take out trash monday")
             assertRegexMatch(result, "add_reminder", "remind me to take out trash monday")
         }
+
+        @Test
+        fun `remind me to buy milk saturday routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk Saturday")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("saturday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `remind me to buy milk sunday routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk Sunday")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("sunday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `remind me to buy milk fri routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk Fri")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("friday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `remind me to buy milk sat routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk Sat")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("saturday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `remind me to buy milk sun routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk Sun")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("sunday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `remind me to buy milk next saturday routes to add_reminder with day`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk next Saturday")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("next saturday", match.intent.params["day"])
+        }
         @Test
         fun `incomplete imperative reminder forms retain item and ask for day`() {
             val requests = listOf(

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3938,6 +3938,30 @@ class QuickIntentRouterTest {
             assertRegexMatch(result, "add_reminder", "remind me to take out trash monday")
         }
         @Test
+        fun `incomplete imperative reminder forms retain item and ask for day`() {
+            val requests = listOf(
+                "Remind me to buy milk",
+                "Please remind me to buy milk",
+                "Can you remind me to buy milk?",
+                "Set a reminder to buy milk",
+                "Remind me about buying milk",
+                "Don't let me forget to buy milk",
+            )
+
+            requests.forEach { request ->
+                val result = regexOnlyRouter.route(request)
+                val needsSlot = assertInstanceOf(
+                    QuickIntentRouter.RouteResult.NeedsSlot::class.java,
+                    result,
+                    "Expected slot fill for '$request', got $result",
+                )
+                assertEquals("add_reminder", needsSlot.intent.intentName)
+                assertEquals("buy milk", needsSlot.intent.params["item"])
+                assertEquals("day", needsSlot.missingSlot.name)
+            }
+        }
+
+        @Test
         fun `remind me at 9am routes to set_alarm not add_reminder`() {
             val result = hybridRouter.route("remind me at 9am")
             assertRegexMatch(result, "set_alarm", "remind me at 9am")

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/QuickIntentRouterTest.kt
@@ -3962,6 +3962,48 @@ class QuickIntentRouterTest {
         }
 
         @Test
+        fun `task-bearing reminder with time first routes to add_reminder`() {
+            val result = regexOnlyRouter.route("Remind me tomorrow at 5 pm to buy milk")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("tomorrow", match.intent.params["day"])
+            assertEquals("17:00", match.intent.params["time"])
+        }
+
+        @Test
+        fun `set reminder with time first routes to add_reminder`() {
+            val result = regexOnlyRouter.route("Set a reminder for 5 pm tomorrow to buy milk")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("tomorrow", match.intent.params["day"])
+            assertEquals("17:00", match.intent.params["time"])
+        }
+
+        @Test
+        fun `time-only reminder remains a direct add_reminder match`() {
+            val result = regexOnlyRouter.route("Remind me to buy milk at 5 pm")
+            val match = assertInstanceOf(
+                QuickIntentRouter.RouteResult.RegexMatch::class.java,
+                result,
+            )
+
+            assertEquals("add_reminder", match.intent.intentName)
+            assertEquals("buy milk", match.intent.params["item"])
+            assertEquals("17:00", match.intent.params["time"])
+        }
+
+
+        @Test
         fun `remind me at 9am routes to set_alarm not add_reminder`() {
             val result = hybridRouter.route("remind me at 9am")
             assertRegexMatch(result, "set_alarm", "remind me at 9am")
@@ -3993,6 +4035,19 @@ class QuickIntentRouterTest {
             assertRegexMatch(result, "add_reminder", "remind me to call dentist mon")
             val match = result as QuickIntentRouter.RouteResult.RegexMatch
             assertEquals("monday", match.intent.params["day"])
+        }
+
+        @Test
+        fun `non-reminder phrases fall through to ordinary conversation`() {
+            val phrases = listOf(
+                "I need to buy milk",
+                "Why do I always forget to buy milk?",
+                "What is the best time to buy milk?",
+            )
+            phrases.forEach { phrase ->
+                val result = regexOnlyRouter.route(phrase)
+                assertFallThrough(result, phrase)
+            }
         }
     }
 

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -297,6 +297,72 @@ class SlotFillerManagerTest {
     }
 
     @Test
+    fun `reminder schedule reply can fill day and time together`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "Tomorrow at 5 pm"),
+        )
+
+        assertEquals(
+            mapOf("item" to "buy milk", "day" to "tomorrow", "time" to "17:00"),
+            completed.params,
+        )
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `reminder day reply preserves item and asks only for time`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val needsMore = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "Tomorrow"),
+        )
+
+        assertEquals("tomorrow", needsMore.request.existingParams["day"])
+        assertEquals("time", needsMore.request.missingSlot.name)
+    }
+
+    @Test
+    fun `reminder time reply completes using existing day`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk", "day" to "tomorrow"),
+                missingSlot = SlotSpec("time", "What time on tomorrow should I remind you to buy milk?"),
+            ),
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "5 pm"),
+        )
+
+        assertEquals(
+            mapOf("item" to "buy milk", "day" to "tomorrow", "time" to "17:00"),
+            completed.params,
+        )
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
     fun `blank reply cancels and clears pending request`() {
         manager.startSlotFill(
             conversationOne,

--- a/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
+++ b/core/skills/src/test/java/com/kernel/ai/core/skills/slot/SlotFillerManagerTest.kt
@@ -340,6 +340,56 @@ class SlotFillerManagerTest {
     }
 
     @Test
+    fun `reminder time-first reply retains time and asks for day`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val needsMore = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "5 pm"),
+        )
+
+        assertEquals("17:00", needsMore.request.existingParams["time"])
+        assertEquals("day", needsMore.request.missingSlot.name)
+        assertTrue(manager.hasPending)
+    }
+
+    @Test
+    fun `time-first reminder completes after day follow-up`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val needsMore = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "5 pm"),
+        )
+        manager.startSlotFill(conversationOne, needsMore.request)
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "tomorrow"),
+        )
+
+        assertEquals(
+            mapOf("item" to "buy milk", "time" to "17:00", "day" to "tomorrow"),
+            completed.params,
+        )
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
     fun `reminder time reply completes using existing day`() {
         manager.startSlotFill(
             conversationOne,
@@ -357,6 +407,50 @@ class SlotFillerManagerTest {
 
         assertEquals(
             mapOf("item" to "buy milk", "day" to "tomorrow", "time" to "17:00"),
+            completed.params,
+        )
+        assertFalse(manager.hasPending)
+    }
+
+    @Test
+    fun `reminder next monday reply fills day with prefix`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val needsMore = assertInstanceOf(
+            SlotFillResult.NeedsMore::class.java,
+            manager.onUserReply(conversationOne, "Next Monday"),
+        )
+
+        assertEquals("next monday", needsMore.request.existingParams["day"])
+        assertEquals("time", needsMore.request.missingSlot.name)
+        assertTrue(manager.hasPending)
+    }
+
+    @Test
+    fun `reminder next monday at 5 pm fills day with prefix and time`() {
+        manager.startSlotFill(
+            conversationOne,
+            PendingSlotRequest(
+                intentName = "add_reminder",
+                existingParams = mapOf("item" to "buy milk"),
+                missingSlot = SlotSpec("day", "Which day should I set the reminder for?"),
+            ),
+        )
+
+        val completed = assertInstanceOf(
+            SlotFillResult.Completed::class.java,
+            manager.onUserReply(conversationOne, "Next Monday at 5 pm"),
+        )
+
+        assertEquals(
+            mapOf("item" to "buy milk", "day" to "next monday", "time" to "17:00"),
             completed.params,
         )
         assertFalse(manager.hasPending)

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -1471,10 +1471,29 @@ class ActionsViewModel @Inject constructor(
         clearExpectedSlotPromptSpeech()
         val reminderSchedule = if (pending.request.intentName == "add_reminder") {
             parseReminderScheduleReply(text)
-                .takeIf { it.containsKey(pending.request.missingSlot.name) }
-                ?: emptyMap()
         } else {
             emptyMap()
+        }
+        if (pending.request.intentName == "add_reminder" &&
+            pending.request.missingSlot.name !in reminderSchedule &&
+            reminderSchedule.isNotEmpty()
+        ) {
+            val mergedParams = pending.request.existingParams + reminderSchedule
+            val nextMissingSlot = quickIntentRouter.nextMissingSlot(
+                intentName = pending.request.intentName,
+                params = mergedParams,
+            )
+            if (nextMissingSlot != null) {
+                primePendingSlot(
+                    intentName = pending.request.intentName,
+                    existingParams = mergedParams,
+                    missingSlot = nextMissingSlot,
+                    originalQuery = pending.originalQuery,
+                    inputMode = pending.inputMode,
+                    delayVoicePrompt = pending.inputMode == InputMode.Voice,
+                )
+                return
+            }
         }
         val normalizedText = reminderSchedule[pending.request.missingSlot.name]
             ?: if (pending.inputMode == InputMode.Voice) {

--- a/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
+++ b/feature/chat/src/main/java/com/kernel/ai/feature/chat/ActionsViewModel.kt
@@ -19,6 +19,7 @@ import com.kernel.ai.core.skills.ToolPresentationJson
 import com.kernel.ai.core.skills.toSpokenSummary
 import com.kernel.ai.core.skills.slot.PendingSlotRequest
 import com.kernel.ai.core.skills.slot.normalizeSlotReply
+import com.kernel.ai.core.skills.slot.parseReminderScheduleReply
 import com.kernel.ai.core.voice.StartListeningCueContext
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.VoiceCaptureMode
@@ -1468,17 +1469,26 @@ class ActionsViewModel @Inject constructor(
         Log.d(TAG, "ADB_SLOT_STATE action=reply intent=${pending.request.intentName} slot=${pending.request.missingSlot.name} reply=\"$text\"")
         setSlotReplyAutoRearmArmed(false, "onSlotReply")
         clearExpectedSlotPromptSpeech()
-        val normalizedText = if (pending.inputMode == InputMode.Voice) {
-            normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
+        val reminderSchedule = if (pending.request.intentName == "add_reminder") {
+            parseReminderScheduleReply(text)
+                .takeIf { it.containsKey(pending.request.missingSlot.name) }
+                ?: emptyMap()
         } else {
-            normalizeSlotReply(text, pending.request.missingSlot.name)
+            emptyMap()
         }
+        val normalizedText = reminderSchedule[pending.request.missingSlot.name]
+            ?: if (pending.inputMode == InputMode.Voice) {
+                normalizeVoiceSlotReply(text, pending.request.missingSlot.name)
+            } else {
+                normalizeSlotReply(text, pending.request.missingSlot.name)
+            }
         if (normalizedText.isBlank()) {
             cancelSlotFill()
             return
         }
 
         val mergedParams = pending.request.existingParams +
+            reminderSchedule +
             mapOf(pending.request.missingSlot.name to normalizedText)
         val nextMissingSlot = quickIntentRouter.nextMissingSlot(
             intentName = pending.request.intentName,

--- a/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
+++ b/feature/chat/src/test/java/com/kernel/ai/feature/chat/ActionsViewModelTest.kt
@@ -372,6 +372,112 @@ class ActionsViewModelTest {
     }
 
     @Test
+    fun `reminder time-first reply is retained across Quick Actions slot prompts`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("Remind me to buy milk")
+        advanceUntilIdle()
+        assertEquals("day", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+
+        viewModel.onSlotReply("5 pm")
+        advanceUntilIdle()
+
+        assertEquals("day", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+        assertEquals("17:00", viewModel.pendingSlot.value?.request?.existingParams?.get("time"))
+        assertEquals(0, runIntentSkill.calls.size)
+
+        viewModel.onSlotReply("tomorrow")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(
+            mapOf(
+                "intent_name" to "add_reminder",
+                "item" to "buy milk",
+                "time" to "17:00",
+                "day" to "tomorrow",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+    }
+
+    @Test
+    fun `incomplete reminder starts slot-fill without navigating to chat`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("Remind me to buy milk")
+        advanceUntilIdle()
+
+        // Slot-fill is active with day missing
+        assertEquals("day", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+        assertEquals("add_reminder", viewModel.pendingSlot.value?.request?.intentName)
+        assertEquals("buy milk", viewModel.pendingSlot.value?.request?.existingParams["item"])
+        // No direct execution
+        assertEquals(0, runIntentSkill.calls.size)
+        // No fallthrough to chat/LLM (no llm_fallthrough entity inserted)
+        assertEquals(0, insertedActions.size)
+    }
+
+    @Test
+    fun `complete time-only reminder executes directly without slot-fill`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("Remind me to buy milk at 5 pm")
+        advanceUntilIdle()
+
+        // No pending slot — executed directly
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(1, runIntentSkill.calls.size)
+    }
+
+    @Test
+    fun `combined reminder with next Monday at 5 pm fills all slots`() = runTest(dispatcher) {
+        val runIntentSkill = CapturingRunIntentSkill()
+        every { skillRegistry.get(any()) } answers {
+            when (firstArg<String>()) {
+                "run_intent" -> runIntentSkill
+                else -> null
+            }
+        }
+
+        viewModel.executeAction("Remind me to buy milk")
+        advanceUntilIdle()
+        assertEquals("day", viewModel.pendingSlot.value?.request?.missingSlot?.name)
+
+        viewModel.onSlotReply("Next Monday at 5 pm")
+        advanceUntilIdle()
+
+        assertNull(viewModel.pendingSlot.value)
+        assertEquals(
+            mapOf(
+                "intent_name" to "add_reminder",
+                "item" to "buy milk",
+                "day" to "next monday",
+                "time" to "17:00",
+            ),
+            runIntentSkill.calls.single().arguments,
+        )
+    }
+
+    @Test
     fun `slot reply execution failure records truthful error state`() = runTest(dispatcher) {
         val failingSkill = CapturingRunIntentSkill { throw IllegalStateException("Dialer exploded") }
         every { skillRegistry.get(any()) } answers {


### PR DESCRIPTION
## Summary

Closes #1417.

Incomplete reminder requests now remain deterministic QuickIntentRouter matches with the extracted `item` retained and the missing schedule slot surfaced to the existing slot-fill flow.

## Changes

- Route imperative forms such as `Remind me to buy milk` and `Set a reminder to buy milk` to `add_reminder` with `item=buy milk` and a missing `day` slot.
- Preserve existing complete reminder routing, including day-only forms and alarm disambiguation.
- Parse one natural-language schedule reply for both `day` and `time` values, so `Tomorrow at 5 pm` completes both slots in one reply.
- Keep item/day state across partial replies and use the existing `ActionsViewModel` / `SlotFillerManager` ownership boundaries.

## Validation

- `:core:skills:testDebugUnitTest` — PASS
- `:feature:chat:testDebugUnitTest` — PASS
- `:app:testDebugUnitTest` — PASS
- `git diff --check` — PASS

No Room schema or unrelated action behavior was changed.