### PR TITLE
fix(#1007): preserve crash diagnostics after process restart

### DIFF
--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutScreen.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutScreen.kt
@@ -132,11 +132,23 @@ fun AboutScreen(
             ListItem(
                 modifier = Modifier.fillMaxWidth(),
                 headlineContent = { Text("Export logs") },
-                supportingContent = { Text("Share recent logcat output as a text file") },
+                supportingContent = { Text("Share recent crash information and current logs") },
                 trailingContent = {
                     val isLoading = uiState.exportState is ExportState.Loading
                     Button(
-                        onClick = { if (!isLoading) viewModel.exportLogs() },
+                        onClick = {
+                            if (!isLoading) {
+                                viewModel.exportLogs(
+                                    DiagnosticBuildInfo(
+                                        versionName = versionName,
+                                        versionCode = versionCode,
+                                        buildType = buildType,
+                                        gitSha = gitSha,
+                                        buildTimestamp = buildTimestamp,
+                                    ),
+                                )
+                            }
+                        },
                         enabled = !isLoading,
                     ) {
                         if (isLoading) {

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -68,7 +68,23 @@ internal const val ANR_TRACE_MAX_CHARS = 8192
 /** Maximum characters of logcat stderr detail kept in a warning (bounded). */
 internal const val MAX_STDERR_WARNING_CHARS = 500
 
-private data class AnrTrace(val text: String, val truncated: Boolean)
+/**
+ * Result of inspecting an [ApplicationExitInfo] trace stream, preserving the
+ * distinction between "no trace", "trace available", and "trace access failed".
+ */
+private sealed class TraceState {
+    /** Android reports no trace stream for this exit. */
+    object Absent : TraceState()
+
+    /** A trace stream was obtained; [text] holds the bounded ANR excerpt when read. */
+    data class Available(val text: String? = null, val truncated: Boolean = false) : TraceState()
+
+    /**
+     * Obtaining/reading the trace failed. [streamExisted] is true when a stream was
+     * obtained but could not be read, false when obtaining the stream itself failed.
+     */
+    data class AccessFailed(val detail: String, val streamExisted: Boolean) : TraceState()
+}
 
 private data class LogcatCapture(val output: String?, val failureDetail: String?)
 
@@ -267,45 +283,79 @@ class AboutViewModel @Inject constructor(
         sb.appendLine("RSS: ${formatMemory(info.rss)}")
         when (info.reason) {
             ApplicationExitInfo.REASON_ANR -> renderAnrTrace(sb, info, warnings)
-            ApplicationExitInfo.REASON_CRASH_NATIVE -> {
-                val available = hasTraceStream(info)
-                sb.appendLine("System trace available: ${if (available) "yes" else "no"}")
-                sb.appendLine("Trace note: native tombstone; use native/ADB diagnostics")
-            }
-            else -> {
-                val available = hasTraceStream(info)
-                sb.appendLine("System trace available: ${if (available) "yes" else "no"}")
-            }
+            ApplicationExitInfo.REASON_CRASH_NATIVE -> renderNativeTraceNote(sb, info, warnings)
+            else -> renderTraceAvailability(sb, info, warnings)
         }
         sb.appendLine()
     }
 
-    /** Reads a textual ANR trace, bounded to [ANR_TRACE_MAX_CHARS]; never fails the export. */
+    /** Renders a textual ANR trace (bounded to [ANR_TRACE_MAX_CHARS]); never fails the export. */
     private fun renderAnrTrace(sb: StringBuilder, info: ApplicationExitInfo, warnings: MutableList<String>) {
-        val trace = readAnrTrace(info, warnings)
-        if (trace == null) {
-            sb.appendLine("System trace available: no")
-            sb.appendLine("Trace note: no readable ANR trace (see Exporter warnings)")
+        val state = queryTraceState(info)
+        if (state is TraceState.Available) {
+            sb.appendLine("System trace available: yes")
+            sb.appendLine("ANR trace excerpt:")
+            sb.append(state.text ?: "")
+            if (state.truncated) {
+                sb.appendLine("\n[ANR trace excerpt truncated at $ANR_TRACE_MAX_CHARS characters]")
+            }
             return
         }
-        sb.appendLine("System trace available: yes")
-        sb.appendLine("ANR trace excerpt:")
-        sb.append(trace.text)
-        if (trace.truncated) {
-            sb.appendLine("\n[ANR trace excerpt truncated at $ANR_TRACE_MAX_CHARS characters]")
+        renderTraceState(sb, state, warnings)
+    }
+
+    /** Native tombstone traces are never decoded; only availability is recorded. */
+    private fun renderNativeTraceNote(sb: StringBuilder, info: ApplicationExitInfo, warnings: MutableList<String>) {
+        val state = queryTraceState(info)
+        if (state is TraceState.Available) {
+            sb.appendLine("System trace available: yes")
+            sb.appendLine("Trace note: native tombstone; use native/ADB diagnostics")
+            return
+        }
+        renderTraceState(sb, state, warnings)
+    }
+
+    private fun renderTraceAvailability(sb: StringBuilder, info: ApplicationExitInfo, warnings: MutableList<String>) {
+        renderTraceState(sb, queryTraceState(info), warnings)
+    }
+
+    private fun renderTraceState(sb: StringBuilder, state: TraceState, warnings: MutableList<String>) {
+        when (state) {
+            TraceState.Absent -> sb.appendLine("System trace available: no")
+            is TraceState.Available -> sb.appendLine("System trace available: yes")
+            is TraceState.AccessFailed -> {
+                if (state.streamExisted) {
+                    warnings += "Could not read ANR trace: ${state.detail}"
+                    sb.appendLine("System trace available: yes (could not be read)")
+                } else {
+                    warnings += "Trace access failed: ${state.detail}"
+                    sb.appendLine("System trace available: unknown (access failed)")
+                }
+            }
         }
     }
 
-    private fun readAnrTrace(info: ApplicationExitInfo, warnings: MutableList<String>): AnrTrace? {
+    /**
+     * Inspects the trace stream without conflating "absent" with "could not be read".
+     * ANR streams are read as text within the fixed bound; native/other streams are
+     * only opened and immediately closed to report availability.
+     */
+    private fun queryTraceState(info: ApplicationExitInfo): TraceState {
         val stream = try {
             info.traceInputStream
         } catch (e: Exception) {
-            warnings += "Could not open ANR trace: ${e.message ?: e.javaClass.simpleName}"
-            return null
+            return TraceState.AccessFailed(
+                detail = e.message ?: e.javaClass.simpleName,
+                streamExisted = false,
+            )
         }
         if (stream == null) {
-            warnings += "ANR exit record has no trace stream"
-            return null
+            return TraceState.Absent
+        }
+        if (info.reason != ApplicationExitInfo.REASON_ANR) {
+            // Availability only — never read native/other trace content.
+            runCatching { stream.close() }
+            return TraceState.Available()
         }
         return try {
             stream.bufferedReader(Charsets.UTF_8).use { reader ->
@@ -316,18 +366,18 @@ class AboutViewModel @Inject constructor(
                     if (n == -1) break
                     count += n
                 }
-                AnrTrace(String(buffer, 0, count), truncated = count == ANR_TRACE_MAX_CHARS)
+                TraceState.Available(
+                    text = String(buffer, 0, count),
+                    truncated = count == ANR_TRACE_MAX_CHARS,
+                )
             }
         } catch (e: Exception) {
-            warnings += "Could not read ANR trace: ${e.message ?: e.javaClass.simpleName}"
-            null
+            TraceState.AccessFailed(
+                detail = e.message ?: e.javaClass.simpleName,
+                streamExisted = true,
+            )
         }
     }
-
-    /** Opens and immediately closes the trace stream to report availability without reading it. */
-    private fun hasTraceStream(info: ApplicationExitInfo): Boolean = runCatching {
-        info.traceInputStream?.use { true } ?: false
-    }.getOrDefault(false)
 
     private fun formatExitReason(reason: Int): String = when (reason) {
         ApplicationExitInfo.REASON_UNKNOWN -> "REASON_UNKNOWN ($reason)"

--- a/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/kernel/ai/feature/settings/AboutViewModel.kt
@@ -1,8 +1,11 @@
 package com.kernel.ai.feature.settings
 
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.os.Process
 import androidx.core.content.FileProvider
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -27,7 +30,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.IOException
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Named
@@ -44,6 +50,28 @@ sealed class ExportState {
     data class Error(val message: String) : ExportState()
 }
 
+/** Build identity already rendered on the About screen, passed into the export call. */
+data class DiagnosticBuildInfo(
+    val versionName: String,
+    val versionCode: Int,
+    val buildType: String,
+    val gitSha: String,
+    val buildTimestamp: String,
+)
+
+/** Most recent exit records to include, newest first (bounded). */
+internal const val MAX_EXIT_RECORDS = 5
+
+/** Maximum characters of a textual ANR trace to include in the export (bounded). */
+internal const val ANR_TRACE_MAX_CHARS = 8192
+
+/** Maximum characters of logcat stderr detail kept in a warning (bounded). */
+internal const val MAX_STDERR_WARNING_CHARS = 500
+
+private data class AnrTrace(val text: String, val truncated: Boolean)
+
+private data class LogcatCapture(val output: String?, val failureDetail: String?)
+
 @HiltViewModel
 class AboutViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -56,6 +84,16 @@ class AboutViewModel @Inject constructor(
 
     private companion object {
         val KEY_VERBOSE_LOGGING = booleanPreferencesKey("verbose_logging")
+        val TIMESTAMP_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS")
+        val EXIT_TIMESTAMP_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+        /** `MM-DD HH:MM:SS.mmm  PID  TID LEVEL TAG: message` from `logcat -v threadtime`. */
+        val THREADTIME_ENTRY: Regex =
+            Regex("""^\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\s+\d+\s+\d+\s+[VDIWEF]\s""")
+
+        /** Normal logcat buffer headings, e.g. `--------- beginning of main`. */
+        val LOGCAT_HEADING: Regex = Regex("""^-+ beginning of \w+""")
     }
 
     private val defaultVerboseLoggingEnabled: Boolean
@@ -99,34 +137,15 @@ class AboutViewModel @Inject constructor(
         }
     }
 
-    fun exportLogs() {
+    fun exportLogs(buildInfo: DiagnosticBuildInfo) {
         _uiState.update { it.copy(exportState = ExportState.Loading) }
         viewModelScope.launch {
             try {
                 val shareIntent = withContext(ioDispatcher) {
-                    val pid = android.os.Process.myPid()
-                    val process = Runtime.getRuntime().exec(
-                        arrayOf("logcat", "-d", "-v", "threadtime", "--pid=$pid", "-t", "500"),
-                    )
-                    val logText = process.inputStream.bufferedReader().use { it.readText() }
-                    val stderrText = process.errorStream.bufferedReader().use { it.readText() }
-                    val exitCode = process.waitFor()
-                    if (logText.isBlank()) {
-                        val detail = stderrText.trim().ifEmpty { "exit code $exitCode" }
-                        throw Exception(
-                            "No log entries captured ($detail). This device may restrict logcat " +
-                                "access for user apps. Use ADB instead:\n" +
-                                "adb logcat -s KernelAI",
-                        )
-                    }
-                    val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS"))
-                    val versionName = try {
-                        context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "unknown"
-                    } catch (_: Exception) {
-                        "unknown"
-                    }
-                    val logFile = File(context.cacheDir, "kernel_debug_log_${versionName}_${timestamp}.txt")
-                    logFile.writeText(logText)
+                    val content = buildDiagnosticExport(buildInfo)
+                    val timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER)
+                    val logFile = File(context.cacheDir, "kernel_debug_log_${buildInfo.versionName}_$timestamp.txt")
+                    logFile.writeText(content)
                     val uri = FileProvider.getUriForFile(
                         context,
                         "${context.packageName}.fileprovider",
@@ -143,6 +162,255 @@ class AboutViewModel @Inject constructor(
             } catch (e: Exception) {
                 _uiState.update { it.copy(exportState = ExportState.Error(e.message ?: "Export failed")) }
             }
+        }
+    }
+
+    /**
+     * Assembles the bounded diagnostic text bundle. Each evidence source is isolated:
+     * failure of one never prevents the others from exporting. Only when no useful
+     * evidence exists at all does this throw, which surfaces as [ExportState.Error].
+     */
+    private fun buildDiagnosticExport(buildInfo: DiagnosticBuildInfo): String {
+        val warnings = mutableListOf<String>()
+        val exitRecords = queryExitHistory(warnings)
+        val logcat = captureCurrentLogcat(warnings)
+
+        if (exitRecords.isEmpty() && logcat.output == null) {
+            val detail = logcat.failureDetail ?: "no recent process exits were recorded"
+            throw Exception(
+                "No useful diagnostics were available ($detail). This device may restrict " +
+                    "logcat access for user apps. Use ADB instead:\nadb logcat -s KernelAI",
+            )
+        }
+
+        return buildString {
+            appendLine("Jandal diagnostic export")
+            appendLine()
+            appendLine("App/build information")
+            appendLine("---------------------")
+            appendLine("Version: ${buildInfo.versionName}")
+            appendLine("Version code: ${buildInfo.versionCode}")
+            appendLine("Build type: ${buildInfo.buildType}")
+            appendLine("Commit: ${buildInfo.gitSha}")
+            appendLine("Built: ${buildInfo.buildTimestamp}")
+            appendLine("Package: ${context.packageName}")
+            appendLine()
+            appendLine("Recent process exits")
+            appendLine("--------------------")
+            if (exitRecords.isEmpty()) {
+                appendLine("No recent process exit records found.")
+            } else {
+                exitRecords.forEachIndexed { index, record ->
+                    val block = StringBuilder()
+                    runCatching { renderExitRecord(block, index + 1, record, warnings) }
+                        .onSuccess { append(block) }
+                        .onFailure { e ->
+                            warnings += "Could not render exit record ${index + 1}: " +
+                                "${e.message ?: e.javaClass.simpleName}"
+                        }
+                }
+            }
+            appendLine()
+            appendLine("Current process logcat")
+            appendLine("----------------------")
+            appendLine(logcat.output ?: "No current-process logcat captured (see Exporter warnings below).")
+            appendLine()
+            appendLine("Exporter warnings")
+            appendLine("-----------------")
+            if (warnings.isEmpty()) {
+                appendLine("None.")
+            } else {
+                warnings.forEach { appendLine("- $it") }
+            }
+        }
+    }
+
+    private fun queryExitHistory(warnings: MutableList<String>): List<ApplicationExitInfo> {
+        val activityManager = try {
+            context.getSystemService(ActivityManager::class.java)
+        } catch (e: Exception) {
+            warnings += "Could not query process exit history: ${e.message ?: e.javaClass.simpleName}"
+            return emptyList()
+        }
+        if (activityManager == null) {
+            warnings += "Could not query process exit history: ActivityManager service unavailable"
+            return emptyList()
+        }
+        return try {
+            activityManager.getHistoricalProcessExitReasons(context.packageName, 0, MAX_EXIT_RECORDS).orEmpty()
+        } catch (e: Exception) {
+            warnings += "Could not query process exit history: ${e.message ?: e.javaClass.simpleName}"
+            emptyList()
+        }
+    }
+
+    private fun renderExitRecord(
+        sb: StringBuilder,
+        index: Int,
+        info: ApplicationExitInfo,
+        warnings: MutableList<String>,
+    ) {
+        sb.appendLine("Exit $index")
+        sb.appendLine("Timestamp: ${EXIT_TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(info.timestamp).atOffset(ZoneOffset.UTC))}")
+        sb.appendLine("Process name: ${info.processName}")
+        sb.appendLine("Reason: ${formatExitReason(info.reason)}")
+        if (info.reason == ApplicationExitInfo.REASON_SIGNALED) {
+            sb.appendLine("Status/signal: ${info.status} (signal)")
+        } else {
+            sb.appendLine("Status: ${info.status}")
+        }
+        sb.appendLine("Importance: ${formatImportance(info.importance)}")
+        if (!info.description.isNullOrBlank()) {
+            sb.appendLine("Description: ${info.description}")
+        }
+        sb.appendLine("PSS: ${formatMemory(info.pss)}")
+        sb.appendLine("RSS: ${formatMemory(info.rss)}")
+        when (info.reason) {
+            ApplicationExitInfo.REASON_ANR -> renderAnrTrace(sb, info, warnings)
+            ApplicationExitInfo.REASON_CRASH_NATIVE -> {
+                val available = hasTraceStream(info)
+                sb.appendLine("System trace available: ${if (available) "yes" else "no"}")
+                sb.appendLine("Trace note: native tombstone; use native/ADB diagnostics")
+            }
+            else -> {
+                val available = hasTraceStream(info)
+                sb.appendLine("System trace available: ${if (available) "yes" else "no"}")
+            }
+        }
+        sb.appendLine()
+    }
+
+    /** Reads a textual ANR trace, bounded to [ANR_TRACE_MAX_CHARS]; never fails the export. */
+    private fun renderAnrTrace(sb: StringBuilder, info: ApplicationExitInfo, warnings: MutableList<String>) {
+        val trace = readAnrTrace(info, warnings)
+        if (trace == null) {
+            sb.appendLine("System trace available: no")
+            sb.appendLine("Trace note: no readable ANR trace (see Exporter warnings)")
+            return
+        }
+        sb.appendLine("System trace available: yes")
+        sb.appendLine("ANR trace excerpt:")
+        sb.append(trace.text)
+        if (trace.truncated) {
+            sb.appendLine("\n[ANR trace excerpt truncated at $ANR_TRACE_MAX_CHARS characters]")
+        }
+    }
+
+    private fun readAnrTrace(info: ApplicationExitInfo, warnings: MutableList<String>): AnrTrace? {
+        val stream = try {
+            info.traceInputStream
+        } catch (e: Exception) {
+            warnings += "Could not open ANR trace: ${e.message ?: e.javaClass.simpleName}"
+            return null
+        }
+        if (stream == null) {
+            warnings += "ANR exit record has no trace stream"
+            return null
+        }
+        return try {
+            stream.bufferedReader(Charsets.UTF_8).use { reader ->
+                val buffer = CharArray(ANR_TRACE_MAX_CHARS)
+                var count = 0
+                while (count < ANR_TRACE_MAX_CHARS) {
+                    val n = reader.read(buffer, count, ANR_TRACE_MAX_CHARS - count)
+                    if (n == -1) break
+                    count += n
+                }
+                AnrTrace(String(buffer, 0, count), truncated = count == ANR_TRACE_MAX_CHARS)
+            }
+        } catch (e: Exception) {
+            warnings += "Could not read ANR trace: ${e.message ?: e.javaClass.simpleName}"
+            null
+        }
+    }
+
+    /** Opens and immediately closes the trace stream to report availability without reading it. */
+    private fun hasTraceStream(info: ApplicationExitInfo): Boolean = runCatching {
+        info.traceInputStream?.use { true } ?: false
+    }.getOrDefault(false)
+
+    private fun formatExitReason(reason: Int): String = when (reason) {
+        ApplicationExitInfo.REASON_UNKNOWN -> "REASON_UNKNOWN ($reason)"
+        ApplicationExitInfo.REASON_EXIT_SELF -> "REASON_EXIT_SELF ($reason)"
+        ApplicationExitInfo.REASON_SIGNALED -> "REASON_SIGNALED ($reason)"
+        ApplicationExitInfo.REASON_LOW_MEMORY -> "REASON_LOW_MEMORY ($reason)"
+        ApplicationExitInfo.REASON_CRASH -> "REASON_CRASH ($reason)"
+        ApplicationExitInfo.REASON_CRASH_NATIVE -> "REASON_CRASH_NATIVE ($reason)"
+        ApplicationExitInfo.REASON_ANR -> "REASON_ANR ($reason)"
+        ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "REASON_INITIALIZATION_FAILURE ($reason)"
+        ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "REASON_PERMISSION_CHANGE ($reason)"
+        ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "REASON_EXCESSIVE_RESOURCE_USAGE ($reason)"
+        ApplicationExitInfo.REASON_USER_REQUESTED -> "REASON_USER_REQUESTED ($reason)"
+        ApplicationExitInfo.REASON_USER_STOPPED -> "REASON_USER_STOPPED ($reason)"
+        ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "REASON_DEPENDENCY_DIED ($reason)"
+        ApplicationExitInfo.REASON_OTHER -> "REASON_OTHER ($reason)"
+        ApplicationExitInfo.REASON_FREEZER -> "REASON_FREEZER ($reason)"
+        ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "REASON_PACKAGE_STATE_CHANGE ($reason)"
+        ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "REASON_PACKAGE_UPDATED ($reason)"
+        else -> "UNKNOWN ($reason)"
+    }
+
+    private fun formatImportance(importance: Int): String = when (importance) {
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND -> "IMPORTANCE_FOREGROUND ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE -> "IMPORTANCE_FOREGROUND_SERVICE ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "IMPORTANCE_TOP_SLEEPING ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "IMPORTANCE_VISIBLE ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "IMPORTANCE_PERCEPTIBLE ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "IMPORTANCE_SERVICE ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_BACKGROUND -> "IMPORTANCE_BACKGROUND ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_EMPTY -> "IMPORTANCE_EMPTY ($importance)"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "IMPORTANCE_GONE ($importance)"
+        else -> "UNKNOWN ($importance)"
+    }
+
+    private fun formatMemory(bytes: Long): String = if (bytes >= 0) "$bytes KB" else "n/a"
+
+    /** Captures current-process logcat; a failure is a warning, never an export failure by itself. */
+    private fun captureCurrentLogcat(warnings: MutableList<String>): LogcatCapture {
+        val pid = Process.myPid()
+        val process = try {
+            Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime", "--pid=$pid", "-t", "500"))
+        } catch (e: IOException) {
+            return unavailable(warnings, "could not start logcat: ${e.message ?: e.javaClass.simpleName}")
+        }
+        val stdout = try {
+            process.inputStream.bufferedReader().use { it.readText() }
+        } catch (e: IOException) {
+            return unavailable(warnings, "could not read logcat output: ${e.message ?: e.javaClass.simpleName}")
+        }
+        val stderr = runCatching { process.errorStream.bufferedReader().use { it.readText() } }
+            .getOrDefault("")
+            .trim()
+        val exitCode = runCatching { process.waitFor() }.getOrDefault(-1)
+        if (stderr.isNotBlank()) {
+            warnings += "logcat stderr: ${stderr.take(MAX_STDERR_WARNING_CHARS)}"
+        }
+        if (exitCode != 0) {
+            warnings += "logcat exited with code $exitCode"
+        }
+        if (stdout.isBlank()) {
+            val detail = stderr.ifEmpty { "exit code $exitCode" }
+            return unavailable(warnings, "no log entries captured ($detail)")
+        }
+        if (!isPlausibleLogcat(stdout)) {
+            return unavailable(warnings, "logcat output did not look like threadtime logcat")
+        }
+        return LogcatCapture(stdout, null)
+    }
+
+    private fun unavailable(warnings: MutableList<String>, detail: String): LogcatCapture {
+        warnings += "Current-process logcat unavailable: $detail"
+        return LogcatCapture(null, detail)
+    }
+
+    /**
+     * Narrow plausibility check for `logcat -v threadtime` output: at least one line must
+     * look like a threadtime entry or a logcat buffer heading. Rejects opaque vendor
+     * payloads (e.g. MagicOS `HKS…HKE` blobs) without trying to parse logcat.
+     */
+    private fun isPlausibleLogcat(output: String): Boolean {
+        return output.lineSequence().any { line ->
+            THREADTIME_ENTRY.containsMatchIn(line) || LOGCAT_HEADING.containsMatchIn(line)
         }
     }
 

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
@@ -1,19 +1,21 @@
 package com.kernel.ai.feature.settings
 
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import androidx.core.content.FileProvider
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
+import com.kernel.ai.core.voice.VoiceOutputPreferences
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
-import com.kernel.ai.core.voice.VoiceOutputPreferences
+import java.io.IOException
+import java.io.InputStream
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,6 +29,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -34,16 +37,31 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.time.Duration.Companion.seconds
 
+private val VALID_THREADTIME_LOG =
+    "08-11 02:49:00.123  1234  5678 I KernelAI: test log entry\n" +
+        "08-11 02:49:00.456  1234  5678 W KernelAI: second entry\n"
+
+/** Representative opaque MagicOS/vendor payload (Honor HKS…HKE blob) — not real logcat. */
+private const val OPAQUE_VENDOR_PAYLOAD =
+    "HKS2026081113490000f3a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5f6a7b8c9d0e1f2a3b4c5HKE\n"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class AboutViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
 
+    private val buildInfo = DiagnosticBuildInfo(
+        versionName = "1.2.3",
+        versionCode = 42,
+        buildType = "debug",
+        gitSha = "0123456789abcdef",
+        buildTimestamp = "2026-08-09T12:00:00Z",
+    )
+
     private val context: Context = mockk()
     private val applicationInfo = ApplicationInfo().apply { flags = ApplicationInfo.FLAG_DEBUGGABLE }
-    private val packageManager: PackageManager = mockk()
-    private val packageInfo = PackageInfo().apply { versionName = "1.2.3" }
+    private val activityManager: ActivityManager = mockk()
     private lateinit var cacheDir: File
     private val voiceOutputPreferences: VoiceOutputPreferences = mockk(relaxed = true)
     private val preferencesState = MutableStateFlow<Preferences>(emptyPreferences())
@@ -63,11 +81,11 @@ class AboutViewModelTest {
     fun setUp() {
         cacheDir = Files.createTempDirectory("kernel-test-cache").toFile()
         Dispatchers.setMain(testDispatcher)
-        every { context.packageManager } returns packageManager
         every { context.applicationInfo } returns applicationInfo
         every { context.packageName } returns "com.kernel.ai.test"
         every { context.cacheDir } returns cacheDir
-        every { packageManager.getPackageInfo("com.kernel.ai.test", 0) } returns packageInfo
+        // Default: no exit history unless a test stubs ActivityManager explicitly.
+        every { context.getSystemService(ActivityManager::class.java) } returns null
         preferencesState.value = emptyPreferences()
         viewModel = AboutViewModel(context, dataStore, voiceOutputPreferences)
         viewModel.ioDispatcher = testDispatcher
@@ -79,71 +97,87 @@ class AboutViewModelTest {
         cacheDir.deleteRecursively()
     }
 
-    /** Stubs Runtime.getRuntime().exec() to return a non-empty log, avoiding real logcat calls. */
-    private fun stubRuntime(logContent: String = "I/KernelAI: test log entry\n") {
+    /** Stubs Runtime.getRuntime().exec() to return the given logcat output, avoiding real logcat calls. */
+    private fun stubRuntime(
+        logContent: String = VALID_THREADTIME_LOG,
+        stderrText: String = "",
+        exitCode: Int = 0,
+    ) {
         mockkStatic(Runtime::class)
         val mockProcess = mockk<Process>()
         every { Runtime.getRuntime() } returns mockk(relaxed = true) {
             every { exec(any<Array<String>>()) } returns mockProcess
         }
         every { mockProcess.inputStream } answers { logContent.byteInputStream() }
-        every { mockProcess.errorStream } answers { "".byteInputStream() }
-        every { mockProcess.waitFor() } returns 0
+        every { mockProcess.errorStream } answers { stderrText.byteInputStream() }
+        every { mockProcess.waitFor() } returns exitCode
     }
 
-    /** Stubs logcat to return blank output (simulates Honor MagicOS log-access restriction). */
-    private fun stubRuntimeEmpty(stderrText: String = "") {
-        mockkStatic(Runtime::class)
-        val mockProcess = mockk<Process>()
-        every { Runtime.getRuntime() } returns mockk(relaxed = true) {
-            every { exec(any<Array<String>>()) } returns mockProcess
-        }
-        every { mockProcess.inputStream } answers { "".byteInputStream() }
-        every { mockProcess.errorStream } answers { stderrText.byteInputStream() }
-        every { mockProcess.waitFor() } returns 0
+    /** Stubs ActivityManager to return the given historical exit records (newest first). */
+    private fun stubExitHistory(vararg records: ApplicationExitInfo) {
+        every { context.getSystemService(ActivityManager::class.java) } returns activityManager
+        every { activityManager.getHistoricalProcessExitReasons(any(), any(), any()) } returns records.toList()
     }
+
+    /** Builds a mock ApplicationExitInfo record with deterministic values. */
+    private fun mockExitInfo(
+        reason: Int = ApplicationExitInfo.REASON_CRASH,
+        timestamp: Long = 1_786_416_540_123L, // 2026-08-11T02:49:00.123Z
+        processName: String = "com.kernel.ai.test",
+        status: Int = 0,
+        importance: Int = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND,
+        description: String? = "Process crashed",
+        pss: Long = 123_456,
+        rss: Long = 65_432,
+        pid: Int = 9999,
+        trace: InputStream? = null,
+    ): ApplicationExitInfo {
+        val info = mockk<ApplicationExitInfo>()
+        every { info.reason } returns reason
+        every { info.timestamp } returns timestamp
+        every { info.processName } returns processName
+        every { info.status } returns status
+        every { info.importance } returns importance
+        every { info.description } returns description
+        every { info.pss } returns pss
+        every { info.rss } returns rss
+        every { info.pid } returns pid
+        every { info.traceInputStream } returns trace
+        return info
+    }
+
+    private fun mockShare() {
+        mockkStatic(FileProvider::class)
+        mockkStatic(Intent::class)
+        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
+        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
+    }
+
+    private fun runExport(buildInfo: DiagnosticBuildInfo = this.buildInfo) {
+        viewModel.exportLogs(buildInfo)
+        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+    }
+
+    private fun latestExportFile(): File =
+        cacheDir.listFiles()?.firstOrNull { it.name.endsWith(".txt") }
+            ?: error("Expected an export file in cacheDir")
+
+    private fun exportContent(): String = latestExportFile().readText()
 
     @Test
     fun `exportLogs generates filename with version and timestamp`() = testScope.runTest {
         stubRuntime()
-        mockkStatic(FileProvider::class)
-        mockkStatic(Intent::class)
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
-        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
+        mockShare()
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+        runExport()
 
         val state = viewModel.uiState.value.exportState
         assertTrue(state is ExportState.Ready)
 
-        val logFile = cacheDir.listFiles()?.firstOrNull { it.name.endsWith(".txt") }
-        assertTrue(logFile != null, "Expected a log file to be written to cacheDir")
-        assertTrue(logFile!!.name.startsWith("kernel_debug_log_1.2.3_"))
+        val logFile = latestExportFile()
+        assertTrue(logFile.name.startsWith("kernel_debug_log_1.2.3_"))
         assertTrue(logFile.name.endsWith(".txt"))
-    }
-
-    @Test
-    fun `exportLogs handles missing package info gracefully`() = testScope.runTest {
-        stubRuntime()
-        mockkStatic(FileProvider::class)
-        mockkStatic(Intent::class)
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
-        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
-        every { packageManager.getPackageInfo("com.kernel.ai.test", 0) } throws
-            PackageManager.NameNotFoundException("not found")
-
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
-
-        val state = viewModel.uiState.value.exportState
-        assertTrue(state is ExportState.Ready)
-
-        val logFile = cacheDir.listFiles()?.firstOrNull { it.name.endsWith(".txt") }
-        assertTrue(logFile != null, "Expected a log file to be written to cacheDir")
-        assertTrue(logFile!!.name.startsWith("kernel_debug_log_unknown_"))
     }
 
     @Test
@@ -152,9 +186,7 @@ class AboutViewModelTest {
         mockkStatic(FileProvider::class)
         every { FileProvider.getUriForFile(any(), any(), any()) } throws RuntimeException("disk full")
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+        runExport()
 
         val state = viewModel.uiState.value.exportState
         assertTrue(state is ExportState.Error)
@@ -164,15 +196,10 @@ class AboutViewModelTest {
     @Test
     fun `exportLogs generates unique filenames per timestamp`() = testScope.runTest {
         stubRuntime()
-        mockkStatic(FileProvider::class)
-        mockkStatic(Intent::class)
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
-        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
+        mockShare()
 
         repeat(3) {
-            viewModel.exportLogs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            testDispatcher.scheduler.advanceTimeBy(1.seconds)
+            runExport()
             viewModel.clearExportState()
         }
 
@@ -192,9 +219,7 @@ class AboutViewModelTest {
             firstArg<Intent>()
         }
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+        runExport()
 
         assertTrue(createChooserCalled, "Expected Intent.createChooser to be called")
         assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
@@ -203,12 +228,9 @@ class AboutViewModelTest {
     @Test
     fun `exportState transitions through Loading to Ready`() = testScope.runTest {
         stubRuntime()
-        mockkStatic(FileProvider::class)
-        mockkStatic(Intent::class)
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
-        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
+        mockShare()
 
-        viewModel.exportLogs()
+        viewModel.exportLogs(buildInfo)
         // Loading is set synchronously before the coroutine runs — check before advancing.
         assertTrue(viewModel.uiState.value.exportState is ExportState.Loading)
 
@@ -222,15 +244,9 @@ class AboutViewModelTest {
     @Test
     fun `clearExportState resets to Idle`() = testScope.runTest {
         stubRuntime()
-        mockkStatic(FileProvider::class)
-        mockkStatic(Intent::class)
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockk()
-        every { Intent.createChooser(any(), any()) } answers { firstArg<Intent>() }
+        mockShare()
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
-
+        runExport()
         assertEquals(ExportState.Ready::class, viewModel.uiState.value.exportState::class)
 
         viewModel.clearExportState()
@@ -254,33 +270,289 @@ class AboutViewModelTest {
     }
 
     @Test
-    fun `exportLogs with blank logcat output sets error state with ADB hint`() = testScope.runTest {
+    fun `blank logcat without exit history sets error state with ADB hint`() = testScope.runTest {
         // Simulates Honor MagicOS (and similar OEMs) where the OS SELinux policy silently
         // blocks logcat access for user apps — process exits 0 but stdout is empty.
-        stubRuntimeEmpty()
+        stubRuntime(logContent = "")
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+        runExport()
 
         val state = viewModel.uiState.value.exportState
-        assertTrue(state is ExportState.Error, "Expected Error state when logcat returns no output")
+        assertTrue(state is ExportState.Error, "Expected Error when no diagnostics are available")
         val message = (state as ExportState.Error).message
-        assertTrue(message.contains("No log entries captured"), "Error should explain empty capture")
+        assertTrue(message.contains("No useful diagnostics were available"), "Error should explain missing diagnostics")
         assertTrue(message.contains("adb logcat"), "Error should include ADB fallback hint")
     }
 
     @Test
-    fun `exportLogs with blank logcat includes stderr detail in error message`() = testScope.runTest {
-        stubRuntimeEmpty(stderrText = "read: unexpected EOF!")
+    fun `blank logcat includes stderr detail in error message`() = testScope.runTest {
+        stubRuntime(logContent = "", stderrText = "read: unexpected EOF!")
 
-        viewModel.exportLogs()
-        testDispatcher.scheduler.advanceUntilIdle()
-        testDispatcher.scheduler.advanceTimeBy(1.seconds)
+        runExport()
 
         val state = viewModel.uiState.value.exportState
         assertTrue(state is ExportState.Error)
         assertTrue((state as ExportState.Error).message.contains("read: unexpected EOF!"))
+    }
+
+    @Test
+    fun `recent exit metadata is rendered`() = testScope.runTest {
+        stubRuntime()
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        val content = exportContent()
+        assertTrue(content.contains("Exit 1"))
+        assertTrue(content.contains("Timestamp: 2026-08-11T02:49:00.123Z"))
+        assertTrue(content.contains("Process name: com.kernel.ai.test"))
+        assertTrue(content.contains("Reason: REASON_CRASH (4)"))
+        assertTrue(content.contains("Status: 0"))
+        assertTrue(content.contains("Importance: IMPORTANCE_FOREGROUND (100)"))
+        assertTrue(content.contains("Description: Process crashed"))
+        assertTrue(content.contains("PSS: 123456 KB"))
+        assertTrue(content.contains("RSS: 65432 KB"))
+        assertTrue(content.contains("System trace available: no"))
+    }
+
+    @Test
+    fun `exit history is queried for any pid and survives a new process`() = testScope.runTest {
+        stubRuntime()
+        val pidSlot = slot<Int>()
+        every { context.getSystemService(ActivityManager::class.java) } returns activityManager
+        every { activityManager.getHistoricalProcessExitReasons(any(), capture(pidSlot), any()) } returns
+            listOf(mockExitInfo(pid = 9999))
+        mockShare()
+
+        runExport()
+
+        // pid 0 asks for records of every process of the package, including a previous PID.
+        assertEquals(0, pidSlot.captured)
+        val content = exportContent()
+        assertTrue(content.contains("Exit 1"))
+        assertTrue(content.contains("Process name: com.kernel.ai.test"))
+        assertTrue(content.contains("Reason: REASON_CRASH (4)"))
+    }
+
+    @Test
+    fun `signaled exit renders human readable reason and signal status`() = testScope.runTest {
+        stubRuntime()
+        stubExitHistory(
+            mockExitInfo(
+                reason = ApplicationExitInfo.REASON_SIGNALED,
+                status = 9,
+                importance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE,
+            ),
+        )
+        mockShare()
+
+        runExport()
+
+        val content = exportContent()
+        assertTrue(content.contains("Reason: REASON_SIGNALED (2)"))
+        assertTrue(content.contains("Status/signal: 9 (signal)"))
+        assertTrue(content.contains("Importance: IMPORTANCE_GONE (1000)"))
+    }
+
+    @Test
+    fun `ANR textual trace is included and bounded`() = testScope.runTest {
+        stubRuntime()
+        val hugeTrace = "X".repeat(ANR_TRACE_MAX_CHARS + 5000) + "TRACE-END-MARKER"
+        stubExitHistory(mockExitInfo(reason = ApplicationExitInfo.REASON_ANR, trace = hugeTrace.byteInputStream()))
+        mockShare()
+
+        runExport()
+
+        val content = exportContent()
+        assertTrue(content.contains("System trace available: yes"))
+        assertTrue(content.contains("ANR trace excerpt:"))
+        assertTrue(content.contains("truncated at $ANR_TRACE_MAX_CHARS characters"))
+        assertFalse(content.contains("TRACE-END-MARKER"), "Trace tail beyond the bound must not be exported")
+        assertFalse(content.contains("X".repeat(ANR_TRACE_MAX_CHARS + 1)), "Excerpt must stay within the bound")
+    }
+
+    @Test
+    fun `ANR trace read failure adds warning and continues`() = testScope.runTest {
+        stubRuntime()
+        val failingStream = mockk<InputStream>(relaxed = true)
+        every { failingStream.read() } throws IOException("trace corrupt")
+        every { failingStream.read(any(), any(), any()) } throws IOException("trace corrupt")
+        stubExitHistory(mockExitInfo(reason = ApplicationExitInfo.REASON_ANR, trace = failingStream))
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("Exit 1"))
+        assertTrue(content.contains("Reason: REASON_ANR (6)"))
+        assertTrue(content.contains("System trace available: no"))
+        assertTrue(content.contains("Could not read ANR trace"))
+        assertTrue(content.contains("Current process logcat"))
+    }
+
+    @Test
+    fun `native crash trace is not decoded as text and notes ADB diagnostics`() = testScope.runTest {
+        stubRuntime()
+        val nativeStream = mockk<InputStream>(relaxed = true)
+        every { nativeStream.read() } throws AssertionError("native trace must not be decoded as text")
+        every { nativeStream.read(any(), any(), any()) } throws AssertionError("native trace must not be decoded as text")
+        stubExitHistory(mockExitInfo(reason = ApplicationExitInfo.REASON_CRASH_NATIVE, trace = nativeStream))
+        mockShare()
+
+        runExport()
+
+        // If the exporter tried to read the tombstone stream, the AssertionError would fail the export.
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("System trace available: yes"))
+        assertTrue(content.contains("Trace note: native tombstone; use native/ADB diagnostics"))
+        assertFalse(content.contains("ANR trace excerpt"), "Native tombstone must not be treated as textual ANR trace")
+    }
+
+    @Test
+    fun `blank logcat with exit history succeeds with warning`() = testScope.runTest {
+        stubRuntime(logContent = "")
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("Reason: REASON_CRASH (4)"))
+        assertTrue(content.contains("Current-process logcat unavailable: no log entries captured"))
+        assertTrue(content.contains("No current-process logcat captured"))
+        assertTrue(content.contains("Exporter warnings"))
+    }
+
+    @Test
+    fun `logcat launch failure with exit history succeeds with warning`() = testScope.runTest {
+        mockkStatic(Runtime::class)
+        every { Runtime.getRuntime() } returns mockk(relaxed = true) {
+            every { exec(any<Array<String>>()) } throws IOException("logcat not found")
+        }
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("could not start logcat"))
+        assertTrue(content.contains("Reason: REASON_CRASH (4)"))
+    }
+
+    @Test
+    fun `non zero logcat exit with exit history succeeds with warning`() = testScope.runTest {
+        stubRuntime(exitCode = 1)
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("logcat exited with code 1"))
+        assertTrue(content.contains("I KernelAI: test log entry"))
+    }
+
+    @Test
+    fun `opaque MagicOS vendor payload is rejected as unusable logcat`() = testScope.runTest {
+        stubRuntime(logContent = OPAQUE_VENDOR_PAYLOAD)
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertFalse(content.contains("HKS"), "Opaque vendor payload must not be presented as logcat")
+        assertTrue(content.contains("did not look like threadtime logcat"))
+        assertTrue(content.contains("Reason: REASON_CRASH (4)"))
+    }
+
+    @Test
+    fun `valid threadtime logcat is accepted`() = testScope.runTest {
+        stubRuntime()
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        val content = exportContent()
+        assertTrue(content.contains("I KernelAI: test log entry"))
+        assertTrue(content.contains("W KernelAI: second entry"))
+        assertFalse(content.contains("unavailable"))
+    }
+
+    @Test
+    fun `exit history plus valid logcat produces both sections`() = testScope.runTest {
+        stubRuntime()
+        stubExitHistory(mockExitInfo())
+        mockShare()
+
+        runExport()
+
+        val content = exportContent()
+        assertTrue(content.contains("Recent process exits"))
+        assertTrue(content.contains("Current process logcat"))
+        assertTrue(content.contains("Exit 1"))
+        assertTrue(content.contains("I KernelAI: test log entry"))
+        assertTrue(content.contains("Exporter warnings"))
+    }
+
+    @Test
+    fun `no exit history with valid logcat still succeeds`() = testScope.runTest {
+        stubRuntime()
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("No recent process exit records found."))
+        assertTrue(content.contains("I KernelAI: test log entry"))
+    }
+
+    @Test
+    fun `no exit history with unusable logcat produces error`() = testScope.runTest {
+        stubRuntime(logContent = OPAQUE_VENDOR_PAYLOAD)
+
+        runExport()
+
+        val state = viewModel.uiState.value.exportState
+        assertTrue(state is ExportState.Error)
+        val message = (state as ExportState.Error).message
+        assertTrue(message.contains("No useful diagnostics were available"))
+        assertTrue(message.contains("did not look like threadtime logcat"))
+        assertTrue(message.contains("adb logcat"))
+    }
+
+    @Test
+    fun `app and build metadata appears in exported content`() = testScope.runTest {
+        stubRuntime()
+        mockShare()
+
+        runExport(
+            buildInfo = DiagnosticBuildInfo(
+                versionName = "0.1.0",
+                versionCode = 2916,
+                buildType = "release",
+                gitSha = "51c0a3f5",
+                buildTimestamp = "2026-08-09T12:00:00Z",
+            ),
+        )
+
+        val content = exportContent()
+        assertTrue(content.contains("Jandal diagnostic export"))
+        assertTrue(content.contains("Version: 0.1.0"))
+        assertTrue(content.contains("Version code: 2916"))
+        assertTrue(content.contains("Build type: release"))
+        assertTrue(content.contains("Commit: 51c0a3f5"))
+        assertTrue(content.contains("Built: 2026-08-09T12:00:00Z"))
+        assertTrue(content.contains("Package: com.kernel.ai.test"))
     }
 
 }

--- a/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
+++ b/feature/settings/src/test/java/com/kernel/ai/feature/settings/AboutViewModelTest.kt
@@ -387,9 +387,28 @@ class AboutViewModelTest {
         val content = exportContent()
         assertTrue(content.contains("Exit 1"))
         assertTrue(content.contains("Reason: REASON_ANR (6)"))
-        assertTrue(content.contains("System trace available: no"))
+        assertTrue(content.contains("System trace available: yes (could not be read)"))
+        assertFalse(content.contains("System trace available: no"), "Trace existed, so availability must not read 'no'")
         assertTrue(content.contains("Could not read ANR trace"))
         assertTrue(content.contains("Current process logcat"))
+    }
+
+    @Test
+    fun `trace access failure reports unknown state with warning and continues`() = testScope.runTest {
+        stubRuntime()
+        val info = mockExitInfo(reason = ApplicationExitInfo.REASON_CRASH_NATIVE)
+        every { info.traceInputStream } throws IOException("trace file unreadable")
+        stubExitHistory(info)
+        mockShare()
+
+        runExport()
+
+        assertTrue(viewModel.uiState.value.exportState is ExportState.Ready)
+        val content = exportContent()
+        assertTrue(content.contains("System trace available: unknown (access failed)"))
+        assertFalse(content.contains("System trace available: no"), "Access failure must not be reported as no trace")
+        assertTrue(content.contains("Trace access failed: trace file unreadable"))
+        assertTrue(content.contains("Reason: REASON_CRASH_NATIVE (5)"))
     }
 
     @Test


### PR DESCRIPTION
Closes #1007

## Problem

Settings → About → **Export logs** produced a file that is useless after a crash-and-relaunch: it captured only current-process logcat (`logcat -d -v threadtime --pid=<current pid> -t 500`), treated any non-blank stdout as valid logcat, and failed the whole export when current-process logcat was blank. A user who reopens Jandal after a crash cannot export evidence from the process that actually crashed.

Observed failure (2026-08-09, Honor Magic 8 Pro, #1449): the export contained only an opaque MagicOS/vendor `HKS…HKE` blob — no Jandal timestamps, no previous-process exit information.

## Solution

The exporter now assembles a single bounded text bundle from independent evidence sources:

1. **Recent process exits** — `ActivityManager.getHistoricalProcessExitReasons(packageName, pid = 0, max = 5)` (newest first, any PID of the package), rendering timestamp, process name, human-readable reason (`REASON_CRASH (4)` style), status/signal (with `(signal)` marker for `REASON_SIGNALED`), importance, description, PSS, RSS, and trace availability.
2. **ANR traces** — read as text only for `REASON_ANR`, bounded to 8192 characters with a truncation note; open/read failures add an exporter warning and continue.
3. **Native crashes** — `REASON_CRASH_NATIVE` traces are never decoded as text (API 31+ may expose a tombstone protobuf); the export records `Trace note: native tombstone; use native/ADB diagnostics`. No protobuf, no parser, no binary bytes.
4. **Current-process logcat** — kept as the existing PID-scoped secondary section, but now validated by a narrow plausibility check (threadtime entry or logcat buffer-heading line must appear). Opaque MagicOS `HKS…HKE` payloads are rejected as unusable and never presented as Jandal logs.
5. **App/build identity** — version name/code, build type, git SHA, build timestamp (already rendered on About) and package name are passed in via a small `DiagnosticBuildInfo` value object; no app↔feature BuildConfig dependency.

### Export success semantics

| Exit history | Logcat | Result |
|---|---|---|
| exists | valid | **Success** — both sections |
| exists | blank/unavailable/unusable | **Success** — exit history + warning (the Honor-after-crash path) |
| none | valid | **Success** — live-debug case |
| none | unusable | **Error** — explains no useful diagnostics were available, with ADB hint |

Each source is failure-isolated: ActivityManager failure, logcat launch/read failure, and per-record/trace failures never prevent the other evidence from exporting. Only file creation/FileProvider/share failures fail an already-assembled bundle.

## Test coverage (AboutViewModelTest, 147 tests total)

- exit metadata rendering (timestamp, reason, status/signal, importance, description, PSS, RSS, trace availability)
- history queried with pid=0 → records from a previous PID remain useful after relaunch
- human-readable reason formatting incl. `REASON_SIGNALED (2)` + `Status/signal: 9 (signal)`
- ANR trace included and bounded (8192 chars, truncation note, tail marker absent)
- ANR trace read failure → warning, export continues
- native-crash trace never read/decoded (read stubs throw AssertionError; export still succeeds; ADB note present)
- blank logcat + exit history → success with warning
- logcat launch failure + exit history → success with warning
- non-zero logcat exit + history → success with warning
- representative opaque MagicOS `HKS…HKE` payload rejected as unusable
- valid threadtime logcat accepted
- history + valid logcat → both sections
- no history + valid logcat → success
- no history + unusable logcat → `ExportState.Error` with ADB hint
- existing FileProvider/share-intent flow preserved (action, chooser, filename, Loading→Ready→Idle transitions)
- app/build metadata present in exported content

## Scope

- **#1449 crash remediation is out of scope** — this PR only makes the exporter able to classify the next reproduced exit (ANR vs native crash vs other) and guide the diagnostic path. No physical #1449 reproduction was performed.
- No Clear-logs UI, diagnostics history, dashboard, tombstone parser, protobuf dependency, persistent log store, telemetry, or third-party logging added. Export remains a local, user-initiated FileProvider text share.

## Validation

- `./gradlew :feature:settings:test` — 147 tests, all pass
- `./gradlew :app:assembleDebug` — success
- `./gradlew :feature:settings:lintDebug` — success
- `git diff --check` — clean

Do not merge — wait for review.