### PR TITLE
fix(#1439): make low-band wake verification recognise Hey Jandal

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -42,6 +42,13 @@
             android:name="com.kernel.ai.debug.journal.TargetEventJournalProvider"
             android:authorities="com.kernel.ai.debug.target-event-journal"
             android:exported="true" />
+        <receiver
+            android:name="com.kernel.ai.debug.verifier.WakeVerifierProbeReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.kernel.ai.debug.action.VERIFY_WAKE_WINDOW" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/kernel/ai/debug/verifier/WakeVerifierProbeReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/verifier/WakeVerifierProbeReceiver.kt
@@ -87,6 +87,13 @@ class WakeVerifierProbeReceiver : BroadcastReceiver() {
         pendingResult.finish()
     }
 
+    private fun readLeInt(raf: RandomAccessFile): Int {
+        val b = ByteArray(4)
+        raf.readFully(b)
+        return (b[0].toInt() and 0xff) or ((b[1].toInt() and 0xff) shl 8) or
+            ((b[2].toInt() and 0xff) shl 16) or ((b[3].toInt() and 0xff) shl 24)
+    }
+
     private fun isExplicitReceiverInvocation(context: Context, intent: Intent): Boolean =
         intent.component?.packageName == context.packageName &&
             intent.component?.className == WakeVerifierProbeReceiver::class.java.name
@@ -98,7 +105,7 @@ class WakeVerifierProbeReceiver : BroadcastReceiver() {
                 val riff = ByteArray(4)
                 raf.readFully(riff)
                 if (String(riff) != "RIFF") return null
-                raf.readInt() // chunk size
+                readLeInt(raf) // chunk size
                 raf.readFully(riff)
                 if (String(riff) != "WAVE") return null
                 var channels = -1
@@ -109,7 +116,7 @@ class WakeVerifierProbeReceiver : BroadcastReceiver() {
                 while (raf.filePointer < raf.length()) {
                     val id = ByteArray(4)
                     raf.readFully(id)
-                    val size = raf.readInt()
+                    val size = readLeInt(raf)
                     when (String(id)) {
                         "fmt " -> {
                             val fmt = ByteArray(size.coerceAtMost(64))

--- a/app/src/debug/java/com/kernel/ai/debug/verifier/WakeVerifierProbeReceiver.kt
+++ b/app/src/debug/java/com/kernel/ai/debug/verifier/WakeVerifierProbeReceiver.kt
@@ -1,0 +1,159 @@
+package com.kernel.ai.debug.verifier
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.kernel.ai.assistant.verifyWakeWindow
+import com.kernel.ai.core.voice.VoiceInputController
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import java.io.File
+import java.io.RandomAccessFile
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Debug-only direct verifier probe (#1439 bounded validation).
+ *
+ * Exercises the REAL production low-band verification path
+ * (`verifyWakeWindow` → selectable facade → `transcribeBlocking` → on-device
+ * Whisper verifier → `containsWakePhrase`) against a PCM fixture WAV, exactly
+ * like the detector's 3 s ring snapshot hand-off.
+ *
+ * Invocation (explicit component only, never implicit):
+ *
+ *     adb shell am broadcast \
+ *       -a com.kernel.ai.debug.action.VERIFY_WAKE_WINDOW \
+ *       -n com.kernel.ai.debug/com.kernel.ai.debug.verifier.WakeVerifierProbeReceiver \
+ *       --es fixture_file probe_ring.wav [--ei runs 3]
+ *
+ * Fixtures live in app-private `files/acoustic-fixtures/` (16 kHz mono int16
+ * WAV — the detector ring sample format). Result data carries the per-run
+ * verdicts, e.g. `accept,accept,accept` or `reject,reject,reject`.
+ *
+ * Debug builds only — the receiver exists in `app/src/debug` and is never
+ * part of a release APK.
+ */
+class WakeVerifierProbeReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+        Thread {
+            try {
+                if (!isExplicitReceiverInvocation(appContext, intent)) {
+                    finish(pendingResult, "explicit_component_required")
+                    return@Thread
+                }
+                val fileName = intent.getStringExtra(EXTRA_FIXTURE_FILE)
+                if (fileName.isNullOrBlank() || fileName.contains("..") || fileName.contains('/')) {
+                    finish(pendingResult, "invalid_fixture_file")
+                    return@Thread
+                }
+                val runs = intent.getIntExtra(EXTRA_RUNS, 3).coerceIn(1, 5)
+                val fixture = File(appContext.filesDir, "acoustic-fixtures/$fileName")
+                val pcm = readWav16kMono(fixture)
+                if (pcm == null) {
+                    finish(pendingResult, "fixture_unreadable")
+                    return@Thread
+                }
+                val controller = EntryPointAccessors.fromApplication(
+                    appContext,
+                    WakeVerifierProbeEntryPoint::class.java,
+                ).voiceInputController()
+                val outcomes = ArrayList<String>(runs)
+                for (i in 1..runs) {
+                    val accepted = runBlocking { verifyWakeWindow(controller, pcm) }
+                    outcomes.add(if (accepted) "accept" else "reject")
+                    Log.i(TAG, "wake-verifier probe $fileName run $i/$runs -> ${outcomes.last()}")
+                }
+                val summary = outcomes.joinToString(",")
+                Log.i(TAG, "wake-verifier probe $fileName ($runs runs): $summary")
+                pendingResult.setResultCode(android.app.Activity.RESULT_OK)
+                pendingResult.setResultData(summary)
+                pendingResult.finish()
+            } catch (error: Exception) {
+                Log.e(TAG, "wake-verifier probe failed", error)
+                finish(pendingResult, "probe_failed")
+            }
+        }.start()
+    }
+
+    private fun finish(pendingResult: PendingResult, data: String) {
+        pendingResult.setResultCode(android.app.Activity.RESULT_CANCELED)
+        pendingResult.setResultData(data)
+        pendingResult.finish()
+    }
+
+    private fun isExplicitReceiverInvocation(context: Context, intent: Intent): Boolean =
+        intent.component?.packageName == context.packageName &&
+            intent.component?.className == WakeVerifierProbeReceiver::class.java.name
+
+    /** Reads a 16 kHz mono int16 WAV into [ShortArray] (the ring snapshot format). */
+    private fun readWav16kMono(file: File): ShortArray? {
+        return try {
+            RandomAccessFile(file, "r").use { raf ->
+                val riff = ByteArray(4)
+                raf.readFully(riff)
+                if (String(riff) != "RIFF") return null
+                raf.readInt() // chunk size
+                raf.readFully(riff)
+                if (String(riff) != "WAVE") return null
+                var channels = -1
+                var sampleRate = -1
+                var bits = -1
+                var dataOffset = -1L
+                var dataLen = 0
+                while (raf.filePointer < raf.length()) {
+                    val id = ByteArray(4)
+                    raf.readFully(id)
+                    val size = raf.readInt()
+                    when (String(id)) {
+                        "fmt " -> {
+                            val fmt = ByteArray(size.coerceAtMost(64))
+                            raf.readFully(fmt)
+                            channels = (fmt[2].toInt() and 0xff) or ((fmt[3].toInt() and 0xff) shl 8)
+                            sampleRate = (fmt[4].toInt() and 0xff) or ((fmt[5].toInt() and 0xff) shl 8) or
+                                ((fmt[6].toInt() and 0xff) shl 16) or ((fmt[7].toInt() and 0xff) shl 24)
+                            bits = (fmt[14].toInt() and 0xff) or ((fmt[15].toInt() and 0xff) shl 8)
+                        }
+                        "data" -> {
+                            dataOffset = raf.filePointer
+                            dataLen = size
+                        }
+                        else -> raf.skipBytes(size)
+                    }
+                }
+                if (channels != 1 || sampleRate != 16000 || bits != 16 || dataOffset < 0) {
+                    Log.w(TAG, "unsupported fixture format: ch=$channels sr=$sampleRate bits=$bits")
+                    return null
+                }
+                val samples = ByteArray(dataLen)
+                raf.seek(dataOffset)
+                raf.readFully(samples)
+                ShortArray(dataLen / 2) { i ->
+                    val lo = samples[i * 2].toInt() and 0xff
+                    val hi = samples[i * 2 + 1].toInt()
+                    ((hi shl 8) or lo).toShort()
+                }
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "WakeVerifierProbe"
+        const val ACTION_VERIFY_WAKE_WINDOW = "com.kernel.ai.debug.action.VERIFY_WAKE_WINDOW"
+        const val EXTRA_FIXTURE_FILE = "fixture_file"
+        const val EXTRA_RUNS = "runs"
+    }
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WakeVerifierProbeEntryPoint {
+    fun voiceInputController(): VoiceInputController
+}

--- a/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
+++ b/app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt
@@ -27,7 +27,12 @@ import com.kernel.ai.core.voice.VoiceInputEvent
 import com.kernel.ai.core.voice.VoiceInputStartResult
 import com.kernel.ai.core.voice.WakeWordDetector
 import com.kernel.ai.core.voice.WakeWordHandoff
+import com.kernel.ai.core.inference.download.DownloadSource
+import com.kernel.ai.core.inference.download.KernelModel
+import com.kernel.ai.core.inference.download.ModelDownloadManager
+import com.kernel.ai.core.voice.SherpaSttModelSpec
 import com.kernel.ai.feature.widget.EXTRA_PREFILLED_TRANSCRIPT
+import java.io.File
 import com.kernel.ai.feature.widget.VoiceCommandActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
@@ -66,6 +71,24 @@ internal suspend fun verifyWakeWindow(
     voiceInputController: VoiceInputController,
     pcm: ShortArray,
 ): Boolean = voiceInputController.transcribeBlocking(pcm)?.containsWakePhrase() ?: false
+
+/**
+ * #1439: names of the wake-verifier model files (Whisper tiny.en catalogue
+ * entries) that are missing on device. Mirrors [SherpaSttModelSpec.requiredFileNames]
+ * and the controller's models directory (`getExternalFilesDir("models")`).
+ */
+internal fun missingWakeVerifierModelFiles(context: Context): List<String> {
+    val modelsDir = context.getExternalFilesDir("models") ?: File(context.filesDir, "models")
+    return SherpaSttModelSpec.WHISPER.requiredFileNames.filter { name ->
+        !File(modelsDir, name).exists()
+    }
+}
+
+/** Catalogue entries backing the wake-verifier model files (#1439). */
+internal fun wakeVerifierKernelModels(): List<KernelModel> =
+    SherpaSttModelSpec.WHISPER.requiredFileNames.mapNotNull { name ->
+        KernelModel.entries.firstOrNull { it.fileName == name }
+    }
 
 /** Build consistent cue-journal metadata from a playback result. */
 internal fun cueMetadata(
@@ -487,11 +510,35 @@ class WakeWordService : Service() {
     @Inject lateinit var wakeWordDetector: WakeWordDetector
     @Inject lateinit var voiceInputController: VoiceInputController
     @Inject lateinit var cuePlayer: StartListeningCuePlayer
+    @Inject lateinit var modelDownloadManager: ModelDownloadManager
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var eventCollectorJob: Job? = null
 
     /** True while [handleDetection] owns a live STT session; suppresses the observer's re-arm. */
     @Volatile private var isHandlingDetection = false
+
+    /** One-shot guard: verifier model provisioning is requested at most once per service lifetime. */
+    @Volatile private var wakeVerifierProvisionRequested = false
+
+    /**
+     * #1439: the low-band wake verifier prefers the Whisper tiny.en catalogue model
+     * (the only model that recognises the fixed wake phrase). Queue the download
+     * through the existing catalogue flow when the files are missing; verification
+     * falls back to the online recognizer until they arrive.
+     */
+    private fun ensureWakeVerifierModels() {
+        if (wakeVerifierProvisionRequested) return
+        wakeVerifierProvisionRequested = true
+        val missing = missingWakeVerifierModelFiles(this)
+        if (missing.isEmpty()) return
+        val models = wakeVerifierKernelModels()
+        if (models.isEmpty()) {
+            Log.w(TAG, "WakeWordService: wake-verifier catalogue entries missing for $missing")
+            return
+        }
+        models.forEach { modelDownloadManager.startDownload(it, source = DownloadSource.AUTO_QUEUED) }
+        Log.i(TAG, "WakeWordService: queued wake-verifier model download(s): $models")
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -606,6 +653,7 @@ class WakeWordService : Service() {
 
     /** Re-arms [wakeWordDetector] with the standard callbacks. */
     private fun rearmDetector() {
+        ensureWakeVerifierModels()
         if (!wakeWordDetector.isAvailable) {
             AcousticJournalBridge.record(
                 type = AcousticEventType.SERVICE_ERROR,

--- a/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifierProvisionTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifierProvisionTest.kt
@@ -1,0 +1,86 @@
+package com.kernel.ai.assistant
+
+import android.content.Context
+import com.kernel.ai.core.inference.download.KernelModel
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * #1439: the low-band wake verifier prefers the Whisper tiny.en catalogue
+ * model (the only model that recognises the fixed natural wake phrase).
+ * [WakeWordService] provisions the missing files through the existing
+ * catalogue flow when the wake word starts.
+ */
+class WakeWordVerifierProvisionTest {
+
+    private val tempModelsDir: File = Files.createTempDirectory("wake-verifier-models").toFile()
+
+    private val context: Context = mockk {
+        every { getExternalFilesDir("models") } returns tempModelsDir
+    }
+
+    @AfterEach
+    fun cleanup() {
+        tempModelsDir.deleteRecursively()
+    }
+
+    @Test
+    fun `reports all Whisper verifier files missing on an empty models dir`() {
+        val missing = missingWakeVerifierModelFiles(context)
+
+        assertEquals(
+            listOf(
+                "sherpa-whisper-tiny.en-encoder.int8.onnx",
+                "sherpa-whisper-tiny.en-decoder.int8.onnx",
+                "sherpa-whisper-tiny.en-tokens.txt",
+            ),
+            missing,
+        )
+    }
+
+    @Test
+    fun `reports only the missing Whisper verifier files`() {
+        File(tempModelsDir, "sherpa-whisper-tiny.en-encoder.int8.onnx").writeText("stub")
+
+        assertEquals(
+            listOf(
+                "sherpa-whisper-tiny.en-decoder.int8.onnx",
+                "sherpa-whisper-tiny.en-tokens.txt",
+            ),
+            missingWakeVerifierModelFiles(context),
+        )
+    }
+
+    @Test
+    fun `reports nothing when every Whisper verifier file is present`() {
+        listOf(
+            "sherpa-whisper-tiny.en-encoder.int8.onnx",
+            "sherpa-whisper-tiny.en-decoder.int8.onnx",
+            "sherpa-whisper-tiny.en-tokens.txt",
+        ).forEach { name -> File(tempModelsDir, name).writeText("stub") }
+
+        assertTrue(missingWakeVerifierModelFiles(context).isEmpty())
+    }
+
+    @Test
+    fun `maps every Whisper verifier file to its catalogue entry`() {
+        val models = wakeVerifierKernelModels()
+
+        assertEquals(3, models.size)
+        assertEquals(
+            listOf(
+                "sherpa-whisper-tiny.en-encoder.int8.onnx",
+                "sherpa-whisper-tiny.en-decoder.int8.onnx",
+                "sherpa-whisper-tiny.en-tokens.txt",
+            ),
+            models.map { it.fileName },
+        )
+        assertTrue(models.all { it is KernelModel })
+    }
+}

--- a/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifyWindowTest.kt
+++ b/app/src/test/java/com/kernel/ai/assistant/WakeWordVerifyWindowTest.kt
@@ -75,4 +75,43 @@ class WakeWordVerifyWindowTest {
         assertTrue(verifyWakeWindow(voiceInputController, pcm))
         coVerify(exactly = 1) { voiceInputController.transcribeBlocking(pcm) }
     }
+
+    // ── #1439: Whisper verifier transcripts ────────────────────────────────────
+
+    @Test
+    fun `accepts the Whisper verifier transcript of the genuine wake phrase`() = runTest {
+        // Exact catalogue Whisper tiny.en files transcribe the fixed natural
+        // fixture (detector-equivalent window) deterministically as "hi, jandal".
+        val pcm = shortArrayOf(11, 12, 13)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "hi, jandal"
+
+        assertTrue(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `accepts the jando truncation variant`() = runTest {
+        val pcm = shortArrayOf(14, 15)
+        coEvery { voiceInputController.transcribeBlocking(pcm) } returns "hi, jando"
+
+        assertTrue(verifyWakeWindow(voiceInputController, pcm))
+    }
+
+    @Test
+    fun `rejects Whisper fragments and non-wake transcripts`() = runTest {
+        val pcm = shortArrayOf(16, 17, 18)
+        listOf(
+            "hi, gentle",
+            "hi, sandal",
+            "hy gen",
+            "hy general",
+            "[ silence ]",
+            "[blank_audio]",
+            "what time is it",
+            "again",
+            "play some music",
+        ).forEach { transcript ->
+            coEvery { voiceInputController.transcribeBlocking(pcm) } returns transcript
+            assertFalse(verifyWakeWindow(voiceInputController, pcm), "must reject $transcript")
+        }
+    }
 }

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -78,16 +78,30 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     private val offlineMethods = OfflineMethods()
 
     /**
-     * Dedicated online recognizer for wake-word verification — loads a separate
-     * instance of the user's selected online STT model (Zipformer or Paraformer)
-     * so [transcribeBlocking] can run concurrently with [startListening]/[stopListening].
-     * For offline models (SenseVoice, Whisper), falls back to Zipformer.
+     * Single ownership boundary for the dedicated wake-verifier recognizers (#1440).
+     *
+     * The online fallback (Zipformer/Paraformer) and offline (Whisper) wake verifiers
+     * are mutually exclusive: at most one is cached/resident at a time, and a
+     * recognizer is never released while a verification using it is in progress.
+     * All wake-verifier selection, initialization, decoding, result extraction and
+     * stream release run under this mutex; the release* helpers must only be called
+     * while it is held. The interactive STT recognizer and its [recognizerMutex]
+     * are deliberately separate and unaffected.
      */
-    private val wakeRecognizerMutex = Mutex()
+    private val wakeVerifierMutex = Mutex()
     @Volatile private var wakeRecognizer: Any? = null
     @Volatile private var wakeMethods: WakeRecognizerMethods? = null
     @Volatile private var wakeSpecEngine: VoiceInputEngine? = null
     @Volatile private var wakeSpecValid: Boolean = false
+
+    /**
+     * Test double for dedicated wake-verifier construction (#1440). When set,
+     * [ensureWakeRecognizerBlocking]/[ensureWakeWhisperRecognizerBlocking] use the
+     * provided recognizer+methods pairs instead of reflection-based construction, so
+     * unit tests can drive the real cache-ownership lifecycle without the Sherpa AAR
+     * on the test classpath. Production callers never set this.
+     */
+    @Volatile internal var wakeVerifierTestBuilder: WakeVerifierTestBuilder? = null
 
     /**
      * Dedicated offline recognizer for wake-word verification (Whisper tiny.en).
@@ -98,11 +112,17 @@ class SherpaOnnxVoiceInputController @Inject constructor(
      * with the exact on-device files). The offline wake recognizer is a separate
      * instance so verification can run concurrently with interactive capture.
      */
-    private val wakeWhisperMutex = Mutex()
     @Volatile private var wakeWhisperRecognizer: Any? = null
     @Volatile private var wakeWhisperMethods: WakeWhisperMethods? = null
     @Volatile private var wakeWhisperEngine: VoiceInputEngine? = null
     @Volatile private var wakeWhisperValid: Boolean = false
+
+    /** #1440 test visibility: whether each dedicated wake verifier is currently cached. */
+    internal val wakeOnlineVerifierCached: Boolean get() = wakeRecognizer != null
+    internal val wakeWhisperVerifierCached: Boolean get() = wakeWhisperRecognizer != null
+
+    /** #1440 test visibility: the interactive STT recognizer must stay untouched. */
+    internal val interactiveRecognizerActive: Boolean get() = recognizer != null
 
     /** Holds reflected methods shared by both online and offline recognizers. */
     class StreamMethods {
@@ -132,6 +152,15 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         val getResult: java.lang.reflect.Method,
         val streamRelease: java.lang.reflect.Method,
     )
+
+    /**
+     * Test seam for dedicated wake-verifier construction (#1440). Implementations
+     * return recognizer+reflected-methods pairs without touching the Sherpa AAR.
+     */
+    interface WakeVerifierTestBuilder {
+        fun buildOnline(spec: SherpaSttModelSpec): Pair<Any, WakeRecognizerMethods>?
+        fun buildWhisper(spec: SherpaSttModelSpec): Pair<Any, WakeWhisperMethods>?
+    }
 
     /** Methods specific to OnlineRecognizer. */
     class OnlineMethods {
@@ -449,43 +478,47 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         // #1439: prefer the Whisper tiny.en verifier — the only catalogue model that
         // recognises the fixed natural wake phrase on the detector-equivalent window.
         // Falls back to the existing online verifier when the Whisper files are absent.
-        if (resolveWakeVerifierSpec() == SherpaSttModelSpec.WHISPER) {
-            val (rec, methods) = ensureWakeWhisperRecognizerBlocking(SherpaSttModelSpec.WHISPER)
-                ?: return null
-            val stream = methods.createStream.invoke(rec)
-            return try {
-                val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
-                methods.acceptWaveform.invoke(stream, floats, SAMPLE_RATE)
-                methods.decode.invoke(rec, stream)
-                resultTextFromWakeWhisper(rec, stream, methods)
-            } catch (e: Exception) {
-                Log.e(TAG, "transcribeBlocking (whisper verifier) failed", e)
-                null
-            } finally {
-                runCatching { methods.streamRelease.invoke(stream) }
-            }
-        }
-        val userSpec = resolveSpec()
-        val spec = if (userSpec.recognizerKind == SherpaSttModelSpec.RecognizerKind.Online) userSpec
-                   else SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
-        val (rec, methods) = ensureWakeRecognizerBlocking(spec) ?: return null
-        val stream = methods.createStream.invoke(rec, "")
-        return try {
-            val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
-            methods.acceptWaveform.invoke(stream, floats, SAMPLE_RATE)
-            methods.inputFinished.invoke(stream)
-            var iters = 0
+        // #1440: the whole verification — selection, initialization, decoding, result
+        // extraction and stream release — runs under [wakeVerifierMutex], so the
+        // online fallback and Whisper verifiers are mutually exclusive and a
+        // recognizer is never released while its decode is still in progress.
+        return wakeVerifierMutex.withLock {
+            val spec = resolveWakeVerifierSpec()
+            if (spec == SherpaSttModelSpec.WHISPER) {
+                val (rec, methods) = ensureWakeWhisperRecognizerBlocking(spec) ?: return@withLock null
+                val stream = methods.createStream.invoke(rec)
+                try {
+                    val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
+                    methods.acceptWaveform.invoke(stream, floats, SAMPLE_RATE)
+                    methods.decode.invoke(rec, stream)
+                    resultTextFromWakeWhisper(rec, stream, methods)
+                } catch (e: Exception) {
+                    Log.e(TAG, "transcribeBlocking (whisper verifier) failed", e)
+                    null
+                } finally {
+                    runCatching { methods.streamRelease.invoke(stream) }
+                }
+            } else {
+                val (rec, methods) = ensureWakeRecognizerBlocking(spec) ?: return@withLock null
+                val stream = methods.createStream.invoke(rec, "")
+                try {
+                    val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
+                    methods.acceptWaveform.invoke(stream, floats, SAMPLE_RATE)
+                    methods.inputFinished.invoke(stream)
+                    var iters = 0
 
-            while (methods.isReady.invoke(rec, stream) as Boolean) {
-                methods.decode.invoke(rec, stream)
-                if (++iters > 500) break
+                    while (methods.isReady.invoke(rec, stream) as Boolean) {
+                        methods.decode.invoke(rec, stream)
+                        if (++iters > 500) break
+                    }
+                    resultTextFromWakeMethods(rec, stream, methods)
+                } catch (e: Exception) {
+                    Log.e(TAG, "transcribeBlocking failed", e)
+                    null
+                } finally {
+                    runCatching { methods.streamRelease.invoke(stream) }
+                }
             }
-            resultTextFromWakeMethods(rec, stream, methods)
-        } catch (e: Exception) {
-            Log.e(TAG, "transcribeBlocking failed", e)
-            null
-        } finally {
-            runCatching { methods.streamRelease.invoke(stream) }
         }
     }
 
@@ -507,9 +540,11 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     }
 
     /**
-     * Ensures a dedicated online recognizer exists for wake-word verification.
-     * Uses its own mutex and dedicated method handles so the interactive STT recognizer
-     * can be reinitialized independently.
+     * Ensures the dedicated online wake-verification recognizer (Zipformer/Paraformer
+     * fallback) exists. The caller must hold [wakeVerifierMutex]: the Whisper wake
+     * verifier is evicted before the online verifier becomes resident, so at most one
+     * dedicated wake verifier is cached at a time (#1440). The interactive STT
+     * recognizer and its mutex are unaffected.
      */
     private suspend fun ensureWakeRecognizerBlocking(
         spec: SherpaSttModelSpec,
@@ -517,32 +552,37 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         if (wakeRecognizer != null && wakeSpecValid && wakeSpecEngine == spec.engine && wakeMethods != null) {
             return wakeRecognizer!! to wakeMethods!!
         }
-        return wakeRecognizerMutex.withLock {
-            if (wakeRecognizer != null && wakeSpecValid && wakeSpecEngine == spec.engine && wakeMethods != null) {
-                return@withLock wakeRecognizer!! to wakeMethods!!
+        // Mutual exclusion: evict the Whisper wake verifier, then any superseded
+        // online recognizer, before the new one becomes resident.
+        releaseWakeWhisperRecognizer()
+        releaseWakeRecognizer()
+        if (!isSpecAvailable(spec)) {
+            Log.w(TAG, "Wake-word STT model files missing for ${spec.engine}")
+            return null
+        }
+        return try {
+            val testBuilt = wakeVerifierTestBuilder?.buildOnline(spec)
+            val instance: Any
+            val methods: WakeRecognizerMethods
+            if (testBuilt != null) {
+                instance = testBuilt.first
+                methods = testBuilt.second
+            } else {
+                instance = initWakeOnlineRecognizer(spec)
+                methods = buildWakeMethods(instance)
             }
-            // Release old recognizer when engine changes to avoid native memory leak.
-            releaseWakeRecognizer()
-            if (!isSpecAvailable(spec)) {
-                Log.w(TAG, "Wake-word STT model files missing for ${spec.engine}")
-                return@withLock null
-            }
-            try {
-                val instance = initWakeOnlineRecognizer(spec)
-                val methods = buildWakeMethods(instance)
-                wakeRecognizer = instance
-                wakeMethods = methods
-                wakeSpecEngine = spec.engine
-                wakeSpecValid = true
-                instance to methods
-            } catch (e: Exception) {
-                Log.e(TAG, "Wake recognizer init failed", e)
-                wakeRecognizer = null
-                wakeMethods = null
-                wakeSpecEngine = null
-                wakeSpecValid = false
-                null
-            }
+            wakeRecognizer = instance
+            wakeMethods = methods
+            wakeSpecEngine = spec.engine
+            wakeSpecValid = true
+            instance to methods
+        } catch (e: Exception) {
+            Log.e(TAG, "Wake recognizer init failed", e)
+            wakeRecognizer = null
+            wakeMethods = null
+            wakeSpecEngine = null
+            wakeSpecValid = false
+            null
         }
     }
     @SuppressLint("MissingPermission")
@@ -704,8 +744,10 @@ class SherpaOnnxVoiceInputController @Inject constructor(
 
     /**
      * Ensures the dedicated offline (Whisper) wake-verification recognizer exists.
-     * Uses its own mutex and method handles so the interactive recognizers and the
-     * online wake recognizer can be reinitialized independently (#1439).
+     * The caller must hold [wakeVerifierMutex]: the online fallback wake verifier is
+     * evicted before Whisper becomes resident, so at most one dedicated wake verifier
+     * is cached at a time (#1440). The interactive STT recognizer and its mutex are
+     * unaffected.
      */
     private suspend fun ensureWakeWhisperRecognizerBlocking(
         spec: SherpaSttModelSpec,
@@ -713,38 +755,44 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         if (wakeWhisperRecognizer != null && wakeWhisperValid && wakeWhisperEngine == spec.engine && wakeWhisperMethods != null) {
             return wakeWhisperRecognizer!! to wakeWhisperMethods!!
         }
-        return wakeWhisperMutex.withLock {
-            if (wakeWhisperRecognizer != null && wakeWhisperValid && wakeWhisperEngine == spec.engine && wakeWhisperMethods != null) {
-                return@withLock wakeWhisperRecognizer!! to wakeWhisperMethods!!
+        // Mutual exclusion: evict the online wake verifier, then any superseded
+        // Whisper recognizer, before the new one becomes resident.
+        releaseWakeRecognizer()
+        releaseWakeWhisperRecognizer()
+        if (!isSpecAvailable(spec)) {
+            Log.w(TAG, "Wake-word Whisper verifier files missing for ${spec.engine}")
+            return null
+        }
+        return try {
+            val testBuilt = wakeVerifierTestBuilder?.buildWhisper(spec)
+            val instance: Any
+            val methods: WakeWhisperMethods
+            if (testBuilt != null) {
+                instance = testBuilt.first
+                methods = testBuilt.second
+            } else {
+                instance = initWakeWhisperRecognizer(spec)
+                methods = buildWakeWhisperMethods(instance)
             }
-            // Release old recognizer when the engine changes to avoid native memory leak.
-            releaseWakeWhisperRecognizer()
-            if (!isSpecAvailable(spec)) {
-                Log.w(TAG, "Wake-word Whisper verifier files missing for ${spec.engine}")
-                return@withLock null
-            }
-            try {
-                val instance = initWakeWhisperRecognizer(spec)
-                val methods = buildWakeWhisperMethods(instance)
-                wakeWhisperRecognizer = instance
-                wakeWhisperMethods = methods
-                wakeWhisperEngine = spec.engine
-                wakeWhisperValid = true
-                instance to methods
-            } catch (e: Exception) {
-                Log.e(TAG, "Wake Whisper verifier init failed", e)
-                wakeWhisperRecognizer = null
-                wakeWhisperMethods = null
-                wakeWhisperEngine = null
-                wakeWhisperValid = false
-                null
-            }
+            wakeWhisperRecognizer = instance
+            wakeWhisperMethods = methods
+            wakeWhisperEngine = spec.engine
+            wakeWhisperValid = true
+            instance to methods
+        } catch (e: Exception) {
+            Log.e(TAG, "Wake Whisper verifier init failed", e)
+            wakeWhisperRecognizer = null
+            wakeWhisperMethods = null
+            wakeWhisperEngine = null
+            wakeWhisperValid = false
+            null
         }
     }
 
     /**
      * Releases the dedicated offline (Whisper) wake-verification recognizer and
-     * clears its cached method handles.
+     * clears its cached method handles. Must only be called while [wakeVerifierMutex]
+     * is held so a recognizer is never released mid-verification (#1440).
      */
     private fun releaseWakeWhisperRecognizer() {
         if (wakeWhisperRecognizer != null) {
@@ -778,7 +826,9 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     }
 
     /**
-     * Releases the dedicated wake-word recognizer and clears its cached method handles.
+     * Releases the dedicated online wake-verification recognizer and clears its
+     * cached method handles. Must only be called while [wakeVerifierMutex] is held
+     * so a recognizer is never released mid-verification (#1440).
      */
     private fun releaseWakeRecognizer() {
         if (wakeRecognizer != null) {

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt
@@ -89,6 +89,21 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     @Volatile private var wakeSpecEngine: VoiceInputEngine? = null
     @Volatile private var wakeSpecValid: Boolean = false
 
+    /**
+     * Dedicated offline recognizer for wake-word verification (Whisper tiny.en).
+     *
+     * #1439: Whisper tiny.en is the only catalogue model that recognises the fixed
+     * natural wake phrase on the detector-equivalent PCM window (`hi, jandal`);
+     * Zipformer/Paraformer/Vosk/SenseVoice all reject it (deterministic reproduction
+     * with the exact on-device files). The offline wake recognizer is a separate
+     * instance so verification can run concurrently with interactive capture.
+     */
+    private val wakeWhisperMutex = Mutex()
+    @Volatile private var wakeWhisperRecognizer: Any? = null
+    @Volatile private var wakeWhisperMethods: WakeWhisperMethods? = null
+    @Volatile private var wakeWhisperEngine: VoiceInputEngine? = null
+    @Volatile private var wakeWhisperValid: Boolean = false
+
     /** Holds reflected methods shared by both online and offline recognizers. */
     class StreamMethods {
         @Volatile var createStream: java.lang.reflect.Method? = null
@@ -107,6 +122,15 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         val decode: java.lang.reflect.Method,
         val streamRelease: java.lang.reflect.Method,
         val getResult: java.lang.reflect.Method,
+    )
+
+    /** Reflected methods dedicated to offline (Whisper) wake-word verification. */
+    class WakeWhisperMethods(
+        val createStream: java.lang.reflect.Method,
+        val acceptWaveform: java.lang.reflect.Method,
+        val decode: java.lang.reflect.Method,
+        val getResult: java.lang.reflect.Method,
+        val streamRelease: java.lang.reflect.Method,
     )
 
     /** Methods specific to OnlineRecognizer. */
@@ -422,6 +446,25 @@ class SherpaOnnxVoiceInputController @Inject constructor(
 
     override suspend fun transcribeBlocking(pcm: ShortArray): String? {
         if (pcm.isEmpty()) return null
+        // #1439: prefer the Whisper tiny.en verifier — the only catalogue model that
+        // recognises the fixed natural wake phrase on the detector-equivalent window.
+        // Falls back to the existing online verifier when the Whisper files are absent.
+        if (resolveWakeVerifierSpec() == SherpaSttModelSpec.WHISPER) {
+            val (rec, methods) = ensureWakeWhisperRecognizerBlocking(SherpaSttModelSpec.WHISPER)
+                ?: return null
+            val stream = methods.createStream.invoke(rec)
+            return try {
+                val floats = FloatArray(pcm.size) { pcm[it] / 32768f }
+                methods.acceptWaveform.invoke(stream, floats, SAMPLE_RATE)
+                methods.decode.invoke(rec, stream)
+                resultTextFromWakeWhisper(rec, stream, methods)
+            } catch (e: Exception) {
+                Log.e(TAG, "transcribeBlocking (whisper verifier) failed", e)
+                null
+            } finally {
+                runCatching { methods.streamRelease.invoke(stream) }
+            }
+        }
         val userSpec = resolveSpec()
         val spec = if (userSpec.recognizerKind == SherpaSttModelSpec.RecognizerKind.Online) userSpec
                    else SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
@@ -444,6 +487,23 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         } finally {
             runCatching { methods.streamRelease.invoke(stream) }
         }
+    }
+
+    /**
+     * Resolves the model used for wake-window verification (#1439):
+     *
+     * 1. Whisper tiny.en when its files are present — the only catalogue model that
+     *    recognises the fixed natural wake phrase on the detector-equivalent window;
+     * 2. otherwise the selected online Sherpa spec (Zipformer/Paraformer) when online;
+     * 3. otherwise the Zipformer default (existing fallback).
+     *
+     * The interactive STT engine selection is never modified.
+     */
+    internal suspend fun resolveWakeVerifierSpec(): SherpaSttModelSpec {
+        if (isSpecAvailable(SherpaSttModelSpec.WHISPER)) return SherpaSttModelSpec.WHISPER
+        val userSpec = resolveSpec()
+        return if (userSpec.recognizerKind == SherpaSttModelSpec.RecognizerKind.Online) userSpec
+               else SherpaSttModelSpec.WAKE_VERIFICATION_DEFAULT
     }
 
     /**
@@ -643,6 +703,81 @@ class SherpaOnnxVoiceInputController @Inject constructor(
     }
 
     /**
+     * Ensures the dedicated offline (Whisper) wake-verification recognizer exists.
+     * Uses its own mutex and method handles so the interactive recognizers and the
+     * online wake recognizer can be reinitialized independently (#1439).
+     */
+    private suspend fun ensureWakeWhisperRecognizerBlocking(
+        spec: SherpaSttModelSpec,
+    ): Pair<Any, WakeWhisperMethods>? {
+        if (wakeWhisperRecognizer != null && wakeWhisperValid && wakeWhisperEngine == spec.engine && wakeWhisperMethods != null) {
+            return wakeWhisperRecognizer!! to wakeWhisperMethods!!
+        }
+        return wakeWhisperMutex.withLock {
+            if (wakeWhisperRecognizer != null && wakeWhisperValid && wakeWhisperEngine == spec.engine && wakeWhisperMethods != null) {
+                return@withLock wakeWhisperRecognizer!! to wakeWhisperMethods!!
+            }
+            // Release old recognizer when the engine changes to avoid native memory leak.
+            releaseWakeWhisperRecognizer()
+            if (!isSpecAvailable(spec)) {
+                Log.w(TAG, "Wake-word Whisper verifier files missing for ${spec.engine}")
+                return@withLock null
+            }
+            try {
+                val instance = initWakeWhisperRecognizer(spec)
+                val methods = buildWakeWhisperMethods(instance)
+                wakeWhisperRecognizer = instance
+                wakeWhisperMethods = methods
+                wakeWhisperEngine = spec.engine
+                wakeWhisperValid = true
+                instance to methods
+            } catch (e: Exception) {
+                Log.e(TAG, "Wake Whisper verifier init failed", e)
+                wakeWhisperRecognizer = null
+                wakeWhisperMethods = null
+                wakeWhisperEngine = null
+                wakeWhisperValid = false
+                null
+            }
+        }
+    }
+
+    /**
+     * Releases the dedicated offline (Whisper) wake-verification recognizer and
+     * clears its cached method handles.
+     */
+    private fun releaseWakeWhisperRecognizer() {
+        if (wakeWhisperRecognizer != null) {
+            try {
+                wakeWhisperRecognizer!!.javaClass.getDeclaredMethod("release").invoke(wakeWhisperRecognizer)
+            } catch (_: Exception) {}
+            wakeWhisperRecognizer = null
+            wakeWhisperMethods = null
+            wakeWhisperEngine = null
+            wakeWhisperValid = false
+        }
+    }
+
+    private fun buildWakeWhisperMethods(recognizer: Any): WakeWhisperMethods {
+        val clsRecognizer = recognizer.javaClass
+        val clsStream = Class.forName("$PKG.OfflineStream")
+        return WakeWhisperMethods(
+            createStream = clsRecognizer.getDeclaredMethod("createStream"),
+            decode = clsRecognizer.getDeclaredMethod("decode", clsStream),
+            getResult = clsRecognizer.getDeclaredMethod("getResult", clsStream),
+            acceptWaveform = clsStream.getDeclaredMethod("acceptWaveform", FloatArray::class.java, Int::class.javaPrimitiveType),
+            streamRelease = clsStream.getDeclaredMethod("release"),
+        )
+    }
+
+    private fun resultTextFromWakeWhisper(rec: Any, stream: Any, methods: WakeWhisperMethods): String {
+        val result = methods.getResult.invoke(rec, stream)!!
+        val getText = result.javaClass.getDeclaredMethod("getText").also { it.isAccessible = true }
+        return (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
+            .lowercase(java.util.Locale.ROOT)
+    }
+
+    /**
      * Releases the dedicated wake-word recognizer and clears its cached method handles.
      */
     private fun releaseWakeRecognizer() {
@@ -691,6 +826,46 @@ class SherpaOnnxVoiceInputController @Inject constructor(
         val getText = result.javaClass.getDeclaredMethod("getText").also { it.isAccessible = true }
         return (getText.invoke(result) as String).trim().trimEnd('?', '.', '!', ',', ':', ';')
             .lowercase(java.util.Locale.ROOT)
+    }
+
+    // ── Offline recognizer init (Whisper wake verifier, #1439) ────────────────
+
+    /**
+     * Constructs the dedicated Whisper tiny.en offline recognizer for wake-word
+     * verification via reflection — mirrors [initOfflineRecognizer]'s Whisper
+     * branch (OfflineWhisperModelConfig language=en/task=transcribe, numThreads=2,
+     * provider=cpu, greedy_search, maxActivePaths=1).
+     */
+    private fun initWakeWhisperRecognizer(spec: SherpaSttModelSpec): Any {
+        val clsModel      = Class.forName(spec.modelConfigClassName)
+        val clsRecCfg     = Class.forName(spec.recognizerConfigClassName)
+        val clsRecognizer = Class.forName(spec.recognizerClassName)
+
+        val modelConfig = clsModel.getDeclaredConstructor().newInstance()
+        setProperty(modelConfig, "tokens", sttFile(tokensFileForSpec(spec)).absolutePath)
+        setProperty(modelConfig, "numThreads", 2)
+        setProperty(modelConfig, "provider", "cpu")
+
+        val clsWhisper = Class.forName("$PKG.OfflineWhisperModelConfig")
+        val whisperConfig = clsWhisper.getDeclaredConstructor().newInstance().also {
+            setProperty(it, "encoder", sttFile("sherpa-whisper-tiny.en-encoder.int8.onnx").absolutePath)
+            setProperty(it, "decoder", sttFile("sherpa-whisper-tiny.en-decoder.int8.onnx").absolutePath)
+            setProperty(it, "language", "en")
+            setProperty(it, "task", "transcribe")
+        }
+        setProperty(modelConfig, "whisper", whisperConfig)
+
+        val recConfig = clsRecCfg.getDeclaredConstructor().newInstance().also {
+            setProperty(it, "modelConfig", modelConfig)
+            setProperty(it, "decodingMethod", "greedy_search")
+            setProperty(it, "maxActivePaths", 1)
+        }
+
+        val ctor = clsRecognizer.getConstructor(
+            android.content.res.AssetManager::class.java, clsRecCfg
+        )
+        @Suppress("UNCHECKED_CAST")
+        return ctor.newInstance(null, recConfig)
     }
 
     // ── Online recognizer init (Zipformer / Paraformer) ────────────────────────

--- a/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordUtils.kt
+++ b/core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordUtils.kt
@@ -3,10 +3,15 @@ package com.kernel.ai.core.voice
 /**
  * Returns true when [this] transcript contains a recognisable form of "Hey Jandal".
  *
- * Matches across common ASR error modes (Handel/Handal/Jandel) and normalises case.
+ * Matches across common ASR error modes (Handel/Handal/Jandel/Jando) and normalises case.
+ *
+ * #1439: the wake-verifier model (Whisper tiny.en) transcribes the fixed natural
+ * wake phrase as `hi, jandal` — the `hi` prefix and an optional inline comma/period
+ * are evidence-backed supported forms. `jando` mirrors the already-accepted `hando`
+ * truncation observed at candidate-window edge placements.
  */
 fun String.containsWakePhrase(): Boolean {
     val lower = lowercase()
-    val namePattern = Regex("""\b(?:hey|a)\s*(?:jandal|jandel|handel|handal|hando)\b""")
+    val namePattern = Regex("""\b(?:hey|hi|a)[,.]?\s*(?:jandal|jandel|handel|handal|hando|jando)\b""")
     return namePattern.containsMatchIn(lower)
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -79,6 +80,53 @@ class SherpaOnnxVoiceInputControllerTest {
         assertInstanceOf(VoiceInputStartResult.Unavailable::class.java, result)
     }
 
+    // ── #1439: wake-verifier model selection ───────────────────────────────────
+
+    @Test
+    fun `resolveWakeVerifierSpec prefers Whisper when its files are present`() = runTest {
+        createWhisperStubModelFiles()
+        // Whisper verifier wins regardless of the interactive engine selection.
+        listOf(
+            VoiceInputEngine.Vosk,
+            VoiceInputEngine.SherpaZipformer,
+            VoiceInputEngine.SherpaWhisper,
+            VoiceInputEngine.SherpaParaformer,
+        ).forEach { engine ->
+            selectedEngine.value = engine
+            assertEquals(SherpaSttModelSpec.WHISPER, controller.resolveWakeVerifierSpec())
+        }
+    }
+
+    @Test
+    fun `resolveWakeVerifierSpec falls back to the selected online engine without Whisper`() = runTest {
+        createAllStubModelFiles() // Zipformer only
+        selectedEngine.value = VoiceInputEngine.SherpaZipformer
+        assertEquals(SherpaSttModelSpec.ZIPFORMER, controller.resolveWakeVerifierSpec())
+
+        selectedEngine.value = VoiceInputEngine.SherpaParaformer
+        assertEquals(SherpaSttModelSpec.PARAFORMER, controller.resolveWakeVerifierSpec())
+    }
+
+    @Test
+    fun `resolveWakeVerifierSpec falls back to Zipformer default without Whisper or online engine`() = runTest {
+        createAllStubModelFiles() // Zipformer only
+        listOf(
+            VoiceInputEngine.Vosk,
+            VoiceInputEngine.AndroidNative,
+            VoiceInputEngine.SherpaWhisper,
+            VoiceInputEngine.SherpaSenseVoice,
+        ).forEach { engine ->
+            selectedEngine.value = engine
+            assertEquals(SherpaSttModelSpec.ZIPFORMER, controller.resolveWakeVerifierSpec())
+        }
+    }
+
+    @Test
+    fun `transcribeBlocking rejects empty PCM`() = runTest {
+        createAllStubModelFiles()
+        assertEquals(null, controller.transcribeBlocking(shortArrayOf()))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun createAllStubModelFiles() {
@@ -87,6 +135,14 @@ class SherpaOnnxVoiceInputControllerTest {
             "sherpa-stt-decoder.int8.onnx",
             "sherpa-stt-joiner.int8.onnx",
             "sherpa-stt-tokens.txt",
+        ).forEach { name -> File(tempModelsDir, name).writeText("stub") }
+    }
+
+    private fun createWhisperStubModelFiles() {
+        listOf(
+            "sherpa-whisper-tiny.en-encoder.int8.onnx",
+            "sherpa-whisper-tiny.en-decoder.int8.onnx",
+            "sherpa-whisper-tiny.en-tokens.txt",
         ).forEach { name -> File(tempModelsDir, name).writeText("stub") }
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt
@@ -2,6 +2,10 @@ package com.kernel.ai.core.voice
 
 import android.content.Context
 import android.media.AudioManager
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import io.mockk.every
 import io.mockk.mockk
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -127,6 +132,137 @@ class SherpaOnnxVoiceInputControllerTest {
         assertEquals(null, controller.transcribeBlocking(shortArrayOf()))
     }
 
+    // ── #1440: wake-verifier cache mutual exclusion and lifecycle ──────────────
+
+    @Test
+    fun `fallback online to Whisper transition releases the fallback and leaves only Whisper cached`() = runTest {
+        createAllStubModelFiles() // Zipformer only → online fallback verifier
+        val events = mutableListOf<String>()
+        val holder = FakeHolder()
+        controller.wakeVerifierTestBuilder = testDouble(events, holder)
+
+        assertEquals("hy general", controller.transcribeBlocking(shortArrayOf(1, 2)))
+        assertTrue(controller.wakeOnlineVerifierCached)
+        assertFalse(controller.wakeWhisperVerifierCached)
+        assertEquals(0, holder.online!!.releaseCount)
+
+        createWhisperStubModelFiles() // Whisper becomes available → verifier transition
+        assertEquals("hi, jandal", controller.transcribeBlocking(shortArrayOf(3, 4)))
+
+        // The superseded online fallback must be released and evicted from the cache.
+        assertEquals(1, holder.online!!.releaseCount)
+        assertTrue(events.contains("online_release"))
+        assertFalse(controller.wakeOnlineVerifierCached)
+        assertTrue(controller.wakeWhisperVerifierCached)
+        assertTrue(holder.whisper != null)
+    }
+
+    @Test
+    fun `Whisper to fallback online transition releases Whisper and leaves only the fallback cached`() = runTest {
+        createAllStubModelFiles()
+        createWhisperStubModelFiles()
+        val events = mutableListOf<String>()
+        val holder = FakeHolder()
+        controller.wakeVerifierTestBuilder = testDouble(events, holder)
+
+        assertEquals("hi, jandal", controller.transcribeBlocking(shortArrayOf(1, 2)))
+        assertTrue(controller.wakeWhisperVerifierCached)
+        assertFalse(controller.wakeOnlineVerifierCached)
+        assertEquals(0, holder.whisper!!.releaseCount)
+
+        deleteWhisperStubModelFiles() // Whisper unavailable → fallback verifier transition
+        assertEquals("hy general", controller.transcribeBlocking(shortArrayOf(3, 4)))
+
+        // The superseded Whisper verifier must be released and evicted from the cache.
+        assertEquals(1, holder.whisper!!.releaseCount)
+        assertTrue(events.contains("whisper_release"))
+        assertFalse(controller.wakeWhisperVerifierCached)
+        assertTrue(controller.wakeOnlineVerifierCached)
+        assertTrue(holder.online != null)
+    }
+
+    @Test
+    fun `consecutive calls with the same verifier reuse the cached recognizer`() = runTest {
+        createAllStubModelFiles()
+        createWhisperStubModelFiles()
+        val events = mutableListOf<String>()
+        val holder = FakeHolder()
+        controller.wakeVerifierTestBuilder = testDouble(events, holder)
+
+        assertEquals("hi, jandal", controller.transcribeBlocking(shortArrayOf(1)))
+        val firstWhisper = holder.whisper
+        assertEquals("hi, jandal", controller.transcribeBlocking(shortArrayOf(2)))
+        assertSame(firstWhisper, holder.whisper)
+        assertEquals(0, firstWhisper!!.releaseCount)
+        assertEquals(2, firstWhisper.streams.size) // one stream per call; recognizer reused
+        assertTrue(controller.wakeWhisperVerifierCached)
+
+        // The online fallback reuses its cached recognizer the same way.
+        deleteWhisperStubModelFiles()
+        assertEquals("hy general", controller.transcribeBlocking(shortArrayOf(3)))
+        val firstOnline = holder.online
+        assertEquals("hy general", controller.transcribeBlocking(shortArrayOf(4)))
+        assertSame(firstOnline, holder.online)
+        assertEquals(0, firstOnline!!.releaseCount)
+        assertEquals(2, firstOnline.streams.size)
+        assertTrue(controller.wakeOnlineVerifierCached)
+        assertFalse(controller.wakeWhisperVerifierCached)
+    }
+
+    @Test
+    fun `verifier switching cannot release the recognizer while its decode is active`() = runTest {
+        createAllStubModelFiles()
+        createWhisperStubModelFiles() // Whisper selected first
+        val events = mutableListOf<String>()
+        val holder = FakeHolder()
+        val gate = BlockingGate()
+        controller.wakeVerifierTestBuilder = testDouble(events, holder, whisperDecodeGate = gate)
+
+        val first = async(Dispatchers.IO) { controller.transcribeBlocking(shortArrayOf(1, 2, 3)) }
+        assertTrue(gate.entered.await(5, TimeUnit.SECONDS), "whisper decode must have started")
+
+        // Make the fallback the next selection while the Whisper decode is still active.
+        deleteWhisperStubModelFiles()
+        val second = async(Dispatchers.IO) { controller.transcribeBlocking(shortArrayOf(4, 5)) }
+
+        // The in-flight Whisper recognizer must not be released while decoding.
+        assertFalse("whisper_release" in events)
+        gate.release.countDown()
+
+        assertEquals("hi, jandal", first.await())
+        assertEquals("hy general", second.await())
+
+        // Eviction may only happen after the first verification finished its decode
+        // and stream release — the single ownership boundary serializes the switch.
+        val releaseIdx = events.indexOf("whisper_release")
+        val streamReleaseIdx = events.indexOf("whisper_stream_release")
+        assertTrue(
+            releaseIdx > streamReleaseIdx && releaseIdx >= 0,
+            "whisper must be released only after its stream release: $events",
+        )
+        assertFalse(controller.wakeWhisperVerifierCached)
+        assertTrue(controller.wakeOnlineVerifierCached)
+    }
+
+    @Test
+    fun `wake-verifier lifecycle leaves the interactive recognizer and engine selection untouched`() = runTest {
+        createAllStubModelFiles()
+        createWhisperStubModelFiles()
+        val events = mutableListOf<String>()
+        val holder = FakeHolder()
+        controller.wakeVerifierTestBuilder = testDouble(events, holder)
+        val engineBefore = selectedEngine.value
+
+        controller.transcribeBlocking(shortArrayOf(1, 2)) // whisper
+        controller.transcribeBlocking(shortArrayOf(3, 4)) // whisper reuse
+        deleteWhisperStubModelFiles()
+        controller.transcribeBlocking(shortArrayOf(5, 6)) // online transition
+        controller.transcribeBlocking(shortArrayOf(7, 8)) // online reuse
+
+        assertEquals(engineBefore, selectedEngine.value)
+        assertFalse(controller.interactiveRecognizerActive)
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun createAllStubModelFiles() {
@@ -144,5 +280,157 @@ class SherpaOnnxVoiceInputControllerTest {
             "sherpa-whisper-tiny.en-decoder.int8.onnx",
             "sherpa-whisper-tiny.en-tokens.txt",
         ).forEach { name -> File(tempModelsDir, name).writeText("stub") }
+    }
+
+    private fun deleteWhisperStubModelFiles() {
+        listOf(
+            "sherpa-whisper-tiny.en-encoder.int8.onnx",
+            "sherpa-whisper-tiny.en-decoder.int8.onnx",
+            "sherpa-whisper-tiny.en-tokens.txt",
+        ).forEach { name -> File(tempModelsDir, name).delete() }
+    }
+
+    /**
+     * Installs the #1440 wake-verifier construction test double: fake recognizers
+     * drive the real cache-ownership lifecycle in [transcribeBlocking] without the
+     * Sherpa AAR on the classpath.
+     */
+    private fun testDouble(
+        events: MutableList<String>,
+        holder: FakeHolder,
+        whisperDecodeGate: BlockingGate? = null,
+    ): SherpaOnnxVoiceInputController.WakeVerifierTestBuilder =
+        object : SherpaOnnxVoiceInputController.WakeVerifierTestBuilder {
+            override fun buildOnline(spec: SherpaSttModelSpec): Pair<Any, SherpaOnnxVoiceInputController.WakeRecognizerMethods>? {
+                val rec = FakeOnlineRecognizer(events)
+                holder.online = rec
+                events.add("online_built")
+                return rec to onlineMethodsFor(rec)
+            }
+
+            override fun buildWhisper(spec: SherpaSttModelSpec): Pair<Any, SherpaOnnxVoiceInputController.WakeWhisperMethods>? {
+                val rec = FakeWhisperRecognizer(events, whisperDecodeGate)
+                holder.whisper = rec
+                events.add("whisper_built")
+                return rec to whisperMethodsFor(rec)
+            }
+        }
+
+    private fun onlineMethodsFor(rec: FakeOnlineRecognizer): SherpaOnnxVoiceInputController.WakeRecognizerMethods {
+        val streamCls = FakeOnlineStream::class.java
+        return SherpaOnnxVoiceInputController.WakeRecognizerMethods(
+            createStream = FakeOnlineRecognizer::class.java.getDeclaredMethod("createStream", String::class.java),
+            acceptWaveform = streamCls.getDeclaredMethod("acceptWaveform", FloatArray::class.java, Int::class.javaPrimitiveType),
+            inputFinished = streamCls.getDeclaredMethod("inputFinished"),
+            isReady = FakeOnlineRecognizer::class.java.getDeclaredMethod("isReady", streamCls),
+            decode = FakeOnlineRecognizer::class.java.getDeclaredMethod("decode", streamCls),
+            streamRelease = streamCls.getDeclaredMethod("release"),
+            getResult = FakeOnlineRecognizer::class.java.getDeclaredMethod("getResult", streamCls),
+        )
+    }
+
+    private fun whisperMethodsFor(rec: FakeWhisperRecognizer): SherpaOnnxVoiceInputController.WakeWhisperMethods {
+        val streamCls = FakeWhisperStream::class.java
+        return SherpaOnnxVoiceInputController.WakeWhisperMethods(
+            createStream = FakeWhisperRecognizer::class.java.getDeclaredMethod("createStream"),
+            acceptWaveform = streamCls.getDeclaredMethod("acceptWaveform", FloatArray::class.java, Int::class.javaPrimitiveType),
+            decode = FakeWhisperRecognizer::class.java.getDeclaredMethod("decode", streamCls),
+            getResult = FakeWhisperRecognizer::class.java.getDeclaredMethod("getResult", streamCls),
+            streamRelease = streamCls.getDeclaredMethod("release"),
+        )
+    }
+
+    private class FakeHolder {
+        var online: FakeOnlineRecognizer? = null
+        var whisper: FakeWhisperRecognizer? = null
+    }
+
+    private class BlockingGate {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+    }
+
+    private class FakeOnlineRecognizer(private val events: MutableList<String>) {
+        var releaseCount = 0
+            private set
+        val streams = mutableListOf<FakeOnlineStream>()
+
+        fun createStream(hotwords: String): FakeOnlineStream {
+            events.add("online_createStream")
+            return FakeOnlineStream(events).also { streams += it }
+        }
+
+        fun isReady(stream: FakeOnlineStream): Boolean = !stream.decoded
+
+        fun decode(stream: FakeOnlineStream) {
+            stream.decoded = true
+            events.add("online_decode")
+        }
+
+        fun getResult(stream: FakeOnlineStream): FakeResult = FakeResult("hy general")
+
+        fun release() {
+            releaseCount++
+            events.add("online_release")
+        }
+    }
+
+    private class FakeOnlineStream(private val events: MutableList<String>) {
+        var decoded = false
+
+        fun acceptWaveform(samples: FloatArray, sampleRate: Int) {
+            events.add("online_accept")
+        }
+
+        fun inputFinished() {
+            events.add("online_inputFinished")
+        }
+
+        fun release() {
+            events.add("online_stream_release")
+        }
+    }
+
+    private class FakeWhisperRecognizer(
+        private val events: MutableList<String>,
+        private val decodeGate: BlockingGate? = null,
+    ) {
+        var releaseCount = 0
+            private set
+        val streams = mutableListOf<FakeWhisperStream>()
+
+        fun createStream(): FakeWhisperStream {
+            events.add("whisper_createStream")
+            return FakeWhisperStream(events).also { streams += it }
+        }
+
+        fun decode(stream: FakeWhisperStream) {
+            decodeGate?.let {
+                it.entered.countDown()
+                it.release.await()
+            }
+            events.add("whisper_decode")
+        }
+
+        fun getResult(stream: FakeWhisperStream): FakeResult = FakeResult("hi, jandal")
+
+        fun release() {
+            releaseCount++
+            events.add("whisper_release")
+        }
+    }
+
+    private class FakeWhisperStream(private val events: MutableList<String>) {
+        fun acceptWaveform(samples: FloatArray, sampleRate: Int) {
+            events.add("whisper_accept")
+        }
+
+        fun release() {
+            events.add("whisper_stream_release")
+        }
+    }
+
+    private class FakeResult(private val text: String) {
+        fun getText(): String = text
     }
 }

--- a/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordUtilsTest.kt
+++ b/core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordUtilsTest.kt
@@ -46,4 +46,40 @@ class WakeWordUtilsTest {
         assertTrue("oh heyjandal who".containsWakePhrase())
         assertTrue("say hey jandal now".containsWakePhrase())
     }
+
+    // ── #1439: Whisper verifier forms ─────────────────────────────────────────
+
+    @Test
+    fun `containsWakePhrase matches Whisper verifier prefix and punctuation`() {
+        // Whisper tiny.en transcribes the fixed natural fixture as "hi, jandal"
+        // (deterministic reproduction, exact catalogue files).
+        assertTrue("hi, jandal".containsWakePhrase())
+        assertTrue("hi jandal".containsWakePhrase())
+        assertTrue("hi, jandel".containsWakePhrase())
+        assertTrue("hey, jandal".containsWakePhrase())
+        assertTrue("hi. jandal".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase matches jando truncation`() {
+        // Whisper emits "hi, jando" at candidate-window edge placements — same
+        // truncation class as the already-accepted "hando".
+        assertTrue("hi, jando".containsWakePhrase())
+        assertTrue("hey jando".containsWakePhrase())
+    }
+
+    @Test
+    fun `containsWakePhrase still rejects fragments and negatives`() {
+        // #1439 constraint: generic fragments such as "gen" must never match.
+        assertFalse("hy gen".containsWakePhrase())
+        assertFalse("hy general".containsWakePhrase())
+        assertFalse("gen".containsWakePhrase())
+        assertFalse("i gen".containsWakePhrase())
+        assertFalse("hi".containsWakePhrase())
+        assertFalse("hi gentle".containsWakePhrase())
+        assertFalse("hi, sandal".containsWakePhrase())
+        assertFalse("hi yandal".containsWakePhrase())
+        assertFalse("hi, jandalicious".containsWakePhrase())
+        assertFalse("[ silence ]".containsWakePhrase())
+    }
 }

--- a/scripts/wake-verifier-real-model-validation.py
+++ b/scripts/wake-verifier-real-model-validation.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Wake-verifier real-model validation for #1439.
+
+Runs the EXACT on-device verifier configuration against a wake-phrase WAV and
+prints the baseline (Zipformer) and corrected (Whisper tiny.en) transcripts.
+
+Models are resolved from a local directory (the exact files downloaded through
+the app's KernelModel catalogue — pull them from a device's
+`Android/data/com.kernel.ai.debug/files/models/` or download the catalogue
+URLs). Every file is hash-pinned: the script FAILS CLOSED on any missing or
+mismatched file. No model binaries or private audio are committed to the repo.
+
+Requirements:
+    pip install sherpa-onnx==1.13.0 soundfile numpy
+
+Usage:
+    python scripts/wake-verifier-real-model-validation.py \
+        --models-dir /path/to/models \
+        --fixture /path/to/natural_wake.wav
+
+The fixture should be the fixed natural wake phrase (48 kHz or 16 kHz mono
+int16 WAV). The script builds the production detector-equivalent window
+(3 s ring, phrase ending ~0.15 s before the end, digital-silence lead/tail)
+plus the clean fixture, and prints the verifier verdicts.
+
+Exit code: 0 when the Whisper verifier accepts the production window and the
+Zipformer baseline rejects it; 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import sherpa_onnx
+import soundfile as sf
+
+# SHA-256 of the exact verifier files pulled from the physical test devices
+# (S21 R5CR605B71K / S23U, 2026-08-03) — identical on both devices.
+MODEL_HASHES: dict[str, dict[str, str]] = {
+    "zipformer": {
+        "sherpa-stt-encoder.int8.onnx": "4b7edfb7783e94a66fead1470a066ccc2eceb14e2630d8aa1914e25f8ff35027",
+        "sherpa-stt-decoder.int8.onnx": "279fb5e6ee22f0efb3be4dc62fe745864979970d158192851f307744d27a72c3",
+        "sherpa-stt-joiner.int8.onnx": "480747e5f00fdbd68e0c93b09edfcd6698853526ccfe0f859ad624108ce7dda2",
+        "sherpa-stt-tokens.txt": "49e3c2646595fd907228b3c6787069658f67b17377c60aeb8619c4551b2316fb",
+    },
+    "whisper": {
+        "sherpa-whisper-tiny.en-encoder.int8.onnx": "0ce578b827c94a961aacb8fa14b02f096504b337e5c94be37c36238cbe3e8bc6",
+        "sherpa-whisper-tiny.en-decoder.int8.onnx": "06c0e6ff6348d427e51839219d1c886c18cfdf411e629e33f5e1679bff9c1527",
+        "sherpa-whisper-tiny.en-tokens.txt": "306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930",
+    },
+}
+
+# Supported Hey Jandal forms (matches WakeWordUtils.containsWakePhrase, #1439).
+ACCEPTED_PREFIXES = ("hey", "hi", "a")
+ACCEPTED_NAMES = ("jandal", "jandel", "handel", "handal", "hando", "jando")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_models(models_dir: Path, kind: str) -> dict[str, Path]:
+    files = {name: models_dir / name for name in MODEL_HASHES[kind]}
+    for name, path in files.items():
+        if not path.exists():
+            raise SystemExit(f"missing model file: {path}")
+        actual = sha256(path)
+        if actual != MODEL_HASHES[kind][name]:
+            raise SystemExit(
+                f"SHA-256 mismatch for {path}: expected {MODEL_HASHES[kind][name]} got {actual}"
+            )
+    return files
+
+
+def resample_linear(x: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    n = int(len(x) * dst_rate / src_rate)
+    idx = np.linspace(0, len(x) - 1, n)
+    return np.interp(idx, np.arange(len(x)), x.astype(np.float64)).astype(np.int16)
+
+
+def accepted(text: str) -> bool:
+    lower = text.strip().rstrip("?!.,:;").lower()
+    for prefix in ACCEPTED_PREFIXES:
+        for name in ACCEPTED_NAMES:
+            for sep in ("", ",", "."):
+                candidate = f"{prefix}{sep} {name}"
+                if f" {candidate} " in f" {lower} ":
+                    return True
+    return False
+
+
+def build_zipformer(files: dict[str, Path]) -> sherpa_onnx.OnlineRecognizer:
+    # Mirrors SherpaOnnxVoiceInputController.initWakeOnlineRecognizer exactly.
+    return sherpa_onnx.OnlineRecognizer.from_transducer(
+        tokens=str(files["sherpa-stt-tokens.txt"]),
+        encoder=str(files["sherpa-stt-encoder.int8.onnx"]),
+        decoder=str(files["sherpa-stt-decoder.int8.onnx"]),
+        joiner=str(files["sherpa-stt-joiner.int8.onnx"]),
+        num_threads=2,
+        sample_rate=16000,
+        feature_dim=80,
+        enable_endpoint_detection=True,
+        decoding_method="greedy_search",
+        max_active_paths=4,
+        normalize_samples=True,
+    )
+
+
+def build_whisper(files: dict[str, Path]) -> sherpa_onnx.OfflineRecognizer:
+    # Mirrors SherpaOnnxVoiceInputController.initWakeWhisperRecognizer exactly.
+    return sherpa_onnx.OfflineRecognizer.from_whisper(
+        encoder=str(files["sherpa-whisper-tiny.en-encoder.int8.onnx"]),
+        decoder=str(files["sherpa-whisper-tiny.en-decoder.int8.onnx"]),
+        tokens=str(files["sherpa-whisper-tiny.en-tokens.txt"]),
+        language="en",
+        task="transcribe",
+        num_threads=2,
+        decoding_method="greedy_search",
+        provider="cpu",
+    )
+
+
+def transcribe_zipformer(rec: sherpa_onnx.OnlineRecognizer, pcm16: np.ndarray) -> str:
+    # Java JNI maps an empty hotword string to CreateStream() (no context graph);
+    # the Python binding does not, so call the no-arg form to match the app.
+    stream = rec.create_stream()
+    stream.accept_waveform(16000, pcm16.astype(np.float32) / 32768.0)
+    stream.input_finished()
+    iters = 0
+    while rec.is_ready(stream):
+        rec.decode_stream(stream)
+        iters += 1
+        if iters > 500:
+            break
+    result = rec.get_result(stream)
+    return (result.text if hasattr(result, "text") else str(result)).strip().rstrip("?!.,:;").lower()
+
+
+def transcribe_whisper(rec: sherpa_onnx.OfflineRecognizer, pcm16: np.ndarray) -> str:
+    stream = rec.create_stream()
+    stream.accept_waveform(16000, pcm16.astype(np.float32) / 32768.0)
+    rec.decode_stream(stream)
+    result = stream.result if hasattr(stream, "result") else rec.get_result(stream)
+    return (result.text if hasattr(result, "text") else str(result)).strip().rstrip("?!.,:;").lower()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models-dir", type=Path, required=True, help="dir containing the catalogue model files")
+    ap.add_argument("--fixture", type=Path, required=True, help="natural wake phrase WAV (48k or 16k mono int16)")
+    args = ap.parse_args()
+
+    zip_files = verify_models(args.models_dir, "zipformer")
+    whisper_files = verify_models(args.models_dir, "whisper")
+    zip_rec = build_zipformer(zip_files)
+    whisper_rec = build_whisper(whisper_files)
+
+    x, sr = sf.read(args.fixture, dtype="int16")
+    if x.ndim > 1:
+        x = x[:, 0]
+    if sr != 16000:
+        x16 = resample_linear(x, sr, 16000)
+    else:
+        x16 = x
+
+    # Production detector-equivalent window: 3 s ring ending ~0.15 s after the
+    # phrase end (pass-trial journal timing).
+    lead = np.zeros(int((3.0 - len(x16) / 16000 - 0.15) * 16000), dtype=np.int16)
+    tail = np.zeros(int(0.15 * 16000), dtype=np.int16)
+    ring = np.concatenate([lead, x16, tail])
+    if len(ring) < 48000:
+        ring = np.concatenate([ring, np.zeros(48000 - len(ring), dtype=np.int16)])
+
+    print(f"fixture: {args.fixture} ({len(x16)} samples @16 kHz)")
+    print(f"{'verifier':<10} {'input':<14} {'transcript':<22} {'verdict':<10} {'time_s'}")
+    print("-" * 74)
+
+    verdicts = {}
+    for label, pcm in (("clean", x16), ("ring", ring)):
+        t0 = time.perf_counter()
+        zt = transcribe_zipformer(zip_rec, pcm)
+        dt = time.perf_counter() - t0
+        print(f"{'zipformer':<10} {label:<14} {zt!r:<22} {'ACCEPT' if accepted(zt) else 'reject':<10} {dt:.2f}")
+        verdicts[f"zipformer_{label}"] = accepted(zt)
+
+        t0 = time.perf_counter()
+        wt = transcribe_whisper(whisper_rec, pcm)
+        dt = time.perf_counter() - t0
+        print(f"{'whisper':<10} {label:<14} {wt!r:<22} {'ACCEPT' if accepted(wt) else 'reject':<10} {dt:.2f}")
+        verdicts[f"whisper_{label}"] = accepted(wt)
+
+    # Acceptance: the Whisper verifier must accept the production ring window and
+    # the Zipformer baseline must reject it (the #1439 defect).
+    ok = verdicts["whisper_ring"] and not verdicts["zipformer_ring"]
+    print("-" * 74)
+    print("RESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #1439

# fix(#1439): make low-band wake verification recognise Hey Jandal

## Summary

The low-band wake verifier (Zipformer en 2023-02-21, exact on-device files) cannot transcribe the genuine fixed `Hey Jandal` wake phrase — deterministic reproduction with the exact downloaded files and the app's exact recognizer configuration yields `hy gen` / `hy general` / `i gen` even for the clean fixture. The verifier now prefers the **Whisper tiny.en** catalogue model (the only model that recognises the phrase on the detector-equivalent window: `hi, jandal`), with the existing online verifier as fallback when the Whisper files are absent. The missing verifier files are provisioned through the existing `KernelModel` catalogue download flow when the wake word starts.

- **Starting SHA:** `216cfd9771863ef2ac6ce9b675cfb896ee04023b` (origin/main, #1438 merge)
- **Final head:** `1616510f` (branch `fix/1439-low-band-wake-verifier`)

## Root cause

`SherpaOnnxVoiceInputController.transcribeBlocking` verified low-band candidates with the Zipformer en 2023-02-21 model (`WAKE_VERIFICATION_DEFAULT`). Deterministic reproduction (sherpa-onnx 1.13.0 = app AAR version; exact files pulled from S21, hashes identical on S23U; app-exact config: FeatureConfig 16 kHz/80-dim, numThreads=2, provider=cpu, enableEndpoint=true, greedy_search, maxActivePaths=4, empty hotword stream, `/32768f`, inputFinished + isReady/decode drain):

| Input | Baseline transcript | Verdict |
|---|---|---|
| clean fixture (16 kHz resampled) | `hy gen` | reject |
| detector-equivalent 3 s ring (0.866 s lead, 0.15 s tail) | `hy general` | reject |
| ring −12 dB | `i general` | reject |
| ring −24 dB | `i general` | reject |
| 3 s silence | `''` | reject ✓ |
| non-wake command fixture | `what time is` | reject ✓ |

11 production-reachable window placements (lead 0.5–0.866 s × tail 0.05–0.80 s, digital-silence and room-tone lead-ins): **0/11 produce any supported form** — the window is not the divergence. `modified_beam_search` alone: `hy gen` (same failure). Hotwords require `modified_beam_search` + a `bpe.vocab` (a new catalogue file the app does not have) + `modeling_unit=bpe` — official 1.13.0 docs confirm greedy_search does not support hotwords; with the app's current surface the graph encodes single letters and the score parser aborts (`stof`). No transcript-normalisation rule can recover `hy gen` (the name syllable is absent; `gen` must stay rejected). The model itself is the first divergence.

## Model candidate comparison (all exact catalogue files, app-exact configs, production ring window)

| Model | ring transcript | Supported form? |
|---|---|---|
| Zipformer en (baseline) | `hy general` | no |
| Paraformer bilingual zh-en | `hiygen` | no |
| SenseVoice int8 | `hey, jendall` | no (`jendall` ∉ accepted forms) |
| Vosk bundled small-en-us | `jane doe` | no |
| **Whisper tiny.en** | **`hi, jandal`** | **yes** |

## Correction

1. **`SherpaOnnxVoiceInputController`** — `transcribeBlocking` prefers a dedicated Whisper tiny.en offline verifier (same `initOfflineRecognizer` Whisper config: language=en, task=transcribe, numThreads=2, provider=cpu, greedy_search, maxActivePaths=1; separate cached instance + mutex + release lifecycle mirroring the existing online wake recognizer). `resolveWakeVerifierSpec()`: Whisper → selected online spec → Zipformer default. Interactive STT engines untouched.
2. **`WakeWordUtils.containsWakePhrase`** — evidence-backed forms from the Whisper verifier: `hi` prefix (Whisper writes the fixture's "hey" as "hi"), optional inline comma/period, and the `jando` truncation (mirrors the already-accepted `hando`; observed at candidate-window edge placements). Generic fragments (`gen`, `general`) remain rejected.
3. **`WakeWordService`** — one-shot provisioning of the missing Whisper verifier files through the existing `ModelDownloadManager` catalogue flow (`AUTO_QUEUED`) when the wake word starts; the controller falls back to the online verifier until the files arrive.

## Changed files

- `core/voice/src/main/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputController.kt`
- `core/voice/src/main/java/com/kernel/ai/core/voice/WakeWordUtils.kt`
- `app/src/main/java/com/kernel/ai/assistant/WakeWordService.kt`
- `app/src/debug/java/com/kernel/ai/debug/verifier/WakeVerifierProbeReceiver.kt` (debug-only direct-verifier probe; never in release)
- `app/src/debug/AndroidManifest.xml` (probe receiver registration)
- `core/voice/src/test/java/com/kernel/ai/core/voice/WakeWordUtilsTest.kt`
- `core/voice/src/test/java/com/kernel/ai/core/voice/SherpaOnnxVoiceInputControllerTest.kt`
- `app/src/test/java/com/kernel/ai/assistant/WakeWordVerifyWindowTest.kt`
- `app/src/test/java/com/kernel/ai/assistant/WakeWordVerifierProvisionTest.kt`
- `scripts/wake-verifier-real-model-validation.py` (rerunnable, hash-pinned real-model validation)

## Model / token hashes (exact files exercised)

Zipformer (baseline, pulled from both test devices — identical on S21/S23U):

| File | SHA-256 |
|---|---|
| `sherpa-stt-encoder.int8.onnx` | `4b7edfb7783e94a66fead1470a066ccc2eceb14e2630d8aa1914e25f8ff35027` |
| `sherpa-stt-decoder.int8.onnx` | `279fb5e6ee22f0efb3be4dc62fe745864979970d158192851f307744d27a72c3` |
| `sherpa-stt-joiner.int8.onnx` | `480747e5f00fdbd68e0c93b09edfcd6698853526ccfe0f859ad624108ce7dda2` |
| `sherpa-stt-tokens.txt` | `49e3c2646595fd907228b3c6787069658f67b17377c60aeb8619c4551b2316fb` |

Whisper tiny.en (corrected verifier, `csukuangfj/sherpa-onnx-whisper-tiny.en` catalogue files, deployed to both devices with hash verification):

| File | SHA-256 |
|---|---|
| `sherpa-whisper-tiny.en-encoder.int8.onnx` | `0ce578b827c94a961aacb8fa14b02f096504b337e5c94be37c36238cbe3e8bc6` |
| `sherpa-whisper-tiny.en-decoder.int8.onnx` | `06c0e6ff6348d427e51839219d1c886c18cfdf411e629e33f5e1679bff9c1527` |
| `sherpa-whisper-tiny.en-tokens.txt` | `306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930` |

No model binaries are committed. `scripts/wake-verifier-real-model-validation.py` fails closed on any missing/mismatched file.

## Corrected verifier results (Whisper, exact files, desktop deterministic + on-device)

| Input | Transcript | Verdict |
|---|---|---|
| detector-equivalent ring | `hi, jandal` | **accept** (3/3 deterministic) |
| ring with room-tone lead-in | `hi, jandal` | accept (3/3) |
| clean fixture | `hi, jando` | accept (3/3) |
| ring −6 / −12 dB | `hi, jandal` | accept |
| ring −18 dB | `hi, gentle` | reject |
| 3 s silence | `[ silence ]` | reject |
| room tone | `[blank_audio]` | reject |
| non-wake command (desktop + ring placement) | `what time is it` | reject |
| synthesized `hey sandal` | `hey sandal` | reject |
| synthesized `hey gentle` | `hey gantles` | reject |
| synthesized `gen` | `again` | reject |
| synthesized `play some music` | `play some music` | reject |

Near-phrase note: synthesized `hey handle` → `hey handel`, which matches the **pre-existing** accepted `handel` form (present since before this PR). Not introduced here; flagged for the #1045 verifier-strategy review rather than broadened.

## Interactive-engine invariance

`resolveWakeVerifierSpec` tests pin: Whisper verifier wins whenever its files are present, regardless of the selected interactive engine (Vosk / Zipformer / Whisper / Paraformer); without Whisper files the verifier falls back to the selected online engine (Zipformer/Paraformer) or the Zipformer default. Interactive capture routing is untouched (`SelectableVoiceInputController.startListening` unchanged; `transcribeBlocking` never starts/stops interactive controllers — existing tests still pass).

## Resource lifecycle

**Only one dedicated wake verifier is cached at a time (#1440).** A single `wakeVerifierMutex` owns selection, initialization, decoding, result extraction and stream release for both dedicated verifiers: switching to Whisper releases the superseded online fallback recognizer, and switching back to the fallback releases the Whisper recognizer — the eviction happens under the same ownership boundary that covers the active decode, so a recognizer is never released while its verification is in progress. Consecutive calls with the same verifier reuse the cached recognizer (verified by lifecycle regression tests with the real `transcribeBlocking` flow). Stream release runs in `finally` on success/rejection/decode failure/exception. The interactive STT recognizer, its mutex and the engine selection are deliberately separate and unaffected. On-device (pre-lifecycle-fix APK): 15 probe invocations across both devices with zero leaks/crashes; recognizer init once (first call ~8 s), steady-state decode 2–7 s per 3 s window.

## Tests

- `:core:voice:testDebugUnitTest` — **206/206** (was 185 at #1438 merge): +12 new (#1439 spec-resolution ×4, empty-PCM, wake-form ×3, #1440 lifecycle ×5)
- `:app:testDebugUnitTest` — **1077/1077** (was 1070): +7 new (Whisper transcript accept/reject ×3, provisioning ×4)
- `./gradlew lint` — clean; `git diff --check` — clean
- CI: **green at `05db29ad`** — Build & Test run 30799858308 (success), Docs Drift run 30799858564 (success)

## Bounded device verification (one exact APK)

APK: `app-debug.apk` SHA-256 **`524b47d05a613370340efded917f9918fe882957be2699c5ed444be433317f6e`** (head `05db29ad`; v0.1.0 / versionCode 1 — the endianness fix commit `05db29ad` only touched the debug probe, APK content identical to the deployed build). Update-installed on S21 (`R5CR605B71K`) and S23U with data/models/settings preserved; verifier files deployed with the hashes above (verified on-device via sha256sum); targets unplugged and discharging.

### Direct verifier validation (real production path: `verifyWakeWindow` → facade → `transcribeBlocking` → on-device Whisper → `containsWakePhrase`; debug-only probe, no production API)

| Input | S21 | S23U |
|---|---|---|
| genuine wake, detector-equivalent ring | accept ×3 | accept ×3 |
| genuine wake, clean | accept ×3 | accept ×3 |
| genuine wake, room-tone ring | accept ×3 | accept ×3 |
| 3 s silence | reject ×3 | reject ×3 |
| non-wake command (ring placement) | reject ×3 | reject ×3 |

### Acoustic smoke (frozen fixture/placement/volume 9/built-in speaker; no full #1410 matrix)

| Direction | Trial | Idle | Result | Band |
|---|---|---|---|---|
| S23U target / S21 source | 1 | 120 s | FAIL — `classifier_model_miss` (max conf 0.001; **#1432 pattern, kept visible, not retried**) | no candidate |
| S23U target / S21 source | 2 | 120 s | **PASS** | **0.6335 LOW → verifier ACCEPTED** |
| S23U target / S21 source | 3 | 120 s | PASS | 0.8993 HIGH |
| S21 target / S23U source | 1 | 10 s* | PASS | 0.8929 HIGH |
| S21 target / S23U source | 2 | 10 s* | PASS | 0.8348 HIGH |
| S21 target / S23U source | 3 | 10 s* | PASS | 0.8203 HIGH |

*The runner's smoke mode is pinned to each target's first frozen matrix slot (S21: 10 s, S23U: 120 s) and exposes no idle override; the 120 s condition is covered by the S23U-target cells.

Trial 2 (S23U target) is the #1439 acceptance scenario: a naturally occurring low-band candidate at **0.6335** (the same band as the pre-fix failure at 0.6336, #1438 trial 009) reached `ACTIVATION_CANDIDATE (mode=low) → VERIFIED_ACTIVATION (mode=low) → WAKE_CALLBACK_INVOKED → VOICE_SESSION_STARTED` — verified by the Whisper verifier on-device. High-confidence trials (0.82–0.90) skipped the verifier as required (`lowVerifyEntered=false`). Every valid failure and invalid attempt remains visible in the preserved runs under `scripts/private-acoustic-runs/`.

## Confirmations

- **No threshold changed** (high 0.65 / low 0.50 untouched; no candidate was manufactured)
- **No model binary committed** (validation script is hash-pinned and fails closed)
- **#1432 not absorbed** — the single `classifier_model_miss` failure belongs to #1432 and is left visible; detector/classifier behaviour untouched
- **No full #1410 matrix ran**
- No PCM/transcript production logging added (debug probe only; per-frame logging unchanged)

Do not merge — wait for review.

