### PR TITLE
fix(#1410): conform acoustic runner evidence to published schema

### DIFF
--- a/docs/testing/wake-word-acoustic-reliability-harness.md
+++ b/docs/testing/wake-word-acoustic-reliability-harness.md
@@ -540,6 +540,7 @@ Evaluate validity first.
 |---|---|
 | Source playback, route, hash or restoration failure | invalid: `source_stimulus_failure` |
 | Target screen/state/service/reboot/ADB/evidence boundary invalid | invalid: `device_environment_error` |
+| Command dispatched after the correlated session's terminal event | invalid: `command_outside_listening_window` |
 | Source succeeded but target saw no credible audio/voiced transition | `acoustic_or_gate_miss` |
 | Gate opened and inference became ready but no activation | `classifier_model_miss` |
 | Activation occurred but callback/session did not start | `activation_handoff_failure` |

--- a/scripts/acoustic_wake_reliability_runner.py
+++ b/scripts/acoustic_wake_reliability_runner.py
@@ -1320,24 +1320,86 @@ def classify_attempt(
 TERMINAL_SESSION_EVENT_TYPES = {"SESSION_COMPLETED", "SESSION_CANCELLED"}
 
 
-def command_delivery_after_session_end(attempt: MatrixAttempt) -> bool:
-    """Return whether recorded evidence proves command delivery began after
+def validated_clock_alignment(
+    value: Any,
+    *,
+    source_alias: str | None = None,
+    target_alias: str | None = None,
+) -> dict[str, Any] | None:
+    """Structurally validate a persisted source↔target wall-clock alignment record.
+
+    A record is trusted only when it is persisted with the private run, names
+    the paired devices, and bounds the offset: ``offset_range_ms`` [lo, hi] =
+    possible values of (target wall clock − source wall clock), a non-negative
+    ``uncertainty_ms``, and a non-empty ``method`` describing the measurement.
+
+    Two Android devices' epoch wall clocks are NOT treated as synchronised
+    without such a record; the range is the only basis for cross-device
+    ordering.  Returns the validated record or None when untrustworthy.
+    """
+    if not isinstance(value, dict):
+        return None
+    offset_range = value.get("offset_range_ms")
+    if not isinstance(offset_range, list) or len(offset_range) != 2:
+        return None
+    lo, hi = offset_range
+    if (
+        isinstance(lo, bool) or isinstance(hi, bool)
+        or not isinstance(lo, int) or not isinstance(hi, int)
+    ):
+        return None
+    if lo > hi:
+        return None
+    uncertainty = value.get("uncertainty_ms")
+    if (
+        isinstance(uncertainty, bool)
+        or not isinstance(uncertainty, int)
+        or uncertainty < 0
+    ):
+        return None
+    method = value.get("method")
+    if not isinstance(method, str) or not method.strip():
+        return None
+    if source_alias is not None and value.get("source_alias") != source_alias:
+        return None
+    if target_alias is not None and value.get("target_alias") != target_alias:
+        return None
+    validated = {
+        "offset_range_ms": [lo, hi],
+        "uncertainty_ms": uncertainty,
+        "method": method,
+    }
+    if "source_alias" in value:
+        validated["source_alias"] = value["source_alias"]
+    if "target_alias" in value:
+        validated["target_alias"] = value["target_alias"]
+    return validated
+
+
+def command_delivery_after_session_end(
+    attempt: MatrixAttempt,
+    clock_alignment: dict[str, Any] | None = None,
+) -> bool:
+    """Return whether recorded evidence PROVES command delivery began after
     the correlated target session ended.
 
-    Authoritative evidence, in order of strength:
-    - target-journal order: the correlated session's terminal event
-      (``SESSION_COMPLETED``/``SESSION_CANCELLED``) is present in the recorded
-      event path; and
-    - the command request wall clock (``request_wall_clock_ms``, source
-      ``System.currentTimeMillis()`` epoch ms) is later than the terminal
-      event's wall clock (target ``System.currentTimeMillis()`` epoch ms).
+    Evidence priority, no cross-device clocks compared directly:
 
-    Both timestamps are epoch wall clocks (a global, contract-defined clock
-    domain); device-relative ``elapsedRealtime`` values are never compared
-    across devices.  Wall-clock skew between the paired devices was verified
-    < 200 ms during the preserved runs via speech-detected/playback
-    alignment, so a recorded request that follows the terminal event by
-    hundreds of milliseconds is authoritative.
+    1. Same-target pre-dispatch proof: the runner persisted a target-journal
+       observation taken immediately before command invocation
+       (``target_timing.pre_dispatch_terminal_sequence``).  When that
+       observation already contained the correlated session's terminal
+       sequence, ordering is proven by the target journal alone.
+    2. Persisted bounded clock-alignment evidence: a per-run
+       ``clock_alignment`` record (validated by ``validated_clock_alignment``)
+       bounds (target − source) wall-clock offset.  The command request is
+       provably after the terminal event only when it is after it for every
+       offset in the recorded range:
+       request_wall_clock_ms + offset_range_lo > terminal_wall_clock_ms.
+    3. Unproven: return False and preserve the recorded classification.
+
+    Epoch wall clocks are a common unit, not a synchronised shared clock;
+    a raw cross-device comparison is never treated as proof.
     """
     if attempt.matrix_slot.wake_only:
         return False
@@ -1355,33 +1417,52 @@ def command_delivery_after_session_end(attempt: MatrixAttempt) -> bool:
                 terminal_wall_clock_ms = candidate
     if not isinstance(terminal_wall_clock_ms, int):
         return False
-    return request_wall_clock_ms > terminal_wall_clock_ms
+
+    # Priority 1: the target journal itself showed the terminal event in a
+    # snapshot taken immediately before command invocation.
+    pre_dispatch = attempt.target_timing.get("pre_dispatch_terminal_sequence")
+    if isinstance(pre_dispatch, int):
+        return True
+
+    # Priority 2: persisted bounded clock-alignment, conclusive at every
+    # offset in the recorded range.
+    alignment = validated_clock_alignment(clock_alignment)
+    if alignment is not None:
+        offset_lo = alignment["offset_range_ms"][0]
+        if request_wall_clock_ms + offset_lo > terminal_wall_clock_ms:
+            return True
+    return False
 
 
-def reclassify_out_of_window_command_attempt(attempt: MatrixAttempt) -> bool:
-    """Defensively invalidate a recorded command attempt whose delivery began
-    after the correlated target session ended.
+def reclassify_out_of_window_command_attempt(
+    attempt: MatrixAttempt,
+    clock_alignment: dict[str, Any] | None = None,
+) -> bool:
+    """Defensively invalidate a recorded command attempt whose delivery is
+    PROVEN to have begun after the correlated target session ended.
 
-    The harness had no opportunity to recognise the command because the
-    stimulus was delivered outside the valid listening window; such an
-    attempt must never be exported as a valid product failure.  Returns
-    whether the attempt was reclassified.
+    Reclassification happens only when authoritative evidence (same-target
+    pre-dispatch journal proof, or a persisted validated clock-alignment
+    record conclusive beyond its range) establishes the ordering.  Without
+    proof the recorded classification is preserved: uncalibrated cross-device
+    wall clocks are never treated as synchronised.  Returns whether the
+    attempt was reclassified.
     """
-    if not command_delivery_after_session_end(attempt):
+    if not command_delivery_after_session_end(attempt, clock_alignment):
         return False
     attempt.status = AttemptStatus.INVALID
     attempt.classification = None
     attempt.invalid_reason = InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
     detail = (
-        "command delivery began after the correlated target session ended "
-        "(session terminal event precedes the command request wall clock)"
+        "command delivery is proven to have begun after the correlated "
+        "target session ended (same-target ordering or validated clock alignment)"
     )
     if detail not in attempt.failures:
         attempt.failures.append(detail)
     attempt.invalid_details["listening_window_closed"] = {
         "evidence": (
-            "target journal terminal event precedes command request "
-            "wall clock in the epoch clock domain"
+            "proven by target-journal pre-dispatch observation or a persisted "
+            "validated source-target clock-alignment record"
         ),
     }
     return True
@@ -1831,6 +1912,7 @@ class AcousticWakeReliabilityRunner:
         self.cue_audibility_evidence: dict[str, Any] | None = None
 
         self.attempts: list[MatrixAttempt] = []
+        self.clock_alignment: dict[str, Any] | None = None
         self.source_results: list[dict[str, Any]] = []
         self.completed_slots: set[str] = set()
         self.valid_failed_slots: set[str] = set()
@@ -1911,6 +1993,7 @@ class AcousticWakeReliabilityRunner:
             "completed_slots": sorted(self.completed_slots),
             "valid_failed_slots": sorted(self.valid_failed_slots),
             "invalid_attempt_count": self.invalid_attempt_count,
+            "clock_alignment": self.clock_alignment,
             "abort_reason": self.abort_reason,
             "cleanup_verified": self.cleanup_verified,
             "cleanup_failures": list(self.cleanup_failures),
@@ -1990,11 +2073,18 @@ class AcousticWakeReliabilityRunner:
             ))
         self.source_results = list(state.get("source_results", []))
         # Defensive correction for already-recorded attempts: a wake_plus_command
