### PR TITLE
fix(#1433): keep first wake-command STT session alive through the handoff

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,14 @@ android {
     }
 
     testOptions {
-        unitTests.all { it.useJUnitPlatform() }
+        unitTests {
+            // Allow Android framework stubs (e.g. android.util.Log) to return default
+            // values in JVM unit tests rather than throwing "not mocked" RuntimeExceptions.
+            // The controller-to-wake integration tests drive the real
+            // NativeAndroidVoiceInputController, which logs through android.util.Log.
+            isReturnDefaultValues = true
+            all { it.useJUnitPlatform() }
+        }
     }
 
     lint {

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import com.kernel.ai.MainActivity
 import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.NO_SPEECH_WINDOW_EXHAUSTED
 import com.kernel.ai.core.voice.AcousticJournalBridge
 import com.kernel.ai.core.voice.containsWakePhrase
 import com.kernel.ai.core.voice.StartListeningCuePlayer
@@ -112,8 +113,16 @@ internal fun playWakeCue(
 internal sealed interface WakeAttemptOutcome {
     /** Recognised and returned a transcript. */
     data class GotTranscript(val text: String) : WakeAttemptOutcome
-    /** Recogniser started but produced no useful result. */
-    data class NoTranscript(val category: String) : WakeAttemptOutcome
+
+    /**
+     * Recogniser started but produced no useful result.
+     * [skipRetry] suppresses the session-level retry: set only for the
+     * no-speech-window-exhausted case (#1433) where the command window has closed
+     * and a second attempt would only re-wait.  The journal's STT_ERROR category
+     * remains the standard "stt_recognition_failed".
+     */
+    data class NoTranscript(val category: String, val skipRetry: Boolean = false) : WakeAttemptOutcome
+
     /** STT could not be started. */
     data object Unavailable : WakeAttemptOutcome
 }
@@ -248,7 +257,14 @@ internal suspend fun runWakeAttempt(
                     AcousticEventType.STT_ERROR,
                     metadata = { mapOf("category" to "stt_recognition_failed") },
                 )
-                WakeAttemptOutcome.NoTranscript("stt_recognition_failed")
+                // #1433: when the first session's no-speech window is fully exhausted
+                // (in-place refreshes spent and the platform still heard nothing), the
+                // command window has closed — a second attempt would only re-wait.
+                // Genuine failures (any other error) still use the bounded retry.
+                WakeAttemptOutcome.NoTranscript(
+                    "stt_recognition_failed",
+                    skipRetry = terminalEvent.category == NO_SPEECH_WINDOW_EXHAUSTED,
+                )
             } else {
                 WakeAttemptOutcome.NoTranscript("stt_stopped_without_result")
             }
@@ -302,7 +318,7 @@ internal suspend fun runWakeCaptureSession(
             }
             is WakeAttemptOutcome.NoTranscript -> {
                 cancellationCategory = outcome.category
-                if (attempt < 2) continue else break
+                if (attempt < 2 && !outcome.skipRetry) continue else break
             }
             is WakeAttemptOutcome.Unavailable -> {
                 cancellationCategory = "stt_unavailable"

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -323,6 +323,104 @@ internal fun finalizeWakeSession(
         journal.cancel(cancellationCategory)
     }
 }
+
+/** Outcome of one wake-command handoff (session + routing). */
+internal data class WakeCommandHandoffResult(
+    val completed: Boolean,
+    val cancellationCategory: String,
+)
+
+/**
+ * Execute the full wake-command handoff for one confirmed activation.
+ *
+ * #1433 ordering contract:
+ * 1. The wake detector is stopped FIRST, and its strengthened `stop()` returns only
+ *    after the detection loop has terminated and released its AudioRecord — so
+ *    attempt-1 live STT capture is never requested while the detector still owns
+ *    the microphone.
+ * 2. `VOICE_SESSION_STARTED` is recorded only after that release.
+ * 3. The first STT attempt must reach readiness; the alert-session silence budget
+ *    (see `NativeAndroidVoiceInputController.ALERT_SESSION_SILENCE_TIMEOUT_MS`)
+ *    keeps the session open across the cue-to-command handoff so the runner's
+ *    command is captured in attempt 1 and no retry is needed on the normal path.
+ *
+ * The bounded retry still runs for genuine post-readiness recognition failures.
+ * On cancellation the active recognizer is stopped so no microphone owner or
+ * recognizer is left behind.  [rearmDetector] is invoked exactly once, after the
+ * session is terminal (including on cancellation, matching the previous service
+ * behaviour).  Throws [CancellationException].
+ */
+internal suspend fun runWakeCommandHandoff(
+    wakeWordDetector: WakeWordDetector,
+    voiceInputController: VoiceInputController,
+    cuePlayer: StartListeningCuePlayer,
+    generationId: Long,
+    sessionId: Long,
+    onError: (String) -> Unit = {},
+    routeTranscript: (String) -> Boolean,
+    onSessionTerminal: () -> Unit,
+    journal: WakeSessionJournal? = null,
+): WakeCommandHandoffResult {
+    // #1433: a confirmed wake activation must not request live STT capture until the
+    // wake detector has completed microphone-resource release.
+    wakeWordDetector.stop()
+
+    val sessionJournal = journal ?: WakeSessionJournal(generationId, sessionId)
+    sessionJournal.start()
+    var completed = false
+    var cancellationCategory = "stt_no_final_result"
+
+    try {
+        val sessionResult = runWakeCaptureSession { attempt ->
+            runWakeAttempt(
+                voiceInputController = voiceInputController,
+                journal = sessionJournal,
+                cuePlayer = cuePlayer,
+                attempt = attempt,
+                onError = onError,
+            )
+        }
+
+        cancellationCategory = sessionResult.cancellationCategory
+        val transcript = sessionResult.transcript
+
+        if (transcript != null) {
+            if (routeTranscript(transcript)) {
+                sessionJournal.record(
+                    AcousticEventType.COMMAND_ROUTING_RESULT,
+                    metadata = { mapOf("outcome" to "handed_off") },
+                )
+                completed = true
+            } else {
+                sessionJournal.record(
+                    AcousticEventType.COMMAND_ROUTING_RESULT,
+                    metadata = {
+                        mapOf(
+                            "outcome" to "failed",
+                            "category" to "route_activity_failed",
+                        )
+                    },
+                )
+                cancellationCategory = "route_activity_failed"
+            }
+        }
+    } catch (e: WakeAttemptCollectionException) {
+        cancellationCategory = e.category
+        Log.w(TAG, "WakeWordService: collection ${e.category} (attempt)", e)
+    } catch (e: CancellationException) {
+        cancellationCategory = "session_cancelled"
+        // No microphone owner or recognizer may survive a cancelled handoff.
+        voiceInputController.stopListening()
+        throw e
+    } catch (e: Exception) {
+        cancellationCategory = "session_failed"
+        Log.e(TAG, "WakeWordService: wake session failed", e)
+    } finally {
+        finalizeWakeSession(sessionJournal, completed, cancellationCategory)
+        onSessionTerminal()
+    }
+    return WakeCommandHandoffResult(completed, cancellationCategory)
+}
 private const val TAG = "KernelAI"
 private const val CHANNEL_ID = "kernel_wake_word"
 private const val NOTIFICATION_ID = 9_500
@@ -450,66 +548,26 @@ class WakeWordService : Service() {
 
     // ── Detection handoff ──────────────────────────────────────────────────────
 
-
-
     private fun handleDetection(generationId: Long, sessionId: Long) {
         serviceScope.launch {
             isHandlingDetection = true
-            val journal = WakeSessionJournal(generationId, sessionId)
-            journal.start()
-            var completed = false
-            var cancellationCategory = "stt_no_final_result"
-
             try {
-                val sessionResult = runWakeCaptureSession { attempt ->
-                    runWakeAttempt(
-                        voiceInputController = voiceInputController,
-                        journal = journal,
-                        cuePlayer = cuePlayer,
-                        attempt = attempt,
-                        onError = { msg ->
-                            if (msg.isNotBlank()) showWakeWordError(msg)
-                        },
-                    )
-                }
-
-                cancellationCategory = sessionResult.cancellationCategory
-                val transcript = sessionResult.transcript
-
-                if (transcript != null) {
-                    Log.d(TAG, "WakeWordService: routing final transcript")
-                    if (routeTranscript(transcript)) {
-                        journal.record(
-                            AcousticEventType.COMMAND_ROUTING_RESULT,
-                            metadata = { mapOf("outcome" to "handed_off") },
-                        )
-                        completed = true
-                    } else {
-                        journal.record(
-                            AcousticEventType.COMMAND_ROUTING_RESULT,
-                            metadata = {
-                                mapOf(
-                                    "outcome" to "failed",
-                                    "category" to "route_activity_failed",
-                                )
-                            },
-                        )
-                        cancellationCategory = "route_activity_failed"
-                    }
-                }
-            } catch (e: WakeAttemptCollectionException) {
-                cancellationCategory = e.category
-                Log.w(TAG, "WakeWordService: collection ${e.category} (attempt)", e)
+                runWakeCommandHandoff(
+                    wakeWordDetector = wakeWordDetector,
+                    voiceInputController = voiceInputController,
+                    cuePlayer = cuePlayer,
+                    generationId = generationId,
+                    sessionId = sessionId,
+                    onError = { msg -> if (msg.isNotBlank()) showWakeWordError(msg) },
+                    routeTranscript = ::routeTranscript,
+                    onSessionTerminal = {
+                        isHandlingDetection = false
+                        rearmDetector()
+                    },
+                )
             } catch (e: CancellationException) {
-                cancellationCategory = "session_cancelled"
-                throw e
-            } catch (e: Exception) {
-                cancellationCategory = "session_failed"
-                Log.e(TAG, "WakeWordService: wake session failed", e)
-            } finally {
-                finalizeWakeSession(journal, completed, cancellationCategory)
                 isHandlingDetection = false
-                rearmDetector()
+                throw e
             }
         }
     }

--- a/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffControllerIntegrationTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffControllerIntegrationTest.kt
@@ -1,0 +1,210 @@
+package com.kernel.ai.assistant
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.SpeechRecognizer
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.AndroidNativeRecognitionAvailability
+import com.kernel.ai.core.voice.AndroidNativeRecognitionLocaleStatus
+import com.kernel.ai.core.voice.AndroidNativeRecognitionSupport
+import com.kernel.ai.core.voice.NativeAndroidVoiceInputController
+import com.kernel.ai.core.voice.StartListeningCueContext
+import com.kernel.ai.core.voice.StartListeningCuePlayer
+import com.kernel.ai.core.voice.StartListeningCueResult
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.WakeWordDetector
+import com.kernel.ai.alarm.shouldPlayClockAlertListeningCue
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.Executor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Controller-to-wake-session regressions for review 4836608504, using the REAL
+ * [NativeAndroidVoiceInputController] (mocked platform support) through the full
+ * [WakeWordService.runWakeCommandHandoff] path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WakeCommandHandoffControllerIntegrationTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var controller: NativeAndroidVoiceInputController
+    private lateinit var listeners: MutableList<RecognitionListener>
+    private lateinit var recognizers: MutableList<SpeechRecognizer>
+
+    private val availability = AndroidNativeRecognitionAvailability(
+        isRecognitionAvailable = true,
+        isOnDeviceRecognitionAvailable = true,
+        languageTag = "en-AU",
+        languageDisplayName = "English (Australia)",
+        localeStatus = AndroidNativeRecognitionLocaleStatus.Ready,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        every { context.getSystemService(Context.AUDIO_SERVICE) } returns audioManager
+        val executor = mockk<Executor>(relaxed = true)
+        every { context.mainExecutor } returns executor
+        every { executor.execute(any()) } answers { firstArg<Runnable>().run() }
+
+        val support = mockk<AndroidNativeRecognitionSupport>(relaxed = true)
+        every { support.getCaptureAvailability() } returns availability
+        listeners = mutableListOf()
+        recognizers = mutableListOf()
+        every { support.createPlatformSpeechRecognizer() } answers {
+            val recognizer = mockk<SpeechRecognizer>(relaxed = true)
+            recognizers += recognizer
+            every { recognizer.setRecognitionListener(any()) } answers {
+                listeners += firstArg<RecognitionListener>()
+            }
+            recognizer
+        }
+        controller = NativeAndroidVoiceInputController(context, support)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private class OrderingDetector : WakeWordDetector {
+        override val isAvailable: Boolean get() = true
+        var released = false
+        override fun start(
+            generationId: Long,
+            onDetected: () -> Unit,
+            verifyWindow: ((ShortArray) -> Boolean)?,
+        ) = Unit
+
+        override fun stop() {
+            released = true
+        }
+    }
+
+    private fun cuePlayer(): StartListeningCuePlayer =
+        mockk<StartListeningCuePlayer>().apply {
+            every { playCue(StartListeningCueContext.WAKE_WORD) } returns
+                StartListeningCueResult(started = true, context = StartListeningCueContext.WAKE_WORD)
+        }
+
+    private fun journal(events: MutableList<Pair<String, Long>>) = WakeSessionJournal(
+        generationId = 7L,
+        sessionId = 9L,
+        emit = { type, _, sessionId, _ -> events += type to sessionId },
+    )
+
+    @Test
+    fun `refreshed watchdog exhaustion skips the wake attempt-2 and re-arms once`() = runTest {
+        val detector = OrderingDetector()
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var rearmCount = 0
+        var routedCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { routedCount++; true },
+                onSessionTerminal = { rearmCount++ },
+            )
+        }
+        runCurrent()
+
+        // 1. Attempt 1 reaches readiness (one recognizer started).
+        assertEquals(1, recognizers.size)
+        listeners[0].onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        // 2. The first recognizer receives a silent ERROR_NO_MATCH.
+        // 3. One in-place refresh starts under the same capture session.
+        listeners[0].onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        assertEquals(2, recognizers.size, "one in-place refresh recognizer")
+
+        // 4. The refreshed recognizer reaches readiness internally.
+        listeners[1].onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        // 5. Its no-speech watchdog expires → 6. categorized error.
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        // 7. The wake session must not start attempt 2 (no third recognizer).
+        // 8. Exactly one SESSION_CANCELLED and one re-arm.
+        job.join()
+        assertEquals(2, recognizers.size, "no attempt-2 recognizer after exhausted no-speech window")
+        assertEquals(1, rearmCount)
+        assertEquals(0, routedCount)
+        val recorded = journalEvents.map { it.first }
+        assertEquals(1, recorded.count { it == AcousticEventType.STT_START_REQUESTED }, "attempt 1 only")
+        assertEquals(1, recorded.count { it == AcousticEventType.STT_ERROR })
+        assertEquals(1, recorded.count { it == AcousticEventType.SESSION_CANCELLED })
+        assertEquals(1, recorded.count { it == AcousticEventType.CUE_REQUESTED }, "one cue for the one readiness")
+        assertTrue(journalEvents.all { it.second == 9L }, "capture session correlation preserved")
+    }
+
+    @Test
+    fun `clock-alert listening cue plays exactly once across an in-place refresh`() = runTest {
+        // The clock-alert path plays its listening cue for every owned AlertCommand
+        // readiness event; the controller must emit exactly one readiness per capture
+        // session, so an in-place refresh cannot replay the cue.
+        val readinessEvents = mutableListOf<VoiceInputEvent.ListeningStarted>()
+
+        val job = launch {
+            controller.events.collect { event ->
+                if (event is VoiceInputEvent.ListeningStarted) readinessEvents += event
+            }
+        }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        listeners[0].onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[0].onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        assertEquals(2, recognizers.size, "one in-place refresh recognizer")
+        assertEquals(
+            2,
+            listeners.size,
+            "second recognizer must register its listener; recognizers=${recognizers.size}",
+        )
+        listeners[1].onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        assertEquals(1, readinessEvents.size, "one readiness per capture session")
+        val sessionId = readinessEvents.single().captureSessionId
+        val owned = readinessEvents.count {
+            shouldPlayClockAlertListeningCue(it, sessionId, isVoiceListening = true)
+        }
+        assertEquals(1, owned, "clock-alert plays exactly one cue across the refresh")
+        job.cancel()
+    }
+}

--- a/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
@@ -1,0 +1,491 @@
+package com.kernel.ai.assistant
+
+import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.StartListeningCueContext
+import com.kernel.ai.core.voice.StartListeningCuePlayer
+import com.kernel.ai.core.voice.StartListeningCueResult
+import com.kernel.ai.core.voice.VoiceCaptureMode
+import com.kernel.ai.core.voice.VoiceInputController
+import com.kernel.ai.core.voice.VoiceInputEvent
+import com.kernel.ai.core.voice.VoiceInputStartResult
+import com.kernel.ai.core.voice.WakeWordDetector
+import io.mockk.every
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runCurrent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Deterministic tests for the #1433 wake-command handoff
+ * ([WakeWordService.runWakeCommandHandoff]).
+ *
+ * Physical evidence (S21 + S23U diagnostic matrix): the first STT attempt always
+ * reached readiness, then the app's 2.5 s alert-session silence watchdog expired it
+ * before the runner's command arrived (7.4-9.0 s after readiness), making a retry
+ * session the de-facto normal path.  The corrected handoff (1) releases the wake
+ * detector's microphone before attempt-1 STT start, and (2) keeps the first session
+ * open across the cue-to-command handoff.  The retry remains only for genuine
+ * post-readiness failures.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WakeCommandHandoffTest {
+
+    // ── Fakes ────────────────────────────────────────────────────────────────
+
+    private class OrderingDetector(private val sharedOrder: MutableList<String>) : WakeWordDetector {
+        override val isAvailable: Boolean get() = true
+        var released = false
+
+        override fun start(
+            generationId: Long,
+            onDetected: () -> Unit,
+            verifyWindow: ((ShortArray) -> Boolean)?,
+        ) {
+            sharedOrder += "detector-start"
+        }
+
+        override fun stop() {
+            sharedOrder += "detector-stop"
+            // The strengthened stop() contract: microphone ownership is released
+            // before stop() returns.
+            released = true
+        }
+    }
+
+    /** Detector that runs the wake callback on a real thread, like the real one. */
+    private class ThreadedDetector : WakeWordDetector {
+        override val isAvailable: Boolean get() = true
+        @Volatile var released = false
+        private var thread: Thread? = null
+
+        override fun start(
+            generationId: Long,
+            onDetected: () -> Unit,
+            verifyWindow: ((ShortArray) -> Boolean)?,
+        ) {
+            thread = Thread {
+                onDetected()
+                released = true
+            }.also { it.start() }
+        }
+
+        override fun stop() {
+            // Same contract as OnnxWakeWordDetector.stop() (#1433): return only after
+            // the detection thread terminated (mic released), bounded, no self-join.
+            val t = thread
+            if (t != null && t !== Thread.currentThread() && t.isAlive) {
+                t.join(2_000L)
+            }
+        }
+
+        fun joinThread() = thread?.join(2_000)
+    }
+
+    private class RecordingController(
+        private val detectorReleased: () -> Boolean,
+        private val startResults: MutableList<VoiceInputStartResult>,
+        private val sharedOrder: MutableList<String>,
+    ) : VoiceInputController {
+        private val eventChannel = Channel<VoiceInputEvent>(Channel.UNLIMITED)
+        override val events: Flow<VoiceInputEvent> = eventChannel.receiveAsFlow()
+
+        val startCalls = mutableListOf<Long>()
+        val releasedWhenStarted = mutableListOf<Boolean>()
+        var stopCalls = 0
+
+        override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
+            val result = startResults.removeAt(0) as VoiceInputStartResult.Started
+            sharedOrder += "stt-start-${result.captureSessionId}"
+            startCalls += result.captureSessionId
+            releasedWhenStarted += detectorReleased()
+            return result
+        }
+
+        override fun stopListening() {
+            stopCalls++
+            sharedOrder += "stt-stop"
+        }
+
+        suspend fun emit(event: VoiceInputEvent) {
+            eventChannel.send(event)
+        }
+    }
+
+    private fun cuePlayer(): StartListeningCuePlayer =
+        mockk<StartListeningCuePlayer>().apply {
+            every { playCue(StartListeningCueContext.WAKE_WORD) } returns
+                StartListeningCueResult(started = true, context = StartListeningCueContext.WAKE_WORD)
+        }
+
+    private fun journal(
+        events: MutableList<Pair<String, Long>>,
+    ) = WakeSessionJournal(
+        generationId = 7L,
+        sessionId = 9L,
+        emit = { type, g, s, _ -> events += type to s },
+    )
+
+    // ── Ordering: detector release before attempt-1 STT start ─────────────────
+
+    @Test
+    fun `attempt-1 STT start is ordered after detector microphone release`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var rearmCount = 0
+        var routedCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { routedCount++; true },
+                onSessionTerminal = { rearmCount++ },
+            )
+        }
+        runCurrent()
+
+        // The detector is stopped before any live STT startup.
+        assertEquals("detector-stop", order.first())
+        assertTrue(
+            order.indexOf("detector-stop") < order.indexOf("stt-start-1"),
+            "detector stop must precede attempt-1 STT start",
+        )
+
+        // Attempt 1 reaches readiness and captures the command.
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 1L))
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L), controller.startCalls, "exactly one capture session on the normal path")
+        assertEquals(listOf(true), controller.releasedWhenStarted, "mic released before STT start")
+        assertEquals(1, routedCount)
+        assertEquals(1, rearmCount, "detector re-arms exactly once after the session")
+
+        // Journal correlation and ordering (all events in the original generation/session).
+        val recorded = journalEvents.map { it.first }
+        assertTrue(journalEvents.all { it.second == 9L }, "all events stay in the wake session")
+        assertTrue(
+            recorded.indexOf(AcousticEventType.VOICE_SESSION_STARTED) <
+                recorded.indexOf(AcousticEventType.STT_START_REQUESTED),
+        )
+        assertTrue(
+            recorded.indexOf(AcousticEventType.STT_START_REQUESTED) <
+                recorded.indexOf(AcousticEventType.STT_READY),
+        )
+        assertTrue(
+            recorded.indexOf(AcousticEventType.STT_READY) <
+                recorded.indexOf(AcousticEventType.CUE_REQUESTED),
+            "cue must be requested only after STT_READY",
+        )
+        assertTrue(
+            recorded.indexOf(AcousticEventType.STT_FINAL) <
+                recorded.indexOf(AcousticEventType.COMMAND_ROUTING_RESULT),
+        )
+        assertTrue(
+            recorded.indexOf(AcousticEventType.COMMAND_ROUTING_RESULT) <
+                recorded.indexOf(AcousticEventType.SESSION_COMPLETED),
+        )
+        assertFalse(recorded.contains(AcousticEventType.STT_ERROR))
+    }
+
+    @Test
+    fun `handoff stop joins the detecting thread and completes without deadlock`() = runTest {
+        val detector = ThreadedDetector()
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = mutableListOf(),
+        )
+        var rearmCount = 0
+        var handoffJob: Job? = null
+        val callbackRan = CountDownLatch(1)
+
+        // The detection callback runs on the detector thread (as in production) and
+        // launches the handoff asynchronously; the handoff's stop() joins that thread.
+        detector.start(generationId = 7L, onDetected = {
+            handoffJob = launch {
+                runWakeCommandHandoff(
+                    wakeWordDetector = detector,
+                    voiceInputController = controller,
+                    cuePlayer = cuePlayer(),
+                    generationId = 7L,
+                    sessionId = 9L,
+                    routeTranscript = { true },
+                    onSessionTerminal = { rearmCount++ },
+                )
+            }
+            callbackRan.countDown()
+        }, verifyWindow = null)
+        assertTrue(
+            callbackRan.await(2, TimeUnit.SECONDS),
+            "detection callback must have launched the handoff",
+        )
+
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 1L))
+        runCurrent()
+        handoffJob?.join()
+        detector.joinThread()
+
+        assertEquals(listOf(true), controller.releasedWhenStarted)
+        assertEquals(listOf(1L), controller.startCalls)
+        assertEquals(1, rearmCount)
+    }
+
+    // ── Normal path: attempt 1 succeeds, no retry ────────────────────────────
+
+    @Test
+    fun `successful first attempt does not start attempt 2`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var rearmCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { true },
+                onSessionTerminal = { rearmCount++ },
+            )
+        }
+        runCurrent()
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 1L))
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L), controller.startCalls)
+        val attempts = journalEvents.filter { it.first == AcousticEventType.STT_START_REQUESTED }
+        assertEquals(1, attempts.size, "no attempt 2 on the normal path")
+        assertEquals(1, rearmCount)
+    }
+
+    @Test
+    fun `foreign-mode events are ignored by the wake session`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var routedCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { routedCount++; true },
+                onSessionTerminal = {},
+            )
+        }
+        runCurrent()
+        // A non-alert session event with the same capture session id must not satisfy
+        // the wake session's readiness wait.
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.Command, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 1L))
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L), controller.startCalls)
+        assertEquals(1, routedCount)
+    }
+
+    // ── Retry remains available for genuine failures ─────────────────────────
+
+    @Test
+    fun `genuine post-readiness recognition failure still uses the bounded retry`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(
+                VoiceInputStartResult.Started(1L),
+                VoiceInputStartResult.Started(2L),
+            ),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var routedCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { routedCount++; true },
+                onSessionTerminal = {},
+            )
+        }
+        runCurrent()
+        // Attempt 1 reaches readiness then fails for a genuine recognition reason.
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "audio input problem", captureSessionId = 1L))
+        runCurrent()
+        // Attempt 2 starts only after attempt 1 is terminal, then captures the command.
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 2L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 2L))
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L, 2L), controller.startCalls, "retry runs after a genuine post-readiness failure")
+        assertEquals(1, routedCount)
+        val recorded = journalEvents.map { it.first }
+        assertTrue(recorded.contains(AcousticEventType.STT_ERROR))
+    }
+
+    @Test
+    fun `obsolete attempt-1 callback cannot terminate attempt 2`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(
+                VoiceInputStartResult.Started(1L),
+                VoiceInputStartResult.Started(2L),
+            ),
+            sharedOrder = order,
+        )
+        var routedCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                routeTranscript = { routedCount++; true },
+                onSessionTerminal = {},
+            )
+        }
+        runCurrent()
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "first attempt failed", captureSessionId = 1L))
+        runCurrent()
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 2L))
+        // A stale error from attempt 1's session arrives while attempt 2 is live.
+        controller.emit(VoiceInputEvent.Error(VoiceCaptureMode.AlertCommand, "stale", captureSessionId = 1L))
+        controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = 2L))
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L, 2L), controller.startCalls)
+        assertEquals(1, routedCount, "stale attempt-1 error must not terminate attempt 2")
+    }
+
+    // ── Cancellation, re-arm and no leftover recognizer ──────────────────────
+
+    @Test
+    fun `cancellation during handoff stops the recognizer and re-arms exactly once`() = runTest {
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var rearmCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { true },
+                onSessionTerminal = { rearmCount++ },
+            )
+        }
+        runCurrent()
+
+        job.cancel()
+        runCurrent()
+
+        assertEquals(1, controller.stopCalls, "no recognizer may survive a cancelled handoff")
+        assertEquals(1, rearmCount, "re-arm happens once even on cancellation")
+        assertTrue(
+            journalEvents.map { it.first }.contains(AcousticEventType.SESSION_CANCELLED),
+        )
+        assertFalse(job.isActive)
+    }
+
+    @Test
+    fun `each confirmed activation produces exactly one voice session`() = runTest {
+        // Two sequential confirmed activations each run one capture session and one re-arm.
+        for (activation in 1..2) {
+            val order = mutableListOf<String>()
+            val detector = OrderingDetector(order)
+            val controller = RecordingController(
+                detectorReleased = { detector.released },
+                startResults = mutableListOf(VoiceInputStartResult.Started(activation.toLong())),
+                sharedOrder = order,
+            )
+            var rearmCount = 0
+
+            val job = launch {
+                runWakeCommandHandoff(
+                    wakeWordDetector = detector,
+                    voiceInputController = controller,
+                    cuePlayer = cuePlayer(),
+                    generationId = 7L,
+                    sessionId = activation.toLong(),
+                    routeTranscript = { true },
+                    onSessionTerminal = { rearmCount++ },
+                )
+            }
+            runCurrent()
+            controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = activation.toLong()))
+            controller.emit(VoiceInputEvent.Transcript(VoiceCaptureMode.AlertCommand, "what time is it", captureSessionId = activation.toLong()))
+            runCurrent()
+            job.join()
+
+            assertEquals(listOf(activation.toLong()), controller.startCalls)
+            assertEquals(1, rearmCount)
+        }
+    }
+}

