### PR TITLE
fix(#1432): delegate wake verification and add detector diagnostics

### DIFF
--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -57,6 +57,16 @@ internal fun transcriptEvidenceSha256(text: String): String {
         .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
 }
 
+/**
+ * Low-confidence wake-candidate verification wiring used by [WakeWordService]:
+ * the delegated wake transcript must contain a supported Hey Jandal form.
+ * `null` (no wake-verification support or transcription failure) rejects.
+ */
+internal suspend fun verifyWakeWindow(
+    voiceInputController: VoiceInputController,
+    pcm: ShortArray,
+): Boolean = voiceInputController.transcribeBlocking(pcm)?.containsWakePhrase() ?: false
+
 /** Build consistent cue-journal metadata from a playback result. */
 internal fun cueMetadata(
     cueResult: StartListeningCueResult,
@@ -627,7 +637,7 @@ class WakeWordService : Service() {
             verifyWindow = { pcm ->
                 try {
                     kotlinx.coroutines.runBlocking {
-                        voiceInputController.transcribeBlocking(pcm)?.containsWakePhrase() ?: false
+                        verifyWakeWindow(voiceInputController, pcm)
                     }
                 } catch (e: Exception) {
                     Log.w(TAG, "WakeWordService: wake word verification failed", e)

--- a/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifyWindowTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifyWindowTest.kt
@@ -1,0 +1,78 @@
+package com.kernel.ai.assistant
+
+import com.kernel.ai.core.voice.VoiceInputController
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Deterministic tests for the #1432 low-confidence wake verification wiring:
+ * [WakeWordService.verifyWakeWindow] must consult the delegated controller's
+ * wake transcript and accept only a supported Hey Jandal form.
+ *
+ * Physical evidence (trials 019 / 026 of the #1410 `regression_post_fix`
+ * matrix): low-mode `ACTIVATION_CANDIDATE`s were emitted (~0.5165 / ~0.6002)
+ * but the facade's interface-default `transcribeBlocking` returned `null`, so
+ * every low-band candidate was guaranteed to reject.  These tests pin the
+ * corrected wiring: the PCM is forwarded to the delegate, and only the
+ * delegate's transcript (never the interactive engine selection) decides.
+ */
+class WakeWordVerifyWindowTest {
+
+    private val voiceInputController: VoiceInputController = mockk()
+
+    @Test
+    fun `activates when the delegated transcript contains a supported Hey Jandal form`() = runTest {
+        val pcm = shortArrayOf(10, 20, 30, 40)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "hey jandal, set a timer"
+
+        assertTrue(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `activates for ASR variant spellings of the wake phrase`() = runTest {
+        val pcm = shortArrayOf(1)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "a jandel"
+
+        assertTrue(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `rejects a non-wake transcript`() = runTest {
+        val pcm = shortArrayOf(2, 3)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "play some music"
+
+        assertFalse(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `rejects null truthfully`() = runTest {
+        val pcm = shortArrayOf(4, 5, 6)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns null
+
+        assertFalse(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `forwards the wake-window PCM exactly once to the delegate`() = runTest {
+        val pcm = shortArrayOf(7, 8, 9)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "hey jandal"
+
+        verifyWakeWindow(voiceInputController, pcm)
+
+        coVerify(exactly = 1) { voiceInputController.transcribeBlocking(pcm) }
+    }
+
+    @Test
+    fun `forwards even an empty window instead of short-circuiting`() = runTest {
+        val pcm = shortArrayOf()
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "hey jandal"
+
+        assertTrue(verifyWakeWindow(voiceInputController, pcm))
+        coVerify(exactly = 1) { voiceInputController.transcribeBlocking(pcm) }
+    }
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -467,15 +467,9 @@ class OnnxWakeWordDetector @Inject constructor(
         val silenceGateState = SilenceGateTransitionState()
         var emittedStage3Ready = false
         // Per-gate-exit confidence summary (#1432 bounded reproduction).
-        // Debug-gated: only maintained and logged when the WakeWordDiag tag
-        // is DEBUG-enabled; zero allocations or branches otherwise.
-        var exitEpisodeOpen = false
-        var exitStage3Evaluations = 0
-        var exitMaxConfidence = -1f
-        var exitMaxConfidenceChunk = 0
-        var exitLowVerifyEntered = false
-        var exitLowVerifyAccepted = false
-        var gatedStage2Executions = 0L
+        // Debug-gated: only instantiated when the WakeWordDiag tag is
+        // DEBUG-enabled; zero allocations or branches otherwise.
+        val gateExitDiag = if (diagnosticsEnabled) WakeWordGateExitDiagnostics(generationId) else null
 
         try {
             val env = OrtEnvironment.getEnvironment()
@@ -626,14 +620,7 @@ class OnnxWakeWordDetector @Inject constructor(
                             type = AcousticEventType.VOICED_FRAME_AFTER_SILENCE,
                             generationId = generationId,
                         )
-                        if (diagnostics != null) {
-                            exitEpisodeOpen = true
-                            exitStage3Evaluations = 0
-                            exitMaxConfidence = -1f
-                            exitMaxConfidenceChunk = chunkCount
-                            exitLowVerifyEntered = false
-                            exitLowVerifyAccepted = false
-                        }
+                        gateExitDiag?.onGateExited(chunkCount)
                     }
                     silenceFrames = 0
                     voicedFrameStreak = 0
@@ -706,21 +693,8 @@ class OnnxWakeWordDetector @Inject constructor(
                             type = AcousticEventType.SILENCE_GATE_ENTERED,
                             generationId = generationId,
                         )
-                        if (diagnostics != null) {
-                            Log.d(
-                                DIAGNOSTIC_TAG,
-                                buildGateExitSummary(
-                                    generationId = generationId,
-                                    episodeOpen = exitEpisodeOpen,
-                                    stage3Evaluations = exitStage3Evaluations,
-                                    maxConfidence = exitMaxConfidence,
-                                    maxConfidenceChunk = exitMaxConfidenceChunk,
-                                    lowVerifyEntered = exitLowVerifyEntered,
-                                    lowVerifyAccepted = exitLowVerifyAccepted,
-                                    gatedStage2Executions = gatedStage2Executions,
-                                ),
-                            )
-                            exitEpisodeOpen = false
+                        gateExitDiag?.onGateEntered(chunkCount)?.let { summary ->
+                            Log.d(DIAGNOSTIC_TAG, summary)
                         }
                     }
                     continue  // wake word not expected — skip expensive Stage 2/3
@@ -733,13 +707,16 @@ class OnnxWakeWordDetector @Inject constructor(
                 // melRing is already [76 × 32] row-major.  We reinterpret as [76 × 32 × 1] by
                 // passing the same flat array with shape [1, 76, 32, 1] — the channel is implicit
                 // (every element maps to exactly one channel-1 position).
+                // Capture whether this execution is a gated periodic probe before
+                // any state transition may clear the gated state.
+                val wasGatedProbe = gateExitDiag != null && silenceGateState.isGated
                 if (silenceGateState.onStage2Execution()) {
                     AcousticJournalBridge.record(
                         type = AcousticEventType.STAGE2_RESUMED,
                         generationId = generationId,
                     )
                 }
-                if (diagnostics != null && silenceGateState.isGated) gatedStage2Executions++
+                if (wasGatedProbe) gateExitDiag?.onGatedProbeExecution()
                 melRing.copyInto(embedInput4D)
                 diagnostics?.recordStage2Execution()
                 val embedding: FloatArray = OnnxTensor.createTensor(
@@ -782,13 +759,7 @@ class OnnxWakeWordDetector @Inject constructor(
                     }
                 }
                 // Stage 3 count is retained in low-frequency diagnostics; avoid per-second logs.
-                if (diagnostics != null && exitEpisodeOpen) {
-                    exitStage3Evaluations++
-                    if (confidence > exitMaxConfidence) {
-                        exitMaxConfidence = confidence
-                        exitMaxConfidenceChunk = chunkCount
-                    }
-                }
+                gateExitDiag?.onStage3Evaluation(confidence, chunkCount)
 
 
                 when {
@@ -826,10 +797,7 @@ class OnnxWakeWordDetector @Inject constructor(
                         val snapshot = extractPcmSnapshot(pcmRing, pcmRingHead, pcmFilled)
                         val verified = verifyWindow(snapshot)
                         diagnostics?.recordVerifierResult(verified)
-                        if (diagnostics != null) {
-                            exitLowVerifyEntered = true
-                            exitLowVerifyAccepted = verified
-                        }
+                        gateExitDiag?.onLowVerify(verified)
                         if (verified) {
                             Log.i(TAG, "WakeWordDetector: STT verification passed — activating")
                             if (running.compareAndSet(true, false)) {
@@ -867,21 +835,9 @@ class OnnxWakeWordDetector @Inject constructor(
             diagnostics?.let {
                 val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
                 Log.d(DIAGNOSTIC_TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
-                if (exitEpisodeOpen) {
-                    Log.d(
-                        DIAGNOSTIC_TAG,
-                        buildGateExitSummary(
-                            generationId = generationId,
-                            episodeOpen = exitEpisodeOpen,
-                            stage3Evaluations = exitStage3Evaluations,
-                            maxConfidence = exitMaxConfidence,
-                            maxConfidenceChunk = exitMaxConfidenceChunk,
-                            lowVerifyEntered = exitLowVerifyEntered,
-                            lowVerifyAccepted = exitLowVerifyAccepted,
-                            gatedStage2Executions = gatedStage2Executions,
-                        ),
-                    )
-                }
+            }
+            gateExitDiag?.finish()?.let { summary ->
+                Log.d(DIAGNOSTIC_TAG, summary)
             }
         }
     }
@@ -955,32 +911,146 @@ internal fun secondsToFrames(seconds: Float): Int =
     kotlin.math.ceil(seconds / WAKE_WORD_FRAME_DURATION_SECONDS).toInt().coerceAtLeast(1)
 
 /**
+ * Debug-gated per-gate-exit diagnostic lifecycle (#1432 bounded reproduction).
+ *
+ * Models exactly one real detector lifecycle:
+ *
+ * ```
+ * gate entered
+ * → zero or more periodic gated Stage-2 probes
+ * → gate exited on voiced audio
+ * → zero or more Stage-3 evaluations / verifier attempts
+ * → gate entered again or detector generation ended
+ * → one summary emitted
+ * ```
+ *
+ * Every emitted summary describes exactly one exit episode: its own Stage-3
+ * evaluation count, its own maximum classifier confidence and the offset of
+ * that maximum relative to the gate-exit frame (exit frame = offset 0), its
+ * own low-verification entry/outcome, and the probe executions from the
+ * immediately preceding gated interval only.  Initial gate entry emits
+ * nothing; gate re-entry without an intervening exit emits nothing; detector
+ * shutdown emits only when a real exit episode is open.
+ *
+ * The holder is only instantiated when the WakeWordDiag DEBUG tag is enabled
+ * (same gate as the existing aggregate counters), so it has zero cost in
+ * production.  It never touches silence-gate, Stage-2/3, threshold, verifier
+ * or activation behaviour.  No PCM, transcripts or per-frame output.
+ */
+internal class WakeWordGateExitDiagnostics(
+    private val generationId: Long,
+) {
+    /** True while a gate-exit episode is open (exit occurred, gate not re-entered). */
+    var episodeOpen: Boolean = false
+        private set
+
+    /** Periodic Stage-2 probe executions since the last gate entry. */
+    var gatedProbeExecutions: Long = 0
+        private set
+
+    private var stage3Evaluations = 0
+    private var maxConfidence = -1f
+    private var maxConfidenceOffsetFrames = -1
+    private var lowVerifyEntered = false
+    private var lowVerifyAccepted = false
+    private var exitChunk = 0
+
+    /**
+     * Records a gate entry.  Returns the summary of the just-closed exit
+     * episode, or `null` when no exit episode was open (initial gate entry or
+     * a re-entry without an intervening exit).  Always starts a fresh gated
+     * interval, so probe counts never bleed between gated intervals.
+     */
+    fun onGateEntered(chunk: Int): String? {
+        val summary = if (episodeOpen) currentSummary() else null
+        episodeOpen = false
+        resetEpisode()
+        gatedProbeExecutions = 0
+        return summary
+    }
+
+    /** Records the gate exit on voiced audio that starts an exit episode. */
+    fun onGateExited(chunk: Int) {
+        resetEpisode()
+        exitChunk = chunk
+        episodeOpen = true
+    }
+
+    /** Records one Stage-3 evaluation at [chunk], tracked only for the open episode. */
+    fun onStage3Evaluation(confidence: Float, chunk: Int) {
+        if (!episodeOpen) return
+        stage3Evaluations++
+        if (confidence > maxConfidence) {
+            maxConfidence = confidence
+            maxConfidenceOffsetFrames = chunk - exitChunk
+        }
+    }
+
+    /** Records the outcome of a low-band verifier attempt within the open episode. */
+    fun onLowVerify(accepted: Boolean) {
+        if (!episodeOpen) return
+        lowVerifyEntered = true
+        lowVerifyAccepted = accepted
+    }
+
+    /** Records one gated periodic Stage-2 probe execution (pre-episode interval). */
+    fun onGatedProbeExecution() {
+        gatedProbeExecutions++
+    }
+
+    /**
+     * Detector shutdown.  Returns the final summary when a real exit episode
+     * is still open, otherwise `null`.
+     */
+    fun finish(): String? = if (episodeOpen) currentSummary() else null
+
+    private fun currentSummary(): String = buildGateExitSummary(
+        generationId = generationId,
+        stage3Evaluations = stage3Evaluations,
+        maxConfidence = maxConfidence,
+        maxConfidenceOffsetFrames = maxConfidenceOffsetFrames,
+        lowVerifyEntered = lowVerifyEntered,
+        lowVerifyAccepted = lowVerifyAccepted,
+        gatedProbeExecutions = gatedProbeExecutions,
+    )
+
+    private fun resetEpisode() {
+        stage3Evaluations = 0
+        maxConfidence = -1f
+        maxConfidenceOffsetFrames = -1
+        lowVerifyEntered = false
+        lowVerifyAccepted = false
+        exitChunk = 0
+    }
+}
+
+/**
  * One bounded aggregate summary per silence-gate exit episode (#1432
- * reproduction): how many Stage-3 evaluations the classifier performed while
- * the detector was un-gated, the maximum confidence observed, the frame offset
- * of that maximum, whether a low-band STT verification was entered and its
- * boolean outcome, and how many gated probe embeddings preceded the episode
- * (ring composition context).  No PCM, no transcripts and no per-frame output;
- * emitted only when WakeWordDiag DEBUG is enabled.
+ * reproduction): how many Stage-3 evaluations the classifier performed during
+ * that exit episode, the maximum confidence observed, its offset in detector
+ * frames from the gate-exit frame (exit frame = offset 0), whether a low-band
+ * STT verification was entered and its boolean outcome, and how many gated
+ * periodic probe executions preceded the episode from the immediately
+ * preceding gated interval only (ring composition context).  No PCM, no
+ * transcripts and no per-frame output; emitted only when WakeWordDiag DEBUG
+ * is enabled.
  */
 internal fun buildGateExitSummary(
     generationId: Long,
-    episodeOpen: Boolean,
     stage3Evaluations: Int,
     maxConfidence: Float,
-    maxConfidenceChunk: Int,
+    maxConfidenceOffsetFrames: Int,
     lowVerifyEntered: Boolean,
     lowVerifyAccepted: Boolean,
-    gatedStage2Executions: Long,
+    gatedProbeExecutions: Long,
 ): String = buildString {
     append("WakeWordDetector: gateExitSummary")
     append(" gen=").append(generationId)
-    append(" episodeOpen=").append(episodeOpen)
     append(" stage3Evals=").append(stage3Evaluations)
     append(" maxConfidence=")
     if (maxConfidence >= 0f) append(maxConfidence.toString()) else append("none")
-    append(" maxConfidenceChunk=").append(maxConfidenceChunk)
+    append(" maxConfidenceOffsetFrames=").append(maxConfidenceOffsetFrames)
     append(" lowVerifyEntered=").append(lowVerifyEntered)
     append(" lowVerifyAccepted=").append(lowVerifyAccepted)
-    append(" gatedStage2Executions=").append(gatedStage2Executions)
+    append(" gatedProbeExecutions=").append(gatedProbeExecutions)
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/OnnxWakeWordDetector.kt
@@ -466,6 +466,16 @@ class OnnxWakeWordDetector @Inject constructor(
         // ── Target event journal tracking ──────────────────────────────────────
         val silenceGateState = SilenceGateTransitionState()
         var emittedStage3Ready = false
+        // Per-gate-exit confidence summary (#1432 bounded reproduction).
+        // Debug-gated: only maintained and logged when the WakeWordDiag tag
+        // is DEBUG-enabled; zero allocations or branches otherwise.
+        var exitEpisodeOpen = false
+        var exitStage3Evaluations = 0
+        var exitMaxConfidence = -1f
+        var exitMaxConfidenceChunk = 0
+        var exitLowVerifyEntered = false
+        var exitLowVerifyAccepted = false
+        var gatedStage2Executions = 0L
 
         try {
             val env = OrtEnvironment.getEnvironment()
@@ -616,6 +626,14 @@ class OnnxWakeWordDetector @Inject constructor(
                             type = AcousticEventType.VOICED_FRAME_AFTER_SILENCE,
                             generationId = generationId,
                         )
+                        if (diagnostics != null) {
+                            exitEpisodeOpen = true
+                            exitStage3Evaluations = 0
+                            exitMaxConfidence = -1f
+                            exitMaxConfidenceChunk = chunkCount
+                            exitLowVerifyEntered = false
+                            exitLowVerifyAccepted = false
+                        }
                     }
                     silenceFrames = 0
                     voicedFrameStreak = 0
@@ -688,6 +706,22 @@ class OnnxWakeWordDetector @Inject constructor(
                             type = AcousticEventType.SILENCE_GATE_ENTERED,
                             generationId = generationId,
                         )
+                        if (diagnostics != null) {
+                            Log.d(
+                                DIAGNOSTIC_TAG,
+                                buildGateExitSummary(
+                                    generationId = generationId,
+                                    episodeOpen = exitEpisodeOpen,
+                                    stage3Evaluations = exitStage3Evaluations,
+                                    maxConfidence = exitMaxConfidence,
+                                    maxConfidenceChunk = exitMaxConfidenceChunk,
+                                    lowVerifyEntered = exitLowVerifyEntered,
+                                    lowVerifyAccepted = exitLowVerifyAccepted,
+                                    gatedStage2Executions = gatedStage2Executions,
+                                ),
+                            )
+                            exitEpisodeOpen = false
+                        }
                     }
                     continue  // wake word not expected — skip expensive Stage 2/3
                 }
@@ -705,6 +739,7 @@ class OnnxWakeWordDetector @Inject constructor(
                         generationId = generationId,
                     )
                 }
+                if (diagnostics != null && silenceGateState.isGated) gatedStage2Executions++
                 melRing.copyInto(embedInput4D)
                 diagnostics?.recordStage2Execution()
                 val embedding: FloatArray = OnnxTensor.createTensor(
@@ -747,6 +782,13 @@ class OnnxWakeWordDetector @Inject constructor(
                     }
                 }
                 // Stage 3 count is retained in low-frequency diagnostics; avoid per-second logs.
+                if (diagnostics != null && exitEpisodeOpen) {
+                    exitStage3Evaluations++
+                    if (confidence > exitMaxConfidence) {
+                        exitMaxConfidence = confidence
+                        exitMaxConfidenceChunk = chunkCount
+                    }
+                }
 
 
                 when {
@@ -784,6 +826,10 @@ class OnnxWakeWordDetector @Inject constructor(
                         val snapshot = extractPcmSnapshot(pcmRing, pcmRingHead, pcmFilled)
                         val verified = verifyWindow(snapshot)
                         diagnostics?.recordVerifierResult(verified)
+                        if (diagnostics != null) {
+                            exitLowVerifyEntered = true
+                            exitLowVerifyAccepted = verified
+                        }
                         if (verified) {
                             Log.i(TAG, "WakeWordDetector: STT verification passed — activating")
                             if (running.compareAndSet(true, false)) {
@@ -821,6 +867,21 @@ class OnnxWakeWordDetector @Inject constructor(
             diagnostics?.let {
                 val elapsedMillis = SystemClock.elapsedRealtime() - diagnosticsStartedAt
                 Log.d(DIAGNOSTIC_TAG, formatDiagnosticSummary(it.snapshot(elapsedMillis), nnapiStatus, final = true))
+                if (exitEpisodeOpen) {
+                    Log.d(
+                        DIAGNOSTIC_TAG,
+                        buildGateExitSummary(
+                            generationId = generationId,
+                            episodeOpen = exitEpisodeOpen,
+                            stage3Evaluations = exitStage3Evaluations,
+                            maxConfidence = exitMaxConfidence,
+                            maxConfidenceChunk = exitMaxConfidenceChunk,
+                            lowVerifyEntered = exitLowVerifyEntered,
+                            lowVerifyAccepted = exitLowVerifyAccepted,
+                            gatedStage2Executions = gatedStage2Executions,
+                        ),
+                    )
+                }
             }
         }
     }
@@ -892,3 +953,34 @@ internal fun calculateRms(chunk: ShortArray): Double {
 
 internal fun secondsToFrames(seconds: Float): Int =
     kotlin.math.ceil(seconds / WAKE_WORD_FRAME_DURATION_SECONDS).toInt().coerceAtLeast(1)
+
+/**
+ * One bounded aggregate summary per silence-gate exit episode (#1432
+ * reproduction): how many Stage-3 evaluations the classifier performed while
+ * the detector was un-gated, the maximum confidence observed, the frame offset
+ * of that maximum, whether a low-band STT verification was entered and its
+ * boolean outcome, and how many gated probe embeddings preceded the episode
+ * (ring composition context).  No PCM, no transcripts and no per-frame output;
+ * emitted only when WakeWordDiag DEBUG is enabled.
+ */
+internal fun buildGateExitSummary(
+    generationId: Long,
+    episodeOpen: Boolean,
+    stage3Evaluations: Int,
+    maxConfidence: Float,
+    maxConfidenceChunk: Int,
+    lowVerifyEntered: Boolean,
+    lowVerifyAccepted: Boolean,
+    gatedStage2Executions: Long,
+): String = buildString {
+    append("WakeWordDetector: gateExitSummary")
+    append(" gen=").append(generationId)
+    append(" episodeOpen=").append(episodeOpen)
+    append(" stage3Evals=").append(stage3Evaluations)
+    append(" maxConfidence=")
+    if (maxConfidence >= 0f) append(maxConfidence.toString()) else append("none")
+    append(" maxConfidenceChunk=").append(maxConfidenceChunk)
+    append(" lowVerifyEntered=").append(lowVerifyEntered)
+    append(" lowVerifyAccepted=").append(lowVerifyAccepted)
+    append(" gatedStage2Executions=").append(gatedStage2Executions)
+}

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SelectableVoiceInputController.kt
@@ -45,6 +45,16 @@ class SelectableVoiceInputController @Inject constructor(
         stopAllControllers()
     }
 
+    /**
+     * Wake-word verification always runs through the dedicated Sherpa wake
+     * recognizer ([SherpaOnnxVoiceInputController.transcribeBlocking]),
+     * independent of the selected interactive STT engine. The interactive
+     * selection and [activeController] are deliberately untouched so the
+     * currently selected engine keeps its normal capture behaviour.
+     */
+    override suspend fun transcribeBlocking(pcm: ShortArray): String? =
+        sherpaOnnxVoiceInputController.transcribeBlocking(pcm)
+
     private fun stopInactiveControllers(active: VoiceInputController) {
         if (active !== voskOfflineVoiceInputController) voskOfflineVoiceInputController.stopListening()
         if (active !== nativeAndroidVoiceInputController) nativeAndroidVoiceInputController.stopListening()

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SelectableVoiceInputControllerTest.kt
@@ -1,6 +1,7 @@
 package com.kernel.ai.core.voice
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -14,6 +15,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -129,5 +131,156 @@ class SelectableVoiceInputControllerTest {
 
         verify(exactly = 1) { voskOfflineVoiceInputController.stopListening() }
         verify(exactly = 1) { nativeAndroidVoiceInputController.stopListening() }
+    }
+
+    // ── wake-window verification delegation (#1432) ────────────────────────
+
+    @Test
+    fun `transcribeBlocking forwards the wake-window PCM exactly once to the Sherpa verifier`() = runTest(dispatcher) {
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        val pcm = shortArrayOf(1, 2, 3, 4)
+        coEvery { sherpaOnnxVoiceInputController.transcribeBlocking(pcm) } returns "hey jandal"
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+
+        assertEquals("hey jandal", controller.transcribeBlocking(pcm))
+
+        coVerify(exactly = 1) { sherpaOnnxVoiceInputController.transcribeBlocking(pcm) }
+    }
+
+    @Test
+    fun `transcribeBlocking propagates the returned wake transcript`() = runTest(dispatcher) {
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        val pcm = shortArrayOf(9, 8, 7)
+        coEvery { sherpaOnnxVoiceInputController.transcribeBlocking(pcm) } returns "a jandel"
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+
+        assertEquals("a jandel", controller.transcribeBlocking(pcm))
+    }
+
+    @Test
+    fun `transcribeBlocking propagates null truthfully`() = runTest(dispatcher) {
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        val pcm = shortArrayOf(5, 5, 5)
+        coEvery { sherpaOnnxVoiceInputController.transcribeBlocking(pcm) } returns null
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+
+        assertNull(controller.transcribeBlocking(pcm))
+    }
+
+    @Test
+    fun `transcribeBlocking never starts or stops interactive controllers`() = runTest(dispatcher) {
+        every { voiceInputPreferences.selectedEngine } returns MutableStateFlow(VoiceInputEngine.Vosk)
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+        every { sherpaOnnxVoiceInputController.stopListening() } just runs
+        coEvery { sherpaOnnxVoiceInputController.transcribeBlocking(any()) } returns null
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+
+        controller.transcribeBlocking(shortArrayOf(1, 2))
+
+        coVerify(exactly = 0) { voskOfflineVoiceInputController.startListening(any()) }
+        coVerify(exactly = 0) { nativeAndroidVoiceInputController.startListening(any()) }
+        coVerify(exactly = 0) { sherpaOnnxVoiceInputController.startListening(any()) }
+        verify(exactly = 0) { voskOfflineVoiceInputController.stopListening() }
+        verify(exactly = 0) { nativeAndroidVoiceInputController.stopListening() }
+        verify(exactly = 0) { sherpaOnnxVoiceInputController.stopListening() }
+    }
+
+    @Test
+    fun `transcribeBlocking leaves the interactive engine selection untouched`() = runTest(dispatcher) {
+        val selectedEngine = MutableStateFlow(VoiceInputEngine.Vosk)
+        every { voiceInputPreferences.selectedEngine } returns selectedEngine
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+        every { sherpaOnnxVoiceInputController.stopListening() } just runs
+        coEvery { voskOfflineVoiceInputController.startListening(VoiceCaptureMode.Command) } returns
+            VoiceInputStartResult.Started(1L)
+        coEvery { sherpaOnnxVoiceInputController.transcribeBlocking(any()) } returns "hey jandal"
+
+        val controller = SelectableVoiceInputController(
+            voiceInputPreferences = voiceInputPreferences,
+            voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+            nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+            sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+        )
+
+        // Verification runs while Vosk is selected; the interactive selection must survive.
+        assertEquals("hey jandal", controller.transcribeBlocking(shortArrayOf(1, 2)))
+        assertEquals(VoiceInputEngine.Vosk, selectedEngine.value)
+        assertEquals(VoiceInputStartResult.Started(1L), controller.startListening(VoiceCaptureMode.Command))
+        coVerify(exactly = 1) { voskOfflineVoiceInputController.startListening(VoiceCaptureMode.Command) }
+        coVerify(exactly = 0) { nativeAndroidVoiceInputController.startListening(any()) }
+        coVerify(exactly = 0) { sherpaOnnxVoiceInputController.startListening(any()) }
+    }
+
+    @Test
+    fun `every interactive engine selection keeps its normal capture behaviour`() = runTest(dispatcher) {
+        every { voskOfflineVoiceInputController.events } returns MutableSharedFlow()
+        every { nativeAndroidVoiceInputController.events } returns MutableSharedFlow()
+        every { sherpaOnnxVoiceInputController.events } returns MutableSharedFlow()
+        every { voskOfflineVoiceInputController.stopListening() } just runs
+        every { nativeAndroidVoiceInputController.stopListening() } just runs
+        every { sherpaOnnxVoiceInputController.stopListening() } just runs
+
+        val engines = listOf(
+            VoiceInputEngine.Vosk to voskOfflineVoiceInputController,
+            VoiceInputEngine.AndroidNative to nativeAndroidVoiceInputController,
+            VoiceInputEngine.SherpaZipformer to sherpaOnnxVoiceInputController,
+        )
+        for ((engine, expected) in engines) {
+            every { voiceInputPreferences.selectedEngine } returns MutableStateFlow(engine)
+            coEvery { expected.startListening(VoiceCaptureMode.Command) } returns
+                VoiceInputStartResult.Started(1L)
+
+            val controller = SelectableVoiceInputController(
+                voiceInputPreferences = voiceInputPreferences,
+                voskOfflineVoiceInputController = voskOfflineVoiceInputController,
+                nativeAndroidVoiceInputController = nativeAndroidVoiceInputController,
+                sherpaOnnxVoiceInputController = sherpaOnnxVoiceInputController,
+            )
+
+            assertEquals(
+                VoiceInputStartResult.Started(1L),
+                controller.startListening(VoiceCaptureMode.Command),
+                "capture must route to $engine",
+            )
+            coVerify(exactly = 1) { expected.startListening(VoiceCaptureMode.Command) }
+        }
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordGateExitSummaryTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordGateExitSummaryTest.kt
@@ -1,73 +1,237 @@
 package com.kernel.ai.core.voice
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Contract tests for the #1432 debug-gated per-gate-exit diagnostic summary
- * ([buildGateExitSummary]).  The summary is the bounded instrument used to
- * capture sub-threshold classifier confidence during the physical smoke, so
- * its format and value rounding must be stable and parseable.
+ * Lifecycle contract tests for the #1432 debug-gated per-gate-exit diagnostic
+ * ([WakeWordGateExitDiagnostics] + [buildGateExitSummary]).
+ *
+ * The diagnostic is the bounded instrument used to capture sub-threshold
+ * classifier confidence during the physical smoke, so its lifecycle must match
+ * the real detector exactly:
+ *
+ * ```
+ * gate entered
+ * → zero or more periodic gated Stage-2 probes
+ * → gate exited on voiced audio
+ * → zero or more Stage-3 evaluations / verifier attempts
+ * → gate entered again or detector generation ended
+ * → one summary emitted
+ * ```
+ *
+ * These tests exercise the actual lifecycle state holder used by
+ * [OnnxWakeWordDetector], not string construction in isolation.
  */
 class WakeWordGateExitSummaryTest {
 
-    @Test
-    fun `summary carries all bounded aggregate fields`() {
-        val s = buildGateExitSummary(
-            generationId = 7L,
-            episodeOpen = true,
-            stage3Evaluations = 42,
-            maxConfidence = 0.51654834f,
-            maxConfidenceChunk = 503,
-            lowVerifyEntered = true,
-            lowVerifyAccepted = false,
-            gatedStage2Executions = 61L,
-        )
+    private fun newDiag(generationId: Long = 1L) = WakeWordGateExitDiagnostics(generationId)
 
+    // ── Lifecycle: emission rules ──────────────────────────────────────────
+
+    @Test
+    fun `initial gate entry produces no summary`() {
+        val diag = newDiag()
+
+        assertNull(diag.onGateEntered(100))
+        assertTrue(!diag.episodeOpen)
+    }
+
+    @Test
+    fun `second gate entry without an intervening exit produces no fabricated summary`() {
+        val diag = newDiag()
+        diag.onGateEntered(100)
+
+        assertNull(diag.onGateEntered(400))
+    }
+
+    @Test
+    fun `termination emits one final summary for an open episode`() {
+        val diag = newDiag()
+        diag.onGateEntered(100)
+        diag.onGateExited(200)
+        diag.onStage3Evaluation(0.42f, 202)
+
+        val s = diag.finish()!!
+
+        assertTrue(s.contains("stage3Evals=1"))
+        assertTrue(s.contains("maxConfidence=0.42"))
+        assertTrue(s.contains("maxConfidenceOffsetFrames=2"))
+        assertTrue(s.contains("lowVerifyEntered=false"))
+    }
+
+    @Test
+    fun `termination emits nothing when no episode is open`() {
+        assertNull(newDiag().finish())
+
+        val diag = newDiag()
+        diag.onGateEntered(100)
+        assertNull(diag.finish())
+
+        val diag2 = newDiag()
+        diag2.onGateEntered(100)
+        diag2.onGateExited(200)
+        diag2.onGateEntered(300) // episode closed by re-entry
+        assertNull(diag2.finish())
+    }
+
+    @Test
+    fun `gate re-entry after a closed episode emits no second summary`() {
+        val diag = newDiag()
+        diag.onGateEntered(100)
+        diag.onGateExited(200)
+        diag.onStage3Evaluation(0.5f, 201)
+        val first = diag.onGateEntered(300)!!
+
+        // Second gate entry with no intervening exit: no fabricated summary.
+        assertNull(diag.onGateEntered(500))
+    }
+
+    // ── Lifecycle: one episode's own values ────────────────────────────────
+
+    @Test
+    fun `one episode reports only its own probes evals max offset and verifier result`() {
+        val diag = newDiag(generationId = 7L)
+        diag.onGateEntered(100)
+        diag.onGatedProbeExecution()
+        diag.onGatedProbeExecution()
+        diag.onGateExited(200) // exit frame 200 = offset 0
+        diag.onStage3Evaluation(0.1f, 200)
+        diag.onStage3Evaluation(0.6f, 201)
+        diag.onLowVerify(accepted = false)
+
+        val s = diag.onGateEntered(500)!!
         assertTrue(s.contains("gen=7"))
-        assertTrue(s.contains("episodeOpen=true"))
-        assertTrue(s.contains("stage3Evals=42"))
-        assertTrue(s.contains("maxConfidence=0.51654834"))
-        assertTrue(s.contains("maxConfidenceChunk=503"))
+        assertTrue(s.contains("stage3Evals=2"))
+        assertTrue(s.contains("maxConfidence=0.6"))
+        assertTrue(s.contains("maxConfidenceOffsetFrames=1"))
         assertTrue(s.contains("lowVerifyEntered=true"))
         assertTrue(s.contains("lowVerifyAccepted=false"))
-        assertTrue(s.contains("gatedStage2Executions=61"))
+        assertTrue(s.contains("gatedProbeExecutions=2"))
+    }
+
+    @Test
+    fun `maximum confidence at the exit frame reports offset 0`() {
+        val diag = newDiag()
+        diag.onGateEntered(0)
+        diag.onGateExited(77)
+        diag.onStage3Evaluation(0.88f, 77) // same chunk as the exit
+
+        val s = diag.onGateEntered(100)!!
+        assertTrue(s.contains("maxConfidence=0.88"))
+        assertTrue(s.contains("maxConfidenceOffsetFrames=0"))
+    }
+
+    @Test
+    fun `evaluations before any episode are not counted`() {
+        val diag = newDiag()
+        diag.onStage3Evaluation(0.9f, 50) // startup, no episode open
+        diag.onGateEntered(100)
+        diag.onGateExited(200)
+        diag.onStage3Evaluation(0.4f, 201)
+
+        val s = diag.onGateEntered(300)!!
+        assertTrue(s.contains("stage3Evals=1"))
+        assertTrue(s.contains("maxConfidence=0.4"))
+    }
+
+    // ── Lifecycle: episode isolation ───────────────────────────────────────
+
+    @Test
+    fun `two consecutive episodes produce independent summaries with no state leakage`() {
+        val diag = newDiag()
+
+        // Episode 1: 0 probes, 1 evaluation at 0.9 (offset 1), verifier accepted.
+        diag.onGateEntered(0)
+        diag.onGateExited(10)
+        diag.onStage3Evaluation(0.9f, 11)
+        diag.onLowVerify(accepted = true)
+        val first = diag.onGateEntered(100)!!
+        assertTrue(first.contains("stage3Evals=1"))
+        assertTrue(first.contains("maxConfidence=0.9"))
+        assertTrue(first.contains("maxConfidenceOffsetFrames=1"))
+        assertTrue(first.contains("lowVerifyEntered=true"))
+        assertTrue(first.contains("lowVerifyAccepted=true"))
+        assertTrue(first.contains("gatedProbeExecutions=0"))
+
+        // Episode 2: 3 probes, 2 evaluations peaking at 0.5 (offset 1),
+        // verifier rejected — nothing may bleed from episode 1.
+        diag.onGatedProbeExecution()
+        diag.onGatedProbeExecution()
+        diag.onGatedProbeExecution()
+        diag.onGateExited(200)
+        diag.onStage3Evaluation(0.3f, 200)
+        diag.onStage3Evaluation(0.5f, 201)
+        diag.onLowVerify(accepted = false)
+        val second = diag.onGateEntered(300)!!
+        assertTrue(second.contains("stage3Evals=2"))
+        assertTrue(second.contains("maxConfidence=0.5"))
+        assertTrue(second.contains("maxConfidenceOffsetFrames=1"))
+        assertTrue(second.contains("lowVerifyEntered=true"))
+        assertTrue(second.contains("lowVerifyAccepted=false"))
+        assertTrue(second.contains("gatedProbeExecutions=3"))
+
+        // Episode 1's summary is an immutable snapshot — unchanged after episode 2.
+        assertTrue(first.contains("stage3Evals=1"))
+        assertTrue(first.contains("lowVerifyAccepted=true"))
+    }
+
+    @Test
+    fun `probe counts do not bleed into the next gated interval`() {
+        val diag = newDiag()
+        diag.onGateEntered(0)
+        diag.onGatedProbeExecution()
+        diag.onGatedProbeExecution()
+        diag.onGateExited(10)
+        diag.onStage3Evaluation(0.5f, 11)
+        val first = diag.onGateEntered(100)!!
+        assertTrue(first.contains("gatedProbeExecutions=2"))
+
+        // New gated interval without probes: next episode must report 0.
+        diag.onGateExited(200)
+        diag.onStage3Evaluation(0.6f, 201)
+        val second = diag.onGateEntered(300)!!
+        assertTrue(second.contains("gatedProbeExecutions=0"))
+    }
+
+    // ── Formatting contract ────────────────────────────────────────────────
+
+    @Test
+    fun `summary formatting is locale-independent and parseable`() {
+        val s = buildGateExitSummary(
+            generationId = 1L,
+            stage3Evaluations = 42,
+            maxConfidence = 0.6f,
+            maxConfidenceOffsetFrames = 3,
+            lowVerifyEntered = true,
+            lowVerifyAccepted = true,
+            gatedProbeExecutions = 5L,
+        )
+
+        assertTrue(s.startsWith("WakeWordDetector: gateExitSummary"))
+        // Float.toString() is locale-independent; a comma decimal separator
+        // would break logcat parsing.
+        assertEquals("0.6", s.substringAfter("maxConfidence=").substringBefore(" maxConfidenceOffsetFrames="))
     }
 
     @Test
     fun `summary reports none when no score was observed in the episode`() {
         val s = buildGateExitSummary(
             generationId = 8L,
-            episodeOpen = false,
             stage3Evaluations = 0,
             maxConfidence = -1f,
-            maxConfidenceChunk = 0,
+            maxConfidenceOffsetFrames = -1,
             lowVerifyEntered = false,
             lowVerifyAccepted = false,
-            gatedStage2Executions = 0L,
+            gatedProbeExecutions = 0L,
         )
 
         assertTrue(s.contains("stage3Evals=0"))
         assertTrue(s.contains("maxConfidence=none"))
+        assertTrue(s.contains("maxConfidenceOffsetFrames=-1"))
         assertTrue(s.contains("lowVerifyEntered=false"))
-    }
-
-    @Test
-    fun `summary uses locale-independent float formatting`() {
-        val s = buildGateExitSummary(
-            generationId = 1L,
-            episodeOpen = true,
-            stage3Evaluations = 1,
-            maxConfidence = 0.6f,
-            maxConfidenceChunk = 100,
-            lowVerifyEntered = true,
-            lowVerifyAccepted = true,
-            gatedStage2Executions = 3L,
-        )
-
-        // Float.toString() is locale-independent; a comma decimal separator
-        // would break logcat parsing.
-        assertEquals("0.6", s.substringAfter("maxConfidence=").substringBefore(" maxConfidenceChunk="))
+        assertTrue(s.contains("gatedProbeExecutions=0"))
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordGateExitSummaryTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordGateExitSummaryTest.kt
@@ -1,0 +1,73 @@
+package com.kernel.ai.core.voice
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract tests for the #1432 debug-gated per-gate-exit diagnostic summary
+ * ([buildGateExitSummary]).  The summary is the bounded instrument used to
+ * capture sub-threshold classifier confidence during the physical smoke, so
+ * its format and value rounding must be stable and parseable.
+ */
+class WakeWordGateExitSummaryTest {
+
+    @Test
+    fun `summary carries all bounded aggregate fields`() {
+        val s = buildGateExitSummary(
+            generationId = 7L,
+            episodeOpen = true,
+            stage3Evaluations = 42,
+            maxConfidence = 0.51654834f,
+            maxConfidenceChunk = 503,
+            lowVerifyEntered = true,
+            lowVerifyAccepted = false,
+            gatedStage2Executions = 61L,
+        )
+
+        assertTrue(s.contains("gen=7"))
+        assertTrue(s.contains("episodeOpen=true"))
+        assertTrue(s.contains("stage3Evals=42"))
+        assertTrue(s.contains("maxConfidence=0.51654834"))
+        assertTrue(s.contains("maxConfidenceChunk=503"))
+        assertTrue(s.contains("lowVerifyEntered=true"))
+        assertTrue(s.contains("lowVerifyAccepted=false"))
+        assertTrue(s.contains("gatedStage2Executions=61"))
+    }
+
+    @Test
+    fun `summary reports none when no score was observed in the episode`() {
+        val s = buildGateExitSummary(
+            generationId = 8L,
+            episodeOpen = false,
+            stage3Evaluations = 0,
+            maxConfidence = -1f,
+            maxConfidenceChunk = 0,
+            lowVerifyEntered = false,
+            lowVerifyAccepted = false,
+            gatedStage2Executions = 0L,
+        )
+
+        assertTrue(s.contains("stage3Evals=0"))
+        assertTrue(s.contains("maxConfidence=none"))
+        assertTrue(s.contains("lowVerifyEntered=false"))
+    }
+
+    @Test
+    fun `summary uses locale-independent float formatting`() {
+        val s = buildGateExitSummary(
+            generationId = 1L,
+            episodeOpen = true,
+            stage3Evaluations = 1,
+            maxConfidence = 0.6f,
+            maxConfidenceChunk = 100,
+            lowVerifyEntered = true,
+            lowVerifyAccepted = true,
+            gatedStage2Executions = 3L,
+        )
+
+        // Float.toString() is locale-independent; a comma decimal separator
+        // would break logcat parsing.
+        assertEquals("0.6", s.substringAfter("maxConfidence=").substringBefore(" maxConfidenceChunk="))
+    }
+}

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordRingResumeTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordRingResumeTest.kt
@@ -364,6 +364,36 @@ class WakeWordRingResumeTest {
     }
 
     @Test
+    fun `accepted low band candidate records candidate before verified and invokes the wake callback exactly once`() {
+        val sim = DetectorSim(
+            phraseTimeline(exitNoiseFrame = null),
+            flushRingOnGateExit = false,
+            scorer = { end, phraseEnd -> if (tailLagSeconds(end, phraseEnd) in 0.15..0.35) 0.55f else 0.05f },
+            verifierAccepts = true,
+        ).apply { run() }
+
+        assertNotNull(sim.candidateFrame)
+        assertTrue(sim.events.indexOf("ACTIVATION_CANDIDATE") < sim.events.indexOf("VERIFIED_ACTIVATION"))
+        assertEquals(1, sim.verifierInvocations)
+        assertEquals(1, sim.onDetectedCount, "wake callback must fire exactly once on success")
+    }
+
+    @Test
+    fun `rejected low band candidate records no verified activation and no wake callback`() {
+        val sim = DetectorSim(
+            phraseTimeline(exitNoiseFrame = null),
+            flushRingOnGateExit = false,
+            scorer = { end, phraseEnd -> if (tailLagSeconds(end, phraseEnd) in 0.15..0.35) 0.55f else 0.05f },
+            verifierAccepts = false,
+        ).apply { run() }
+
+        assertNotNull(sim.candidateFrame)
+        assertFalse("VERIFIED_ACTIVATION" in sim.events)
+        assertTrue(sim.verifierInvocations >= 1, "every low-band crossing invokes the verifier")
+        assertEquals(0, sim.onDetectedCount)
+    }
+
+    @Test
     fun `silence gate cadence and probe cadence unchanged by the fix`() {
         // Negative timeline: both behaviours run to completion identically, so
         // gating/probe counters are directly comparable (the fixed behaviour
@@ -456,6 +486,7 @@ class WakeWordRingResumeTest {
         private val timeline: Timeline,
         private val flushRingOnGateExit: Boolean,
         private val scorer: (windowEndFrame: Int, phraseEndFrame: Int) -> Float = ::tailScorer,
+        private val verifierAccepts: Boolean = true,
     ) {
         private val ring = WakeWordEmbeddingRingState()
         private val gate = SilenceGateTransitionState()
@@ -479,6 +510,9 @@ class WakeWordRingResumeTest {
             private set
         var verifierInvocations = 0
             private set
+        var onDetectedCount = 0
+            private set
+        private var activated = false
 
         fun run() {
             var chunkCount = 0
@@ -487,7 +521,7 @@ class WakeWordRingResumeTest {
             var emittedStage3Ready = false
             var lastGateExitFrame = Int.MAX_VALUE
 
-            while (chunkCount < timeline.totalFrames && candidateFrame == null) {
+            while (chunkCount < timeline.totalFrames && !activated) {
                 chunkCount++
                 val frame = chunkCount - 1
                 val audioClass = timeline.audioClass(frame)
@@ -550,12 +584,18 @@ class WakeWordRingResumeTest {
                         candidateFrame = frame
                         events += "ACTIVATION_CANDIDATE"
                         events += "VERIFIED_ACTIVATION"
+                        onDetectedCount++
+                        activated = true
                     }
                     confidence >= WAKE_WORD_DEFAULT_LOW_THRESHOLD -> {
                         candidateFrame = frame
                         verifierInvocations++
                         events += "ACTIVATION_CANDIDATE"
-                        events += "VERIFIED_ACTIVATION"
+                        if (verifierAccepts) {
+                            events += "VERIFIED_ACTIVATION"
+                            onDetectedCount++
+                            activated = true
+                        }
                     }
                     else -> Unit
                 }


### PR DESCRIPTION
Refs #1432

Draft — **do not merge; wait for review.** Residual detector recall failures are **not** resolved by this PR; it delivers the proven verifier-delegation prerequisite and the diagnostic instrument, and reports two distinct residual mechanisms (see below).

## SHAs

- Starting `main`: `f6148de47d9661b2e06170f9eee9131494c6f016` (expected, verified; PR #1434 merge `a278e755` and PR #1437 merge `f6148de4` both ancestors)
- Branch: `fix/1432-residual-detector-recall`
- Physical smoke head/APK: `c78872085c0a4151e2a7ce354f64adc7a9a8aab3` (APK SHA-256 `0b34f5d4bacdcb6750d3e6ec61738d230a6940ed65a138d6e2f423a64a263a1d`)
- Final PR head: `6089d8a1b136a886b5332e34853cf9d32ca8aa70` — post-smoke remediation changed **only debug diagnostic bookkeeping and PR metadata**; wake detection, verifier delegation and activation behaviour are unchanged. The diagnostic formatting at this head was **not** physically re-tested.

## Corrected eight-versus-two evidence distinction

Preserved run: `regression_post_fix-2026-08-02T08-55-02Z-ee8c4b07` (evidence branch `ab598d73`, sanitized evidence byte-identical to published `test-results/results/release/launch-gate-2026-08-02/on_device/`). Of the 10 `classifier_model_miss` trials:

- **Eight no-candidate** (006, 008, 009, 012, 013, 015, 016, 022): valid gate/resume activity, `STAGE3_READY` re-armed at every exit, never an `ACTIVATION_CANDIDATE`.
- **Two low-band rejected candidates** (019 ≈ 0.5165 low, 026 ≈ 0.6002 low): candidate emitted, verifier path failed.

## Pattern 1 — low-band candidates: delegation defect FIXED; verifier-model defect PROVEN (unresolved)

### Root cause A (fixed): selectable wake-verifier delegation

`VoiceModule` binds `VoiceInputController` → `SelectableVoiceInputController`; `WakeWordService` calls `transcribeBlocking(pcm)` for every low-band candidate; the facade never overrode it, so the interface default returned `null` and trials 019/026 were guaranteed to reject. `SherpaOnnxVoiceInputController.transcribeBlocking` (dedicated wake recognizer + fallback spec selection) existed but was unreachable.

**Fix:** the facade now delegates directly to `sherpaOnnxVoiceInputController.transcribeBlocking(pcm)`; `activeController`/engine selection/thresholds/STT behaviour untouched. Service wiring extracted to `verifyWakeWindow` (identical expression). Deterministic before/after: before = facade `null` → reject; after = PCM forwarded exactly once, phrase transcript activates, non-wake/`null` reject truthfully.

### Root cause B (proven, NOT fixed — out of scope, unresolved)

The exact on-device wake-verifier models (Zipformer int8, same files/config the app loads) transcribe the committed natural fixture as `HY GEN` / `HYGENDEL` even clean — no supported Hey Jandal form ever matches, so **low-band candidates cannot verify with the current model**. Distinct verifier-model defect, outside #1432's fix scope ("do not replace models or providers; do not add another verifier abstraction"); reported for verifier-model decision (#986/#1410).

## Pattern 2 — eight no-candidate failures: first divergence CAPTURED on-device; unresolved

The debug-gated per-gate-exit diagnostic captured the missing scores: S23U smoke trial 002's phrase episode ran 2442 Stage-3 evaluations with max confidence **0.34444994** (< 0.50) while the same run's trials 001/003 scored 0.9014 / 0.7149 — the classifier under-scores the physical phrase in some trials. Offline parity found a real production-vs-training mel-ring divergence (5 vs 8 rows/chunk, `mel(1760)[3:8] == mel(1280)[0:5]` exactly) but deterministic sweeps do not prove it causal, so no detector change is shipped without proof.

## Diagnostic instrument (this remediation — review 4840825797)

Episode-scoped per-gate-exit summary via `WakeWordDiag` logcat, modelled by `WakeWordGateExitDiagnostics` — exactly one detector lifecycle per emitted summary:

```
gate entered
→ zero or more periodic gated Stage-2 probes
→ gate exited on voiced audio
→ zero or more Stage-3 evaluations / verifier attempts
→ gate entered again or detector generation ended
→ one summary emitted
```

Fields: `stage3Evals` (episode only), `maxConfidence` + `maxConfidenceOffsetFrames` (offset from the gate-exit frame; exit frame = 0), `lowVerifyEntered`/`lowVerifyAccepted` (episode only), `gatedProbeExecutions` (**immediately preceding gated interval only**, captured before any state transition may clear the gated state). Initial gate entry emits nothing; re-entry without an intervening exit emits nothing; shutdown emits only for a real open episode; all episode fields reset at gate exit, probes reset at gate entry. No PCM, transcripts or per-frame output; `Log.isLoggable`-gated like the existing diagnostics; zero cost when disabled.

## Shared cause?

**No.** Pattern 1 = delegation defect (fixed) + verifier-model defect (proven, out of scope, unresolved). Pattern 2 = classifier under-scoring the physical phrase (reproduced on-device; cause not proven, unresolved). Treated independently per scope.

## Threshold / model / provider / fixture invariance

No thresholds, models, providers, fixtures, volumes or runner rules changed. `hey_jandal.onnx` (`11bcdb0d…38c206`) remains the test-exercised committed asset. Post-smoke remediation changes only diagnostic bookkeeping + PR metadata.

## Tests

- `:core:voice:testDebugUnitTest` — 194/194 (incl. 12 diagnostic-lifecycle tests and real-model classifier tests 11/11)
- `:app:testDebugUnitTest` — 1070/1070 (unchanged; verifier delegation untouched by this remediation)
- `lint` — 0 errors (3 pre-existing baseline-filtered); no findings on changed files
- runner tests 90/90; full `scripts/tests` 715/715; `fixture` mode PASS; `git diff --check` clean

## CI and Docs Drift

Pending at head `6089d8a1` (runs started after push; will confirm).

## Bounded physical smoke — results (no full matrix ran; historical evidence, unchanged)

Frozen setup: natural fixture, 0.6 m placement, volume 9, built-in speaker route, cue policy 2026-07-cue-v1; fresh monitored preflights approved for both directions (S21 target `7fde4dd8…`, S23U target `2d5905e8…`); targets discharging; one exact APK (`c7887208` / `0b34f5d4…`) per cell.

### S21 target / S23U source (`smoke-2026-08-03T03-25-56Z-eb0badbb`) — 10 valid, 9 PASS, 1 FAIL

| Trial | Idle | Result | Confidence | Path |
|---|---|---|---|---|
| 001 | 10 s | PASS | 0.8482 | high |
| 002 | 10 s | PASS | 0.9219 | high |
| 003 | 10 s | PASS | 0.8988 | high |
| 004 | 30 s | PASS | 0.5891 low-rejected → 0.9105 high | low verify rejected, high recovered |
| 005 | 30 s | PASS | 0.8147 | high |
| 006 | 30 s | PASS | 0.9067 | high |
| 007 | 120 s | PASS | 0.8271 | high |
| 008 | 120 s | PASS | 0.9092 | high |
| 009 | 120 s | **FAIL** | 0.6336 low | candidate → verifier REJECTED (Root cause B) |
| 010 | 900 s | PASS | 0.8855 | high |

All 10 valid, 0 invalid.

### S23U target / S21 source (`smoke-2026-08-03T04-22-20Z-64d762cc`) — 3 valid, 2 PASS, 1 FAIL

| Trial | Idle | Result | Confidence | Path |
|---|---|---|---|---|
| 001 | 120 s | PASS | 0.9014 | high |
| 002 | 120 s | **FAIL** | max 0.3444 | no candidate (phrase under-scored; diagnostic-captured) |
| 003 | 120 s | PASS | 0.7149 | high |

All 3 valid, 0 invalid.

### Acceptance status (explicitly unmet — no claim of resolution)

- Zero valid detector failures: **NOT met** (009 verifier-rejection; 002 no-candidate).
- A naturally occurring low-band candidate verified successfully: **NOT met** — proven blocked by the verifier-model defect (Root cause B), not by delegation.
- No valid failure retried away; no invalid attempts in either run; historical 027–030 untouched; previous physical results remain historical evidence — nothing rewritten, deleted or reclassified.

## Scope confirmations

- **No full #1410 matrix ran** (only the bounded cells above).
- **#1398/#1399 not absorbed** — no PCM pre-roll/replay.
- **#1433 not modified** — handoff tests pass unchanged.
- Historical failures and invalid attempts preserved untouched.