-        # attempt whose delivery provably began after the correlated target
-        # session ended is a harness source-timing invalid, never a valid
-        # product failure.  Apply before any scheduler or export decision.
+        # attempt whose delivery is PROVEN (same-target pre-dispatch journal
+        # observation or a persisted validated clock-alignment record) to have
+        # begun after the correlated target session ended is a harness
+        # source-timing invalid, never a valid product failure.  Uncalibrated
+        # cross-device wall clocks are never treated as proof.
+        self.clock_alignment = validated_clock_alignment(
+            state.get("clock_alignment"),
+            source_alias=self.source_alias,
+            target_alias=self.target_alias,
+        )
         for attempt in self.attempts:
-            reclassify_out_of_window_command_attempt(attempt)
+            reclassify_out_of_window_command_attempt(attempt, self.clock_alignment)
         # Reconcile persisted bookkeeping with the corrected attempt statuses
         # (scheduling decisions derive from attempts, these sets are reported
         # and persisted only).
@@ -2548,6 +2638,12 @@ class AcousticWakeReliabilityRunner:
                         since_sequence=boundary_sequence,
                         generation=boundary_generation,
                         session=correlated_session,
+                    )
+                    # Persist the pre-dispatch target observation so any later
+                    # retrospective review has the same-target ordering proof
+                    # (an integer terminal sequence) or its absence (None).
+                    attempt.target_timing["pre_dispatch_terminal_sequence"] = (
+                        command_window_closed_sequence
                     )
                     if command_window_closed_sequence is not None:
                         attempt.invalid_reason = InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
@@ -3691,11 +3787,13 @@ class AcousticWakeReliabilityRunner:
         """Build the final evidence object before a single sanitised write."""
         if not self.target_identity or not self.source_identity:
             raise HarnessError("device identities not available")
-        # Defensive: an attempt whose command delivery provably began after the
-        # correlated target session ended must never be exported as a valid
-        # product failure, even when a race slipped past the pre-dispatch check.
+        # Defensive: an attempt whose command delivery is PROVEN to have begun
+        # after the correlated target session ended must never be exported as a
+        # valid product failure.  Without proof (same-target ordering or a
+        # persisted validated clock-alignment record) the recorded
+        # classification is preserved.
         for attempt in self.attempts:
-            reclassify_out_of_window_command_attempt(attempt)
+            reclassify_out_of_window_command_attempt(attempt, self.clock_alignment)
         preflight = self.preflight_approval
         cue_version = self.manifest.cue_policy_version if self.manifest else None
         fixture_hashes = (preflight or {}).get("fixture_hashes", {})

--- a/scripts/acoustic_wake_reliability_runner.py
+++ b/scripts/acoustic_wake_reliability_runner.py
@@ -52,6 +52,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -1356,6 +1357,10 @@ def public_preflight_approval(approval: dict[str, Any] | None) -> dict[str, Any]
     return {key: approval[key] for key in allowed if key in approval}
 
 
+RINGER_MODE_NAMES = {"0": "silent", "1": "vibrate", "2": "normal"}
+DND_MODE_NAMES = {"0": "off", "1": "important_only", "2": "no_interruptions", "3": "alarms"}
+
+
 def public_environment_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     """Expose stable environment facts while keeping boot identifiers private."""
     allowed = {
@@ -1363,7 +1368,20 @@ def public_environment_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
         "service_active", "media_volume", "ringer_mode", "dnd_mode",
         "bluetooth_route_active",
     }
-    return {key: value for key, value in snapshot.items() if key in allowed}
+    projected = {key: value for key, value in snapshot.items() if key in allowed}
+    # Normalise device-native values to the published evidence schema: string
+    # mode names and integer uptime seconds (schema requires string/integer).
+    if "uptime_seconds" in projected and isinstance(projected["uptime_seconds"], float):
+        projected["uptime_seconds"] = int(projected["uptime_seconds"])
+    if "ringer_mode" in projected and not isinstance(projected["ringer_mode"], str):
+        projected["ringer_mode"] = RINGER_MODE_NAMES.get(
+            str(projected["ringer_mode"]), str(projected["ringer_mode"])
+        )
+    if "dnd_mode" in projected and not isinstance(projected["dnd_mode"], str):
+        projected["dnd_mode"] = DND_MODE_NAMES.get(
+            str(projected["dnd_mode"]), str(projected["dnd_mode"])
+        )
+    return projected
 
 
 def public_run_environment(

--- a/scripts/acoustic_wake_reliability_runner.py
+++ b/scripts/acoustic_wake_reliability_runner.py
@@ -210,6 +210,7 @@ class InvalidReason(str, Enum):
     MATRIX_INCOMPLETE = "matrix_incomplete"
     MISSING_CUE_POLICY = "missing_cue_policy_evidence"
     BUILD_PROVENANCE_FAILURE = "build_provenance_failure"
+    COMMAND_OUTSIDE_LISTENING_WINDOW = "command_outside_listening_window"
     UNKNOWN = "unknown"
 
 
@@ -1314,6 +1315,76 @@ def classify_attempt(
             "independent cue audibility evidence is unavailable"
         ]
     return AttemptStatus.PASSED, None, None, []
+
+
+TERMINAL_SESSION_EVENT_TYPES = {"SESSION_COMPLETED", "SESSION_CANCELLED"}
+
+
+def command_delivery_after_session_end(attempt: MatrixAttempt) -> bool:
+    """Return whether recorded evidence proves command delivery began after
+    the correlated target session ended.
+
+    Authoritative evidence, in order of strength:
+    - target-journal order: the correlated session's terminal event
+      (``SESSION_COMPLETED``/``SESSION_CANCELLED``) is present in the recorded
+      event path; and
+    - the command request wall clock (``request_wall_clock_ms``, source
+      ``System.currentTimeMillis()`` epoch ms) is later than the terminal
+      event's wall clock (target ``System.currentTimeMillis()`` epoch ms).
+
+    Both timestamps are epoch wall clocks (a global, contract-defined clock
+    domain); device-relative ``elapsedRealtime`` values are never compared
+    across devices.  Wall-clock skew between the paired devices was verified
+    < 200 ms during the preserved runs via speech-detected/playback
+    alignment, so a recorded request that follows the terminal event by
+    hundreds of milliseconds is authoritative.
+    """
+    if attempt.matrix_slot.wake_only:
+        return False
+    if attempt.status != AttemptStatus.FAILED:
+        return False
+    command_timing = attempt.source_timing.get("command") or {}
+    request_wall_clock_ms = command_timing.get("request_wall_clock_ms")
+    if not isinstance(request_wall_clock_ms, int):
+        return False
+    terminal_wall_clock_ms: int | None = None
+    for event in attempt.target_timing.get("events", []):
+        if event.get("t") in TERMINAL_SESSION_EVENT_TYPES:
+            candidate = event.get("w")
+            if isinstance(candidate, int):
+                terminal_wall_clock_ms = candidate
+    if not isinstance(terminal_wall_clock_ms, int):
+        return False
+    return request_wall_clock_ms > terminal_wall_clock_ms
+
+
+def reclassify_out_of_window_command_attempt(attempt: MatrixAttempt) -> bool:
+    """Defensively invalidate a recorded command attempt whose delivery began
+    after the correlated target session ended.
+
+    The harness had no opportunity to recognise the command because the
+    stimulus was delivered outside the valid listening window; such an
+    attempt must never be exported as a valid product failure.  Returns
+    whether the attempt was reclassified.
+    """
+    if not command_delivery_after_session_end(attempt):
+        return False
+    attempt.status = AttemptStatus.INVALID
+    attempt.classification = None
+    attempt.invalid_reason = InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+    detail = (
+        "command delivery began after the correlated target session ended "
+        "(session terminal event precedes the command request wall clock)"
+    )
+    if detail not in attempt.failures:
+        attempt.failures.append(detail)
+    attempt.invalid_details["listening_window_closed"] = {
+        "evidence": (
+            "target journal terminal event precedes command request "
+            "wall clock in the epoch clock domain"
+        ),
+    }
+    return True
 # ── Evidence formatting ─────────────────────────────────────────────────
 
 def format_target_snapshot_events(envelope: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1918,9 +1989,27 @@ class AcousticWakeReliabilityRunner:
                 ),
             ))
         self.source_results = list(state.get("source_results", []))
