### PR TITLE
fix(#1415): remove misleading Manage voice models links from Voice settings

### DIFF
--- a/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
+++ b/app/src/main/java/com/kernel/ai/navigation/KernelNavHost.kt
@@ -700,9 +700,6 @@ fun KernelNavHost(
                 composable(ROUTE_VOICE) {
                     VoiceScreen(
                         onBack = { navController.popBackOrNavigateHome() },
-                        onNavigateToModelManagement = {
-                            navController.navigate(ROUTE_MODEL_MANAGEMENT)
-                        },
                     )
                 }
 

--- a/docs/manual-test-scenarios-1067.md
+++ b/docs/manual-test-scenarios-1067.md
@@ -84,7 +84,6 @@
 - Not-downloaded voices show `Not available` badge, radio button disabled
 - Downloading voices show `Preparing` badge with progress
 - `ModelCardCompact` has NO action buttons (consistent with design)
-- "Manage voice models" `TextButton` at bottom of each section navigates to Model Management
 
 ---
 
@@ -184,11 +183,10 @@
 **Steps:**
 1. From Chat onboarding → tap "Manage models" → verify navigation
 2. From Settings → tap "Model availability" row → verify navigation
-3. From Voice screen → tap "Manage voice models" → verify navigation
-4. Press back from Model Management → verify correct return screen
+3. Press back from Model Management → verify correct return screen
 
 **Expected:**
-- All three entry points navigate to Model Management
+- Both entry points navigate to Model Management
 - Back navigation returns to the correct previous screen
 - No double-navigation or crash
 

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/VoiceScreen.kt
@@ -105,7 +105,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 @Composable
 fun VoiceScreen(
     onBack: () -> Unit,
-    onNavigateToModelManagement: () -> Unit = {},
     viewModel: VoiceViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -249,7 +248,6 @@ fun VoiceScreen(
         onActiveSpeakerIdChanged = viewModel::setActiveSpeakerId,
         onKokoroVoiceSelected = viewModel::setKokoroVoice,
         onKokoroActiveSpeakerIdChanged = viewModel::setKokoroActiveSpeakerId,
-        onNavigateToModelManagement = onNavigateToModelManagement,
         onDownloadSherpaStt = viewModel::downloadSherpaStt,
         onCancelSherpaStt = viewModel::cancelSherpaSttDownload,
         onDeleteSherpaStt = viewModel::deleteSherpaStt,
@@ -406,7 +404,6 @@ private fun VoiceScreenContent(
     onActiveSpeakerIdChanged: (Int) -> Unit,
     onKokoroVoiceSelected: (SherpaKokoroVoice) -> Unit,
     onKokoroActiveSpeakerIdChanged: (Int) -> Unit,
-    onNavigateToModelManagement: () -> Unit,
     onDownloadSherpaStt: (VoiceInputEngine) -> Unit = { _ -> },
     onCancelSherpaStt: (VoiceInputEngine) -> Unit = { _ -> },
     onDeleteSherpaStt: (VoiceInputEngine) -> Unit = { _ -> },
@@ -992,12 +989,6 @@ private fun VoiceScreenContent(
                         }
                     }
                 }
-                TextButton(
-                    onClick = onNavigateToModelManagement,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                ) {
-                    Text("Manage voice models")
-                }
             }
 
             if (uiState.selectedOutputEngine == VoiceOutputEngine.KokoroExperimental) {
@@ -1132,12 +1123,6 @@ private fun VoiceScreenContent(
                             onSpeakerSelected = onKokoroActiveSpeakerIdChanged,
                         )
                     }
-                }
-                TextButton(
-                    onClick = onNavigateToModelManagement,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                ) {
-                    Text("Manage voice models")
                 }
             }
 
@@ -1608,7 +1593,6 @@ private fun VoiceScreenPreview() {
             onActiveSpeakerIdChanged = {},
             onKokoroVoiceSelected = {},
             onKokoroActiveSpeakerIdChanged = {},
-            onNavigateToModelManagement = {},
         )
     }
 }


### PR DESCRIPTION
Closes #1415

## Summary

Removes two misleading "Manage voice models" `TextButton`s from `VoiceScreen.kt` (one after Sherpa Piper voices, one after Kokoro voices) and their now-unused `onNavigateToModelManagement` callback plumbing.

## Changes

### VoiceScreen.kt
- Removed `onNavigateToModelManagement` parameter from `VoiceScreen` composable
- Removed `onNavigateToModelManagement` parameter from `VoiceScreenContent` composable
- Removed both "Manage voice models" `TextButton`s (after Sherpa Piper and Kokoro voice lists)
- Removed `onNavigateToModelManagement` from `VoiceScreenPreview`
- Preserved `TextButton` import — still used by other controls (Set default assistant, sentence count selector)

### KernelNavHost.kt
- Removed `onNavigateToModelManagement` callback from `ROUTE_VOICE` composable destination
- All other model management routes preserved: `ROUTE_MODEL_MANAGEMENT`, `buildModelManagementRoute`, Chat onboarding's "Manage models", Settings "Model availability" row

### docs/manual-test-scenarios-1067.md
- Removed "Manage voice models" expectation from Voice screen scenario
- Removed Voice screen entry from Model Management navigation scenario; adjusted count from "All three" → "Both"

## What remains unchanged
- Inline Sherpa STT model download/cancel/delete/selection controls
- Inline Sherpa Piper voice download/cancel/delete/selection/speaker controls
- Inline Kokoro voice download/cancel/delete/selection/speaker controls
- `VoiceViewModel` — untouched
- Model availability state, download behaviour, selection rules, voice-engine behaviour
- All legitimate Model Management entry points (Chat onboarding, Settings)

## Verification

```
./gradlew :feature:settings:testDebugUnitTest   → BUILD SUCCESSFUL
./gradlew assembleDebug                          → BUILD SUCCESSFUL
git diff --check                                 → no whitespace errors
```

Final commit SHA: `65ccb86f`

Do not merge — wait for review.