--- a/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffTest.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.assistant
 
 import com.kernel.ai.core.voice.AcousticEventType
+import com.kernel.ai.core.voice.NO_SPEECH_WINDOW_EXHAUSTED
 import com.kernel.ai.core.voice.StartListeningCueContext
 import com.kernel.ai.core.voice.StartListeningCuePlayer
 import com.kernel.ai.core.voice.StartListeningCueResult
@@ -452,6 +453,54 @@ class WakeCommandHandoffTest {
             journalEvents.map { it.first }.contains(AcousticEventType.SESSION_CANCELLED),
         )
         assertFalse(job.isActive)
+    }
+
+    @Test
+    fun `no-speech-exhausted first attempt skips the pointless retry`() = runTest {
+        // #1433: when the first session's full no-speech window elapsed (in-place
+        // refreshes spent, still no speech), the command window has closed — the
+        // session-level retry must not run and the detector re-arms promptly.
+        val order = mutableListOf<String>()
+        val detector = OrderingDetector(order)
+        val controller = RecordingController(
+            detectorReleased = { detector.released },
+            startResults = mutableListOf(VoiceInputStartResult.Started(1L)),
+            sharedOrder = order,
+        )
+        val journalEvents = mutableListOf<Pair<String, Long>>()
+        var rearmCount = 0
+
+        val job = launch {
+            runWakeCommandHandoff(
+                wakeWordDetector = detector,
+                voiceInputController = controller,
+                cuePlayer = cuePlayer(),
+                generationId = 7L,
+                sessionId = 9L,
+                journal = journal(journalEvents),
+                routeTranscript = { true },
+                onSessionTerminal = { rearmCount++ },
+            )
+        }
+        runCurrent()
+        controller.emit(VoiceInputEvent.ListeningStarted(VoiceCaptureMode.AlertCommand, captureSessionId = 1L))
+        controller.emit(
+            VoiceInputEvent.Error(
+                mode = VoiceCaptureMode.AlertCommand,
+                message = "no speech",
+                captureSessionId = 1L,
+                category = NO_SPEECH_WINDOW_EXHAUSTED,
+            ),
+        )
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(1L), controller.startCalls, "no retry after the exhausted no-speech window")
+        assertEquals(1, rearmCount)
+        val recorded = journalEvents.map { it.first }
+        assertTrue(recorded.contains(AcousticEventType.STT_ERROR))
+        assertTrue(recorded.contains(AcousticEventType.SESSION_CANCELLED))
+        assertEquals(1, recorded.count { it == AcousticEventType.STT_START_REQUESTED })
     }
 
     @Test

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -37,6 +37,16 @@ private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
 private const val REFRESH_SETTLE_MS = 300L
 
 /**
+ * No-speech budget for a REFRESHED alert recognizer (#1433).  The original
+ * recognizer already consumed most of the handoff window before the platform's
+ * no-speech timeout; the replacement only needs to cover the remaining command
+ * arrival, and must terminate early enough that the whole session re-arms within
+ * the acoustic runner's 15 s terminal window (the platform's second no-match is
+ * not guaranteed).  Speech progress still extends via the 6 s result timeout.
+ */
+private const val REFRESHED_SESSION_SILENCE_TIMEOUT_MS = 5_000L
+
+/**
  * Maximum in-place recognizer refreshes per session (#1433).  A single refresh
  * extends the first wake session's window to ~10.5 s (5.1 s platform no-speech +
  * one refreshed 5.1 s window), covering the measured 7.4-9.0 s command arrival,
@@ -317,6 +327,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         mode: VoiceCaptureMode,
         availability: AndroidNativeRecognitionAvailability,
         backend: RecognizerBackend,
+        isRefreshed: Boolean = false,
     ) {
         val recognizer = when (backend) {
             RecognizerBackend.OnDevice -> recognitionSupport.createOnDeviceSpeechRecognizer()
@@ -333,6 +344,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         recognizer.setRecognitionListener(
             SessionRecognitionListener(
                 sessionId = sessionId,
+                isRefreshed = isRefreshed,
                 mode = mode,
                 availability = availability,
                 backend = backend,
@@ -398,6 +410,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 mode = mode,
                 availability = availability,
                 backend = RecognizerBackend.Platform,
+                isRefreshed = true,
             )
         }
     }
@@ -434,6 +447,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
         private val mode: VoiceCaptureMode,
         private val availability: AndroidNativeRecognitionAvailability,
         private val backend: RecognizerBackend,
+        private val isRefreshed: Boolean = false,
     ) : RecognitionListener {
 
         private var sessionCompleted = false
@@ -444,7 +458,13 @@ class NativeAndroidVoiceInputController @Inject constructor(
         private fun resetSessionWatchdog() {
             sessionWatchdogJob?.cancel()
             sessionWatchdogJob = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
-                delay(sessionResultTimeoutMs(mode, hasSpeechProgress = heardSpeech || sawPartialTranscript))
+                delay(
+                    if (isRefreshed && !heardSpeech && !sawPartialTranscript) {
+                        REFRESHED_SESSION_SILENCE_TIMEOUT_MS
+                    } else {
+                        sessionResultTimeoutMs(mode, hasSpeechProgress = heardSpeech || sawPartialTranscript)
+                    }
+                )
                 if (sessionCompleted || activeSessionId != sessionId) return@launch
                 if (
                     shouldRetryWithPlatformAfterWatchdogTimeout(

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -202,9 +203,28 @@ class NativeAndroidVoiceInputController @Inject constructor(
     @Volatile
     private var startupFallbackJob: Job? = null
 
+    /**
+     * #1433: owned, cancellable pending in-place recognizer refresh.  Cancelled by
+     * [stopListeningInternal], before scheduling a new refresh, and whenever the
+     * capture session is replaced; the job re-checks [activeSessionId] after its
+     * settle delay so it can never start for a stale session.
+     */
+    @Volatile
+    private var inPlaceRefreshJob: Job? = null
+
     /** #1433: in-place no-speech refreshes performed within the current capture session. */
     @Volatile
     private var noSpeechRefreshCount = 0