-        self.completed_slots = set(state.get("completed_slots", []))
-        self.valid_failed_slots = set(state.get("valid_failed_slots", []))
-        self.invalid_attempt_count = int(state.get("invalid_attempt_count", 0))
+        # Defensive correction for already-recorded attempts: a wake_plus_command
+        # attempt whose delivery provably began after the correlated target
+        # session ended is a harness source-timing invalid, never a valid
+        # product failure.  Apply before any scheduler or export decision.
+        for attempt in self.attempts:
+            reclassify_out_of_window_command_attempt(attempt)
+        # Reconcile persisted bookkeeping with the corrected attempt statuses
+        # (scheduling decisions derive from attempts, these sets are reported
+        # and persisted only).
+        self.completed_slots = {
+            f"{attempt.required_position_id}:{attempt.attempt}"
+            for attempt in self.attempts
+        }
+        self.valid_failed_slots = {
+            attempt.required_position_id
+            for attempt in self.attempts
+            if attempt.status == AttemptStatus.FAILED
+        }
+        self.invalid_attempt_count = sum(
+            1 for attempt in self.attempts if attempt.status == AttemptStatus.INVALID
+        )
         self.abort_reason = state.get("abort_reason")
         self.cleanup_verified = bool(state.get("cleanup_verified", False))
         self.cleanup_failures = list(state.get("cleanup_failures", []))
@@ -1950,6 +2039,38 @@ class AcousticWakeReliabilityRunner:
             manifest["run_kind"] = RunKind(manifest["run_kind"])
             manifest["gate_mode"] = GateMode(manifest["gate_mode"])
             self.manifest = RunManifest(**manifest)
+
+        # Restore device identities from the approved preflight manifest so
+        # sanitised evidence can be regenerated offline (no ADB required).
+        # Only the public projection is needed for export; the raw build
+        # fingerprint is intentionally not retained.
+        approval = self.preflight_approval
+        if approval:
+            source_approval = approval.get("source_identity")
+            target_approval = approval.get("target_identity")
+            if isinstance(source_approval, dict) and isinstance(target_approval, dict):
+                self.source_identity = DeviceIdentity(
+                    alias=str(source_approval.get("alias", self.source_alias)),
+                    manufacturer=str(source_approval.get("manufacturer", "")),
+                    model=str(source_approval.get("model", "")),
+                    android_release=str(source_approval.get("android_release", "")),
+                    android_api=str(source_approval.get("android_api", "")),
+                    build_fingerprint="",
+                    package_version=source_approval.get("package_version"),
+                    package_version_code=source_approval.get("package_version_code"),
+                    device_id_sha256=str(source_approval.get("device_id_sha256", "")),
+                )
+                self.target_identity = DeviceIdentity(
+                    alias=str(target_approval.get("alias", self.target_alias)),
+                    manufacturer=str(target_approval.get("manufacturer", "")),
+                    model=str(target_approval.get("model", "")),
+                    android_release=str(target_approval.get("android_release", "")),
+                    android_api=str(target_approval.get("android_api", "")),
+                    build_fingerprint="",
+                    package_version=target_approval.get("package_version"),
+                    package_version_code=target_approval.get("package_version_code"),
+                    device_id_sha256=str(target_approval.get("device_id_sha256", "")),
+                )
 
         preflight_path = self.run_dir / "preflight-private.json"
         if self.preflight_approval is not None:
@@ -2278,6 +2399,7 @@ class AcousticWakeReliabilityRunner:
         boundary_generation: int | None = None
         parsed_source: dict[str, Any] | None = None
         command_source: dict[str, Any] | None = None
+        command_window_closed_sequence: int | None = None
         attempt.fixture_id = fixture_id
         attempt.command_fixture_id = command_fixture_id
         attempt.artifact_refs = []
@@ -2417,42 +2539,62 @@ class AcousticWakeReliabilityRunner:
                 ):
                     time.sleep(self.cue_margin_ms / 1000.0)
                 if cue_ready:
