### PR TITLE
fix(#1409): correct acoustic-runner playback-start, terminal-rearm and event-dedup defects

### DIFF
--- a/scripts/acoustic_wake_reliability_runner.py
+++ b/scripts/acoustic_wake_reliability_runner.py
@@ -4147,8 +4147,16 @@ def load_later_run_preflight(
         )
 
 def finalize_evidence(runner: AcousticWakeReliabilityRunner) -> dict[str, Any]:
-    """Capture final cleanup state before serialising public evidence."""
+    """Capture final cleanup state before serialising public evidence.
+
+    #1409 review 4840085897: the final checkpoint is persisted only after
+    cleanup completes, so a later offline ``resume --export-only`` re-render
+    retains the authoritative post-cleanup state (``cleanup_verified``,
+    ``cleanup_failures``, ``run_environment_after``, final ``abort_reason``
+    and ``primary_failure``) instead of the pre-cleanup checkpoint defaults.
+    """
     runner.cleanup()
+    runner.checkpoint()
     return runner.export_evidence()
 
 

--- a/scripts/acoustic_wake_reliability_runner.py
+++ b/scripts/acoustic_wake_reliability_runner.py
@@ -101,6 +101,27 @@ TARGET_ERROR_UNKNOWN_REQUEST_ID = "argument_error:unknown_request_id"
 TARGET_WAIT_DEFAULT_TIMEOUT_MS = 15_000
 TARGET_WAIT_MIN_TIMEOUT_MS = 500
 TARGET_WAIT_MAX_TIMEOUT_MS = 60_000
+# Bounded terminal/re-arm observation for the DETECTOR_REARMED wait (#1409).
+# The default 15 s wait expired while a supported STT retry was still active
+# (preserved regression trials 001/017: attempt-1 recognition failure, the
+# attempt-2 session still finalising when the observation ended).  The bound
+# below covers the complete supported bounded lifecycle, derived from the
+# production constants in NativeAndroidVoiceInputController.kt and the
+# wake-command handoff in WakeWordService.kt (max 2 session attempts):
+#   attempt-1 result envelope:
+#     ALERT_SESSION_SILENCE_TIMEOUT_MS (10 s speech budget)
+#     + SESSION_RESULT_TIMEOUT_MS (6 s speech-progress result)          = 16 s
+#     (the in-place no-speech refresh chain, ~5 s platform no-speech + 0.3 s
+#     REFRESH_SETTLE_MS + 5 s REFRESHED_SESSION_SILENCE_TIMEOUT_MS + 6 s
+#     result, is bounded within the same envelope)
+#   attempt-2 recogniser readiness: ON_DEVICE_READY_TIMEOUT_MS (1.5 s)
+#   attempt-2 result envelope: same 16 s bound                        = 17.5 s
+#   session terminal -> detector re-arm: <= 2 s budget
+#     (observed 12-63 ms across the preserved 31-trial run)
+#   total worst supported chain: 16 + 1.5 + 16 + 2 = 35.5 s
+# Rounded to 40 s: the smallest round bound above the derived worst case,
+# deterministic (never open-ended), within the provider's 60 s maximum.
+TARGET_WAIT_TERMINAL_REARM_MS = 40_000
 # Retained only for non-blocking legacy reads on older debug APKs.
 TARGET_RECEIVER_CLS = "com.kernel.ai.debug.journal.TargetEventJournalReceiver"
 TARGET_ACTION_GET_SEQUENCE = "com.kernel.ai.debug.action.GET_JOURNAL_SEQUENCE"
@@ -837,6 +858,34 @@ def parse_source_result(
 
 
 
+def source_playback_start_wall_clock_ms(
+    source_result: dict[str, Any],
+) -> int | None:
+    """Resolve the validated audible playback-start wall clock from a source result.
+
+    The Android source helper (``AcousticStimulusEngine``) records the
+    physical playback-start event with ``name == "started"`` (issue #1409
+    review: the runner previously searched for a Python-only
+    ``playback_started`` name that no physical producer emits, so physical
+    command trials persisted a null value).
+
+    Exactly one ``started`` event is authoritative.  Zero events produce no
+    value, and multiple matching events are ambiguous and also fail closed;
+    the request wall clock is never substituted and playback start is never
+    inferred from source monotonic time.
+    """
+    started_events = [
+        event for event in (source_result.get("events") or [])
+        if event.get("name") == "started"
+    ]
+    if len(started_events) != 1:
+        return None
+    candidate = started_events[0].get("wall_clock_ms")
+    if isinstance(candidate, bool) or not isinstance(candidate, int):
+        return None
+    return candidate
+
+
 def service_active(client: AdbClient, package: str) -> bool:
     """Check whether WakeWordService is running on the device."""
     return "WakeWordService" in client.shell("dumpsys", "activity", "services", package)
@@ -1394,7 +1443,7 @@ def command_delivery_after_session_end(
        ``clock_alignment`` record (validated by ``validated_clock_alignment``)
        bounds (target − source) wall-clock offset.  The command's ACTUAL
        AUDIBLE PLAYBACK START (``command.playback_start_wall_clock_ms``, the
-       source helper's validated ``playback_started`` event wall clock) is
+       source helper's validated ``started`` event wall clock) is
        provably after the terminal event only when it is after it for every
        offset in the recorded range:
        playback_start_wall_clock_ms + offset_range_lo > terminal_wall_clock_ms.
@@ -1496,6 +1545,39 @@ def format_target_snapshot_events(envelope: dict[str, Any]) -> list[dict[str, An
         }
         for ev in events
     ]
+
+
+def deduplicate_projected_events(
+    events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Collapse repeated projection of the same authoritative journal event.
+
+    The correlated path projects some journal events twice: e.g.
+    ``ACTIVATION_CANDIDATE`` appears both in ``gate_activity`` (its type is
+    in ``MEANINGFUL_WAKE_EVENTS``) and as its own named path entry (#1409).
+    Normalised evidence must contain one record per authoritative journal
+    sequence number.
+
+    - journal sequence order is preserved;
+    - distinct events are never removed merely because they share an event
+      type (the key is the sequence number);
+    - an identical repeated projection is dropped;
+    - the same sequence with conflicting content fails closed instead of
+      silently choosing one record.
+    """
+    deduplicated: list[dict[str, Any]] = []
+    by_sequence: dict[int, dict[str, Any]] = {}
+    for event in events:
+        sequence = event["s"]
+        previous = by_sequence.get(sequence)
+        if previous is None:
+            by_sequence[sequence] = event
+            deduplicated.append(event)
+        elif previous != event:
+            raise HarnessError(
+                f"conflicting journal projections for sequence {sequence}"
+            )
+    return deduplicated
 
 
 def public_preflight_approval(approval: dict[str, Any] | None) -> dict[str, Any]:
@@ -2098,6 +2180,45 @@ class AcousticWakeReliabilityRunner:
         )
         for attempt in self.attempts:
             reclassify_out_of_window_command_attempt(attempt, self.clock_alignment)
+            # #1409: normalise already-recorded projections to one record per
+            # authoritative journal sequence (old checkpoints captured
+            # ACTIVATION_CANDIDATE twice).  Conflicting projections of the
+            # same sequence fail closed.
+            stored_events = attempt.target_timing.get("events")
+            if stored_events is not None:
+                attempt.target_timing["events"] = deduplicate_projected_events(
+                    stored_events
+                )
+            # #1409: re-derive the command playback-start wall clock from the
+            # preserved source results.  The pre-fix runner searched for a
+            # Python-only ``playback_started`` event name and persisted null;
+            # the preserved artifacts carry the physical ``started`` event, so
+            # offline evidence regeneration can populate the actual audible
+            # playback-start wall clock.  Request time is never substituted.
+            command_timing = attempt.source_timing.get("command")
+            if command_timing is not None:
+                command_trial_id = f"{attempt.trial_id}-cmd"
+                command_result = next(
+                    (
+                        result for result in self.source_results
+                        if result.get("trial_id") == command_trial_id
+                    ),
+                    None,
+                )
+                if command_result is None:
+                    # No preserved source result for this checkpoint (e.g.
+                    # synthetic fixtures): keep the recorded value untouched
+                    # rather than fabricating one.
+                    continue
+                parsed_command = parse_source_result(
+                    json.dumps(command_result),
+                    expected_trial_id=command_trial_id,
+                    expected_fixture_id=attempt.command_fixture_id,
+                    expected_fixture_sha256=attempt.command_fixture_sha256,
+                )
+                command_timing["playback_start_wall_clock_ms"] = (
+                    source_playback_start_wall_clock_ms(parsed_command)
+                )
         # Reconcile persisted bookkeeping with the corrected attempt statuses
         # (scheduling decisions derive from attempts, these sets are reported
         # and persisted only).
@@ -2706,10 +2827,15 @@ class AcousticWakeReliabilityRunner:
                         self.checkpoint("post-command")
 
             attempt.invalid_reason = InvalidReason.EVIDENCE_BOUNDARY_LOST
+            # Bounded terminal/re-arm observation covering the complete
+            # supported STT lifecycle (see TARGET_WAIT_TERMINAL_REARM_MS for
+            # the derivation).  A genuinely exhausted bound keeps the existing
+            # failure semantics: the final snapshot simply lacks the terminal
+            # and the attempt classifies UNCLASSIFIED.
             self._wait_for_target_events(
                 since_sequence=boundary_sequence,
                 event_type="DETECTOR_REARMED",
-                timeout_ms=TARGET_WAIT_DEFAULT_TIMEOUT_MS,
+                timeout_ms=TARGET_WAIT_TERMINAL_REARM_MS,
             )
             final_code, final_data = self._call_target_provider(
                 TARGET_METHOD_GET_SNAPSHOT,
@@ -2745,6 +2871,11 @@ class AcousticWakeReliabilityRunner:
                 else:
                     correlated_events.append(value)
             correlated_events.sort(key=lambda event: event["s"])
+            # One record per authoritative journal sequence: the correlated
+            # path projects ACTIVATION_CANDIDATE through both gate_activity
+            # and its named entry (#1409).  Conflicting projections of the
+            # same sequence fail closed.
+            correlated_events = deduplicate_projected_events(correlated_events)
             attempt.target_timing["events"] = format_target_snapshot_events(
                 {"events": correlated_events}
             )
@@ -2801,22 +2932,14 @@ class AcousticWakeReliabilityRunner:
                         "completion_monotonic_ms",
                     )
                 }
-                # #1431 review 4837126355: persist the wall clock of the
-                # validated playback_started source event so retrospective
-                # ordering compares actual audible playback start rather than
-                # request submission time.  Missing evidence stays None and is
-                # never inferred from request or monotonic time.
-                playback_started_events = [
-                    event for event in (parsed_command_source.get("events") or [])
-                    if event.get("name") == "playback_started"
-                ]
-                playback_start_wall_clock_ms: int | None = None
-                if len(playback_started_events) == 1:
-                    candidate = playback_started_events[0].get("wall_clock_ms")
-                    if isinstance(candidate, int) and not isinstance(candidate, bool):
-                        playback_start_wall_clock_ms = candidate
+                # #1431 review 4837126355 / #1409 review: persist the wall
+                # clock of the source helper's validated ``started`` playback
+                # event so retrospective ordering compares actual audible
+                # playback start rather than request submission time.  Missing
+                # or ambiguous evidence stays None and is never inferred from
+                # request or monotonic time.
                 attempt.source_timing["command"]["playback_start_wall_clock_ms"] = (
-                    playback_start_wall_clock_ms
+                    source_playback_start_wall_clock_ms(parsed_command_source)
                 )
             if environment_failures:
                 attempt.status = AttemptStatus.INVALID

--- a/scripts/testdata/fixtures/acoustic-wake-reliability/source-result-valid.json
+++ b/scripts/testdata/fixtures/acoustic-wake-reliability/source-result-valid.json
@@ -30,8 +30,8 @@
     {"name": "request_submitted", "monotonic_ms": 1000, "wall_clock_ms": 1705300000123},
     {"name": "prepare_started", "monotonic_ms": 1100, "wall_clock_ms": 1705300000223},
     {"name": "prepared", "monotonic_ms": 1200, "wall_clock_ms": 1705300000323},
-    {"name": "playback_started", "monotonic_ms": 1300, "wall_clock_ms": 1705300000423},
-    {"name": "playback_completed", "monotonic_ms": 3200, "wall_clock_ms": 1705300002323},
+    {"name": "started", "monotonic_ms": 1300, "wall_clock_ms": 1705300000423},
+    {"name": "completed", "monotonic_ms": 3200, "wall_clock_ms": 1705300002323},
     {"name": "cleanup_completed", "monotonic_ms": 3400, "wall_clock_ms": 1705300002523,
      "cleanup_success": true, "exact_restoration_verified": true}
   ]

--- a/scripts/tests/test_acoustic_wake_reliability_runner.py
+++ b/scripts/tests/test_acoustic_wake_reliability_runner.py
@@ -916,12 +916,160 @@ class EvidenceAndModeTests(unittest.TestCase):
         order: list[str] = []
         harness = Mock()
         harness.cleanup.side_effect = lambda: order.append("cleanup")
+        harness.checkpoint.side_effect = lambda: order.append("checkpoint")
         harness.export_evidence.side_effect = lambda: order.append("export") or {"ok": True}
 
         evidence = runner.finalize_evidence(harness)
 
-        self.assertEqual(order, ["cleanup", "export"])
+        # #1409 review 4840085897: the final checkpoint is written only after
+        # cleanup completes so later offline re-renders retain final state.
+        self.assertEqual(order, ["cleanup", "checkpoint", "export"])
         self.assertEqual(evidence, {"ok": True})
+
+    def _finalize_harness(self, private_root: Path, *,
+                          restoration_failures: list[str] | None = None):
+        producer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.REGRESSION, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        manifest = preflight_manifest(
+            source_identity={
+                "alias": "s23u", "manufacturer": "samsung",
+                "model": "SM-S918B", "android_release": "15",
+                "android_api": "35", "package_version": "1.0",
+                "package_version_code": 1,
+                "build_fingerprint_sha256": "a" * 64,
+                "device_id_sha256": "b" * 64,
+            },
+            target_identity={
+                "alias": "s21", "manufacturer": "samsung",
+                "model": "SM-G991B", "android_release": "15",
+                "android_api": "35", "package_version": "1.0",
+                "package_version_code": 1,
+                "build_fingerprint_sha256": "c" * 64,
+                "device_id_sha256": "d" * 64,
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "preflight.json"
+            path.write_text(json.dumps(manifest))
+            producer.load_preflight_manifest(path)
+        producer.run_environment_before = {
+            "source": {"reachable": True, "alias": "s23u", "media_volume": 12},
+            "target": {"reachable": True, "alias": "s21", "media_volume": 10},
+        }
+        producer.attempts = [
+            runner.MatrixAttempt(
+                "trial-001",
+                runner.MatrixSlot(idle_s=10, wake_only=True, ordinal=1),
+                1, runner.AttemptStatus.PASSED,
+            ),
+        ]
+        failures = restoration_failures if restoration_failures is not None else []
+        with patch.object(producer, "_cancel_active_wait"), \
+                patch.object(producer, "_cancel_active_source_playback", return_value=[]), \
+                patch.object(producer, "_recover_active_source_result", return_value=[]), \
+                patch.object(producer, "_verify_source_restoration", return_value=failures), \
+                patch.object(producer, "_snapshot_source_state",
+                             return_value={"reachable": True, "alias": "s23u",
+                                           "media_volume": 12}), \
+                patch.object(producer, "_snapshot_target_state",
+                             return_value={"reachable": True, "alias": "s21",
+                                           "media_volume": 10}), \
+                patch.object(producer, "_environment_failures", return_value=[]), \
+                patch.object(producer, "_source_environment_failures", return_value=[]):
+            yield producer
+
+    def test_finalize_persists_post_cleanup_checkpoint(self) -> None:
+        """A completed run's final checkpoint contains the post-cleanup result
+        and post-run environment, not the pre-cleanup defaults."""
+        private_root = Path(tempfile.mkdtemp())
+        for producer in self._finalize_harness(private_root):
+            with patch.object(producer, "export_evidence", return_value={"ok": True}):
+                runner.finalize_evidence(producer)
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.REGRESSION, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+        self.assertTrue(consumer.cleanup_verified)
+        self.assertEqual(consumer.cleanup_failures, [])
+        self.assertEqual(
+            consumer.run_environment_after,
+            {
+                "source": {"reachable": True, "alias": "s23u", "media_volume": 12},
+                "target": {"reachable": True, "alias": "s21", "media_volume": 10},
+            },
+        )
+        self.assertIsNone(consumer.abort_reason)
+        self.assertIsNone(consumer.primary_failure)
+
+    def test_export_only_preserves_post_cleanup_state_without_device_calls(self) -> None:
+        """Loading the final checkpoint and running export-only retains the
+        authoritative cleanup and final-environment values, performs no live
+        ADB/device calls, and never runs cleanup again."""
+        private_root = Path(tempfile.mkdtemp())
+        for producer in self._finalize_harness(private_root):
+            with patch.object(producer, "export_evidence", return_value={"ok": True}):
+                runner.finalize_evidence(producer)
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.REGRESSION, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+        with patch.object(consumer, "cleanup",
+                          side_effect=AssertionError("cleanup must not run during export-only")), \
+                patch.object(consumer.source, "shell",
+                             side_effect=AssertionError("no device calls during export-only")), \
+                patch.object(consumer.target, "shell",
+                             side_effect=AssertionError("no device calls during export-only")):
+            evidence = consumer.export_evidence()
+        reliability = evidence["wake_reliability"]
+        self.assertTrue(reliability["cleanup_verified"])
+        self.assertEqual(reliability["cleanup_failures"], [])
+        # The export projects the environment through the public snapshot
+        # allow-list (alias and other private fields are intentionally dropped).
+        self.assertEqual(
+            reliability["run_environment_after"],
+            {
+                "source": {"reachable": True, "media_volume": 12},
+                "target": {"reachable": True, "media_volume": 10},
+            },
+        )
+        self.assertTrue(reliability["completion"]["cleanup_verified"])
+        self.assertEqual(reliability["completion"]["status"], "completed")
+
+    def test_failed_cleanup_is_preserved_truthfully(self) -> None:
+        """A failed cleanup is never converted into a successful result: the
+        final checkpoint and the offline export keep the failure visible."""
+        private_root = Path(tempfile.mkdtemp())
+        for producer in self._finalize_harness(
+            private_root,
+            restoration_failures=["source volume restoration failed"],
+        ):
+            with patch.object(producer, "export_evidence", return_value={"ok": True}):
+                runner.finalize_evidence(producer)
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.REGRESSION, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+        self.assertFalse(consumer.cleanup_verified)
+        self.assertEqual(consumer.cleanup_failures, ["source volume restoration failed"])
+        with patch.object(consumer.source, "shell",
+                          side_effect=AssertionError("no device calls during export-only")), \
+                patch.object(consumer.target, "shell",
+                             side_effect=AssertionError("no device calls during export-only")):
+            evidence = consumer.export_evidence()
+        reliability = evidence["wake_reliability"]
+        self.assertFalse(reliability["cleanup_verified"])
+        self.assertEqual(
+            reliability["cleanup_failures"], ["source volume restoration failed"]
+        )
+        self.assertFalse(reliability["completion"]["cleanup_verified"])
 
     def test_fixed_delay_is_feasibility_only(self) -> None:
         with self.assertRaisesRegex(runner.HarnessError, "feasibility"):

--- a/scripts/tests/test_acoustic_wake_reliability_runner.py
+++ b/scripts/tests/test_acoustic_wake_reliability_runner.py
@@ -1320,6 +1320,430 @@ class EvidenceAndModeTests(unittest.TestCase):
             "normal",
         )
 
+class SourcePlaybackStartContractTests(unittest.TestCase):
+    """Physical source-helper playback-start event contract (#1409)."""
+
+    def test_single_started_event_is_persisted(self) -> None:
+        """Exactly one physical ``started`` event yields its validated wall
+        clock; the request wall clock is never substituted."""
+        result = source_result()
+        self.assertEqual(
+            runner.source_playback_start_wall_clock_ms(result),
+            1_705_300_000_423,
+        )
+        self.assertEqual(result["request_wall_clock_ms"], 1_705_300_000_123)
+
+    def test_zero_started_events_produce_no_value(self) -> None:
+        """A source result without the physical ``started`` event yields no
+        playback-start value even when request timing exists."""
+        result = source_result()
+        result["events"] = [
+            event for event in result["events"]
+            if event["name"] != "started"
+        ]
+        self.assertIsNone(runner.source_playback_start_wall_clock_ms(result))
+
+    def test_multiple_started_events_fail_closed(self) -> None:
+        """Ambiguous playback-start evidence stays None; nothing is inferred."""
+        result = source_result()
+        result["events"].append(
+            {"name": "started", "monotonic_ms": 1400, "wall_clock_ms": 999}
+        )
+        self.assertIsNone(runner.source_playback_start_wall_clock_ms(result))
+
+    def test_started_event_with_invalid_wall_clock_fails_closed(self) -> None:
+        result = source_result()
+        result["events"] = [
+            {"name": "started", "monotonic_ms": 1300, "wall_clock_ms": "not-an-int"}
+        ]
+        self.assertIsNone(runner.source_playback_start_wall_clock_ms(result))
+
+    def test_run_trial_never_falls_back_to_request_time(self) -> None:
+        """When the preserved command source result has no ``started`` event,
+        the persisted playback-start stays None while request timing is kept
+        unchanged (never substituted)."""
+        harness = make_runner()
+        fixture_sha256 = source_result()["fixture_sha256"]
+        harness.installed_fixture_hashes = {
+            "natural_wake": fixture_sha256,
+            "qwen_command": fixture_sha256,
+        }
+        harness.installed_command_transcript_hashes = {"qwen_command": "b" * 64}
+        harness.preflight_approval = {
+            "source_volume_index": 7,
+            "cue_audibility_evidence_verified": True,
+            "source_environment_state": {},
+            "target_environment_state": {},
+        }
+        harness.cue_audibility_evidence_verified = True
+        final_events = complete_events(runner.TrialType.WAKE_PLUS_COMMAND)
+        boundary_envelope = envelope([
+            event(3, "DETECTOR_GENERATION_STARTED", generation=4, session=0),
+        ], lowest=3)
+        pre_command_open_events = [
+            item for item in final_events
+            if item["t"] not in {"STT_SPEECH_DETECTED", "STT_FINAL",
+                                  "COMMAND_ROUTING_RESULT", "SESSION_COMPLETED",
+                                  "DETECTOR_REARMED"}
+        ]
+        provider_call = self._provider_snapshots(
+            {
+                "boundary": boundary_envelope,
+                "open": envelope(pre_command_open_events),
+                "final": envelope(final_events),
+            },
+            ["boundary", "open", "final"],
+        )
+        call_order: list[str] = []
+
+        def invoke_command_source(**kwargs):
+            command_result = source_result("trial-nofallback-cmd", "qwen_command")
+            command_result["events"] = [
+                event_item for event_item in command_result["events"]
+                if event_item["name"] != "started"
+            ]
+            command_events = [event(15, "COMMAND_ROUTING_RESULT")]
+            return command_result, command_events, envelope(command_events, lowest=15)
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source", side_effect=self._invoke_wake(call_order)), \
+                patch.object(harness, "_invoke_command_source_with_armed_wait", side_effect=invoke_command_source), \
+                patch.object(harness, "_wait_for_target_events", side_effect=self._target_wait(call_order)), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-nofallback",
+                runner.MatrixSlot(idle_s=1, wake_only=False, ordinal=2),
+                "natural_wake",
+                "qwen_command",
+            )
+
+        command_timing = attempt.source_timing["command"]
+        self.assertIsNone(command_timing["playback_start_wall_clock_ms"])
+        self.assertEqual(command_timing["request_wall_clock_ms"], 1_705_300_000_123)
+
+    def _provider_snapshots(self, envelopes: dict[str, dict], order: list[str]):
+        provider_snapshots = iter([envelopes[key] for key in order])
+
+        def provider_call(method, extras=None, timeout=15.0):
+            if method == runner.TARGET_METHOD_GET_SEQUENCE:
+                return runner.TARGET_RESULT_OK, "3"
+            if method == runner.TARGET_METHOD_GET_SNAPSHOT:
+                return runner.TARGET_RESULT_OK, json.dumps(next(provider_snapshots))
+            self.fail(f"unexpected provider method {method}")
+
+        return provider_call
+
+    def _target_wait(self, call_order: list[str]):
+        def target_wait(**kwargs):
+            event_type = kwargs["event_type"]
+            if event_type == "STT_READY":
+                call_order.append("wait-STT_READY")
+            elif event_type == "CUE_REQUESTED":
+                call_order.append("wait-CUE_REQUESTED")
+            waited = event(
+                {"STT_READY": 11, "CUE_REQUESTED": 12, "DETECTOR_REARMED": 18}[event_type],
+                event_type,
+            )
+            return [waited], envelope([waited], lowest=waited["s"])
+
+        return target_wait
+
+    def _invoke_wake(self, call_order: list[str]):
+        def invoke_wake_source(trial_id: str, fixture_id: str, volume_index: int) -> dict:
+            call_order.append("wake-completed")
+            return source_result(trial_id, fixture_id)
+
+        return invoke_wake_source
+
+
+class TerminalRearmObservationTests(unittest.TestCase):
+    """Bounded terminal/re-arm observation covering the supported STT
+    lifecycle (#1409)."""
+
+    def _harness(self) -> tuple[Any, dict]:
+        harness = make_runner()
+        fixture_sha256 = source_result()["fixture_sha256"]
+        harness.installed_fixture_hashes = {"natural_wake": fixture_sha256}
+        harness.preflight_approval = {
+            "source_volume_index": 7,
+            "cue_audibility_evidence_verified": True,
+            "source_environment_state": {},
+            "target_environment_state": {},
+        }
+        harness.cue_audibility_evidence_verified = True
+        boundary_envelope = envelope([
+            event(3, "DETECTOR_GENERATION_STARTED", generation=4, session=0),
+        ], lowest=3)
+        return harness, boundary_envelope
+
+    def _provider_snapshots(self, envelopes: dict[str, dict], order: list[str]):
+        provider_snapshots = iter([envelopes[key] for key in order])
+
+        def provider_call(method, extras=None, timeout=15.0):
+            if method == runner.TARGET_METHOD_GET_SEQUENCE:
+                return runner.TARGET_RESULT_OK, "3"
+            if method == runner.TARGET_METHOD_GET_SNAPSHOT:
+                return runner.TARGET_RESULT_OK, json.dumps(next(provider_snapshots))
+            self.fail(f"unexpected provider method {method}")
+
+        return provider_call
+
+    def _terminal_wait(self, timeout_observed: list[int], rearm_found: bool = True):
+        def target_wait(**kwargs):
+            event_type = kwargs["event_type"]
+            if event_type == "DETECTOR_REARMED":
+                timeout_observed.append(kwargs["timeout_ms"])
+                if not rearm_found:
+                    # Provider timeout: no matching event before the bound.
+                    return [], envelope([], lowest=1)
+                rearm_event = event(14, "DETECTOR_REARMED", generation=5)
+                return [rearm_event], envelope([rearm_event], lowest=1)
+            waited = event(11, "STT_READY")
+            return [waited], envelope([waited], lowest=waited["s"])
+
+        return target_wait
+
+    def test_rearm_after_old_bound_within_new_bound_classifies_normally(self) -> None:
+        """The terminal/re-arm lands 18 s after STT_READY: beyond the old 15 s
+        bound but inside the derived bound.  The wait observes it (the fake
+        provider only reports it for timeout >= 18 s) and the attempt
+        classifies normally instead of unclassified."""
+        harness, boundary_envelope = self._harness()
+        final_events = complete_events(runner.TrialType.WAKE_ONLY)
+        timeout_observed: list[int] = []
+        provider_call = self._provider_snapshots(
+            {
+                "boundary": boundary_envelope,
+                "final": envelope(final_events),
+            },
+            ["boundary", "final"],
+        )
+
+        def terminal_wait(**kwargs):
+            event_type = kwargs["event_type"]
+            if event_type == "DETECTOR_REARMED":
+                timeout_observed.append(kwargs["timeout_ms"])
+                if kwargs["timeout_ms"] < 18_000:
+                    # The old 15 s bound would have expired before the re-arm.
+                    return [], envelope([], lowest=1)
+                rearm_event = event(14, "DETECTOR_REARMED", generation=5)
+                return [rearm_event], envelope([rearm_event], lowest=1)
+            waited = event(11, "STT_READY")
+            return [waited], envelope([waited], lowest=waited["s"])
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source",
+                             side_effect=lambda trial_id, fixture_id, volume_index:
+                             source_result(trial_id, fixture_id)), \
+                patch.object(harness, "_wait_for_target_events", side_effect=terminal_wait), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-rearm-late",
+                runner.MatrixSlot(idle_s=1, wake_only=True, ordinal=1),
+                "natural_wake",
+                None,
+            )
+
+        self.assertEqual(timeout_observed, [runner.TARGET_WAIT_TERMINAL_REARM_MS])
+        self.assertEqual(attempt.status, runner.AttemptStatus.PASSED)
+        self.assertIsNone(attempt.classification)
+        self.assertNotIn("missing correlated session terminal", attempt.failures)
+
+    def test_no_terminal_before_new_bound_stops_deterministically(self) -> None:
+        """A genuinely exhausted bound keeps the existing failure semantics:
+        the final snapshot lacks the terminal and the attempt is UNCLASSIFIED
+        with the correlated-terminal failure, never treated as success."""
+        harness, boundary_envelope = self._harness()
+        retry_events = complete_events(runner.TrialType.WAKE_ONLY)[:-2]
+        retry_events += [
+            event(13, "STT_SPEECH_DETECTED"),
+            event(14, "STT_ERROR", data={"category": "stt_recognition_failed"}),
+            event(15, "STT_START_REQUESTED", data={"attempt": "2"}),
+            event(16, "STT_READY"),
+            event(17, "CUE_REQUESTED"),
+            event(18, "STT_SPEECH_DETECTED"),
+        ]
+        timeout_observed: list[int] = []
+        provider_call = self._provider_snapshots(
+            {
+                "boundary": boundary_envelope,
+                "final": envelope(retry_events),
+            },
+            ["boundary", "final"],
+        )
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source",
+                             side_effect=lambda trial_id, fixture_id, volume_index:
+                             source_result(trial_id, fixture_id)), \
+                patch.object(harness, "_wait_for_target_events",
+                             side_effect=self._terminal_wait(timeout_observed, rearm_found=False)), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-rearm-exhausted",
+                runner.MatrixSlot(idle_s=1, wake_only=True, ordinal=1),
+                "natural_wake",
+                None,
+            )
+
+        self.assertEqual(timeout_observed, [runner.TARGET_WAIT_TERMINAL_REARM_MS])
+        self.assertEqual(attempt.status, runner.AttemptStatus.FAILED)
+        self.assertEqual(
+            attempt.classification, runner.FailureClassification.UNCLASSIFIED
+        )
+        self.assertIn("missing correlated session terminal", attempt.failures)
+
+    def test_terminal_wait_provider_error_remains_fail_closed(self) -> None:
+        """Provider errors during the terminal observation keep the existing
+        deterministic invalid-attempt semantics."""
+        harness, boundary_envelope = self._harness()
+        provider_call = self._provider_snapshots(
+            {"boundary": boundary_envelope, "final": envelope([])},
+            ["boundary", "final"],
+        )
+
+        def error_wait(**kwargs):
+            if kwargs["event_type"] == "DETECTOR_REARMED":
+                raise runner.HarnessError("target wait status failed: provider unavailable")
+            waited = event(11, "STT_READY")
+            return [waited], envelope([waited], lowest=waited["s"])
+
+        with patch.object(harness, "_call_target_provider", side_effect=provider_call), \
+                patch.object(harness, "_invoke_source",
+                             side_effect=lambda trial_id, fixture_id, volume_index:
+                             source_result(trial_id, fixture_id)), \
+                patch.object(harness, "_wait_for_target_events", side_effect=error_wait), \
+                patch.object(harness, "_snapshot_target_state", return_value={"reachable": True}), \
+                patch.object(harness, "_snapshot_source_state", return_value={"reachable": True}), \
+                patch.object(harness, "_environment_failures", return_value=[]), \
+                patch.object(harness, "_source_environment_failures", return_value=[]), \
+                patch.object(harness, "checkpoint"), \
+                patch.object(runner.time, "sleep"):
+            attempt = harness.run_trial(
+                "trial-rearm-error",
+                runner.MatrixSlot(idle_s=1, wake_only=True, ordinal=1),
+                "natural_wake",
+                None,
+            )
+
+        self.assertEqual(attempt.status, runner.AttemptStatus.INVALID)
+        self.assertEqual(
+            attempt.invalid_reason, runner.InvalidReason.EVIDENCE_BOUNDARY_LOST
+        )
+        self.assertIn("provider unavailable", attempt.operational_failure)
+
+
+class NormalisedEventDeduplicationTests(unittest.TestCase):
+    """Normalised target events: one record per authoritative sequence (#1409)."""
+
+    def test_duplicated_candidate_projection_collapses(self) -> None:
+        candidate = event(6, "ACTIVATION_CANDIDATE")
+        events = [
+            event(4, "STAGE3_READY"),
+            candidate,
+            event(7, "VERIFIED_ACTIVATION"),
+            candidate,
+        ]
+        result = runner.deduplicate_projected_events(events)
+        self.assertEqual([item["s"] for item in result], [4, 6, 7])
+
+    def test_distinct_events_sharing_type_are_kept(self) -> None:
+        events = [
+            event(6, "ACTIVATION_CANDIDATE", data={"confidence": "0.9"}),
+            event(9, "ACTIVATION_CANDIDATE", data={"confidence": "0.7"}),
+        ]
+        result = runner.deduplicate_projected_events(events)
+        self.assertEqual([item["s"] for item in result], [6, 9])
+
+    def test_conflicting_records_for_one_sequence_fail_closed(self) -> None:
+        events = [
+            event(6, "ACTIVATION_CANDIDATE", data={"confidence": "0.9"}),
+            event(6, "ACTIVATION_CANDIDATE", data={"confidence": "0.8"}),
+        ]
+        with self.assertRaisesRegex(
+            runner.HarnessError, "conflicting journal projections for sequence 6"
+        ):
+            runner.deduplicate_projected_events(events)
+
+    def test_sequence_order_is_preserved(self) -> None:
+        candidate = event(6, "ACTIVATION_CANDIDATE")
+        events = [
+            event(7, "VERIFIED_ACTIVATION"),
+            candidate,
+            event(4, "STAGE3_READY"),
+            candidate,
+        ]
+        result = runner.deduplicate_projected_events(events)
+        self.assertEqual([item["s"] for item in result], [7, 6, 4])
+
+    def test_checkpoint_load_deduplicates_and_repopulates_playback_start(self) -> None:
+        """Offline regeneration: a preserved checkpoint with duplicated
+        projections and null playback-start wall clocks is normalised on load
+        from the preserved source results alone."""
+        private_root = Path(tempfile.mkdtemp())
+        slot = runner.MatrixSlot(idle_s=10, wake_only=False, ordinal=2)
+        command_result = source_result("trial-007-cmd", "qwen_command")
+        producer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        candidate = event(6, "ACTIVATION_CANDIDATE")
+        producer.source_results = [command_result]
+        producer.attempts = [
+            runner.MatrixAttempt(
+                "trial-007", slot, 1, runner.AttemptStatus.PASSED,
+                source_timing={"command": {
+                    "request_wall_clock_ms": 1_705_300_000_123,
+                    "playback_start_wall_clock_ms": None,
+                }},
+                target_timing={"events": [
+                    event(5, "STAGE3_READY"),
+                    candidate,
+                    event(7, "VERIFIED_ACTIVATION"),
+                    candidate,
+                ]},
+                command_fixture_id="qwen_command",
+                command_fixture_sha256=command_result["fixture_sha256"],
+            ),
+        ]
+        producer.checkpoint()
+
+        consumer = runner.AcousticWakeReliabilityRunner(
+            runner.RunKind.DIAGNOSTIC, "s23u", "s21",
+            FakeAdb("source"), FakeAdb("target"), private_root=private_root,
+        )
+        consumer.load_checkpoint(producer.run_id)
+
+        attempt = consumer.attempts[0]
+        self.assertEqual(
+            [item["s"] for item in attempt.target_timing["events"]],
+            [5, 6, 7],
+        )
+        self.assertEqual(
+            attempt.source_timing["command"]["playback_start_wall_clock_ms"],
+            1_705_300_000_423,
+        )
+        self.assertEqual(
+            attempt.source_timing["command"]["request_wall_clock_ms"],
+            1_705_300_000_123,
+        )
+
+
 class OutOfWindowCommandTests(unittest.TestCase):
     """Harness source-timing invalidation for out-of-window command delivery."""
 
@@ -1880,8 +2304,8 @@ class OutOfWindowCommandTests(unittest.TestCase):
         valid, issues = evidence_metrics.validate_record(evidence, [])
         self.assertTrue(valid, issues)
     def test_run_trial_persists_playback_start_wall_clock_ms(self) -> None:
-        """run_trial() persists the source helper's validated
-        playback_started.wall_clock_ms as playback_start_wall_clock_ms while
+        """run_trial() persists the source helper's validated physical
+        ``started`` event wall clock as playback_start_wall_clock_ms while
         keeping the request fields unchanged."""
         harness, envelopes, _ = self._command_harness()
         broken_final = copy.deepcopy(envelopes["final"])
@@ -1923,8 +2347,8 @@ class OutOfWindowCommandTests(unittest.TestCase):
             )
 
         command_timing = attempt.source_timing["command"]
-        # The validated playback_started event's wall clock is persisted under
-        # the dedicated field; request timing is kept untouched.
+        # The validated physical ``started`` event's wall clock is persisted
+        # under the dedicated field; request timing is kept untouched.
         self.assertEqual(command_timing["playback_start_wall_clock_ms"], 1_705_300_000_423)
         self.assertEqual(command_timing["request_wall_clock_ms"], 1_705_300_000_123)
         self.assertEqual(


### PR DESCRIPTION
Refs #1409

Harness/evidence correction only. No production wake-word or STT behavior changed; no physical trials executed. Closes nothing: #1409 is closed only after post-merge release-scoped publication succeeds.

## SHAs

- Previous head: `ee8015d85e721a1cc424b72ed0127f6476a16ea5`
- New head (review 4840085897 remediation): `af1f8e9b983d762c79a30e4ada02f5b25c7db900`
- Base: `c2c148b7723ab68ec5a8a996d270d93bbdf5e1a2` (current `main`)

## Files changed

- `scripts/acoustic_wake_reliability_runner.py` — the three accepted corrections (playback-start contract, 40 s terminal/re-arm bound, event dedup) plus the final-checkpoint correction below
- `scripts/testdata/fixtures/acoustic-wake-reliability/source-result-valid.json` — synthetic event vocabulary aligned to the physical helper
- `scripts/tests/test_acoustic_wake_reliability_runner.py` — +16 focused tests (90 focused, 715 full `scripts/tests` pass)

## Accepted corrections (unchanged by this remediation)

1. **Playback-start contract** — the runner consumes the physical `started` event (`AcousticStimulusEngine.kt:367`) via `source_playback_start_wall_clock_ms()`; exactly one event persists its validated `wall_clock_ms`; zero/multiple fail closed (`None`); request time is never substituted.
2. **Terminal/re-arm bound** — `TARGET_WAIT_TERMINAL_REARM_MS = 40_000` (derivation documented beside the constant: 16 s attempt-1 envelope + 1.5 s readiness + 16 s attempt-2 envelope + ≤2 s re-arm = 35.5 s worst supported chain); deterministic, within the provider 60 s max; exhausted bound keeps existing `UNCLASSIFIED` semantics.
3. **Event dedup** — `deduplicate_projected_events()` keeps one record per journal sequence, preserving order, failing closed on conflicting same-sequence content; applied at run-time projection and on checkpoint load.

## Finding-1 remediation — final-checkpoint correction and authoritative-baseline regeneration

### Root cause

The normal finalization path never wrote a checkpoint after cleanup, so `resume --export-only` re-renders replaced the authoritative post-cleanup state (`cleanup_verified`, `run_environment_after`, completion cleanup status) with pre-cleanup checkpoint defaults, and rewrote branch/timestamp metadata.

### Future runs (committed)

```python
def finalize_evidence(runner):
    runner.cleanup()
    runner.checkpoint()          # added
    return runner.export_evidence()
```

`checkpoint()` already serializes `cleanup_verified`, `cleanup_failures`, `run_environment_after`, final `abort_reason` and `primary_failure` — no new checkpoint fields. `resume --export-only` still performs no cleanup and no device calls.

Tests added (EvidenceAndModeTests):
1. finalization records cleanup → checkpoint → export in order;
2. the post-cleanup checkpoint contains the final cleanup result and post-run environment;
3. loading that checkpoint and export-only preserves those values;
4. no live ADB/device calls (source/target shells raise) and no cleanup run during export-only;
5. a failed cleanup is preserved truthfully (never converted to success).

### Current run (local one-off transformation, not committed)

Baseline: the authoritative published release record on the `test-results` branch — `results/release/launch-gate-2026-08-02/on_device/evidence.json` (run `regression_post_fix-2026-08-02T08-55-02Z-ee8c4b07`, tested commit `c2c148b7…`; byte-identical to the preserved run's original sanitized evidence). A local one-off script applied only the two proven corrections, with a strict invariance assertion that fails unless every difference is:

- a null `source_timing.command.playback_start_wall_clock_ms` replaced by the validated physical `started.wall_clock_ms`; or
- removal of an exactly repeated projection of the same journal sequence.

Result: **0 unexpected field changes**. All other authoritative values preserved verbatim: run ID, tested commit, original timestamp (`2026-08-02T14:03:09+00:00`), branch (`evidence/1410-regression-post-fix`), `pr: null`, device/model metadata, preflight approval and manifest hash, totals/statuses/classifications, invalid attempts, `cleanup_verified: true`, `cleanup_failures: []`, `run_environment_before/after`, completion status with `cleanup_verified: true`, release-gate result, artifact references. `run-summary.md` regenerated from the corrected record (`Verified: True`).

## Validation

```bash
python3 -m unittest scripts.tests.test_acoustic_wake_reliability_runner   # 90 tests OK
python3 -m unittest discover -s scripts/tests                             # 715 tests OK
python3 scripts/acoustic_wake_reliability_runner.py fixture               # PASS, no ADB
git diff --check                                                           # clean
```

- Schema validation (`validate_record`): valid, no issues; publisher schema validation passed during dry-run.
- Privacy: `PRIVATE_PATTERNS` clean; no private artifact names in the sanitized tree; device `serial: null`.
- Commit-safety (`assert_commit_safe`): clean on evidence.json, run-summary.md and all 101 trials artifacts.
- Matrix completeness: 27/27 required positions, 0 missing, 0 duplicate valid outcomes.
- Evidence reconciliation: totals and classifications identical to the authoritative record (27 valid, 15P/12F, 4 invalid, 2 `unclassified` preserved).
- Dashboard dry-run (`build_test_dashboard.py` @ feature/1408): 1 valid record, reconciled 27/15/12.
- Raw/private integrity: all 107 preserved files byte-for-byte unchanged (SHA-256 manifest identical before/after, both in the preserved run and the regeneration copy).
- CI (Build & Test) and Docs Drift Check on head `af1f8e9b…`: **success**.

## Corrected evidence summary (authoritative → corrected)

- Playback-start: **8 corrections** — the eight dispatched command trials now persist the physical `started.wall_clock_ms` (007 → 1785661192487, 020 → 1785662714226, 021 → 1785662860052, 027 → 1785672076215, 028 → 1785673901740, 029 → 1785675728186, 030 → 1785677553442, 031 → 1785679378776); the 4 non-dispatched command cases stay unchanged.
- Duplicate projections: **23 → 0**.
- Cleanup and final environment fields: **unchanged** (`cleanup_verified: true`, `cleanup_failures: []`, `run_environment_after` populated, `completion.cleanup_verified: true`).
- Totals/classifications: unchanged.

## Post-merge publication (release-scoped, exact command)

```bash
python3 scripts/publish_test_evidence.py \
  --input-dir scripts/private-acoustic-runs/regression_post_fix-2026-08-02T08-55-02Z-ee8c4b07/sanitized \
  --source on_device \
  --release launch-gate-2026-08-02 \
  --commit c2c148b7723ab68ec5a8a996d270d93bbdf5e1a2
```

Dry-run (run locally, not executed): 103 files, scope `release launch-gate-2026-08-02`, target branch `test-results`, destinations `results/release/launch-gate-2026-08-02/on_device/evidence.json`, `…/run-summary.md`, `…/trials/…`; commit message `test-results: add on_device evidence for release launch-gate-2026-08-02 @ c2c148b7723a`. No `--pr`, no `--allow-pr-mismatch`, no new release tag, no new run identity. Publication remains a post-merge action and will replace the existing release-scoped record.

## Confirmation

- No physical trials executed; no production Android files touched; no wake detector/STT behavior changed.
- The accepted 40 s bound, playback-start semantics, and dedup semantics are unchanged.
- No generic migration framework, compatibility layer, or new CLI configuration added.
- #1409, #1410, #1432, #1402 not closed.

Do not merge — wait for focused re-review.