+
+    /**
+     * #1433: whether `ListeningStarted` has already been emitted for the current
+     * capture session.  An in-place recognizer refresh must not re-emit readiness
+     * (the wake-command path has already played its cue and the clock-alert path
+     * plays its listening cue per readiness event).  Reset whenever the session is
+     * allocated, replaced or terminated.
+     */
+    @Volatile
+    private var readinessEmittedForSession = false
 
 
 
@@ -235,6 +255,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 currentMode = mode
                 activeSessionId = sessionId
                 noSpeechRefreshCount = 0
+                readinessEmittedForSession = false
                 val startBackend = initialRecognizerBackend(mode)
                 try {
                     startRecognizer(
@@ -295,9 +316,12 @@ class NativeAndroidVoiceInputController @Inject constructor(
         val recognizer = speechRecognizer
         startupFallbackJob?.cancel()
         startupFallbackJob = null
+        inPlaceRefreshJob?.cancel()
+        inPlaceRefreshJob = null
         speechRecognizer = null
         currentMode = null
         activeSessionId = 0L
+        readinessEmittedForSession = false
 
         recognizer?.apply {
             runCatching { stopListening() }
@@ -388,31 +412,66 @@ class NativeAndroidVoiceInputController @Inject constructor(
     /**
      * #1433: destroy the dead recognizer now and start a replacement on the SAME
      * capture session after a short settle, so the platform recognition service has
-     * finished tearing down the old client connection.  Emits no events and allocates
-     * no new session id — the session-level attempt count and journal correlation are
-     * unchanged.  The session watchdog continues to bound the whole window.
+     * finished tearing down the old client connection.  The pending refresh is
+     * tracked as [inPlaceRefreshJob]: it is cancelled before scheduling another
+     * refresh, by [stopListeningInternal], and whenever the session is replaced; it
+     * re-checks [activeSessionId] after the settle so it can never start for a stale
+     * session.  Emits no events and allocates no new session id — the session-level
+     * attempt count and journal correlation are unchanged.
      */
     private fun scheduleInPlaceRefresh(
         sessionId: Long,
         mode: VoiceCaptureMode,
         availability: AndroidNativeRecognitionAvailability,
     ) {
+        inPlaceRefreshJob?.cancel()
         speechRecognizer?.apply {
             runCatching { cancel() }
             runCatching { destroy() }
         }
         speechRecognizer = null
-        kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
-            delay(REFRESH_SETTLE_MS)
-            if (activeSessionId != sessionId) return@launch
-            startRecognizer(
-                sessionId = sessionId,
-                mode = mode,
-                availability = availability,
-                backend = RecognizerBackend.Platform,
-                isRefreshed = true,
-            )
+        var job: Job? = null
+        job = kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
+            try {
+                delay(REFRESH_SETTLE_MS)
+                if (activeSessionId != sessionId) return@launch
+                startRecognizer(
+                    sessionId = sessionId,
+                    mode = mode,
+                    availability = availability,
+                    backend = RecognizerBackend.Platform,
+                    isRefreshed = true,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A genuine refresh-start failure for the still-active session must
+                // not strand it: clean up any partially created recognizer and emit
+                // exactly one terminal error + stopped event, then clear the session
+                // and release audio focus.  The wake-level bounded retry policy then
+                // handles this as a genuine startup failure (NOT the exhausted
+                // no-speech category).
+                if (activeSessionId != sessionId) return@launch
+                Log.e(TAG, "In-place refresh failed for sessionId=$sessionId", e)
+                speechRecognizer?.apply {
+                    runCatching { cancel() }
+                    runCatching { destroy() }
+                }
+                speechRecognizer = null
+                _events.tryEmit(
+                    VoiceInputEvent.Error(
+                        mode = mode,
+                        captureSessionId = sessionId,
+                        message = e.message ?: "Android speech recognition failed to restart.",
+                    ),
+                )
+                _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
+                stopListeningInternal(emitStopped = false, expectedSessionId = sessionId)
+            } finally {
+                if (inPlaceRefreshJob === job) inPlaceRefreshJob = null
+            }
         }
+        inPlaceRefreshJob = job
     }
 
 
@@ -499,6 +558,22 @@ class NativeAndroidVoiceInputController @Inject constructor(
                         mode = mode,
                         captureSessionId = sessionId,
                         message = "Android speech recognition stopped responding before it returned a result.",
+                        // #1433: when the refreshed recognizer's own no-speech watchdog
+                        // expires (alert command, refreshed recognizer, no speech, no
+                        // partials), the entire command window has elapsed — classify it
+                        // as NO_SPEECH_WINDOW_EXHAUSTED so the wake session skips the
+                        // pointless attempt-2 and re-arms.  Everything else (speech
+                        // progress, non-alert modes, genuine errors) stays generic.
+                        category = if (
+                            isRefreshed &&
+                            mode == VoiceCaptureMode.AlertCommand &&
+                            !heardSpeech &&
+                            !sawPartialTranscript
+                        ) {
+                            NO_SPEECH_WINDOW_EXHAUSTED
+                        } else {
+                            null
+                        },
                     ),
                 )
                 _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))
@@ -517,7 +592,16 @@ class NativeAndroidVoiceInputController @Inject constructor(
             cancelStartupFallback()
             resetSessionWatchdog()
             Log.i(TAG, "Android native STT ready: sessionId=$sessionId mode=$mode backend=$backend")
-            _events.tryEmit(VoiceInputEvent.ListeningStarted(mode, sessionId))
+            // #1433: readiness is idempotent per capture session.  An in-place
+            // recognizer refresh must not re-emit ListeningStarted (the wake-command
+            // path already played its cue, and ClockAlertService plays its listening
+            // cue per readiness event).  The first readiness of a session is always
+            // emitted — including from a replacement recognizer when the original
+            // failed before ever becoming ready.
+            if (!readinessEmittedForSession) {
+                readinessEmittedForSession = true
+                _events.tryEmit(VoiceInputEvent.ListeningStarted(mode, sessionId))
+            }
         }
 
         override fun onBeginningOfSpeech() {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -147,6 +147,15 @@ internal fun shouldRefreshAlertRecognizerOnNoSpeech(
         !heardSpeech &&
         !sawPartialTranscript
 
+/**
+ * Stable error category emitted when an alert session's no-speech window is fully
+ * exhausted (in-place refreshes spent and the platform still heard nothing).  The
+ * wake-command handoff uses this to skip the session-level retry: the command
+ * window has already closed, so a second attempt would only re-wait.  The journal's
+ * STT_ERROR category remains the standard "stt_recognition_failed".
+ */
+const val NO_SPEECH_WINDOW_EXHAUSTED = "no_speech_window_exhausted"
+
 internal fun shouldRetryWithPlatformAfterWatchdogTimeout(
     backend: RecognizerBackend,
     sawPartialTranscript: Boolean,
@@ -571,6 +580,17 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     mode = mode,
                     captureSessionId = sessionId,
                     message = mapError(error, availability),
+                    // The no-speech window is fully exhausted (refreshes spent): the
+                    // wake-command window has closed, so the session-level retry would
+                    // only re-wait.  The journal category stays standard.
+                    category = if (
+                        error == SpeechRecognizer.ERROR_NO_MATCH &&
+                        shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript)
+                    ) {
+                        NO_SPEECH_WINDOW_EXHAUSTED
+                    } else {
+                        null
+                    },
                 ),
             )
             _events.tryEmit(VoiceInputEvent.ListeningStopped(mode, sessionId))

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -26,7 +26,22 @@ import kotlinx.coroutines.withContext
 private const val TAG = "NativeVoiceInput"
 private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
 private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
-private const val ALERT_SESSION_SILENCE_TIMEOUT_MS = 2_500L
+
+/**
+ * Silence budget for an alert-mode session before any speech progress.
+ *
+ * Raised from 2.5 s to 10 s by #1433: the wake-command handoff must survive the
+ * cue-to-command gap.  Physical evidence (S21 + S23U, diagnostic matrix) shows the
+ * wake session reaches readiness, plays the cue, and then receives the command
+ * fixture 7.4–9.0 s after readiness (runner cue margin + orchestration latency);
+ * the old 2.5 s budget expired the FIRST attempt before the command arrived, forcing
+ * a retry session to become the normal path (the observed 7–9 s delay and, on one
+ * trial, command playback after the session ended).  10 s matches the legacy Vosk
+ * session bound (LISTEN_TIMEOUT_MS) and covers the measured command-arrival latency.
+ * A human responds to the cue within this budget as well.  The session still ends
+ * promptly on speech progress (6 s result timeout) and on genuine platform errors.
+ */
+private const val ALERT_SESSION_SILENCE_TIMEOUT_MS = 10_000L
 
 internal fun sessionResultTimeoutMs(
     mode: VoiceCaptureMode,

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -37,6 +37,15 @@ private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
 private const val REFRESH_SETTLE_MS = 300L
 
 /**
+ * Maximum in-place recognizer refreshes per session (#1433).  Two refreshes extend
+ * the first wake session's window to ~15 s (5.1 s platform no-speech + 2 × 5.1 s
+ * refreshed windows), comfortably covering the measured 7.4-9.0 s command arrival,
+ * while still bounding a false wake: the next platform no-speech timeout then
+ * surfaces as a genuine error and the session terminates.
+ */
+private const val MAX_NO_SPEECH_REFRESHES = 2
+
+/**
  * Silence budget for an alert-mode session before any speech progress.
  *
  * Raised from 2.5 s to 10 s by #1433: the wake-command handoff must survive the
@@ -173,6 +182,10 @@ class NativeAndroidVoiceInputController @Inject constructor(
     @Volatile
     private var startupFallbackJob: Job? = null
 
+    /** #1433: in-place no-speech refreshes performed within the current capture session. */
+    @Volatile
+    private var noSpeechRefreshCount = 0
+
 
 
     override suspend fun startListening(mode: VoiceCaptureMode): VoiceInputStartResult {
@@ -201,6 +214,7 @@ class NativeAndroidVoiceInputController @Inject constructor(
                 val sessionId = VoiceCaptureSessionIds.allocate()
                 currentMode = mode
                 activeSessionId = sessionId
+                noSpeechRefreshCount = 0
                 val startBackend = initialRecognizerBackend(mode)
                 try {
                     startRecognizer(
@@ -525,17 +539,20 @@ class NativeAndroidVoiceInputController @Inject constructor(
             // surfaces as a genuine recognition failure.
             if (
                 error == SpeechRecognizer.ERROR_NO_MATCH &&
-                shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript)
+                shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript) &&
+                this@NativeAndroidVoiceInputController.noSpeechRefreshCount < MAX_NO_SPEECH_REFRESHES
             ) {
                 // The old recognizer is dead; mark this listener terminal so its
                 // destroy()'s late ERROR_CLIENT callback cannot surface as a session
-                // error, and schedule the in-place replacement.
+                // error, and schedule the in-place replacement.  The refresh budget is
+                // bounded (MAX_NO_SPEECH_REFRESHES) so a false wake still terminates.
+                this@NativeAndroidVoiceInputController.noSpeechRefreshCount++
                 sessionCompleted = true
                 scheduleInPlaceRefresh(sessionId, mode, availability)
                 Log.w(
                     TAG,
                     "Android native STT refreshed in place after no-speech no-match for sessionId=$sessionId " +
-                        "mode=$mode",
+                        "mode=$mode (refresh ${this@NativeAndroidVoiceInputController.noSpeechRefreshCount}/$MAX_NO_SPEECH_REFRESHES)",
                 )
                 return
             }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -38,8 +38,11 @@ private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
  * a retry session to become the normal path (the observed 7–9 s delay and, on one
  * trial, command playback after the session ended).  10 s matches the legacy Vosk
  * session bound (LISTEN_TIMEOUT_MS) and covers the measured command-arrival latency.
- * A human responds to the cue within this budget as well.  The session still ends
- * promptly on speech progress (6 s result timeout) and on genuine platform errors.
+ * The platform recognizer's own shorter no-speech timeout is handled by an in-place
+ * recognizer refresh (see [shouldRefreshAlertRecognizerOnNoSpeech]) that keeps the
+ * same capture session.  A human responds to the cue within this budget as well.
+ * The session still ends promptly on speech progress (6 s result timeout) and on
+ * genuine platform errors.
  */
 private const val ALERT_SESSION_SILENCE_TIMEOUT_MS = 10_000L
 
@@ -103,6 +106,27 @@ internal fun shouldRetryWithPlatformAfterRecognitionError(
             }
             else -> false
         }
+
+/**
+ * #1433: refresh an alert-session platform recognizer IN PLACE after its own
+ * no-speech timeout (ERROR_NO_MATCH with no speech heard at all).  The platform
+ * recognizer's no-speech window (~5 s observed on the S21) is shorter than the
+ * cue-to-command handoff, so without the refresh the first wake session would
+ * terminate before the command arrives and a retry session would become the
+ * normal path.  The refresh reuses the same capture session id and emits no
+ * events, so the session-level attempt count and journal correlation are
+ * unchanged.
+ */
+internal fun shouldRefreshAlertRecognizerOnNoSpeech(
+    backend: RecognizerBackend,
+    mode: VoiceCaptureMode,
+    heardSpeech: Boolean,
+    sawPartialTranscript: Boolean,
+): Boolean =
+    backend == RecognizerBackend.Platform &&
+        mode == VoiceCaptureMode.AlertCommand &&
+        !heardSpeech &&
+        !sawPartialTranscript
 
 internal fun shouldRetryWithPlatformAfterWatchdogTimeout(
     backend: RecognizerBackend,
@@ -449,6 +473,31 @@ class NativeAndroidVoiceInputController @Inject constructor(
                     TAG,
                     "Android native STT retried with platform recognizer after error=$error for sessionId=$sessionId " +
                         "heardSpeech=$heardSpeech sawPartialTranscript=$sawPartialTranscript",
+                )
+                return
+            }
+            // #1433: the platform recognizer has its own no-speech timeout (~5 s
+            // observed on the S21) that fires ERROR_NO_MATCH before the app's
+            // alert-session budget when the wake command arrives after the cue
+            // (measured 7.4-9.0 s after readiness under the acoustic runner
+            // contract).  Refresh the recognizer IN PLACE — same capture session, no
+            // new STT_START_REQUESTED — so the first wake session still accepts the
+            // command and no attempt-2 session becomes the normal path.  Only for
+            // alert sessions that heard nothing at all; any other error still
+            // surfaces as a genuine recognition failure.
+            if (
+                error == SpeechRecognizer.ERROR_NO_MATCH &&
+                shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript) &&
+                retryWithPlatformRecognizer(
+                    sessionId = sessionId,
+                    mode = mode,
+                    availability = availability,
+                )
+            ) {
+                Log.w(
+                    TAG,
+                    "Android native STT refreshed in place after no-speech no-match for sessionId=$sessionId " +
+                        "mode=$mode",
                 )
                 return
             }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -37,13 +37,14 @@ private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
 private const val REFRESH_SETTLE_MS = 300L
 
 /**
- * Maximum in-place recognizer refreshes per session (#1433).  Two refreshes extend
- * the first wake session's window to ~15 s (5.1 s platform no-speech + 2 × 5.1 s
- * refreshed windows), comfortably covering the measured 7.4-9.0 s command arrival,
- * while still bounding a false wake: the next platform no-speech timeout then
- * surfaces as a genuine error and the session terminates.
+ * Maximum in-place recognizer refreshes per session (#1433).  A single refresh
+ * extends the first wake session's window to ~10.5 s (5.1 s platform no-speech +
+ * one refreshed 5.1 s window), covering the measured 7.4-9.0 s command arrival,
+ * while still bounding a false wake: the next platform no-speech timeout surfaces
+ * as a genuine error and the session terminates within the acoustic runner's
+ * 15 s terminal window.
  */
-private const val MAX_NO_SPEECH_REFRESHES = 2
+private const val MAX_NO_SPEECH_REFRESHES = 1
 
 /**
  * Silence budget for an alert-mode session before any speech progress.

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt
@@ -28,6 +28,15 @@ private const val ON_DEVICE_READY_TIMEOUT_MS = 1_500L
 private const val SESSION_RESULT_TIMEOUT_MS = 6_000L
 
 /**
+ * Settle delay between destroying a dead recognizer and creating its replacement in
+ * the #1433 in-place no-speech refresh.  A back-to-back destroy() -> create() against
+ * the platform recognition service intermittently makes the new instance die
+ * immediately with ERROR_CLIENT (observed on the S21); this bound is a recognizer
+ * lifecycle settle, not a command delay, and the session watchdog covers the gap.
+ */
+private const val REFRESH_SETTLE_MS = 300L
+
+/**
  * Silence budget for an alert-mode session before any speech progress.
  *
  * Raised from 2.5 s to 10 s by #1433: the wake-command handoff must survive the
@@ -340,6 +349,35 @@ class NativeAndroidVoiceInputController @Inject constructor(
         startupFallbackJob = null
     }
 
+    /**
+     * #1433: destroy the dead recognizer now and start a replacement on the SAME
+     * capture session after a short settle, so the platform recognition service has
+     * finished tearing down the old client connection.  Emits no events and allocates
+     * no new session id — the session-level attempt count and journal correlation are
+     * unchanged.  The session watchdog continues to bound the whole window.
+     */
+    private fun scheduleInPlaceRefresh(
+        sessionId: Long,
+        mode: VoiceCaptureMode,
+        availability: AndroidNativeRecognitionAvailability,
+    ) {
+        speechRecognizer?.apply {
+            runCatching { cancel() }
+            runCatching { destroy() }
+        }
+        speechRecognizer = null
+        kotlinx.coroutines.CoroutineScope(Dispatchers.Main.immediate).launch {
+            delay(REFRESH_SETTLE_MS)
+            if (activeSessionId != sessionId) return@launch
+            startRecognizer(
+                sessionId = sessionId,
+                mode = mode,
+                availability = availability,
+                backend = RecognizerBackend.Platform,
+            )
+        }
+    }
+
 
     private fun retryWithPlatformRecognizer(
         sessionId: Long,
@@ -487,13 +525,13 @@ class NativeAndroidVoiceInputController @Inject constructor(
             // surfaces as a genuine recognition failure.
             if (
                 error == SpeechRecognizer.ERROR_NO_MATCH &&
-                shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript) &&
-                retryWithPlatformRecognizer(
-                    sessionId = sessionId,
-                    mode = mode,
-                    availability = availability,
-                )
+                shouldRefreshAlertRecognizerOnNoSpeech(backend, mode, heardSpeech, sawPartialTranscript)
             ) {
+                // The old recognizer is dead; mark this listener terminal so its
+                // destroy()'s late ERROR_CLIENT callback cannot surface as a session
+                // error, and schedule the in-place replacement.
+                sessionCompleted = true
+                scheduleInPlaceRefresh(sessionId, mode, availability)
                 Log.w(
                     TAG,
                     "Android native STT refreshed in place after no-speech no-match for sessionId=$sessionId " +

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -171,6 +171,28 @@ private const val MEL_RING_SIZE = 76
 private const val EMBEDDING_FRAMES = 16
 private const val EMBEDDING_DIM = 96
 
+/**
+ * Upper bound for [OnnxWakeWordDetector.stop]'s join on the detection thread.
+ * The loop exits immediately after a wake callback (running is already cleared),
+ * so this is only a safety bound for a pathological in-flight read.
+ */
+private const val STOP_TEARDOWN_TIMEOUT_MS = 2_000L
+
+/**
+ * Wait (bounded) for [thread] to terminate.  Never joins the caller's own thread,
+ * so this is safe even when invoked from the thread being stopped.  Interruptions
+ * of the caller are preserved rather than swallowed.
+ */
+internal fun awaitThreadTermination(thread: Thread?, timeoutMs: Long) {
+    if (thread != null && thread !== Thread.currentThread() && thread.isAlive) {
+        try {
+            thread.join(timeoutMs)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}
+
 // ── PCM verification ring buffer ─────────────────────────────────────────────
 /**
  * Number of PCM samples to retain for STT verification on a LOW_THRESHOLD crossing.
@@ -376,8 +398,17 @@ class OnnxWakeWordDetector @Inject constructor(
     override fun stop() {
         running.set(false)
         runCatching { activeAudioRecord?.stop() }
-        runCatching { detectionThread?.interrupt() }
+        val thread = detectionThread
+        runCatching { thread?.interrupt() }
         detectionThread = null
+        // #1433: return only after the detection loop has terminated and released its
+        // AudioRecord, so callers know microphone ownership is handed over when stop()
+        // completes.  The loop exits promptly: onDetected runs after `running` has
+        // already been cleared and the next loop iteration checks it, and an
+        // in-progress read is unblocked by the AudioRecord.stop() above.  The join is
+        // bounded and never joins the caller's own thread, so stop() cannot deadlock
+        // even if it were invoked from the detection thread itself.
+        awaitThreadTermination(thread, STOP_TEARDOWN_TIMEOUT_MS)
         Log.d(TAG, "WakeWordDetector: stopped")
     }
     @Suppress("LongMethod")

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/VoiceInputController.kt
@@ -41,6 +41,11 @@ sealed interface VoiceInputEvent {
         override val mode: VoiceCaptureMode,
         val message: String,
         override val captureSessionId: Long = 0L,
+        /**
+         * Stable machine category for flow decisions (e.g. skip the session-level
+         * retry after the no-speech window is exhausted).  Null = generic error.
+         */
+        val category: String? = null,
     ) : VoiceInputEvent
     data class ListeningStopped(
         override val mode: VoiceCaptureMode,

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -409,8 +409,8 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         // #1433: a false wake must still terminate.  After the bounded in-place
         // refreshes are exhausted, the next platform no-speech no-match surfaces as
         // a genuine session error on the same capture session.
-        val recognizers = (1..3).map { mockk<SpeechRecognizer>(relaxed = true) }
-        val listeners = (1..3).map { slot<RecognitionListener>() }
+        val recognizers = (1..2).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..2).map { slot<RecognitionListener>() }
         every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
         listeners.forEachIndexed { i, slot ->
             every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
@@ -424,26 +424,24 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
             VoiceInputStartResult.Started
         val sessionId = result.captureSessionId
 
-        // Two in-place refreshes extend the window.
-        for (i in 0 until 2) {
-            listeners[i].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
-            runCurrent()
-            listeners[i].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
-            runCurrent()
-            advanceTimeBy(300)
-            runCurrent()
-        }
+        // One in-place refresh extends the window.
+        listeners[0].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
         assertFalse(events.any { it is VoiceInputEvent.Error })
 
-        // The third recognizer reaches readiness, then its no-speech no-match is
-        // past the budget and surfaces as an error on the same capture session.
-        listeners[2].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        // The second recognizer reaches readiness, then its no-speech no-match is
+        // past the refresh budget and surfaces as an error on the same session.
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
         runCurrent()
-        listeners[2].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        listeners[1].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
         runCurrent()
         val error = events.filterIsInstance<VoiceInputEvent.Error>().single()
         assertEquals(sessionId, error.captureSessionId)
-        verify(exactly = 3) { recognitionSupport.createPlatformSpeechRecognizer() }
+        verify(exactly = 2) { recognitionSupport.createPlatformSpeechRecognizer() }
         collector.cancel()
     }
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -372,15 +372,21 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         assertTrue(events.any { it is VoiceInputEvent.ListeningStarted })
 
         // Platform no-speech timeout: no Error must surface; the recognizer is
-        // replaced in place and the same session keeps listening.
+        // replaced in place (after the settle) and the same session keeps listening.
         firstListener.captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
         runCurrent()
         assertFalse(
             events.any { it is VoiceInputEvent.Error },
             "no-speech no-match must not surface as an error",
         )
-        verify(exactly = 2) { recognitionSupport.createPlatformSpeechRecognizer() }
         verify(atLeast = 1) { firstRecognizer.destroy() }
+        verify(exactly = 1) { recognitionSupport.createPlatformSpeechRecognizer() }
+
+        // The in-place replacement starts after the settle and reaches readiness on
+        // the SAME capture session.
+        advanceTimeBy(300)
+        runCurrent()
+        verify(exactly = 2) { recognitionSupport.createPlatformSpeechRecognizer() }
 
         // The refreshed recognizer reaches readiness on the SAME capture session
         // and captures the command.

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -446,6 +446,44 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
     }
 
     @Test
+    fun `refreshed alert recognizer no-speech window is bounded by the shorter budget`() = runTest {
+        // #1433: the platform's second no-speech timeout is not guaranteed, so the
+        // refreshed recognizer's own watchdog must end a silent session within the
+        // shorter refreshed budget (5 s) — keeping the whole session (original +
+        // refresh) inside the acoustic runner's 15 s terminal window.
+        val recognizers = (1..2).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..2).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        listeners[0].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        // No platform no-match arrives; the refreshed watchdog must still end the
+        // silent session inside the shorter budget.
+        advanceTimeBy(4_900)
+        runCurrent()
+        assertFalse(events.any { it is VoiceInputEvent.Error })
+        advanceTimeBy(500)
+        runCurrent()
+        assertTrue(events.any { it is VoiceInputEvent.Error }, "refreshed session must end at the shorter budget")
+        collector.cancel()
+    }
+
+    @Test
     fun `alert session errors other than no-speech no-match still surface`() = runTest {
         val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
         val listener = slot<RecognitionListener>()

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -73,6 +73,32 @@ class NativeAndroidVoiceInputControllerTest {
         assertEquals(false, shouldRetryWithPlatformAfterWatchdogTimeout(RecognizerBackend.Platform, false))
     }
 
+    @Test
+    fun `shouldRefreshAlertRecognizerOnNoSpeech refreshes only silent platform alert sessions`() {
+        // #1433: platform no-speech ERROR_NO_MATCH within an alert session is the
+        // only in-place-refresh case.
+        assertEquals(true, shouldRefreshAlertRecognizerOnNoSpeech(
+            RecognizerBackend.Platform, VoiceCaptureMode.AlertCommand,
+            heardSpeech = false, sawPartialTranscript = false,
+        ))
+        assertEquals(false, shouldRefreshAlertRecognizerOnNoSpeech(
+            RecognizerBackend.Platform, VoiceCaptureMode.AlertCommand,
+            heardSpeech = true, sawPartialTranscript = false,
+        ))
+        assertEquals(false, shouldRefreshAlertRecognizerOnNoSpeech(
+            RecognizerBackend.Platform, VoiceCaptureMode.AlertCommand,
+            heardSpeech = false, sawPartialTranscript = true,
+        ))
+        assertEquals(false, shouldRefreshAlertRecognizerOnNoSpeech(
+            RecognizerBackend.OnDevice, VoiceCaptureMode.AlertCommand,
+            heardSpeech = false, sawPartialTranscript = false,
+        ))
+        assertEquals(false, shouldRefreshAlertRecognizerOnNoSpeech(
+            RecognizerBackend.Platform, VoiceCaptureMode.Command,
+            heardSpeech = false, sawPartialTranscript = false,
+        ))
+    }
+
 
     @Test
     fun `shouldRetryWithPlatformAfterStartupTimeout retries only on-device recognizer`() {
@@ -316,6 +342,82 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
                 .all { it.captureSessionId == result.captureSessionId },
             "the terminal error must belong to the same capture session",
         )
+        collector.cancel()
+    }
+
+    @Test
+    fun `alert session no-speech no-match refreshes the recognizer in place without erroring`() = runTest {
+        // #1433: the platform recognizer's own ~5 s no-speech timeout fires
+        // ERROR_NO_MATCH before the alert-session budget.  The controller must
+        // refresh the recognizer in place (same capture session, no Error event,
+        // no session-level retry) so the first wake session accepts the command.
+        val firstRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val secondRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val firstListener = slot<RecognitionListener>()
+        val secondListener = slot<RecognitionListener>()
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany
+            listOf(firstRecognizer, secondRecognizer)
+        every { firstRecognizer.setRecognitionListener(capture(firstListener)) } just runs
+        every { secondRecognizer.setRecognitionListener(capture(secondListener)) } just runs
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        val result = controller.startListening(VoiceCaptureMode.AlertCommand) as
+            VoiceInputStartResult.Started
+        val sessionId = result.captureSessionId
+        firstListener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        assertTrue(events.any { it is VoiceInputEvent.ListeningStarted })
+
+        // Platform no-speech timeout: no Error must surface; the recognizer is
+        // replaced in place and the same session keeps listening.
+        firstListener.captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        assertFalse(
+            events.any { it is VoiceInputEvent.Error },
+            "no-speech no-match must not surface as an error",
+        )
+        verify(exactly = 2) { recognitionSupport.createPlatformSpeechRecognizer() }
+        verify(atLeast = 1) { firstRecognizer.destroy() }
+
+        // The refreshed recognizer reaches readiness on the SAME capture session
+        // and captures the command.
+        secondListener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        secondListener.captured.onResults(
+            mockk<Bundle>(relaxed = true).apply {
+                every { getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION) } returns
+                    arrayListOf("what time is it")
+            },
+        )
+        runCurrent()
+        val transcript = events.filterIsInstance<VoiceInputEvent.Transcript>().single()
+        assertEquals(sessionId, transcript.captureSessionId)
+        assertEquals("what time is it", transcript.text)
+        collector.cancel()
+    }
+
+    @Test
+    fun `alert session errors other than no-speech no-match still surface`() = runTest {
+        val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val listener = slot<RecognitionListener>()
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returns platformRecognizer
+        every { platformRecognizer.setRecognitionListener(capture(listener)) } just runs
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        listener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        listener.captured.onError(SpeechRecognizer.ERROR_AUDIO)
+        runCurrent()
+
+        assertTrue(events.any { it is VoiceInputEvent.Error })
+        assertEquals(1, events.filterIsInstance<VoiceInputEvent.Error>().size)
         collector.cancel()
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -16,13 +16,16 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -52,10 +55,13 @@ class NativeAndroidVoiceInputControllerTest {
 
 
     @Test
-    fun `sessionResultTimeoutMs keeps alert pre-speech timeout short but allows more time after progress`() {
+    fun `sessionResultTimeoutMs keeps alert pre-speech timeout within the cue-to-command handoff but allows more time after progress`() {
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.Command))
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.SlotReply))
-        assertEquals(2_500L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand))
+        // #1433: the first wake-command attempt must survive the cue-to-command
+        // handoff (measured command arrival 7.4-9.0 s after readiness on both
+        // devices), so the pre-speech alert budget is 10 s, not 2.5 s.
+        assertEquals(10_000L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand))
         assertEquals(6_000L, sessionResultTimeoutMs(VoiceCaptureMode.AlertCommand, hasSpeechProgress = true))
     }
 
@@ -264,5 +270,52 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         val result = controller.startListening(VoiceCaptureMode.Command)
 
         assertEquals(true, result is VoiceInputStartResult.Unavailable)
+    }
+
+    @Test
+    fun `alert session survives the cue-to-command handoff and errors only at the extended budget`() = runTest {
+        // #1433: the first wake-command attempt reaches readiness, plays the cue, and
+        // then must still be listening when the command arrives (measured 7.4-9.0 s
+        // after readiness on both devices).  The pre-fix 2.5 s budget expired the
+        // first attempt before the command, forcing a retry session to become the
+        // normal path.  This test pins the corrected budget: no error at the old
+        // 2.5 s point, terminal error only at the extended alert budget.
+        val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val listener = slot<RecognitionListener>()
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returns platformRecognizer
+        every { platformRecognizer.setRecognitionListener(capture(listener)) } just runs
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        val result = controller.startListening(VoiceCaptureMode.AlertCommand) as
+            VoiceInputStartResult.Started
+        listener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        assertTrue(
+            events.any { it is VoiceInputEvent.ListeningStarted },
+            "attempt must reach readiness",
+        )
+
+        advanceTimeBy(3_000)
+        runCurrent()
+        assertFalse(
+            events.any { it is VoiceInputEvent.Error },
+            "first attempt must still be listening at the old 2.5 s deadline",
+        )
+
+        advanceTimeBy(7_000)
+        runCurrent()
+        assertTrue(
+            events.any { it is VoiceInputEvent.Error },
+            "session must end at the extended alert budget",
+        )
+        assertTrue(
+            events.filterIsInstance<VoiceInputEvent.Error>()
+                .all { it.captureSessionId == result.captureSessionId },
+            "the terminal error must belong to the same capture session",
+        )
+        collector.cancel()
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -200,6 +200,7 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var context: Context
+    private lateinit var audioManager: AudioManager
     private lateinit var recognitionSupport: AndroidNativeRecognitionSupport
     private lateinit var controller: NativeAndroidVoiceInputController
 
@@ -216,8 +217,11 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         Dispatchers.setMain(testDispatcher)
 
         context = mockk(relaxed = true)
-        val audioManager = mockk<AudioManager>(relaxed = true)
+        audioManager = mockk<AudioManager>(relaxed = true)
         every { context.getSystemService(Context.AUDIO_SERVICE) } returns audioManager
+        val mainExecutor = mockk<java.util.concurrent.Executor>(relaxed = true)
+        every { context.mainExecutor } returns mainExecutor
+        every { mainExecutor.execute(any()) } answers { firstArg<Runnable>().run() }
         recognitionSupport = mockk(relaxed = true)
 
         // getAvailability / getCaptureAvailability both return the ready availability
@@ -480,6 +484,230 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
         advanceTimeBy(500)
         runCurrent()
         assertTrue(events.any { it is VoiceInputEvent.Error }, "refreshed session must end at the shorter budget")
+        collector.cancel()
+    }
+
+    @Test
+    fun `refreshed watchdog exhaustion emits the exhausted category and stops the session`() = runTest {
+        // #1433 (review 4836608504 finding 1): the refreshed recognizer's own
+        // no-speech watchdog expiry must be classified as NO_SPEECH_WINDOW_EXHAUSTED
+        // (alert command, refreshed recognizer, no speech, no partials) so the wake
+        // session skips attempt 2, with exactly one error + one stopped event and
+        // normal cleanup.
+        val recognizers = (1..2).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..2).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        val result = controller.startListening(VoiceCaptureMode.AlertCommand) as
+            VoiceInputStartResult.Started
+        val sessionId = result.captureSessionId
+        listeners[0].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        advanceTimeBy(4_900)
+        runCurrent()
+        assertFalse(events.any { it is VoiceInputEvent.Error })
+        advanceTimeBy(500)
+        runCurrent()
+
+        val errors = events.filterIsInstance<VoiceInputEvent.Error>()
+        assertEquals(1, errors.size, "exactly one terminal error")
+        assertEquals(NO_SPEECH_WINDOW_EXHAUSTED, errors.single().category)
+        assertEquals(sessionId, errors.single().captureSessionId)
+        assertEquals(1, events.filterIsInstance<VoiceInputEvent.ListeningStopped>().size)
+        assertEquals(sessionId, events.filterIsInstance<VoiceInputEvent.ListeningStopped>().single().captureSessionId)
+        verify(atLeast = 1) { recognizers[1].destroy() }
+        collector.cancel()
+    }
+
+    @Test
+    fun `refresh recognizer creation throwing emits one error and one stopped event and clears the session`() = runTest {
+        // #1433 (review 4836608504 finding 2): a refresh-start failure for the
+        // still-active session must not strand it — one error (NOT the exhausted
+        // category), one stopped event, recognizer/audio-focus cleanup, and the
+        // exception must not escape the scheduler.
+        val firstRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val firstListener = slot<RecognitionListener>()
+        var createCalls = 0
+        every { recognitionSupport.createPlatformSpeechRecognizer() } answers {
+            createCalls++
+            if (createCalls == 1) {
+                firstRecognizer
+            } else {
+                throw RuntimeException("platform recognizer creation failed")
+            }
+        }
+        every { firstRecognizer.setRecognitionListener(capture(firstListener)) } just runs
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        firstListener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        firstListener.captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+
+        val errors = events.filterIsInstance<VoiceInputEvent.Error>()
+        assertEquals(1, errors.size)
+        assertEquals(null, errors.single().category, "startup failure must not be labelled exhausted")
+        assertEquals(1, events.filterIsInstance<VoiceInputEvent.ListeningStopped>().size)
+        verify(atLeast = 1) { firstRecognizer.destroy() }
+        // JVM unit tests run below API 26, so audio focus release uses the
+        // deprecated abandonAudioFocus(null) path.
+        verify(atLeast = 1) { audioManager.abandonAudioFocus(null) }
+        collector.cancel()
+    }
+
+    @Test
+    fun `refresh startListening throwing cleans up the partial recognizer`() = runTest {
+        // #1433 (review 4836608504 finding 2): if startListening() throws after the
+        // replacement recognizer was created, the partial recognizer is destroyed and
+        // exactly one terminal error + stopped event are emitted.
+        val firstRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val secondRecognizer = mockk<SpeechRecognizer>(relaxed = true)
+        val firstListener = slot<RecognitionListener>()
+        val secondListener = slot<RecognitionListener>()
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany
+            listOf(firstRecognizer, secondRecognizer)
+        every { firstRecognizer.setRecognitionListener(capture(firstListener)) } just runs
+        every { secondRecognizer.setRecognitionListener(capture(secondListener)) } just runs
+        every { secondRecognizer.startListening(any()) } throws RuntimeException("start failed")
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        firstListener.captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        firstListener.captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+
+        val errors = events.filterIsInstance<VoiceInputEvent.Error>()
+        assertEquals(1, errors.size)
+        assertEquals(1, events.filterIsInstance<VoiceInputEvent.ListeningStopped>().size)
+        verify(atLeast = 1) { secondRecognizer.destroy() }
+        collector.cancel()
+    }
+
+    @Test
+    fun `refreshed readiness is emitted once per capture session`() = runTest {
+        // #1433 (review 4836608504 finding 3): an in-place refresh must not re-emit
+        // ListeningStarted for the same capture session.
+        val recognizers = (1..2).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..2).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        val result = controller.startListening(VoiceCaptureMode.AlertCommand) as
+            VoiceInputStartResult.Started
+        val sessionId = result.captureSessionId
+        listeners[0].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        val ready = events.filterIsInstance<VoiceInputEvent.ListeningStarted>()
+        assertEquals(1, ready.size, "one readiness per capture session")
+        assertEquals(sessionId, ready.single().captureSessionId)
+        collector.cancel()
+    }
+
+    @Test
+    fun `replacement ready emits the first readiness when the original never became ready`() = runTest {
+        // #1433 (review 4836608504 finding 3): suppressing duplicates must not
+        // suppress the FIRST readiness — a replacement recognizer that becomes ready
+        // when the original failed before readiness still emits it.
+        val recognizers = (1..2).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..2).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        // The original recognizer errors with no-speech before ever becoming ready.
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+
+        val ready = events.filterIsInstance<VoiceInputEvent.ListeningStarted>()
+        assertEquals(1, ready.size)
+        collector.cancel()
+    }
+
+    @Test
+    fun `pending refresh is cancelled by stopListening and stale refresh cannot start after a new session`() = runTest {
+        // #1433 (review 4836608504 finding 2): the pending refresh job is cancelled
+        // by stopListening, and a stale refresh can never start for a replaced session.
+        val recognizers = (1..3).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..3).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+        val collector = launch { controller.events.collect { } }
+        runCurrent()
+
+        // Session 1: ready, then a no-match schedules an in-place refresh.
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        listeners[0].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        listeners[0].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+
+        // stopListening() cancels the pending refresh.
+        controller.stopListening()
+        advanceTimeBy(300)
+        runCurrent()
+        verify(exactly = 1) { recognitionSupport.createPlatformSpeechRecognizer() }
+
+        // Session 2 replaces session 1 while another refresh is pending; the stale
+        // refresh must not create a recognizer for the old session.
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        listeners[1].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        listeners[1].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        controller.startListening(VoiceCaptureMode.AlertCommand)
+        runCurrent()
+        advanceTimeBy(300)
+        runCurrent()
+        verify(exactly = 3) { recognitionSupport.createPlatformSpeechRecognizer() }
         collector.cancel()
     }
 

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputControllerTest.kt
@@ -405,6 +405,49 @@ class NativeAndroidVoiceInputControllerStartListeningTest {
     }
 
     @Test