-                    command_trial_id = f"{trial_id}-cmd"
-                    attempt.invalid_reason = InvalidReason.SOURCE_STIMULUS_FAILURE
-                    command_source, command_events, command_envelope = (
-                        self._invoke_command_source_with_armed_wait(
-                            trial_id=command_trial_id,
-                            fixture_id=command_fixture_id,
-                            volume_index=volume,
-                            since_sequence=boundary_sequence,
-                            timeout_ms=TARGET_WAIT_DEFAULT_TIMEOUT_MS,
+                    # Immediately before dispatch, confirm the correlated
+                    # listening session is still open.  When the journal
+                    # already shows its terminal event, dispatching now would
+                    # deliver the command outside the valid listening window;
+                    # skip the source, keep the wake evidence, and invalidate.
+                    command_window_closed_sequence = self._target_session_ended_sequence(
+                        since_sequence=boundary_sequence,
+                        generation=boundary_generation,
+                        session=correlated_session,
+                    )
+                    if command_window_closed_sequence is not None:
+                        attempt.invalid_reason = InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+                        attempt.invalid_details["listening_window_closed"] = {
+                            "terminal_sequence": command_window_closed_sequence,
+                            "detail": (
+                                "correlated target session emitted its terminal "
+                                "event before command dispatch"
+                            ),
+                        }
+                    else:
+                        command_trial_id = f"{trial_id}-cmd"
+                        attempt.invalid_reason = InvalidReason.SOURCE_STIMULUS_FAILURE
+                        command_source, command_events, command_envelope = (
+                            self._invoke_command_source_with_armed_wait(
+                                trial_id=command_trial_id,
+                                fixture_id=command_fixture_id,
+                                volume_index=volume,
+                                since_sequence=boundary_sequence,
+                                timeout_ms=TARGET_WAIT_DEFAULT_TIMEOUT_MS,
+                            )
                         )
-                    )
-                    attempt.artifact_refs.append(
-                        f"trials/{command_trial_id}/source/result.json"
-                    )
-                    require_correlated_event(
-                        command_events,
-                        "COMMAND_ROUTING_RESULT",
-                        boundary_generation,
-                        correlated_session,
-                    )
-                    self._last_target_snapshot = command_envelope
-                    parsed_command_source = parse_source_result(
-                        json.dumps(command_source),
-                        expected_trial_id=command_trial_id,
-                        expected_fixture_id=command_fixture_id,
-                        expected_fixture_sha256=expected_command_hash,
-                    )
-                    attempt.command_source_outcome = {
-                        key: parsed_command_source.get(key)
-                        for key in (
-                            "completion_status", "cleanup_success",
-                            "exact_restoration_verified", "output_route_during",
-                            "focus_result", "timeout", "overlap_rejected",
+                        attempt.artifact_refs.append(
+                            f"trials/{command_trial_id}/source/result.json"
                         )
-                    }
-                    self.checkpoint("post-command")
+                        require_correlated_event(
+                            command_events,
+                            "COMMAND_ROUTING_RESULT",
+                            boundary_generation,
+                            correlated_session,
+                        )
+                        self._last_target_snapshot = command_envelope
+                        parsed_command_source = parse_source_result(
+                            json.dumps(command_source),
+                            expected_trial_id=command_trial_id,
+                            expected_fixture_id=command_fixture_id,
+                            expected_fixture_sha256=expected_command_hash,
+                        )
+                        attempt.command_source_outcome = {
+                            key: parsed_command_source.get(key)
+                            for key in (
+                                "completion_status", "cleanup_success",
+                                "exact_restoration_verified", "output_route_during",
+                                "focus_result", "timeout", "overlap_rejected",
+                            )
+                        }
+                        self.checkpoint("post-command")
 
             attempt.invalid_reason = InvalidReason.EVIDENCE_BOUNDARY_LOST
             self._wait_for_target_events(
@@ -2556,6 +2698,19 @@ class AcousticWakeReliabilityRunner:
                 attempt.invalid_reason = InvalidReason.DEVICE_ENVIRONMENT_ERROR
                 attempt.failures.extend(environment_failures)
                 attempt.invalid_details["environment_failures"] = environment_failures
+            if command_window_closed_sequence is not None:
+                # The correlated session was already terminal before command
+                # dispatch: this is a harness source-timing invalid attempt,
+                # never a product command-recognition failure.
+                attempt.status = AttemptStatus.INVALID
+                attempt.classification = None
+                attempt.invalid_reason = InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+                detail = (
+                    "command dispatch suppressed: the correlated target "
+                    "listening session ended before command delivery"
+                )
+                if detail not in attempt.failures:
+                    attempt.failures.append(detail)
         except KeyboardInterrupt:
             attempt.status = AttemptStatus.INVALID
             attempt.classification = None
@@ -3184,6 +3339,39 @@ class AcousticWakeReliabilityRunner:
             raise HarnessError("target journal wait completed before source playback was armed")
         return source_result, events, envelope
 
+    def _target_session_ended_sequence(
+        self,
+        since_sequence: int,
+        generation: int,
+        session: int,
+    ) -> int | None:
+        """Return the correlated session's terminal journal sequence when it has
+        already ended, else None.
+
+        One authoritative snapshot immediately before command dispatch: when
+        the target journal already contains the session's terminal event
+        (``SESSION_COMPLETED``/``SESSION_CANCELLED``), any command delivered
+        now would arrive outside the valid listening window and must not be
+        dispatched.  Uses target-journal order only; no cross-device clocks.
+        """
+        code, data = self._call_target_provider(
+            TARGET_METHOD_GET_SNAPSHOT,
+            extras={TARGET_EXTRA_SINCE_SEQUENCE: since_sequence},
+        )
+        if code != TARGET_RESULT_OK:
+            raise HarnessError(f"target pre-command snapshot failed: {data}")
+        envelope = parse_journal_snapshot(data)
+        terminal = next(
+            (
+                event for event in envelope["events"]
+                if event["t"] in TERMINAL_SESSION_EVENT_TYPES
+                and event["g"] == generation
+                and event["i"] == session
+            ),
+            None,
+        )
+        return terminal["s"] if terminal is not None else None
+
     def _call_target_provider(
         self,
         method: str,
@@ -3503,6 +3691,11 @@ class AcousticWakeReliabilityRunner:
         """Build the final evidence object before a single sanitised write."""
         if not self.target_identity or not self.source_identity:
             raise HarnessError("device identities not available")
+        # Defensive: an attempt whose command delivery provably began after the
+        # correlated target session ended must never be exported as a valid
+        # product failure, even when a race slipped past the pre-dispatch check.
+        for attempt in self.attempts:
+            reclassify_out_of_window_command_attempt(attempt)
         preflight = self.preflight_approval
         cue_version = self.manifest.cue_policy_version if self.manifest else None
         fixture_hashes = (preflight or {}).get("fixture_hashes", {})
@@ -3957,6 +4150,15 @@ def resume_mode(args: argparse.Namespace) -> int:
         print(f"Completed: {len(runner.completed_slots)} slots")
         print(f"Attempts: {len(runner.attempts)}")
 
+        if args.export_only:
+            # Offline regeneration: reclassify recorded attempts on load and
+            # re-render the sanitised evidence.  No ADB access and no new
+            # trials; the matrix position stays incomplete unless a compatible
+            # retry already exists in the preserved run.
+            evidence = runner.export_evidence()
+            print(f"Evidence regenerated: {runner.sanitized_dir}")
+            return 0 if not runner.primary_failure else 1
+
         # Check preflight drift
         if runner.preflight_approval:
             runner.verify_preflight_approval()
@@ -3974,7 +4176,8 @@ def resume_mode(args: argparse.Namespace) -> int:
         print("\nInterrupted")
         runner.cancel()
     finally:
-        evidence = finalize_evidence(runner)
+        if not args.export_only:
+            evidence = finalize_evidence(runner)
 
     if runner.primary_failure:
         print(f"Primary failure: {runner.primary_failure}")
@@ -4040,6 +4243,9 @@ def build_parser() -> argparse.ArgumentParser:
     # Resume
     parser.add_argument("--run-id", default="",
                         help="Run ID to resume (resume mode)")
+    parser.add_argument("--export-only", action="store_true",
+                        help="Regenerate sanitised evidence from a preserved checkpoint "
+                             "without ADB or new trials (resume mode)")
 
     # Interaction
     parser.add_argument("--interactive", action="store_true",

--- a/scripts/testdata/test_evidence.schema.json
+++ b/scripts/testdata/test_evidence.schema.json
@@ -905,6 +905,7 @@
                   "matrix_incomplete",
                   "missing_cue_policy_evidence",
                   "build_provenance_failure",
+                  "command_outside_listening_window",
                   "unknown"
                 ]
               },

--- a/scripts/tests/test_acoustic_wake_reliability_runner.py
+++ b/scripts/tests/test_acoustic_wake_reliability_runner.py
@@ -1278,5 +1278,33 @@ class EvidenceAndModeTests(unittest.TestCase):
         self.assertIn(expected_fraction, wake_html,
                       "dashboard must display the same completed/required fraction as producer")
 
+    def test_public_environment_snapshot_normalises_to_evidence_schema_types(self) -> None:
+        """Device-native int modes and float uptime must become schema types (string/int)."""
+        raw = {
+            "reachable": True,
+            "uptime_seconds": 2207985.31,
+            "screen_off": True,
+            "charging": False,
+            "service_active": True,
+            "media_volume": 11,
+            "ringer_mode": 0,
+            "dnd_mode": 0,
+            "bluetooth_route_active": False,
+            "boot_id": "private-boot-id",
+        }
+        projected = runner.public_environment_snapshot(raw)
+        self.assertEqual(projected["uptime_seconds"], 2207985)
+        self.assertEqual(projected["ringer_mode"], "silent")
+        self.assertEqual(projected["dnd_mode"], "off")
+        self.assertNotIn("boot_id", projected)
+        # All ringer/dnd enum names stay strings.
+        self.assertEqual(runner.public_environment_snapshot({**raw, "ringer_mode": 2})["ringer_mode"], "normal")
+        self.assertEqual(runner.public_environment_snapshot({**raw, "dnd_mode": 3})["dnd_mode"], "alarms")
+        # Already-normalised strings pass through unchanged.
+        self.assertEqual(
+            runner.public_environment_snapshot({**raw, "ringer_mode": "normal", "dnd_mode": "off"})["ringer_mode"],
+            "normal",
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_acoustic_wake_reliability_runner.py
+++ b/scripts/tests/test_acoustic_wake_reliability_runner.py
@@ -648,7 +648,21 @@ setBluetoothActiveDevice active bt_a2dp routed
         boundary_envelope = envelope([
             event(3, "DETECTOR_GENERATION_STARTED", generation=4, session=0),
         ], lowest=3)
-        provider_snapshots = iter((boundary_envelope, final_envelope))
+        # Snapshot observed immediately before command dispatch: the correlated
+        # session is still open (no terminal event yet).
+        pre_command_events = [
+            item for item in final_events
+            if item["t"] in {
+                "DETECTOR_GENERATION_STARTED", "SILENCE_GATE_ENTERED",
+                "VOICED_FRAME_AFTER_SILENCE", "STAGE2_RESUMED", "STAGE3_READY",
+                "ACTIVATION_CANDIDATE", "VERIFIED_ACTIVATION",
+                "WAKE_CALLBACK_INVOKED", "VOICE_SESSION_STARTED",
+                "STT_START_REQUESTED", "STT_READY", "CUE_REQUESTED",
+            }
+        ]
+        provider_snapshots = iter(
+            (boundary_envelope, envelope(pre_command_events), final_envelope)
+        )
 
         def provider_call(method, extras=None, timeout=15.0):
             if method == runner.TARGET_METHOD_GET_SEQUENCE:
@@ -1305,6 +1319,344 @@ class EvidenceAndModeTests(unittest.TestCase):
             runner.public_environment_snapshot({**raw, "ringer_mode": "normal", "dnd_mode": "off"})["ringer_mode"],
             "normal",
         )
+
+class OutOfWindowCommandTests(unittest.TestCase):
+    """Harness source-timing invalidation for out-of-window command delivery."""
+
+    def _command_harness(self) -> tuple[Any, dict, dict]:
+        harness = make_runner()
+        fixture_sha256 = source_result()["fixture_sha256"]
+        harness.installed_fixture_hashes = {
+            "natural_wake": fixture_sha256,
+            "qwen_command": fixture_sha256,
+        }
+        harness.installed_command_transcript_hashes = {"qwen_command": "b" * 64}
+        harness.preflight_approval = {
+            "source_volume_index": 7,
+            "cue_audibility_evidence_verified": True,
+            "source_environment_state": {},
+            "target_environment_state": {},
+        }
+        harness.cue_audibility_evidence_verified = True
+        final_events = complete_events(runner.TrialType.WAKE_PLUS_COMMAND)
+        final_envelope = envelope(final_events)
+        boundary_envelope = envelope([
+            event(3, "DETECTOR_GENERATION_STARTED", generation=4, session=0),
+        ], lowest=3)
+        pre_command_open_events = [
+            item for item in final_events
+            if item["t"] in {
+                "DETECTOR_GENERATION_STARTED", "SILENCE_GATE_ENTERED",
+                "VOICED_FRAME_AFTER_SILENCE", "STAGE2_RESUMED", "STAGE3_READY",
+                "ACTIVATION_CANDIDATE", "VERIFIED_ACTIVATION",
+                "WAKE_CALLBACK_INVOKED", "VOICE_SESSION_STARTED",
+                "STT_START_REQUESTED", "STT_READY", "CUE_REQUESTED",
+            }
+        ]
+        return harness, {
+            "boundary": boundary_envelope,
+            "open": envelope(pre_command_open_events),
+            "final": final_envelope,
+        }, final_events
+
+    def _provider_snapshots(self, envelopes: dict[str, dict], order: list[str]):
+        provider_snapshots = iter([envelopes[key] for key in order])
+
+        def provider_call(method, extras=None, timeout=15.0):
+            if method == runner.TARGET_METHOD_GET_SEQUENCE:
+                return runner.TARGET_RESULT_OK, "3"
+            if method == runner.TARGET_METHOD_GET_SNAPSHOT:
+                return runner.TARGET_RESULT_OK, json.dumps(next(provider_snapshots))
+            self.fail(f"unexpected provider method {method}")
+
+        return provider_call
+
+    def _target_wait(self, call_order: list[str]):
+        def target_wait(**kwargs):
+            event_type = kwargs["event_type"]
+            if event_type == "STT_READY":
+                call_order.append("wait-STT_READY")
+            elif event_type == "CUE_REQUESTED":
+                call_order.append("wait-CUE_REQUESTED")
+            waited = event(
+                {"STT_READY": 11, "CUE_REQUESTED": 12, "DETECTOR_REARMED": 18}[event_type],
+                event_type,
+            )
+            return [waited], envelope([waited], lowest=waited["s"])
+
+        return target_wait
+
+    def _invoke_wake(self, call_order: list[str]):
+        def invoke_wake_source(trial_id: str, fixture_id: str, volume_index: int) -> dict:
+            call_order.append("wake-completed")
+            return source_result(trial_id, fixture_id)
+
+        return invoke_wake_source
+
+    def test_terminal_before_dispatch_suppresses_command_and_invalidates(self) -> None:
+        """A SESSION_COMPLETED observed before dispatch prevents source invocation
+        and the attempt becomes INVALID with the explicit harness-timing reason."""
+        harness, envelopes, _ = self._command_harness()
+        call_order: list[str] = []
+        provider_call = self._provider_snapshots(
+            envelopes, ["boundary", "final", "final"]
+        )
+
+        def invoke_command_source(**kwargs):
+            self.fail("command source must not be invoked after the session ended")
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source", side_effect=self._invoke_wake(call_order)), \
+                patch.object(harness, "_invoke_command_source_with_armed_wait", side_effect=invoke_command_source), \
+                patch.object(harness, "_wait_for_target_events", side_effect=self._target_wait(call_order)), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-window-closed",
+                runner.MatrixSlot(idle_s=1, wake_only=False, ordinal=2),
+                "natural_wake",
+                "qwen_command",
+            )
+
+        self.assertEqual(attempt.status, runner.AttemptStatus.INVALID, attempt.__dict__)
+        self.assertIsNone(attempt.classification)
+        self.assertEqual(
+            attempt.invalid_reason,
+            runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW,
+        )
+        self.assertTrue(
+            any("listening session ended before command delivery" in failure
+                for failure in attempt.failures),
+            attempt.failures,
+        )
+        self.assertIn("listening_window_closed", attempt.invalid_details)
+        self.assertEqual(
+            attempt.invalid_details["listening_window_closed"]["terminal_sequence"],
+            16,
+        )
+        # The wake and target events stay preserved: the attempt remains visible.
+        self.assertIs(harness.attempts[-1], attempt)
+        self.assertTrue(attempt.target_timing["events"])
+
+    def test_command_inside_window_failure_stays_valid_product_failure(self) -> None:
+        """A command delivered while the session is open continues through the
+        existing path; a genuine capture/routing failure remains a valid failure."""
+        harness, envelopes, final_events = self._command_harness()
+        broken_final = copy.deepcopy(envelopes["final"])
+        broken_final["events"] = [
+            item for item in broken_final["events"] if item["t"] != "STT_FINAL"
+        ]
+        broken_final["highestSequence"] = broken_final["events"][-1]["s"]
+        provider_call = self._provider_snapshots(
+            {
+                "boundary": envelopes["boundary"],
+                "open": envelopes["open"],
+                "final": broken_final,
+            },
+            ["boundary", "open", "final"],
+        )
+        call_order: list[str] = []
+
+        def invoke_command_source(**kwargs):
+            call_order.append("command-dispatched")
+            command_events = [event(15, "COMMAND_ROUTING_RESULT")]
+            command_result = source_result("trial-window-open-cmd", "qwen_command")
+            command_result["command_transcript_sha256"] = "b" * 64
+            return command_result, command_events, envelope(command_events, lowest=15)
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source", side_effect=self._invoke_wake(call_order)), \
+                patch.object(harness, "_invoke_command_source_with_armed_wait", side_effect=invoke_command_source), \
+                patch.object(harness, "_wait_for_target_events", side_effect=self._target_wait(call_order)), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-window-open",
+                runner.MatrixSlot(idle_s=1, wake_only=False, ordinal=2),
+                "natural_wake",
+                "qwen_command",
+            )
+
+        self.assertIn("command-dispatched", call_order)
+        self.assertEqual(attempt.status, runner.AttemptStatus.FAILED)
+        self.assertEqual(
+            attempt.classification,
+            runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+        )
+        self.assertEqual(harness.valid_failed_slots, {"1:wake_plus_command:2"})
+
+    def test_reclassify_proves_delivery_after_session_end(self) -> None:
+        """The pure defensive check uses epoch wall clocks only and never
+        mislabels in-window or unproven deliveries."""
+        def attempt(request_ms: int | None, terminal_w: int | None,
+                    *, wake_only: bool = False,
+                    status: runner.AttemptStatus = runner.AttemptStatus.FAILED,
+                    with_command: bool = True) -> runner.MatrixAttempt:
+            events = [] if terminal_w is None else [
+                {"s": 16, "t": "SESSION_COMPLETED", "w": terminal_w, "g": 11, "i": 10}
+            ]
+            timing = (
+                {"command": {"request_wall_clock_ms": request_ms}}
+                if with_command else {}
+            )
+            return runner.MatrixAttempt(
+                "t", runner.MatrixSlot(idle_s=10, wake_only=wake_only, ordinal=1),
+                1, status,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing=timing,
+                target_timing={"events": events},
+            )
+
+        # Delivery provably began after the session terminal event.
+        late = attempt(request_ms=2_000, terminal_w=1_000)
+        self.assertTrue(runner.command_delivery_after_session_end(late))
+        self.assertTrue(runner.reclassify_out_of_window_command_attempt(late))
+        self.assertEqual(late.status, runner.AttemptStatus.INVALID)
+        self.assertIsNone(late.classification)
+        self.assertEqual(
+            late.invalid_reason, runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+        )
+        self.assertTrue(any("session ended" in f for f in late.failures), late.failures)
+        self.assertIn("listening_window_closed", late.invalid_details)
+
+        # Delivery inside the window: unchanged valid failure.
+        in_window = attempt(request_ms=900, terminal_w=1_000)
+        self.assertFalse(runner.command_delivery_after_session_end(in_window))
+        self.assertFalse(runner.reclassify_out_of_window_command_attempt(in_window))
+        self.assertEqual(in_window.status, runner.AttemptStatus.FAILED)
+        self.assertEqual(
+            in_window.classification,
+            runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+        )
+
+        # Missing command timing, missing terminal, wake-only and passed
+        # attempts are never reclassified.
+        self.assertFalse(runner.command_delivery_after_session_end(
+            attempt(None, 1_000)))
+        self.assertFalse(runner.command_delivery_after_session_end(
+            attempt(2_000, None)))
+        self.assertFalse(runner.command_delivery_after_session_end(
+            attempt(2_000, 1_000, wake_only=True)))
+        self.assertFalse(runner.command_delivery_after_session_end(
+            attempt(2_000, 1_000, status=runner.AttemptStatus.PASSED)))
+        self.assertFalse(runner.command_delivery_after_session_end(
+            attempt(2_000, 1_000, with_command=False)))
+
+    def test_checkpoint_load_reclassifies_and_keeps_slot_retryable(self) -> None:
+        """Loading a preserved run invalidates the out-of-window attempt, keeps
+        the position incomplete, and leaves it eligible for bounded retry."""
+        private_root = Path(tempfile.mkdtemp())
+        slot = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=2)
+        slot_open = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=3)
+        producer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        producer.attempts = [
+            runner.MatrixAttempt(
+                "trial-007", slot, 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                failures=["captured command transcript does not match the approved fixture expectation"],
+                source_timing={"command": {"request_wall_clock_ms": 2_000}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+            runner.MatrixAttempt(
+                "trial-008", slot_open, 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 900}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+        ]
+        producer.checkpoint()
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+
+        by_id = {attempt.trial_id: attempt for attempt in consumer.attempts}
+        self.assertEqual(by_id["trial-007"].status, runner.AttemptStatus.INVALID)
+        self.assertEqual(
+            by_id["trial-007"].invalid_reason,
+            runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW,
+        )
+        self.assertEqual(by_id["trial-008"].status, runner.AttemptStatus.FAILED)
+        # The required position is incomplete and stays eligible for bounded retry.
+        self.assertFalse(consumer.is_matrix_complete())
+        self.assertEqual(consumer._invalid_count_for(slot), 1)
+        self.assertLess(consumer._invalid_count_for(slot), runner.VALID_MAX_ATTEMPTS)
+        self.assertEqual(consumer.valid_failed_slots, {slot_open.position_id})
+        self.assertEqual(consumer.invalid_attempt_count, 1)
+        self.assertEqual(
+            consumer.completed_slots,
+            {f"{slot.position_id}:1", f"{slot_open.position_id}:1"},
+        )
+
+    def test_export_reclassifies_and_reconciles_summary_counts(self) -> None:
+        """Reclassification reconciles evidence summary counts and exports the
+        explicit invalid reason; schema validation passes."""
+        harness = make_runner(runner.RunKind.DIAGNOSTIC)
+        harness.target_identity = runner.DeviceIdentity(
+            "s21", "samsung", "SM-G991B", "15", "35", "fingerprint", "pkg", 1,
+        )
+        harness.source_identity = runner.DeviceIdentity(
+            "s23u", "samsung", "SM-S918B", "15", "35", "fingerprint", "pkg", 1,
+        )
+        harness.manifest = runner.RunManifest(
+            "run-1", runner.RunKind.DIAGNOSTIC, runner.GateMode.DIAGNOSTIC,
+            runner.MATRIX_ID, runner.MATRIX_VERSION, runner.utc_now(),
+            "s23u", "s21", "set-1", {"natural_wake": "hash"}, None, None,
+        )
+        slots = runner.matrix_slots_for_target("s21")
+        command_slots = [s for s in slots if not s.wake_only]
+        harness.attempts = [
+            runner.MatrixAttempt(
+                "pass-1", command_slots[0], 1, runner.AttemptStatus.PASSED),
+            runner.MatrixAttempt(
+                "fail-in-window", command_slots[1], 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 900}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+            runner.MatrixAttempt(
+                "fail-out-of-window", command_slots[2], 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 2_000}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+        ]
+        evidence = harness.export_evidence()
+        summary = evidence["summary"]
+        self.assertEqual(summary["total_attempts"], 3)
+        self.assertEqual(summary["valid"], 2)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["invalid"], 1)
+        by_name = {case["name"]: case for case in evidence["cases"]}
+        self.assertEqual(
+            by_name["fail-out-of-window"]["status"], "invalid")
+        self.assertEqual(
+            by_name["fail-out-of-window"]["invalid_reason"],
+            "command_outside_listening_window",
+        )
+        self.assertEqual(by_name["fail-in-window"]["status"], "failed")
+        self.assertEqual(
+            by_name["fail-in-window"]["failure_classification"],
+            "command_capture_or_routing_failure",
+        )
+        self.assertFalse(evidence["wake_reliability"]["complete_valid_matrix"])
+        valid, issues = evidence_metrics.validate_record(evidence, [])
+        self.assertTrue(valid, issues)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_acoustic_wake_reliability_runner.py
+++ b/scripts/tests/test_acoustic_wake_reliability_runner.py
@@ -1438,6 +1438,9 @@ class OutOfWindowCommandTests(unittest.TestCase):
             attempt.invalid_details["listening_window_closed"]["terminal_sequence"],
             16,
         )
+        # The pre-dispatch target observation is persisted as same-target
+        # ordering evidence for any later retrospective review.
+        self.assertEqual(attempt.target_timing["pre_dispatch_terminal_sequence"], 16)
         # The wake and target events stay preserved: the attempt remains visible.
         self.assertIs(harness.attempts[-1], attempt)
         self.assertTrue(attempt.target_timing["events"])
@@ -1491,15 +1494,19 @@ class OutOfWindowCommandTests(unittest.TestCase):
             attempt.classification,
             runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
         )
+        # The pre-dispatch observation recorded no terminal: dispatch proceeded.
+        self.assertIsNone(attempt.target_timing["pre_dispatch_terminal_sequence"])
         self.assertEqual(harness.valid_failed_slots, {"1:wake_plus_command:2"})
 
-    def test_reclassify_proves_delivery_after_session_end(self) -> None:
-        """The pure defensive check uses epoch wall clocks only and never
-        mislabels in-window or unproven deliveries."""
+    def test_retrospective_reclassification_requires_proof(self) -> None:
+        """Raw cross-device wall clocks are never proof: reclassification needs
+        same-target pre-dispatch ordering or a persisted validated alignment
+        record conclusive beyond its range."""
         def attempt(request_ms: int | None, terminal_w: int | None,
                     *, wake_only: bool = False,
                     status: runner.AttemptStatus = runner.AttemptStatus.FAILED,
-                    with_command: bool = True) -> runner.MatrixAttempt:
+                    with_command: bool = True,
+                    pre_dispatch: int | None = None) -> runner.MatrixAttempt:
             events = [] if terminal_w is None else [
                 {"s": 16, "t": "SESSION_COMPLETED", "w": terminal_w, "g": 11, "i": 10}
             ]