+    fun `alert session no-speech refresh budget is bounded and then surfaces the error`() = runTest {
+        // #1433: a false wake must still terminate.  After the bounded in-place
+        // refreshes are exhausted, the next platform no-speech no-match surfaces as
+        // a genuine session error on the same capture session.
+        val recognizers = (1..3).map { mockk<SpeechRecognizer>(relaxed = true) }
+        val listeners = (1..3).map { slot<RecognitionListener>() }
+        every { recognitionSupport.createPlatformSpeechRecognizer() } returnsMany recognizers
+        listeners.forEachIndexed { i, slot ->
+            every { recognizers[i].setRecognitionListener(capture(slot)) } just runs
+        }
+
+        val events = mutableListOf<VoiceInputEvent>()
+        val collector = launch { controller.events.collect { events += it } }
+        runCurrent()
+
+        val result = controller.startListening(VoiceCaptureMode.AlertCommand) as
+            VoiceInputStartResult.Started
+        val sessionId = result.captureSessionId
+
+        // Two in-place refreshes extend the window.
+        for (i in 0 until 2) {
+            listeners[i].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+            runCurrent()
+            listeners[i].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+            runCurrent()
+            advanceTimeBy(300)
+            runCurrent()
+        }
+        assertFalse(events.any { it is VoiceInputEvent.Error })
+
+        // The third recognizer reaches readiness, then its no-speech no-match is
+        // past the budget and surfaces as an error on the same capture session.
+        listeners[2].captured.onReadyForSpeech(mockk<Bundle>(relaxed = true))
+        runCurrent()
+        listeners[2].captured.onError(SpeechRecognizer.ERROR_NO_MATCH)
+        runCurrent()
+        val error = events.filterIsInstance<VoiceInputEvent.Error>().single()
+        assertEquals(sessionId, error.captureSessionId)
+        verify(exactly = 3) { recognitionSupport.createPlatformSpeechRecognizer() }
+        collector.cancel()
+    }
+
+    @Test
     fun `alert session errors other than no-speech no-match still surface`() = runTest {
         val platformRecognizer = mockk<SpeechRecognizer>(relaxed = true)
         val listener = slot<RecognitionListener>()

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDetectorLifecycleTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordDetectorLifecycleTest.kt
@@ -1,0 +1,77 @@
+package com.kernel.ai.core.voice
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the #1433 detector-stop contract: `OnnxWakeWordDetector.stop()` must not
+ * return until the detection loop has terminated and released its AudioRecord, and
+ * must never deadlock when invoked near (or from) the detection callback.
+ *
+ * The join mechanics are extracted into [awaitThreadTermination] so they are
+ * deterministic to test without an Android AudioRecord.
+ */
+class WakeWordDetectorLifecycleTest {
+
+    @Test
+    fun `awaitThreadTermination returns only after the thread has terminated`() {
+        val latch = CountDownLatch(1)
+        val thread = Thread { latch.await() }.also { it.start() }
+
+        assertTrue(thread.isAlive)
+        latch.countDown()
+
+        awaitThreadTermination(thread, 2_000L)
+
+        assertFalse(thread.isAlive)
+    }
+
+    @Test
+    fun `awaitThreadTermination never joins the caller's own thread`() {
+        // Would deadlock if it joined the current thread; must return immediately.
+        awaitThreadTermination(Thread.currentThread(), 1_000L)
+    }
+
+    @Test
+    fun `awaitThreadTermination is bounded and does not wait for a live thread forever`() {
+        val thread = Thread { Thread.sleep(30_000) }.also { it.start() }
+
+        val started = System.nanoTime()
+        awaitThreadTermination(thread, 100L)
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertTrue(elapsedMs < 5_000L, "join must be bounded, took ${elapsedMs}ms")
+        assertTrue(thread.isAlive)
+        thread.interrupt()
+        thread.join(2_000)
+    }
+
+    @Test
+    fun `awaitThreadTermination tolerates a null thread`() {
+        awaitThreadTermination(null, 100L)
+    }
+
+    @Test
+    fun `awaitThreadTermination returns after the thread dies even when it outlives the bound`() {
+        val gate = CountDownLatch(1)
+        val thread = Thread {
+            try {
+                gate.await(10, TimeUnit.SECONDS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+        }.also { it.start() }
+
+        // First call times out with the thread still alive…
+        awaitThreadTermination(thread, 50L)
+        assertTrue(thread.isAlive)
+
+        // …and a second call completes once the thread actually terminates.
+        gate.countDown()
+        awaitThreadTermination(thread, 2_000L)
+        assertFalse(thread.isAlive)
+    }
+}


### PR DESCRIPTION
Fixes #1433

## Evidence examined

Preserved #1410 diagnostic journals (S21 `a2bbaf4a`, S23U `0701ebb6`), same-device monotonic ordering only:

- **Attempt 1 always reaches readiness** — S21 trial 007: `STT_START_REQUESTED(+8ms) → STT_READY(+165ms) → CUE(+203ms)`; S23U trial 006: `STT_READY(+1485ms)`. The microphone handoff to the recognizer succeeds on every trial.
- **The first session is then killed by the app's own alert-session silence watchdog** — `STT_ERROR` lands at exactly `READY + 2.5 s` on both devices (`ALERT_SESSION_SILENCE_TIMEOUT_MS = 2_500`), before any speech arrives. Trial 008 shows the speech-progress variant: speech detected at +0.69 s extends the watchdog to 6 s and it fires at +6.53 s.
- **The command arrives 7.4–9.0 s after first readiness** (runner cue-margin + orchestration contract; T1→T3 measured 7.38–9.04 s across trials), always after attempt 1's window closed.
- The retry (attempt 2) catches the command only when it happens to arrive inside the retry's window (trials 008/019/021/006); trial 007's command arrived after even attempt 2 ended (`COMMAND_ROUTING_RESULT` after `SESSION_COMPLETED` → `command_capture_or_routing_failure`).
- The observed 7–9 s delay = the first session dying at 2.5 s + the runner re-waiting on the retry session's readiness before playing the command.

## Leading hypothesis: REJECTED

The microphone-teardown race (STT starting while the wake detector still owns `AudioRecord`) is **disproven** by the evidence: attempt 1 reaches `STT_READY` and captures audio in every trial on both devices. The first divergence is the session-lifetime deadline, not mic ownership.

## Exact attempt-1 provider error

The app's own alert-session watchdog fired first in every trial (timing matches the 2.5 s constant exactly on both devices; `SESSION_RESULT_TIMEOUT_MS=6 s` variant after speech progress) — "Android speech recognition stopped responding before it returned a result" (`stt_recognition_failed`). No platform error code was ever reached on attempt 1.

## Smallest sufficient correction (two parts)

1. **Ordering** (`WakeWordService`, `OnnxWakeWordDetector`): a confirmed activation now stops the wake detector — and `stop()` returns only after the detection loop has terminated and released its `AudioRecord` (bounded join, never self-joining) — before `STT_START_REQUESTED`. The service's session logic is extracted into testable `runWakeCommandHandoff()` (stop → `VOICE_SESSION_STARTED` → attempt-1 STT → route → terminal → re-arm once).
2. **Lifetime** (`NativeAndroidVoiceInputController`): `ALERT_SESSION_SILENCE_TIMEOUT_MS` 2.5 s → 10 s so the first session survives the cue-to-command handoff (measured 7.4–9.0 s; 10 s matches the legacy Vosk session bound). Speech progress still extends via the 6 s result timeout; the bounded retry still runs for genuine post-readiness failures.

No fixed delays, no runner changes, no additional retry layer, no thresholds/models/providers changed. Cancellation now also stops the active recognizer (no leftover mic owner).

## Production files changed

- `app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt` — extracted `runWakeCommandHandoff`; detector released before attempt-1 STT; recognizer stopped on cancellation; re-arm once after terminal.
- `core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt` — `stop()` returns only after AudioRecord release (bounded join via `awaitThreadTermination`).
- `core/voice/src/main/java/com/kernel/ai/core/voice/NativeAndroidVoiceInputController.kt` — alert-session silence budget 10 s.

## Lifecycle and concurrency tests

New `WakeCommandHandoffTest` (8 tests): attempt-1 STT ordered after detector release; handoff from the detection callback joins without deadlock; successful first attempt starts exactly one session (no attempt 2); foreign-mode events filtered; genuine post-readiness failure still retries; obsolete attempt-1 callback cannot terminate attempt 2; cancellation stops the recognizer and re-arms once; one session per activation. New `WakeWordDetectorLifecycleTest` (5 tests): bounded join semantics, no self-join, timeout bound, null safety, re-join after death. New native-controller watchdog test: first session survives the old 2.5 s point and errors only at the extended budget, same capture session. `sessionResultTimeoutMs` assertion updated to the new budget.

Focused runs: `WakeCommandHandoffTest` 8/8, `WakeWordDetectorLifecycleTest` 5/5, native controller tests 9/9, `WakeWordCueTest` 16/16, `WakeSessionJournalTest` 5/5. Full suites: `:core:voice` 163/163, `:app` 1061/1061, lint clean for changed files (baseline unchanged), `git diff --check` clean.

## Expected event ordering (validated by the tests; physical smoke pending)

`VERIFIED_ACTIVATION → WAKE_CALLBACK_INVOKED → detector mic released → VOICE_SESSION_STARTED → STT_START_REQUESTED(attempt=1) → STT_READY → CUE_REQUESTED → CUE_PLAYBACK_STARTED → STT_SPEECH_DETECTED → STT_FINAL → COMMAND_ROUTING_RESULT(handed_off) → SESSION_COMPLETED → DETECTOR_REARMED` — no attempt-1 `STT_ERROR`, no attempt-2.

## Exclusions

- Detector recall (#1432) untouched; no wake models/thresholds/providers/silence gating changes.
- No runner delay changes (runner untouched; the smoke uses its existing modes).
- Full #1410 `regression_post_fix` matrix deferred to #1410.

## Bounded physical smoke — S21 target / S23U source (frozen volume 9, one exact APK `e7d69bdc…`→`cedb3c12…`, frozen fixtures, fixed placement)

Diagnostic matrix stopped after the required cells (run `diagnostic_pre_fix-2026-08-01T21-33-21Z-fb7ce590`, evidence in `scripts/private-acoustic-runs/`):

| Cell | Trials | Result |
|---|---|---|
| 10 s wake+command | 006, 007, 008 | **3/3 PASS** |
| 120 s wake+command | 019, 020, 022 (021 invalid source-stimulus, retried as 022) | **3/3 PASS** |

Every passing command trial: wake fires (high, 0.68–0.73), **attempt-1 `STT_READY` at 156–411 ms after `STT_START_REQUESTED`**, command captured (`STT_FINAL`), `COMMAND_ROUTING_RESULT handed_off`, `SESSION_COMPLETED`, `DETECTOR_REARMED` — **no attempt-1 `STT_ERROR` and no attempt-2 `STT_START_REQUESTED` in any passing trial**. The pre-fix first-attempt failure (STT_ERROR at READY+2.5 s → retry) is gone.

Extra-position failures preserved + investigated (never retried away): trial 003 (10 s wake_only — `classifier_model_miss`, no wake heard — acoustic variance); trials 009/012/015/016/017 (wake_only — session terminal beyond the runner's 15 s window under an earlier build; corrected by bounding the refreshed recognizer's no-speech window, head `84e6513c`).

## Bounded physical smoke — S23U target / S21 source (COMPLETE)

Run `diagnostic_pre_fix-2026-08-01T22-25-20Z-702d587d` (frozen volume 9, one exact APK, frozen fixtures, fixed placement): the frozen S23U matrix `(120, 3, 2) + (1800, 2, 1)` provides three command cells:

| Cell | Trials | Result |
|---|---|---|
| 120 s wake+command | 004, 005 | **2/2 PASS** |
| 1800 s wake+command | 008 | **1/1 PASS** |

Attempt-1 `STT_READY` at 124–134 ms after `STT_START_REQUESTED`, command captured + routed, `SESSION_COMPLETED`, re-arm — **no attempt-1 `STT_ERROR`, no attempt-2** in any passing trial. The 120 s/1800 s wake_only extras (002/003/006/007) missed the wake (`classifier_model_miss` — the S21→S23U acoustic leg is the weakest, consistent with the #1410 Phase 1B 2/8 pass rate); preserved and investigated — detector-path misses, not command-path failures.

## Remediation of review 4836608504 (2026-08-02)

Review `4836608504` (CHANGES_REQUESTED, 2026-08-02T02:11:40Z) raised three defects in the refreshed-recognizer path. All three are fixed in `NativeAndroidVoiceInputController.kt` (only production file changed for this remediation):

1. **Refreshed watchdog expiry was an untyped error** → the wake session started attempt 2 instead of terminating/re-arming. The session watchdog's expiry now emits `category = NO_SPEECH_WINDOW_EXHAUSTED` only when the mode is `AlertCommand`, the recognizer is the refreshed one, no speech was heard and no partial transcript was seen — exactly one `Error` + one `ListeningStopped` on the existing capture session id, with normal cleanup. Command/slot-reply, speech-progress, genuine-error and startup-failure paths stay generic.
2. **`scheduleInPlaceRefresh()` launched an unmanaged coroutine** → a refresh-start throw (recognizer creation, listener registration, `startListening()`) could escape on the main dispatcher and strand the session. The pending refresh is now an owned `inPlaceRefreshJob`: cancelled before scheduling another refresh, by `stopListeningInternal()`, and when a new session starts; it re-checks `activeSessionId` after the settle; a genuine refresh-start failure cleans up the partial recognizer, emits one generic `Error` + one `ListeningStopped` (NOT the exhausted category), clears active state and releases audio focus — the existing wake-level bounded retry then applies.
3. **The refreshed recognizer re-emitted `ListeningStarted`** for the same capture session (replaying the clock-alert listening cue). Readiness is now idempotent per capture session (`readinessEmittedForSession`): internal watchdog setup always runs, `ListeningStarted` is emitted at most once per session, a replacement emits the first readiness when the original failed before ready, and the flag resets on session allocation/termination/stop. A refresh still allocates no new capture session id.

Files changed: `core/voice/.../NativeAndroidVoiceInputController.kt`, `core/voice/.../NativeAndroidVoiceInputControllerTest.kt` (+7 regression tests), new `app/src/test/java/com/kernel/ai/assistant/WakeCommandHandoffControllerIntegrationTest.kt` (real controller through `runWakeCommandHandoff`), `app/build.gradle.kts` (`isReturnDefaultValues = true` so the controller integration tests can drive `android.util.Log`; mirrors `:core:voice`). `WakeWordService.kt` / `OnnxWakeWordDetector.kt` untouched by this remediation.

Focused results: `NativeAndroidVoiceInputControllerTest` 10/10, `NativeAndroidVoiceInputControllerStartListeningTest` 14/14 (7 new), `WakeCommandHandoffTest` 9/9, `WakeCommandHandoffControllerIntegrationTest` 2/2 — refreshed watchdog exhaustion emits the exhausted category, the wake session skips attempt 2 (no third recognizer, exactly one `STT_ERROR` + one `SESSION_CANCELLED` + one re-arm, one `CUE_REQUESTED`), and the clock-alert path plays exactly one listening cue across an in-place refresh. Full suites: `:core:voice` 174/174, `:app` 1064/1064, lint clean, `git diff --check` clean.

No physical smoke repeated for this remediation head (findings 1–3 are deterministic and covered by automated tests; no new APK/device claim). The accepted S21/S23U command smoke below remains historical evidence for head `84e6513c` (APK `cedb3c12…`).

## Final head and APK

Synchronised head (current): `840aa0d48e1a5f25d3758d80d2bf2be1b9bcd6978` — a normal merge of current `main` (head `f428413465e976e72dc4e78879784ee34e59a145`, incl. merged PR #1436) into `fix/1433-first-attempt-stt-handoff`; no conflicts, the merged #1436 playback-start evidence correction is intact and unchanged (runner scripts identical to `main`). Intervening commits inspected: `a3a8f58c` + merge `f4284134` (both the #1436 playback-start fix; disjoint from the #1433 Kotlin remediation). Exact-head CI (run `30734849196`, incl. `:core:voice:testDebugUnitTest`, `:app:testDebugUnitTest`, lint, debug build) + Docs Drift (runs `30734849191`/`30734856363`/`30734860880`) pass at `840aa0d4`.

Synchronised-head verification (no physical-device claim): focused `WakeCommandHandoffTest` / `WakeCommandHandoffControllerIntegrationTest` / `WakeWordDetectorLifecycleTest` / `NativeAndroidVoiceInputControllerTest` (+ start-listening) / wake cue / wake session journal 61/61; full suites `:core:voice` 174/174, `:app` 1064/1064; lint clean for changed modules; acoustic runner module 74/74; full `scripts/tests` 699/699; `git diff --check` clean. The complete PR diff vs `main` still contains only the #1433 remediation (9 files: handoff ordering, detector release before attempt-1 STT, 10 s alert budget, one bounded in-place refresh, refreshed no-speech-window exhaustion without attempt 2, refresh-start failure cleanup, readiness idempotence, cancellation + single re-arm, stale-callback protection).

Physical smoke remains HISTORICAL evidence for head `84e6513cffeb41c1d7862ceeae38debfed67447e` only; final smoke APK SHA-256: `cedb3c12064deff39038c4431f4985039cb3425de1132c1cc3362106ec5baf00` (update-installed on both devices, data preserved; S21 10 s command 3/3 + 120 s command 3/3 PASS, S23U 120 s 2/2 + 1800 s 1/1 PASS, attempt-1 `STT_READY` 124–411 ms, no STT_ERROR/attempt-2 in any passing trial). No new APK/device evidence is claimed for the synchronised head.

Do not merge — wait for review.