@@ -1507,52 +1514,127 @@ class OutOfWindowCommandTests(unittest.TestCase):
                 {"command": {"request_wall_clock_ms": request_ms}}
                 if with_command else {}
             )
+            target = {"events": events}
+            if pre_dispatch is not None:
+                target["pre_dispatch_terminal_sequence"] = pre_dispatch
             return runner.MatrixAttempt(
                 "t", runner.MatrixSlot(idle_s=10, wake_only=wake_only, ordinal=1),
                 1, status,
                 classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
                 source_timing=timing,
-                target_timing={"events": events},
+                target_timing=target,
             )
 
-        # Delivery provably began after the session terminal event.
-        late = attempt(request_ms=2_000, terminal_w=1_000)
-        self.assertTrue(runner.command_delivery_after_session_end(late))
-        self.assertTrue(runner.reclassify_out_of_window_command_attempt(late))
-        self.assertEqual(late.status, runner.AttemptStatus.INVALID)
-        self.assertIsNone(late.classification)
-        self.assertEqual(
-            late.invalid_reason, runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
-        )
-        self.assertTrue(any("session ended" in f for f in late.failures), late.failures)
-        self.assertIn("listening_window_closed", late.invalid_details)
+        ALIGNED = {
+            "source_alias": "s23u", "target_alias": "s21",
+            "offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+            "method": "preflight_alignment_probe",
+        }
 
-        # Delivery inside the window: unchanged valid failure.
+        # Raw wall-clock ordering without any calibration or marker is NOT
+        # proof: an unmeasured source-ahead offset could explain it.
+        uncalibrated = attempt(request_ms=2_000, terminal_w=1_000)
+        self.assertFalse(runner.command_delivery_after_session_end(uncalibrated))
+        self.assertFalse(runner.reclassify_out_of_window_command_attempt(uncalibrated))
+        self.assertEqual(uncalibrated.status, runner.AttemptStatus.FAILED)
+        self.assertEqual(
+            uncalibrated.classification,
+            runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+        )
+
+        # Priority 1: same-target pre-dispatch journal observation.
+        marked = attempt(request_ms=2_000, terminal_w=1_000, pre_dispatch=16)
+        self.assertTrue(runner.command_delivery_after_session_end(marked))
+        self.assertTrue(runner.reclassify_out_of_window_command_attempt(marked))
+        self.assertEqual(marked.status, runner.AttemptStatus.INVALID)
+        self.assertIsNone(marked.classification)
+        self.assertEqual(
+            marked.invalid_reason, runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+        )
+        self.assertTrue(any("proven" in f for f in marked.failures), marked.failures)
+        self.assertIn("listening_window_closed", marked.invalid_details)
+
+        # Priority 2: validated alignment conclusive for every offset in range.
+        conclusive = attempt(request_ms=2_000, terminal_w=1_000)
+        self.assertTrue(runner.command_delivery_after_session_end(conclusive, ALIGNED))
+        self.assertTrue(runner.reclassify_out_of_window_command_attempt(conclusive, ALIGNED))
+        self.assertEqual(conclusive.status, runner.AttemptStatus.INVALID)
+        self.assertEqual(
+            conclusive.invalid_reason, runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW
+        )
+
+        # Review scenario: source clock 750 ms ahead; command actually requested
+        # 300 ms before session end appears 450 ms after it.  Even with the
+        # persisted [-800, -700] range the adjusted ordering is not conclusive.
+        source_ahead = attempt(request_ms=1_450, terminal_w=1_000)
+        source_ahead_alignment = {
+            **ALIGNED, "offset_range_ms": [-800, -700],
+        }
+        self.assertFalse(runner.command_delivery_after_session_end(
+            source_ahead, source_ahead_alignment))
+        self.assertFalse(runner.reclassify_out_of_window_command_attempt(
+            source_ahead, source_ahead_alignment))
+        self.assertEqual(source_ahead.status, runner.AttemptStatus.FAILED)
+
+        # Same range but genuinely late by more than the worst-case offset:
+        # conclusive.
+        genuinely_late = attempt(request_ms=3_000, terminal_w=1_000)
+        self.assertTrue(runner.command_delivery_after_session_end(
+            genuinely_late, source_ahead_alignment))
+
+        # Delivery inside the window with aligned clocks: unchanged.
         in_window = attempt(request_ms=900, terminal_w=1_000)
-        self.assertFalse(runner.command_delivery_after_session_end(in_window))
-        self.assertFalse(runner.reclassify_out_of_window_command_attempt(in_window))
+        self.assertFalse(runner.command_delivery_after_session_end(in_window, ALIGNED))
+        self.assertFalse(runner.reclassify_out_of_window_command_attempt(in_window, ALIGNED))
         self.assertEqual(in_window.status, runner.AttemptStatus.FAILED)
         self.assertEqual(
             in_window.classification,
             runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
         )
 
+        # Untrustworthy alignment records are never used.  (Alias pairing is
+        # enforced by the runner at load time — see
+        # test_checkpoint_load_rejects_alignment_for_other_devices.)
+        for broken in (
+            None,
+            {"offset_range_ms": [-100, 100], "uncertainty_ms": 25},
+            {"offset_range_ms": [100, -100], "uncertainty_ms": 25,
+             "method": "probe"},
+            {"offset_range_ms": [-100, 100], "uncertainty_ms": -1,
+             "method": "probe"},
+            {"offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+             "method": " "},
+            {"offset_range_ms": [True, 100], "uncertainty_ms": 25,
+             "method": "probe"},
+            {"offset_range_ms": [-100, 100], "uncertainty_ms": True,
+             "method": "probe"},
+            {"offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+             "method": 7},
+        ):
+            with self.subTest(alignment=broken):
+                late = attempt(request_ms=2_000, terminal_w=1_000)
+                self.assertFalse(
+                    runner.command_delivery_after_session_end(late, broken))
+                self.assertFalse(
+                    runner.reclassify_out_of_window_command_attempt(late, broken))
+                self.assertEqual(late.status, runner.AttemptStatus.FAILED)
+
         # Missing command timing, missing terminal, wake-only and passed
         # attempts are never reclassified.
         self.assertFalse(runner.command_delivery_after_session_end(
-            attempt(None, 1_000)))
+            attempt(None, 1_000), ALIGNED))
         self.assertFalse(runner.command_delivery_after_session_end(
-            attempt(2_000, None)))
+            attempt(2_000, None), ALIGNED))
         self.assertFalse(runner.command_delivery_after_session_end(
-            attempt(2_000, 1_000, wake_only=True)))
+            attempt(2_000, 1_000, wake_only=True), ALIGNED))
         self.assertFalse(runner.command_delivery_after_session_end(
-            attempt(2_000, 1_000, status=runner.AttemptStatus.PASSED)))
+            attempt(2_000, 1_000, status=runner.AttemptStatus.PASSED), ALIGNED))
         self.assertFalse(runner.command_delivery_after_session_end(
-            attempt(2_000, 1_000, with_command=False)))
+            attempt(2_000, 1_000, with_command=False), ALIGNED))
 
-    def test_checkpoint_load_reclassifies_and_keeps_slot_retryable(self) -> None:
-        """Loading a preserved run invalidates the out-of-window attempt, keeps
-        the position incomplete, and leaves it eligible for bounded retry."""
+    def test_checkpoint_load_preserves_uncalibrated_classification(self) -> None:
+        """An uncalibrated preserved run keeps its recorded classification:
+        raw wall-clock ordering is never reclassified on load."""
         private_root = Path(tempfile.mkdtemp())
         slot = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=2)
         slot_open = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=3)
@@ -1584,26 +1666,110 @@ class OutOfWindowCommandTests(unittest.TestCase):
         consumer.load_checkpoint(producer.run_id)
 
         by_id = {attempt.trial_id: attempt for attempt in consumer.attempts}
-        self.assertEqual(by_id["trial-007"].status, runner.AttemptStatus.INVALID)
+        # No clock-alignment record and no same-target marker: preserved.
+        self.assertIsNone(consumer.clock_alignment)
+        self.assertEqual(by_id["trial-007"].status, runner.AttemptStatus.FAILED)
         self.assertEqual(
-            by_id["trial-007"].invalid_reason,
-            runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW,
+            by_id["trial-007"].classification,
+            runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
         )
         self.assertEqual(by_id["trial-008"].status, runner.AttemptStatus.FAILED)
-        # The required position is incomplete and stays eligible for bounded retry.
-        self.assertFalse(consumer.is_matrix_complete())
-        self.assertEqual(consumer._invalid_count_for(slot), 1)
-        self.assertLess(consumer._invalid_count_for(slot), runner.VALID_MAX_ATTEMPTS)
-        self.assertEqual(consumer.valid_failed_slots, {slot_open.position_id})
-        self.assertEqual(consumer.invalid_attempt_count, 1)
+        # Both positions remain validly complete; the slot is not retried away.
+        self.assertEqual(
+            consumer.valid_failed_slots, {slot.position_id, slot_open.position_id})
+        self.assertEqual(consumer.invalid_attempt_count, 0)
         self.assertEqual(
             consumer.completed_slots,
             {f"{slot.position_id}:1", f"{slot_open.position_id}:1"},
         )
 
-    def test_export_reclassifies_and_reconciles_summary_counts(self) -> None:
-        """Reclassification reconciles evidence summary counts and exports the
-        explicit invalid reason; schema validation passes."""
+    def test_checkpoint_load_reclassifies_with_validated_alignment(self) -> None:
+        """A persisted validated clock-alignment record conclusive beyond its
+        range reclassifies on load; the position stays retryable; the record
+        round-trips through the checkpoint."""
+        private_root = Path(tempfile.mkdtemp())
+        slot = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=2)
+        producer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        producer.clock_alignment = {
+            "source_alias": "s23u", "target_alias": "s21",
+            "offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+            "method": "preflight_alignment_probe",
+        }
+        producer.attempts = [
+            runner.MatrixAttempt(
+                "trial-007", slot, 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                failures=["captured command transcript does not match the approved fixture expectation"],
+                source_timing={"command": {"request_wall_clock_ms": 2_000}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+        ]
+        producer.checkpoint()
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+
+        self.assertEqual(
+            consumer.clock_alignment,
+            {
+                "source_alias": "s23u", "target_alias": "s21",
+                "offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+                "method": "preflight_alignment_probe",
+            },
+        )
+        attempt = consumer.attempts[0]
+        self.assertEqual(attempt.status, runner.AttemptStatus.INVALID)
+        self.assertEqual(
+            attempt.invalid_reason,
+            runner.InvalidReason.COMMAND_OUTSIDE_LISTENING_WINDOW,
+        )
+        # The required position is incomplete and stays eligible for bounded retry.
+        self.assertFalse(consumer.is_matrix_complete())
+        self.assertEqual(consumer._invalid_count_for(slot), 1)
+        self.assertLess(consumer._invalid_count_for(slot), runner.VALID_MAX_ATTEMPTS)
+        self.assertEqual(consumer.valid_failed_slots, set())
+        self.assertEqual(consumer.invalid_attempt_count, 1)
+
+    def test_checkpoint_load_rejects_alignment_for_other_devices(self) -> None:
+        """An alignment record naming a different device pair is untrustworthy."""
+        private_root = Path(tempfile.mkdtemp())
+        slot = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=2)
+        producer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        producer.clock_alignment = {
+            "source_alias": "other", "target_alias": "s21",
+            "offset_range_ms": [-100, 100], "uncertainty_ms": 25,
+            "method": "preflight_alignment_probe",
+        }
+        producer.attempts = [
+            runner.MatrixAttempt(
+                "trial-007", slot, 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 2_000}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+        ]
+        producer.checkpoint()
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+        self.assertIsNone(consumer.clock_alignment)
+        self.assertEqual(consumer.attempts[0].status, runner.AttemptStatus.FAILED)
+
+    def test_export_reconciles_counts_without_unproven_reclassification(self) -> None:
+        """Unproven wall-clock ordering never changes exported totals: the
+        attempt stays a valid product failure and counts reconcile."""
         harness = make_runner(runner.RunKind.DIAGNOSTIC)
         harness.target_identity = runner.DeviceIdentity(
             "s21", "samsung", "SM-G991B", "15", "35", "fingerprint", "pkg", 1,
@@ -1628,10 +1794,63 @@ class OutOfWindowCommandTests(unittest.TestCase):
                 target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
             ),
             runner.MatrixAttempt(
-                "fail-out-of-window", command_slots[2], 1, runner.AttemptStatus.FAILED,
+                "fail-wall-clock-only", command_slots[2], 1, runner.AttemptStatus.FAILED,
                 classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
                 source_timing={"command": {"request_wall_clock_ms": 2_000}},
                 target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+        ]
+        evidence = harness.export_evidence()
+        summary = evidence["summary"]
+        self.assertEqual(summary["total_attempts"], 3)
+        self.assertEqual(summary["valid"], 3)
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(summary["invalid"], 0)
+        by_name = {case["name"]: case for case in evidence["cases"]}
+        self.assertEqual(by_name["fail-wall-clock-only"]["status"], "failed")
+        self.assertEqual(
+            by_name["fail-wall-clock-only"]["failure_classification"],
+            "command_capture_or_routing_failure",
+        )
+        self.assertEqual(by_name["fail-in-window"]["status"], "failed")
+        valid, issues = evidence_metrics.validate_record(evidence, [])
+        self.assertTrue(valid, issues)
+
+    def test_export_reclassifies_only_with_persisted_proof(self) -> None:
+        """With same-target pre-dispatch proof the attempt is reclassified at
+        export and summary counts reconcile; schema validation passes."""
+        harness = make_runner(runner.RunKind.DIAGNOSTIC)
+        harness.target_identity = runner.DeviceIdentity(
+            "s21", "samsung", "SM-G991B", "15", "35", "fingerprint", "pkg", 1,
+        )
+        harness.source_identity = runner.DeviceIdentity(
+            "s23u", "samsung", "SM-S918B", "15", "35", "fingerprint", "pkg", 1,
+        )
+        harness.manifest = runner.RunManifest(
+            "run-1", runner.RunKind.DIAGNOSTIC, runner.GateMode.DIAGNOSTIC,
+            runner.MATRIX_ID, runner.MATRIX_VERSION, runner.utc_now(),
+            "s23u", "s21", "set-1", {"natural_wake": "hash"}, None, None,
+        )
+        slots = runner.matrix_slots_for_target("s21")
+        command_slots = [s for s in slots if not s.wake_only]
+        harness.attempts = [
+            runner.MatrixAttempt(
+                "pass-1", command_slots[0], 1, runner.AttemptStatus.PASSED),
+            runner.MatrixAttempt(
+                "fail-in-window", command_slots[1], 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 900}},
+                target_timing={"events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}]},
+            ),
+            runner.MatrixAttempt(
+                "fail-proven-out-of-window", command_slots[2], 1, runner.AttemptStatus.FAILED,
+                classification=runner.FailureClassification.COMMAND_CAPTURE_OR_ROUTING_FAILURE,
+                source_timing={"command": {"request_wall_clock_ms": 2_000}},
+                target_timing={
+                    "events": [{"s": 16, "t": "SESSION_COMPLETED", "w": 1_000}],
+                    "pre_dispatch_terminal_sequence": 16,
+                },
             ),
         ]
         evidence = harness.export_evidence()
@@ -1642,16 +1861,10 @@ class OutOfWindowCommandTests(unittest.TestCase):
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["invalid"], 1)
         by_name = {case["name"]: case for case in evidence["cases"]}
+        self.assertEqual(by_name["fail-proven-out-of-window"]["status"], "invalid")
         self.assertEqual(
-            by_name["fail-out-of-window"]["status"], "invalid")
-        self.assertEqual(
-            by_name["fail-out-of-window"]["invalid_reason"],
+            by_name["fail-proven-out-of-window"]["invalid_reason"],
             "command_outside_listening_window",
-        )
-        self.assertEqual(by_name["fail-in-window"]["status"], "failed")
-        self.assertEqual(
-            by_name["fail-in-window"]["failure_classification"],
-            "command_capture_or_routing_failure",
         )
         self.assertFalse(evidence["wake_reliability"]["complete_valid_matrix"])
         valid, issues = evidence_metrics.validate_record(evidence, [])


### PR DESCRIPTION
## Summary

Harness-only fixes surfaced by the physical #1410 acoustic matrix execution (no production code changes).

1. **`public_environment_snapshot`** now normalises device-native values to the published evidence schema (`scripts/testdata/test_evidence.schema.json`): string `ringer_mode`/`dnd_mode` names and integer `uptime_seconds`. Previously the runner emitted int modes and float uptime, which failed schema validation on real devices (`schema:cases.0 … ringer_mode 0 is not of type 'string'`), blocking all evidence export for physical runs.
2. **Missing `import sys`** — the `__main__` fatal handler referenced `sys.stderr`/`SystemExit(2)` without importing `sys`, masking the schema error with a `NameError`.
3. Regression test `test_public_environment_snapshot_normalises_to_evidence_schema_types` locks the projection contract.

## Out-of-window command handling (reviews 4833215906 + 4833514166)

**Forward prevention (accepted, unchanged):** immediately before command dispatch the runner takes one target-journal snapshot; if it already contains the correlated session's terminal event (`SESSION_COMPLETED`/`SESSION_CANCELLED`), command playback is suppressed, the attempt is `INVALID` / `command_outside_listening_window`, and the slot stays eligible for bounded retry. No idle polling, no fixed delay. The pre-dispatch target observation is persisted per attempt (`target_timing.pre_dispatch_terminal_sequence`) as same-target ordering evidence.

**Retrospective reclassification now requires proof (remediation of review 4833514166):** the prior raw cross-device wall-clock comparison (`source request_wall_clock_ms > target terminal w`) is **removed** — two Android devices' epoch wall clocks are not a synchronised clock. Reclassification on checkpoint load / evidence export happens only when:

1. **Same-target pre-dispatch proof** — a persisted target-journal observation taken before command invocation already contained the correlated terminal sequence (authoritative, no cross-device clocks); or
2. **Persisted bounded clock-alignment evidence** — a per-run `clock_alignment` record (validated structurally and against the run's device pair: `offset_range_ms` [lo, hi] bounding target−source wall-clock offset, non-negative `uncertainty_ms`, non-empty `method`) makes the command provably after the terminal for every offset in range (`request + lo > terminal`).

Without either, the recorded classification is **preserved** — an unmeasured source-ahead offset must not silently remove a genuine product failure. Evidence priority 1→2→3 is implemented in `command_delivery_after_session_end()` / `reclassify_out_of_window_command_attempt()` with the runner-level `clock_alignment` checkpoint field.

## Physical evidence (regenerated from the preserved private run, no new trials)

The preserved S21 run contains **no pre-command target snapshot and no clock-alignment record**, so trial 007 (10s wake+cmd) keeps its recorded `FAILED / command_capture_or_routing_failure` classification:

- **S21 diagnostic: 27/27 valid — 15 passed / 12 failed / 8 invalid** (complete matrix); classifications 11× `classifier_model_miss` + 1× `command_capture_or_routing_failure`.
- **S23U comparison: unchanged 8/8 — 2 passed / 6 failed / 5 invalid**, all failures `classifier_model_miss`.

Raw fixtures, checkpoints and the preserved snapshot were not altered; totals derive from attempt records via the corrected runner path.

## Tests

`OutOfWindowCommandTests` now also covers: raw wall-clock ordering without calibration or marker is **not** reclassified; source-ahead/source-behind skew scenarios (the review's 750 ms-ahead example) are inconclusive even with a persisted range unless conclusive at every offset; same-target pre-dispatch markers and conclusive validated alignment records do reclassify; untrustworthy alignment records (bad range/uncertainty/method/wrong device pair) are rejected; uncalibrated preserved runs keep their classification on load; exported totals reconcile in both directions. Forward-path tests unchanged.

## Verification (head `195ae7d2`)

- `python3 -m unittest scripts.tests.test_acoustic_wake_reliability_runner`: **69 passed**; full `scripts/tests` discovery: **694 passed**.
- Runner fixture/self-test: PASS.
- Regenerated evidence: schema errors 0; `validate_record` privacy/schema valid; dashboard renders **27/27** (S21) and **8/8** (S23U).
- `git diff --check`: clean.

## Evidence

Physical run evidence remains private under `scripts/private-acoustic-runs/` (gitignored). Final totals and the trial-007 classification note are recorded on the updated #1410 and #1402 execution comments.

Closes #1410 evidence-export blocker only; the wake reliability remediation decision is recorded separately on #1402.

Do not merge — wait for review.